### PR TITLE
Fix profile photo upload, first-login loading bug, and update deps

### DIFF
--- a/app/src/main/java/com/example/shytalk/data/repository/StorageRepository.kt
+++ b/app/src/main/java/com/example/shytalk/data/repository/StorageRepository.kt
@@ -1,8 +1,7 @@
 package com.example.shytalk.data.repository
 
-import android.net.Uri
 import com.example.shytalk.core.util.Resource
 
 interface StorageRepository {
-    suspend fun uploadImage(userId: String, path: String, imageUri: Uri): Resource<String>
+    suspend fun uploadImage(userId: String, path: String, imageData: ByteArray): Resource<String>
 }

--- a/app/src/main/java/com/example/shytalk/data/repository/StorageRepositoryImpl.kt
+++ b/app/src/main/java/com/example/shytalk/data/repository/StorageRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.example.shytalk.data.repository
 
-import android.net.Uri
 import com.example.shytalk.core.util.Resource
 import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.tasks.await
@@ -10,10 +9,10 @@ class StorageRepositoryImpl @Inject constructor(
     private val storage: FirebaseStorage
 ) : StorageRepository {
 
-    override suspend fun uploadImage(userId: String, path: String, imageUri: Uri): Resource<String> {
+    override suspend fun uploadImage(userId: String, path: String, imageData: ByteArray): Resource<String> {
         return try {
-            val ref = storage.reference.child("$path/$userId/image.jpg")
-            ref.putFile(imageUri).await()
+            val ref = storage.reference.child("$path/$userId/${System.currentTimeMillis()}.jpg")
+            ref.putBytes(imageData).await()
             val downloadUrl = ref.downloadUrl.await().toString()
             Resource.Success(downloadUrl)
         } catch (e: Exception) {

--- a/app/src/main/java/com/example/shytalk/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/shytalk/feature/profile/ProfileScreen.kt
@@ -109,11 +109,9 @@ fun ProfileScreen(
         }
     }
 
-    // Load profile for the specified userId when used as a navigated screen
+    // Load profile for the current or specified user
     LaunchedEffect(userId) {
-        if (userId != null) {
-            viewModel.loadProfile(userId)
-        }
+        viewModel.loadProfile(userId)
     }
 
     val user = uiState.user
@@ -121,26 +119,32 @@ fun ProfileScreen(
 
     // If this is embedded in a tab (no scaffold needed), just render the content
     if (!showBackButton) {
-        ProfileContent(
-            uiState = uiState,
-            isOwn = isOwn,
-            editDisplayName = editDisplayName,
-            onEditDisplayNameChange = { editDisplayName = it },
-            editDescription = editDescription,
-            onEditDescriptionChange = { editDescription = it },
-            editNationality = editNationality,
-            onShowCountryPicker = { showCountryPicker = true },
-            onToggleEditing = { viewModel.toggleEditing() },
-            onSaveEdits = {
-                viewModel.saveProfileEdits(editDisplayName, editDescription, editNationality)
-            },
-            onPickProfilePhoto = { profilePhotoPicker.launch("image/*") },
-            onPickCoverPhoto = { coverPhotoPicker.launch("image/*") },
-            onBlockToggle = { showBlockDialog = true },
-            onSignOut = onSignOut,
-            snackbarHostState = snackbarHostState,
-            modifier = modifier
-        )
+        Box(modifier = modifier) {
+            ProfileContent(
+                uiState = uiState,
+                isOwn = isOwn,
+                editDisplayName = editDisplayName,
+                onEditDisplayNameChange = { editDisplayName = it },
+                editDescription = editDescription,
+                onEditDescriptionChange = { editDescription = it },
+                editNationality = editNationality,
+                onShowCountryPicker = { showCountryPicker = true },
+                onToggleEditing = { viewModel.toggleEditing() },
+                onSaveEdits = {
+                    viewModel.saveProfileEdits(editDisplayName, editDescription, editNationality)
+                },
+                onPickProfilePhoto = { profilePhotoPicker.launch("image/*") },
+                onPickCoverPhoto = { coverPhotoPicker.launch("image/*") },
+                onBlockToggle = { showBlockDialog = true },
+                onSignOut = onSignOut,
+                snackbarHostState = snackbarHostState,
+                modifier = Modifier.fillMaxSize()
+            )
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier.align(Alignment.BottomCenter)
+            )
+        }
     } else {
         Scaffold(
             snackbarHost = { SnackbarHost(snackbarHostState) },

--- a/app/src/main/java/com/example/shytalk/feature/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/shytalk/feature/profile/ProfileViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.shytalk.feature.profile
 
+import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -11,6 +12,7 @@ import com.example.shytalk.data.repository.StorageRepository
 import com.example.shytalk.data.repository.UserRepository
 import com.google.firebase.Timestamp
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -33,6 +35,7 @@ data class ProfileUiState(
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    @ApplicationContext private val context: Context,
     private val authRepository: AuthRepository,
     private val userRepository: UserRepository,
     private val storageRepository: StorageRepository
@@ -46,7 +49,6 @@ class ProfileViewModel @Inject constructor(
     init {
         val currentUid = authRepository.currentUser?.uid ?: ""
         _uiState.value = _uiState.value.copy(currentUserId = currentUid)
-        loadProfile(targetUserId)
     }
 
     fun loadProfile(userId: String?) {
@@ -142,7 +144,12 @@ class ProfileViewModel @Inject constructor(
                         user = _uiState.value.user?.copy(uniqueId = result.data)
                     )
                 }
-                else -> {}
+                is Resource.Error -> {
+                    _uiState.value = _uiState.value.copy(
+                        error = result.message ?: "Failed to generate unique ID"
+                    )
+                }
+                is Resource.Loading -> {}
             }
         }
     }
@@ -207,14 +214,36 @@ class ProfileViewModel @Inject constructor(
         val userId = authRepository.currentUser?.uid ?: return
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isUploadingPhoto = true)
-            when (val result = storageRepository.uploadImage(userId, "profile_photos", uri)) {
+            val imageData = try {
+                context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+            } catch (e: Exception) {
+                null
+            }
+            if (imageData == null) {
+                _uiState.value = _uiState.value.copy(
+                    isUploadingPhoto = false,
+                    error = "Failed to read image"
+                )
+                return@launch
+            }
+            when (val result = storageRepository.uploadImage(userId, "profile_photos", imageData)) {
                 is Resource.Success -> {
                     val url = result.data
-                    userRepository.updateProfile(userId, mapOf("profilePhotoUrl" to url))
-                    _uiState.value = _uiState.value.copy(
-                        isUploadingPhoto = false,
-                        user = _uiState.value.user?.copy(profilePhotoUrl = url)
-                    )
+                    when (val saveResult = userRepository.updateProfile(userId, mapOf("profilePhotoUrl" to url))) {
+                        is Resource.Success -> {
+                            _uiState.value = _uiState.value.copy(
+                                isUploadingPhoto = false,
+                                user = _uiState.value.user?.copy(profilePhotoUrl = url)
+                            )
+                        }
+                        is Resource.Error -> {
+                            _uiState.value = _uiState.value.copy(
+                                isUploadingPhoto = false,
+                                error = saveResult.message ?: "Failed to save photo URL"
+                            )
+                        }
+                        is Resource.Loading -> {}
+                    }
                 }
                 is Resource.Error -> {
                     _uiState.value = _uiState.value.copy(
@@ -231,14 +260,36 @@ class ProfileViewModel @Inject constructor(
         val userId = authRepository.currentUser?.uid ?: return
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isUploadingPhoto = true)
-            when (val result = storageRepository.uploadImage(userId, "cover_photos", uri)) {
+            val imageData = try {
+                context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+            } catch (e: Exception) {
+                null
+            }
+            if (imageData == null) {
+                _uiState.value = _uiState.value.copy(
+                    isUploadingPhoto = false,
+                    error = "Failed to read image"
+                )
+                return@launch
+            }
+            when (val result = storageRepository.uploadImage(userId, "cover_photos", imageData)) {
                 is Resource.Success -> {
                     val url = result.data
-                    userRepository.updateProfile(userId, mapOf("coverPhotoUrl" to url))
-                    _uiState.value = _uiState.value.copy(
-                        isUploadingPhoto = false,
-                        user = _uiState.value.user?.copy(coverPhotoUrl = url)
-                    )
+                    when (val saveResult = userRepository.updateProfile(userId, mapOf("coverPhotoUrl" to url))) {
+                        is Resource.Success -> {
+                            _uiState.value = _uiState.value.copy(
+                                isUploadingPhoto = false,
+                                user = _uiState.value.user?.copy(coverPhotoUrl = url)
+                            )
+                        }
+                        is Resource.Error -> {
+                            _uiState.value = _uiState.value.copy(
+                                isUploadingPhoto = false,
+                                error = saveResult.message ?: "Failed to save photo URL"
+                            )
+                        }
+                        is Resource.Loading -> {}
+                    }
                 }
                 is Resource.Error -> {
                     _uiState.value = _uiState.value.copy(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,21 +2,20 @@
 agp = "9.0.0"
 kotlin = "2.1.10"
 ksp = "2.3.5"
-composeBom = "2024.09.00"
-coreKtx = "1.13.1"
-lifecycleRuntimeKtx = "2.8.7"
-activityCompose = "1.9.3"
-navigationCompose = "2.8.4"
+composeBom = "2026.01.01"
+coreKtx = "1.17.0"
+lifecycleRuntimeKtx = "2.10.0"
+activityCompose = "1.12.3"
+navigationCompose = "2.9.7"
 hilt = "2.59.1"
 hiltNavigationCompose = "1.2.0"
-firebaseBom = "33.7.0"
-googleServices = "4.4.2"
-coroutines = "1.9.0"
+firebaseBom = "34.9.0"
+googleServices = "4.4.4"
+coroutines = "1.10.2"
 coil = "2.7.0"
 agora = "4.6.2"
 credentials = "1.5.0"
-googleid = "1.1.1"
-materialIconsExtended = "1.7.5"
+googleid = "1.2.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
@@ -38,7 +37,7 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
-androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 
 # Navigation
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
@@ -50,10 +49,10 @@ hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-com
 
 # Firebase
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
-firebase-auth = { group = "com.google.firebase", name = "firebase-auth-ktx" }
-firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore-ktx" }
-firebase-functions = { group = "com.google.firebase", name = "firebase-functions-ktx" }
-firebase-storage = { group = "com.google.firebase", name = "firebase-storage-ktx" }
+firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
+firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore" }
+firebase-functions = { group = "com.google.firebase", name = "firebase-functions" }
+firebase-storage = { group = "com.google.firebase", name = "firebase-storage" }
 
 # Coroutines
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }


### PR DESCRIPTION
## Summary
- **Photo upload fix**: Read URI bytes eagerly in ViewModel (fixes content:// permission loss), use putBytes instead of putFile, check Firestore write result, add timestamped filenames to avoid cache staleness
- **First-login loading fix**: Remove loadProfile from ViewModel init -- it raced with saveProfile and kept first-time users stuck on a loading screen after setting their name
- **Snackbar fix**: Add SnackbarHost in profile tab mode so upload/ID errors are visible
- **Error handling**: Surface generateUniqueId failures instead of silently swallowing them
- **Dependency updates**: Firebase BOM 34.9, Compose BOM 2026.01, google-services 4.4.4, Navigation 2.9.7, Lifecycle 2.10, and more -- resolves Gradle 10 deprecation warnings

## Test plan
- [ ] First-time login: set name -> click Continue -> should navigate to main screen (not stuck on loading)
- [ ] Upload profile photo -> restart app -> photo persists
- [ ] Upload cover photo -> restart app -> photo persists
- [ ] Turn off network -> attempt upload -> error snackbar appears in both tab and standalone profile views
- [ ] Verify unique ID appears on profile page
- [ ] Build with gradlew assembleDebug -- no errors or Gradle 10 deprecation warnings

Generated with [Claude Code](https://claude.com/claude-code)
