### PR TITLE
Fix users being able to block themselves

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,7 +21,9 @@
       "Bash(powershell.exe:*)",
       "WebFetch(domain:developers.google.com)",
       "Bash(find:*)",
-      "Bash(./gradlew assembleDebug:*)"
+      "Bash(./gradlew assembleDebug:*)",
+      "Bash(git push:*)",
+      "Bash(git checkout:*)"
     ]
   }
 }

--- a/app/src/main/java/com/example/shytalk/feature/room/RoomScreen.kt
+++ b/app/src/main/java/com/example/shytalk/feature/room/RoomScreen.kt
@@ -316,6 +316,7 @@ fun RoomScreen(
                 UserCardPopup(
                     user = user,
                     isBlocked = userId in uiState.blockedUserIds,
+                    isSelf = userId == uiState.currentUserId,
                     onViewProfile = {
                         showUserCardForId = null
                         onNavigateToUserProfile(userId)

--- a/app/src/main/java/com/example/shytalk/feature/room/components/UserCardPopup.kt
+++ b/app/src/main/java/com/example/shytalk/feature/room/components/UserCardPopup.kt
@@ -40,6 +40,7 @@ import com.example.shytalk.core.util.flagEmojiForCode
 fun UserCardPopup(
     user: User,
     isBlocked: Boolean,
+    isSelf: Boolean,
     onViewProfile: () -> Unit,
     onBlock: () -> Unit,
     onUnblock: () -> Unit,
@@ -120,23 +121,25 @@ fun UserCardPopup(
                     ) {
                         Text("View Profile")
                     }
-                    OutlinedButton(
-                        onClick = {
-                            if (isBlocked) {
-                                onUnblock()
-                            } else {
-                                showBlockConfirm = true
-                            }
-                        },
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        Icon(
-                            Icons.Default.Block,
-                            contentDescription = null,
-                            modifier = Modifier.size(16.dp)
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Text(if (isBlocked) "Unblock" else "Block")
+                    if (!isSelf) {
+                        OutlinedButton(
+                            onClick = {
+                                if (isBlocked) {
+                                    onUnblock()
+                                } else {
+                                    showBlockConfirm = true
+                                }
+                            },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Icon(
+                                Icons.Default.Block,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp)
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(if (isBlocked) "Unblock" else "Block")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Hide the block/unblock button in `UserCardPopup` when the user is viewing their own card
- Added `isSelf` parameter to `UserCardPopup` composable
- `ProfileScreen` already guarded this via `isOwnProfile`, but the room's `UserCardPopup` was missing the check

## Test plan
- [ ] Open a room and tap your own seat/avatar — verify no block button appears in the popup
- [ ] Tap another user's seat/avatar — verify block button still appears
- [ ] Tap a user from the participant list panel — verify block button behavior is correct for self vs others

🤖 Generated with [Claude Code](https://claude.com/claude-code)