### PR TITLE
Enforce one account per device restriction

### DIFF
--- a/app/src/main/java/com/example/shytalk/MainActivity.kt
+++ b/app/src/main/java/com/example/shytalk/MainActivity.kt
@@ -24,14 +24,9 @@ class MainActivity : ComponentActivity() {
         setContent {
             ShyTalkTheme {
                 val navController = rememberNavController()
-                val startDestination = if (authRepository.isAuthenticated) {
-                    Screen.Main.route
-                } else {
-                    Screen.GoogleSignIn.route
-                }
                 NavGraph(
                     navController = navController,
-                    startDestination = startDestination,
+                    startDestination = Screen.GoogleSignIn.route,
                     onSignOut = { authRepository.signOut() }
                 )
             }

--- a/app/src/main/java/com/example/shytalk/core/di/AppModule.kt
+++ b/app/src/main/java/com/example/shytalk/core/di/AppModule.kt
@@ -1,12 +1,16 @@
 package com.example.shytalk.core.di
 
+import android.content.Context
+import android.provider.Settings
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -24,4 +28,10 @@ object AppModule {
     @Provides
     @Singleton
     fun provideFirebaseStorage(): FirebaseStorage = FirebaseStorage.getInstance()
+
+    @Provides
+    @Singleton
+    @Named("deviceId")
+    fun provideDeviceId(@ApplicationContext context: Context): String =
+        Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
 }

--- a/app/src/main/java/com/example/shytalk/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/shytalk/core/di/RepositoryModule.kt
@@ -2,6 +2,8 @@ package com.example.shytalk.core.di
 
 import com.example.shytalk.data.repository.AuthRepository
 import com.example.shytalk.data.repository.AuthRepositoryImpl
+import com.example.shytalk.data.repository.DeviceRepository
+import com.example.shytalk.data.repository.DeviceRepositoryImpl
 import com.example.shytalk.data.repository.MessageRepository
 import com.example.shytalk.data.repository.MessageRepositoryImpl
 import com.example.shytalk.data.repository.RoomRepository
@@ -45,4 +47,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindStorageRepository(impl: StorageRepositoryImpl): StorageRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindDeviceRepository(impl: DeviceRepositoryImpl): DeviceRepository
 }

--- a/app/src/main/java/com/example/shytalk/data/repository/DeviceRepository.kt
+++ b/app/src/main/java/com/example/shytalk/data/repository/DeviceRepository.kt
@@ -1,0 +1,8 @@
+package com.example.shytalk.data.repository
+
+import com.example.shytalk.core.util.Resource
+
+interface DeviceRepository {
+    suspend fun getDeviceBinding(deviceId: String): Resource<String?>
+    suspend fun bindDevice(deviceId: String, userId: String): Resource<Unit>
+}

--- a/app/src/main/java/com/example/shytalk/data/repository/DeviceRepositoryImpl.kt
+++ b/app/src/main/java/com/example/shytalk/data/repository/DeviceRepositoryImpl.kt
@@ -1,0 +1,42 @@
+package com.example.shytalk.data.repository
+
+import com.example.shytalk.core.util.Resource
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+class DeviceRepositoryImpl @Inject constructor(
+    private val firestore: FirebaseFirestore
+) : DeviceRepository {
+
+    private val deviceBindingsCollection = firestore.collection("deviceBindings")
+
+    override suspend fun getDeviceBinding(deviceId: String): Resource<String?> {
+        return try {
+            val doc = deviceBindingsCollection.document(deviceId).get().await()
+            if (doc.exists()) {
+                val userId = doc.getString("userId")
+                Resource.Success(userId)
+            } else {
+                Resource.Success(null)
+            }
+        } catch (e: Exception) {
+            Resource.Error(e.message ?: "Failed to check device binding", e)
+        }
+    }
+
+    override suspend fun bindDevice(deviceId: String, userId: String): Resource<Unit> {
+        return try {
+            deviceBindingsCollection.document(deviceId).set(
+                mapOf(
+                    "userId" to userId,
+                    "boundAt" to FieldValue.serverTimestamp()
+                )
+            ).await()
+            Resource.Success(Unit)
+        } catch (e: Exception) {
+            Resource.Error(e.message ?: "Failed to bind device", e)
+        }
+    }
+}

--- a/app/src/main/java/com/example/shytalk/feature/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/example/shytalk/feature/auth/AuthViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.shytalk.core.util.Resource
 import com.example.shytalk.data.repository.AuthRepository
+import com.example.shytalk.data.repository.DeviceRepository
 import com.example.shytalk.data.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -11,18 +12,22 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Named
 
 data class AuthUiState(
     val isLoading: Boolean = false,
     val error: String? = null,
     val isAuthenticated: Boolean = false,
-    val hasProfile: Boolean = false
+    val hasProfile: Boolean = false,
+    val isDeviceLocked: Boolean = false
 )
 
 @HiltViewModel
 class AuthViewModel @Inject constructor(
     private val authRepository: AuthRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val deviceRepository: DeviceRepository,
+    @param:Named("deviceId") private val deviceId: String
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AuthUiState())
@@ -33,24 +38,55 @@ class AuthViewModel @Inject constructor(
     }
 
     private fun checkAuthState() {
-        if (authRepository.isAuthenticated) {
-            viewModelScope.launch {
-                val userId = authRepository.currentUser?.uid ?: return@launch
-                when (val result = userRepository.userExists(userId)) {
-                    is Resource.Success -> {
+        if (!authRepository.isAuthenticated) {
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true)
+            val userId = authRepository.currentUser?.uid
+            if (userId == null) {
+                _uiState.value = _uiState.value.copy(isLoading = false)
+                return@launch
+            }
+
+            when (val binding = deviceRepository.getDeviceBinding(deviceId)) {
+                is Resource.Success -> {
+                    val boundUserId = binding.data
+                    if (boundUserId != null && boundUserId != userId) {
+                        authRepository.signOut()
                         _uiState.value = _uiState.value.copy(
-                            isAuthenticated = true,
-                            hasProfile = result.data
+                            isLoading = false,
+                            isDeviceLocked = true
                         )
+                        return@launch
                     }
-                    is Resource.Error -> {
-                        _uiState.value = _uiState.value.copy(
-                            isAuthenticated = true,
-                            hasProfile = false
-                        )
+                    if (boundUserId == null) {
+                        deviceRepository.bindDevice(deviceId, userId)
                     }
-                    is Resource.Loading -> {}
                 }
+                is Resource.Error -> {
+                    // Lenient: let user through on network failure
+                }
+                is Resource.Loading -> {}
+            }
+
+            when (val result = userRepository.userExists(userId)) {
+                is Resource.Success -> {
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        isAuthenticated = true,
+                        hasProfile = result.data
+                    )
+                }
+                is Resource.Error -> {
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        isAuthenticated = true,
+                        hasProfile = false
+                    )
+                }
+                is Resource.Loading -> {}
             }
         }
     }
@@ -61,6 +97,28 @@ class AuthViewModel @Inject constructor(
             when (val result = authRepository.signInWithGoogleIdToken(idToken)) {
                 is Resource.Success -> {
                     val user = result.data
+
+                    when (val binding = deviceRepository.getDeviceBinding(deviceId)) {
+                        is Resource.Success -> {
+                            val boundUserId = binding.data
+                            if (boundUserId != null && boundUserId != user.uid) {
+                                authRepository.signOut()
+                                _uiState.value = _uiState.value.copy(
+                                    isLoading = false,
+                                    isDeviceLocked = true
+                                )
+                                return@launch
+                            }
+                            if (boundUserId == null) {
+                                deviceRepository.bindDevice(deviceId, user.uid)
+                            }
+                        }
+                        is Resource.Error -> {
+                            // Lenient: let user through on network failure
+                        }
+                        is Resource.Loading -> {}
+                    }
+
                     val exists = userRepository.userExists(user.uid)
                     val hasProfile = exists is Resource.Success && exists.data
                     _uiState.value = _uiState.value.copy(
@@ -82,6 +140,10 @@ class AuthViewModel @Inject constructor(
 
     fun clearError() {
         _uiState.value = _uiState.value.copy(error = null)
+    }
+
+    fun clearDeviceLocked() {
+        _uiState.value = _uiState.value.copy(isDeviceLocked = false)
     }
 
     fun signOut() {

--- a/app/src/main/java/com/example/shytalk/feature/auth/GoogleSignInScreen.kt
+++ b/app/src/main/java/com/example/shytalk/feature/auth/GoogleSignInScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -14,6 +15,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -50,6 +52,25 @@ fun GoogleSignInScreen(
         if (uiState.isAuthenticated) {
             onAuthSuccess(uiState.hasProfile)
         }
+    }
+
+    if (uiState.isDeviceLocked) {
+        AlertDialog(
+            onDismissRequest = { viewModel.clearDeviceLocked() },
+            title = { Text("Account Restricted") },
+            text = {
+                Text(
+                    "This device is already linked to another account.\n" +
+                        "Only one account is allowed per device.\n\n" +
+                        "For support, contact shytalk.help@gmail.com"
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { viewModel.clearDeviceLocked() }) {
+                    Text("OK")
+                }
+            }
+        )
     }
 
     LaunchedEffect(uiState.error) {


### PR DESCRIPTION
## Summary
- Adds a device binding system using `ANDROID_ID` to restrict each device to a single account
- Stores bindings in a Firestore `deviceBindings/{deviceId}` collection with `userId` and `boundAt` timestamp
- Shows an "Account Restricted" `AlertDialog` with support email when a second account is attempted on a bound device
- Always routes through `GoogleSignInScreen` on app launch to verify device binding before navigating to main

## Changes
- **New:** `DeviceRepository` interface + `DeviceRepositoryImpl` (Firestore)
- **New:** `@Named("deviceId")` provider in `AppModule` via `Settings.Secure.ANDROID_ID`
- **Modified:** `AuthViewModel` — device binding checks in `checkAuthState()` and `signInWithGoogle()`
- **Modified:** `GoogleSignInScreen` — `AlertDialog` for device-locked state
- **Modified:** `MainActivity` — `startDestination` always set to `GoogleSignIn`

## Test plan
- [ ] Fresh install → sign in with Account A → binding created in Firestore → navigates to profile/main
- [ ] Sign out → sign in with Account B → "Account Restricted" dialog appears with support email
- [ ] Dismiss dialog → returns to sign-in screen, cannot proceed with different account
- [ ] Sign out → sign in with Account A again → works, navigates to main
- [ ] Kill and relaunch app → brief loading spinner → auto-navigates to main
- [ ] Airplane mode relaunch → still works (lenient error handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)