### PR TITLE
Fix voice chat audio and add mic status indicators

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/data/remote/AgoraVoiceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/AgoraVoiceService.kt
@@ -96,6 +96,8 @@ class AgoraVoiceService @Inject constructor(
                     Constants.AUDIO_SCENARIO_CHATROOM
                 )
                 enableAudioVolumeIndication(300, 3, true)
+                enableAudio()
+                setDefaultAudioRoutetoSpeakerphone(true)
             }
         } catch (e: Exception) {
             // Log or handle initialization failure

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -1,6 +1,10 @@
 package com.shyden.shytalk.feature.room
 
+import android.Manifest
+import android.content.pm.PackageManager
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInHorizontally
@@ -34,13 +38,17 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.launch
 import com.shyden.shytalk.core.model.RoomRole
 import com.shyden.shytalk.core.model.RoomState
 import com.shyden.shytalk.core.model.SeatState
@@ -65,6 +73,31 @@ fun RoomScreen(
     var showSettings by remember { mutableStateOf(false) }
     var showUserCardForId by remember { mutableStateOf<String?>(null) }
     var showParticipantPanel by remember { mutableStateOf(false) }
+
+    // Audio permission handling
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        viewModel.onAudioPermissionResult(granted)
+        if (!granted) {
+            scope.launch {
+                snackbarHostState.showSnackbar("Microphone permission denied. You won't be able to use voice chat.")
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        val already = ContextCompat.checkSelfPermission(
+            context, Manifest.permission.RECORD_AUDIO
+        ) == PackageManager.PERMISSION_GRANTED
+        if (already) {
+            viewModel.onAudioPermissionResult(true)
+        } else {
+            permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+        }
+    }
 
     BackHandler(enabled = showParticipantPanel) {
         showParticipantPanel = false

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -51,7 +51,8 @@ data class RoomUiState(
     val blockedUserIds: Set<String> = emptySet(),
     val blockWarning: BlockWarning? = null,
     val hasJoined: Boolean = false,
-    val shouldNavigateBack: Boolean = false
+    val shouldNavigateBack: Boolean = false,
+    val hasAudioPermission: Boolean = false
 )
 
 @HiltViewModel
@@ -167,7 +168,9 @@ class RoomViewModel @Inject constructor(
                     }
 
                     if (currentlySeated && !isSeated) {
-                        joinVoiceChannel(room.agoraChannelName)
+                        if (_uiState.value.hasAudioPermission) {
+                            joinVoiceChannel(room.agoraChannelName)
+                        }
                     } else if (!currentlySeated && isSeated) {
                         agoraVoiceService.leaveChannel()
                     }
@@ -687,6 +690,14 @@ class RoomViewModel @Inject constructor(
 
     fun clearError() {
         _uiState.value = _uiState.value.copy(error = null)
+    }
+
+    fun onAudioPermissionResult(granted: Boolean) {
+        _uiState.value = _uiState.value.copy(hasAudioPermission = granted)
+        if (granted && isSeated) {
+            val channelName = _uiState.value.room?.agoraChannelName ?: return
+            joinVoiceChannel(channelName)
+        }
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/shyden/shytalk/feature/room/components/SeatItem.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/components/SeatItem.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MicOff
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PersonAdd
@@ -197,21 +198,24 @@ fun SeatItem(
                 }
             }
 
-            // Mute indicator
-            if (seat.state == SeatState.OCCUPIED && seat.isMuted) {
+            // Mic status indicator
+            if (seat.state == SeatState.OCCUPIED) {
                 Box(
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
                         .size(18.dp)
                         .clip(CircleShape)
-                        .background(MaterialTheme.colorScheme.error),
+                        .background(
+                            if (seat.isMuted) MaterialTheme.colorScheme.error
+                            else Color(0xFF4CAF50)
+                        ),
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
-                        Icons.Default.MicOff,
-                        contentDescription = "Muted",
+                        if (seat.isMuted) Icons.Default.MicOff else Icons.Default.Mic,
+                        contentDescription = if (seat.isMuted) "Muted" else "Unmuted",
                         modifier = Modifier.size(12.dp),
-                        tint = MaterialTheme.colorScheme.onError
+                        tint = Color.White
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- **Fix broken voice chat**: Added `enableAudio()` and `setDefaultAudioRoutetoSpeakerphone(true)` in `AgoraVoiceService.initialize()` so the audio module actually starts and routes to loudspeaker
- **Add runtime RECORD_AUDIO permission**: Request microphone permission on room entry via `rememberLauncherForActivityResult`; shows snackbar if denied
- **Gate voice join on permission**: Voice channel join only triggers after permission is granted; if user is already seated when permission comes through, joins immediately
- **Mic status indicators on all seats**: Every occupied seat now shows a badge — green mic (unmuted) or red mic-off (muted), not just muted users

## Test plan
- [ ] Enter a room — Android should prompt for microphone permission
- [ ] Grant permission, take a seat — verify you join the Agora voice channel (audio through speaker)
- [ ] Have two users seated — verify they can hear each other
- [ ] Verify speaking users show green pulsing border animation
- [ ] Verify all occupied seats show mic icon (green = unmuted, red = muted)
- [ ] Mute/unmute — verify icon toggles correctly
- [ ] Deny permission — verify snackbar appears and user can still use text chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)