### PR TITLE
Add force update check on app startup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,7 @@ play {
     serviceAccountCredentials.set(rootProject.file("play-service-account.json"))
     track.set("internal")
     defaultToAppBundles.set(true)
+    releaseStatus.set(com.github.triplet.gradle.androidpublisher.ReleaseStatus.DRAFT)
 }
 
 android {
@@ -58,6 +59,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     packaging {
         jniLibs {

--- a/app/src/main/java/com/shyden/shytalk/MainActivity.kt
+++ b/app/src/main/java/com/shyden/shytalk/MainActivity.kt
@@ -4,12 +4,20 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.navigation.compose.rememberNavController
+import com.google.firebase.firestore.FirebaseFirestore
 import com.shyden.shytalk.data.repository.AuthRepository
+import com.shyden.shytalk.feature.update.ForceUpdateScreen
 import com.shyden.shytalk.navigation.NavGraph
 import com.shyden.shytalk.navigation.Screen
 import com.shyden.shytalk.ui.theme.ShyTalkTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -23,12 +31,37 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             ShyTalkTheme {
-                val navController = rememberNavController()
-                NavGraph(
-                    navController = navController,
-                    startDestination = Screen.GoogleSignIn.route,
-                    onSignOut = { authRepository.signOut() }
-                )
+                var updateRequired by remember { mutableStateOf(false) }
+                var checkComplete by remember { mutableStateOf(false) }
+
+                LaunchedEffect(Unit) {
+                    try {
+                        val doc = FirebaseFirestore.getInstance()
+                            .collection("config")
+                            .document("app")
+                            .get()
+                            .await()
+                        val minVersion = (doc.getLong("minVersionCode") ?: 0).toInt()
+                        updateRequired = BuildConfig.VERSION_CODE < minVersion
+                    } catch (_: Exception) {
+                        // If check fails, allow the user through
+                        updateRequired = false
+                    }
+                    checkComplete = true
+                }
+
+                if (checkComplete) {
+                    if (updateRequired) {
+                        ForceUpdateScreen()
+                    } else {
+                        val navController = rememberNavController()
+                        NavGraph(
+                            navController = navController,
+                            startDestination = Screen.GoogleSignIn.route,
+                            onSignOut = { authRepository.signOut() }
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/shyden/shytalk/feature/update/ForceUpdateScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/update/ForceUpdateScreen.kt
@@ -1,0 +1,72 @@
+package com.shyden.shytalk.feature.update
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SystemUpdate
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ForceUpdateScreen() {
+    val context = LocalContext.current
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.SystemUpdate,
+            contentDescription = null,
+            modifier = Modifier.size(80.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "Update Required",
+            style = MaterialTheme.typography.headlineMedium,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = "A new version of ShyTalk is available. Please update to continue using the app.",
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(onClick = {
+            val intent = Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse("https://play.google.com/store/apps/details?id=com.shyden.shytalk")
+            )
+            context.startActivity(intent)
+        }) {
+            Text("Update Now")
+        }
+    }
+}

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,0 +1,9 @@
+Voice Chat & Stability Improvements
+
+- Fixed voice chat: users can now hear each other when seated
+- Added mic mute/unmute button in the chat input area
+- App now detects when users close the app and removes them from rooms automatically
+- Users can no longer be in multiple rooms at the same time
+- Fixed issue where "Someone" appeared instead of the user's name
+- Removed redundant system messages from the chat
+- Various room management bug fixes (invites, seat requests, leave cleanup)


### PR DESCRIPTION
## Summary
- Checks `config/app.minVersionCode` in Firestore on launch
- If app version is below minimum, shows a blocking "Update Required" screen with Play Store link
- Fails open if Firestore check errors (no internet, etc.)
- Enables `BuildConfig` generation

## Test plan
- [ ] App launches normally when `minVersionCode` is 1
- [ ] Setting `minVersionCode` higher than current version shows update screen
- [ ] "Update Now" button opens Play Store

🤖 Generated with [Claude Code](https://claude.com/claude-code)