### PR TITLE
Close all existing rooms before creating a new one

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepository.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepository.kt
@@ -30,4 +30,5 @@ interface RoomRepository {
     suspend fun findActiveRoomByOwner(ownerId: String): String?
     suspend fun recordFirstJoinTimestamp(roomId: String, userId: String): Resource<Unit>
     suspend fun leaveAllRooms(userId: String, exceptRoomId: String? = null): Resource<Unit>
+    suspend fun closeAllRoomsByOwner(ownerId: String): Resource<Unit>
 }

--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
@@ -363,6 +363,22 @@ class RoomRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun closeAllRoomsByOwner(ownerId: String): Resource<Unit> {
+        return try {
+            val snapshot = roomsCollection
+                .whereEqualTo("ownerId", ownerId)
+                .whereIn("state", listOf(RoomState.ACTIVE.name, RoomState.OWNER_AWAY.name))
+                .get()
+                .await()
+            for (doc in snapshot.documents) {
+                closeRoom(doc.id)
+            }
+            Resource.Success(Unit)
+        } catch (e: Exception) {
+            Resource.Error(e.message ?: "Failed to close rooms", e)
+        }
+    }
+
     override suspend fun closeRoom(roomId: String): Resource<Unit> {
         return try {
             val emptySeats = (0 until Constants.MAX_SEATS).associate { i ->

--- a/app/src/main/java/com/shyden/shytalk/feature/home/HomeViewModel.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/home/HomeViewModel.kt
@@ -134,6 +134,8 @@ class HomeViewModel @Inject constructor(
         val userId = authRepository.currentUser?.uid ?: return
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            // Close any existing rooms owned by this user
+            roomRepository.closeAllRoomsByOwner(userId)
             when (val result = roomRepository.createRoom(name, userId)) {
                 is Resource.Success -> {
                     _uiState.value = _uiState.value.copy(


### PR DESCRIPTION
## Summary
- Adds `closeAllRoomsByOwner()` to RoomRepository that queries and closes all active/owner-away rooms owned by the user
- Calls it in `HomeViewModel.createRoom()` before creating the new room
- Prevents users from having multiple active rooms

## Test plan
- [ ] Creating a room when you already have one closes the old room first
- [ ] Other users in the old room see it close properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)