### PR TITLE
Room management & UX improvements

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 8
-        versionName = "0.08"
+        versionCode = 9
+        versionName = "0.09"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -111,6 +111,9 @@ dependencies {
 
     // Coil
     implementation(libs.coil.compose)
+
+    // Image Cropper
+    implementation(libs.android.image.cropper)
 
     // Agora
     implementation(libs.agora.rtc)

--- a/app/src/main/java/com/shyden/shytalk/data/remote/AgoraVoiceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/AgoraVoiceService.kt
@@ -129,6 +129,12 @@ class AgoraVoiceService @Inject constructor(
             return
         }
 
+        // Leave any existing channel first
+        if (_isJoined.value) {
+            Log.d(TAG, "Already in a channel, leaving first")
+            engine.leaveChannel()
+        }
+
         // Enable audio right before joining — this is when RECORD_AUDIO permission is guaranteed
         engine.enableAudio()
 
@@ -153,16 +159,21 @@ class AgoraVoiceService @Inject constructor(
             Log.e(TAG, "joinChannel failed with error code $result")
         } else {
             Log.d(TAG, "joinChannel call succeeded (waiting for onJoinChannelSuccess callback)")
-            // Force speakerphone on after join for reliable audio routing
+            // Force speakerphone on and unmute mic after join
             engine.setEnableSpeakerphone(true)
+            engine.muteLocalAudioStream(false)
+            engine.adjustRecordingSignalVolume(400)
+            Log.d(TAG, "Audio configured: speakerphone=on, mic=unmuted, recordingVolume=400")
         }
     }
 
     fun leaveChannel() {
+        Log.d(TAG, "leaveChannel called, isJoined=${_isJoined.value}")
         rtcEngine?.leaveChannel()
     }
 
     fun muteLocalAudio(mute: Boolean) {
+        Log.d(TAG, "muteLocalAudio mute=$mute")
         rtcEngine?.muteLocalAudioStream(mute)
     }
 

--- a/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
@@ -1,8 +1,13 @@
 package com.shyden.shytalk.feature.profile
 
+import android.graphics.Color as AndroidColor
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import com.canhub.cropper.CropImageContract
+import com.canhub.cropper.CropImageContractOptions
+import com.canhub.cropper.CropImageOptions
+import com.canhub.cropper.CropImageView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -91,16 +96,20 @@ fun ProfileScreen(
     var showCountryPicker by remember { mutableStateOf(false) }
     var showBlockDialog by remember { mutableStateOf(false) }
 
-    // Photo pickers
-    val profilePhotoPicker = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent()
-    ) { uri: Uri? ->
-        uri?.let { viewModel.uploadProfilePhoto(it) }
+    // Photo pickers with cropping
+    val profilePhotoCropper = rememberLauncherForActivityResult(
+        contract = CropImageContract()
+    ) { result ->
+        if (result.isSuccessful) {
+            result.uriContent?.let { viewModel.uploadProfilePhoto(it) }
+        }
     }
-    val coverPhotoPicker = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent()
-    ) { uri: Uri? ->
-        uri?.let { viewModel.uploadCoverPhoto(it) }
+    val coverPhotoCropper = rememberLauncherForActivityResult(
+        contract = CropImageContract()
+    ) { result ->
+        if (result.isSuccessful) {
+            result.uriContent?.let { viewModel.uploadCoverPhoto(it) }
+        }
     }
 
     LaunchedEffect(uiState.error) {
@@ -134,8 +143,38 @@ fun ProfileScreen(
                 onSaveEdits = {
                     viewModel.saveProfileEdits(editDisplayName, editDescription, editNationality)
                 },
-                onPickProfilePhoto = { profilePhotoPicker.launch("image/*") },
-                onPickCoverPhoto = { coverPhotoPicker.launch("image/*") },
+                onPickProfilePhoto = {
+                    profilePhotoCropper.launch(
+                        CropImageContractOptions(
+                            uri = null,
+                            cropImageOptions = CropImageOptions(
+                                guidelines = CropImageView.Guidelines.ON,
+                                aspectRatioX = 1,
+                                aspectRatioY = 1,
+                                fixAspectRatio = true,
+                                cropShape = CropImageView.CropShape.OVAL,
+                                outputCompressQuality = 80,
+                                activityBackgroundColor = AndroidColor.BLACK
+                            )
+                        )
+                    )
+                },
+                onPickCoverPhoto = {
+                    coverPhotoCropper.launch(
+                        CropImageContractOptions(
+                            uri = null,
+                            cropImageOptions = CropImageOptions(
+                                guidelines = CropImageView.Guidelines.ON,
+                                aspectRatioX = 16,
+                                aspectRatioY = 9,
+                                fixAspectRatio = true,
+                                cropShape = CropImageView.CropShape.RECTANGLE,
+                                outputCompressQuality = 80,
+                                activityBackgroundColor = AndroidColor.BLACK
+                            )
+                        )
+                    )
+                },
                 onBlockToggle = { showBlockDialog = true },
                 onSignOut = onSignOut,
                 snackbarHostState = snackbarHostState,
@@ -173,8 +212,38 @@ fun ProfileScreen(
                 onSaveEdits = {
                     viewModel.saveProfileEdits(editDisplayName, editDescription, editNationality)
                 },
-                onPickProfilePhoto = { profilePhotoPicker.launch("image/*") },
-                onPickCoverPhoto = { coverPhotoPicker.launch("image/*") },
+                onPickProfilePhoto = {
+                    profilePhotoCropper.launch(
+                        CropImageContractOptions(
+                            uri = null,
+                            cropImageOptions = CropImageOptions(
+                                guidelines = CropImageView.Guidelines.ON,
+                                aspectRatioX = 1,
+                                aspectRatioY = 1,
+                                fixAspectRatio = true,
+                                cropShape = CropImageView.CropShape.OVAL,
+                                outputCompressQuality = 80,
+                                activityBackgroundColor = AndroidColor.BLACK
+                            )
+                        )
+                    )
+                },
+                onPickCoverPhoto = {
+                    coverPhotoCropper.launch(
+                        CropImageContractOptions(
+                            uri = null,
+                            cropImageOptions = CropImageOptions(
+                                guidelines = CropImageView.Guidelines.ON,
+                                aspectRatioX = 16,
+                                aspectRatioY = 9,
+                                fixAspectRatio = true,
+                                cropShape = CropImageView.CropShape.RECTANGLE,
+                                outputCompressQuality = 80,
+                                activityBackgroundColor = AndroidColor.BLACK
+                            )
+                        )
+                    )
+                },
                 onBlockToggle = { showBlockDialog = true },
                 onSignOut = onSignOut,
                 snackbarHostState = snackbarHostState,

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -56,6 +56,7 @@ import com.shyden.shytalk.feature.room.components.ChatPanel
 import com.shyden.shytalk.feature.room.components.OwnerAwayBanner
 import com.shyden.shytalk.feature.room.components.ParticipantInfo
 import com.shyden.shytalk.feature.room.components.ParticipantListPanel
+import com.shyden.shytalk.feature.room.components.RoomClosedSummaryPanel
 import com.shyden.shytalk.feature.room.components.RoomToolbar
 import com.shyden.shytalk.feature.room.components.SeatGrid
 import com.shyden.shytalk.feature.room.components.UserCardPopup
@@ -103,10 +104,18 @@ fun RoomScreen(
         showParticipantPanel = false
     }
 
-    LaunchedEffect(uiState.roomClosed) {
-        if (uiState.roomClosed) {
-            onNavigateBack()
-        }
+    // Show kicked dialog
+    if (uiState.wasKicked) {
+        AlertDialog(
+            onDismissRequest = {},
+            title = { Text("Removed from Room") },
+            text = { Text("You have been kicked from this room.") },
+            confirmButton = {
+                TextButton(onClick = { onNavigateBack() }) {
+                    Text("OK")
+                }
+            }
+        )
     }
 
     LaunchedEffect(uiState.shouldNavigateBack) {
@@ -125,6 +134,20 @@ fun RoomScreen(
     // Block warning dialogs
     uiState.blockWarning?.let { warning ->
         when (warning) {
+            is BlockWarning.BlockedByRoomOwner -> {
+                AlertDialog(
+                    onDismissRequest = {},
+                    title = { Text("Cannot Enter Room") },
+                    text = {
+                        Text("You are not allowed to enter this room.")
+                    },
+                    confirmButton = {
+                        TextButton(onClick = { onNavigateBack() }) {
+                            Text("Go Back")
+                        }
+                    }
+                )
+            }
             is BlockWarning.BlockedUserInRoom -> {
                 AlertDialog(
                     onDismissRequest = {},
@@ -239,7 +262,16 @@ fun RoomScreen(
                 .fillMaxSize()
                 .padding(padding)
         ) {
-            if (uiState.isLoading) {
+            val closedSummary = uiState.roomClosedSummary
+            if (uiState.roomClosed && closedSummary != null) {
+                RoomClosedSummaryPanel(
+                    summary = closedSummary,
+                    onDismiss = onNavigateBack
+                )
+            } else if (uiState.roomClosed) {
+                // Room closed but no summary data available, navigate back
+                LaunchedEffect(Unit) { onNavigateBack() }
+            } else if (uiState.isLoading) {
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center
@@ -259,9 +291,7 @@ fun RoomScreen(
                     // Owner Away Banner
                     if (uiState.room?.state == RoomState.OWNER_AWAY) {
                         OwnerAwayBanner(
-                            remainingMs = uiState.ownerAwayRemainingMs,
-                            isOwner = uiState.currentRole == RoomRole.OWNER,
-                            onOwnerReturn = { viewModel.ownerReturn() }
+                            remainingMs = uiState.ownerAwayRemainingMs
                         )
                     }
 
@@ -315,21 +345,6 @@ fun RoomScreen(
                             } else if (seat?.userId == null) {
                                 viewModel.takeSeat(seatIndex)
                             }
-                        },
-                        onRemoveFromSeat = { seatIndex ->
-                            viewModel.removeFromSeat(seatIndex)
-                        },
-                        onToggleSelfMute = { seatIndex ->
-                            viewModel.toggleSelfMute(seatIndex)
-                        },
-                        onForceMute = { seatIndex ->
-                            viewModel.forceMuteUser(seatIndex)
-                        },
-                        onKickUser = { seatIndex ->
-                            viewModel.kickUser(seatIndex)
-                        },
-                        onMoveSeat = { fromIndex, toIndex ->
-                            viewModel.moveSeat(fromIndex, toIndex)
                         },
                         onTapUser = { userId ->
                             showUserCardForId = userId
@@ -419,9 +434,31 @@ fun RoomScreen(
         showUserCardForId?.let { userId ->
             val user = uiState.seatUsers[userId] ?: uiState.participantUsers[userId]
             if (user != null) {
+                val targetSeatEntry = uiState.room?.seats?.entries?.find {
+                    it.value.userId == userId && it.value.state == SeatState.OCCUPIED
+                }
+                val isTargetSeated = targetSeatEntry != null
+                val targetSeatIndex = targetSeatEntry?.key?.toIntOrNull()
+
+                val targetRole = when {
+                    userId == uiState.room?.ownerId -> RoomRole.OWNER
+                    userId in (uiState.room?.hostIds ?: emptyList()) -> RoomRole.HOST
+                    else -> RoomRole.ATTENDEE
+                }
+
                 val canInviteFromCard = (uiState.currentRole == RoomRole.OWNER || uiState.currentRole == RoomRole.HOST)
                         && userId != uiState.currentUserId
-                        && uiState.room?.seats?.values?.none { it.userId == userId && it.state == SeatState.OCCUPIED } == true
+                        && !isTargetSeated
+
+                // Mod capabilities: owner/host can act on normal users
+                val isTargetNormalUser = userId != uiState.currentUserId && targetRole == RoomRole.ATTENDEE
+                val canModerate = isTargetNormalUser && isTargetSeated
+                        && (uiState.currentRole == RoomRole.OWNER || uiState.currentRole == RoomRole.HOST)
+
+                val emptySeats = uiState.room?.seats?.entries
+                    ?.filter { it.value.state != SeatState.OCCUPIED && it.key.toInt() != com.shyden.shytalk.core.util.Constants.OWNER_SEAT_INDEX }
+                    ?.map { it.key.toInt() } ?: emptyList()
+
                 UserCardPopup(
                     user = user,
                     isBlocked = userId in uiState.blockedUserIds,
@@ -444,6 +481,22 @@ fun RoomScreen(
                             showUserCardForId = null
                         }
                     } else null,
+                    onMuteToggle = if (canModerate && targetSeatIndex != null) {
+                        { viewModel.forceMuteUser(targetSeatIndex) }
+                    } else null,
+                    isTargetMuted = targetSeatEntry?.value?.isMuted ?: false,
+                    onRemoveFromSeat = if (canModerate && targetSeatIndex != null
+                        && targetSeatIndex != com.shyden.shytalk.core.util.Constants.OWNER_SEAT_INDEX) {
+                        { viewModel.removeFromSeat(targetSeatIndex) }
+                    } else null,
+                    onKickFromRoom = if (canModerate && targetSeatIndex != null) {
+                        { viewModel.kickUser(targetSeatIndex) }
+                    } else null,
+                    onMoveSeat = if (canModerate && targetSeatIndex != null && emptySeats.isNotEmpty()
+                        && targetSeatIndex != com.shyden.shytalk.core.util.Constants.OWNER_SEAT_INDEX) {
+                        { toIndex -> viewModel.moveSeat(targetSeatIndex, toIndex) }
+                    } else null,
+                    emptySeats = emptySeats,
                     onDismiss = { showUserCardForId = null }
                 )
             }

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -29,13 +29,22 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import android.util.Log
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 sealed class BlockWarning {
+    data object BlockedByRoomOwner : BlockWarning()
     data object BlockedUserInRoom : BlockWarning()
     data object BlockedByUserInRoom : BlockWarning()
 }
+
+data class RoomClosedSummary(
+    val roomName: String,
+    val durationMs: Long,
+    val hostUsers: List<User>,
+    val totalVisitors: Int
+)
 
 data class RoomUiState(
     val room: ChatRoom? = null,
@@ -46,6 +55,7 @@ data class RoomUiState(
     val isLoading: Boolean = true,
     val error: String? = null,
     val roomClosed: Boolean = false,
+    val roomClosedSummary: RoomClosedSummary? = null,
     val ownerAwayRemainingMs: Long = 0L,
     val speakingUids: Set<Int> = emptySet(),
     val isVoiceJoined: Boolean = false,
@@ -56,6 +66,7 @@ data class RoomUiState(
     val blockWarning: BlockWarning? = null,
     val hasJoined: Boolean = false,
     val shouldNavigateBack: Boolean = false,
+    val wasKicked: Boolean = false,
     val hasAudioPermission: Boolean = false
 )
 
@@ -71,6 +82,10 @@ class RoomViewModel @Inject constructor(
     private val presenceService: PresenceService
 ) : ViewModel() {
 
+    companion object {
+        private const val TAG = "RoomViewModel"
+    }
+
     private val roomId: String = savedStateHandle["roomId"] ?: ""
 
     private val _uiState = MutableStateFlow(RoomUiState())
@@ -82,6 +97,8 @@ class RoomViewModel @Inject constructor(
     private var blockCheckDone = false
     private var firstJoinTimestamp: Timestamp? = null
     private var allMessages: List<Message> = emptyList()
+    private var lastKnownRoom: ChatRoom? = null
+    private var ownerReturnTriggered = false
 
     init {
         val userId = authRepository.currentUser?.uid ?: ""
@@ -119,22 +136,38 @@ class RoomViewModel @Inject constructor(
                 .collect { room ->
                     if (room == null || room.state == RoomState.CLOSED) {
                         agoraVoiceService.leaveChannel()
+                        presenceService.removePresence()
+                        val summary = buildClosedSummary(room)
                         _uiState.value = _uiState.value.copy(
                             isLoading = false,
-                            roomClosed = true
+                            roomClosed = true,
+                            roomClosedSummary = summary
                         )
                         return@collect
                     }
+
+                    // Cache room data for summary if it closes later
+                    lastKnownRoom = room
 
                     val userId = _uiState.value.currentUserId
 
                     // Only check kicked status after we've joined
                     if (_uiState.value.hasJoined) {
-                        if (userId !in room.participantIds || userId in room.bannedUserIds) {
+                        if (userId in room.bannedUserIds) {
                             agoraVoiceService.leaveChannel()
+                            presenceService.removePresence()
                             _uiState.value = _uiState.value.copy(
                                 isLoading = false,
-                                roomClosed = true
+                                wasKicked = true
+                            )
+                            return@collect
+                        }
+                        if (userId !in room.participantIds) {
+                            agoraVoiceService.leaveChannel()
+                            presenceService.removePresence()
+                            _uiState.value = _uiState.value.copy(
+                                isLoading = false,
+                                shouldNavigateBack = true
                             )
                             return@collect
                         }
@@ -167,16 +200,31 @@ class RoomViewModel @Inject constructor(
                         return@collect
                     }
 
+                    // Auto-detect owner return
+                    if (room.state == RoomState.OWNER_AWAY
+                        && room.ownerId == userId
+                        && _uiState.value.hasJoined
+                        && !ownerReturnTriggered
+                    ) {
+                        ownerReturnTriggered = true
+                        ownerReturn()
+                    }
+                    if (room.state == RoomState.ACTIVE) {
+                        ownerReturnTriggered = false
+                    }
+
                     // Normal room updates after joining
                     val currentlySeated = room.seats.values.any {
                         it.userId == userId && it.state == SeatState.OCCUPIED
                     }
 
                     if (currentlySeated && !isSeated) {
+                        Log.d(TAG, "User became seated, hasAudioPermission=${_uiState.value.hasAudioPermission}")
                         if (_uiState.value.hasAudioPermission) {
                             joinVoiceChannel(room.agoraChannelName)
                         }
                     } else if (!currentlySeated && isSeated) {
+                        Log.d(TAG, "User left seat, leaving voice channel")
                         agoraVoiceService.leaveChannel()
                     }
                     isSeated = currentlySeated
@@ -214,6 +262,29 @@ class RoomViewModel @Inject constructor(
             val userId = _uiState.value.currentUserId
             val myBlockedIds = _uiState.value.blockedUserIds
 
+            // Check if user is banned from this room (kicked previously)
+            if (userId in room.bannedUserIds) {
+                _uiState.value = _uiState.value.copy(
+                    blockWarning = BlockWarning.BlockedByRoomOwner
+                )
+                return@launch
+            }
+
+            // Always check room owner's block list (even if owner is away)
+            val ownerUser = userCache[room.ownerId] ?: when (val result = userRepository.getUser(room.ownerId)) {
+                is Resource.Success -> {
+                    userCache[room.ownerId] = result.data
+                    result.data
+                }
+                else -> null
+            }
+            if (ownerUser != null && userId in ownerUser.blockedUserIds) {
+                _uiState.value = _uiState.value.copy(
+                    blockWarning = BlockWarning.BlockedByRoomOwner
+                )
+                return@launch
+            }
+
             // Check if any participant is blocked by me
             val blockedInRoom = room.participantIds.any { it in myBlockedIds && it != userId }
             if (blockedInRoom) {
@@ -223,9 +294,9 @@ class RoomViewModel @Inject constructor(
                 return@launch
             }
 
-            // Check if any participant has blocked me
+            // Check if any other participant (non-owner) has blocked me
             for (participantId in room.participantIds) {
-                if (participantId == userId) continue
+                if (participantId == userId || participantId == room.ownerId) continue
                 val cached = userCache[participantId]
                 val participantUser = if (cached != null) {
                     cached
@@ -329,6 +400,7 @@ class RoomViewModel @Inject constructor(
     private fun joinVoiceChannel(channelName: String) {
         viewModelScope.launch {
             val uid = _uiState.value.currentUserId.hashCode() and 0x7FFFFFFF
+            Log.d(TAG, "joinVoiceChannel channel=$channelName uid=$uid")
             agoraVoiceService.joinChannel(channelName, uid)
         }
     }
@@ -499,8 +571,15 @@ class RoomViewModel @Inject constructor(
             val isTargetHost = targetUserId in room.hostIds
             if (isTargetOwner || isTargetHost) return@launch
 
+            val kickerName = _uiState.value.currentUserName
+            val targetUser = userCache[targetUserId]
+            val targetName = targetUser?.displayName ?: "A user"
+
             roomRepository.kickUser(roomId, targetUserId, seatIndex)
-            messageRepository.sendSystemMessage(roomId, "A user was kicked from the room")
+            messageRepository.sendSystemMessage(
+                roomId,
+                "$targetName was kicked by $kickerName"
+            )
         }
     }
 
@@ -583,12 +662,19 @@ class RoomViewModel @Inject constructor(
             withContext(NonCancellable) {
                 room.seats.forEach { (index, seat) ->
                     if (seat.userId == userId) {
-                        if (index.toInt() == Constants.OWNER_SEAT_INDEX && room.ownerId == userId) {
-                            roomRepository.leaveSeat(roomId, index.toInt())
-                            roomRepository.setOwnerAway(roomId)
-                        } else {
-                            roomRepository.leaveSeat(roomId, index.toInt())
-                        }
+                        roomRepository.leaveSeat(roomId, index.toInt())
+                    }
+                }
+
+                if (room.ownerId == userId) {
+                    // Check if anyone else is still on mic
+                    val anyoneOnMic = room.seats.any { (_, seat) ->
+                        seat.userId != null && seat.userId != userId && seat.state == SeatState.OCCUPIED
+                    }
+                    if (anyoneOnMic) {
+                        roomRepository.setOwnerAway(roomId)
+                    } else {
+                        roomRepository.closeRoom(roomId)
                     }
                 }
 
@@ -719,11 +805,37 @@ class RoomViewModel @Inject constructor(
         }
     }
 
+    private fun buildClosedSummary(closedRoom: ChatRoom?): RoomClosedSummary? {
+        // Use closed room data if available, fall back to last known snapshot
+        val room = closedRoom ?: lastKnownRoom ?: return null
+
+        val createdMs = room.createdAt.toDate().time
+        val closedMs = room.closedAt?.toDate()?.time ?: System.currentTimeMillis()
+        val durationMs = closedMs - createdMs
+
+        // Host users: owner + anyone in hostIds
+        val hostIds = (listOf(room.ownerId) + room.hostIds).distinct()
+        val hostUsers = hostIds.mapNotNull { userCache[it] }
+
+        // Total unique visitors from firstJoinTimestamps, fall back to lastKnownRoom
+        val visitors = room.firstJoinTimestamps.size.coerceAtLeast(
+            lastKnownRoom?.participantIds?.size ?: 0
+        )
+
+        return RoomClosedSummary(
+            roomName = room.name,
+            durationMs = durationMs,
+            hostUsers = hostUsers,
+            totalVisitors = visitors
+        )
+    }
+
     fun clearError() {
         _uiState.value = _uiState.value.copy(error = null)
     }
 
     fun onAudioPermissionResult(granted: Boolean) {
+        Log.d(TAG, "onAudioPermissionResult granted=$granted isSeated=$isSeated")
         _uiState.value = _uiState.value.copy(hasAudioPermission = granted)
         if (granted && isSeated) {
             val channelName = _uiState.value.room?.agoraChannelName ?: return

--- a/app/src/main/java/com/shyden/shytalk/feature/room/components/ChatPanel.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/components/ChatPanel.kt
@@ -18,6 +18,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -60,6 +62,17 @@ fun ChatPanel(
     }
     val isSeated = currentSeatEntry != null
     val isSelfMuted = currentSeatEntry?.value?.isMuted ?: false
+
+    // Auto-scroll: with reverseLayout=true, index 0 is the bottom (newest message)
+    val isAtBottom by remember {
+        derivedStateOf { listState.firstVisibleItemIndex == 0 }
+    }
+
+    LaunchedEffect(messages.size) {
+        if (isAtBottom) {
+            listState.animateScrollToItem(0)
+        }
+    }
 
     Column(modifier = modifier) {
         LazyColumn(

--- a/app/src/main/java/com/shyden/shytalk/feature/room/components/OwnerAwayBanner.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/components/OwnerAwayBanner.kt
@@ -1,23 +1,17 @@
 package com.shyden.shytalk.feature.room.components
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun OwnerAwayBanner(
-    remainingMs: Long,
-    isOwner: Boolean,
-    onOwnerReturn: () -> Unit
+    remainingMs: Long
 ) {
     val minutes = (remainingMs / 60_000).toInt()
     val seconds = ((remainingMs % 60_000) / 1_000).toInt()
@@ -26,24 +20,13 @@ fun OwnerAwayBanner(
         color = MaterialTheme.colorScheme.errorContainer,
         modifier = Modifier.fillMaxWidth()
     ) {
-        Row(
+        Text(
+            text = "Owner away - Room closes in ${minutes}:${"%02d".format(seconds)}",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onErrorContainer,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Text(
-                text = "Owner away - Room closes in ${minutes}:${"%02d".format(seconds)}",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onErrorContainer
-            )
-
-            if (isOwner) {
-                Button(onClick = onOwnerReturn) {
-                    Text("Return")
-                }
-            }
-        }
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        )
     }
 }

--- a/app/src/main/java/com/shyden/shytalk/feature/room/components/RoomClosedSummaryPanel.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/components/RoomClosedSummaryPanel.kt
@@ -1,0 +1,172 @@
+package com.shyden.shytalk.feature.room.components
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.feature.room.RoomClosedSummary
+
+@Composable
+fun RoomClosedSummaryPanel(
+    summary: RoomClosedSummary,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val hours = (summary.durationMs / 3_600_000).toInt()
+    val minutes = ((summary.durationMs % 3_600_000) / 60_000).toInt()
+    val durationText = when {
+        hours > 0 -> "${hours}h ${minutes}m"
+        minutes > 0 -> "${minutes}m"
+        else -> "< 1m"
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Room Closed",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = summary.roomName,
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 24.dp))
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Duration
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Schedule,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Open for $durationText",
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Total visitors
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Groups,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "${summary.totalVisitors} visitor${if (summary.totalVisitors != 1) "s" else ""}",
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 24.dp))
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Hosts section
+        if (summary.hostUsers.isNotEmpty()) {
+            Text(
+                text = "Hosts",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                for (host in summary.hostUsers) {
+                    HostChip(host)
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(onClick = onDismiss) {
+            Text("Back to Home")
+        }
+    }
+}
+
+@Composable
+private fun HostChip(user: User) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        AsyncImage(
+            model = user.profilePhotoUrl ?: user.avatarUrl,
+            contentDescription = user.displayName,
+            modifier = Modifier
+                .size(56.dp)
+                .clip(CircleShape)
+                .border(2.dp, MaterialTheme.colorScheme.primary, CircleShape),
+            contentScale = ContentScale.Crop
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = user.displayName,
+            style = MaterialTheme.typography.bodySmall,
+            textAlign = TextAlign.Center,
+            maxLines = 1
+        )
+    }
+}

--- a/app/src/main/java/com/shyden/shytalk/feature/room/components/SeatGrid.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/components/SeatGrid.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.shyden.shytalk.core.model.RoomRole
 import com.shyden.shytalk.core.model.Seat
-import com.shyden.shytalk.core.model.SeatState
 import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.util.Constants
 
@@ -23,19 +22,9 @@ fun SeatGrid(
     speakingUids: Set<Int>,
     seatUsers: Map<String, User> = emptyMap(),
     onSeatClick: (Int) -> Unit,
-    onRemoveFromSeat: (Int) -> Unit,
-    onToggleSelfMute: (Int) -> Unit,
-    onForceMute: (Int) -> Unit,
-    onKickUser: (Int) -> Unit,
-    onMoveSeat: (fromIndex: Int, toIndex: Int) -> Unit,
     onTapUser: (String) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
-    // Collect empty seat indices for the move dialog
-    val emptySeats = seats.entries
-        .filter { it.value.state != SeatState.OCCUPIED && it.key.toInt() != Constants.OWNER_SEAT_INDEX }
-        .map { it.key.toInt() }
-
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -56,17 +45,6 @@ fun SeatGrid(
                         else -> RoomRole.ATTENDEE
                     }
 
-                    val isTargetNormalUser = seat.userId != null
-                        && seat.userId != currentUserId
-                        && seatRole == RoomRole.ATTENDEE
-
-                    val canModerate = when {
-                        !isTargetNormalUser -> false
-                        currentRole == RoomRole.OWNER -> true
-                        currentRole == RoomRole.HOST -> true
-                        else -> false
-                    }
-
                     // Check if this seat's user is speaking via Agora UID
                     val isSpeaking = seatUserId != null &&
                         (seatUserId.hashCode() and 0x7FFFFFFF) in speakingUids
@@ -83,19 +61,9 @@ fun SeatGrid(
                         seatRole = seatRole,
                         isCurrentUser = seat.userId == currentUserId,
                         canLeaveSeat = seat.userId == currentUserId && !isOwnerOnOwnSeat,
-                        canRemove = canModerate && seatIndex != Constants.OWNER_SEAT_INDEX,
-                        canMute = canModerate,
-                        canKick = canModerate,
-                        canMove = canModerate && emptySeats.isNotEmpty() && seatIndex != Constants.OWNER_SEAT_INDEX,
-                        emptySeats = emptySeats,
                         isSpeaking = isSpeaking,
                         user = seatUser,
                         onClick = { onSeatClick(seatIndex) },
-                        onRemove = { onRemoveFromSeat(seatIndex) },
-                        onToggleSelfMute = { onToggleSelfMute(seatIndex) },
-                        onForceMute = { onForceMute(seatIndex) },
-                        onKick = { onKickUser(seatIndex) },
-                        onMoveTo = { toIndex -> onMoveSeat(seatIndex, toIndex) },
                         onTapUser = seatUserId?.let { uid -> { onTapUser(uid) } },
                         modifier = Modifier.weight(1f)
                     )

--- a/app/src/main/java/com/shyden/shytalk/feature/room/components/SeatItem.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/components/SeatItem.kt
@@ -24,14 +24,12 @@ import androidx.compose.material.icons.filled.MicOff
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -60,27 +58,13 @@ fun SeatItem(
     seatRole: RoomRole,
     isCurrentUser: Boolean,
     canLeaveSeat: Boolean,
-    canRemove: Boolean,
-    canMute: Boolean,
-    canKick: Boolean,
-    canMove: Boolean,
-    emptySeats: List<Int>,
     isSpeaking: Boolean,
     user: User? = null,
     onClick: () -> Unit,
-    onRemove: () -> Unit,
-    onToggleSelfMute: () -> Unit,
-    onForceMute: () -> Unit,
-    onKick: () -> Unit,
-    onMoveTo: (toIndex: Int) -> Unit,
     onTapUser: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     var showMenu by remember { mutableStateOf(false) }
-    var showMoveDialog by remember { mutableStateOf(false) }
-
-    val hasSelfActions = canLeaveSeat || isCurrentUser
-    val hasModActions = canRemove || canMute || canKick || canMove
 
     // Speaking animation
     val infiniteTransition = rememberInfiniteTransition(label = "speaking")
@@ -136,7 +120,7 @@ fun SeatItem(
                             }
                         },
                         onLongClick = {
-                            if (hasModActions || hasSelfActions) {
+                            if (canLeaveSeat) {
                                 showMenu = true
                             }
                         }
@@ -220,55 +204,17 @@ fun SeatItem(
                 }
             }
 
-            // Context menu
+            // Context menu (only leave seat for current user)
             DropdownMenu(
                 expanded = showMenu,
                 onDismissRequest = { showMenu = false }
             ) {
-                // Self actions
                 if (canLeaveSeat) {
                     DropdownMenuItem(
                         text = { Text("Leave seat") },
                         onClick = {
                             showMenu = false
                             onClick()
-                        }
-                    )
-                }
-                // Moderation actions on normal users
-                if (canMute) {
-                    DropdownMenuItem(
-                        text = { Text(if (seat.isMuted) "Unmute user" else "Mute user") },
-                        onClick = {
-                            showMenu = false
-                            onForceMute()
-                        }
-                    )
-                }
-                if (canMove) {
-                    DropdownMenuItem(
-                        text = { Text("Move to seat\u2026") },
-                        onClick = {
-                            showMenu = false
-                            showMoveDialog = true
-                        }
-                    )
-                }
-                if (canRemove) {
-                    DropdownMenuItem(
-                        text = { Text("Remove from seat") },
-                        onClick = {
-                            showMenu = false
-                            onRemove()
-                        }
-                    )
-                }
-                if (canKick) {
-                    DropdownMenuItem(
-                        text = { Text("Kick from room") },
-                        onClick = {
-                            showMenu = false
-                            onKick()
                         }
                     )
                 }
@@ -287,32 +233,6 @@ fun SeatItem(
             textAlign = TextAlign.Center,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
-        )
-    }
-
-    // Move-to-seat picker dialog
-    if (showMoveDialog) {
-        AlertDialog(
-            onDismissRequest = { showMoveDialog = false },
-            title = { Text("Move to which seat?") },
-            text = {
-                Column {
-                    emptySeats.forEach { targetIndex ->
-                        TextButton(onClick = {
-                            showMoveDialog = false
-                            onMoveTo(targetIndex)
-                        }) {
-                            Text("Seat ${targetIndex + 1}")
-                        }
-                    }
-                }
-            },
-            confirmButton = {},
-            dismissButton = {
-                TextButton(onClick = { showMoveDialog = false }) {
-                    Text("Cancel")
-                }
-            }
         )
     }
 }

--- a/app/src/main/java/com/shyden/shytalk/feature/room/components/UserCardPopup.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/components/UserCardPopup.kt
@@ -13,8 +13,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.EventSeat
 import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.MicOff
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.PersonOff
+import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -30,6 +34,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -46,9 +51,18 @@ fun UserCardPopup(
     onBlock: () -> Unit,
     onUnblock: () -> Unit,
     onDismiss: () -> Unit,
-    onInvite: (() -> Unit)? = null
+    onInvite: (() -> Unit)? = null,
+    // Moderation actions (null = not available)
+    onMuteToggle: (() -> Unit)? = null,
+    isTargetMuted: Boolean = false,
+    onRemoveFromSeat: (() -> Unit)? = null,
+    onKickFromRoom: (() -> Unit)? = null,
+    onMoveSeat: ((Int) -> Unit)? = null,
+    emptySeats: List<Int> = emptyList()
 ) {
     var showBlockConfirm by remember { mutableStateOf(false) }
+    var showKickConfirm by remember { mutableStateOf(false) }
+    var showMoveDialog by remember { mutableStateOf(false) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -160,6 +174,87 @@ fun UserCardPopup(
                         Text("Invite to Mic")
                     }
                 }
+
+                // Moderation actions
+                if (onMuteToggle != null || onRemoveFromSeat != null || onMoveSeat != null || onKickFromRoom != null) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text(
+                        text = "Moderation",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+
+                if (onMuteToggle != null) {
+                    OutlinedButton(
+                        onClick = {
+                            onMuteToggle()
+                            onDismiss()
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(
+                            if (isTargetMuted) Icons.Default.Mic else Icons.Default.MicOff,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(if (isTargetMuted) "Unmute User" else "Mute User")
+                    }
+                }
+
+                if (onMoveSeat != null && emptySeats.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    OutlinedButton(
+                        onClick = { showMoveDialog = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(
+                            Icons.Default.SwapHoriz,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text("Move to Seat")
+                    }
+                }
+
+                if (onRemoveFromSeat != null) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    OutlinedButton(
+                        onClick = {
+                            onRemoveFromSeat()
+                            onDismiss()
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(
+                            Icons.Default.EventSeat,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text("Remove from Seat")
+                    }
+                }
+
+                if (onKickFromRoom != null) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    OutlinedButton(
+                        onClick = { showKickConfirm = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(
+                            Icons.Default.PersonOff,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.error
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text("Kick from Room", color = MaterialTheme.colorScheme.error)
+                    }
+                }
             }
         },
         confirmButton = {},
@@ -185,6 +280,54 @@ fun UserCardPopup(
             },
             dismissButton = {
                 TextButton(onClick = { showBlockConfirm = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    if (showKickConfirm) {
+        AlertDialog(
+            onDismissRequest = { showKickConfirm = false },
+            title = { Text("Kick User") },
+            text = { Text("Are you sure you want to kick ${user.displayName} from the room? They will not be able to rejoin.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showKickConfirm = false
+                    onKickFromRoom?.invoke()
+                    onDismiss()
+                }) {
+                    Text("Kick", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showKickConfirm = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    if (showMoveDialog) {
+        AlertDialog(
+            onDismissRequest = { showMoveDialog = false },
+            title = { Text("Move to which seat?") },
+            text = {
+                Column {
+                    emptySeats.forEach { targetIndex ->
+                        TextButton(onClick = {
+                            showMoveDialog = false
+                            onMoveSeat?.invoke(targetIndex)
+                            onDismiss()
+                        }) {
+                            Text("Seat ${targetIndex + 1}")
+                        }
+                    }
+                }
+            },
+            confirmButton = {},
+            dismissButton = {
+                TextButton(onClick = { showMoveDialog = false }) {
                     Text("Cancel")
                 }
             }

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,9 +1,13 @@
-Voice Chat & Stability Improvements
+Room Management & UX Improvements
 
-- Fixed voice chat: users can now hear each other when seated
-- Added mic mute/unmute button in the chat input area
-- App now detects when users close the app and removes them from rooms automatically
-- Users can no longer be in multiple rooms at the same time
-- Fixed issue where "Someone" appeared instead of the user's name
-- Removed redundant system messages from the chat
-- Various room management bug fixes (invites, seat requests, leave cleanup)
+- Room closed summary: see room duration, hosts, and visitor count when a room closes
+- Owner return auto-detected: no more "Return" button needed
+- Rooms close immediately when owner leaves and no one is on mic
+- Chat auto-scrolls to latest messages
+- Moderation actions (mute, kick, move) moved to user card popup
+- Blocked/kicked users are now fully denied room entry
+- Kicked users see a notification and the chat shows who kicked them
+- Profile and cover photo cropping before upload
+- Improved Agora token authentication
+
+WARNING: Voice chat is currently not working and will be fixed in a later version.

--- a/functions/index.js
+++ b/functions/index.js
@@ -22,10 +22,9 @@ exports.generateAgoraToken = onCall((request) => {
     );
   }
 
-  // Token expires in 24 hours
-  const expirationTimeInSeconds = 86400;
-  const currentTimestamp = Math.floor(Date.now() / 1000);
-  const privilegeExpiredTs = currentTimestamp + expirationTimeInSeconds;
+  // agora-token v2 expects relative expiration in seconds (not absolute timestamps)
+  const tokenExpirationSeconds = 86400; // 24 hours
+  const privilegeExpirationSeconds = 86400;
 
   const token = RtcTokenBuilder.buildTokenWithUid(
     AGORA_APP_ID,
@@ -33,10 +32,11 @@ exports.generateAgoraToken = onCall((request) => {
     channelName,
     uid,
     RtcRole.PUBLISHER,
-    privilegeExpiredTs,
-    privilegeExpiredTs
+    tokenExpirationSeconds,
+    privilegeExpirationSeconds
   );
 
+  console.log(`Generated token for channel=${channelName} uid=${uid}`);
   return { token };
 });
 
@@ -98,11 +98,37 @@ exports.onPresenceRemoved = onValueDeleted(
           updates[`pendingInvites.${userId}`] = require("firebase-admin/firestore").FieldValue.delete();
         }
 
-        // If this user is the owner, set room to OWNER_AWAY
+        // If this user is the owner, check if anyone is still on mic
         if (room.ownerId === userId && room.state === "ACTIVE") {
-          updates.state = "OWNER_AWAY";
-          updates.ownerLeftAt = require("firebase-admin/firestore").Timestamp.now();
-          console.log(`Owner left room ${roomId}, setting OWNER_AWAY`);
+          // Check if any other user is still seated (on mic) after clearing this user's seats
+          let anyoneOnMic = false;
+          for (let i = 0; i < MAX_SEATS; i++) {
+            const key = i.toString();
+            // Skip seats we just cleared for this user
+            if (updates[`seats.${key}`]) continue;
+            const seat = seats[key];
+            if (seat && seat.userId && seat.userId !== userId && seat.state === "OCCUPIED") {
+              anyoneOnMic = true;
+              break;
+            }
+          }
+
+          if (anyoneOnMic) {
+            // Someone is still on mic, enter grace period
+            updates.state = "OWNER_AWAY";
+            updates.ownerLeftAt = require("firebase-admin/firestore").Timestamp.now();
+            console.log(`Owner left room ${roomId}, users still on mic - setting OWNER_AWAY`);
+          } else {
+            // No one on mic, close immediately
+            updates.state = "CLOSED";
+            updates.closedAt = require("firebase-admin/firestore").Timestamp.now();
+            updates.participantIds = [];
+            // Clear all seats
+            for (let i = 0; i < MAX_SEATS; i++) {
+              updates[`seats.${i.toString()}`] = { userId: null, state: "EMPTY", isMuted: false };
+            }
+            console.log(`Owner left room ${roomId}, no users on mic - closing immediately`);
+          }
         }
 
         transaction.update(roomRef, updates);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ firebaseBom = "34.9.0"
 googleServices = "4.4.4"
 coroutines = "1.10.2"
 coil = "2.7.0"
+imageCropper = "4.6.0"
 agora = "4.6.2"
 credentials = "1.5.0"
 googleid = "1.2.0"
@@ -61,6 +62,9 @@ kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "ko
 
 # Coil (image loading)
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+
+# Image Cropper
+android-image-cropper = { group = "com.vanniktech", name = "android-image-cropper", version.ref = "imageCropper" }
 
 # Credential Manager (Google Sign-In)
 androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }


### PR DESCRIPTION
## Summary
- **Room closed summary**: When a room closes, users see duration, hosts (with profile pics), and visitor count instead of being silently navigated away
- **Auto-detect owner return**: Owner presence is detected automatically — no more "Return" button needed when host comes back
- **Immediate room close**: Rooms close instantly when the owner leaves and no one else is on mic (skips 5-min grace period)
- **Chat auto-scroll**: Chat automatically scrolls to the latest message unless user has scrolled up
- **Mod actions on user card**: Mute, kick, move, and remove actions moved from seat long-press menu to the user card popup
- **Block/kick entry denial**: Blocked users and kicked users are fully denied room entry with appropriate warning dialogs
- **Kick notifications**: Kicked users see a popup notification, and a system message appears in chat showing who was kicked and by whom
- **Image cropping**: Profile photos (1:1 oval) and cover photos (16:9 rectangle) can be cropped before upload
- **Agora token fix**: Token generation updated to use relative expiration (seconds) instead of absolute timestamps

## Test plan
- [ ] Open a room, close it, verify the summary panel shows duration/hosts/visitors
- [ ] As room owner, leave and return — verify countdown cancels automatically without clicking "Return"
- [ ] As room owner, leave with no one on mic — verify room closes immediately
- [ ] Send messages in chat, verify auto-scroll to bottom
- [ ] Tap a seated user's avatar, verify moderation actions appear in the user card popup
- [ ] Have a blocked user try to enter — verify they are denied
- [ ] Kick a user, verify they see a notification popup and the chat shows a kick message
- [ ] Upload a profile photo and cover photo — verify crop UI appears
- [ ] Voice chat: join a room and verify token authentication succeeds (note: voice is still under investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)