### PR TITLE
Fix photo cropping crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 9
-        versionName = "0.09"
+        versionCode = 10
+        versionName = "0.10"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,13 +1,3 @@
-Room Management & UX Improvements
+Bug fix: photo cropping crash resolved
 
-- Room closed summary: see room duration, hosts, and visitor count when a room closes
-- Owner return auto-detected: no more "Return" button needed
-- Rooms close immediately when owner leaves and no one is on mic
-- Chat auto-scrolls to latest messages
-- Moderation actions (mute, kick, move) moved to user card popup
-- Blocked/kicked users are now fully denied room entry
-- Kicked users see a notification and the chat shows who kicked them
-- Profile and cover photo cropping before upload
-- Improved Agora token authentication
-
-WARNING: Voice chat is currently not working and will be fixed in a later version.
+WARNING: Voice chat not working, fix coming in a later version.

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.ShyTalk" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.ShyTalk" parent="Theme.AppCompat.Light.NoActionBar" />
 </resources>


### PR DESCRIPTION
## Summary
- Fix crash when tapping camera icon to crop profile/cover photos
- Root cause: app theme (`android:Theme.Material.Light.NoActionBar`) is not AppCompat-compatible, but `CropImageActivity` requires an AppCompat theme
- Changed theme parent to `Theme.AppCompat.Light.NoActionBar` — no visual change since all UI is Compose

## Test plan
- [ ] Edit profile, tap camera icon on profile photo — crop UI opens without crash
- [ ] Edit profile, tap camera icon on cover photo — crop UI opens without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)