### PR TITLE
Bump version to 0.13 with release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 local.properties
 /keystore.jks
 /play-service-account.json
+functions/node_modules/
+nul

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 12
-        versionName = "0.12"
+        versionCode = 13
+        versionName = "0.13"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,4 +1,4 @@
-v0.12 - Unit Tests, Custom Crop & Performance
+v0.13 - Unit Tests, Custom Crop & Performance
 
 - Replaced deprecated photo cropper with custom CropActivity
 - Removed unnecessary storage permission prompts (uses modern photo picker)


### PR DESCRIPTION
## Summary
- Bump versionCode from 12 to 13, versionName to 0.13
- Updated release notes for Play Store internal track
- Added functions/node_modules/ and nul to .gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)