### PR TITLE
Shorten release notes for Play Store limit

### DIFF
--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,12 +1,10 @@
-v0.14 - Performance, Refactoring & Expanded Tests
+v0.14 - Performance, Refactoring & Tests
 
-- Deduplicated Agora speaking state to reduce unnecessary recompositions
-- Batch parallel loading for block checks (was sequential per-participant)
-- Merged owner + seat user loading into single batch in home screen
-- Refactored MessageRepository, ProfileViewModel, and RoomViewModel for DRY code
-- Broke down 150-line observeRoom into 5 focused handler functions
-- Added 28 new tests (User model, ActiveRoomManager) — now 205 total
-- Custom CropActivity replacing deprecated photo cropper
-- PiP support, room mini bar, privacy policy screen
-- Force update check on app startup
-- Various bug fixes and stability improvements
+- Deduplicated Agora speaking state to reduce recompositions
+- Batch parallel loading for block checks and user fetching
+- Refactored MessageRepository, ProfileViewModel, RoomViewModel
+- Extracted observeRoom into 5 focused handler functions
+- 205 unit tests (28 new: User model, ActiveRoomManager)
+- Custom CropActivity, PiP support, room mini bar
+- Force update check, privacy policy screen
+- Bug fixes and stability improvements


### PR DESCRIPTION
## Summary
- Shortened release notes from 675 to under 500 characters (Play Store limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)