### PR TITLE
Fix crop toolbar obscured by status bar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 14
-        versionName = "0.14"
+        versionCode = 15
+        versionName = "0.15"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/shyden/shytalk/core/crop/CropActivity.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/crop/CropActivity.kt
@@ -3,6 +3,7 @@ package com.shyden.shytalk.core.crop
 import android.app.Activity
 import android.content.Intent
 import android.graphics.Bitmap
+import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -18,6 +19,7 @@ class CropActivity : AppCompatActivity(), CropImageView.OnCropImageCompleteListe
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.statusBarColor = Color.parseColor("#FF444444")
         setContentView(R.layout.activity_crop)
 
         cropImageView = findViewById(R.id.cropImageView)

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,10 +1,6 @@
-v0.14 - Performance, Refactoring & Tests
+v0.15 - Crop Toolbar Fix & Tests
 
-- Deduplicated Agora speaking state to reduce recompositions
-- Batch parallel loading for block checks and user fetching
-- Refactored MessageRepository, ProfileViewModel, RoomViewModel
-- Extracted observeRoom into 5 focused handler functions
-- 205 unit tests (28 new: User model, ActiveRoomManager)
-- Custom CropActivity, PiP support, room mini bar
-- Force update check, privacy policy screen
-- Bug fixes and stability improvements
+- Fixed crop photo toolbar hidden behind the status bar
+- Status bar now matches toolbar color for seamless look
+- Added 6 CropContract unit tests (211 total)
+- Performance and refactoring improvements from v0.14

--- a/app/src/main/res/layout/activity_crop.xml
+++ b/app/src/main/res/layout/activity_crop.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#FF000000"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <LinearLayout

--- a/app/src/test/java/com/shyden/shytalk/core/crop/CropContractTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/crop/CropContractTest.kt
@@ -1,0 +1,91 @@
+package com.shyden.shytalk.core.crop
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class CropContractTest {
+
+    private val contract = CropContract()
+    private val mockUri = mockk<Uri>()
+
+    @Before
+    fun setup() {
+        mockkStatic(Uri::class)
+        every { Uri.parse(any()) } returns mockUri
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Uri::class)
+    }
+
+    // --- parseResult ---
+
+    @Test
+    fun `parseResult returns uri on RESULT_OK with valid uri`() {
+        val intent = mockk<Intent>()
+        every { intent.getStringExtra(CropActivity.EXTRA_RESULT_URI) } returns "file:///tmp/cropped.jpg"
+
+        val result = contract.parseResult(Activity.RESULT_OK, intent)
+        assertEquals(mockUri, result)
+    }
+
+    @Test
+    fun `parseResult returns null on RESULT_CANCELED`() {
+        val intent = mockk<Intent>()
+        every { intent.getStringExtra(CropActivity.EXTRA_RESULT_URI) } returns "file:///tmp/cropped.jpg"
+
+        assertNull(contract.parseResult(Activity.RESULT_CANCELED, intent))
+    }
+
+    @Test
+    fun `parseResult returns null when intent is null`() {
+        assertNull(contract.parseResult(Activity.RESULT_OK, null))
+    }
+
+    @Test
+    fun `parseResult returns null when intent has no uri extra`() {
+        val intent = mockk<Intent>()
+        every { intent.getStringExtra(CropActivity.EXTRA_RESULT_URI) } returns null
+
+        assertNull(contract.parseResult(Activity.RESULT_OK, intent))
+    }
+
+    // --- CropInput defaults ---
+
+    @Test
+    fun `CropInput has correct defaults`() {
+        val input = CropInput(uri = mockUri, aspectRatioX = 1, aspectRatioY = 1)
+        assertEquals("rectangle", input.cropShape)
+        assertEquals(80, input.quality)
+        assertEquals("Crop", input.title)
+    }
+
+    @Test
+    fun `CropInput preserves custom values`() {
+        val input = CropInput(
+            uri = mockUri,
+            aspectRatioX = 16,
+            aspectRatioY = 9,
+            cropShape = "oval",
+            quality = 95,
+            title = "Edit Cover"
+        )
+        assertEquals(mockUri, input.uri)
+        assertEquals(16, input.aspectRatioX)
+        assertEquals(9, input.aspectRatioY)
+        assertEquals("oval", input.cropShape)
+        assertEquals(95, input.quality)
+        assertEquals("Edit Cover", input.title)
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed crop photo toolbar hidden behind the Android status bar by adding `fitsSystemWindows` to the layout root
- Set status bar color to match toolbar background (#FF444444) for a seamless look
- Added 6 CropContract unit tests (211 total, all passing)
- Bump version to 0.15

## Test plan
- [x] `./gradlew test` — 211 tests all passing
- [x] `./gradlew assembleDebug` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)