### PR TITLE
Bump version to 0.16 with voice chat fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 15
-        versionName = "0.15"
+        versionCode = 16
+        versionName = "0.16"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/shyden/shytalk/MainActivity.kt
+++ b/app/src/main/java/com/shyden/shytalk/MainActivity.kt
@@ -1,9 +1,8 @@
 package com.shyden.shytalk
 
-import android.app.PictureInPictureParams
+import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
-import android.util.Rational
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -16,6 +15,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.rememberNavController
 import com.google.firebase.firestore.FirebaseFirestore
 import com.shyden.shytalk.core.pip.PipContent
+import com.shyden.shytalk.core.pip.PipHelper
 import com.shyden.shytalk.core.room.ActiveRoomManager
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.feature.privacy.PrivacyPolicyScreen
@@ -24,7 +24,12 @@ import com.shyden.shytalk.navigation.NavGraph
 import com.shyden.shytalk.navigation.Screen
 import com.shyden.shytalk.ui.theme.ShyTalkTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -37,6 +42,7 @@ class MainActivity : ComponentActivity() {
     lateinit var activeRoomManager: ActiveRoomManager
 
     private val isInPipMode = mutableStateOf(false)
+    private val _navigateToRoom = mutableStateOf<String?>(null)
 
     companion object {
         private const val PREFS_NAME = "shytalk_prefs"
@@ -99,6 +105,18 @@ class MainActivity : ComponentActivity() {
                             ForceUpdateScreen()
                         } else {
                             val navController = rememberNavController()
+                            val navigateToRoomId by _navigateToRoom
+
+                            LaunchedEffect(navigateToRoomId) {
+                                val roomId = navigateToRoomId
+                                if (roomId != null) {
+                                    navController.navigate(Screen.Room.createRoute(roomId)) {
+                                        launchSingleTop = true
+                                    }
+                                    _navigateToRoom.value = null
+                                }
+                            }
+
                             NavGraph(
                                 navController = navController,
                                 startDestination = Screen.GoogleSignIn.route,
@@ -110,15 +128,29 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+
+        // Handle notification tap to open room (cold start)
+        handleRoomIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleRoomIntent(intent)
+    }
+
+    private fun handleRoomIntent(intent: Intent?) {
+        if (intent?.action == "OPEN_ROOM") {
+            val roomId = intent.getStringExtra("roomId")
+            if (roomId != null) {
+                _navigateToRoom.value = roomId
+            }
+        }
     }
 
     override fun onUserLeaveHint() {
         super.onUserLeaveHint()
         if (activeRoomManager.isInAnyRoom()) {
-            val params = PictureInPictureParams.Builder()
-                .setAspectRatio(Rational(9, 16))
-                .build()
-            enterPictureInPictureMode(params)
+            PipHelper.enterPipMode(this)
         }
     }
 
@@ -128,5 +160,22 @@ class MainActivity : ComponentActivity() {
     ) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
         isInPipMode.value = isInPictureInPictureMode
+
+        if (!isInPictureInPictureMode) {
+            if (isFinishing) {
+                // PIP was swiped away — leave room cleanly
+                CoroutineScope(Dispatchers.Main.immediate).launch {
+                    withContext(NonCancellable) {
+                        activeRoomManager.leaveRoom()
+                    }
+                }
+            } else {
+                // PIP tapped to expand — navigate to active room
+                val roomId = activeRoomManager.activeRoomId.value
+                if (roomId != null) {
+                    _navigateToRoom.value = roomId
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/shyden/shytalk/core/di/AppModule.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/di/AppModule.kt
@@ -32,7 +32,7 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideFirebaseDatabase(): FirebaseDatabase = FirebaseDatabase.getInstance()
+    fun provideFirebaseDatabase(): FirebaseDatabase = FirebaseDatabase.getInstance("https://shytalk-7ba69-default-rtdb.asia-southeast1.firebasedatabase.app")
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/shyden/shytalk/core/pip/PipHelper.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/pip/PipHelper.kt
@@ -32,7 +32,7 @@ object PipHelper {
         )
 
         return PictureInPictureParams.Builder()
-            .setAspectRatio(Rational(3, 4))
+            .setAspectRatio(Rational(1, 1))
             .setActions(listOf(leaveAction))
             .build()
     }

--- a/app/src/main/java/com/shyden/shytalk/core/room/ActiveRoomManager.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/room/ActiveRoomManager.kt
@@ -1,6 +1,7 @@
 package com.shyden.shytalk.core.room
 
 import android.content.Context
+import android.util.Log
 import com.shyden.shytalk.core.model.ChatRoom
 import com.shyden.shytalk.core.model.Message
 import com.shyden.shytalk.core.model.RoomRole
@@ -9,6 +10,7 @@ import com.shyden.shytalk.core.model.SeatState
 import com.shyden.shytalk.core.util.Constants
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.data.remote.AgoraVoiceService
+import com.shyden.shytalk.data.remote.PresenceService
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.MessageRepository
 import com.shyden.shytalk.data.repository.RoomRepository
@@ -36,6 +38,7 @@ class ActiveRoomManager @Inject constructor(
     private val userRepository: UserRepository,
     private val seatRequestRepository: SeatRequestRepository,
     val agoraVoiceService: AgoraVoiceService,
+    private val presenceService: PresenceService,
     @param:ApplicationContext private val context: Context
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -62,6 +65,7 @@ class ActiveRoomManager @Inject constructor(
     private var messageObserverJob: Job? = null
     private var ownerAwayCountdownJob: Job? = null
     private var connectionMonitorJob: Job? = null
+    private var presenceMonitorJob: Job? = null
     private var isSeated = false
 
     var currentUserName: String = ""
@@ -78,6 +82,8 @@ class ActiveRoomManager @Inject constructor(
         _activeRoomId.value = roomId
         _roomClosed.value = false
         RoomService.start(context, roomId)
+        startConnectionMonitor()
+        startPresenceMonitor()
     }
 
     /** Called by RoomViewModel on each room update. Keeps notification current. */
@@ -121,6 +127,8 @@ class ActiveRoomManager @Inject constructor(
         val roomId = _activeRoomId.value ?: return
         val room = _activeRoom.value ?: return
         val userId = currentUserId
+
+        presenceService.removePresence()
 
         // Vacate seats
         room.seats.forEach { (index, seat) ->
@@ -167,6 +175,7 @@ class ActiveRoomManager @Inject constructor(
         messageObserverJob?.cancel()
         ownerAwayCountdownJob?.cancel()
         connectionMonitorJob?.cancel()
+        presenceMonitorJob?.cancel()
         isSeated = false
         _activeRoomId.value = null
         _activeRoom.value = null
@@ -209,15 +218,14 @@ class ActiveRoomManager @Inject constructor(
                         return@collect
                     }
 
-                    // Agora join/leave based on seat status
+                    // Switch Agora role based on seat status
                     val currentlySeated = room.seats.values.any {
                         it.userId == userId && it.state == SeatState.OCCUPIED
                     }
                     if (currentlySeated && !isSeated) {
-                        val uid = userId.hashCode() and 0x7FFFFFFF
-                        agoraVoiceService.joinChannel(room.agoraChannelName, uid)
+                        agoraVoiceService.setRole(true)
                     } else if (!currentlySeated && isSeated) {
-                        agoraVoiceService.leaveChannel()
+                        agoraVoiceService.setRole(false)
                     }
                     isSeated = currentlySeated
 
@@ -246,29 +254,77 @@ class ActiveRoomManager @Inject constructor(
         connectionMonitorJob?.cancel()
         connectionMonitorJob = scope.launch {
             var graceJob: Job? = null
+            var wasEverConnected = false
+
             agoraVoiceService.connectionState.collect { state ->
                 val room = _activeRoom.value ?: return@collect
-                if (room.ownerId != currentUserId) return@collect
+                val userId = currentUserId
+
+                // Only monitor when user is seated (has an Agora connection)
+                val currentlySeated = room.seats.values.any {
+                    it.userId == userId && it.state == SeatState.OCCUPIED
+                }
+                if (!currentlySeated) {
+                    graceJob?.cancel()
+                    wasEverConnected = false
+                    return@collect
+                }
 
                 when (state) {
+                    AgoraVoiceService.ConnectionState.CONNECTED -> {
+                        wasEverConnected = true
+                        graceJob?.cancel()
+                    }
                     AgoraVoiceService.ConnectionState.DISCONNECTED -> {
+                        if (!wasEverConnected) return@collect
+
                         graceJob?.cancel()
                         graceJob = scope.launch {
                             delay(Constants.AGORA_DISCONNECT_GRACE_PERIOD_MS)
-                            // Still disconnected after grace period — set owner away
                             if (_activeRoomId.value != null) {
                                 leaveRoom()
                             }
                         }
                     }
-                    AgoraVoiceService.ConnectionState.CONNECTED -> {
-                        graceJob?.cancel()
-                    }
                     AgoraVoiceService.ConnectionState.RECONNECTING -> {
-                        // Wait — don't act yet
+                        // Wait — Agora is trying to reconnect
                     }
                 }
             }
+        }
+    }
+
+    private fun startPresenceMonitor() {
+        val roomId = _activeRoomId.value ?: return
+        presenceMonitorJob?.cancel()
+        presenceMonitorJob = scope.launch {
+            val graceTimers = mutableMapOf<String, Job>()
+
+            presenceService.observeRoomPresence(roomId)
+                .catch { e -> Log.w("ActiveRoomManager", "Presence monitor error", e) }
+                .collect { presentUserIds ->
+                    val room = _activeRoom.value ?: return@collect
+                    val participantIds = room.participantIds.toSet()
+
+                    // Users in room but not present in RTDB
+                    val absentUsers = participantIds - presentUserIds - currentUserId
+
+                    // Cancel timers for users who reappeared
+                    val reappeared = graceTimers.keys - absentUsers
+                    for (userId in reappeared) {
+                        graceTimers.remove(userId)?.cancel()
+                    }
+
+                    // Start grace timers for newly absent users
+                    for (userId in absentUsers) {
+                        if (userId in graceTimers) continue
+                        graceTimers[userId] = scope.launch {
+                            delay(Constants.PRESENCE_TIMEOUT_MS)
+                            roomRepository.removeDisconnectedUser(roomId, userId)
+                            graceTimers.remove(userId)
+                        }
+                    }
+                }
         }
     }
 

--- a/app/src/main/java/com/shyden/shytalk/core/room/RoomService.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/room/RoomService.kt
@@ -16,8 +16,11 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -104,6 +107,17 @@ class RoomService : Service() {
             .setOngoing(true)
             .setSilent(true)
             .build()
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        // Process is being killed — use runBlocking to ensure Firestore cleanup completes
+        runBlocking {
+            withContext(NonCancellable) {
+                activeRoomManager.leaveRoom()
+            }
+        }
+        stopSelf()
     }
 
     override fun onBind(intent: Intent?): IBinder? = null

--- a/app/src/main/java/com/shyden/shytalk/core/util/Constants.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/util/Constants.kt
@@ -5,6 +5,7 @@ object Constants {
     const val OWNER_LEAVE_TIMEOUT_MS = 300_000L // 5 minutes
     const val OWNER_SEAT_INDEX = 0
     const val AGORA_DISCONNECT_GRACE_PERIOD_MS = 30_000L // 30 seconds
+    const val PRESENCE_TIMEOUT_MS = 30_000L // 30 seconds
     const val ROOM_NOTIFICATION_ID = 1001
     const val ROOM_NOTIFICATION_CHANNEL_ID = "room_service_channel"
 }

--- a/app/src/main/java/com/shyden/shytalk/data/remote/AgoraVoiceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/AgoraVoiceService.kt
@@ -7,7 +7,6 @@ import io.agora.rtc2.ChannelMediaOptions
 import io.agora.rtc2.Constants
 import io.agora.rtc2.IRtcEngineEventHandler
 import io.agora.rtc2.RtcEngine
-import io.agora.rtc2.RtcEngineConfig
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -35,6 +34,8 @@ class AgoraVoiceService @Inject constructor(
 
     private var rtcEngine: RtcEngine? = null
     private var currentChannelName: String? = null
+    private var localUid: Int = 0
+    private var isLocalMuted = false
 
     private val _speakingUsers = MutableStateFlow<Set<Int>>(emptySet())
     val speakingUsers: StateFlow<Set<Int>> = _speakingUsers.asStateFlow()
@@ -44,6 +45,11 @@ class AgoraVoiceService @Inject constructor(
 
     private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
     val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    fun clearError() { _error.value = null }
 
     private val rtcEventHandler = object : IRtcEngineEventHandler() {
         override fun onJoinChannelSuccess(channel: String?, uid: Int, elapsed: Int) {
@@ -61,6 +67,7 @@ class AgoraVoiceService @Inject constructor(
 
         override fun onError(err: Int) {
             Log.e(TAG, "Agora onError code=$err")
+            _error.value = "Voice error (code $err)"
         }
 
         override fun onConnectionStateChanged(state: Int, reason: Int) {
@@ -78,7 +85,8 @@ class AgoraVoiceService @Inject constructor(
         ) {
             val speaking = speakers
                 ?.filter { it.volume > 50 }
-                ?.map { it.uid }
+                ?.filter { !(it.uid == 0 && isLocalMuted) }
+                ?.map { if (it.uid == 0) localUid else it.uid }
                 ?.toSet() ?: emptySet()
             if (speaking != _speakingUsers.value) {
                 _speakingUsers.value = speaking
@@ -103,12 +111,12 @@ class AgoraVoiceService @Inject constructor(
         if (rtcEngine != null) return
 
         try {
-            val config = RtcEngineConfig().apply {
-                mContext = context
-                mAppId = AGORA_APP_ID
-                mEventHandler = rtcEventHandler
+            rtcEngine = RtcEngine.create(context, AGORA_APP_ID, rtcEventHandler)
+            if (rtcEngine == null) {
+                Log.e(TAG, "RtcEngine.create() returned null — check Agora App ID and SDK setup")
+                _error.value = "Voice engine returned null — check Agora App ID"
+                return
             }
-            rtcEngine = RtcEngine.create(config)
             Log.d(TAG, "RtcEngine created successfully")
             rtcEngine?.apply {
                 setChannelProfile(Constants.CHANNEL_PROFILE_LIVE_BROADCASTING)
@@ -121,11 +129,12 @@ class AgoraVoiceService @Inject constructor(
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize RtcEngine", e)
+            _error.value = "Voice engine init failed: ${e.message}"
             rtcEngine = null
         }
     }
 
-    suspend fun joinChannel(channelName: String, uid: Int) {
+    suspend fun joinChannel(channelName: String, uid: Int, asBroadcaster: Boolean = false) {
         // Already in this channel — no-op
         if (_isJoined.value && currentChannelName == channelName) {
             Log.d(TAG, "Already joined channel=$channelName, skipping rejoin")
@@ -135,6 +144,7 @@ class AgoraVoiceService @Inject constructor(
         initialize()
         val engine = rtcEngine ?: run {
             Log.e(TAG, "RtcEngine is null, cannot join channel")
+            _error.value = "Voice engine failed to initialize"
             return
         }
 
@@ -144,47 +154,78 @@ class AgoraVoiceService @Inject constructor(
             engine.leaveChannel()
         }
 
-        // Enable audio right before joining — this is when RECORD_AUDIO permission is guaranteed
-        engine.enableAudio()
+        // Only enable audio capture when joining as broadcaster (requires RECORD_AUDIO permission)
+        if (asBroadcaster) {
+            engine.enableAudio()
+        }
 
         val token: String? = try {
             tokenService.fetchToken(channelName, uid)
         } catch (e: Exception) {
             Log.w(TAG, "Token fetch failed, joining without token (App Certificate must be disabled in Agora Console)", e)
+            _error.value = "Token fetch failed — check Cloud Function deployment"
             null  // null = no token mode; empty string may cause auth errors
         }
 
         val options = ChannelMediaOptions().apply {
-            clientRoleType = Constants.CLIENT_ROLE_BROADCASTER
+            clientRoleType = if (asBroadcaster) Constants.CLIENT_ROLE_BROADCASTER else Constants.CLIENT_ROLE_AUDIENCE
             channelProfile = Constants.CHANNEL_PROFILE_LIVE_BROADCASTING
             autoSubscribeAudio = true
-            publishMicrophoneTrack = true
+            publishMicrophoneTrack = asBroadcaster
             autoSubscribeVideo = false
         }
 
-        Log.d(TAG, "Joining channel=$channelName uid=$uid hasToken=${token != null}")
+        Log.d(TAG, "Joining channel=$channelName uid=$uid asBroadcaster=$asBroadcaster hasToken=${token != null}")
         val result = engine.joinChannel(token, channelName, uid, options)
         if (result != 0) {
             Log.e(TAG, "joinChannel failed with error code $result")
+            _error.value = "Voice join failed (code $result)"
         } else {
             currentChannelName = channelName
+            localUid = uid
             Log.d(TAG, "joinChannel call succeeded (waiting for onJoinChannelSuccess callback)")
-            // Force speakerphone on and unmute mic after join
+            if (asBroadcaster) {
+                engine.setEnableSpeakerphone(true)
+                engine.muteLocalAudioStream(false)
+                engine.adjustRecordingSignalVolume(400)
+                Log.d(TAG, "Audio configured: speakerphone=on, mic=unmuted, recordingVolume=400")
+            }
+        }
+    }
+
+    fun setRole(broadcaster: Boolean) {
+        val engine = rtcEngine ?: return
+        Log.d(TAG, "setRole broadcaster=$broadcaster")
+        if (broadcaster) {
+            engine.enableAudio()
+            engine.setClientRole(Constants.CLIENT_ROLE_BROADCASTER)
+            engine.updateChannelMediaOptions(ChannelMediaOptions().apply {
+                publishMicrophoneTrack = true
+            })
             engine.setEnableSpeakerphone(true)
             engine.muteLocalAudioStream(false)
             engine.adjustRecordingSignalVolume(400)
-            Log.d(TAG, "Audio configured: speakerphone=on, mic=unmuted, recordingVolume=400")
+            isLocalMuted = false
+        } else {
+            engine.setClientRole(Constants.CLIENT_ROLE_AUDIENCE)
+            engine.updateChannelMediaOptions(ChannelMediaOptions().apply {
+                publishMicrophoneTrack = false
+            })
+            isLocalMuted = false
         }
     }
 
     fun leaveChannel() {
         Log.d(TAG, "leaveChannel called, isJoined=${_isJoined.value}")
         currentChannelName = null
+        localUid = 0
+        isLocalMuted = false
         rtcEngine?.leaveChannel()
     }
 
     fun muteLocalAudio(mute: Boolean) {
         Log.d(TAG, "muteLocalAudio mute=$mute")
+        isLocalMuted = mute
         rtcEngine?.muteLocalAudioStream(mute)
     }
 
@@ -195,5 +236,6 @@ class AgoraVoiceService @Inject constructor(
         _isJoined.value = false
         _speakingUsers.value = emptySet()
         _connectionState.value = ConnectionState.DISCONNECTED
+        isLocalMuted = false
     }
 }

--- a/app/src/main/java/com/shyden/shytalk/data/remote/PresenceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/PresenceService.kt
@@ -1,8 +1,14 @@
 package com.shyden.shytalk.data.remote
 
 import android.util.Log
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ServerValue
+import com.google.firebase.database.ValueEventListener
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -43,5 +49,21 @@ class PresenceService @Inject constructor(
 
         currentRoomId = null
         currentUserId = null
+    }
+
+    fun observeRoomPresence(roomId: String): Flow<Set<String>> = callbackFlow {
+        val ref = database.getReference("presence/$roomId")
+        val listener = object : ValueEventListener {
+            override fun onDataChange(snapshot: DataSnapshot) {
+                val presentUserIds = snapshot.children.mapNotNull { it.key }.toSet()
+                trySend(presentUserIds)
+            }
+
+            override fun onCancelled(error: DatabaseError) {
+                close(error.toException())
+            }
+        }
+        ref.addValueEventListener(listener)
+        awaitClose { ref.removeEventListener(listener) }
     }
 }

--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepository.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepository.kt
@@ -31,4 +31,5 @@ interface RoomRepository {
     suspend fun recordFirstJoinTimestamp(roomId: String, userId: String): Resource<Unit>
     suspend fun leaveAllRooms(userId: String, exceptRoomId: String? = null): Resource<Unit>
     suspend fun closeAllRoomsByOwner(ownerId: String): Resource<Unit>
+    suspend fun removeDisconnectedUser(roomId: String, userId: String): Resource<Unit>
 }

--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
@@ -379,6 +379,44 @@ class RoomRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun removeDisconnectedUser(roomId: String, userId: String): Resource<Unit> {
+        return try {
+            val docRef = roomsCollection.document(roomId)
+            firestore.runTransaction { transaction ->
+                val snapshot = transaction.get(docRef)
+                val room = snapshot.data?.let { ChatRoom.fromMap(it, snapshot.id) }
+                    ?: throw Exception("Room not found")
+
+                if (userId !in room.participantIds) return@runTransaction
+
+                val updates = mutableMapOf<String, Any>()
+
+                // Clear seats occupied by this user
+                for ((idx, seat) in room.seats) {
+                    if (seat.userId == userId && seat.state == SeatState.OCCUPIED) {
+                        updates["seats.$idx"] = Seat().toMap()
+                    }
+                }
+
+                if (room.ownerId == userId) {
+                    // Owner disconnected: set OWNER_AWAY
+                    updates["state"] = RoomState.OWNER_AWAY.name
+                    updates["ownerLeftAt"] = Timestamp.now()
+                } else {
+                    // Non-owner: remove from participants
+                    updates["participantIds"] = FieldValue.arrayRemove(userId)
+                }
+
+                if (updates.isNotEmpty()) {
+                    transaction.update(docRef, updates)
+                }
+            }.await()
+            Resource.Success(Unit)
+        } catch (e: Exception) {
+            Resource.Error(e.message ?: "Failed to remove disconnected user", e)
+        }
+    }
+
     override suspend fun closeRoom(roomId: String): Resource<Unit> {
         return try {
             val emptySeats = (0 until Constants.MAX_SEATS).associate { i ->

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -206,6 +206,18 @@ class RoomViewModel @Inject constructor(
             _uiState.value = _uiState.value.copy(
                 room = room, currentRole = role, isLoading = false, hasJoined = true
             )
+            // Track seat state so handleNormalUpdate detects transitions correctly
+            isSeated = room.seats.values.any {
+                it.userId == userId && it.state == SeatState.OCCUPIED
+            }
+            // Rejoin voice if not already connected (ViewModel recreated)
+            if (room.agoraChannelName.isNotEmpty()) {
+                val asBroadcaster = isSeated && _uiState.value.hasAudioPermission
+                viewModelScope.launch {
+                    val uid = userId.hashCode() and 0x7FFFFFFF
+                    agoraVoiceService.joinChannel(room.agoraChannelName, uid, asBroadcaster = asBroadcaster)
+                }
+            }
             activeRoomManager.updateTrackedRoom(room)
             loadSeatUsers(room)
             loadParticipantUsers(room)
@@ -248,11 +260,11 @@ class RoomViewModel @Inject constructor(
         if (currentlySeated && !isSeated) {
             Log.d(TAG, "User became seated, hasAudioPermission=${_uiState.value.hasAudioPermission}")
             if (_uiState.value.hasAudioPermission) {
-                joinVoiceChannel(room.agoraChannelName)
+                agoraVoiceService.setRole(true)
             }
         } else if (!currentlySeated && isSeated) {
-            Log.d(TAG, "User left seat, leaving voice channel")
-            agoraVoiceService.leaveChannel()
+            Log.d(TAG, "User left seat, switching to audience")
+            agoraVoiceService.setRole(false)
         }
         isSeated = currentlySeated
 
@@ -392,6 +404,14 @@ class RoomViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(isVoiceJoined = joined)
             }
         }
+        viewModelScope.launch {
+            agoraVoiceService.error.collect { errorMsg ->
+                if (errorMsg != null) {
+                    _uiState.value = _uiState.value.copy(error = errorMsg)
+                    agoraVoiceService.clearError()
+                }
+            }
+        }
     }
 
     private fun joinRoom() {
@@ -427,6 +447,18 @@ class RoomViewModel @Inject constructor(
             // Start foreground service via ActiveRoomManager
             activeRoomManager.trackRoom(roomId)
 
+            // Join voice channel — as broadcaster if already seated with permission, otherwise audience
+            val channel = room?.agoraChannelName
+            if (!channel.isNullOrEmpty()) {
+                val uid = userId.hashCode() and 0x7FFFFFFF
+                val alreadySeated = room.seats.values.any {
+                    it.userId == userId && it.state == SeatState.OCCUPIED
+                }
+                val asBroadcaster = alreadySeated && _uiState.value.hasAudioPermission
+                if (alreadySeated) isSeated = true
+                agoraVoiceService.joinChannel(channel, uid, asBroadcaster = asBroadcaster)
+            }
+
             if (userName.isNotEmpty()) {
                 messageRepository.sendJoinMessage(
                     roomId,
@@ -438,11 +470,11 @@ class RoomViewModel @Inject constructor(
         }
     }
 
-    private fun joinVoiceChannel(channelName: String) {
+    private fun joinVoiceChannelAsAudience(channelName: String) {
         viewModelScope.launch {
             val uid = _uiState.value.currentUserId.hashCode() and 0x7FFFFFFF
-            Log.d(TAG, "joinVoiceChannel channel=$channelName uid=$uid")
-            agoraVoiceService.joinChannel(channelName, uid)
+            Log.d(TAG, "joinVoiceChannelAsAudience channel=$channelName uid=$uid")
+            agoraVoiceService.joinChannel(channelName, uid, asBroadcaster = false)
         }
     }
 
@@ -901,8 +933,7 @@ class RoomViewModel @Inject constructor(
         Log.d(TAG, "onAudioPermissionResult granted=$granted isSeated=$isSeated")
         _uiState.value = _uiState.value.copy(hasAudioPermission = granted)
         if (granted && isSeated) {
-            val channelName = _uiState.value.room?.agoraChannelName ?: return
-            joinVoiceChannel(channelName)
+            agoraVoiceService.setRole(true)
         }
     }
 

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,6 +1,9 @@
-v0.15 - Crop Toolbar Fix & Tests
+v0.16 - Voice Chat & Presence Fixes
 
-- Fixed crop photo toolbar hidden behind the status bar
-- Status bar now matches toolbar color for seamless look
-- Added 6 CropContract unit tests (211 total)
-- Performance and refactoring improvements from v0.14
+- All users can now hear speakers without sitting on a seat
+- Speaking animation visible for all users, not just yourself
+- Speaking indicator hidden when muted
+- Fixed voice engine crash on Android 16 (OnePlus 15)
+- Ghost users auto-removed via realtime presence monitoring
+- Fixed room owner voice not working after joining
+- 327 unit tests (up from 211)

--- a/app/src/test/java/com/shyden/shytalk/core/room/ActiveRoomManagerTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/room/ActiveRoomManagerTest.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import com.google.firebase.auth.FirebaseUser
 import com.shyden.shytalk.core.model.ChatRoom
 import com.shyden.shytalk.core.model.RoomRole
+import com.shyden.shytalk.core.model.RoomState
 import com.shyden.shytalk.core.model.SeatState
 import com.shyden.shytalk.core.util.Constants
 import com.shyden.shytalk.data.remote.AgoraVoiceService
+import com.shyden.shytalk.data.remote.PresenceService
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.MessageRepository
 import com.shyden.shytalk.data.repository.RoomRepository
@@ -17,8 +19,10 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -42,10 +46,13 @@ class ActiveRoomManagerTest {
     private lateinit var userRepository: UserRepository
     private lateinit var seatRequestRepository: SeatRequestRepository
     private lateinit var agoraVoiceService: AgoraVoiceService
+    private lateinit var presenceService: PresenceService
     private lateinit var context: Context
     private lateinit var manager: ActiveRoomManager
 
     private val currentUserId = "user-1"
+    private val connectionStateFlow = MutableStateFlow(AgoraVoiceService.ConnectionState.DISCONNECTED)
+    private val presenceFlow = MutableStateFlow<Set<String>>(emptySet())
 
     @Before
     fun setup() {
@@ -57,7 +64,11 @@ class ActiveRoomManagerTest {
         userRepository = mockk(relaxed = true)
         seatRequestRepository = mockk(relaxed = true)
         agoraVoiceService = mockk(relaxed = true)
+        presenceService = mockk(relaxed = true)
         context = mockk(relaxed = true)
+
+        every { agoraVoiceService.connectionState } returns connectionStateFlow
+        every { presenceService.observeRoomPresence(any()) } returns presenceFlow
 
         val firebaseUser = mockk<FirebaseUser>()
         every { firebaseUser.uid } returns currentUserId
@@ -70,6 +81,7 @@ class ActiveRoomManagerTest {
             userRepository = userRepository,
             seatRequestRepository = seatRequestRepository,
             agoraVoiceService = agoraVoiceService,
+            presenceService = presenceService,
             context = context
         )
     }
@@ -230,7 +242,8 @@ class ActiveRoomManagerTest {
         every { authRepository.currentUser?.uid } returns "host-1"
         val hostManager = ActiveRoomManager(
             roomRepository, messageRepository, authRepository,
-            userRepository, seatRequestRepository, agoraVoiceService, context
+            userRepository, seatRequestRepository, agoraVoiceService,
+            presenceService, context
         )
         hostManager.trackRoom("room-1")
         val hostRoom = TestData.createTestRoom(
@@ -511,5 +524,272 @@ class ActiveRoomManagerTest {
         manager.moveSeat(2, 3)
 
         coVerify(exactly = 0) { roomRepository.moveSeat(any(), any(), any(), any()) }
+    }
+
+    // --- leaveRoom ---
+
+    @Test
+    fun `leaveRoom - removes presence`() = runTest {
+        manager.trackRoom("room-1")
+        val seats = TestData.createSeatsWithOwner("other-owner").toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = currentUserId)
+        val room = TestData.createTestRoom(
+            ownerId = "other-owner",
+            participantIds = listOf("other-owner", currentUserId),
+            seats = seats
+        )
+        manager.updateTrackedRoom(room)
+
+        manager.leaveRoom()
+
+        coVerify { presenceService.removePresence() }
+    }
+
+    @Test
+    fun `leaveRoom - vacates seats and leaves agora`() = runTest {
+        manager.trackRoom("room-1")
+        val seats = TestData.createSeatsWithOwner("other-owner").toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = currentUserId)
+        val room = TestData.createTestRoom(
+            ownerId = "other-owner",
+            participantIds = listOf("other-owner", currentUserId),
+            seats = seats
+        )
+        manager.updateTrackedRoom(room)
+
+        manager.leaveRoom()
+
+        coVerify { roomRepository.leaveSeat("room-1", 3) }
+        coVerify { agoraVoiceService.leaveChannel() }
+        coVerify { roomRepository.leaveRoom("room-1", currentUserId) }
+    }
+
+    @Test
+    fun `leaveRoom - owner sets owner away`() = runTest {
+        manager.trackRoom("room-1")
+        val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = listOf(currentUserId),
+            seats = seats
+        )
+        manager.updateTrackedRoom(room)
+
+        manager.leaveRoom()
+
+        coVerify { roomRepository.leaveSeat("room-1", 0) }
+        coVerify { roomRepository.setOwnerAway("room-1") }
+    }
+
+    @Test
+    fun `leaveRoom - clears active state`() = runTest {
+        manager.trackRoom("room-1")
+        val room = TestData.createTestRoom(
+            ownerId = "other-owner",
+            participantIds = listOf("other-owner", currentUserId)
+        )
+        manager.updateTrackedRoom(room)
+
+        manager.leaveRoom()
+
+        assertNull(manager.activeRoomId.value)
+        assertNull(manager.activeRoom.value)
+        assertFalse(manager.isInAnyRoom())
+    }
+
+    @Test
+    fun `leaveRoom - no-op when not in room`() = runTest {
+        // No trackRoom called
+        manager.leaveRoom()
+
+        coVerify(exactly = 0) { presenceService.removePresence() }
+        coVerify(exactly = 0) { agoraVoiceService.leaveChannel() }
+    }
+
+    // --- trackRoom starts connection monitor ---
+
+    @Test
+    fun `trackRoom - starts connection monitor without crashing`() {
+        // This verifies trackRoom calls startConnectionMonitor without errors
+        // The connectionState starts as DISCONNECTED but wasEverConnected=false
+        // so no grace period should trigger
+        manager.trackRoom("room-1")
+
+        assertTrue(manager.isInRoom("room-1"))
+    }
+
+    // --- presence monitor ---
+
+    @Test
+    fun `presence monitor - removes disconnected non-owner after timeout`() = runTest {
+        manager.trackRoom("room-1")
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = listOf(currentUserId, "user-2")
+        )
+        manager.updateTrackedRoom(room)
+
+        // user-2 is absent from presence
+        presenceFlow.value = setOf(currentUserId)
+
+        // Advance past the timeout
+        testScheduler.advanceTimeBy(Constants.PRESENCE_TIMEOUT_MS + 100)
+
+        coVerify { roomRepository.removeDisconnectedUser("room-1", "user-2") }
+    }
+
+    @Test
+    fun `presence monitor - does not remove user who reappears before timeout`() = runTest {
+        manager.trackRoom("room-1")
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = listOf(currentUserId, "user-2")
+        )
+        manager.updateTrackedRoom(room)
+
+        // user-2 disappears
+        presenceFlow.value = setOf(currentUserId)
+
+        // Advance partway
+        testScheduler.advanceTimeBy(15_000)
+
+        // user-2 reappears
+        presenceFlow.value = setOf(currentUserId, "user-2")
+
+        // Advance past the original timeout
+        testScheduler.advanceTimeBy(20_000)
+
+        coVerify(exactly = 0) { roomRepository.removeDisconnectedUser(any(), any()) }
+    }
+
+    @Test
+    fun `presence monitor - does not remove self`() = runTest {
+        // Start with both users present so the initial flow value isn't empty
+        presenceFlow.value = setOf(currentUserId, "other-owner")
+
+        manager.trackRoom("room-1")
+        val room = TestData.createTestRoom(
+            ownerId = "other-owner",
+            participantIds = listOf("other-owner", currentUserId)
+        )
+        manager.updateTrackedRoom(room)
+
+        // Both disappear from presence
+        presenceFlow.value = setOf("nobody")
+
+        testScheduler.advanceTimeBy(Constants.PRESENCE_TIMEOUT_MS + 100)
+
+        // Should only try to remove other-owner, not self
+        coVerify(exactly = 0) { roomRepository.removeDisconnectedUser("room-1", currentUserId) }
+        coVerify { roomRepository.removeDisconnectedUser("room-1", "other-owner") }
+    }
+
+    @Test
+    fun `presence monitor - removes multiple absent users`() = runTest {
+        presenceFlow.value = setOf(currentUserId, "user-2", "user-3")
+
+        manager.trackRoom("room-1")
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = listOf(currentUserId, "user-2", "user-3")
+        )
+        manager.updateTrackedRoom(room)
+
+        // Both user-2 and user-3 disappear
+        presenceFlow.value = setOf(currentUserId)
+
+        testScheduler.advanceTimeBy(Constants.PRESENCE_TIMEOUT_MS + 100)
+
+        coVerify { roomRepository.removeDisconnectedUser("room-1", "user-2") }
+        coVerify { roomRepository.removeDisconnectedUser("room-1", "user-3") }
+    }
+
+    @Test
+    fun `presence monitor - no-op when all participants present`() = runTest {
+        presenceFlow.value = setOf(currentUserId, "user-2")
+
+        manager.trackRoom("room-1")
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = listOf(currentUserId, "user-2")
+        )
+        manager.updateTrackedRoom(room)
+
+        // Everyone stays present
+        presenceFlow.value = setOf(currentUserId, "user-2", "extra-user")
+
+        testScheduler.advanceTimeBy(Constants.PRESENCE_TIMEOUT_MS + 100)
+
+        coVerify(exactly = 0) { roomRepository.removeDisconnectedUser(any(), any()) }
+    }
+
+    // --- closeRoom ---
+
+    @Test
+    fun `closeRoom - leaves agora and closes`() = runTest {
+        manager.trackRoom("room-1")
+        val room = TestData.createTestRoom(ownerId = currentUserId)
+        manager.updateTrackedRoom(room)
+
+        manager.closeRoom()
+
+        verify { agoraVoiceService.leaveChannel() }
+        coVerify { roomRepository.closeRoom("room-1") }
+        coVerify { messageRepository.sendSystemMessage("room-1", any()) }
+        // cleanup() resets roomClosed and activeRoomId
+        assertNull(manager.activeRoomId.value)
+    }
+
+    @Test
+    fun `closeRoom - no-op when not in room`() = runTest {
+        manager.closeRoom()
+
+        coVerify(exactly = 0) { roomRepository.closeRoom(any()) }
+    }
+
+    // --- ownerReturn ---
+
+    @Test
+    fun `ownerReturn - only works for owner`() = runTest {
+        manager.trackRoom("room-1")
+        val room = TestData.createTestRoom(ownerId = "other-owner")
+        manager.updateTrackedRoom(room)
+
+        manager.ownerReturn()
+
+        coVerify(exactly = 0) { roomRepository.setOwnerReturned(any(), any()) }
+    }
+
+    @Test
+    fun `ownerReturn - owner can return`() = runTest {
+        manager.trackRoom("room-1")
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            state = RoomState.OWNER_AWAY
+        )
+        manager.updateTrackedRoom(room)
+
+        manager.ownerReturn()
+
+        coVerify { roomRepository.setOwnerReturned("room-1", currentUserId) }
+    }
+
+    // --- ensureSingleRoom ---
+
+    @Test
+    fun `ensureSingleRoom - closes owned rooms`() = runTest {
+        coEvery { roomRepository.findActiveRoomByOwner(currentUserId) } returns "old-room"
+
+        manager.ensureSingleRoom()
+
+        coVerify { roomRepository.closeRoom("old-room") }
+    }
+
+    // --- clearError ---
+
+    @Test
+    fun `clearError clears error state`() {
+        manager.clearError()
+        assertNull(manager.error.value)
     }
 }

--- a/app/src/test/java/com/shyden/shytalk/data/remote/PresenceServiceTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/remote/PresenceServiceTest.kt
@@ -1,0 +1,145 @@
+package com.shyden.shytalk.data.remote
+
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.database.ValueEventListener
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PresenceServiceTest {
+
+    private lateinit var database: FirebaseDatabase
+    private lateinit var presenceService: PresenceService
+    private lateinit var rootRef: DatabaseReference
+
+    @Before
+    fun setup() {
+        database = mockk(relaxed = true)
+        rootRef = mockk(relaxed = true)
+        every { database.getReference(any<String>()) } returns rootRef
+        presenceService = PresenceService(database)
+    }
+
+    @Test
+    fun `setPresence writes to correct path`() {
+        presenceService.setPresence("room-1", "user-1")
+
+        verify { database.getReference("presence/room-1/user-1") }
+        verify { rootRef.setValue(any()) }
+        verify { rootRef.onDisconnect() }
+    }
+
+    @Test
+    fun `removePresence clears reference and cancels onDisconnect`() {
+        presenceService.setPresence("room-1", "user-1")
+        presenceService.removePresence()
+
+        verify { rootRef.removeValue() }
+    }
+
+    @Test
+    fun `removePresence is no-op when not in room`() {
+        // No setPresence called
+        presenceService.removePresence()
+
+        verify(exactly = 0) { rootRef.removeValue() }
+    }
+
+    @Test
+    fun `setPresence cleans up previous room when switching`() {
+        val ref1 = mockk<DatabaseReference>(relaxed = true)
+        val ref2 = mockk<DatabaseReference>(relaxed = true)
+
+        every { database.getReference("presence/room-1/user-1") } returns ref1
+        every { database.getReference("presence/room-2/user-1") } returns ref2
+
+        presenceService.setPresence("room-1", "user-1")
+        presenceService.setPresence("room-2", "user-1")
+
+        // First room should have been cleaned up
+        verify { ref1.removeValue() }
+        verify { ref2.setValue(any()) }
+    }
+
+    @Test
+    fun `observeRoomPresence emits present user IDs`() = runTest {
+        val listenerSlot = slot<ValueEventListener>()
+        val presenceRef = mockk<DatabaseReference>(relaxed = true)
+        every { database.getReference("presence/room-1") } returns presenceRef
+        every { presenceRef.addValueEventListener(capture(listenerSlot)) } answers { listenerSlot.captured }
+
+        var emittedUsers: Set<String>? = null
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            presenceService.observeRoomPresence("room-1").first { users ->
+                emittedUsers = users
+                true
+            }
+        }
+
+        // Simulate RTDB snapshot with 2 users
+        val child1 = mockk<DataSnapshot> { every { key } returns "user-1" }
+        val child2 = mockk<DataSnapshot> { every { key } returns "user-2" }
+        val snapshot = mockk<DataSnapshot> {
+            every { children } returns listOf(child1, child2)
+        }
+
+        listenerSlot.captured.onDataChange(snapshot)
+
+        assertEquals(setOf("user-1", "user-2"), emittedUsers)
+        job.cancel()
+    }
+
+    @Test
+    fun `observeRoomPresence emits empty set when no users present`() = runTest {
+        val listenerSlot = slot<ValueEventListener>()
+        val presenceRef = mockk<DatabaseReference>(relaxed = true)
+        every { database.getReference("presence/room-1") } returns presenceRef
+        every { presenceRef.addValueEventListener(capture(listenerSlot)) } answers { listenerSlot.captured }
+
+        var emittedUsers: Set<String>? = null
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            presenceService.observeRoomPresence("room-1").first { users ->
+                emittedUsers = users
+                true
+            }
+        }
+
+        val snapshot = mockk<DataSnapshot> {
+            every { children } returns emptyList()
+        }
+
+        listenerSlot.captured.onDataChange(snapshot)
+
+        assertTrue(emittedUsers!!.isEmpty())
+        job.cancel()
+    }
+
+    @Test
+    fun `observeRoomPresence removes listener on cancel`() = runTest {
+        val listenerSlot = slot<ValueEventListener>()
+        val presenceRef = mockk<DatabaseReference>(relaxed = true)
+        every { database.getReference("presence/room-1") } returns presenceRef
+        every { presenceRef.addValueEventListener(capture(listenerSlot)) } answers { listenerSlot.captured }
+
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            presenceService.observeRoomPresence("room-1").collect { }
+        }
+
+        job.cancel()
+
+        verify { presenceRef.removeEventListener(listenerSlot.captured) }
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/data/repository/AuthRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/AuthRepositoryImplTest.kt
@@ -1,0 +1,110 @@
+package com.shyden.shytalk.data.repository
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.AuthCredential
+import com.google.firebase.auth.AuthResult
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GoogleAuthProvider
+import com.shyden.shytalk.core.util.Resource
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AuthRepositoryImplTest {
+
+    private lateinit var auth: FirebaseAuth
+    private lateinit var repo: AuthRepositoryImpl
+
+    @Before
+    fun setup() {
+        auth = mockk(relaxed = true)
+        repo = AuthRepositoryImpl(auth)
+        mockkStatic(GoogleAuthProvider::class)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(GoogleAuthProvider::class)
+    }
+
+    @Test
+    fun `currentUser returns auth currentUser`() {
+        val user = mockk<FirebaseUser>()
+        every { auth.currentUser } returns user
+        assertEquals(user, repo.currentUser)
+    }
+
+    @Test
+    fun `currentUser returns null when not signed in`() {
+        every { auth.currentUser } returns null
+        assertNull(repo.currentUser)
+    }
+
+    @Test
+    fun `isAuthenticated returns true when user exists`() {
+        every { auth.currentUser } returns mockk()
+        assertTrue(repo.isAuthenticated)
+    }
+
+    @Test
+    fun `isAuthenticated returns false when no user`() {
+        every { auth.currentUser } returns null
+        assertFalse(repo.isAuthenticated)
+    }
+
+    @Test
+    fun `signInWithGoogleIdToken returns Success on valid user`() = runTest {
+        val user = mockk<FirebaseUser>()
+        val authResult = mockk<AuthResult> { every { this@mockk.user } returns user }
+        val credential = mockk<AuthCredential>()
+        every { GoogleAuthProvider.getCredential("token123", null) } returns credential
+        every { auth.signInWithCredential(credential) } returns Tasks.forResult(authResult)
+
+        val result = repo.signInWithGoogleIdToken("token123")
+
+        assertTrue(result is Resource.Success)
+        assertEquals(user, (result as Resource.Success).data)
+    }
+
+    @Test
+    fun `signInWithGoogleIdToken returns Error when user is null`() = runTest {
+        val authResult = mockk<AuthResult> { every { user } returns null }
+        val credential = mockk<AuthCredential>()
+        every { GoogleAuthProvider.getCredential("token123", null) } returns credential
+        every { auth.signInWithCredential(credential) } returns Tasks.forResult(authResult)
+
+        val result = repo.signInWithGoogleIdToken("token123")
+
+        assertTrue(result is Resource.Error)
+        assertEquals("Sign in failed: no user returned", (result as Resource.Error).message)
+    }
+
+    @Test
+    fun `signInWithGoogleIdToken returns Error on exception`() = runTest {
+        val credential = mockk<AuthCredential>()
+        every { GoogleAuthProvider.getCredential("token123", null) } returns credential
+        every { auth.signInWithCredential(credential) } returns Tasks.forException(RuntimeException("Network error"))
+
+        val result = repo.signInWithGoogleIdToken("token123")
+
+        assertTrue(result is Resource.Error)
+        assertTrue((result as Resource.Error).message.contains("Network error"))
+    }
+
+    @Test
+    fun `signOut calls auth signOut`() {
+        repo.signOut()
+        verify { auth.signOut() }
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/data/repository/DeviceRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/DeviceRepositoryImplTest.kt
@@ -1,0 +1,90 @@
+package com.shyden.shytalk.data.repository
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import com.shyden.shytalk.core.util.Resource
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class DeviceRepositoryImplTest {
+
+    private lateinit var firestore: FirebaseFirestore
+    private lateinit var collection: CollectionReference
+    private lateinit var docRef: DocumentReference
+    private lateinit var repo: DeviceRepositoryImpl
+
+    @Before
+    fun setup() {
+        firestore = mockk(relaxed = true)
+        collection = mockk(relaxed = true)
+        docRef = mockk(relaxed = true)
+        every { firestore.collection("deviceBindings") } returns collection
+        every { collection.document(any<String>()) } returns docRef
+        repo = DeviceRepositoryImpl(firestore)
+    }
+
+    @Test
+    fun `getDeviceBinding returns userId when document exists`() = runTest {
+        val snapshot = mockk<DocumentSnapshot> {
+            every { exists() } returns true
+            every { getString("userId") } returns "user-123"
+        }
+        every { docRef.get() } returns Tasks.forResult(snapshot)
+
+        val result = repo.getDeviceBinding("device-1")
+
+        assertTrue(result is Resource.Success)
+        assertEquals("user-123", (result as Resource.Success).data)
+    }
+
+    @Test
+    fun `getDeviceBinding returns null when document does not exist`() = runTest {
+        val snapshot = mockk<DocumentSnapshot> {
+            every { exists() } returns false
+        }
+        every { docRef.get() } returns Tasks.forResult(snapshot)
+
+        val result = repo.getDeviceBinding("device-1")
+
+        assertTrue(result is Resource.Success)
+        assertNull((result as Resource.Success).data)
+    }
+
+    @Test
+    fun `getDeviceBinding returns Error on exception`() = runTest {
+        every { docRef.get() } returns Tasks.forException(RuntimeException("Firestore error"))
+
+        val result = repo.getDeviceBinding("device-1")
+
+        assertTrue(result is Resource.Error)
+    }
+
+    @Test
+    fun `bindDevice returns Success`() = runTest {
+        every { docRef.set(any()) } returns Tasks.forResult(null)
+
+        val result = repo.bindDevice("device-1", "user-123")
+
+        assertTrue(result is Resource.Success)
+        verify { collection.document("device-1") }
+    }
+
+    @Test
+    fun `bindDevice returns Error on exception`() = runTest {
+        every { docRef.set(any()) } returns Tasks.forException(RuntimeException("Write failed"))
+
+        val result = repo.bindDevice("device-1", "user-123")
+
+        assertTrue(result is Resource.Error)
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/data/repository/MessageRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/MessageRepositoryImplTest.kt
@@ -1,0 +1,92 @@
+package com.shyden.shytalk.data.repository
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.FirebaseFirestore
+import com.shyden.shytalk.core.util.Resource
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class MessageRepositoryImplTest {
+
+    private lateinit var firestore: FirebaseFirestore
+    private lateinit var roomsCollection: CollectionReference
+    private lateinit var roomDoc: DocumentReference
+    private lateinit var messagesCollection: CollectionReference
+    private lateinit var messageDoc: DocumentReference
+    private lateinit var repo: MessageRepositoryImpl
+
+    @Before
+    fun setup() {
+        firestore = mockk(relaxed = true)
+        roomsCollection = mockk(relaxed = true)
+        roomDoc = mockk(relaxed = true)
+        messagesCollection = mockk(relaxed = true)
+        messageDoc = mockk(relaxed = true)
+
+        every { firestore.collection("rooms") } returns roomsCollection
+        every { roomsCollection.document(any<String>()) } returns roomDoc
+        every { roomDoc.collection("messages") } returns messagesCollection
+        every { messagesCollection.document(any<String>()) } returns messageDoc
+        every { messageDoc.set(any()) } returns Tasks.forResult(null)
+
+        repo = MessageRepositoryImpl(firestore)
+    }
+
+    @Test
+    fun `sendMessage returns Success and writes to correct path`() = runTest {
+        val result = repo.sendMessage("room-1", "user-1", "Alice", "Hello!")
+
+        assertTrue(result is Resource.Success)
+        verify { roomsCollection.document("room-1") }
+        verify { roomDoc.collection("messages") }
+        val mapSlot = slot<Map<String, Any?>>()
+        verify { messageDoc.set(capture(mapSlot)) }
+        val data = mapSlot.captured
+        assertTrue(data["senderId"] == "user-1")
+        assertTrue(data["senderName"] == "Alice")
+        assertTrue(data["text"] == "Hello!")
+        assertTrue(data["type"] == "TEXT")
+    }
+
+    @Test
+    fun `sendSystemMessage uses system sender`() = runTest {
+        val result = repo.sendSystemMessage("room-1", "Room closed")
+
+        assertTrue(result is Resource.Success)
+        val mapSlot = slot<Map<String, Any?>>()
+        verify { messageDoc.set(capture(mapSlot)) }
+        val data = mapSlot.captured
+        assertTrue(data["senderId"] == "system")
+        assertTrue(data["senderName"] == "System")
+        assertTrue(data["type"] == "SYSTEM")
+    }
+
+    @Test
+    fun `sendJoinMessage uses JOIN type`() = runTest {
+        val result = repo.sendJoinMessage("room-1", "user-2", "Bob", "Bob joined")
+
+        assertTrue(result is Resource.Success)
+        val mapSlot = slot<Map<String, Any?>>()
+        verify { messageDoc.set(capture(mapSlot)) }
+        val data = mapSlot.captured
+        assertTrue(data["senderId"] == "user-2")
+        assertTrue(data["type"] == "JOIN")
+    }
+
+    @Test
+    fun `sendMessage returns Error on exception`() = runTest {
+        every { messageDoc.set(any()) } returns Tasks.forException(RuntimeException("Write failed"))
+
+        val result = repo.sendMessage("room-1", "user-1", "Alice", "Hello!")
+
+        assertTrue(result is Resource.Error)
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
@@ -1,0 +1,318 @@
+package com.shyden.shytalk.data.repository
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.Transaction
+import com.shyden.shytalk.core.model.ChatRoom
+import com.shyden.shytalk.core.model.RoomState
+import com.shyden.shytalk.core.model.Seat
+import com.shyden.shytalk.core.model.SeatState
+import com.shyden.shytalk.core.util.Resource
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RoomRepositoryImplTest {
+
+    private lateinit var firestore: FirebaseFirestore
+    private lateinit var roomsCollection: CollectionReference
+    private lateinit var docRef: DocumentReference
+    private lateinit var repo: RoomRepositoryImpl
+
+    @Before
+    fun setup() {
+        firestore = mockk(relaxed = true)
+        roomsCollection = mockk(relaxed = true)
+        docRef = mockk(relaxed = true)
+        every { firestore.collection("rooms") } returns roomsCollection
+        every { roomsCollection.document(any<String>()) } returns docRef
+        repo = RoomRepositoryImpl(firestore)
+    }
+
+    // --- createRoom ---
+
+    @Test
+    fun `createRoom returns Success with roomId`() = runTest {
+        every { docRef.set(any()) } returns Tasks.forResult(null)
+
+        val result = repo.createRoom("My Room", "owner-1")
+
+        assertTrue(result is Resource.Success)
+        assertNotNull((result as Resource.Success).data)
+    }
+
+    @Test
+    fun `createRoom returns Error on exception`() = runTest {
+        every { docRef.set(any()) } returns Tasks.forException(RuntimeException("Firestore error"))
+
+        val result = repo.createRoom("My Room", "owner-1")
+
+        assertTrue(result is Resource.Error)
+    }
+
+    // --- joinRoom ---
+
+    @Test
+    fun `joinRoom returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.joinRoom("room-1", "user-1")
+
+        assertTrue(result is Resource.Success)
+    }
+
+    @Test
+    fun `joinRoom returns Error on exception`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forException(RuntimeException("Fail"))
+
+        val result = repo.joinRoom("room-1", "user-1")
+
+        assertTrue(result is Resource.Error)
+    }
+
+    // --- leaveRoom ---
+
+    @Test
+    fun `leaveRoom returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.leaveRoom("room-1", "user-1")
+
+        assertTrue(result is Resource.Success)
+    }
+
+    // --- leaveSeat ---
+
+    @Test
+    fun `leaveSeat returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.leaveSeat("room-1", 3)
+
+        assertTrue(result is Resource.Success)
+    }
+
+    // --- removeFromSeat delegates to leaveSeat ---
+
+    @Test
+    fun `removeFromSeat delegates to leaveSeat`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.removeFromSeat("room-1", 3)
+
+        assertTrue(result is Resource.Success)
+    }
+
+    // --- moveSeat ---
+
+    @Test
+    fun `moveSeat returns Success`() = runTest {
+        every { docRef.update(any<Map<String, Any?>>()) } returns Tasks.forResult(null)
+
+        val result = repo.moveSeat("room-1", 1, 3, "user-1")
+
+        assertTrue(result is Resource.Success)
+    }
+
+    // --- kickUser ---
+
+    @Test
+    fun `kickUser with seatIndex clears seat`() = runTest {
+        val mapSlot = slot<Map<String, Any>>()
+        every { docRef.update(capture(mapSlot)) } returns Tasks.forResult(null)
+
+        val result = repo.kickUser("room-1", "bad-user", 2)
+
+        assertTrue(result is Resource.Success)
+        assertTrue(mapSlot.captured.containsKey("seats.2"))
+    }
+
+    @Test
+    fun `kickUser without seatIndex does not clear seat`() = runTest {
+        val mapSlot = slot<Map<String, Any>>()
+        every { docRef.update(capture(mapSlot)) } returns Tasks.forResult(null)
+
+        val result = repo.kickUser("room-1", "bad-user", null)
+
+        assertTrue(result is Resource.Success)
+        assertTrue(mapSlot.captured.keys.none { it.startsWith("seats.") })
+    }
+
+    // --- toggleMute ---
+
+    @Test
+    fun `toggleMute returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.toggleMute("room-1", 2, true)
+
+        assertTrue(result is Resource.Success)
+        verify { docRef.update("seats.2.isMuted", true) }
+    }
+
+    // --- addHost / removeHost ---
+
+    @Test
+    fun `addHost returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.addHost("room-1", "user-1")
+
+        assertTrue(result is Resource.Success)
+    }
+
+    @Test
+    fun `removeHost returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.removeHost("room-1", "user-1")
+
+        assertTrue(result is Resource.Success)
+    }
+
+    // --- setRequireApproval ---
+
+    @Test
+    fun `setRequireApproval returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.setRequireApproval("room-1", true)
+
+        assertTrue(result is Resource.Success)
+        verify { docRef.update("requireApproval", true) }
+    }
+
+    // --- setOwnerAway ---
+
+    @Test
+    fun `setOwnerAway returns Success`() = runTest {
+        every { docRef.update(any<Map<String, Any?>>()) } returns Tasks.forResult(null)
+
+        val result = repo.setOwnerAway("room-1")
+
+        assertTrue(result is Resource.Success)
+    }
+
+    // --- setOwnerReturned ---
+
+    @Test
+    fun `setOwnerReturned returns Success`() = runTest {
+        every { docRef.update(any<Map<String, Any?>>()) } returns Tasks.forResult(null)
+
+        val result = repo.setOwnerReturned("room-1", "owner-1")
+
+        assertTrue(result is Resource.Success)
+    }
+
+    // --- sendInvite / cancelInvite ---
+
+    @Test
+    fun `sendInvite returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.sendInvite("room-1", "user-1", "owner-1")
+
+        assertTrue(result is Resource.Success)
+    }
+
+    @Test
+    fun `cancelInvite returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.cancelInvite("room-1", "user-1")
+
+        assertTrue(result is Resource.Success)
+    }
+
+    // --- findActiveRoomByOwner ---
+
+    @Test
+    fun `findActiveRoomByOwner returns roomId when found`() = runTest {
+        val query = mockk<Query>(relaxed = true)
+        val doc = mockk<DocumentSnapshot> { every { id } returns "room-42" }
+        val querySnapshot = mockk<QuerySnapshot> { every { documents } returns listOf(doc) }
+        every { roomsCollection.whereEqualTo("ownerId", "owner-1") } returns query
+        every { query.whereIn("state", any()) } returns query
+        every { query.get() } returns Tasks.forResult(querySnapshot)
+
+        val result = repo.findActiveRoomByOwner("owner-1")
+
+        assertEquals("room-42", result)
+    }
+
+    @Test
+    fun `findActiveRoomByOwner returns null when not found`() = runTest {
+        val query = mockk<Query>(relaxed = true)
+        val querySnapshot = mockk<QuerySnapshot> { every { documents } returns emptyList() }
+        every { roomsCollection.whereEqualTo("ownerId", "owner-1") } returns query
+        every { query.whereIn("state", any()) } returns query
+        every { query.get() } returns Tasks.forResult(querySnapshot)
+
+        val result = repo.findActiveRoomByOwner("owner-1")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `findActiveRoomByOwner returns null on exception`() = runTest {
+        val query = mockk<Query>(relaxed = true)
+        every { roomsCollection.whereEqualTo("ownerId", "owner-1") } returns query
+        every { query.whereIn("state", any()) } returns query
+        every { query.get() } returns Tasks.forException(RuntimeException("fail"))
+
+        val result = repo.findActiveRoomByOwner("owner-1")
+
+        assertNull(result)
+    }
+
+    // --- closeRoom ---
+
+    @Test
+    fun `closeRoom returns Success`() = runTest {
+        every { docRef.update(any<Map<String, Any?>>()) } returns Tasks.forResult(null)
+
+        val result = repo.closeRoom("room-1")
+
+        assertTrue(result is Resource.Success)
+    }
+
+    @Test
+    fun `closeRoom returns Error on exception`() = runTest {
+        every { docRef.update(any<Map<String, Any?>>()) } returns Tasks.forException(RuntimeException("fail"))
+
+        val result = repo.closeRoom("room-1")
+
+        assertTrue(result is Resource.Error)
+    }
+
+    // --- closeAllRoomsByOwner ---
+
+    @Test
+    fun `closeAllRoomsByOwner closes all matching rooms`() = runTest {
+        val query = mockk<Query>(relaxed = true)
+        val doc1 = mockk<DocumentSnapshot> { every { id } returns "room-1" }
+        val doc2 = mockk<DocumentSnapshot> { every { id } returns "room-2" }
+        val querySnapshot = mockk<QuerySnapshot> { every { documents } returns listOf(doc1, doc2) }
+        every { roomsCollection.whereEqualTo("ownerId", "owner-1") } returns query
+        every { query.whereIn("state", any()) } returns query
+        every { query.get() } returns Tasks.forResult(querySnapshot)
+        every { docRef.update(any<Map<String, Any?>>()) } returns Tasks.forResult(null)
+
+        val result = repo.closeAllRoomsByOwner("owner-1")
+
+        assertTrue(result is Resource.Success)
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/data/repository/SeatRequestRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/SeatRequestRepositoryImplTest.kt
@@ -1,0 +1,130 @@
+package com.shyden.shytalk.data.repository
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import com.shyden.shytalk.core.model.SeatRequestStatus
+import com.shyden.shytalk.core.util.Resource
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SeatRequestRepositoryImplTest {
+
+    private lateinit var firestore: FirebaseFirestore
+    private lateinit var roomsCollection: CollectionReference
+    private lateinit var roomDoc: DocumentReference
+    private lateinit var requestsCollection: CollectionReference
+    private lateinit var requestDoc: DocumentReference
+    private lateinit var repo: SeatRequestRepositoryImpl
+
+    @Before
+    fun setup() {
+        firestore = mockk(relaxed = true)
+        roomsCollection = mockk(relaxed = true)
+        roomDoc = mockk(relaxed = true)
+        requestsCollection = mockk(relaxed = true)
+        requestDoc = mockk(relaxed = true)
+
+        every { firestore.collection("rooms") } returns roomsCollection
+        every { roomsCollection.document(any<String>()) } returns roomDoc
+        every { roomDoc.collection("seatRequests") } returns requestsCollection
+        every { requestsCollection.document(any<String>()) } returns requestDoc
+
+        repo = SeatRequestRepositoryImpl(firestore)
+    }
+
+    @Test
+    fun `createRequest returns Success when no existing pending request`() = runTest {
+        val query = mockk<Query>(relaxed = true)
+        val querySnapshot = mockk<QuerySnapshot> { every { isEmpty } returns true }
+        every { requestsCollection.whereEqualTo("userId", "user-1") } returns query
+        every { query.whereEqualTo("status", SeatRequestStatus.PENDING.name) } returns query
+        every { query.get() } returns Tasks.forResult(querySnapshot)
+        every { requestDoc.set(any()) } returns Tasks.forResult(null)
+
+        val result = repo.createRequest("room-1", "user-1", "Alice", 2)
+
+        assertTrue(result is Resource.Success)
+    }
+
+    @Test
+    fun `createRequest is no-op when pending request already exists`() = runTest {
+        val query = mockk<Query>(relaxed = true)
+        val querySnapshot = mockk<QuerySnapshot> { every { isEmpty } returns false }
+        every { requestsCollection.whereEqualTo("userId", "user-1") } returns query
+        every { query.whereEqualTo("status", SeatRequestStatus.PENDING.name) } returns query
+        every { query.get() } returns Tasks.forResult(querySnapshot)
+
+        val result = repo.createRequest("room-1", "user-1", "Alice", 2)
+
+        assertTrue(result is Resource.Success)
+        // Should NOT have written a new document
+        verify(exactly = 0) { requestDoc.set(any()) }
+    }
+
+    @Test
+    fun `approveRequest updates status and returns request`() = runTest {
+        val mapSlot = slot<Map<String, Any?>>()
+        every { requestDoc.update(capture(mapSlot)) } returns Tasks.forResult(null)
+        val docSnapshot = mockk<DocumentSnapshot> {
+            every { id } returns "req-1"
+            every { data } returns mapOf(
+                "requestId" to "req-1",
+                "userId" to "user-1",
+                "userName" to "Alice",
+                "seatIndex" to 2L,
+                "status" to "APPROVED",
+                "resolvedBy" to "owner-1"
+            )
+        }
+        every { requestDoc.get() } returns Tasks.forResult(docSnapshot)
+
+        val result = repo.approveRequest("room-1", "req-1", "owner-1")
+
+        assertTrue(result is Resource.Success)
+        val updateData = mapSlot.captured
+        assertTrue(updateData["status"] == SeatRequestStatus.APPROVED.name)
+        assertTrue(updateData["resolvedBy"] == "owner-1")
+    }
+
+    @Test
+    fun `denyRequest updates status to DENIED`() = runTest {
+        val mapSlot = slot<Map<String, Any?>>()
+        every { requestDoc.update(capture(mapSlot)) } returns Tasks.forResult(null)
+
+        val result = repo.denyRequest("room-1", "req-1", "owner-1")
+
+        assertTrue(result is Resource.Success)
+        val updateData = mapSlot.captured
+        assertTrue(updateData["status"] == SeatRequestStatus.DENIED.name)
+        assertTrue(updateData["resolvedBy"] == "owner-1")
+    }
+
+    @Test
+    fun `approveRequest returns Error on exception`() = runTest {
+        every { requestDoc.update(any<Map<String, Any?>>()) } returns Tasks.forException(RuntimeException("Fail"))
+
+        val result = repo.approveRequest("room-1", "req-1", "owner-1")
+
+        assertTrue(result is Resource.Error)
+    }
+
+    @Test
+    fun `denyRequest returns Error on exception`() = runTest {
+        every { requestDoc.update(any<Map<String, Any?>>()) } returns Tasks.forException(RuntimeException("Fail"))
+
+        val result = repo.denyRequest("room-1", "req-1", "owner-1")
+
+        assertTrue(result is Resource.Error)
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/data/repository/StorageRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/StorageRepositoryImplTest.kt
@@ -1,0 +1,49 @@
+package com.shyden.shytalk.data.repository
+
+import com.google.firebase.storage.FirebaseStorage
+import com.google.firebase.storage.StorageReference
+import com.shyden.shytalk.core.util.Resource
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class StorageRepositoryImplTest {
+
+    private lateinit var storage: FirebaseStorage
+    private lateinit var storageRef: StorageReference
+    private lateinit var fileRef: StorageReference
+    private lateinit var repo: StorageRepositoryImpl
+
+    @Before
+    fun setup() {
+        storage = mockk(relaxed = true)
+        storageRef = mockk(relaxed = true)
+        fileRef = mockk(relaxed = true)
+        every { storage.reference } returns storageRef
+        every { storageRef.child(any()) } returns fileRef
+        repo = StorageRepositoryImpl(storage)
+    }
+
+    @Test
+    fun `uploadImage returns Error when putBytes throws`() = runTest {
+        every { fileRef.putBytes(any()) } throws RuntimeException("Upload failed")
+
+        val result = repo.uploadImage("user-1", "avatars", byteArrayOf(1, 2, 3))
+
+        assertTrue(result is Resource.Error)
+        assertTrue((result as Resource.Error).message.contains("Upload failed"))
+    }
+
+    @Test
+    fun `uploadImage constructs correct storage path`() = runTest {
+        every { fileRef.putBytes(any()) } throws RuntimeException("stop here")
+
+        repo.uploadImage("user-1", "avatars", byteArrayOf(1, 2, 3))
+
+        // Verify the child path includes userId and avatars prefix
+        io.mockk.verify { storageRef.child(match { it.startsWith("avatars/user-1/") && it.endsWith(".jpg") }) }
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/data/repository/UserRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/UserRepositoryImplTest.kt
@@ -1,0 +1,255 @@
+package com.shyden.shytalk.data.repository
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.util.Resource
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class UserRepositoryImplTest {
+
+    private lateinit var firestore: FirebaseFirestore
+    private lateinit var usersCollection: CollectionReference
+    private lateinit var docRef: DocumentReference
+    private lateinit var repo: UserRepositoryImpl
+
+    @Before
+    fun setup() {
+        firestore = mockk(relaxed = true)
+        usersCollection = mockk(relaxed = true)
+        docRef = mockk(relaxed = true)
+        every { firestore.collection("users") } returns usersCollection
+        every { usersCollection.document(any<String>()) } returns docRef
+        repo = UserRepositoryImpl(firestore)
+    }
+
+    @Test
+    fun `createOrUpdateUser returns Success`() = runTest {
+        val user = User(uid = "user-1", displayName = "Test")
+        every { docRef.set(any()) } returns Tasks.forResult(null)
+
+        val result = repo.createOrUpdateUser(user)
+
+        assertTrue(result is Resource.Success)
+        verify { usersCollection.document("user-1") }
+    }
+
+    @Test
+    fun `createOrUpdateUser returns Error on exception`() = runTest {
+        val user = User(uid = "user-1", displayName = "Test")
+        every { docRef.set(any()) } returns Tasks.forException(RuntimeException("Firestore down"))
+
+        val result = repo.createOrUpdateUser(user)
+
+        assertTrue(result is Resource.Error)
+    }
+
+    @Test
+    fun `getUser returns Success with parsed user`() = runTest {
+        val ts = Timestamp.now()
+        val data = mapOf<String, Any?>(
+            "displayName" to "Alice",
+            "avatarUrl" to "https://img.com/a.jpg",
+            "profilePhotoUrl" to null,
+            "coverPhotoUrl" to null,
+            "description" to "Hi",
+            "nationality" to "US",
+            "uniqueId" to 12345678L,
+            "blockedUserIds" to listOf("blocked-1"),
+            "phoneNumber" to "+123",
+            "email" to "a@b.com",
+            "createdAt" to ts,
+            "lastSeenAt" to ts
+        )
+        val snapshot = mockk<DocumentSnapshot> {
+            every { exists() } returns true
+            every { this@mockk.data } returns data
+            every { id } returns "user-1"
+        }
+        every { docRef.get() } returns Tasks.forResult(snapshot)
+
+        val result = repo.getUser("user-1")
+
+        assertTrue(result is Resource.Success)
+        val user = (result as Resource.Success).data
+        assertEquals("user-1", user.uid)
+        assertEquals("Alice", user.displayName)
+        assertEquals("https://img.com/a.jpg", user.avatarUrl)
+        assertEquals("Hi", user.description)
+        assertEquals("US", user.nationality)
+        assertEquals(12345678L, user.uniqueId)
+        assertEquals(listOf("blocked-1"), user.blockedUserIds)
+        assertEquals("+123", user.phoneNumber)
+        assertEquals("a@b.com", user.email)
+    }
+
+    @Test
+    fun `getUser returns Error when user not found`() = runTest {
+        val snapshot = mockk<DocumentSnapshot> {
+            every { exists() } returns false
+        }
+        every { docRef.get() } returns Tasks.forResult(snapshot)
+
+        val result = repo.getUser("user-1")
+
+        assertTrue(result is Resource.Error)
+        assertEquals("User not found", (result as Resource.Error).message)
+    }
+
+    @Test
+    fun `getUser returns Error when data is null`() = runTest {
+        val snapshot = mockk<DocumentSnapshot> {
+            every { exists() } returns true
+            every { data } returns null
+            every { id } returns "user-1"
+        }
+        every { docRef.get() } returns Tasks.forResult(snapshot)
+
+        val result = repo.getUser("user-1")
+
+        assertTrue(result is Resource.Error)
+        assertEquals("User data is null", (result as Resource.Error).message)
+    }
+
+    @Test
+    fun `getUser handles missing optional fields with defaults`() = runTest {
+        val data = mapOf<String, Any?>()
+        val snapshot = mockk<DocumentSnapshot> {
+            every { exists() } returns true
+            every { this@mockk.data } returns data
+            every { id } returns "user-1"
+        }
+        every { docRef.get() } returns Tasks.forResult(snapshot)
+
+        val result = repo.getUser("user-1")
+
+        assertTrue(result is Resource.Success)
+        val user = (result as Resource.Success).data
+        assertEquals("", user.displayName)
+        assertEquals(0L, user.uniqueId)
+        assertEquals(emptyList<String>(), user.blockedUserIds)
+    }
+
+    @Test
+    fun `userExists returns true when document exists`() = runTest {
+        val snapshot = mockk<DocumentSnapshot> { every { exists() } returns true }
+        every { docRef.get() } returns Tasks.forResult(snapshot)
+
+        val result = repo.userExists("user-1")
+
+        assertTrue(result is Resource.Success)
+        assertTrue((result as Resource.Success).data)
+    }
+
+    @Test
+    fun `userExists returns false when document does not exist`() = runTest {
+        val snapshot = mockk<DocumentSnapshot> { every { exists() } returns false }
+        every { docRef.get() } returns Tasks.forResult(snapshot)
+
+        val result = repo.userExists("user-1")
+
+        assertTrue(result is Resource.Success)
+        assertFalse((result as Resource.Success).data)
+    }
+
+    @Test
+    fun `updateDisplayName returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.updateDisplayName("user-1", "New Name")
+
+        assertTrue(result is Resource.Success)
+        verify { docRef.update("displayName", "New Name") }
+    }
+
+    @Test
+    fun `updateAvatar returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.updateAvatar("user-1", "https://img.com/new.jpg")
+
+        assertTrue(result is Resource.Success)
+        verify { docRef.update("avatarUrl", "https://img.com/new.jpg") }
+    }
+
+    @Test
+    fun `updateProfile returns Success`() = runTest {
+        every { docRef.update(any<Map<String, Any?>>()) } returns Tasks.forResult(null)
+
+        val fields = mapOf<String, Any?>("description" to "New desc", "nationality" to "UK")
+        val result = repo.updateProfile("user-1", fields)
+
+        assertTrue(result is Resource.Success)
+    }
+
+    @Test
+    fun `blockUser returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.blockUser("user-1", "bad-user")
+
+        assertTrue(result is Resource.Success)
+    }
+
+    @Test
+    fun `unblockUser returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.unblockUser("user-1", "bad-user")
+
+        assertTrue(result is Resource.Success)
+    }
+
+    @Test
+    fun `getBlockedUserIds returns list when doc exists`() = runTest {
+        val data = mapOf<String, Any?>("blockedUserIds" to listOf("b1", "b2"))
+        val snapshot = mockk<DocumentSnapshot> {
+            every { exists() } returns true
+            every { this@mockk.data } returns data
+        }
+        every { docRef.get() } returns Tasks.forResult(snapshot)
+
+        val result = repo.getBlockedUserIds("user-1")
+
+        assertTrue(result is Resource.Success)
+        assertEquals(listOf("b1", "b2"), (result as Resource.Success).data)
+    }
+
+    @Test
+    fun `getBlockedUserIds returns empty list when doc does not exist`() = runTest {
+        val snapshot = mockk<DocumentSnapshot> { every { exists() } returns false }
+        every { docRef.get() } returns Tasks.forResult(snapshot)
+
+        val result = repo.getBlockedUserIds("user-1")
+
+        assertTrue(result is Resource.Success)
+        assertTrue((result as Resource.Success).data.isEmpty())
+    }
+
+    @Test
+    fun `getBlockedUserIds returns empty list when field is missing`() = runTest {
+        val data = mapOf<String, Any?>()
+        val snapshot = mockk<DocumentSnapshot> {
+            every { exists() } returns true
+            every { this@mockk.data } returns data
+        }
+        every { docRef.get() } returns Tasks.forResult(snapshot)
+
+        val result = repo.getBlockedUserIds("user-1")
+
+        assertTrue(result is Resource.Success)
+        assertTrue((result as Resource.Success).data.isEmpty())
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -62,6 +62,7 @@ class RoomViewModelTest {
     private val messagesFlow = MutableStateFlow<List<Message>>(emptyList())
     private val speakingFlow = MutableStateFlow<Set<Int>>(emptySet())
     private val joinedFlow = MutableStateFlow(false)
+    private val voiceErrorFlow = MutableStateFlow<String?>(null)
 
     private val currentUserId = "current-user"
     private val ownerId = "owner-1"
@@ -78,6 +79,7 @@ class RoomViewModelTest {
         every { messageRepository.getMessages(any()) } returns messagesFlow
         every { agoraVoiceService.speakingUsers } returns speakingFlow
         every { agoraVoiceService.isJoined } returns joinedFlow
+        every { agoraVoiceService.error } returns voiceErrorFlow
         coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(
             TestData.createTestUser(uid = currentUserId, displayName = "Current User")
         )
@@ -953,5 +955,221 @@ class RoomViewModelTest {
         advanceUntilIdle()
 
         assertTrue(viewModel.uiState.value.roomClosed)
+    }
+
+    // ===== Voice Error Surfacing =====
+
+    @Test
+    fun `voice error from agora service surfaces in uiState`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsOwner()
+        advanceUntilIdle()
+
+        voiceErrorFlow.value = "Voice join failed (code -7)"
+        advanceUntilIdle()
+
+        assertEquals("Voice join failed (code -7)", viewModel.uiState.value.error)
+        verify { agoraVoiceService.clearError() }
+    }
+
+    @Test
+    fun `null voice error does not overwrite uiState error`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsOwner()
+        advanceUntilIdle()
+
+        voiceErrorFlow.value = null
+        advanceUntilIdle()
+
+        assertNull(viewModel.uiState.value.error)
+    }
+
+    // ===== Voice Channel Audience-First Tests =====
+
+    @Test
+    fun `joinRoom joins voice channel as audience`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsOwner()
+        advanceUntilIdle()
+
+        coVerify { agoraVoiceService.joinChannel("channel-1", any(), asBroadcaster = false) }
+    }
+
+    @Test
+    fun `becoming seated switches role to broadcaster when has audio permission`() = runTest {
+        viewModel = createViewModel()
+        // First emit: user NOT seated (all empty seats) — triggers handleFirstJoin → joinRoom
+        val emptySeats = TestData.createDefaultSeats()
+        emitRoomAsOwner(TestData.createTestRoom(ownerId = currentUserId, seats = emptySeats))
+        advanceUntilIdle()
+
+        // Grant audio permission
+        viewModel.onAudioPermissionResult(true)
+        advanceUntilIdle()
+
+        // Second emit: user IS seated — triggers handleNormalUpdate with currentlySeated=true, isSeated=false
+        val seatedSeats = TestData.createSeatsWithOwner(currentUserId)
+        emitRoomAsOwner(TestData.createTestRoom(ownerId = currentUserId, seats = seatedSeats))
+        advanceUntilIdle()
+
+        verify { agoraVoiceService.setRole(true) }
+    }
+
+    @Test
+    fun `leaving seat switches role to audience instead of leaving channel`() = runTest {
+        // Pre-set room BEFORE creating VM to avoid null initial emission calling leaveChannel
+        val emptySeats = TestData.createDefaultSeats()
+        roomFlow.value = TestData.createTestRoom(ownerId = currentUserId, seats = emptySeats)
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // Grant audio permission
+        viewModel.onAudioPermissionResult(true)
+        advanceUntilIdle()
+
+        // Emit with user seated — handleNormalUpdate sets isSeated = true
+        val seatedSeats = TestData.createSeatsWithOwner(currentUserId)
+        roomFlow.value = TestData.createTestRoom(ownerId = currentUserId, seats = seatedSeats)
+        advanceUntilIdle()
+
+        // Emit with user NOT seated — handleNormalUpdate detects isSeated→not seated
+        roomFlow.value = TestData.createTestRoom(
+            ownerId = currentUserId,
+            seats = emptySeats,
+            name = "Test Room 2"  // change something so MutableStateFlow re-emits
+        )
+        advanceUntilIdle()
+
+        verify { agoraVoiceService.setRole(false) }
+        // Should NOT call leaveChannel when leaving seat
+        verify(exactly = 0) { agoraVoiceService.leaveChannel() }
+    }
+
+    @Test
+    fun `onAudioPermissionResult granted when seated calls setRole`() = runTest {
+        viewModel = createViewModel()
+        // First emit with empty seats to trigger handleFirstJoin → joinRoom → hasJoined=true
+        val emptySeats = TestData.createDefaultSeats()
+        emitRoomAsOwner(TestData.createTestRoom(ownerId = currentUserId, seats = emptySeats))
+        advanceUntilIdle()
+
+        // Second emit with user seated — handleNormalUpdate sets isSeated=true
+        // but hasAudioPermission is false, so no setRole yet
+        val seatedSeats = TestData.createSeatsWithOwner(currentUserId)
+        emitRoomAsOwner(TestData.createTestRoom(ownerId = currentUserId, seats = seatedSeats))
+        advanceUntilIdle()
+
+        // Now grant permission — should trigger setRole(true) since isSeated=true
+        viewModel.onAudioPermissionResult(true)
+        advanceUntilIdle()
+
+        verify { agoraVoiceService.setRole(true) }
+    }
+
+    @Test
+    fun `onAudioPermissionResult granted when not seated does not call setRole`() = runTest {
+        viewModel = createViewModel()
+        val seatsWithoutUser = TestData.createDefaultSeats()
+        emitRoomAsOwner(TestData.createTestRoom(ownerId = currentUserId, seats = seatsWithoutUser))
+        advanceUntilIdle()
+
+        viewModel.onAudioPermissionResult(true)
+        advanceUntilIdle()
+
+        verify(exactly = 0) { agoraVoiceService.setRole(any()) }
+    }
+
+    @Test
+    fun `leaveRoom still calls leaveChannel`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsOwner()
+        advanceUntilIdle()
+
+        viewModel.leaveRoom()
+        advanceUntilIdle()
+
+        verify { agoraVoiceService.leaveChannel() }
+    }
+
+    @Test
+    fun `attendee joining room also joins voice as audience`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsAttendee()
+        advanceUntilIdle()
+
+        coVerify { agoraVoiceService.joinChannel("channel-1", any(), asBroadcaster = false) }
+    }
+
+    @Test
+    fun `owner already seated with permission joins voice as broadcaster directly`() = runTest {
+        viewModel = createViewModel()
+        // Grant audio permission BEFORE room emission
+        viewModel.onAudioPermissionResult(true)
+        advanceUntilIdle()
+
+        // Emit room with owner on seat 0 (default seats)
+        emitRoomAsOwner()
+        advanceUntilIdle()
+
+        // Should join as broadcaster since already seated + has permission
+        coVerify { agoraVoiceService.joinChannel("channel-1", any(), asBroadcaster = true) }
+    }
+
+    @Test
+    fun `owner already seated without permission joins as audience then upgrades on permission grant`() = runTest {
+        viewModel = createViewModel()
+        // Emit room with owner on seat 0, but NO audio permission yet
+        emitRoomAsOwner()
+        advanceUntilIdle()
+
+        // Should join as audience (no permission yet)
+        coVerify { agoraVoiceService.joinChannel("channel-1", any(), asBroadcaster = false) }
+
+        // Grant permission — should call setRole(true) since isSeated was set in joinRoom()
+        viewModel.onAudioPermissionResult(true)
+        advanceUntilIdle()
+
+        verify { agoraVoiceService.setRole(true) }
+    }
+
+    @Test
+    fun `alreadyInRoom path sets isSeated and does not trigger redundant seat transition`() = runTest {
+        // Simulate ViewModel recreation: activeRoomManager reports already in room
+        every { activeRoomManager.isInRoom("room-1") } returns true
+
+        // Pre-set room with owner seated BEFORE creating VM
+        roomFlow.value = TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = listOf(currentUserId)
+        )
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // Grant permission — since isSeated is set in alreadyInRoom path, this should call setRole
+        viewModel.onAudioPermissionResult(true)
+        advanceUntilIdle()
+
+        verify { agoraVoiceService.setRole(true) }
+    }
+
+    @Test
+    fun `alreadyInRoom path without seat does not set broadcaster`() = runTest {
+        every { activeRoomManager.isInRoom("room-1") } returns true
+
+        // Pre-set room with empty seats (user not seated)
+        val emptySeats = TestData.createDefaultSeats()
+        roomFlow.value = TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = listOf(currentUserId),
+            seats = emptySeats
+        )
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // Grant permission — since NOT seated, should NOT call setRole
+        viewModel.onAudioPermissionResult(true)
+        advanceUntilIdle()
+
+        verify(exactly = 0) { agoraVoiceService.setRole(any()) }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,9 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
## Summary
- Audience-first voice architecture: all users join Agora as audience and can hear speakers without sitting on a seat
- Speaking animation visible for all room participants, not just the local user
- Speaking indicator suppressed when user is muted
- Fixed RtcEngine.create() returning null on Android 16 (OnePlus 15)
- Ghost users auto-removed via Firebase RTDB presence monitoring
- Fixed room owner voice race condition (async audience join overwriting broadcaster role)
- 8 new test files, expanded existing tests — 327 total unit tests (up from 211)
- Version bump: 0.15 → 0.16

## Test plan
- [x] All 327 unit tests pass (`./gradlew testDebugUnitTest`)
- [ ] Manual test: join room as attendee, verify speakers are audible without taking a seat
- [ ] Manual test: verify speaking animation shows for remote speakers
- [ ] Manual test: mute yourself, verify no speaking indicator appears
- [ ] Manual test: room owner joins and speaks — verify audible to all participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)