### PR TITLE
Photo caching, room editing, auto-close & fixes v0.22

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 21
-        versionName = "0.21"
+        versionCode = 22
+        versionName = "0.22"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/shyden/shytalk/ShyTalkApp.kt
+++ b/app/src/main/java/com/shyden/shytalk/ShyTalkApp.kt
@@ -3,11 +3,33 @@ package com.shyden.shytalk
 import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import coil.ImageLoader
+import coil.ImageLoaderFactory
+import coil.disk.DiskCache
+import coil.memory.MemoryCache
 import com.shyden.shytalk.core.util.Constants
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class ShyTalkApp : Application() {
+class ShyTalkApp : Application(), ImageLoaderFactory {
+
+    override fun newImageLoader(): ImageLoader {
+        return ImageLoader.Builder(this)
+            .memoryCache {
+                MemoryCache.Builder(this)
+                    .maxSizePercent(0.25)
+                    .build()
+            }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(cacheDir.resolve("image_cache"))
+                    .maxSizeBytes(50L * 1024 * 1024)
+                    .build()
+            }
+            .crossfade(true)
+            .build()
+    }
+
     override fun onCreate() {
         super.onCreate()
         val channel = NotificationChannel(

--- a/app/src/main/java/com/shyden/shytalk/core/chathead/ChatHeadManager.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/chathead/ChatHeadManager.kt
@@ -12,7 +12,8 @@ import android.view.View
 import android.view.ViewConfiguration
 import android.view.WindowManager
 import android.widget.ImageView
-import coil.ImageLoader
+import android.widget.TextView
+import coil.imageLoader
 import coil.request.ImageRequest
 import coil.transform.CircleCropTransformation
 import com.shyden.shytalk.R
@@ -32,7 +33,7 @@ class ChatHeadManager(
     private var closeZoneParams: WindowManager.LayoutParams? = null
     private var voiceWaveView: VoiceWaveView? = null
     private var isShowing = false
-    private val imageLoader by lazy { ImageLoader(context) }
+    private val imageLoader get() = context.imageLoader
 
     private val density = context.resources.displayMetrics.density
     private val screenWidthPx = context.resources.displayMetrics.widthPixels
@@ -70,6 +71,20 @@ class ChatHeadManager(
         handler.post {
             val view = bubbleView ?: return@post
             loadPhoto(view, ownerPhotoUrl)
+        }
+    }
+
+    fun showRoomClosed() {
+        handler.post {
+            val view = bubbleView ?: return@post
+            voiceWaveView?.stopAnimation()
+            voiceWaveView?.visibility = View.GONE
+            view.findViewById<ImageView>(R.id.ownerPhoto)?.visibility = View.GONE
+            view.findViewById<ImageView>(R.id.micIcon)?.visibility = View.GONE
+            view.findViewById<ImageView>(R.id.closeButton)?.visibility = View.GONE
+            view.findViewById<TextView>(R.id.roomClosedText)?.visibility = View.VISIBLE
+            // Auto-dismiss after 3 seconds
+            handler.postDelayed({ destroy() }, ROOM_CLOSED_DISPLAY_MS)
         }
     }
 
@@ -292,5 +307,6 @@ class ChatHeadManager(
         private const val CLOSE_BUTTON_SIZE_DP = 20
         private const val EDGE_MARGIN_DP = 8
         private const val CLOSE_ZONE_HEIGHT_DP = 72
+        private const val ROOM_CLOSED_DISPLAY_MS = 3000L
     }
 }

--- a/app/src/main/java/com/shyden/shytalk/core/room/ActiveRoomManager.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/room/ActiveRoomManager.kt
@@ -139,13 +139,15 @@ class ActiveRoomManager @Inject constructor(
 
         presenceService.removePresence()
 
-        // Vacate seat
+        // Vacate seat — but keep owner in seat 0 for reconnection
         val mySeatEntry = room.seats.entries.find { it.value.userId == userId }
         if (mySeatEntry != null) {
             val seatIndex = mySeatEntry.key.toInt()
-            roomRepository.leaveSeat(roomId, seatIndex)
             if (seatIndex == Constants.OWNER_SEAT_INDEX && room.ownerId == userId) {
+                // Owner keeps their seat for reconnection — just mark away
                 roomRepository.setOwnerAway(roomId)
+            } else {
+                roomRepository.leaveSeat(roomId, seatIndex)
             }
         }
 
@@ -425,7 +427,8 @@ class ActiveRoomManager @Inject constructor(
 
         val seat = room.seats[seatIndex.toString()] ?: return
         val targetUserId = seat.userId ?: return
-        if (targetUserId == room.ownerId || targetUserId in room.hostIds) return
+        if (targetUserId == room.ownerId) return
+        if (role == RoomRole.HOST && targetUserId in room.hostIds) return
 
         roomRepository.toggleMute(roomId, seatIndex, !seat.isMuted)
     }
@@ -455,7 +458,8 @@ class ActiveRoomManager @Inject constructor(
 
         val seat = room.seats[seatIndex.toString()] ?: return
         val targetUserId = seat.userId ?: return
-        if (targetUserId == room.ownerId || targetUserId in room.hostIds) return
+        if (targetUserId == room.ownerId) return
+        if (role == RoomRole.HOST && targetUserId in room.hostIds) return
 
         val displayReason = reason.ifBlank { "No reason given" }
         roomRepository.kickUser(roomId, targetUserId, seatIndex, kickerName = "", reason = displayReason)

--- a/app/src/main/java/com/shyden/shytalk/core/room/RoomService.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/room/RoomService.kt
@@ -35,6 +35,7 @@ class RoomService : Service() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var observerJob: Job? = null
     private var chatHeadJob: Job? = null
+    private var roomClosedJob: Job? = null
     private var chatHeadManager: ChatHeadManager? = null
     private var ownerPhotoUrl: String? = null
 
@@ -107,6 +108,7 @@ class RoomService : Service() {
         startForeground(Constants.ROOM_NOTIFICATION_ID, buildNotification(roomId, "Voice Room"))
         observeRoom()
         observeRoomScreenVisibility()
+        observeRoomClosed()
 
         return START_STICKY
     }
@@ -117,7 +119,7 @@ class RoomService : Service() {
             var lastOwnerId: String? = null
             activeRoomManager.activeRoom.collect { room ->
                 if (room == null) {
-                    stopSelf()
+                    // Don't stopSelf() immediately — let observeRoomClosed show "Room Closed" on chathead
                     return@collect
                 }
                 val notification = buildNotification(room.roomId, room.name)
@@ -136,6 +138,20 @@ class RoomService : Service() {
                         }
                         else -> {}
                     }
+                }
+            }
+        }
+    }
+
+    private fun observeRoomClosed() {
+        roomClosedJob?.cancel()
+        roomClosedJob = serviceScope.launch {
+            activeRoomManager.roomClosed.collect { closed ->
+                if (closed) {
+                    chatHeadManager?.showRoomClosed()
+                    // Stop service after chathead finishes displaying "Room Closed"
+                    kotlinx.coroutines.delay(3500L)
+                    stopSelf()
                 }
             }
         }
@@ -201,6 +217,7 @@ class RoomService : Service() {
         super.onDestroy()
         observerJob?.cancel()
         chatHeadJob?.cancel()
+        roomClosedJob?.cancel()
         chatHeadManager?.destroy()
         chatHeadManager = null
     }

--- a/app/src/main/java/com/shyden/shytalk/core/util/Constants.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/util/Constants.kt
@@ -8,6 +8,7 @@ object Constants {
     const val PRESENCE_TIMEOUT_MS = 30_000L // 30 seconds
     const val ROOM_NOTIFICATION_ID = 1001
     const val ROOM_NOTIFICATION_CHANNEL_ID = "room_service_channel"
+    const val MAX_ROOM_DURATION_MS = 3 * 60 * 60 * 1000L // 3 hours
     const val ACTIVE_ROOMS_QUERY_LIMIT = 100L
 
     // Seat request notification timing

--- a/app/src/main/java/com/shyden/shytalk/data/remote/AgoraVoiceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/AgoraVoiceService.kt
@@ -111,6 +111,11 @@ class AgoraVoiceService @Inject constructor(
             speakers: Array<out AudioVolumeInfo>?,
             totalVolume: Int
         ) {
+            if (Log.isLoggable(TAG, Log.VERBOSE)) {
+                speakers?.forEach {
+                    Log.v(TAG, "volumeIndication uid=${it.uid} vol=${it.volume} vad=${it.vad}")
+                }
+            }
             val speaking = processSpeakers(speakers, localUid, isLocalMuted)
             if (speaking != _speakingUsers.value) {
                 _speakingUsers.value = speaking
@@ -208,49 +213,65 @@ class AgoraVoiceService @Inject constructor(
             autoSubscribeVideo = false
         }
 
-        Log.d(TAG, "Joining channel=$channelName uid=$uid asBroadcaster=$asBroadcaster hasToken=${token != null}")
-        val result = engine.joinChannel(token, channelName, uid, options)
-        if (result != 0) {
-            Log.e(TAG, "joinChannel failed with error code $result")
-            _error.value = "Voice join failed (code $result)"
-        } else {
-            currentChannelName = channelName
-            localUid = uid
-            // Re-apply volume indication after join (may be reset by leaveChannel in some SDK versions)
-            engine.enableAudioVolumeIndication(
-                AppConstants.AGORA_VOLUME_INDICATION_INTERVAL_MS,
-                AppConstants.AGORA_VOLUME_INDICATION_SMOOTH,
-                true
-            )
-            Log.d(TAG, "joinChannel call succeeded (waiting for onJoinChannelSuccess callback)")
-            if (asBroadcaster) {
-                engine.setEnableSpeakerphone(true)
-                engine.muteLocalAudioStream(false)
-                engine.adjustRecordingSignalVolume(AppConstants.AGORA_RECORDING_SIGNAL_VOLUME)
-                Log.d(TAG, "Audio configured: speakerphone=on, mic=unmuted, recordingVolume=${AppConstants.AGORA_RECORDING_SIGNAL_VOLUME}")
+        try {
+            Log.d(TAG, "Joining channel=$channelName uid=$uid asBroadcaster=$asBroadcaster hasToken=${token != null}")
+            val result = engine.joinChannel(token, channelName, uid, options)
+            if (result != 0) {
+                Log.e(TAG, "joinChannel failed with error code $result")
+                _error.value = "Voice join failed (code $result)"
+            } else {
+                currentChannelName = channelName
+                localUid = uid
+                // Re-apply volume indication after join (may be reset by leaveChannel in some SDK versions)
+                engine.enableAudioVolumeIndication(
+                    AppConstants.AGORA_VOLUME_INDICATION_INTERVAL_MS,
+                    AppConstants.AGORA_VOLUME_INDICATION_SMOOTH,
+                    true
+                )
+                Log.d(TAG, "joinChannel call succeeded (waiting for onJoinChannelSuccess callback)")
+                if (asBroadcaster) {
+                    engine.setEnableSpeakerphone(true)
+                    engine.muteLocalAudioStream(false)
+                    engine.adjustRecordingSignalVolume(AppConstants.AGORA_RECORDING_SIGNAL_VOLUME)
+                    Log.d(TAG, "Audio configured: speakerphone=on, mic=unmuted, recordingVolume=${AppConstants.AGORA_RECORDING_SIGNAL_VOLUME}")
+                }
             }
+        } catch (e: Exception) {
+            Log.e(TAG, "joinChannel threw exception", e)
+            _error.value = "Voice join failed: ${e.message}"
         }
     }
 
     fun setRole(broadcaster: Boolean) {
         val engine = rtcEngine ?: return
-        Log.d(TAG, "setRole broadcaster=$broadcaster")
-        if (broadcaster) {
-            engine.enableAudio()
-            engine.setClientRole(Constants.CLIENT_ROLE_BROADCASTER)
-            engine.updateChannelMediaOptions(ChannelMediaOptions().apply {
-                publishMicrophoneTrack = true
-            })
-            engine.setEnableSpeakerphone(true)
-            engine.muteLocalAudioStream(false)
-            engine.adjustRecordingSignalVolume(AppConstants.AGORA_RECORDING_SIGNAL_VOLUME)
-            isLocalMuted = false
-        } else {
-            engine.setClientRole(Constants.CLIENT_ROLE_AUDIENCE)
-            engine.updateChannelMediaOptions(ChannelMediaOptions().apply {
-                publishMicrophoneTrack = false
-            })
-            isLocalMuted = false
+        try {
+            Log.d(TAG, "setRole broadcaster=$broadcaster")
+            if (broadcaster) {
+                engine.enableAudio()
+                engine.setClientRole(Constants.CLIENT_ROLE_BROADCASTER)
+                engine.updateChannelMediaOptions(ChannelMediaOptions().apply {
+                    publishMicrophoneTrack = true
+                })
+                engine.setEnableSpeakerphone(true)
+                engine.muteLocalAudioStream(false)
+                engine.adjustRecordingSignalVolume(AppConstants.AGORA_RECORDING_SIGNAL_VOLUME)
+                isLocalMuted = false
+            } else {
+                engine.setClientRole(Constants.CLIENT_ROLE_AUDIENCE)
+                engine.updateChannelMediaOptions(ChannelMediaOptions().apply {
+                    publishMicrophoneTrack = false
+                })
+                isLocalMuted = false
+            }
+            // Re-enable volume indication after role change — enableAudio() can reset it
+            engine.enableAudioVolumeIndication(
+                AppConstants.AGORA_VOLUME_INDICATION_INTERVAL_MS,
+                AppConstants.AGORA_VOLUME_INDICATION_SMOOTH,
+                true
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "setRole failed", e)
+            _error.value = "Voice role change failed: ${e.message}"
         }
     }
 
@@ -260,18 +281,30 @@ class AgoraVoiceService @Inject constructor(
         currentChannelName = null
         localUid = 0
         isLocalMuted = false
-        rtcEngine?.leaveChannel()
+        try {
+            rtcEngine?.leaveChannel()
+        } catch (e: Exception) {
+            Log.e(TAG, "leaveChannel failed", e)
+        }
     }
 
     fun muteLocalAudio(mute: Boolean) {
         Log.d(TAG, "muteLocalAudio mute=$mute")
         isLocalMuted = mute
-        rtcEngine?.muteLocalAudioStream(mute)
+        try {
+            rtcEngine?.muteLocalAudioStream(mute)
+        } catch (e: Exception) {
+            Log.e(TAG, "muteLocalAudio failed", e)
+        }
     }
 
     fun destroy() {
-        rtcEngine?.leaveChannel()
-        RtcEngine.destroy()
+        try {
+            rtcEngine?.leaveChannel()
+            RtcEngine.destroy()
+        } catch (e: Exception) {
+            Log.e(TAG, "destroy failed", e)
+        }
         rtcEngine = null
         _isJoined.value = false
         _speakingUsers.value = emptySet()

--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepository.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepository.kt
@@ -20,6 +20,7 @@ interface RoomRepository {
     suspend fun toggleMute(roomId: String, seatIndex: Int, isMuted: Boolean): Resource<Unit>
     suspend fun addHost(roomId: String, userId: String): Resource<Unit>
     suspend fun removeHost(roomId: String, userId: String): Resource<Unit>
+    suspend fun updateRoomName(roomId: String, newName: String): Resource<Unit>
     suspend fun setRequireApproval(roomId: String, requireApproval: Boolean): Resource<Unit>
     suspend fun setOwnerAway(roomId: String): Resource<Unit>
     suspend fun setOwnerReturned(roomId: String, ownerId: String): Resource<Unit>

--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
@@ -174,6 +174,10 @@ class RoomRepositoryImpl @Inject constructor(
         ).await()
     }
 
+    override suspend fun updateRoomName(roomId: String, newName: String): Resource<Unit> = firebaseCall("Failed to update room name") {
+        roomsCollection.document(roomId).update("name", newName).await()
+    }
+
     override suspend fun setRequireApproval(roomId: String, requireApproval: Boolean): Resource<Unit> = firebaseCall("Failed to update approval setting") {
         roomsCollection.document(roomId).update(
             "requireApproval", requireApproval
@@ -301,17 +305,20 @@ class RoomRepositoryImpl @Inject constructor(
 
             if (userId !in room.participantIds) return@runTransaction
 
-            val updates = clearUserSeats(room, userId)
+            val isOwner = room.ownerId == userId
+            // Owner keeps seat 0 for reconnection — only clear non-owner seats
+            val updates = if (isOwner) mutableMapOf() else clearUserSeats(room, userId)
 
             val remainingParticipants = room.participantIds - userId
 
-            if (remainingParticipants.isEmpty()) {
+            if (remainingParticipants.isEmpty() && !isOwner) {
                 // Room is now empty — close it
                 updates.putAll(emptySeatsUpdate())
                 updates["state"] = RoomState.CLOSED.name
                 updates["closedAt"] = Timestamp.now()
                 updates["participantIds"] = emptyList<String>()
-            } else if (room.ownerId == userId) {
+            } else if (isOwner) {
+                // Owner disconnected — mark away but keep them in participants and seat
                 updates["state"] = RoomState.OWNER_AWAY.name
                 updates["ownerLeftAt"] = Timestamp.now()
             } else {

--- a/app/src/main/java/com/shyden/shytalk/data/repository/StorageRepository.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/StorageRepository.kt
@@ -4,4 +4,5 @@ import com.shyden.shytalk.core.util.Resource
 
 interface StorageRepository {
     suspend fun uploadImage(userId: String, path: String, imageData: ByteArray): Resource<String>
+    suspend fun deleteImageByUrl(url: String)
 }

--- a/app/src/main/java/com/shyden/shytalk/data/repository/StorageRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/StorageRepositoryImpl.kt
@@ -27,4 +27,12 @@ class StorageRepositoryImpl @Inject constructor(
         }
         throw (lastException ?: Exception("Failed to get download URL"))
     }
+
+    override suspend fun deleteImageByUrl(url: String) {
+        try {
+            storage.getReferenceFromUrl(url).delete().await()
+        } catch (_: Exception) {
+            // Best-effort: ignore if file is already gone or URL is invalid
+        }
+    }
 }

--- a/app/src/main/java/com/shyden/shytalk/feature/home/CreateRoomDialog.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/home/CreateRoomDialog.kt
@@ -32,7 +32,7 @@ fun CreateRoomDialog(
                 Spacer(modifier = Modifier.height(8.dp))
                 OutlinedTextField(
                     value = roomName,
-                    onValueChange = { roomName = it },
+                    onValueChange = { if (it.length <= 50) roomName = it },
                     label = { Text("Room Name") },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true

--- a/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
@@ -56,8 +56,9 @@ class ProfileViewModel @Inject constructor(
         val profileUserId = if (userId.isNullOrEmpty() || userId == currentUid) currentUid else userId
         val isOwn = profileUserId == currentUid
 
+        val alreadyHasData = _uiState.value.user != null
         _uiState.value = _uiState.value.copy(
-            isLoading = true,
+            isLoading = !alreadyHasData,
             isOwnProfile = isOwn,
             currentUserId = currentUid
         )
@@ -209,13 +210,15 @@ class ProfileViewModel @Inject constructor(
     }
 
     fun uploadProfilePhoto(uri: Uri) {
-        uploadPhoto(uri, "profile_photos", "profilePhotoUrl") { url ->
+        val oldUrl = _uiState.value.user?.profilePhotoUrl
+        uploadPhoto(uri, "profile_photos", "profilePhotoUrl", oldUrl) { url ->
             _uiState.value.user?.copy(profilePhotoUrl = url)
         }
     }
 
     fun uploadCoverPhoto(uri: Uri) {
-        uploadPhoto(uri, "cover_photos", "coverPhotoUrl") { url ->
+        val oldUrl = _uiState.value.user?.coverPhotoUrl
+        uploadPhoto(uri, "cover_photos", "coverPhotoUrl", oldUrl) { url ->
             _uiState.value.user?.copy(coverPhotoUrl = url)
         }
     }
@@ -224,6 +227,7 @@ class ProfileViewModel @Inject constructor(
         uri: Uri,
         folder: String,
         profileField: String,
+        oldUrl: String?,
         updateUser: (String) -> User?
     ) {
         val userId = authRepository.currentUser?.uid ?: return
@@ -250,6 +254,10 @@ class ProfileViewModel @Inject constructor(
                                 isUploadingPhoto = false,
                                 user = updateUser(url)
                             )
+                            // Delete old photo from Firebase Storage
+                            if (!oldUrl.isNullOrEmpty()) {
+                                storageRepository.deleteImageByUrl(oldUrl)
+                            }
                         }
                         is Resource.Error -> {
                             _uiState.value = _uiState.value.copy(

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -81,6 +82,7 @@ fun RoomScreen(
     var showSettings by remember { mutableStateOf(false) }
     var showUserCardForId by remember { mutableStateOf<String?>(null) }
     var showParticipantPanel by remember { mutableStateOf(false) }
+    var showRoomNameDialog by remember { mutableStateOf(false) }
 
     // Track room screen visibility for chathead
     DisposableEffect(Unit) {
@@ -277,10 +279,10 @@ fun RoomScreen(
             RoomToolbar(
                 roomName = uiState.room?.name ?: "Room",
                 participantCount = uiState.room?.participantIds?.size ?: 0,
-                isOwnerOrHost = uiState.currentRole == RoomRole.OWNER || uiState.currentRole == RoomRole.HOST,
+                roomExpiryRemainingMs = uiState.roomExpiryRemainingMs,
                 onBack = { onNavigateBack() },
-                onSettings = { showSettings = true },
-                onTogglePeople = { showParticipantPanel = !showParticipantPanel }
+                onTogglePeople = { showParticipantPanel = !showParticipantPanel },
+                onRoomNameClick = { showRoomNameDialog = true }
             )
         }
     ) { padding ->
@@ -412,6 +414,7 @@ fun RoomScreen(
                         currentRole = uiState.currentRole,
                         seats = uiState.room?.seats ?: emptyMap(),
                         userMap = userMap,
+                        isOwnerOrHost = uiState.currentRole == RoomRole.OWNER || uiState.currentRole == RoomRole.HOST,
                         onToggleMic = { seatIndex -> viewModel.toggleSelfMute(seatIndex) },
                         onSendMessage = { viewModel.sendMessage(it) },
                         onTapUser = { userId ->
@@ -420,6 +423,7 @@ fun RoomScreen(
                         onInviteUser = { senderId, senderName ->
                             viewModel.inviteFromMessage(senderId, senderName)
                         },
+                        onSettings = { showSettings = true },
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f)
@@ -499,6 +503,57 @@ fun RoomScreen(
             )
         }
 
+        if (showRoomNameDialog && uiState.room != null) {
+            val isOwner = uiState.currentRole == RoomRole.OWNER
+            if (isOwner) {
+                var editedName by remember { mutableStateOf(uiState.room?.name ?: "") }
+                AlertDialog(
+                    onDismissRequest = { showRoomNameDialog = false },
+                    title = { Text("Edit Room Name") },
+                    text = {
+                        OutlinedTextField(
+                            value = editedName,
+                            onValueChange = { if (it.length <= 50) editedName = it },
+                            singleLine = true,
+                            placeholder = { Text("Room name") }
+                        )
+                    },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            val trimmed = editedName.trim()
+                            if (trimmed.isNotEmpty()) {
+                                viewModel.updateRoomName(trimmed)
+                            }
+                            showRoomNameDialog = false
+                        }) {
+                            Text("Save")
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { showRoomNameDialog = false }) {
+                            Text("Cancel")
+                        }
+                    }
+                )
+            } else {
+                AlertDialog(
+                    onDismissRequest = { showRoomNameDialog = false },
+                    title = { Text("Room Name") },
+                    text = {
+                        Text(
+                            text = uiState.room?.name ?: "",
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                    },
+                    confirmButton = {
+                        TextButton(onClick = { showRoomNameDialog = false }) {
+                            Text("Close")
+                        }
+                    }
+                )
+            }
+        }
+
         val emptySeats = remember(uiState.room?.seats) {
             uiState.room?.seats?.entries
                 ?.filter { it.value.state != SeatState.OCCUPIED && it.key.toInt() != Constants.OWNER_SEAT_INDEX }
@@ -521,10 +576,13 @@ fun RoomScreen(
                         && userId != uiState.currentUserId
                         && !isTargetSeated
 
-                // Mod capabilities: owner/host can act on normal users
-                val isTargetNormalUser = userId != uiState.currentUserId && targetRole == RoomRole.ATTENDEE
-                val canModerate = isTargetNormalUser && isTargetSeated
-                        && (uiState.currentRole == RoomRole.OWNER || uiState.currentRole == RoomRole.HOST)
+                // Mod capabilities: owner can act on hosts + attendees; hosts can act on attendees only
+                val isNotSelf = userId != uiState.currentUserId
+                val isOwner = uiState.currentRole == RoomRole.OWNER
+                val isHostOrOwner = isOwner || uiState.currentRole == RoomRole.HOST
+                val canModerate = isNotSelf && isTargetSeated && isHostOrOwner
+                    && (isOwner || targetRole == RoomRole.ATTENDEE)
+                    && userId != uiState.room?.ownerId
 
                 UserCardPopup(
                     user = user,
@@ -564,6 +622,14 @@ fun RoomScreen(
                         { toIndex -> viewModel.moveSeat(targetSeatIndex, toIndex) }
                     } else null,
                     emptySeats = emptySeats,
+                    onMakeHost = if (isOwner && isNotSelf && isTargetSeated
+                        && targetRole == RoomRole.ATTENDEE) {
+                        { viewModel.addHost(userId) }
+                    } else null,
+                    onRemoveHost = if (isOwner && isNotSelf && targetRole == RoomRole.HOST) {
+                        { viewModel.removeHost(userId) }
+                    } else null,
+                    isHost = targetRole == RoomRole.HOST,
                     onDismiss = { showUserCardForId = null }
                 )
             }

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -65,6 +65,7 @@ data class RoomUiState(
     val roomClosed: Boolean = false,
     val roomClosedSummary: RoomClosedSummary? = null,
     val ownerAwayRemainingMs: Long = 0L,
+    val roomExpiryRemainingMs: Long = 0L,
     val speakingUids: Set<Int> = emptySet(),
     val isVoiceJoined: Boolean = false,
     val pendingInvite: String? = null,
@@ -105,6 +106,7 @@ class RoomViewModel @Inject constructor(
     val uiState: StateFlow<RoomUiState> = _uiState.asStateFlow()
 
     private var ownerAwayCountdownJob: Job? = null
+    private var roomExpiryCountdownJob: Job? = null
     private var isSeated = false
     private val userCache: MutableMap<String, User> = java.util.concurrent.ConcurrentHashMap()
     private var blockCheckDone = false
@@ -256,6 +258,7 @@ class RoomViewModel @Inject constructor(
             loadSeatUsers(room)
             loadParticipantUsers(room)
             handleOwnerAwayCountdown(room)
+            handleRoomExpiryCountdown(room)
             return
         }
 
@@ -270,6 +273,7 @@ class RoomViewModel @Inject constructor(
         loadSeatUsers(room)
         loadParticipantUsers(room)
         handleOwnerAwayCountdown(room)
+        handleRoomExpiryCountdown(room)
     }
 
     private fun handleOwnerReturnDetection(room: ChatRoom, userId: String) {
@@ -423,9 +427,9 @@ class RoomViewModel @Inject constructor(
     private fun updateFilteredMessages() {
         val ts = firstJoinTimestamp
         val filtered = if (ts != null) {
-            allMessages.filter { it.createdAt >= ts && it.type != MessageType.SYSTEM }
+            allMessages.filter { it.createdAt >= ts }
         } else {
-            allMessages.filter { it.type != MessageType.SYSTEM }
+            allMessages
         }
         _uiState.value = _uiState.value.copy(messages = filtered)
     }
@@ -529,6 +533,46 @@ class RoomViewModel @Inject constructor(
         }
     }
 
+    private var expiryWarningSent = false
+
+    private fun handleRoomExpiryCountdown(room: ChatRoom) {
+        if (room.state == RoomState.CLOSED) {
+            roomExpiryCountdownJob?.cancel()
+            return
+        }
+        val elapsed = System.currentTimeMillis() - room.createdAt.toDate().time
+        val remaining = Constants.MAX_ROOM_DURATION_MS - elapsed
+
+        // Only start the countdown loop when under 5 minutes remain
+        if (remaining <= 300_000L) {
+            if (roomExpiryCountdownJob?.isActive == true) return
+            roomExpiryCountdownJob = viewModelScope.launch {
+                // Send warning message once
+                if (!expiryWarningSent) {
+                    expiryWarningSent = true
+                    if (_uiState.value.currentRole == RoomRole.OWNER) {
+                        messageRepository.sendSystemMessage(
+                            roomId,
+                            "This room has reached its maximum time and will close in 5 minutes"
+                        )
+                    }
+                }
+                while (true) {
+                    val now = System.currentTimeMillis() - room.createdAt.toDate().time
+                    val left = Constants.MAX_ROOM_DURATION_MS - now
+                    if (left <= 0) {
+                        if (_uiState.value.currentRole == RoomRole.OWNER) {
+                            roomRepository.closeRoom(roomId)
+                        }
+                        break
+                    }
+                    _uiState.value = _uiState.value.copy(roomExpiryRemainingMs = left)
+                    delay(1000L)
+                }
+            }
+        }
+    }
+
     fun takeSeat(seatIndex: Int) {
         viewModelScope.launch {
             val userId = _uiState.value.currentUserId
@@ -624,10 +668,9 @@ class RoomViewModel @Inject constructor(
             val seat = room.seats[seatIndex.toString()] ?: return@launch
             val targetUserId = seat.userId ?: return@launch
 
-            // Can only force-mute normal users (attendees)
-            val isTargetOwner = targetUserId == room.ownerId
-            val isTargetHost = targetUserId in room.hostIds
-            if (isTargetOwner || isTargetHost) return@launch
+            // Cannot force-mute owner; hosts can't force-mute other hosts
+            if (targetUserId == room.ownerId) return@launch
+            if (role == RoomRole.HOST && targetUserId in room.hostIds) return@launch
 
             roomRepository.toggleMute(roomId, seatIndex, !seat.isMuted)
         }
@@ -667,10 +710,9 @@ class RoomViewModel @Inject constructor(
             val seat = room.seats[seatIndex.toString()] ?: return@launch
             val targetUserId = seat.userId ?: return@launch
 
-            // Cannot kick owner or hosts (hosts can't kick hosts either)
-            val isTargetOwner = targetUserId == room.ownerId
-            val isTargetHost = targetUserId in room.hostIds
-            if (isTargetOwner || isTargetHost) return@launch
+            // Cannot kick owner; hosts can't kick other hosts
+            if (targetUserId == room.ownerId) return@launch
+            if (role == RoomRole.HOST && targetUserId in room.hostIds) return@launch
 
             val kickerName = _uiState.value.currentUserName
             val targetUser = userCache[targetUserId]
@@ -682,6 +724,26 @@ class RoomViewModel @Inject constructor(
                 roomId,
                 "$targetName was kicked by $kickerName. Reason: $displayReason"
             )
+        }
+    }
+
+    fun addHost(userId: String) {
+        viewModelScope.launch {
+            val room = _uiState.value.room ?: return@launch
+            if (_uiState.value.currentUserId != room.ownerId) return@launch
+            val userName = userCache[userId]?.displayName ?: "A user"
+            roomRepository.addHost(roomId, userId)
+            messageRepository.sendSystemMessage(roomId, "$userName was promoted to host")
+        }
+    }
+
+    fun removeHost(userId: String) {
+        viewModelScope.launch {
+            val room = _uiState.value.room ?: return@launch
+            if (_uiState.value.currentUserId != room.ownerId) return@launch
+            val userName = userCache[userId]?.displayName ?: "A user"
+            roomRepository.removeHost(roomId, userId)
+            messageRepository.sendSystemMessage(roomId, "$userName was removed as host")
         }
     }
 
@@ -795,7 +857,39 @@ class RoomViewModel @Inject constructor(
             val room = _uiState.value.room ?: return@launch
             if (room.ownerId != userId) return@launch
 
-            roomRepository.setOwnerReturned(roomId, userId)
+            try {
+                roomRepository.setOwnerReturned(roomId, userId)
+
+                // Re-establish presence and room tracking if lost during disconnect
+                if (!activeRoomManager.isInRoom(roomId)) {
+                    presenceService.setPresence(roomId, userId)
+                    activeRoomManager.trackRoom(roomId)
+                }
+
+                // Rejoin voice as broadcaster if needed
+                val channel = room.agoraChannelName
+                if (channel.isNotEmpty()) {
+                    if (!agoraVoiceService.isJoined.value) {
+                        agoraVoiceService.joinChannel(
+                            channel, userId.toAgoraUid(),
+                            asBroadcaster = _uiState.value.hasAudioPermission
+                        )
+                    } else {
+                        agoraVoiceService.setRole(true)
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "ownerReturn failed, will retry on next room update", e)
+                ownerReturnTriggered = false
+            }
+        }
+    }
+
+    fun updateRoomName(newName: String) {
+        viewModelScope.launch {
+            val room = _uiState.value.room ?: return@launch
+            if (_uiState.value.currentUserId != room.ownerId) return@launch
+            roomRepository.updateRoomName(roomId, newName)
         }
     }
 
@@ -993,12 +1087,21 @@ class RoomViewModel @Inject constructor(
             seatRequestRepository.getPendingRequests(roomId)
                 .catch { /* ignore */ }
                 .collect { requests ->
-                    _uiState.value = _uiState.value.copy(pendingRequestsForPanel = requests)
+                    val room = _uiState.value.room
+                    // Filter out stale requests: user already seated or left the room
+                    val validRequests = requests.filter { req ->
+                        val alreadySeated = room?.seats?.values?.any {
+                            it.isOccupiedBy(req.userId)
+                        } ?: false
+                        val leftRoom = room != null && req.userId !in room.participantIds
+                        !alreadySeated && !leftRoom
+                    }
+                    _uiState.value = _uiState.value.copy(pendingRequestsForPanel = validRequests)
 
                     val role = _uiState.value.currentRole
                     val isHostOrOwner = role == RoomRole.OWNER || role == RoomRole.HOST
                     if (isHostOrOwner && _uiState.value.hasJoined) {
-                        for (request in requests) {
+                        for (request in validRequests) {
                             if (request.requestId !in processedRequestIds) {
                                 enqueueNotification(RoomNotification.SeatRequestReceived(request))
                             }
@@ -1129,6 +1232,7 @@ class RoomViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         ownerAwayCountdownJob?.cancel()
+        roomExpiryCountdownJob?.cancel()
         // DO NOT call presenceService.removePresence() or agoraVoiceService.leaveChannel()
         // Voice/presence survive ViewModel destruction; explicit leaveRoom() handles cleanup.
     }

--- a/app/src/main/java/com/shyden/shytalk/feature/room/components/ChatPanel.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/components/ChatPanel.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MicOff
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -19,7 +20,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,10 +41,12 @@ fun ChatPanel(
     currentRole: RoomRole,
     seats: Map<String, Seat>,
     userMap: Map<String, User>,
+    isOwnerOrHost: Boolean = false,
     onToggleMic: (Int) -> Unit = {},
     onSendMessage: (String) -> Unit,
     onTapUser: (String) -> Unit,
     onInviteUser: (String, String) -> Unit,
+    onSettings: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val listState = rememberLazyListState()
@@ -65,13 +67,11 @@ fun ChatPanel(
     val isSeated = currentSeatEntry != null
     val isSelfMuted = currentSeatEntry?.value?.isMuted ?: false
 
-    // Auto-scroll: with reverseLayout=true, index 0 is the bottom (newest message)
-    val isAtBottom by remember {
-        derivedStateOf { listState.firstVisibleItemIndex == 0 }
-    }
-
+    // Auto-scroll: with reverseLayout=true, index 0 is the bottom (newest message).
+    // When a new message is inserted at index 0, the previous first visible shifts to
+    // index 1, so use <= 1 to still count that as "at bottom".
     LaunchedEffect(messages.size) {
-        if (isAtBottom) {
+        if (listState.firstVisibleItemIndex <= 1) {
             listState.animateScrollToItem(0)
         }
     }
@@ -111,9 +111,19 @@ fun ChatPanel(
                 .padding(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            if (isOwnerOrHost) {
+                IconButton(onClick = onSettings) {
+                    Icon(
+                        Icons.Default.Settings,
+                        contentDescription = "Room settings",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
             OutlinedTextField(
                 value = messageText,
-                onValueChange = { messageText = it },
+                onValueChange = { if (it.length <= 200) messageText = it },
                 placeholder = { Text("Type a message...") },
                 modifier = Modifier.weight(1f),
                 singleLine = true

--- a/app/src/main/java/com/shyden/shytalk/feature/room/components/RoomToolbar.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/components/RoomToolbar.kt
@@ -1,14 +1,16 @@
 package com.shyden.shytalk.feature.room.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.People
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -25,17 +27,40 @@ import androidx.compose.ui.unit.dp
 fun RoomToolbar(
     roomName: String,
     participantCount: Int,
-    isOwnerOrHost: Boolean,
+    roomExpiryRemainingMs: Long = 0L,
     onBack: () -> Unit,
-    onSettings: () -> Unit,
-    onTogglePeople: () -> Unit
+    onTogglePeople: () -> Unit,
+    onRoomNameClick: () -> Unit = {}
 ) {
     TopAppBar(
         title = {
-            Text(
-                text = roomName,
-                style = MaterialTheme.typography.titleMedium
-            )
+            Column {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.clickable { onRoomNameClick() }
+                ) {
+                    Text(
+                        text = roomName,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Icon(
+                        Icons.Default.Edit,
+                        contentDescription = "Room name",
+                        modifier = Modifier.size(16.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                if (roomExpiryRemainingMs in 1..300_000L) {
+                    val minutes = (roomExpiryRemainingMs / 60_000).toInt()
+                    val seconds = ((roomExpiryRemainingMs % 60_000) / 1_000).toInt()
+                    Text(
+                        text = "Closing in ${minutes}:${"%02d".format(seconds)}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
         },
         navigationIcon = {
             IconButton(onClick = onBack) {
@@ -58,11 +83,6 @@ fun RoomToolbar(
                         text = "$participantCount",
                         style = MaterialTheme.typography.labelMedium
                     )
-                }
-            }
-            if (isOwnerOrHost) {
-                IconButton(onClick = onSettings) {
-                    Icon(Icons.Default.Settings, contentDescription = "Room settings")
                 }
             }
         }

--- a/app/src/main/java/com/shyden/shytalk/feature/room/components/SeatItem.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/components/SeatItem.kt
@@ -13,10 +13,12 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Mic
@@ -38,12 +40,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import com.shyden.shytalk.ui.theme.SpeakingGreen
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -75,19 +77,6 @@ fun SeatItem(
     val badgeIconSize = (14.dp * sizeScale).coerceAtMost(18.dp)
     val iconPadding = (14.dp * (seatSize / 70.dp)).coerceIn(14.dp, 40.dp)
 
-    // Speaking animation — transition always exists but scale only applied when speaking
-    val infiniteTransition = rememberInfiniteTransition(label = "speaking")
-    val animatedScale by infiniteTransition.animateFloat(
-        initialValue = 1f,
-        targetValue = 1.15f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(400),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "speakingScale"
-    )
-    val speakingScale = if (isSpeaking) animatedScale else 1f
-
     val borderColor by animateColorAsState(
         targetValue = when {
             isSpeaking -> SpeakingGreen
@@ -98,29 +87,45 @@ fun SeatItem(
         label = "borderColor"
     )
 
+    // Pulsing border width when speaking — expands outward from 2dp to 8dp
+    val infiniteTransition = rememberInfiniteTransition(label = "speakingPulse")
+    val pulsingWidth by infiniteTransition.animateFloat(
+        initialValue = 2f,
+        targetValue = 8f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(600),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "borderPulse"
+    )
+    val borderWidth = if (isSpeaking) pulsingWidth.dp else 2.dp
+
     Column(
         modifier = modifier.padding(4.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
         Box(contentAlignment = Alignment.Center) {
-            Surface(
+            // Outer border box for outward-pulsing speaking indicator
+            Box(
                 modifier = Modifier
-                    .size(seatSize)
-                    .then(
-                        if (isSpeaking) Modifier.scale(speakingScale) else Modifier
-                    )
+                    .size(seatSize + if (isSpeaking) borderWidth * 2 else 0.dp)
                     .then(
                         if (borderColor != Color.Transparent) {
                             Modifier.border(
-                                width = if (isSpeaking) 3.dp else 2.dp,
+                                width = borderWidth,
                                 color = borderColor,
                                 shape = CircleShape
                             )
                         } else {
                             Modifier
                         }
-                    )
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+            Surface(
+                modifier = Modifier
+                    .size(seatSize)
                     .combinedClickable(
                         onClick = {
                             if (seat.state == SeatState.OCCUPIED && !isCurrentUser && onTapUser != null) {
@@ -168,6 +173,7 @@ fun SeatItem(
                         }
                     )
                 }
+            }
             }
 
             // Role indicator badge
@@ -233,17 +239,41 @@ fun SeatItem(
 
         Spacer(modifier = Modifier.height(4.dp))
 
-        Text(
-            text = if (seat.state == SeatState.OCCUPIED && user != null) {
-                val name = user.displayName.ifEmpty { "User" }
-                "#${seatIndex + 1} $name"
-            } else {
-                "Seat ${seatIndex + 1}"
-            },
-            style = MaterialTheme.typography.labelSmall,
-            textAlign = TextAlign.Center,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
+        if (seat.state == SeatState.OCCUPIED && user != null) {
+            val name = user.displayName.ifEmpty { "User" }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.primary),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "${seatIndex + 1}",
+                        style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+                Spacer(modifier = Modifier.width(3.dp))
+                Text(
+                    text = name,
+                    style = MaterialTheme.typography.labelSmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        } else {
+            Text(
+                text = "Seat ${seatIndex + 1}",
+                style = MaterialTheme.typography.labelSmall,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
     }
 }

--- a/app/src/main/java/com/shyden/shytalk/feature/room/components/UserCardPopup.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/components/UserCardPopup.kt
@@ -18,6 +18,8 @@ import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MicOff
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PersonOff
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
@@ -59,7 +61,10 @@ fun UserCardPopup(
     onRemoveFromSeat: (() -> Unit)? = null,
     onKickFromRoom: ((String) -> Unit)? = null,
     onMoveSeat: ((Int) -> Unit)? = null,
-    emptySeats: List<Int> = emptyList()
+    emptySeats: List<Int> = emptyList(),
+    onMakeHost: (() -> Unit)? = null,
+    onRemoveHost: (() -> Unit)? = null,
+    isHost: Boolean = false
 ) {
     var showBlockConfirm by remember { mutableStateOf(false) }
     var showKickConfirm by remember { mutableStateOf(false) }
@@ -178,7 +183,7 @@ fun UserCardPopup(
                 }
 
                 // Moderation actions
-                if (onMuteToggle != null || onRemoveFromSeat != null || onMoveSeat != null || onKickFromRoom != null) {
+                if (onMuteToggle != null || onRemoveFromSeat != null || onMoveSeat != null || onKickFromRoom != null || onMakeHost != null || onRemoveHost != null) {
                     Spacer(modifier = Modifier.height(12.dp))
                     Text(
                         text = "Moderation",
@@ -203,6 +208,44 @@ fun UserCardPopup(
                         )
                         Spacer(modifier = Modifier.width(4.dp))
                         Text(if (isTargetMuted) "Unmute User" else "Mute User")
+                    }
+                }
+
+                if (onMakeHost != null) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    OutlinedButton(
+                        onClick = {
+                            onMakeHost()
+                            onDismiss()
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(
+                            Icons.Default.Star,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text("Make Host")
+                    }
+                }
+
+                if (onRemoveHost != null) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    OutlinedButton(
+                        onClick = {
+                            onRemoveHost()
+                            onDismiss()
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(
+                            Icons.Default.StarBorder,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text("Remove Host")
                     }
                 }
 

--- a/app/src/main/java/com/shyden/shytalk/feature/settings/RoomSettingsSheet.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/settings/RoomSettingsSheet.kt
@@ -7,19 +7,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.PersonRemove
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Switch
@@ -33,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.shyden.shytalk.core.model.SeatState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -65,220 +55,37 @@ fun RoomSettingsSheet(
                 modifier = Modifier.padding(bottom = 16.dp)
             )
 
-            // Lock Seating Toggle
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = "Lock Seating",
-                        style = MaterialTheme.typography.bodyLarge
-                    )
-                    Text(
-                        text = "Only the owner can invite users to sit",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                Switch(
-                    checked = uiState.room?.requireApproval ?: false,
-                    onCheckedChange = { viewModel.toggleRequireApproval() }
-                )
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-            HorizontalDivider()
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Hosts Management (owner only)
             val room = uiState.room
             val isOwner = room != null && viewModel.currentUserId == room.ownerId
 
+            // Lock Seating Toggle (owner only)
             if (isOwner) {
-                Text(
-                    text = "Hosts",
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.padding(bottom = 8.dp)
-                )
-
-                val hostIds = room.hostIds
-                if (hostIds.isEmpty()) {
-                    Text(
-                        text = "No hosts assigned",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                } else {
-                    hostIds.forEach { hostId ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = hostId,
-                                style = MaterialTheme.typography.bodyMedium,
-                                modifier = Modifier.weight(1f)
-                            )
-                            IconButton(onClick = { viewModel.removeHost(hostId) }) {
-                                Icon(
-                                    Icons.Default.PersonRemove,
-                                    contentDescription = "Remove host",
-                                    tint = MaterialTheme.colorScheme.error
-                                )
-                            }
-                        }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Lock Seating",
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                        Text(
+                            text = "Only the owner can invite users to sit",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                     }
-                }
-
-                // Show seated attendees who can be promoted to host
-                val seatedAttendees = room.seats.values.filter { seat ->
-                    seat.state == SeatState.OCCUPIED &&
-                    seat.userId != null &&
-                    seat.userId != room.ownerId &&
-                    seat.userId !in room.hostIds
-                }
-                if (seatedAttendees.isNotEmpty()) {
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = "Promote to Host",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    Switch(
+                        checked = uiState.room?.requireApproval ?: false,
+                        onCheckedChange = { viewModel.toggleRequireApproval() }
                     )
-                    seatedAttendees.forEach { seat ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = seat.userId ?: "",
-                                style = MaterialTheme.typography.bodyMedium,
-                                modifier = Modifier.weight(1f)
-                            )
-                            Button(onClick = { seat.userId?.let { viewModel.addHost(it) } }) {
-                                Text("Make Host")
-                            }
-                        }
-                    }
                 }
 
                 Spacer(modifier = Modifier.height(16.dp))
                 HorizontalDivider()
+                Spacer(modifier = Modifier.height(16.dp))
             }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Invite to Seat section
-            // Owner can always invite; hosts can invite when requireApproval is OFF
-            val canInvite = room != null && (
-                isOwner || (viewModel.currentUserId in (room.hostIds) && !room.requireApproval)
-            )
-            if (canInvite) {
-                val nonSeatedParticipants = room.participantIds.filter { pid ->
-                    pid != room.ownerId &&
-                    pid !in room.pendingInvites &&
-                    room.seats.values.none { it.isOccupiedBy(pid) }
-                }
-                if (nonSeatedParticipants.isNotEmpty()) {
-                    Text(
-                        text = "Invite to Seat",
-                        style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.padding(bottom = 8.dp)
-                    )
-                    nonSeatedParticipants.forEach { userId ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = userId,
-                                style = MaterialTheme.typography.bodyMedium,
-                                modifier = Modifier.weight(1f)
-                            )
-                            Button(onClick = { viewModel.inviteUser(userId, userId) }) {
-                                Text("Invite")
-                            }
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
-                    HorizontalDivider()
-                    Spacer(modifier = Modifier.height(16.dp))
-                }
-            }
-
-            // Pending Seat Requests
-            // When requireApproval is ON, only owner can see approve/deny
-            // When OFF, owner + hosts can see approve/deny
-            val canApprove = room != null && (
-                isOwner || (viewModel.currentUserId in (room.hostIds) && !room.requireApproval)
-            )
-
-            if (canApprove) {
-                Text(
-                    text = "Pending Seat Requests (${uiState.pendingRequests.size})",
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.padding(bottom = 8.dp)
-                )
-
-                if (uiState.pendingRequests.isEmpty()) {
-                    Text(
-                        text = "No pending requests",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                } else {
-                    LazyColumn(
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        modifier = Modifier.height(200.dp)
-                    ) {
-                        items(uiState.pendingRequests, key = { it.requestId }) { request ->
-                            Card(modifier = Modifier.fillMaxWidth()) {
-                                Row(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(12.dp),
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Column(modifier = Modifier.weight(1f)) {
-                                        Text(
-                                            text = request.userName,
-                                            style = MaterialTheme.typography.bodyMedium
-                                        )
-                                        Text(
-                                            text = "Seat ${request.seatIndex + 1}",
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                                        )
-                                    }
-                                    IconButton(onClick = { viewModel.approveRequest(request) }) {
-                                        Icon(
-                                            Icons.Default.Check,
-                                            contentDescription = "Approve",
-                                            tint = MaterialTheme.colorScheme.primary
-                                        )
-                                    }
-                                    IconButton(onClick = { viewModel.denyRequest(request) }) {
-                                        Icon(
-                                            Icons.Default.Close,
-                                            contentDescription = "Deny",
-                                            tint = MaterialTheme.colorScheme.error
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(24.dp))
 
             // Close Room Button (owner only)
             if (isOwner) {

--- a/app/src/main/java/com/shyden/shytalk/feature/settings/RoomSettingsViewModel.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/settings/RoomSettingsViewModel.kt
@@ -6,10 +6,12 @@ import com.shyden.shytalk.core.model.ChatRoom
 import com.shyden.shytalk.core.model.SeatRequest
 import com.shyden.shytalk.core.util.Constants.SEAT_REQUEST_IMMEDIATE_THRESHOLD_MS
 import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.MessageRepository
 import com.shyden.shytalk.data.repository.RoomRepository
 import com.shyden.shytalk.data.repository.SeatRequestRepository
+import com.shyden.shytalk.data.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -22,6 +24,7 @@ import javax.inject.Inject
 data class RoomSettingsUiState(
     val room: ChatRoom? = null,
     val pendingRequests: List<SeatRequest> = emptyList(),
+    val userNames: Map<String, String> = emptyMap(),
     val isLoading: Boolean = false,
     val error: String? = null
 )
@@ -31,7 +34,8 @@ class RoomSettingsViewModel @Inject constructor(
     private val roomRepository: RoomRepository,
     private val seatRequestRepository: SeatRequestRepository,
     private val messageRepository: MessageRepository,
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val userRepository: UserRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(RoomSettingsUiState())
@@ -59,12 +63,36 @@ class RoomSettingsViewModel @Inject constructor(
                         room = room,
                         pendingRequests = requests
                     )
+                    if (room != null) {
+                        resolveUserNames(room)
+                    }
                 }
         }
     }
 
+    private val resolvedIds = mutableSetOf<String>()
+
+    private suspend fun resolveUserNames(room: ChatRoom) {
+        val allIds = room.participantIds + room.hostIds + room.ownerId
+        val newIds = allIds.filter { it !in resolvedIds }
+        if (newIds.isEmpty()) return
+
+        val names = _uiState.value.userNames.toMutableMap()
+        for (id in newIds) {
+            when (val result = userRepository.getUser(id)) {
+                is Resource.Success -> {
+                    names[id] = result.data.displayName.ifEmpty { id.take(8) }
+                    resolvedIds.add(id)
+                }
+                else -> {}
+            }
+        }
+        _uiState.value = _uiState.value.copy(userNames = names)
+    }
+
     fun toggleRequireApproval() {
         val room = _uiState.value.room ?: return
+        if (currentUserId != room.ownerId) return
         viewModelScope.launch {
             roomRepository.setRequireApproval(currentRoomId, !room.requireApproval)
         }

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,8 +1,12 @@
-v0.21 - Kick reasons, locked seating & voice stability
+v0.22 - Photo caching, room editing & auto-close
 
-- Kick with reason: moderators are prompted for a reason when kicking; kicked users see who kicked them and why
-- Locked seating: when seats are locked, attendees see a clear message instead of silent failure
-- Voice stability: voice chat no longer stops when switching to WeChat or other audio apps
-- Seat numbers now shown alongside user names
-- Invite dialog dismiss fix
-- Grace period dialog suppression fix
+- Photos load faster and are saved on your device
+- Room owners can edit the room name from the toolbar
+- Rooms auto-close after 3 hours with a countdown
+- Owners can promote or demote hosts
+- Settings moved to the bottom bar
+- Speaking indicator pulses outward around the avatar
+- Room names can be up to 50 characters
+- Fixed profile flicker when switching tabs
+- Fixed voice reconnection when the owner returns
+- Owners can now kick or mute hosts

--- a/app/src/main/res/layout/chathead_bubble.xml
+++ b/app/src/main/res/layout/chathead_bubble.xml
@@ -35,6 +35,18 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 
+        <!-- Room closed overlay text (hidden by default) -->
+        <TextView
+            android:id="@+id/roomClosedText"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:text="Room\nClosed"
+            android:textColor="#FFFFFF"
+            android:textSize="11sp"
+            android:textStyle="bold"
+            android:visibility="gone" />
+
     </FrameLayout>
 
     <!-- Close button at top-right corner -->

--- a/app/src/test/java/com/shyden/shytalk/core/room/ActiveRoomManagerTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/room/ActiveRoomManagerTest.kt
@@ -560,7 +560,7 @@ class ActiveRoomManagerTest {
     }
 
     @Test
-    fun `leaveRoom - owner sets owner away`() = runTest {
+    fun `leaveRoom - owner sets owner away and keeps seat`() = runTest {
         manager.trackRoom("room-1")
         val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
         val room = TestData.createTestRoom(
@@ -572,7 +572,8 @@ class ActiveRoomManagerTest {
 
         manager.leaveRoom()
 
-        coVerify { roomRepository.leaveSeat("room-1", 0) }
+        // Owner's seat is preserved for reconnection — only setOwnerAway is called
+        coVerify(exactly = 0) { roomRepository.leaveSeat("room-1", 0) }
         coVerify { roomRepository.setOwnerAway("room-1") }
     }
 
@@ -786,5 +787,85 @@ class ActiveRoomManagerTest {
     fun `clearError clears error state`() {
         manager.clearError()
         assertNull(manager.error.value)
+    }
+
+    // --- Owner can kick/force-mute hosts (v0.18 fix) ---
+
+    @Test
+    fun `kickUser - owner can kick a host`() = runTest {
+        manager.trackRoom("room-1")
+        val seats = TestData.createDefaultSeats().toMutableMap()
+        seats["0"] = TestData.createTestSeat(userId = currentUserId)
+        seats["3"] = TestData.createTestSeat(userId = "a-host")
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            hostIds = setOf("a-host"),
+            participantIds = setOf(currentUserId, "a-host"),
+            seats = seats
+        )
+        manager.updateTrackedRoom(room)
+
+        manager.kickUser(3)
+
+        coVerify { roomRepository.kickUser("room-1", "a-host", 3, any(), any()) }
+    }
+
+    @Test
+    fun `kickUser - host cannot kick another host`() = runTest {
+        manager.trackRoom("room-1")
+        val seats = TestData.createDefaultSeats().toMutableMap()
+        seats["0"] = TestData.createTestSeat(userId = "the-owner")
+        seats["2"] = TestData.createTestSeat(userId = currentUserId)
+        seats["3"] = TestData.createTestSeat(userId = "other-host")
+        val room = TestData.createTestRoom(
+            ownerId = "the-owner",
+            hostIds = setOf(currentUserId, "other-host"),
+            participantIds = setOf("the-owner", currentUserId, "other-host"),
+            seats = seats
+        )
+        manager.updateTrackedRoom(room)
+
+        manager.kickUser(3)
+
+        coVerify(exactly = 0) { roomRepository.kickUser(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `forceMuteUser - owner can force-mute a host`() = runTest {
+        manager.trackRoom("room-1")
+        val seats = TestData.createDefaultSeats().toMutableMap()
+        seats["0"] = TestData.createTestSeat(userId = currentUserId)
+        seats["3"] = TestData.createTestSeat(userId = "a-host", isMuted = false)
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            hostIds = setOf("a-host"),
+            participantIds = setOf(currentUserId, "a-host"),
+            seats = seats
+        )
+        manager.updateTrackedRoom(room)
+
+        manager.forceMuteUser(3)
+
+        coVerify { roomRepository.toggleMute("room-1", 3, true) }
+    }
+
+    @Test
+    fun `forceMuteUser - host cannot force-mute another host`() = runTest {
+        manager.trackRoom("room-1")
+        val seats = TestData.createDefaultSeats().toMutableMap()
+        seats["0"] = TestData.createTestSeat(userId = "the-owner")
+        seats["2"] = TestData.createTestSeat(userId = currentUserId)
+        seats["3"] = TestData.createTestSeat(userId = "other-host", isMuted = false)
+        val room = TestData.createTestRoom(
+            ownerId = "the-owner",
+            hostIds = setOf(currentUserId, "other-host"),
+            participantIds = setOf("the-owner", currentUserId, "other-host"),
+            seats = seats
+        )
+        manager.updateTrackedRoom(room)
+
+        manager.forceMuteUser(3)
+
+        coVerify(exactly = 0) { roomRepository.toggleMute(any(), any(), any()) }
     }
 }

--- a/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
@@ -339,6 +339,27 @@ class RoomRepositoryImplTest {
         assertTrue(result is Resource.Error)
     }
 
+    // --- updateRoomName ---
+
+    @Test
+    fun `updateRoomName returns Success`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forResult(null)
+
+        val result = repo.updateRoomName("room-1", "New Name")
+
+        assertTrue(result is Resource.Success)
+        verify { docRef.update("name", "New Name") }
+    }
+
+    @Test
+    fun `updateRoomName returns Error on exception`() = runTest {
+        every { docRef.update(any<String>(), any()) } returns Tasks.forException(RuntimeException("fail"))
+
+        val result = repo.updateRoomName("room-1", "New Name")
+
+        assertTrue(result is Resource.Error)
+    }
+
     // --- closeAllRoomsByOwner ---
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/data/repository/StorageRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/StorageRepositoryImplTest.kt
@@ -46,4 +46,25 @@ class StorageRepositoryImplTest {
         // Verify the child path includes userId and avatars prefix
         io.mockk.verify { storageRef.child(match { it.startsWith("avatars/user-1/") && it.endsWith(".jpg") }) }
     }
+
+    // --- deleteImageByUrl ---
+
+    @Test
+    fun `deleteImageByUrl calls delete on reference from url`() = runTest {
+        val urlRef = mockk<StorageReference>(relaxed = true)
+        every { storage.getReferenceFromUrl("https://firebase.storage/photo.jpg") } returns urlRef
+        every { urlRef.delete() } returns com.google.android.gms.tasks.Tasks.forResult(null)
+
+        repo.deleteImageByUrl("https://firebase.storage/photo.jpg")
+
+        io.mockk.verify { urlRef.delete() }
+    }
+
+    @Test
+    fun `deleteImageByUrl swallows exception silently`() = runTest {
+        every { storage.getReferenceFromUrl(any()) } throws IllegalArgumentException("invalid url")
+
+        // Should not throw
+        repo.deleteImageByUrl("bad-url")
+    }
 }

--- a/app/src/test/java/com/shyden/shytalk/feature/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/profile/ProfileViewModelTest.kt
@@ -431,6 +431,84 @@ class ProfileViewModelTest {
         assertFalse(vm.uiState.value.isUploadingPhoto)
     }
 
+    @Test
+    fun `uploadProfilePhoto - deletes old photo after successful upload`() = runTest {
+        val oldUrl = "https://firebase.storage/old-profile.jpg"
+        val user = TestData.createTestUser(uid = currentUserId, profilePhotoUrl = oldUrl)
+        coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(user)
+        val uri = mockk<Uri>()
+        every { contentResolver.openInputStream(uri) } returns ByteArrayInputStream(byteArrayOf(1, 2))
+        coEvery { storageRepository.uploadImage(currentUserId, "profile_photos", any()) } returns Resource.Success("https://new.url")
+        coEvery { userRepository.updateProfile(currentUserId, any()) } returns Resource.Success(Unit)
+
+        val vm = createViewModel()
+        vm.loadProfile(null)
+        advanceUntilIdle()
+
+        vm.uploadProfilePhoto(uri)
+        advanceUntilIdle()
+
+        coVerify { storageRepository.deleteImageByUrl(oldUrl) }
+    }
+
+    @Test
+    fun `uploadProfilePhoto - no old photo skips delete`() = runTest {
+        val user = TestData.createTestUser(uid = currentUserId, profilePhotoUrl = null)
+        coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(user)
+        val uri = mockk<Uri>()
+        every { contentResolver.openInputStream(uri) } returns ByteArrayInputStream(byteArrayOf(1, 2))
+        coEvery { storageRepository.uploadImage(currentUserId, "profile_photos", any()) } returns Resource.Success("https://new.url")
+        coEvery { userRepository.updateProfile(currentUserId, any()) } returns Resource.Success(Unit)
+
+        val vm = createViewModel()
+        vm.loadProfile(null)
+        advanceUntilIdle()
+
+        vm.uploadProfilePhoto(uri)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { storageRepository.deleteImageByUrl(any()) }
+    }
+
+    @Test
+    fun `uploadProfilePhoto - upload failure does not delete old photo`() = runTest {
+        val oldUrl = "https://firebase.storage/old-profile.jpg"
+        val user = TestData.createTestUser(uid = currentUserId, profilePhotoUrl = oldUrl)
+        coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(user)
+        val uri = mockk<Uri>()
+        every { contentResolver.openInputStream(uri) } returns ByteArrayInputStream(byteArrayOf(1))
+        coEvery { storageRepository.uploadImage(any(), any(), any()) } returns Resource.Error("upload failed")
+
+        val vm = createViewModel()
+        vm.loadProfile(null)
+        advanceUntilIdle()
+
+        vm.uploadProfilePhoto(uri)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { storageRepository.deleteImageByUrl(any()) }
+    }
+
+    @Test
+    fun `uploadProfilePhoto - save url failure does not delete old photo`() = runTest {
+        val oldUrl = "https://firebase.storage/old-profile.jpg"
+        val user = TestData.createTestUser(uid = currentUserId, profilePhotoUrl = oldUrl)
+        coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(user)
+        val uri = mockk<Uri>()
+        every { contentResolver.openInputStream(uri) } returns ByteArrayInputStream(byteArrayOf(1))
+        coEvery { storageRepository.uploadImage(any(), any(), any()) } returns Resource.Success("https://new.url")
+        coEvery { userRepository.updateProfile(any(), any()) } returns Resource.Error("save failed")
+
+        val vm = createViewModel()
+        vm.loadProfile(null)
+        advanceUntilIdle()
+
+        vm.uploadProfilePhoto(uri)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { storageRepository.deleteImageByUrl(any()) }
+    }
+
     // ===== uploadCoverPhoto =====
 
     @Test
@@ -451,6 +529,26 @@ class ProfileViewModelTest {
 
         assertEquals("https://cover.url", vm.uiState.value.user?.coverPhotoUrl)
         assertFalse(vm.uiState.value.isUploadingPhoto)
+    }
+
+    @Test
+    fun `uploadCoverPhoto - deletes old cover after successful upload`() = runTest {
+        val oldUrl = "https://firebase.storage/old-cover.jpg"
+        val user = TestData.createTestUser(uid = currentUserId, coverPhotoUrl = oldUrl)
+        coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(user)
+        val uri = mockk<Uri>()
+        every { contentResolver.openInputStream(uri) } returns ByteArrayInputStream(byteArrayOf(1, 2))
+        coEvery { storageRepository.uploadImage(currentUserId, "cover_photos", any()) } returns Resource.Success("https://new-cover.url")
+        coEvery { userRepository.updateProfile(currentUserId, any()) } returns Resource.Success(Unit)
+
+        val vm = createViewModel()
+        vm.loadProfile(null)
+        advanceUntilIdle()
+
+        vm.uploadCoverPhoto(uri)
+        advanceUntilIdle()
+
+        coVerify { storageRepository.deleteImageByUrl(oldUrl) }
     }
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -33,6 +33,7 @@ import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -411,18 +412,15 @@ class RoomViewModelTest {
     }
 
     @Test
-    fun `forceMuteUser - cannot mute host`() = runTest {
+    fun `forceMuteUser - host cannot mute other host`() = runTest {
         viewModel = createViewModel()
         val otherHost = "host-2"
-        val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
-        seats["3"] = TestData.createTestSeat(userId = otherHost)
-        coEvery { userRepository.getUser(otherHost) } returns Resource.Success(
-            TestData.createTestUser(uid = otherHost, displayName = "Host 2")
-        )
-        emitRoomAsOwner(TestData.createTestRoom(
-            ownerId = currentUserId,
-            participantIds = setOf(currentUserId, otherHost),
-            hostIds = setOf(otherHost),
+        val seats = TestData.createSeatsWithOwner(ownerId).toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = otherHost, isMuted = false)
+        emitRoomAsHost(TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId, otherHost),
+            hostIds = setOf(currentUserId, otherHost),
             seats = seats
         ))
         advanceUntilIdle()
@@ -578,15 +576,15 @@ class RoomViewModelTest {
     }
 
     @Test
-    fun `kickUser - cannot kick host`() = runTest {
+    fun `kickUser - host cannot kick other host`() = runTest {
         viewModel = createViewModel()
         val otherHost = "host-2"
-        val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
+        val seats = TestData.createSeatsWithOwner(ownerId).toMutableMap()
         seats["3"] = TestData.createTestSeat(userId = otherHost)
-        emitRoomAsOwner(TestData.createTestRoom(
-            ownerId = currentUserId,
-            participantIds = setOf(currentUserId, otherHost),
-            hostIds = setOf(otherHost),
+        emitRoomAsHost(TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId, otherHost),
+            hostIds = setOf(currentUserId, otherHost),
             seats = seats
         ))
         advanceUntilIdle()
@@ -1312,12 +1310,16 @@ class RoomViewModelTest {
     @Test
     fun `pending request enqueues SeatRequestReceived notification for owner`() = runTest {
         viewModel = createViewModel()
-        emitRoomAsOwner()
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "attendee-1")
+        ))
         advanceUntilIdle()
 
         val request = TestData.createTestSeatRequest(userId = "attendee-1", userName = "Attendee")
         pendingRequestsFlow.value = listOf(request)
-        // Don't advanceUntilIdle — it advances past the 3s auto-dismiss timer
+        // Advance just enough for the flow collector to run, but not past the 3s auto-dismiss
+        advanceTimeBy(1)
 
         val notif = viewModel.uiState.value.activeNotification
         assertTrue(notif is RoomNotification.SeatRequestReceived)
@@ -1327,12 +1329,17 @@ class RoomViewModelTest {
     @Test
     fun `pending request enqueues SeatRequestReceived notification for host`() = runTest {
         viewModel = createViewModel()
-        emitRoomAsHost()
+        emitRoomAsHost(TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId, "attendee-1"),
+            hostIds = setOf(currentUserId)
+        ))
         advanceUntilIdle()
 
         val request = TestData.createTestSeatRequest(userId = "attendee-1", userName = "Attendee")
         pendingRequestsFlow.value = listOf(request)
-        // Don't advanceUntilIdle — it advances past the 3s auto-dismiss timer
+        // Advance just enough for the flow collector to run, but not past the 3s auto-dismiss
+        advanceTimeBy(1)
 
         val notif = viewModel.uiState.value.activeNotification
         assertTrue(notif is RoomNotification.SeatRequestReceived)
@@ -1354,12 +1361,16 @@ class RoomViewModelTest {
     @Test
     fun `pending requests update panel state`() = runTest {
         viewModel = createViewModel()
-        emitRoomAsOwner()
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "attendee-1")
+        ))
         advanceUntilIdle()
 
         val request = TestData.createTestSeatRequest(userId = "attendee-1", userName = "Attendee")
         pendingRequestsFlow.value = listOf(request)
-        advanceUntilIdle()
+        // Advance just enough for flow collector, but not past 3s auto-dismiss
+        advanceTimeBy(1)
 
         assertEquals(1, viewModel.uiState.value.pendingRequestsForPanel.size)
         assertEquals("attendee-1", viewModel.uiState.value.pendingRequestsForPanel[0].userId)
@@ -1368,12 +1379,16 @@ class RoomViewModelTest {
     @Test
     fun `dismissCurrentNotification clears active notification`() = runTest {
         viewModel = createViewModel()
-        emitRoomAsOwner()
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "attendee-1")
+        ))
         advanceUntilIdle()
 
         val request = TestData.createTestSeatRequest(userId = "attendee-1", userName = "Attendee")
         pendingRequestsFlow.value = listOf(request)
-        // Don't advanceUntilIdle — it advances past the 3s auto-dismiss timer
+        // Advance just enough for flow collector, but not past 3s auto-dismiss
+        advanceTimeBy(1)
         assertNotNull(viewModel.uiState.value.activeNotification)
 
         viewModel.dismissCurrentNotification()
@@ -1541,5 +1556,501 @@ class RoomViewModelTest {
         val notif = viewModel.uiState.value.activeNotification
         assertTrue(notif is RoomNotification.InviteReceived)
         assertEquals(ownerId, (notif as RoomNotification.InviteReceived).inviterUserId)
+    }
+
+    // ===== Owner Can Kick/Force-Mute Hosts (v0.18 fix) =====
+
+    @Test
+    fun `kickUser - owner can kick a host`() = runTest {
+        viewModel = createViewModel()
+        val hostUser = "host-1"
+        val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = hostUser)
+        coEvery { userRepository.getUser(hostUser) } returns Resource.Success(
+            TestData.createTestUser(uid = hostUser, displayName = "Host One")
+        )
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, hostUser),
+            hostIds = setOf(hostUser),
+            seats = seats
+        ))
+        advanceUntilIdle()
+
+        viewModel.kickUser(3)
+        advanceUntilIdle()
+
+        coVerify { roomRepository.kickUser("room-1", hostUser, 3, any(), any()) }
+        coVerify { messageRepository.sendSystemMessage("room-1", any()) }
+    }
+
+    @Test
+    fun `kickUser - host cannot kick another host`() = runTest {
+        viewModel = createViewModel()
+        val otherHost = "host-2"
+        val seats = TestData.createSeatsWithOwner(ownerId).toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = otherHost)
+        emitRoomAsHost(TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId, otherHost),
+            hostIds = setOf(currentUserId, otherHost),
+            seats = seats
+        ))
+        advanceUntilIdle()
+
+        viewModel.kickUser(3)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.kickUser(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `forceMuteUser - owner can force-mute a host`() = runTest {
+        viewModel = createViewModel()
+        val hostUser = "host-1"
+        val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = hostUser, isMuted = false)
+        coEvery { userRepository.getUser(hostUser) } returns Resource.Success(
+            TestData.createTestUser(uid = hostUser, displayName = "Host One")
+        )
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, hostUser),
+            hostIds = setOf(hostUser),
+            seats = seats
+        ))
+        advanceUntilIdle()
+
+        viewModel.forceMuteUser(3)
+        advanceUntilIdle()
+
+        coVerify { roomRepository.toggleMute("room-1", 3, true) }
+    }
+
+    @Test
+    fun `forceMuteUser - host cannot force-mute another host`() = runTest {
+        viewModel = createViewModel()
+        val otherHost = "host-2"
+        val seats = TestData.createSeatsWithOwner(ownerId).toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = otherHost, isMuted = false)
+        emitRoomAsHost(TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId, otherHost),
+            hostIds = setOf(currentUserId, otherHost),
+            seats = seats
+        ))
+        advanceUntilIdle()
+
+        viewModel.forceMuteUser(3)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.toggleMute(any(), any(), any()) }
+    }
+
+    // ===== System Messages Visible (v0.18 fix) =====
+
+    @Test
+    fun `updateFilteredMessages - system messages are included`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsOwner()
+        advanceUntilIdle()
+
+        val textMessage = TestData.createTestMessage(
+            messageId = "msg-1",
+            text = "Hello",
+            type = MessageType.TEXT,
+            createdAt = TestData.BASE_TIMESTAMP
+        )
+        val systemMessage = TestData.createTestMessage(
+            messageId = "msg-2",
+            text = "User joined the room",
+            type = MessageType.SYSTEM,
+            createdAt = TestData.BASE_TIMESTAMP
+        )
+        messagesFlow.value = listOf(textMessage, systemMessage)
+        advanceUntilIdle()
+
+        val messages = viewModel.uiState.value.messages
+        assertEquals(2, messages.size)
+        assertTrue(messages.any { it.type == MessageType.SYSTEM })
+    }
+
+    @Test
+    fun `updateFilteredMessages - system messages not filtered after firstJoinTimestamp set`() = runTest {
+        viewModel = createViewModel()
+        // Emit room with firstJoinTimestamps to trigger firstJoinTimestamp being set
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            firstJoinTimestamps = mapOf(currentUserId to TestData.BASE_TIMESTAMP)
+        )
+        emitRoomAsOwner(room)
+        advanceUntilIdle()
+
+        val systemMessage = TestData.createTestMessage(
+            messageId = "sys-1",
+            text = "Room created",
+            type = MessageType.SYSTEM,
+            createdAt = TestData.BASE_TIMESTAMP
+        )
+        val laterSystemMessage = TestData.createTestMessage(
+            messageId = "sys-2",
+            text = "User joined",
+            type = MessageType.SYSTEM,
+            createdAt = TestData.LATER_TIMESTAMP
+        )
+        messagesFlow.value = listOf(systemMessage, laterSystemMessage)
+        advanceUntilIdle()
+
+        val messages = viewModel.uiState.value.messages
+        // Both messages should be present (system messages are no longer filtered out)
+        // The only filter is the firstJoinTimestamp time-based filter
+        assertTrue(messages.any { it.type == MessageType.SYSTEM })
+    }
+
+    // ===== Stale Seat Requests Filter (v0.18 fix) =====
+
+    @Test
+    fun `pendingRequests - filters out requests where user is already seated`() = runTest {
+        viewModel = createViewModel()
+        val seatedUser = "seated-user"
+        val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = seatedUser)
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, seatedUser),
+            seats = seats
+        ))
+        advanceUntilIdle()
+
+        val staleRequest = TestData.createTestSeatRequest(
+            requestId = "req-stale",
+            userId = seatedUser,
+            userName = "Seated User",
+            seatIndex = 5
+        )
+        pendingRequestsFlow.value = listOf(staleRequest)
+        advanceUntilIdle()
+
+        assertEquals(0, viewModel.uiState.value.pendingRequestsForPanel.size)
+    }
+
+    @Test
+    fun `pendingRequests - filters out requests where user left the room`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId)  // "gone-user" is NOT in participantIds
+        ))
+        advanceUntilIdle()
+
+        val staleRequest = TestData.createTestSeatRequest(
+            requestId = "req-gone",
+            userId = "gone-user",
+            userName = "Gone User",
+            seatIndex = 3
+        )
+        pendingRequestsFlow.value = listOf(staleRequest)
+        advanceUntilIdle()
+
+        assertEquals(0, viewModel.uiState.value.pendingRequestsForPanel.size)
+    }
+
+    @Test
+    fun `pendingRequests - keeps valid requests and filters stale ones`() = runTest {
+        viewModel = createViewModel()
+        val seatedUser = "seated-user"
+        val validUser = "valid-user"
+        val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = seatedUser)
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, seatedUser, validUser),
+            seats = seats
+        ))
+        advanceUntilIdle()
+
+        val staleRequest = TestData.createTestSeatRequest(
+            requestId = "req-stale",
+            userId = seatedUser,
+            userName = "Seated User",
+            seatIndex = 5
+        )
+        val validRequest = TestData.createTestSeatRequest(
+            requestId = "req-valid",
+            userId = validUser,
+            userName = "Valid User",
+            seatIndex = 4
+        )
+        pendingRequestsFlow.value = listOf(staleRequest, validRequest)
+        advanceUntilIdle()
+
+        assertEquals(1, viewModel.uiState.value.pendingRequestsForPanel.size)
+        assertEquals("req-valid", viewModel.uiState.value.pendingRequestsForPanel[0].requestId)
+    }
+
+    // ===== addHost / removeHost from RoomViewModel (v0.18 feature) =====
+
+    @Test
+    fun `addHost - owner can add a host`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsOwner()
+        advanceUntilIdle()
+
+        viewModel.addHost("user-2")
+        advanceUntilIdle()
+
+        coVerify { roomRepository.addHost("room-1", "user-2") }
+        coVerify { messageRepository.sendSystemMessage("room-1", match { it.contains("promoted to host") }) }
+    }
+
+    @Test
+    fun `addHost - non-owner cannot add a host`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsHost()
+        advanceUntilIdle()
+
+        viewModel.addHost("user-2")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.addHost(any(), any()) }
+    }
+
+    @Test
+    fun `addHost - attendee cannot add a host`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsAttendee()
+        advanceUntilIdle()
+
+        viewModel.addHost("user-2")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.addHost(any(), any()) }
+    }
+
+    @Test
+    fun `removeHost - owner can remove a host`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            hostIds = setOf("user-2")
+        ))
+        advanceUntilIdle()
+
+        viewModel.removeHost("user-2")
+        advanceUntilIdle()
+
+        coVerify { roomRepository.removeHost("room-1", "user-2") }
+        coVerify { messageRepository.sendSystemMessage("room-1", match { it.contains("removed as host") }) }
+    }
+
+    @Test
+    fun `removeHost - non-owner cannot remove a host`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsHost(TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId, "host-2"),
+            hostIds = setOf(currentUserId, "host-2")
+        ))
+        advanceUntilIdle()
+
+        viewModel.removeHost("host-2")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.removeHost(any(), any()) }
+    }
+
+    // ===== ownerReturn Tests =====
+
+    @Test
+    fun `ownerReturn - re-establishes presence when not in room`() = runTest {
+        viewModel = createViewModel()
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            state = RoomState.OWNER_AWAY
+        )
+        emitRoomAsOwner(room)
+        advanceUntilIdle()
+        every { activeRoomManager.isInRoom("room-1") } returns false
+
+        viewModel.ownerReturn()
+        advanceUntilIdle()
+
+        coVerify { roomRepository.setOwnerReturned("room-1", currentUserId) }
+        coVerify { presenceService.setPresence("room-1", currentUserId) }
+        verify { activeRoomManager.trackRoom("room-1") }
+    }
+
+    @Test
+    fun `ownerReturn - skips presence setup when already in room`() = runTest {
+        // Set isInRoom BEFORE creating VM and emitting room so the alreadyInRoom path is taken
+        every { activeRoomManager.isInRoom("room-1") } returns true
+        roomFlow.value = TestData.createTestRoom(
+            ownerId = currentUserId,
+            state = RoomState.OWNER_AWAY
+        )
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.ownerReturn()
+        advanceUntilIdle()
+
+        coVerify { roomRepository.setOwnerReturned("room-1", currentUserId) }
+        // Neither joinRoom (early return) nor ownerReturn calls setPresence when already in room
+        coVerify(exactly = 0) { presenceService.setPresence(any(), any()) }
+    }
+
+    @Test
+    fun `ownerReturn - rejoins voice when not joined`() = runTest {
+        viewModel = createViewModel()
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            state = RoomState.OWNER_AWAY
+        )
+        emitRoomAsOwner(room)
+        advanceUntilIdle()
+        joinedFlow.value = false
+
+        viewModel.ownerReturn()
+        advanceUntilIdle()
+
+        coVerify { agoraVoiceService.joinChannel("channel-1", any(), asBroadcaster = any()) }
+    }
+
+    @Test
+    fun `ownerReturn - sets broadcaster role when already joined`() = runTest {
+        viewModel = createViewModel()
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            state = RoomState.OWNER_AWAY
+        )
+        emitRoomAsOwner(room)
+        advanceUntilIdle()
+        joinedFlow.value = true
+
+        viewModel.ownerReturn()
+        advanceUntilIdle()
+
+        verify { agoraVoiceService.setRole(true) }
+    }
+
+    @Test
+    fun `ownerReturn - non-owner cannot return`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsAttendee()
+        advanceUntilIdle()
+
+        viewModel.ownerReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.setOwnerReturned(any(), any()) }
+    }
+
+    // ===== updateRoomName Tests =====
+
+    @Test
+    fun `updateRoomName - owner can update room name`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsOwner()
+        advanceUntilIdle()
+
+        viewModel.updateRoomName("New Room Name")
+        advanceUntilIdle()
+
+        coVerify { roomRepository.updateRoomName("room-1", "New Room Name") }
+    }
+
+    @Test
+    fun `updateRoomName - non-owner cannot update room name`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsAttendee()
+        advanceUntilIdle()
+
+        viewModel.updateRoomName("Hacked Name")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.updateRoomName(any(), any()) }
+    }
+
+    @Test
+    fun `updateRoomName - host cannot update room name`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsHost()
+        advanceUntilIdle()
+
+        viewModel.updateRoomName("Host Name")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.updateRoomName(any(), any()) }
+    }
+
+    @Test
+    fun `updateRoomName - no room does nothing`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.updateRoomName("No Room")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.updateRoomName(any(), any()) }
+    }
+
+    // ===== Room Expiry Countdown Tests =====
+
+    @Test
+    fun `room expiry - countdown not started when room has plenty of time`() = runTest {
+        viewModel = createViewModel()
+        emitRoomAsOwner()
+        advanceUntilIdle()
+
+        // Room created just now — over 5 minutes remain, no countdown active
+        assertEquals(0L, viewModel.uiState.value.roomExpiryRemainingMs)
+    }
+
+    @Test
+    fun `room expiry - owner closes room when time expires`() = runTest {
+        viewModel = createViewModel()
+        val expiredRoom = TestData.createTestRoom(
+            ownerId = currentUserId,
+            createdAt = Timestamp(Date(System.currentTimeMillis() - Constants.MAX_ROOM_DURATION_MS - 1000L))
+        )
+        emitRoomAsOwner(expiredRoom)
+        advanceUntilIdle()
+
+        coVerify { roomRepository.closeRoom("room-1") }
+    }
+
+    @Test
+    fun `room expiry - non-owner does not close room when time expires`() = runTest {
+        viewModel = createViewModel()
+        val expiredRoom = TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId),
+            createdAt = Timestamp(Date(System.currentTimeMillis() - Constants.MAX_ROOM_DURATION_MS - 1000L))
+        )
+        emitRoomAsAttendee(expiredRoom)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.closeRoom(any()) }
+    }
+
+    @Test
+    fun `room expiry - sends system message when under 5 minutes`() = runTest {
+        viewModel = createViewModel()
+        // Room with ~10 seconds remaining — short enough to fully advance through
+        val nearExpiryRoom = TestData.createTestRoom(
+            ownerId = currentUserId,
+            createdAt = Timestamp(Date(System.currentTimeMillis() - Constants.MAX_ROOM_DURATION_MS + 10_000L))
+        )
+        emitRoomAsOwner(nearExpiryRoom)
+        advanceTimeBy(1001L)
+
+        coVerify {
+            messageRepository.sendSystemMessage("room-1", match { it.contains("maximum time") })
+        }
+        val remaining = viewModel.uiState.value.roomExpiryRemainingMs
+        assertTrue("Expected remaining > 0 but was $remaining", remaining > 0)
+
+        // Advance through remaining time so the loop completes
+        advanceUntilIdle()
     }
 }

--- a/app/src/test/java/com/shyden/shytalk/feature/settings/RoomSettingsViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/settings/RoomSettingsViewModelTest.kt
@@ -8,6 +8,7 @@ import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.MessageRepository
 import com.shyden.shytalk.data.repository.RoomRepository
 import com.shyden.shytalk.data.repository.SeatRequestRepository
+import com.shyden.shytalk.data.repository.UserRepository
 import com.shyden.shytalk.testutil.MainDispatcherRule
 import com.shyden.shytalk.testutil.TestData
 import io.mockk.coEvery
@@ -19,8 +20,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -35,6 +39,7 @@ class RoomSettingsViewModelTest {
     private val seatRequestRepository = mockk<SeatRequestRepository>(relaxed = true)
     private val messageRepository = mockk<MessageRepository>(relaxed = true)
     private val authRepository = mockk<AuthRepository>(relaxed = true)
+    private val userRepository = mockk<UserRepository>(relaxed = true)
 
     private val currentUserId = "current-user"
     private val ownerId = "owner-1"
@@ -53,7 +58,8 @@ class RoomSettingsViewModelTest {
         roomRepository = roomRepository,
         seatRequestRepository = seatRequestRepository,
         messageRepository = messageRepository,
-        authRepository = authRepository
+        authRepository = authRepository,
+        userRepository = userRepository
     )
 
     private fun loadRoomAsOwner(vm: RoomSettingsViewModel, requireApproval: Boolean = false) {
@@ -315,6 +321,111 @@ class RoomSettingsViewModelTest {
         advanceUntilIdle()
 
         coVerify { roomRepository.setRequireApproval(roomId, true) }
+    }
+
+    // ===== toggleRequireApproval owner-only (v0.18 fix) =====
+
+    @Test
+    fun `toggleRequireApproval - host cannot toggle`() = runTest {
+        val vm = createViewModel()
+        loadRoomAsHost(vm, requireApproval = false)
+        advanceUntilIdle()
+
+        vm.toggleRequireApproval()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.setRequireApproval(any(), any()) }
+    }
+
+    @Test
+    fun `toggleRequireApproval - attendee cannot toggle`() = runTest {
+        val vm = createViewModel()
+        loadRoomAsAttendee(vm)
+        advanceUntilIdle()
+
+        vm.toggleRequireApproval()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.setRequireApproval(any(), any()) }
+    }
+
+    @Test
+    fun `toggleRequireApproval - owner toggles ON to OFF`() = runTest {
+        val vm = createViewModel()
+        loadRoomAsOwner(vm, requireApproval = true)
+        advanceUntilIdle()
+
+        vm.toggleRequireApproval()
+        advanceUntilIdle()
+
+        coVerify { roomRepository.setRequireApproval(roomId, false) }
+    }
+
+    // ===== resolveUserNames =====
+
+    @Test
+    fun `loadRoom resolves user names for participants`() = runTest {
+        coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(
+            TestData.createTestUser(uid = currentUserId, displayName = "Current User")
+        )
+        val vm = createViewModel()
+        loadRoomAsOwner(vm)
+        advanceUntilIdle()
+
+        val names = vm.uiState.value.userNames
+        assertTrue(names.containsKey(currentUserId))
+        assertEquals("Current User", names[currentUserId])
+    }
+
+    @Test
+    fun `resolveUserNames falls back to ID prefix for empty displayName`() = runTest {
+        coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(
+            TestData.createTestUser(uid = currentUserId, displayName = "")
+        )
+        val vm = createViewModel()
+        loadRoomAsOwner(vm)
+        advanceUntilIdle()
+
+        val names = vm.uiState.value.userNames
+        assertEquals(currentUserId.take(8), names[currentUserId])
+    }
+
+    @Test
+    fun `resolveUserNames skips already resolved IDs on subsequent emissions`() = runTest {
+        coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(
+            TestData.createTestUser(uid = currentUserId, displayName = "Current User")
+        )
+        val roomFlow = MutableStateFlow(TestData.createTestRoom(
+            roomId = roomId,
+            ownerId = currentUserId
+        ))
+        every { roomRepository.getRoomFlow(roomId) } returns roomFlow
+        val vm = createViewModel()
+        vm.loadRoom(roomId)
+        advanceUntilIdle()
+
+        // Re-emit the same room (e.g. a field changed)
+        roomFlow.value = TestData.createTestRoom(
+            roomId = roomId,
+            ownerId = currentUserId,
+            name = "Updated Name"
+        )
+        advanceUntilIdle()
+
+        // getUser should only be called once for the same ID
+        coVerify(exactly = 1) { userRepository.getUser(currentUserId) }
+    }
+
+    @Test
+    fun `resolveUserNames handles failed lookup gracefully`() = runTest {
+        coEvery { userRepository.getUser(currentUserId) } returns Resource.Error("not found")
+        val vm = createViewModel()
+        loadRoomAsOwner(vm)
+        advanceUntilIdle()
+
+        // Name not added on failure, no crash
+        assertFalse(vm.uiState.value.userNames.containsKey(currentUserId))
+        assertNull(vm.uiState.value.error) // no global error set
     }
 
     // ===== clearError =====

--- a/app/src/test/java/com/shyden/shytalk/testutil/TestData.kt
+++ b/app/src/test/java/com/shyden/shytalk/testutil/TestData.kt
@@ -63,6 +63,7 @@ object TestData {
         seats: Map<String, Seat> = createSeatsWithOwner(ownerId),
         agoraChannelName: String = "channel-1",
         firstJoinTimestamps: Map<String, Timestamp> = emptyMap(),
+        createdAt: Timestamp = Timestamp.now(),
         ownerLeftAt: Timestamp? = null,
         closedAt: Timestamp? = null
     ) = ChatRoom(
@@ -79,7 +80,7 @@ object TestData {
         seats = seats,
         agoraChannelName = agoraChannelName,
         firstJoinTimestamps = firstJoinTimestamps,
-        createdAt = BASE_TIMESTAMP,
+        createdAt = createdAt,
         ownerLeftAt = ownerLeftAt,
         closedAt = closedAt
     )


### PR DESCRIPTION
## Summary
- **Photo caching**: Disk + memory cache via ImageLoaderFactory — photos load instantly after first view
- **Room name editing**: Owner can edit room name from toolbar; non-owners see read-only view
- **Room auto-close**: 3-hour maximum with 5-minute countdown warning and system message
- **Host management**: Owner can promote/demote hosts with system messages
- **Settings relocated**: Moved from toolbar to bottom bar (left of mic)
- **Speaking indicator**: Outward-pulsing green border (2dp-8dp)
- **Room name limit**: Increased to 50 characters (create + edit)
- **Old photo cleanup**: Deletes previous profile/cover photo from Storage on upload
- **Bug fixes**: Profile flicker, owner seat preservation on disconnect, voice reconnection on owner return, owner can kick/mute hosts, system messages visible, stale seat request filtering, ChatHead "Room Closed" display

## Test plan
- [x] 457 unit tests passing (+86 new)
- [ ] Create room with 50-char name
- [ ] Edit room name as owner, verify non-owner sees read-only
- [ ] Verify photos load from cache after app restart
- [ ] Let room run to 3-hour mark, verify countdown + auto-close
- [ ] Promote/demote host, verify system messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)