### PR TITLE
Disconnect dimming, mute preservation & optimizations v0.25

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 24
-        versionName = "0.24"
+        versionCode = 25
+        versionName = "0.25"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/shyden/shytalk/ShyTalkApp.kt
+++ b/app/src/main/java/com/shyden/shytalk/ShyTalkApp.kt
@@ -9,6 +9,8 @@ import coil.disk.DiskCache
 import coil.memory.MemoryCache
 import com.shyden.shytalk.core.util.Constants
 import dagger.hilt.android.HiltAndroidApp
+import okhttp3.Cache
+import okhttp3.OkHttpClient
 
 @HiltAndroidApp
 class ShyTalkApp : Application(), ImageLoaderFactory {
@@ -24,6 +26,17 @@ class ShyTalkApp : Application(), ImageLoaderFactory {
                 DiskCache.Builder()
                     .directory(cacheDir.resolve("image_cache"))
                     .maxSizeBytes(50L * 1024 * 1024)
+                    .build()
+            }
+            .okHttpClient {
+                OkHttpClient.Builder()
+                    .cache(Cache(cacheDir.resolve("http_cache"), 25L * 1024 * 1024))
+                    .addNetworkInterceptor { chain ->
+                        chain.proceed(chain.request()).newBuilder()
+                            .removeHeader("Pragma")
+                            .header("Cache-Control", "public, max-age=86400, immutable")
+                            .build()
+                    }
                     .build()
             }
             .crossfade(true)

--- a/app/src/main/java/com/shyden/shytalk/core/model/ChatRoom.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/model/ChatRoom.kt
@@ -27,6 +27,10 @@ data class ChatRoom(
         else -> RoomRole.ATTENDEE
     }
 
+    /** Finds the seat entry occupied by the given user, or null if not seated. */
+    fun findUserSeat(userId: String): Map.Entry<String, Seat>? =
+        seats.entries.find { it.value.isOccupiedBy(userId) }
+
     fun toMap(): Map<String, Any?> = mapOf(
         "roomId" to roomId,
         "name" to name,

--- a/app/src/main/java/com/shyden/shytalk/core/model/Seat.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/model/Seat.kt
@@ -15,6 +15,9 @@ data class Seat(
     )
 
     companion object {
+        /** Cached toMap() result for a default empty seat — avoids repeated allocations. */
+        val EMPTY_MAP: Map<String, Any?> = Seat().toMap()
+
         fun fromMap(map: Map<String, Any?>): Seat = Seat(
             userId = map["userId"] as? String,
             state = (map["state"] as? String)?.let {

--- a/app/src/main/java/com/shyden/shytalk/core/room/ActiveRoomManager.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/room/ActiveRoomManager.kt
@@ -41,6 +41,10 @@ class ActiveRoomManager @Inject constructor(
     private val presenceService: PresenceService,
     @param:ApplicationContext private val context: Context
 ) {
+    companion object {
+        private const val TAG = "ActiveRoomManager"
+    }
+
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     private val _activeRoomId = MutableStateFlow<String?>(null)
@@ -66,6 +70,9 @@ class ActiveRoomManager @Inject constructor(
     private var ownerAwayCountdownJob: Job? = null
     private val _isRoomScreenVisible = MutableStateFlow(false)
     val isRoomScreenVisible: StateFlow<Boolean> = _isRoomScreenVisible.asStateFlow()
+
+    private val _disconnectedUserIds = MutableStateFlow<Set<String>>(emptySet())
+    val disconnectedUserIds: StateFlow<Set<String>> = _disconnectedUserIds.asStateFlow()
 
     private var connectionMonitorJob: Job? = null
     private var presenceMonitorJob: Job? = null
@@ -102,11 +109,16 @@ class ActiveRoomManager @Inject constructor(
 
     /** Called by RoomViewModel when user explicitly leaves. Stops service. */
     fun untrackRoom() {
+        connectionMonitorJob?.cancel()
+        presenceMonitorJob?.cancel()
+        ownerAwayCountdownJob?.cancel()
+        isSeated = false
         _activeRoomId.value = null
         _activeRoom.value = null
         _messages.value = emptyList()
         _ownerAwayRemainingMs.value = 0L
         _roomClosed.value = false
+        _disconnectedUserIds.value = emptySet()
         RoomService.stop(context)
     }
 
@@ -133,28 +145,42 @@ class ActiveRoomManager @Inject constructor(
     }
 
     suspend fun leaveRoom() {
-        val roomId = _activeRoomId.value ?: return
-        val room = _activeRoom.value ?: return
+        val roomId = _activeRoomId.value ?: run {
+            Log.d(TAG, "leaveRoom: no activeRoomId, returning")
+            return
+        }
+        val room = _activeRoom.value ?: run {
+            Log.d(TAG, "leaveRoom: no activeRoom, returning")
+            return
+        }
         val userId = currentUserId
+        val isOwner = room.ownerId == userId
+        Log.d(TAG, "leaveRoom: roomId=$roomId userId=$userId isOwner=$isOwner")
 
         presenceService.removePresence()
 
-        // Vacate seat — but keep owner in seat 0 for reconnection
-        val mySeatEntry = room.seats.entries.find { it.value.isOccupiedBy(userId) }
-        if (mySeatEntry != null) {
-            val seatIndex = mySeatEntry.key.toInt()
-            if (seatIndex == Constants.OWNER_SEAT_INDEX && room.ownerId == userId) {
-                // Owner keeps their seat for reconnection — just mark away
+        // Vacate seat — owner keeps seat 0 for reconnection
+        val mySeatEntry = room.findUserSeat(userId)
+        if (isOwner) {
+            val anyoneOnMic = room.seats.any { (_, seat) ->
+                seat.userId != null && seat.userId != userId && seat.state == SeatState.OCCUPIED
+            }
+            if (anyoneOnMic) {
+                Log.d(TAG, "leaveRoom: owner → setOwnerAway (others present, seat preserved)")
                 roomRepository.setOwnerAway(roomId)
             } else {
-                roomRepository.leaveSeat(roomId, seatIndex)
+                Log.d(TAG, "leaveRoom: owner alone → closeRoom")
+                roomRepository.closeRoom(roomId)
             }
+        } else if (mySeatEntry != null) {
+            Log.d(TAG, "leaveRoom: non-owner → leaveSeat(${mySeatEntry.key})")
+            roomRepository.leaveSeat(roomId, mySeatEntry.key.toInt())
         }
 
         agoraVoiceService.leaveChannel()
 
         // Non-owners leave the participant list
-        if (room.ownerId != userId) {
+        if (!isOwner) {
             roomRepository.leaveRoom(roomId, userId)
         }
 
@@ -175,10 +201,10 @@ class ActiveRoomManager @Inject constructor(
     }
 
     private fun findMySeat(room: ChatRoom, userId: String = currentUserId) =
-        room.seats.values.find { it.isOccupiedBy(userId) }
+        room.findUserSeat(userId)?.value
 
     private fun isUserSeated(room: ChatRoom, userId: String = currentUserId) =
-        room.seats.values.any { it.isOccupiedBy(userId) }
+        room.findUserSeat(userId) != null
 
     private fun cleanup() {
         roomObserverJob?.cancel()
@@ -192,6 +218,7 @@ class ActiveRoomManager @Inject constructor(
         _messages.value = emptyList()
         _ownerAwayRemainingMs.value = 0L
         _roomClosed.value = false
+        _disconnectedUserIds.value = emptySet()
 
         RoomService.stop(context)
     }
@@ -267,6 +294,7 @@ class ActiveRoomManager @Inject constructor(
             agoraVoiceService.connectionState.collect { state ->
                 val room = _activeRoom.value ?: return@collect
                 val userId = currentUserId
+                Log.d(TAG, "connectionMonitor: state=$state userId=$userId ownerId=${room.ownerId} seated=${isUserSeated(room, userId)} wasEver=$wasEverConnected")
 
                 // Only monitor when user is seated (has an Agora connection)
                 val currentlySeated = isUserSeated(room, userId)
@@ -283,6 +311,19 @@ class ActiveRoomManager @Inject constructor(
                     }
                     AgoraVoiceService.ConnectionState.DISCONNECTED -> {
                         if (!wasEverConnected) return@collect
+
+                        // Owner must NOT leave from their own device on network loss.
+                        // The presence monitor on other devices will detect the
+                        // owner's absence and call removeDisconnectedUser, which
+                        // correctly transitions the room to OWNER_AWAY while
+                        // preserving seat 0.  If the owner's device queues a
+                        // leaveRoom() while offline, the Firestore writes can
+                        // overwrite the correct state when connectivity returns.
+                        val isOwner = room.ownerId == userId
+                        if (isOwner) {
+                            Log.d(TAG, "connectionMonitor: owner disconnected — skipping leaveRoom, presence system will handle")
+                            return@collect
+                        }
 
                         graceJob?.cancel()
                         graceJob = scope.launch {
@@ -306,8 +347,15 @@ class ActiveRoomManager @Inject constructor(
         presenceMonitorJob = scope.launch {
             val graceTimers = mutableMapOf<String, Job>()
 
+            fun emitDisconnectedIds() {
+                val newSet = graceTimers.keys.toSet()
+                if (newSet != _disconnectedUserIds.value) {
+                    _disconnectedUserIds.value = newSet
+                }
+            }
+
             presenceService.observeRoomPresence(roomId)
-                .catch { e -> Log.w("ActiveRoomManager", "Presence monitor error", e) }
+                .catch { e -> Log.w(TAG, "Presence monitor error", e) }
                 .collect { presentUserIds ->
                     val room = _activeRoom.value ?: return@collect
                     val participantIds = room.participantIds
@@ -328,8 +376,11 @@ class ActiveRoomManager @Inject constructor(
                             delay(Constants.PRESENCE_TIMEOUT_MS)
                             roomRepository.removeDisconnectedUser(roomId, userId)
                             graceTimers.remove(userId)
+                            emitDisconnectedIds()
                         }
                     }
+
+                    emitDisconnectedIds()
                 }
         }
     }
@@ -342,9 +393,8 @@ class ActiveRoomManager @Inject constructor(
                     val elapsed = System.currentTimeMillis() - room.ownerLeftAt.toDate().time
                     val remaining = Constants.OWNER_LEAVE_TIMEOUT_MS - elapsed
                     if (remaining <= 0) {
-                        if (room.resolveRole(currentUserId) == RoomRole.OWNER) {
-                            roomRepository.closeRoom(room.roomId)
-                        }
+                        // Any remaining participant can close an expired OWNER_AWAY room
+                        roomRepository.closeRoom(room.roomId)
                         break
                     }
                     _ownerAwayRemainingMs.value = remaining
@@ -377,7 +427,7 @@ class ActiveRoomManager @Inject constructor(
         }
         if (role == RoomRole.HOST && room.requireApproval) return
 
-        val currentSeatEntry = room.seats.entries.find { it.value.isOccupiedBy(userId) }
+        val currentSeatEntry = room.findUserSeat(userId)
         if (currentSeatEntry != null) {
             roomRepository.leaveSeat(roomId, currentSeatEntry.key.toInt())
         }

--- a/app/src/main/java/com/shyden/shytalk/core/room/RoomService.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/room/RoomService.kt
@@ -202,6 +202,7 @@ class RoomService : Service() {
 
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
+        android.util.Log.d("RoomService", "onTaskRemoved: app swiped from recents, calling leaveRoom")
         // Process is being killed — use runBlocking to ensure Firestore cleanup completes
         runBlocking {
             withContext(NonCancellable) {

--- a/app/src/main/java/com/shyden/shytalk/data/remote/AgoraVoiceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/AgoraVoiceService.kt
@@ -1,6 +1,7 @@
 package com.shyden.shytalk.data.remote
 
 import android.content.Context
+import android.os.SystemClock
 import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.agora.rtc2.ChannelMediaOptions
@@ -13,6 +14,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import com.shyden.shytalk.core.util.Constants as AppConstants
 import javax.inject.Singleton
@@ -64,6 +66,13 @@ class AgoraVoiceService @Inject constructor(
     @Volatile private var isLocalMuted = false
     private val joinMutex = Mutex()
 
+    // Track last-seen timestamp per speaker UID to merge split SDK callbacks.
+    // The Agora SDK fires onAudioVolumeIndication multiple times per interval
+    // (once for local, once for remote), each replacing the previous set.
+    // By keeping speakers "alive" for one full interval window, both local
+    // and remote speakers remain visible simultaneously.
+    private val speakerLastSeen = ConcurrentHashMap<Int, Long>()
+
     private val _speakingUsers = MutableStateFlow<Set<Int>>(emptySet())
     val speakingUsers: StateFlow<Set<Int>> = _speakingUsers.asStateFlow()
 
@@ -81,14 +90,24 @@ class AgoraVoiceService @Inject constructor(
     private val rtcEventHandler = object : IRtcEngineEventHandler() {
         override fun onJoinChannelSuccess(channel: String?, uid: Int, elapsed: Int) {
             Log.d(TAG, "onJoinChannelSuccess channel=$channel uid=$uid elapsed=${elapsed}ms")
+            localUid = uid  // Use Agora-confirmed UID
             _isJoined.value = true
             _connectionState.value = ConnectionState.CONNECTED
+            // Ensure volume indication is active after channel join completes —
+            // calls made before onJoinChannelSuccess may be ignored by the SDK.
+            // reportVad=false so local + remote speakers arrive in ONE callback.
+            rtcEngine?.enableAudioVolumeIndication(
+                AppConstants.AGORA_VOLUME_INDICATION_INTERVAL_MS,
+                AppConstants.AGORA_VOLUME_INDICATION_SMOOTH,
+                false
+            )
         }
 
         override fun onLeaveChannel(stats: RtcStats?) {
             Log.d(TAG, "onLeaveChannel")
             _isJoined.value = false
             _speakingUsers.value = emptySet()
+            speakerLastSeen.clear()
             _connectionState.value = ConnectionState.DISCONNECTED
         }
 
@@ -111,16 +130,28 @@ class AgoraVoiceService @Inject constructor(
             speakers: Array<out AudioVolumeInfo>?,
             totalVolume: Int
         ) {
-            if (Log.isLoggable(TAG, Log.VERBOSE)) {
-                speakers?.forEach {
-                    Log.v(TAG, "volumeIndication uid=${it.uid} vol=${it.volume} vad=${it.vad}")
-                }
+            val now = SystemClock.elapsedRealtime()
+            val newSpeakers = processSpeakers(speakers, localUid, isLocalMuted)
+
+            // Record timestamp for each speaker reported in this callback
+            for (uid in newSpeakers) {
+                speakerLastSeen[uid] = now
             }
-            // Fast path: skip allocation when no speakers and already empty
-            if (speakers.isNullOrEmpty() && _speakingUsers.value.isEmpty()) return
-            val speaking = processSpeakers(speakers, localUid, isLocalMuted)
-            if (speaking != _speakingUsers.value) {
-                _speakingUsers.value = speaking
+
+            // Keep speakers visible for one full interval + margin so split
+            // callbacks (local vs remote) don't erase each other
+            val keepWindow = AppConstants.AGORA_VOLUME_INDICATION_INTERVAL_MS + 100L
+            val active = speakerLastSeen.entries
+                .filter { now - it.value < keepWindow }
+                .map { it.key }
+                .toSet()
+
+            // Prune stale entries
+            speakerLastSeen.entries.removeIf { now - it.value >= keepWindow }
+
+            if (active != _speakingUsers.value) {
+                Log.d(TAG, "speakingUsers changed: $active (was: ${_speakingUsers.value})")
+                _speakingUsers.value = active
             }
         }
 
@@ -158,7 +189,7 @@ class AgoraVoiceService @Inject constructor(
                 enableAudioVolumeIndication(
                     AppConstants.AGORA_VOLUME_INDICATION_INTERVAL_MS,
                     AppConstants.AGORA_VOLUME_INDICATION_SMOOTH,
-                    true
+                    false
                 )
                 setDefaultAudioRoutetoSpeakerphone(true)
                 // Keep audio session alive when another app (e.g. WeChat) takes audio focus
@@ -228,7 +259,7 @@ class AgoraVoiceService @Inject constructor(
                 engine.enableAudioVolumeIndication(
                     AppConstants.AGORA_VOLUME_INDICATION_INTERVAL_MS,
                     AppConstants.AGORA_VOLUME_INDICATION_SMOOTH,
-                    true
+                    false
                 )
                 Log.d(TAG, "joinChannel call succeeded (waiting for onJoinChannelSuccess callback)")
                 if (asBroadcaster) {
@@ -269,7 +300,7 @@ class AgoraVoiceService @Inject constructor(
             engine.enableAudioVolumeIndication(
                 AppConstants.AGORA_VOLUME_INDICATION_INTERVAL_MS,
                 AppConstants.AGORA_VOLUME_INDICATION_SMOOTH,
-                true
+                false
             )
         } catch (e: Exception) {
             Log.e(TAG, "setRole failed", e)
@@ -310,6 +341,7 @@ class AgoraVoiceService @Inject constructor(
         rtcEngine = null
         _isJoined.value = false
         _speakingUsers.value = emptySet()
+        speakerLastSeen.clear()
         _connectionState.value = ConnectionState.DISCONNECTED
         isLocalMuted = false
     }

--- a/app/src/main/java/com/shyden/shytalk/data/remote/PresenceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/PresenceService.kt
@@ -43,7 +43,11 @@ class PresenceService @Inject constructor(
         val userId = currentUserId ?: return
 
         val ref = database.getReference("presence/$roomId/$userId")
-        ref.onDisconnect().cancel()
+        // Do NOT cancel onDisconnect — it serves as a safety net.
+        // If removeValue() succeeds, the onDisconnect becomes a harmless no-op.
+        // If the process is killed before removeValue() completes, the
+        // onDisconnect fires when the RTDB connection drops and triggers
+        // the Cloud Function to clean up the room.
         ref.removeValue()
         Log.d(TAG, "Presence removed for room=$roomId user=$userId")
 

--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
@@ -25,6 +25,11 @@ class RoomRepositoryImpl @Inject constructor(
 
     companion object {
         private const val TAG = "RoomRepositoryImpl"
+
+        /** Cached map for resetting all 8 seats to empty — avoids re-creating on every call. */
+        private val EMPTY_SEATS_UPDATE: Map<String, Any> by lazy {
+            (0 until Constants.MAX_SEATS).associate { i -> "seats.$i" to Seat.EMPTY_MAP }
+        }
     }
 
     private val roomsCollection = firestore.collection("rooms")
@@ -100,12 +105,7 @@ class RoomRepositoryImpl @Inject constructor(
             if (remaining.isEmpty() ||
                 (remaining.singleOrNull() == room.ownerId && room.state == RoomState.OWNER_AWAY)) {
                 // Room is empty — close it
-                val updates = emptySeatsUpdate() + mapOf(
-                    "state" to RoomState.CLOSED.name,
-                    "closedAt" to Timestamp.now(),
-                    "participantIds" to emptyList<String>()
-                )
-                transaction.update(docRef, updates)
+                transaction.update(docRef, closeRoomUpdates())
             } else {
                 transaction.update(docRef, mapOf(
                     "participantIds" to FieldValue.arrayRemove(userId)
@@ -129,7 +129,7 @@ class RoomRepositoryImpl @Inject constructor(
 
     override suspend fun leaveSeat(roomId: String, seatIndex: Int): Resource<Unit> = firebaseCall("Failed to leave seat") {
         roomsCollection.document(roomId).update(
-            "seats.$seatIndex", Seat().toMap()
+            "seats.$seatIndex", Seat.EMPTY_MAP
         ).await()
     }
 
@@ -140,7 +140,7 @@ class RoomRepositoryImpl @Inject constructor(
     override suspend fun moveSeat(roomId: String, fromIndex: Int, toIndex: Int, userId: String): Resource<Unit> = firebaseCall("Failed to move seat") {
         roomsCollection.document(roomId).update(
             mapOf(
-                "seats.$fromIndex" to Seat().toMap(),
+                "seats.$fromIndex" to Seat.EMPTY_MAP,
                 "seats.$toIndex" to Seat(userId = userId, state = SeatState.OCCUPIED).toMap()
             )
         ).await()
@@ -156,7 +156,7 @@ class RoomRepositoryImpl @Inject constructor(
             )
         )
         if (seatIndex != null) {
-            updates["seats.$seatIndex"] = Seat().toMap()
+            updates["seats.$seatIndex"] = Seat.EMPTY_MAP
         }
         roomsCollection.document(roomId).update(updates).await()
     }
@@ -190,23 +190,37 @@ class RoomRepositoryImpl @Inject constructor(
     }
 
     override suspend fun setOwnerAway(roomId: String): Resource<Unit> = firebaseCall("Failed to set owner away") {
-        roomsCollection.document(roomId).update(
-            mapOf(
+        val docRef = roomsCollection.document(roomId)
+        firestore.runTransaction { transaction ->
+            val snapshot = transaction.get(docRef)
+            val room = snapshot.data?.let { ChatRoom.fromMap(it, snapshot.id) }
+                ?: return@runTransaction
+            // Atomically set OWNER_AWAY and guarantee seat 0 stays occupied by the owner
+            val currentMuted = room.seats[Constants.OWNER_SEAT_INDEX.toString()]?.isMuted ?: false
+            val updates = mutableMapOf<String, Any>(
                 "state" to RoomState.OWNER_AWAY.name,
                 "ownerLeftAt" to Timestamp.now()
             )
-        ).await()
+            updates["seats.${Constants.OWNER_SEAT_INDEX}"] =
+                Seat(userId = room.ownerId, state = SeatState.OCCUPIED, isMuted = currentMuted).toMap()
+            transaction.update(docRef, updates)
+        }.await()
     }
 
     override suspend fun setOwnerReturned(roomId: String, ownerId: String): Resource<Unit> = firebaseCall("Failed to set owner returned") {
-        val seat = Seat(userId = ownerId, state = SeatState.OCCUPIED)
-        roomsCollection.document(roomId).update(
-            mapOf(
+        val docRef = roomsCollection.document(roomId)
+        firestore.runTransaction { transaction ->
+            val snapshot = transaction.get(docRef)
+            val room = snapshot.data?.let { ChatRoom.fromMap(it, snapshot.id) }
+                ?: return@runTransaction
+            val currentMuted = room.seats[Constants.OWNER_SEAT_INDEX.toString()]?.isMuted ?: false
+            val seat = Seat(userId = ownerId, state = SeatState.OCCUPIED, isMuted = currentMuted)
+            transaction.update(docRef, mapOf(
                 "state" to RoomState.ACTIVE.name,
                 "ownerLeftAt" to null,
                 "seats.${Constants.OWNER_SEAT_INDEX}" to seat.toMap()
-            )
-        ).await()
+            ))
+        }.await()
     }
 
     override suspend fun sendInvite(roomId: String, userId: String, invitedBy: String): Resource<Unit> = firebaseCall("Failed to send invite") {
@@ -271,13 +285,28 @@ class RoomRepositoryImpl @Inject constructor(
         val batch = firestore.batch()
         for (doc in docsToUpdate) {
             val room = doc.data?.let { ChatRoom.fromMap(it, doc.id) } ?: continue
-            val updates = clearUserSeats(room, userId)
-            updates["participantIds"] = FieldValue.arrayRemove(userId)
             if (room.ownerId == userId) {
-                updates["state"] = RoomState.OWNER_AWAY.name
-                updates["ownerLeftAt"] = Timestamp.now()
+                val otherParticipants = room.participantIds - userId
+                val updates: MutableMap<String, Any> = if (otherParticipants.isEmpty()) {
+                    // Nobody else in the room — close it
+                    closeRoomUpdates().toMutableMap()
+                } else {
+                    // Others still present — keep owner in seat 0, mark away
+                    val currentMuted = room.seats[Constants.OWNER_SEAT_INDEX.toString()]?.isMuted ?: false
+                    val u = mutableMapOf<String, Any>()
+                    u["participantIds"] = FieldValue.arrayRemove(userId)
+                    u["state"] = RoomState.OWNER_AWAY.name
+                    u["ownerLeftAt"] = Timestamp.now()
+                    u["seats.${Constants.OWNER_SEAT_INDEX}"] =
+                        Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = currentMuted).toMap()
+                    u
+                }
+                batch.update(roomsCollection.document(doc.id), updates)
+            } else {
+                val updates = clearUserSeats(room, userId)
+                updates["participantIds"] = FieldValue.arrayRemove(userId)
+                batch.update(roomsCollection.document(doc.id), updates)
             }
-            batch.update(roomsCollection.document(doc.id), updates)
         }
         batch.commit().await()
     }
@@ -290,11 +319,7 @@ class RoomRepositoryImpl @Inject constructor(
             .await()
         if (snapshot.documents.isEmpty()) return@firebaseCall
         val batch = firestore.batch()
-        val closeUpdates = emptySeatsUpdate() + mapOf(
-            "state" to RoomState.CLOSED.name,
-            "closedAt" to Timestamp.now(),
-            "participantIds" to emptyList<String>()
-        )
+        val closeUpdates = closeRoomUpdates()
         for (doc in snapshot.documents) {
             batch.update(roomsCollection.document(doc.id), closeUpdates)
         }
@@ -318,22 +343,19 @@ class RoomRepositoryImpl @Inject constructor(
 
             if (remainingParticipants.isEmpty() && !isOwner) {
                 // Room is now empty — close it
-                updates.putAll(emptySeatsUpdate())
-                updates["state"] = RoomState.CLOSED.name
-                updates["closedAt"] = Timestamp.now()
-                updates["participantIds"] = emptyList<String>()
+                updates.putAll(closeRoomUpdates())
             } else if (isOwner) {
-                // Owner disconnected — mark away but keep them in participants and seat
+                // Owner disconnected — mark away, keep in participants, and guarantee seat 0
+                val currentMuted = room.seats[Constants.OWNER_SEAT_INDEX.toString()]?.isMuted ?: false
                 updates["state"] = RoomState.OWNER_AWAY.name
                 updates["ownerLeftAt"] = Timestamp.now()
+                updates["seats.${Constants.OWNER_SEAT_INDEX}"] =
+                    Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = currentMuted).toMap()
             } else {
                 updates["participantIds"] = FieldValue.arrayRemove(userId)
                 // If only the owner remains and they're away, close the room
                 if (remainingParticipants.singleOrNull() == room.ownerId && room.state == RoomState.OWNER_AWAY) {
-                    updates.putAll(emptySeatsUpdate())
-                    updates["state"] = RoomState.CLOSED.name
-                    updates["closedAt"] = Timestamp.now()
-                    updates["participantIds"] = emptyList<String>()
+                    updates.putAll(closeRoomUpdates())
                 }
             }
 
@@ -344,22 +366,23 @@ class RoomRepositoryImpl @Inject constructor(
     }
 
     override suspend fun closeRoom(roomId: String): Resource<Unit> = firebaseCall("Failed to close room") {
-        val updates = emptySeatsUpdate() + mapOf(
-            "state" to RoomState.CLOSED.name,
-            "closedAt" to Timestamp.now(),
-            "participantIds" to emptyList<String>()
-        )
-        roomsCollection.document(roomId).update(updates).await()
+        roomsCollection.document(roomId).update(closeRoomUpdates()).await()
     }
 
-    private fun emptySeatsUpdate(): Map<String, Any> =
-        (0 until Constants.MAX_SEATS).associate { i -> "seats.$i" to Seat().toMap() }
+    /** All fields needed to close a room: reset seats, set CLOSED state, clear participants. */
+    private fun closeRoomUpdates(): Map<String, Any> = EMPTY_SEATS_UPDATE + mapOf(
+        "state" to RoomState.CLOSED.name,
+        "closedAt" to Timestamp.now(),
+        "participantIds" to emptyList<String>()
+    )
 
     private fun clearUserSeats(room: ChatRoom, userId: String): MutableMap<String, Any> {
         val updates = mutableMapOf<String, Any>()
         for ((idx, seat) in room.seats) {
             if (seat.isOccupiedBy(userId)) {
-                updates["seats.$idx"] = Seat().toMap()
+                // Owner must never be removed from seat 0
+                if (idx == Constants.OWNER_SEAT_INDEX.toString() && userId == room.ownerId) continue
+                updates["seats.$idx"] = Seat.EMPTY_MAP
             }
         }
         return updates

--- a/app/src/main/java/com/shyden/shytalk/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/UserRepositoryImpl.kt
@@ -8,6 +8,9 @@ import com.google.firebase.firestore.FieldPath
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
@@ -107,11 +110,15 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun getUsers(userIds: List<String>): Resource<List<User>> =
         firebaseCall("Failed to get users") {
             if (userIds.isEmpty()) return@firebaseCall emptyList()
-            userIds.chunked(30).flatMap { chunk ->
-                val snapshot = usersCollection.whereIn(FieldPath.documentId(), chunk).get().await()
-                snapshot.documents.mapNotNull { doc ->
-                    doc.data?.let { User.fromMap(it, doc.id) }
-                }
+            coroutineScope {
+                userIds.chunked(30).map { chunk ->
+                    async {
+                        val snapshot = usersCollection.whereIn(FieldPath.documentId(), chunk).get().await()
+                        snapshot.documents.mapNotNull { doc ->
+                            doc.data?.let { User.fromMap(it, doc.id) }
+                        }
+                    }
+                }.awaitAll().flatten()
             }
         }
 }

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -223,7 +223,7 @@ fun RoomScreen(
             val r = room ?: return@derivedStateOf emptyList<ParticipantInfo>()
             seatedUserIds.mapNotNull { uid ->
                 participantUsers[uid]?.let { user ->
-                    val seat = r.seats.values.find { it.userId == uid }
+                    val seat = r.findUserSeat(uid)?.value
                     ParticipantInfo(user, r.resolveRole(uid), isMuted = seat?.isMuted ?: false)
                 }
             }.sortedWith(
@@ -339,6 +339,7 @@ fun RoomScreen(
                         hostIds = uiState.room?.hostIds ?: emptySet(),
                         speakingUids = uiState.speakingUids,
                         seatUsers = uiState.seatUsers,
+                        disconnectedUserIds = uiState.disconnectedUserIds,
                         onSeatClick = { seatIndex ->
                             val seat = uiState.room?.seats?.get(seatIndex.toString())
                             if (seat?.userId == uiState.currentUserId) {
@@ -382,7 +383,7 @@ fun RoomScreen(
                                 contentDescription = null,
                                 modifier = Modifier.padding(end = 8.dp)
                             )
-                            Text("Take a Seat")
+                            Text("Request a Seat")
                         }
                         Spacer(modifier = Modifier.height(8.dp))
                     }
@@ -545,9 +546,7 @@ fun RoomScreen(
             }
             val user = uiState.seatUsers[userId] ?: uiState.participantUsers[userId]
             if (user != null) {
-                val targetSeatEntry = uiState.room?.seats?.entries?.find {
-                    it.value.isOccupiedBy(userId)
-                }
+                val targetSeatEntry = uiState.room?.findUserSeat(userId)
                 val isTargetSeated = targetSeatEntry != null
                 val targetSeatIndex = targetSeatEntry?.key?.toIntOrNull()
 

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import com.shyden.shytalk.core.util.toAgoraUid
 import android.util.Log
@@ -80,7 +81,8 @@ data class RoomUiState(
     val activeNotification: RoomNotification? = null,
     val pendingRequestsForPanel: List<SeatRequest> = emptyList(),
     val kickedByName: String? = null,
-    val kickReason: String? = null
+    val kickReason: String? = null,
+    val disconnectedUserIds: Set<String> = emptySet()
 )
 
 @HiltViewModel
@@ -133,6 +135,7 @@ class RoomViewModel @Inject constructor(
         observeRoom()
         observeMessages()
         observeVoiceState()
+        observeDisconnectedUsers()
         observePendingRequests()
         observeMyRequest()
     }
@@ -187,10 +190,10 @@ class RoomViewModel @Inject constructor(
         viewModelScope.launch {
             // Fetch host user data so the summary can display them
             if (room != null) {
-                val hostIds = (room.hostIds + room.ownerId).filter { userCache[it] == null }
-                for (id in hostIds) {
-                    when (val result = userRepository.getUser(id)) {
-                        is Resource.Success -> userCache[id] = result.data
+                val uncachedHostIds = (room.hostIds + room.ownerId).filter { it !in userCache }
+                if (uncachedHostIds.isNotEmpty()) {
+                    when (val result = userRepository.getUsers(uncachedHostIds)) {
+                        is Resource.Success -> result.data.forEach { user -> userCache[user.uid] = user }
                         else -> {}
                     }
                 }
@@ -237,9 +240,7 @@ class RoomViewModel @Inject constructor(
         if (alreadyInRoom) {
             _uiState.update { it.copy(room = room, currentRole = role, isLoading = false, hasJoined = true) }
             // Track seat state so handleNormalUpdate detects transitions correctly
-            isSeated = room.seats.values.any {
-                it.isOccupiedBy(userId)
-            }
+            isSeated = room.findUserSeat(userId) != null
             // Rejoin voice if not already connected (ViewModel recreated)
             if (room.agoraChannelName.isNotEmpty()) {
                 val asBroadcaster = isSeated && _uiState.value.hasAudioPermission
@@ -268,10 +269,20 @@ class RoomViewModel @Inject constructor(
     }
 
     private fun handleOwnerReturnDetection(room: ChatRoom, userId: String) {
+        if (room.ownerId != userId || !_uiState.value.hasJoined) return
+
+        // Self-heal: if owner is online but somehow not in seat 0, restore immediately
+        val ownerInSeat0 = room.seats[Constants.OWNER_SEAT_INDEX.toString()]?.isOccupiedBy(userId) == true
+        if (!ownerInSeat0 && activeRoomManager.isInRoom(roomId) && !ownerReturnTriggered) {
+            Log.w(TAG, "Owner self-heal: not in seat 0, restoring via setOwnerReturned")
+            ownerReturnTriggered = true
+            ownerReturn()
+            return
+        }
+
         if (room.state == RoomState.OWNER_AWAY
-            && room.ownerId == userId
-            && _uiState.value.hasJoined
             && !ownerReturnTriggered
+            && activeRoomManager.isInRoom(roomId)
         ) {
             ownerReturnTriggered = true
             ownerReturn()
@@ -282,7 +293,7 @@ class RoomViewModel @Inject constructor(
     }
 
     private fun handleNormalUpdate(room: ChatRoom, userId: String, role: RoomRole) {
-        val mySeat = room.seats.values.find { it.isOccupiedBy(userId) }
+        val mySeat = room.findUserSeat(userId)?.value
         val currentlySeated = mySeat != null
 
         if (currentlySeated && !isSeated) {
@@ -428,12 +439,24 @@ class RoomViewModel @Inject constructor(
                 agoraVoiceService.error
             ) { speaking, joined, errorMsg ->
                 Triple(speaking, joined, errorMsg)
-            }.collect { (speaking, joined, errorMsg) ->
-                _uiState.update { it.copy(speakingUids = speaking, isVoiceJoined = joined) }
-                if (errorMsg != null) {
-                    _uiState.update { it.copy(error = errorMsg) }
-                    agoraVoiceService.clearError()
+            }.distinctUntilChanged()
+            .collect { (speaking, joined, errorMsg) ->
+                _uiState.update {
+                    it.copy(
+                        speakingUids = speaking,
+                        isVoiceJoined = joined,
+                        error = errorMsg ?: it.error
+                    )
                 }
+                if (errorMsg != null) agoraVoiceService.clearError()
+            }
+        }
+    }
+
+    private fun observeDisconnectedUsers() {
+        viewModelScope.launch {
+            activeRoomManager.disconnectedUserIds.collect { ids ->
+                _uiState.update { it.copy(disconnectedUserIds = ids) }
             }
         }
     }
@@ -472,9 +495,7 @@ class RoomViewModel @Inject constructor(
             // Join voice channel — as broadcaster if already seated with permission, otherwise audience
             val channel = room?.agoraChannelName
             if (!channel.isNullOrEmpty()) {
-                val alreadySeated = room.seats.values.any {
-                    it.isOccupiedBy(userId)
-                }
+                val alreadySeated = room.findUserSeat(userId) != null
                 val asBroadcaster = alreadySeated && _uiState.value.hasAudioPermission
                 if (alreadySeated) isSeated = true
                 agoraVoiceService.joinChannel(channel, userId.toAgoraUid(), asBroadcaster = asBroadcaster)
@@ -503,9 +524,8 @@ class RoomViewModel @Inject constructor(
                     val elapsed = System.currentTimeMillis() - room.ownerLeftAt.toDate().time
                     val remaining = Constants.OWNER_LEAVE_TIMEOUT_MS - elapsed
                     if (remaining <= 0) {
-                        if (_uiState.value.currentRole == RoomRole.OWNER) {
-                            roomRepository.closeRoom(roomId)
-                        }
+                        // Any remaining participant can close an expired OWNER_AWAY room
+                        roomRepository.closeRoom(roomId)
                         break
                     }
                     _uiState.update { it.copy(ownerAwayRemainingMs = remaining) }
@@ -690,10 +710,7 @@ class RoomViewModel @Inject constructor(
             val displayReason = reason.ifBlank { "No reason given" }
 
             roomRepository.kickUser(roomId, targetUserId, seatIndex, kickerName, displayReason)
-            messageRepository.sendSystemMessage(
-                roomId,
-                "$targetName was kicked by $kickerName. Reason: $displayReason"
-            )
+            messageRepository.sendSystemMessage(roomId, "$targetName was kicked")
         }
     }
 
@@ -719,10 +736,7 @@ class RoomViewModel @Inject constructor(
             val role = _uiState.value.currentRole
 
             // Don't invite someone who is already seated
-            val alreadySeated = room.seats.values.any {
-                it.isOccupiedBy(userId)
-            }
-            if (alreadySeated) return@launch
+            if (room.findUserSeat(userId) != null) return@launch
 
             // Owner can always invite; hosts only when requireApproval is OFF
             if (role == RoomRole.ATTENDEE) return@launch
@@ -733,12 +747,6 @@ class RoomViewModel @Inject constructor(
     }
 
     fun inviteFromMessage(senderId: String, senderName: String) {
-        val room = _uiState.value.room ?: return
-        // Check the user isn't already seated
-        val alreadySeated = room.seats.values.any {
-            it.isOccupiedBy(senderId)
-        }
-        if (alreadySeated) return
         inviteUser(senderId, senderName)
     }
 
@@ -780,31 +788,39 @@ class RoomViewModel @Inject constructor(
         viewModelScope.launch {
             val userId = _uiState.value.currentUserId
             val room = _uiState.value.room ?: return@launch
+            Log.d(TAG, "leaveRoom (VM): userId=$userId isOwner=${room.ownerId == userId}")
 
             disconnectFromRoom()
 
             // Use NonCancellable so Firestore cleanup completes even if ViewModel is destroyed
             withContext(NonCancellable) {
-                val mySeatIndex = room.seats.entries.find {
-                    it.value.userId == userId
-                }?.key?.toInt()
-                if (mySeatIndex != null) {
-                    roomRepository.leaveSeat(roomId, mySeatIndex)
-                }
-
                 if (room.ownerId == userId) {
                     // Check if anyone else is still on mic
                     val anyoneOnMic = room.seats.any { (_, seat) ->
                         seat.userId != null && seat.userId != userId && seat.state == SeatState.OCCUPIED
                     }
                     if (anyoneOnMic) {
+                        // Owner keeps seat 0 — stays visible during OWNER_AWAY
+                        Log.d(TAG, "leaveRoom (VM): owner with others on mic → setOwnerAway")
                         roomRepository.setOwnerAway(roomId)
                     } else {
+                        Log.d(TAG, "leaveRoom (VM): owner alone → closeRoom")
                         roomRepository.closeRoom(roomId)
+                    }
+                } else {
+                    // Non-owner: clear their seat
+                    val mySeatIndex = room.findUserSeat(userId)?.key?.toInt()
+                    if (mySeatIndex != null) {
+                        Log.d(TAG, "leaveRoom (VM): clearing seat $mySeatIndex")
+                        roomRepository.leaveSeat(roomId, mySeatIndex)
                     }
                 }
 
-                roomRepository.leaveRoom(roomId, userId)
+                // Only non-owners leave the participant list;
+                // owner stays in participants during OWNER_AWAY for reconnection
+                if (room.ownerId != userId) {
+                    roomRepository.leaveRoom(roomId, userId)
+                }
             }
         }
     }
@@ -816,11 +832,16 @@ class RoomViewModel @Inject constructor(
             if (room.ownerId != userId) return@launch
 
             try {
+                Log.d(TAG, "ownerReturn: calling setOwnerReturned")
                 roomRepository.setOwnerReturned(roomId, userId)
 
-                // Re-establish presence and room tracking if lost during disconnect
+                // Always re-establish presence — the RTDB onDisconnect may have
+                // fired while WiFi was off, removing the owner's presence entry.
+                // Without this, other phones keep detecting the owner as absent.
+                presenceService.setPresence(roomId, userId)
+
+                // Re-establish room tracking if lost during disconnect
                 if (!activeRoomManager.isInRoom(roomId)) {
-                    presenceService.setPresence(roomId, userId)
                     activeRoomManager.trackRoom(roomId)
                 }
 
@@ -893,17 +914,11 @@ class RoomViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            coroutineScope {
-                newUserIds.map { uid ->
-                    async {
-                        when (val result = userRepository.getUser(uid)) {
-                            is Resource.Success -> uid to result.data
-                            else -> null
-                        }
-                    }
-                }.awaitAll().filterNotNull().forEach { (id, user) ->
-                    userCache[id] = user
+            when (val result = userRepository.getUsers(newUserIds)) {
+                is Resource.Success -> {
+                    result.data.forEach { user -> userCache[user.uid] = user }
                 }
+                else -> {}
             }
             onLoaded(userCache.filterKeys { it in userIds })
         }
@@ -1039,9 +1054,7 @@ class RoomViewModel @Inject constructor(
                     val room = _uiState.value.room
                     // Filter out stale requests: user already seated or left the room
                     val validRequests = requests.filter { req ->
-                        val alreadySeated = room?.seats?.values?.any {
-                            it.isOccupiedBy(req.userId)
-                        } ?: false
+                        val alreadySeated = room?.findUserSeat(req.userId) != null
                         val leftRoom = room != null && req.userId !in room.participantIds
                         !alreadySeated && !leftRoom
                     }
@@ -1072,9 +1085,7 @@ class RoomViewModel @Inject constructor(
 
                     if (approvedRequest.requestId in processedApprovalIds) return@collect
 
-                    val alreadySeated = _uiState.value.room?.seats?.values?.any {
-                        it.isOccupiedBy(userId)
-                    } ?: false
+                    val alreadySeated = _uiState.value.room?.findUserSeat(userId) != null
                     if (alreadySeated) return@collect
 
                     // During the grace period the owner auto-seats the requester,

--- a/app/src/main/java/com/shyden/shytalk/feature/room/components/SeatGrid.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/components/SeatGrid.kt
@@ -32,6 +32,7 @@ fun SeatGrid(
     hostIds: Set<String>,
     speakingUids: Set<Int>,
     seatUsers: Map<String, User> = emptyMap(),
+    disconnectedUserIds: Set<String> = emptySet(),
     onSeatClick: (Int) -> Unit,
     onTapUser: (String) -> Unit = {},
     modifier: Modifier = Modifier
@@ -72,37 +73,46 @@ fun SeatGrid(
         ) {
             occupiedSeats.forEach { (indexStr, seat) ->
                 key(indexStr) {
-                val seatIndex = indexStr.toIntOrNull() ?: return@forEach
-                val seatUserId = seat.userId
+                    val seatIndex = indexStr.toIntOrNull() ?: return@forEach
+                    val seatUserId = seat.userId
 
-                val seatRole = when {
-                    seatUserId == ownerId -> RoomRole.OWNER
-                    seatUserId != null && seatUserId in hostIds -> RoomRole.HOST
-                    else -> RoomRole.ATTENDEE
-                }
+                    val seatRole = remember(seatUserId, ownerId, hostIds) {
+                        when {
+                            seatUserId == ownerId -> RoomRole.OWNER
+                            seatUserId != null && seatUserId in hostIds -> RoomRole.HOST
+                            else -> RoomRole.ATTENDEE
+                        }
+                    }
 
-                val isSpeaking = seatUserId != null &&
-                    seatUserId.toAgoraUid() in speakingUids
+                    // Only suppress for the local user — Agora reports local mic volume
+                    // even when muted. For remote users, Agora is the source of truth.
+                    val seatAgoraUid = remember(seatUserId) { seatUserId?.toAgoraUid() }
+                    val isSpeaking = seatUserId != null &&
+                        !(seatUserId == currentUserId && seat.isMuted) &&
+                        seatAgoraUid in speakingUids
 
-                val isOwnerOnOwnSeat = seat.userId == currentUserId
-                    && seatIndex == Constants.OWNER_SEAT_INDEX
-                    && currentRole == RoomRole.OWNER
+                    val isDisconnected = seatUserId != null && seatUserId in disconnectedUserIds
 
-                val seatUser = seatUserId?.let { seatUsers[it] }
+                    val isOwnerOnOwnSeat = seatUserId == currentUserId
+                        && seatIndex == Constants.OWNER_SEAT_INDEX
+                        && currentRole == RoomRole.OWNER
 
-                SeatItem(
-                    seatIndex = seatIndex,
-                    seat = seat,
-                    seatRole = seatRole,
-                    isCurrentUser = seat.userId == currentUserId,
-                    canLeaveSeat = seat.userId == currentUserId && !isOwnerOnOwnSeat,
-                    isSpeaking = isSpeaking,
-                    user = seatUser,
-                    seatSize = seatSize,
-                    onClick = { onSeatClick(seatIndex) },
-                    onTapUser = seatUserId?.let { uid -> { onTapUser(uid) } },
-                    modifier = Modifier.weight(1f)
-                )
+                    val seatUser = seatUserId?.let { seatUsers[it] }
+
+                    SeatItem(
+                        seatIndex = seatIndex,
+                        seat = seat,
+                        seatRole = seatRole,
+                        isCurrentUser = seatUserId == currentUserId,
+                        canLeaveSeat = seatUserId == currentUserId && !isOwnerOnOwnSeat,
+                        isSpeaking = isSpeaking && !isDisconnected,
+                        isDisconnected = isDisconnected,
+                        user = seatUser,
+                        seatSize = seatSize,
+                        onClick = { onSeatClick(seatIndex) },
+                        onTapUser = seatUserId?.let { uid -> { onTapUser(uid) } },
+                        modifier = Modifier.weight(1f)
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/shyden/shytalk/feature/room/components/SeatItem.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/components/SeatItem.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -63,6 +64,7 @@ fun SeatItem(
     isCurrentUser: Boolean,
     canLeaveSeat: Boolean,
     isSpeaking: Boolean,
+    isDisconnected: Boolean = false,
     user: User? = null,
     seatSize: Dp = 70.dp,
     onClick: () -> Unit,
@@ -91,7 +93,10 @@ fun SeatItem(
         label = "borderColor"
     )
 
-    // Pulsing border width when speaking — expands outward from 2dp to 8dp
+    // Max border so we can reserve stable layout space
+    val maxBorderWidth = 8.dp
+
+    // Pulsing border width when speaking — animates from 2dp to 8dp
     val borderWidth = if (isSpeaking) {
         val infiniteTransition = rememberInfiniteTransition(label = "speakingPulse")
         val pulsingWidth by infiniteTransition.animateFloat(
@@ -108,14 +113,18 @@ fun SeatItem(
         2.dp
     }
 
+    // Always reserve max border space so the layout never shifts
+    val outerSize = seatSize + maxBorderWidth * 2
+
     Column(
-        modifier = modifier.padding(4.dp),
+        modifier = modifier
+            .padding(4.dp)
+            .alpha(if (isDisconnected) 0.4f else 1f),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
         Box(contentAlignment = Alignment.Center) {
-            // Outer border box for outward-pulsing speaking indicator
-            val outerSize = if (isSpeaking) seatSize + borderWidth * 2 else seatSize
+            // Fixed-size outer box — border pulses inside without affecting layout
             Box(
                 modifier = Modifier
                     .size(outerSize)

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,12 +1,10 @@
-v0.23 - Date of Birth, privacy & performance
+v0.25 - Disconnect dimming & mute preservation
 
-- Date of Birth now required for all users
-- Existing users asked for DOB on next login
-- Age shown on profiles (must be 13+)
-- New "Hide Age" privacy toggle in Settings
-- Batch user loading for faster room lists
-- Thread-safe state updates across all screens
-- Chat text survives screen rotation
-- Memoized seat grid and room card calculations
-- Consolidated block-warning dialogs in rooms
-- Improved performance and stability
+- Disconnected users' seats dim in real time
+- Mute state preserved through disconnect/reconnect
+- Cloud Function preserves owner mute during OWNER_AWAY
+- Grace period prevents false disconnects
+- Deduplicated room-close logic across repository
+- Removed debug stack-trace logging
+- Batched UI state updates for fewer recompositions
+- Memoized per-seat computations in seat grid

--- a/app/src/test/java/com/shyden/shytalk/core/model/ChatRoomTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/ChatRoomTest.kt
@@ -2,6 +2,8 @@ package com.shyden.shytalk.core.model
 
 import com.google.firebase.Timestamp
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.Date
@@ -87,5 +89,63 @@ class ChatRoomTest {
         val restored = ChatRoom.fromMap(map, "room-1")
 
         assertEquals(setOf("banned-1", "banned-2"), restored.bannedUserIds)
+    }
+
+    // --- findUserSeat ---
+
+    @Test
+    fun `findUserSeat returns correct entry for seated user`() {
+        val seats = ChatRoom.DEFAULT_SEATS.toMutableMap()
+        seats["2"] = Seat(userId = "user-A", state = SeatState.OCCUPIED)
+        val room = ChatRoom(
+            roomId = "room-1",
+            ownerId = "owner",
+            seats = seats,
+            createdAt = baseTimestamp
+        )
+
+        val entry = room.findUserSeat("user-A")
+
+        assertNotNull(entry)
+        assertEquals("2", entry!!.key)
+        assertEquals("user-A", entry.value.userId)
+        assertEquals(SeatState.OCCUPIED, entry.value.state)
+    }
+
+    @Test
+    fun `findUserSeat returns null for unseated user`() {
+        val room = ChatRoom(
+            roomId = "room-1",
+            ownerId = "owner",
+            createdAt = baseTimestamp
+        )
+
+        assertNull(room.findUserSeat("user-A"))
+    }
+
+    @Test
+    fun `findUserSeat returns null for empty room`() {
+        val room = ChatRoom(
+            roomId = "room-1",
+            ownerId = "owner",
+            seats = ChatRoom.DEFAULT_SEATS,
+            createdAt = baseTimestamp
+        )
+
+        assertNull(room.findUserSeat("anyone"))
+    }
+
+    @Test
+    fun `findUserSeat ignores non-OCCUPIED seats with matching userId`() {
+        val seats = ChatRoom.DEFAULT_SEATS.toMutableMap()
+        seats["3"] = Seat(userId = "user-B", state = SeatState.EMPTY)
+        val room = ChatRoom(
+            roomId = "room-1",
+            ownerId = "owner",
+            seats = seats,
+            createdAt = baseTimestamp
+        )
+
+        assertNull(room.findUserSeat("user-B"))
     }
 }

--- a/app/src/test/java/com/shyden/shytalk/core/model/SeatFromMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/SeatFromMapTest.kt
@@ -94,4 +94,25 @@ class SeatFromMapTest {
         val seat = Seat()
         assertFalse(seat.isOccupiedBy("user-1"))
     }
+
+    // --- EMPTY_MAP cache ---
+
+    @Test
+    fun `EMPTY_MAP matches default Seat toMap`() {
+        assertEquals(Seat().toMap(), Seat.EMPTY_MAP)
+    }
+
+    @Test
+    fun `EMPTY_MAP is same reference on repeated access`() {
+        val first = Seat.EMPTY_MAP
+        val second = Seat.EMPTY_MAP
+        assertTrue(first === second)
+    }
+
+    @Test
+    fun `EMPTY_MAP contains correct default values`() {
+        assertNull(Seat.EMPTY_MAP["userId"])
+        assertEquals("EMPTY", Seat.EMPTY_MAP["state"])
+        assertEquals(false, Seat.EMPTY_MAP["isMuted"])
+    }
 }

--- a/app/src/test/java/com/shyden/shytalk/core/room/ActiveRoomManagerTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/room/ActiveRoomManagerTest.kt
@@ -5,6 +5,7 @@ import com.google.firebase.auth.FirebaseUser
 import com.shyden.shytalk.core.model.ChatRoom
 import com.shyden.shytalk.core.model.RoomRole
 import com.shyden.shytalk.core.model.RoomState
+import com.shyden.shytalk.core.model.Seat
 import com.shyden.shytalk.core.model.SeatState
 import com.shyden.shytalk.core.util.Constants
 import com.shyden.shytalk.data.remote.AgoraVoiceService
@@ -560,7 +561,7 @@ class ActiveRoomManagerTest {
     }
 
     @Test
-    fun `leaveRoom - owner sets owner away and keeps seat`() = runTest {
+    fun `leaveRoom - owner alone closes room`() = runTest {
         manager.trackRoom("room-1")
         val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
         val room = TestData.createTestRoom(
@@ -572,9 +573,30 @@ class ActiveRoomManagerTest {
 
         manager.leaveRoom()
 
-        // Owner's seat is preserved for reconnection — only setOwnerAway is called
+        // Owner is alone — room should close immediately
+        coVerify(exactly = 0) { roomRepository.leaveSeat("room-1", 0) }
+        coVerify { roomRepository.closeRoom("room-1") }
+        coVerify(exactly = 0) { roomRepository.setOwnerAway(any()) }
+    }
+
+    @Test
+    fun `leaveRoom - owner with others on mic sets owner away`() = runTest {
+        manager.trackRoom("room-1")
+        val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = "other-user")
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "other-user"),
+            seats = seats
+        )
+        manager.updateTrackedRoom(room)
+
+        manager.leaveRoom()
+
+        // Others present — owner keeps seat 0, room goes OWNER_AWAY
         coVerify(exactly = 0) { roomRepository.leaveSeat("room-1", 0) }
         coVerify { roomRepository.setOwnerAway("room-1") }
+        coVerify(exactly = 0) { roomRepository.closeRoom(any()) }
     }
 
     @Test
@@ -612,6 +634,61 @@ class ActiveRoomManagerTest {
         manager.trackRoom("room-1")
 
         assertTrue(manager.isInRoom("room-1"))
+    }
+
+    // --- connection monitor: owner vs non-owner ---
+
+    @Test
+    fun `connection monitor - owner disconnect does NOT trigger leaveRoom`() = runTest {
+        manager.trackRoom("room-1")
+        val seats = TestData.createSeatsWithOwner(currentUserId)
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "user-2"),
+            seats = seats
+        )
+        manager.updateTrackedRoom(room)
+
+        // Emit CONNECTED after room is set so wasEverConnected = true
+        connectionStateFlow.value = AgoraVoiceService.ConnectionState.CONNECTED
+
+        // Simulate Agora disconnect (WiFi off)
+        connectionStateFlow.value = AgoraVoiceService.ConnectionState.DISCONNECTED
+
+        // Advance past the grace period
+        testScheduler.advanceTimeBy(Constants.AGORA_DISCONNECT_GRACE_PERIOD_MS + 1000)
+
+        // Owner should NOT have leaveRoom called — presence system on other devices handles it
+        coVerify(exactly = 0) { roomRepository.setOwnerAway(any()) }
+        coVerify(exactly = 0) { roomRepository.closeRoom(any()) }
+        coVerify(exactly = 0) { roomRepository.leaveSeat(any(), any()) }
+        assertTrue(manager.isInRoom("room-1"))
+    }
+
+    @Test
+    fun `connection monitor - non-owner disconnect triggers leaveRoom after grace period`() = runTest {
+        manager.trackRoom("room-1")
+        val seats = TestData.createSeatsWithOwner("other-owner").toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = currentUserId)
+        val room = TestData.createTestRoom(
+            ownerId = "other-owner",
+            participantIds = setOf("other-owner", currentUserId),
+            seats = seats
+        )
+        manager.updateTrackedRoom(room)
+
+        // Emit CONNECTED after room is set so wasEverConnected = true
+        connectionStateFlow.value = AgoraVoiceService.ConnectionState.CONNECTED
+
+        // Simulate Agora disconnect
+        connectionStateFlow.value = AgoraVoiceService.ConnectionState.DISCONNECTED
+
+        // Advance past the grace period
+        testScheduler.advanceTimeBy(Constants.AGORA_DISCONNECT_GRACE_PERIOD_MS + 1000)
+
+        // Non-owner should have left the room
+        coVerify { roomRepository.leaveSeat("room-1", 3) }
+        coVerify { agoraVoiceService.leaveChannel() }
     }
 
     // --- presence monitor ---
@@ -866,5 +943,92 @@ class ActiveRoomManagerTest {
         manager.forceMuteUser(3)
 
         coVerify(exactly = 0) { roomRepository.toggleMute(any(), any(), any()) }
+    }
+
+    // --- disconnectedUserIds ---
+
+    @Test
+    fun `disconnectedUserIds - initially empty`() {
+        assertEquals(emptySet<String>(), manager.disconnectedUserIds.value)
+    }
+
+    @Test
+    fun `disconnectedUserIds - contains absent user during grace period`() = runTest {
+        manager.trackRoom("room-1")
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "user-2")
+        )
+        manager.updateTrackedRoom(room)
+
+        // user-2 is absent from presence
+        presenceFlow.value = setOf(currentUserId)
+
+        // Advance 15s — within PRESENCE_TIMEOUT_MS (30s), grace timer still running
+        testScheduler.advanceTimeBy(15_000)
+
+        assertTrue(manager.disconnectedUserIds.value.contains("user-2"))
+    }
+
+    @Test
+    fun `disconnectedUserIds - cleared when user reappears`() = runTest {
+        manager.trackRoom("room-1")
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "user-2")
+        )
+        manager.updateTrackedRoom(room)
+
+        // user-2 disappears
+        presenceFlow.value = setOf(currentUserId)
+        testScheduler.advanceTimeBy(15_000)
+        assertTrue(manager.disconnectedUserIds.value.contains("user-2"))
+
+        // user-2 reappears
+        presenceFlow.value = setOf(currentUserId, "user-2")
+        testScheduler.advanceTimeBy(1)
+
+        assertEquals(emptySet<String>(), manager.disconnectedUserIds.value)
+    }
+
+    @Test
+    fun `disconnectedUserIds - cleared on untrackRoom`() = runTest {
+        manager.trackRoom("room-1")
+        val room = TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "user-2")
+        )
+        manager.updateTrackedRoom(room)
+
+        // user-2 disappears
+        presenceFlow.value = setOf(currentUserId)
+        testScheduler.advanceTimeBy(15_000)
+        assertTrue(manager.disconnectedUserIds.value.contains("user-2"))
+
+        manager.untrackRoom()
+
+        assertEquals(emptySet<String>(), manager.disconnectedUserIds.value)
+    }
+
+    @Test
+    fun `disconnectedUserIds - cleared on cleanup via leaveRoom`() = runTest {
+        manager.trackRoom("room-1")
+        val seats = TestData.createSeatsWithOwner("other-owner").toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = currentUserId)
+        val room = TestData.createTestRoom(
+            ownerId = "other-owner",
+            participantIds = setOf("other-owner", currentUserId, "user-2"),
+            seats = seats
+        )
+        manager.updateTrackedRoom(room)
+
+        // user-2 disappears
+        presenceFlow.value = setOf(currentUserId, "other-owner")
+        testScheduler.advanceTimeBy(15_000)
+        assertTrue(manager.disconnectedUserIds.value.contains("user-2"))
+
+        manager.leaveRoom()
+
+        assertEquals(emptySet<String>(), manager.disconnectedUserIds.value)
     }
 }

--- a/app/src/test/java/com/shyden/shytalk/data/remote/SpeakingDetectionTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/remote/SpeakingDetectionTest.kt
@@ -154,6 +154,21 @@ class SpeakingDetectionTest {
         assertTrue(remoteUid1 in result)
     }
 
+    // --- Muted seat regression (UI layer) ---
+
+    @Test
+    fun `muted local user with high volume is excluded from speaking set`() {
+        // Regression: Agora reports mic volume even when muteLocalAudioStream is active.
+        // processSpeakers must exclude the local user when isLocalMuted is true,
+        // regardless of how loud the captured volume is.
+        val speakers = arrayOf(speaker(0, 255)) // max volume
+        val result = AgoraVoiceService.processSpeakers(
+            speakers, localUid, isLocalMuted = true,
+            localThreshold = 50, remoteThreshold = 10
+        )
+        assertTrue("Muted local user must never appear in speaking set", result.isEmpty())
+    }
+
     // --- Edge cases ---
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
@@ -240,7 +240,7 @@ class RoomRepositoryImplTest {
 
     @Test
     fun `setOwnerAway returns Success`() = runTest {
-        every { docRef.update(any<Map<String, Any?>>()) } returns Tasks.forResult(null)
+        every { firestore.runTransaction(any<Transaction.Function<Any?>>()) } returns Tasks.forResult(null)
 
         val result = repo.setOwnerAway("room-1")
 
@@ -251,7 +251,7 @@ class RoomRepositoryImplTest {
 
     @Test
     fun `setOwnerReturned returns Success`() = runTest {
-        every { docRef.update(any<Map<String, Any?>>()) } returns Tasks.forResult(null)
+        every { firestore.runTransaction(any<Transaction.Function<Any?>>()) } returns Tasks.forResult(null)
 
         val result = repo.setOwnerReturned("room-1", "owner-1")
 
@@ -358,6 +358,119 @@ class RoomRepositoryImplTest {
         val result = repo.updateRoomName("room-1", "New Name")
 
         assertTrue(result is Resource.Error)
+    }
+
+    // --- mute state preservation ---
+
+    @Test
+    fun `setOwnerAway preserves isMuted from seat 0`() = runTest {
+        val transaction = mockk<Transaction>(relaxed = true)
+        val snapshot = mockk<DocumentSnapshot>(relaxed = true)
+        every { snapshot.data } returns mapOf(
+            "ownerId" to "owner-1",
+            "state" to "ACTIVE",
+            "participantIds" to listOf("owner-1", "user-2"),
+            "seats" to mapOf(
+                "0" to mapOf("userId" to "owner-1", "state" to "OCCUPIED", "isMuted" to true),
+                "1" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "2" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "3" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "4" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "5" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "6" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "7" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false)
+            )
+        )
+        every { snapshot.id } returns "room-1"
+        every { transaction.get(docRef) } returns snapshot
+        val updateSlot = slot<Map<String, Any>>()
+        every { transaction.update(docRef, capture(updateSlot)) } returns transaction
+        every { firestore.runTransaction(any<Transaction.Function<*>>()) } answers {
+            val fn = firstArg<Transaction.Function<*>>()
+            fn.apply(transaction)
+            Tasks.forResult(null)
+        }
+
+        val result = repo.setOwnerAway("room-1")
+
+        assertTrue(result is Resource.Success)
+        @Suppress("UNCHECKED_CAST")
+        val seatMap = updateSlot.captured["seats.0"] as Map<String, Any?>
+        assertEquals(true, seatMap["isMuted"])
+    }
+
+    @Test
+    fun `setOwnerReturned preserves isMuted from seat 0`() = runTest {
+        val transaction = mockk<Transaction>(relaxed = true)
+        val snapshot = mockk<DocumentSnapshot>(relaxed = true)
+        every { snapshot.data } returns mapOf(
+            "ownerId" to "owner-1",
+            "state" to "OWNER_AWAY",
+            "participantIds" to listOf("owner-1", "user-2"),
+            "seats" to mapOf(
+                "0" to mapOf("userId" to "owner-1", "state" to "OCCUPIED", "isMuted" to true),
+                "1" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "2" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "3" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "4" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "5" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "6" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "7" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false)
+            )
+        )
+        every { snapshot.id } returns "room-1"
+        every { transaction.get(docRef) } returns snapshot
+        val updateSlot = slot<Map<String, Any>>()
+        every { transaction.update(docRef, capture(updateSlot)) } returns transaction
+        every { firestore.runTransaction(any<Transaction.Function<*>>()) } answers {
+            val fn = firstArg<Transaction.Function<*>>()
+            fn.apply(transaction)
+            Tasks.forResult(null)
+        }
+
+        val result = repo.setOwnerReturned("room-1", "owner-1")
+
+        assertTrue(result is Resource.Success)
+        @Suppress("UNCHECKED_CAST")
+        val seatMap = updateSlot.captured["seats.0"] as Map<String, Any?>
+        assertEquals(true, seatMap["isMuted"])
+    }
+
+    @Test
+    fun `removeDisconnectedUser preserves owner isMuted during OWNER_AWAY`() = runTest {
+        val transaction = mockk<Transaction>(relaxed = true)
+        val snapshot = mockk<DocumentSnapshot>(relaxed = true)
+        every { snapshot.data } returns mapOf(
+            "ownerId" to "owner-1",
+            "state" to "ACTIVE",
+            "participantIds" to listOf("owner-1", "user-2"),
+            "seats" to mapOf(
+                "0" to mapOf("userId" to "owner-1", "state" to "OCCUPIED", "isMuted" to true),
+                "1" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "2" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "3" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "4" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "5" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "6" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false),
+                "7" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false)
+            )
+        )
+        every { snapshot.id } returns "room-1"
+        every { transaction.get(docRef) } returns snapshot
+        val updateSlot = slot<Map<String, Any>>()
+        every { transaction.update(docRef, capture(updateSlot)) } returns transaction
+        every { firestore.runTransaction(any<Transaction.Function<*>>()) } answers {
+            val fn = firstArg<Transaction.Function<*>>()
+            fn.apply(transaction)
+            Tasks.forResult(null)
+        }
+
+        val result = repo.removeDisconnectedUser("room-1", "owner-1")
+
+        assertTrue(result is Resource.Success)
+        @Suppress("UNCHECKED_CAST")
+        val seatMap = updateSlot.captured["seats.0"] as Map<String, Any?>
+        assertEquals(true, seatMap["isMuted"])
     }
 
     // --- closeAllRoomsByOwner ---

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -89,9 +89,21 @@ class RoomViewModelTest {
             TestData.createTestUser(uid = currentUserId, displayName = "Current User")
         )
         coEvery { userRepository.getBlockedUserIds(currentUserId) } returns Resource.Success(emptySet())
+        // Delegate batch getUsers to individual getUser mocks so existing per-user mocks work
+        coEvery { userRepository.getUsers(any()) } coAnswers {
+            val ids = firstArg<List<String>>()
+            val users = ids.mapNotNull { id ->
+                when (val result = userRepository.getUser(id)) {
+                    is Resource.Success -> result.data
+                    else -> null
+                }
+            }
+            Resource.Success(users)
+        }
         every { seatRequestRepository.getPendingRequests(any()) } returns pendingRequestsFlow
         every { seatRequestRepository.getRequestsByUser(any(), any()) } returns myRequestsFlow
         every { activeRoomManager.isInRoom(any()) } returns false
+        every { activeRoomManager.disconnectedUserIds } returns MutableStateFlow(emptySet())
     }
 
     private fun createViewModel(): RoomViewModel {
@@ -672,7 +684,7 @@ class RoomViewModelTest {
     }
 
     @Test
-    fun `kickUser - system message includes reason`() = runTest {
+    fun `kickUser - system message does not expose reason to room`() = runTest {
         viewModel = createViewModel()
         val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
         seats["3"] = TestData.createTestSeat(userId = "attendee-1")
@@ -689,8 +701,9 @@ class RoomViewModelTest {
         viewModel.kickUser(3, "Spamming")
         advanceUntilIdle()
 
+        // Room members only see that the person was kicked — reason is private
         coVerify {
-            messageRepository.sendSystemMessage("room-1", match { it.contains("Spamming") })
+            messageRepository.sendSystemMessage("room-1", "Attendee was kicked")
         }
     }
 
@@ -917,6 +930,26 @@ class RoomViewModelTest {
         coVerify { roomRepository.leaveRoom("room-1", currentUserId) }
         coVerify(exactly = 0) { roomRepository.setOwnerAway(any()) }
         coVerify(exactly = 0) { roomRepository.closeRoom(any()) }
+    }
+
+    @Test
+    fun `leaveRoom - owner stays in participants during OWNER_AWAY`() = runTest {
+        viewModel = createViewModel()
+        val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = "other-user")
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "other-user"),
+            seats = seats
+        ))
+        advanceUntilIdle()
+
+        viewModel.leaveRoom()
+        advanceUntilIdle()
+
+        // Owner should NOT be removed from participants — stays for reconnection
+        coVerify(exactly = 0) { roomRepository.leaveRoom("room-1", currentUserId) }
+        coVerify { roomRepository.setOwnerAway("room-1") }
     }
 
     @Test
@@ -1879,7 +1912,7 @@ class RoomViewModelTest {
     }
 
     @Test
-    fun `ownerReturn - skips presence setup when already in room`() = runTest {
+    fun `ownerReturn - always re-establishes presence even when already in room`() = runTest {
         // Set isInRoom BEFORE creating VM and emitting room so the alreadyInRoom path is taken
         every { activeRoomManager.isInRoom("room-1") } returns true
         roomFlow.value = TestData.createTestRoom(
@@ -1893,8 +1926,8 @@ class RoomViewModelTest {
         advanceUntilIdle()
 
         coVerify { roomRepository.setOwnerReturned("room-1", currentUserId) }
-        // Neither joinRoom (early return) nor ownerReturn calls setPresence when already in room
-        coVerify(exactly = 0) { presenceService.setPresence(any(), any()) }
+        // ownerReturn always re-establishes presence as a safety net
+        coVerify { presenceService.setPresence("room-1", currentUserId) }
     }
 
     @Test
@@ -2214,5 +2247,75 @@ class RoomViewModelTest {
 
         viewModel.clearError()
         assertNull(viewModel.uiState.value.error)
+    }
+
+    // ===== Batch user loading (Pass 1 & 6) =====
+
+    @Test
+    fun `loadSeatUsers calls batch getUsers instead of individual getUser`() = runTest {
+        val userA = TestData.createTestUser(uid = "user-a", displayName = "Alice")
+        val userB = TestData.createTestUser(uid = "user-b", displayName = "Bob")
+        coEvery { userRepository.getUsers(any()) } returns Resource.Success(listOf(userA, userB))
+
+        viewModel = createViewModel()
+        val seats = TestData.createDefaultSeats().toMutableMap()
+        seats["0"] = TestData.createTestSeat(userId = currentUserId)
+        seats["1"] = TestData.createTestSeat(userId = "user-a")
+        seats["2"] = TestData.createTestSeat(userId = "user-b")
+
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "user-a", "user-b"),
+            seats = seats
+        ))
+        advanceUntilIdle()
+
+        // Verify batch getUsers was called (not individual getUser for each seat user)
+        coVerify { userRepository.getUsers(match { it.containsAll(listOf("user-a", "user-b")) }) }
+    }
+
+    // ===== Disconnect Dimming Tests =====
+
+    @Test
+    fun `disconnectedUserIds - propagated from ActiveRoomManager`() = runTest {
+        val disconnectedFlow = MutableStateFlow<Set<String>>(emptySet())
+        every { activeRoomManager.disconnectedUserIds } returns disconnectedFlow
+
+        viewModel = createViewModel()
+        emitRoomAsOwner()
+        advanceUntilIdle()
+
+        disconnectedFlow.value = setOf("user-x")
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.disconnectedUserIds.contains("user-x"))
+    }
+
+    @Test
+    fun `handleRoomClosed batch-loads host users`() = runTest {
+        val hostUser = TestData.createTestUser(uid = "host-1", displayName = "Host")
+        val ownerUser = TestData.createTestUser(uid = currentUserId, displayName = "Owner")
+        coEvery { userRepository.getUsers(any()) } returns Resource.Success(listOf(ownerUser, hostUser))
+
+        viewModel = createViewModel()
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            hostIds = setOf("host-1"),
+            participantIds = setOf(currentUserId, "host-1")
+        ))
+        advanceUntilIdle()
+
+        // Close the room
+        roomFlow.value = TestData.createTestRoom(
+            ownerId = currentUserId,
+            state = RoomState.CLOSED,
+            hostIds = setOf("host-1"),
+            closedAt = Timestamp.now()
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.roomClosed)
+        // Verify batch loading was used for host users
+        coVerify { userRepository.getUsers(any()) }
     }
 }

--- a/database.rules.json
+++ b/database.rules.json
@@ -2,8 +2,8 @@
   "rules": {
     "presence": {
       "$roomId": {
+        ".read": "auth != null",
         "$userId": {
-          ".read": "auth != null && auth.uid == $userId",
           ".write": "auth != null && auth.uid == $userId"
         }
       }

--- a/functions/index.js
+++ b/functions/index.js
@@ -2,6 +2,7 @@ const { onCall, HttpsError } = require("firebase-functions/v2/https");
 const { onValueDeleted } = require("firebase-functions/v2/database");
 const { initializeApp } = require("firebase-admin/app");
 const { getFirestore } = require("firebase-admin/firestore");
+const { getDatabase } = require("firebase-admin/database");
 const { RtcTokenBuilder, RtcRole } = require("agora-token");
 
 initializeApp();
@@ -49,6 +50,19 @@ exports.onPresenceRemoved = onValueDeleted(
 
     console.log(`Presence removed: room=${roomId} user=${userId}`);
 
+    // Grace period: wait 15 seconds then re-check presence.
+    // RTDB connections can drop briefly (mobile power management, network
+    // fluctuations).  If the user reconnects within the grace window their
+    // presence entry reappears and we skip cleanup entirely.
+    await new Promise((resolve) => setTimeout(resolve, 15000));
+
+    const rtdb = getDatabase();
+    const presenceSnap = await rtdb.ref(`presence/${roomId}/${userId}`).get();
+    if (presenceSnap.exists()) {
+      console.log(`User ${userId} presence re-established in room ${roomId}, skipping cleanup`);
+      return;
+    }
+
     const db = getFirestore();
     const roomRef = db.collection("rooms").doc(roomId);
 
@@ -75,38 +89,25 @@ exports.onPresenceRemoved = onValueDeleted(
           return;
         }
 
-        const updates = {
-          participantIds: participantIds.filter((id) => id !== userId),
-        };
-
-        // Clear any seats occupied by this user
+        const isOwner = room.ownerId === userId;
         const seats = room.seats || {};
-        for (let i = 0; i < MAX_SEATS; i++) {
-          const key = i.toString();
-          const seat = seats[key];
-          if (seat && seat.userId === userId && seat.state === "OCCUPIED") {
-            updates[`seats.${key}`] = {
-              userId: null,
-              state: "EMPTY",
-              isMuted: false,
-            };
-          }
-        }
+        const updates = {};
 
         // Clear any pending invites for this user
         if (room.pendingInvites && room.pendingInvites[userId]) {
           updates[`pendingInvites.${userId}`] = require("firebase-admin/firestore").FieldValue.delete();
         }
 
-        // If this user is the owner, check if anyone is still on mic
-        if (room.ownerId === userId && room.state === "ACTIVE") {
-          // Check if any other user is still seated (on mic) after clearing this user's seats
+        if (isOwner) {
+          // --- Owner disconnected ---
+          // Owner keeps seat 0 and stays in participantIds for reconnection.
+          // Only transition the room state.
+
+          // Check if any other user is still seated (on mic)
           let anyoneOnMic = false;
           for (let i = 0; i < MAX_SEATS; i++) {
-            const key = i.toString();
-            // Skip seats we just cleared for this user
-            if (updates[`seats.${key}`]) continue;
-            const seat = seats[key];
+            if (i === OWNER_SEAT_INDEX) continue;
+            const seat = seats[i.toString()];
             if (seat && seat.userId && seat.userId !== userId && seat.state === "OCCUPIED") {
               anyoneOnMic = true;
               break;
@@ -114,20 +115,56 @@ exports.onPresenceRemoved = onValueDeleted(
           }
 
           if (anyoneOnMic) {
-            // Someone is still on mic, enter grace period
+            // Others still on mic — mark owner away, preserve seat 0
             updates.state = "OWNER_AWAY";
             updates.ownerLeftAt = require("firebase-admin/firestore").Timestamp.now();
-            console.log(`Owner left room ${roomId}, users still on mic - setting OWNER_AWAY`);
+            const currentOwnerSeat = seats[OWNER_SEAT_INDEX.toString()];
+            updates[`seats.${OWNER_SEAT_INDEX}`] = {
+              userId: userId,
+              state: "OCCUPIED",
+              isMuted: (currentOwnerSeat && currentOwnerSeat.isMuted) || false,
+            };
+            console.log(`Owner left room ${roomId}, users still on mic - setting OWNER_AWAY (seat 0 preserved)`);
           } else {
-            // No one on mic, close immediately
+            // Owner is alone — close immediately
             updates.state = "CLOSED";
             updates.closedAt = require("firebase-admin/firestore").Timestamp.now();
             updates.participantIds = [];
-            // Clear all seats
             for (let i = 0; i < MAX_SEATS; i++) {
               updates[`seats.${i.toString()}`] = { userId: null, state: "EMPTY", isMuted: false };
             }
             console.log(`Owner left room ${roomId}, no users on mic - closing immediately`);
+          }
+        } else {
+          // --- Non-owner disconnected ---
+          // Remove from participants and clear their seats.
+
+          // Clear any seats occupied by this user
+          for (let i = 0; i < MAX_SEATS; i++) {
+            const key = i.toString();
+            const seat = seats[key];
+            if (seat && seat.userId === userId && seat.state === "OCCUPIED") {
+              updates[`seats.${key}`] = {
+                userId: null,
+                state: "EMPTY",
+                isMuted: false,
+              };
+            }
+          }
+
+          const remainingParticipants = participantIds.filter((id) => id !== userId);
+
+          // If only the owner remains and they're away, close the room
+          if (remainingParticipants.length === 1 && remainingParticipants[0] === room.ownerId && room.state === "OWNER_AWAY") {
+            updates.state = "CLOSED";
+            updates.closedAt = require("firebase-admin/firestore").Timestamp.now();
+            updates.participantIds = [];
+            for (let i = 0; i < MAX_SEATS; i++) {
+              updates[`seats.${i.toString()}`] = { userId: null, state: "EMPTY", isMuted: false };
+            }
+            console.log(`Last non-owner left room ${roomId} (owner away) - closing`);
+          } else {
+            updates.participantIds = remainingParticipants;
           }
         }
 


### PR DESCRIPTION
## Summary
- Disconnected users' seats dim in real time (alpha 0.4) via StateFlow chain from ActiveRoomManager through ViewModel to SeatItem
- Mute state preserved through disconnect/reconnect cycles in 3 app-side methods and Cloud Function
- 10 optimization/refactor passes: deduplication, batched UI updates, memoized composables, removed debug logging

## Test plan
- [x] All 537+ unit tests pass
- [x] 9 new tests for disconnect dimming & mute preservation
- [ ] Manual test: Create room, have phone 2 join/seat/mute, toggle WiFi — seat dims, mute preserved
- [ ] Manual test: Owner disconnects — seat dims on phone 2, mute state preserved on reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)