### PR TITLE
Censor email in account settings v0.27

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 26
-        versionName = "0.26"
+        versionCode = 27
+        versionName = "0.27"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/shyden/shytalk/feature/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/settings/AppSettingsScreen.kt
@@ -472,7 +472,7 @@ private fun AccountPage(
                     SettingsRow("ShyTalk ID", "${user.uniqueId}")
                 }
                 user.email?.let { email ->
-                    SettingsRow("Email", email)
+                    SettingsRow("Email", censorEmail(email))
                 }
             }
 
@@ -891,6 +891,18 @@ private fun SettingsSwitch(
             onCheckedChange = onCheckedChange
         )
     }
+}
+
+internal fun censorEmail(email: String): String {
+    val parts = email.split("@", limit = 2)
+    if (parts.size != 2) return email
+    val local = parts[0]
+    val domain = parts[1]
+    val censored = when {
+        local.length <= 2 -> "${local.first()}*"
+        else -> "${local.take(2)}${"*".repeat((local.length - 3).coerceAtLeast(1))}${local.last()}"
+    }
+    return "$censored@$domain"
 }
 
 @Composable

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,8 +1,4 @@
-v0.26 - Request a seat & room improvements
+v0.27 - Privacy & account improvements
 
-- Tap an empty seat to request sitting when seats are open
-- Seat icons now stay perfectly circular on all devices
-- User profiles only open when tapping their avatar
-- Cleaner room closed screen with just profile icons
-- Simplified toolbar when a room ends
-- Performance improvements throughout the app
+- Your email address is now partially hidden in account settings for added privacy
+- Minor stability and performance improvements

--- a/app/src/test/java/com/shyden/shytalk/feature/settings/CensorEmailTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/settings/CensorEmailTest.kt
@@ -1,0 +1,49 @@
+package com.shyden.shytalk.feature.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CensorEmailTest {
+
+    @Test
+    fun `standard email censors middle of local part`() {
+        assertEquals("jo*****e@gmail.com", censorEmail("john.doe@gmail.com"))
+    }
+
+    @Test
+    fun `short local part of 4 chars`() {
+        assertEquals("te*t@gmail.com", censorEmail("test@gmail.com"))
+    }
+
+    @Test
+    fun `3 char local part`() {
+        assertEquals("ab*c@example.com", censorEmail("abc@example.com"))
+    }
+
+    @Test
+    fun `2 char local part shows first char and star`() {
+        assertEquals("a*@example.com", censorEmail("ab@example.com"))
+    }
+
+    @Test
+    fun `1 char local part shows char and star`() {
+        assertEquals("a*@example.com", censorEmail("a@example.com"))
+    }
+
+    @Test
+    fun `no at sign returns original`() {
+        assertEquals("notanemail", censorEmail("notanemail"))
+    }
+
+    @Test
+    fun `domain is preserved fully`() {
+        val result = censorEmail("user@my.long.domain.co.uk")
+        assertEquals("us*r@my.long.domain.co.uk", result)
+    }
+
+    @Test
+    fun `long local part censors correctly`() {
+        // "verylongname" = 12 chars → first 2 + 9 stars + last char
+        assertEquals("ve*********e@test.com", censorEmail("verylongname@test.com"))
+    }
+}


### PR DESCRIPTION
## Summary
- Email addresses in account settings are now partially censored for privacy (e.g. `jo*****e@gmail.com`)
- 8 new unit tests for the censorEmail function
- Bumped to v0.27 (versionCode 27)

## Test plan
- [x] All 558 unit tests pass
- [ ] Open Settings > Account and verify email is partially hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)