### PR TITLE
CNY 2026 Year of the Horse UI overhaul v0.29

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Shyden
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,177 @@
+# ShyTalk
+
+**Voice chat rooms, reimagined.**
+
+[![Android](https://img.shields.io/badge/Platform-Android-green.svg)](https://play.google.com/store/apps/details?id=com.shyden.shytalk)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.0-blue.svg)](https://kotlinlang.org)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+## About
+
+ShyTalk is a social voice chat app where users can create and join real-time voice chat rooms. Built with Kotlin Multiplatform, it targets both Android and iOS with a shared codebase. Whether you want to host a conversation, listen in, or connect with people around the world, ShyTalk makes it easy.
+
+## Features
+
+- **Voice Chat Rooms** — Create or join rooms with real-time voice powered by Agora SDK
+- **Seat Management** — Structured seating system with owner, host, and attendee roles
+- **Real-Time Messaging** — Live text chat alongside voice in every room
+- **User Profiles** — Customizable profiles with photos, cover images, nationality flags, and bios
+- **Follow System** — Follow other users and see when they're active
+- **Moderation Tools** — Mute, kick, move seats, and manage hosts as a room owner
+- **Seat Requests & Invites** — Request to join a seat or invite listeners to speak
+- **Floating Chathead** — Continue voice chat while browsing other parts of the app
+- **Block System** — Block users across rooms and profiles
+- **Room Expiry** — Rooms auto-close when the owner is away, with countdown timers
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| **Framework** | Kotlin Multiplatform (KMP) |
+| **UI** | Compose Multiplatform |
+| **Architecture** | MVVM + Repository Pattern |
+| **DI** | Koin |
+| **Auth** | Firebase Authentication (Google Sign-In) |
+| **Database** | Cloud Firestore |
+| **Storage** | Firebase Storage |
+| **Cloud Functions** | Firebase Functions (Node.js) |
+| **Voice** | Agora Voice SDK |
+| **Image Loading** | Coil 3 (KMP) |
+| **Date/Time** | kotlinx-datetime |
+| **Navigation** | Compose Navigation |
+
+## Architecture
+
+ShyTalk follows **MVVM** with a clean **Repository Pattern**:
+
+```
+┌─────────────────────────────────────────────┐
+│                    UI Layer                  │
+│  Compose Screens → ViewModels → UI State    │
+├─────────────────────────────────────────────┤
+│                  Domain Layer                │
+│         Repository Interfaces                │
+├─────────────────────────────────────────────┤
+│                  Data Layer                  │
+│  Repository Impls → Firebase / Agora         │
+└─────────────────────────────────────────────┘
+```
+
+- **shared module** (`commonMain`) — Models, repositories, ViewModels, and UI shared across platforms
+- **app module** — Android-specific screens and entry point
+- **iosApp module** — iOS-specific entry point
+
+## Project Structure
+
+```
+ShyTalk/
+├── app/                          # Android app module
+│   └── src/main/java/.../
+│       ├── ShyTalkApp.kt         # Application entry point
+│       ├── MainActivity.kt       # Main activity
+│       └── feature/
+│           ├── auth/             # Google Sign-In screen
+│           ├── profile/          # Profile screen
+│           ├── room/             # Room screen & components
+│           └── settings/         # App settings
+├── shared/                       # KMP shared module
+│   └── src/commonMain/kotlin/.../
+│       ├── core/
+│       │   ├── di/               # Koin DI modules
+│       │   ├── model/            # Data models (User, ChatRoom, Seat, etc.)
+│       │   └── util/             # Utilities & constants
+│       ├── data/
+│       │   ├── remote/           # Agora voice service
+│       │   └── repository/       # Repository interfaces & implementations
+│       ├── feature/
+│       │   ├── auth/             # Auth ViewModel
+│       │   ├── home/             # Home screen & room list
+│       │   ├── main/             # Main screen with navigation
+│       │   ├── profile/          # Profile ViewModel
+│       │   ├── room/             # Room ViewModel
+│       │   └── settings/         # Settings screens
+│       ├── navigation/           # Navigation routes
+│       └── ui/
+│           ├── components/       # Shared UI components
+│           └── theme/            # Color palette & theming
+├── iosApp/                       # iOS app module
+├── functions/                    # Firebase Cloud Functions
+├── public/                       # Landing page (Firebase Hosting)
+└── firebase.json                 # Firebase configuration
+```
+
+## Getting Started
+
+### Prerequisites
+
+- **Android Studio** Ladybug or newer
+- **JDK 11+**
+- **Firebase project** with Firestore, Auth, Storage, and Functions enabled
+- **Agora account** with an App ID
+
+### Setup
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/shyden/ShyTalk.git
+   cd ShyTalk
+   ```
+
+2. **Firebase configuration**
+   - Create a Firebase project at [console.firebase.google.com](https://console.firebase.google.com)
+   - Enable **Phone Authentication** and **Google Sign-In**
+   - Download `google-services.json` and place it in `app/`
+
+3. **Agora configuration**
+   - Sign up at [agora.io](https://www.agora.io) and create a project
+   - Copy your App ID into `AgoraVoiceService.kt`
+
+4. **Deploy Cloud Functions**
+   ```bash
+   cd functions
+   npm install
+   firebase deploy --only functions
+   ```
+
+5. **Build and run**
+   ```bash
+   ./gradlew assembleDebug
+   ```
+
+### Configuration
+
+| Item | Location | Description |
+|------|----------|-------------|
+| Firebase | `app/google-services.json` | Firebase project config |
+| Agora App ID | `AgoraVoiceService.kt` | Voice chat engine credentials |
+| Web Client ID | `GoogleSignInScreen.kt` | Google OAuth client ID |
+| Firestore Rules | `database.rules.json` | Security rules for Firestore |
+
+## Contributing
+
+Contributions are welcome! Please:
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/my-feature`)
+3. Commit your changes with clear messages
+4. Push to your fork and open a Pull Request
+
+### Code Style
+
+- Follow Kotlin coding conventions
+- Use meaningful names for variables, functions, and classes
+- Keep composables focused and modular
+- Write ViewModels with unidirectional data flow (StateFlow + UI State)
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+
+## Acknowledgments
+
+- [Firebase](https://firebase.google.com) — Authentication, Firestore, Storage, Functions, Hosting
+- [Agora](https://www.agora.io) — Real-time voice communication
+- [Jetpack Compose](https://developer.android.com/jetpack/compose) — Modern declarative UI
+- [Koin](https://insert-koin.io) — Lightweight dependency injection
+- [Coil](https://coil-kt.github.io/coil/) — Image loading for Kotlin Multiplatform
+- [kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime) — Multiplatform date/time

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 27
-        versionName = "0.27"
+        versionCode = 29
+        versionName = "0.29"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/shyden/shytalk/feature/auth/GoogleSignInScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/auth/GoogleSignInScreen.kt
@@ -1,6 +1,7 @@
 package com.shyden.shytalk.feature.auth
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -23,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.credentials.CredentialManager
@@ -32,10 +35,14 @@ import org.koin.compose.viewmodel.koinViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.shyden.shytalk.ui.components.CnyRoomBackground
+import com.shyden.shytalk.ui.theme.CnyGold
 import kotlinx.coroutines.launch
 
 private const val WEB_CLIENT_ID =
     "517834977595-cdu78p6q7vg57utpsvtik04c195lbh8b.apps.googleusercontent.com"
+
+private val SubtitleWhite = Color.White.copy(alpha = 0.85f)
 
 @Composable
 fun GoogleSignInScreen(
@@ -80,72 +87,104 @@ fun GoogleSignInScreen(
         }
     }
 
-    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(horizontal = 32.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Text(
-                text = "ShyTalk",
-                style = MaterialTheme.typography.headlineLarge,
-                color = MaterialTheme.colorScheme.primary
-            )
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Festive animated background
+        CnyRoomBackground(modifier = Modifier.fillMaxSize())
 
-            Spacer(modifier = Modifier.height(8.dp))
+        Scaffold(
+            containerColor = Color.Transparent,
+            snackbarHost = { SnackbarHost(snackbarHostState) }
+        ) { padding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(horizontal = 32.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "\uD83C\uDFEE \uD83D\uDC0E \uD83C\uDFEE",
+                    style = MaterialTheme.typography.displayLarge
+                )
 
-            Text(
-                text = "Connect with friends through voice",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+                Spacer(modifier = Modifier.height(8.dp))
 
-            Spacer(modifier = Modifier.height(32.dp))
+                Text(
+                    text = "ShyTalk",
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = CnyGold
+                )
 
-            if (uiState.isLoading) {
-                CircularProgressIndicator()
-            } else {
-                Button(
-                    onClick = {
-                        scope.launch {
-                            try {
-                                val googleIdOption = GetGoogleIdOption.Builder()
-                                    .setFilterByAuthorizedAccounts(false)
-                                    .setServerClientId(WEB_CLIENT_ID)
-                                    .build()
+                Spacer(modifier = Modifier.height(8.dp))
 
-                                val request = GetCredentialRequest.Builder()
-                                    .addCredentialOption(googleIdOption)
-                                    .build()
+                Text(
+                    text = "Happy New Year! Connect through voice",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = SubtitleWhite
+                )
 
-                                val result = credentialManager.getCredential(
-                                    request = request,
-                                    context = context
-                                )
+                Text(
+                    text = "Year of the Horse 2026",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = CnyGold
+                )
 
-                                val googleIdToken = GoogleIdTokenCredential
-                                    .createFrom(result.credential.data)
-                                    .idToken
+                Spacer(modifier = Modifier.height(4.dp))
 
-                                viewModel.signInWithGoogle(googleIdToken)
-                            } catch (_: GetCredentialCancellationException) {
-                                // User cancelled - do nothing
-                            } catch (e: Exception) {
-                                snackbarHostState.showSnackbar(
-                                    e.message ?: "Google sign-in failed"
-                                )
+                Text(
+                    text = "\u606D\u559C\u767C\u8CA1",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = CnyGold
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(color = CnyGold)
+                } else {
+                    Button(
+                        onClick = {
+                            scope.launch {
+                                try {
+                                    val googleIdOption = GetGoogleIdOption.Builder()
+                                        .setFilterByAuthorizedAccounts(false)
+                                        .setServerClientId(WEB_CLIENT_ID)
+                                        .build()
+
+                                    val request = GetCredentialRequest.Builder()
+                                        .addCredentialOption(googleIdOption)
+                                        .build()
+
+                                    val result = credentialManager.getCredential(
+                                        request = request,
+                                        context = context
+                                    )
+
+                                    val googleIdToken = GoogleIdTokenCredential
+                                        .createFrom(result.credential.data)
+                                        .idToken
+
+                                    viewModel.signInWithGoogle(googleIdToken)
+                                } catch (_: GetCredentialCancellationException) {
+                                    // User cancelled - do nothing
+                                } catch (e: Exception) {
+                                    snackbarHostState.showSnackbar(
+                                        e.message ?: "Google sign-in failed"
+                                    )
+                                }
                             }
-                        }
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text("Sign in with Google")
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary,
+                            contentColor = CnyGold
+                        )
+                    ) {
+                        Text("Sign in with Google")
+                    }
                 }
             }
-
         }
     }
 }

--- a/app/src/main/java/com/shyden/shytalk/feature/home/LunarNewYearScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/home/LunarNewYearScreen.kt
@@ -1,0 +1,58 @@
+package com.shyden.shytalk.feature.home
+
+import android.annotation.SuppressLint
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+
+private const val LUNAR_NEW_YEAR_URL =
+    "https://shytalk.shyden.co.uk/lunar-new-year.html"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LunarNewYearScreen(
+    onNavigateBack: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Lunar New Year") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        AndroidView(
+            factory = { context ->
+                @SuppressLint("SetJavaScriptEnabled")
+                val webView = WebView(context).apply {
+                    webViewClient = WebViewClient()
+                    settings.javaScriptEnabled = true
+                    loadUrl(LUNAR_NEW_YEAR_URL)
+                }
+                webView
+            },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        )
+    }
+}

--- a/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
@@ -74,6 +74,8 @@ import coil3.compose.AsyncImage
 import com.shyden.shytalk.core.util.calculateAge
 import com.shyden.shytalk.core.util.countryNameForCode
 import com.shyden.shytalk.core.util.flagEmojiForCode
+import com.shyden.shytalk.ui.theme.CnyGold
+import com.shyden.shytalk.ui.theme.SpeakingGreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -534,6 +536,16 @@ private fun ProfileContent(
             }
         }
 
+        // CNY badge
+        Text(
+            text = "\uD83D\uDC0E 2026",
+            style = MaterialTheme.typography.labelSmall,
+            color = CnyGold,
+            modifier = Modifier
+                .offset(y = (-40).dp)
+                .padding(start = 130.dp)
+        )
+
         // Profile info section
         Column(
             modifier = Modifier
@@ -641,7 +653,7 @@ private fun ProfileContent(
                             modifier = Modifier
                                 .size(10.dp)
                                 .clip(CircleShape)
-                                .background(Color(0xFF4CAF50))
+                                .background(SpeakingGreen)
                         )
                     }
                 }

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -44,21 +43,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
-import coil3.compose.AsyncImage
-import coil3.request.ImageRequest
-import com.shyden.shytalk.R
+import com.shyden.shytalk.ui.components.CnyRoomBackground
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.material.icons.Icons
-import androidx.compose.material3.Icon
 import com.shyden.shytalk.core.util.Constants
 import com.shyden.shytalk.core.model.RoomRole
 import com.shyden.shytalk.core.model.RoomState
@@ -282,17 +275,10 @@ fun RoomScreen(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
     ) {
-        // Animated GIF background (full screen, behind toolbar)
-        AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(R.raw.room_background)
-                .build(),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier.fillMaxSize()
-        )
+        // Animated CNY Canvas background
+        CnyRoomBackground(modifier = Modifier.fillMaxSize())
 
-        // Semi-transparent scrim so text remains readable over the GIF
+        // Semi-transparent scrim so text remains readable
         Box(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/shyden/shytalk/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shyden/shytalk/navigation/NavGraph.kt
@@ -24,6 +24,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.shyden.shytalk.core.room.ActiveRoomManager
 import com.shyden.shytalk.feature.auth.GoogleSignInScreen
+import com.shyden.shytalk.feature.home.LunarNewYearScreen
 import com.shyden.shytalk.feature.main.MainScreen
 import com.shyden.shytalk.feature.privacy.PrivacyPolicyScreen
 import com.shyden.shytalk.feature.settings.AppSettingsScreen
@@ -158,6 +159,9 @@ fun NavGraph(
                 onNavigateToSettings = {
                     navController.navigate(Screen.Settings.route)
                 },
+                onNavigateToLunarNewYear = {
+                    navController.navigate(Screen.LunarNewYear.route)
+                },
                 profileContent = { modifier ->
                     ProfileScreen(
                         userId = null,
@@ -239,6 +243,12 @@ fun NavGraph(
                         popUpTo(Screen.Main.route) { inclusive = true }
                     }
                 }
+            )
+        }
+
+        composable(Screen.LunarNewYear.route) {
+            LunarNewYearScreen(
+                onNavigateBack = { navController.popBackStack() }
             )
         }
 

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,4 +1,11 @@
-v0.27 - Privacy & account improvements
+v0.29 - Chinese New Year 2026 celebration
 
-- Your email address is now partially hidden in account settings for added privacy
-- Minor stability and performance improvements
+- Full CNY Year of the Horse festive UI overhaul with animated backgrounds
+- Lightweight Canvas-based room background replaces heavy GIF asset
+- Enhanced sign-in screen with festive decorations and greetings
+- CNY banner on home screen links to new Lunar New Year education page
+- Gold-bordered room cards with lantern corner decorations
+- Red-gold gradient decoration strip on navigation bar
+- New Lunar New Year web page with zodiac, traditions & cultural info
+- Landing page enhanced with galloping horse animation and sparkles
+- Performance optimizations: pre-computed colors, cached gradients, removed unused imports

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -13,9 +13,9 @@
                 android:endX="108"
                 android:endY="108"
                 android:type="linear">
-                <item android:color="#FF7B61C4" android:offset="0.0" />
-                <item android:color="#FF6750A4" android:offset="0.5" />
-                <item android:color="#FF381E72" android:offset="1.0" />
+                <item android:color="#FFEF5350" android:offset="0.0" />
+                <item android:color="#FFC62828" android:offset="0.5" />
+                <item android:color="#FF8E0000" android:offset="1.0" />
             </gradient>
         </aapt:attr>
     </path>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -17,15 +17,15 @@
 
     <!-- Three dots (typing/chat indicator) - fading opacity -->
     <path
-        android:fillColor="#6750A4"
+        android:fillColor="#C62828"
         android:fillAlpha="0.7"
         android:pathData="M42.8,49 A2.2,2.2,0,1,1,47.2,49 A2.2,2.2,0,1,1,42.8,49 Z" />
     <path
-        android:fillColor="#6750A4"
+        android:fillColor="#C62828"
         android:fillAlpha="0.5"
         android:pathData="M48.8,49 A2.2,2.2,0,1,1,53.2,49 A2.2,2.2,0,1,1,48.8,49 Z" />
     <path
-        android:fillColor="#6750A4"
+        android:fillColor="#C62828"
         android:fillAlpha="0.35"
         android:pathData="M54.8,49 A2.2,2.2,0,1,1,59.2,49 A2.2,2.2,0,1,1,54.8,49 Z" />
 

--- a/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
@@ -66,10 +66,10 @@ class UserToMapTest {
     }
 
     @Test
-    fun `toMap contains exactly 19 keys`() {
+    fun `toMap contains exactly 20 keys`() {
         val user = TestData.createTestUser()
         val map = user.toMap()
-        assertEquals(19, map.size)
+        assertEquals(20, map.size)
     }
 
     @Test
@@ -79,7 +79,7 @@ class UserToMapTest {
             "description", "nationality", "uniqueId", "blockedUserIds",
             "followingIds", "followerIds", "dateOfBirth", "hideFollowing",
             "hideOnlineStatus", "hideAge", "email",
-            "currentRoomId", "createdAt", "lastSeenAt"
+            "currentRoomId", "userType", "createdAt", "lastSeenAt"
         )
         val user = TestData.createTestUser()
         assertEquals(expectedKeys, user.toMap().keys)

--- a/app/src/test/java/com/shyden/shytalk/feature/home/HomeUiStateTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/home/HomeUiStateTest.kt
@@ -1,0 +1,75 @@
+package com.shyden.shytalk.feature.home
+
+import com.shyden.shytalk.testutil.TestData
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomeUiStateTest {
+
+    @Test
+    fun `default state has empty rooms`() {
+        val state = HomeUiState()
+        assertTrue(state.rooms.isEmpty())
+    }
+
+    @Test
+    fun `default state is loading`() {
+        assertTrue(HomeUiState().isLoading)
+    }
+
+    @Test
+    fun `default state is not refreshing`() {
+        assertFalse(HomeUiState().isRefreshing)
+    }
+
+    @Test
+    fun `default state has no error`() {
+        assertNull(HomeUiState().error)
+    }
+
+    @Test
+    fun `default state has no createdRoomId`() {
+        assertNull(HomeUiState().createdRoomId)
+    }
+
+    @Test
+    fun `default state has empty seatUsers`() {
+        assertTrue(HomeUiState().seatUsers.isEmpty())
+    }
+
+    @Test
+    fun `copy updates rooms`() {
+        val room = TestData.createTestRoom()
+        val state = HomeUiState().copy(rooms = listOf(room))
+        assertEquals(1, state.rooms.size)
+        assertEquals(room.roomId, state.rooms[0].roomId)
+    }
+
+    @Test
+    fun `copy updates error`() {
+        val state = HomeUiState().copy(error = "Something went wrong")
+        assertEquals("Something went wrong", state.error)
+    }
+
+    @Test
+    fun `copy updates createdRoomId`() {
+        val state = HomeUiState().copy(createdRoomId = "room-42")
+        assertEquals("room-42", state.createdRoomId)
+    }
+
+    @Test
+    fun `copy updates seatUsers`() {
+        val user = TestData.createTestUser(uid = "u1")
+        val state = HomeUiState().copy(seatUsers = mapOf("u1" to user))
+        assertEquals(1, state.seatUsers.size)
+        assertEquals("u1", state.seatUsers["u1"]?.uid)
+    }
+
+    @Test
+    fun `REFRESH_INTERVAL_MS is 30 seconds`() {
+        assertEquals(30_000L, HomeViewModel.REFRESH_INTERVAL_MS)
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/navigation/ScreenTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/navigation/ScreenTest.kt
@@ -1,0 +1,106 @@
+package com.shyden.shytalk.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class ScreenTest {
+
+    @Test
+    fun `SignIn has correct route`() {
+        assertEquals("sign_in", Screen.SignIn.route)
+    }
+
+    @Test
+    fun `ProfileSetup has correct route`() {
+        assertEquals("profile_setup", Screen.ProfileSetup.route)
+    }
+
+    @Test
+    fun `Main has correct route`() {
+        assertEquals("main", Screen.Main.route)
+    }
+
+    @Test
+    fun `Room route contains roomId placeholder`() {
+        assertEquals("room/{roomId}", Screen.Room.route)
+    }
+
+    @Test
+    fun `Room createRoute substitutes roomId`() {
+        assertEquals("room/abc-123", Screen.Room.createRoute("abc-123"))
+    }
+
+    @Test
+    fun `UserProfile route contains userId placeholder`() {
+        assertEquals("profile/{userId}", Screen.UserProfile.route)
+    }
+
+    @Test
+    fun `UserProfile createRoute substitutes userId`() {
+        assertEquals("profile/user-42", Screen.UserProfile.createRoute("user-42"))
+    }
+
+    @Test
+    fun `FollowList route contains both placeholders`() {
+        assertEquals("follow_list/{userId}/{tab}", Screen.FollowList.route)
+    }
+
+    @Test
+    fun `FollowList createRoute substitutes both params`() {
+        assertEquals(
+            "follow_list/user-42/followers",
+            Screen.FollowList.createRoute("user-42", "followers")
+        )
+    }
+
+    @Test
+    fun `RequiredDOB has correct route`() {
+        assertEquals("required_dob", Screen.RequiredDOB.route)
+    }
+
+    @Test
+    fun `LunarNewYear has correct route`() {
+        assertEquals("lunar_new_year", Screen.LunarNewYear.route)
+    }
+
+    @Test
+    fun `Settings has correct route`() {
+        assertEquals("settings", Screen.Settings.route)
+    }
+
+    @Test
+    fun `PrivacyPolicy has correct route`() {
+        assertEquals("privacy_policy", Screen.PrivacyPolicy.route)
+    }
+
+    @Test
+    fun `all static routes are unique`() {
+        val routes = listOf(
+            Screen.SignIn.route,
+            Screen.ProfileSetup.route,
+            Screen.Main.route,
+            Screen.Room.route,
+            Screen.UserProfile.route,
+            Screen.FollowList.route,
+            Screen.RequiredDOB.route,
+            Screen.PrivacyPolicy.route,
+            Screen.LunarNewYear.route,
+            Screen.Settings.route
+        )
+        assertEquals(routes.size, routes.toSet().size)
+    }
+
+    @Test
+    fun `Room createRoute with special characters`() {
+        assertEquals("room/room%20id", Screen.Room.createRoute("room%20id"))
+    }
+
+    @Test
+    fun `FollowList createRoute with following tab`() {
+        assertEquals(
+            "follow_list/user-1/following",
+            Screen.FollowList.createRoute("user-1", "following")
+        )
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/ui/theme/ColorTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/ui/theme/ColorTest.kt
@@ -1,0 +1,49 @@
+package com.shyden.shytalk.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class ColorTest {
+
+    @Test
+    fun `CnyGold has correct hex value`() {
+        assertEquals(Color(0xFFF0C246), CnyGold)
+    }
+
+    @Test
+    fun `SpeakingGreen has correct hex value`() {
+        assertEquals(Color(0xFF4CAF50), SpeakingGreen)
+    }
+
+    @Test
+    fun `light theme primary is CNY red`() {
+        assertEquals(Color(0xFFC62828), ShyTalkPrimary)
+    }
+
+    @Test
+    fun `light theme tertiary is CNY gold accent`() {
+        assertEquals(Color(0xFFC9973A), ShyTalkTertiary)
+    }
+
+    @Test
+    fun `dark theme tertiary is brighter gold`() {
+        assertEquals(Color(0xFFF0C246), ShyTalkTertiaryDark)
+    }
+
+    @Test
+    fun `dark theme primary container is deep red`() {
+        assertEquals(Color(0xFF930009), ShyTalkPrimaryContainerDark)
+    }
+
+    @Test
+    fun `CnyGold is fully opaque`() {
+        assertEquals(1f, CnyGold.alpha)
+    }
+
+    @Test
+    fun `light and dark primaries are distinct`() {
+        assertNotEquals(ShyTalkPrimary, ShyTalkPrimaryDark)
+    }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -6,12 +6,16 @@
 <title>ShyTalk — Coming Soon</title>
 <style>
   :root {
-    --bg: #0f1117;
-    --surface: #1a1d27;
-    --border: #2e3348;
-    --text: #e4e6f0;
-    --text2: #9498b0;
-    --accent: #6c5ce7;
+    --bg: #1a0a0a;
+    --surface: #2a1215;
+    --border: #5c2028;
+    --text: #fde8d0;
+    --text2: #c9a87c;
+    --red: #d4263e;
+    --red-glow: #ff3350;
+    --gold: #f0c246;
+    --gold-dim: #c9973a;
+    --lantern: #e63946;
   }
 
   * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -25,12 +29,94 @@
     align-items: center;
     justify-content: center;
     overflow: hidden;
+    position: relative;
+  }
+
+  /* Radial red glow behind content */
+  body::before {
+    content: "";
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    width: 600px;
+    height: 600px;
+    transform: translate(-50%, -50%);
+    background: radial-gradient(circle, rgba(212,38,62,0.15) 0%, transparent 70%);
+    pointer-events: none;
+  }
+
+  /* Floating lanterns */
+  .lantern {
+    position: fixed;
+    font-size: 2.5rem;
+    opacity: 0.35;
+    animation: sway 4s ease-in-out infinite;
+    pointer-events: none;
+    filter: drop-shadow(0 0 12px rgba(230,57,70,0.5));
+  }
+  .lantern:nth-child(1) { top: 6%; left: 8%; animation-delay: 0s; }
+  .lantern:nth-child(2) { top: 4%; right: 10%; animation-delay: 1.2s; font-size: 2rem; }
+  .lantern:nth-child(3) { top: 12%; left: 25%; animation-delay: 2.4s; font-size: 1.8rem; opacity: 0.25; }
+  .lantern:nth-child(4) { top: 8%; right: 28%; animation-delay: 0.8s; font-size: 2.2rem; opacity: 0.3; }
+
+  @keyframes sway {
+    0%, 100% { transform: rotate(-3deg) translateY(0); }
+    50% { transform: rotate(3deg) translateY(-8px); }
+  }
+
+  /* Falling sparkles */
+  .sparkle {
+    position: fixed;
+    width: 3px;
+    height: 3px;
+    background: var(--gold);
+    border-radius: 50%;
+    opacity: 0;
+    pointer-events: none;
+    animation: fall linear infinite;
+  }
+  .sparkle:nth-child(5)  { left: 5%;  animation-duration: 6s;   animation-delay: 0s; }
+  .sparkle:nth-child(6)  { left: 12%; animation-duration: 8s;   animation-delay: 1s; }
+  .sparkle:nth-child(7)  { left: 22%; animation-duration: 7s;   animation-delay: 3s; }
+  .sparkle:nth-child(8)  { left: 30%; animation-duration: 9s;   animation-delay: 2s; }
+  .sparkle:nth-child(9)  { left: 38%; animation-duration: 6.5s; animation-delay: 4s; }
+  .sparkle:nth-child(10) { left: 46%; animation-duration: 7.5s; animation-delay: 1.5s; }
+  .sparkle:nth-child(11) { left: 54%; animation-duration: 8.5s; animation-delay: 0.5s; }
+  .sparkle:nth-child(12) { left: 62%; animation-duration: 6.8s; animation-delay: 2.5s; }
+  .sparkle:nth-child(13) { left: 70%; animation-duration: 7.2s; animation-delay: 3.5s; }
+  .sparkle:nth-child(14) { left: 78%; animation-duration: 8.2s; animation-delay: 0.8s; }
+  .sparkle:nth-child(15) { left: 85%; animation-duration: 6.3s; animation-delay: 1.8s; }
+  .sparkle:nth-child(16) { left: 93%; animation-duration: 7.8s; animation-delay: 4.2s; }
+
+  @keyframes fall {
+    0%   { transform: translateY(-10px); opacity: 0; }
+    10%  { opacity: 0.8; }
+    90%  { opacity: 0.3; }
+    100% { transform: translateY(100vh); opacity: 0; }
   }
 
   .container {
     text-align: center;
     padding: 2rem;
-    max-width: 480px;
+    max-width: 520px;
+    position: relative;
+    z-index: 1;
+  }
+
+  /* Horse zodiac symbol with galloping animation */
+  .zodiac {
+    font-size: 4rem;
+    margin-bottom: 0.5rem;
+    filter: drop-shadow(0 0 20px rgba(240,194,70,0.4));
+    animation: gallop 2s ease-in-out infinite;
+    display: inline-block;
+  }
+
+  @keyframes gallop {
+    0%, 100% { transform: translateX(0) translateY(0); }
+    25% { transform: translateX(6px) translateY(-8px); }
+    50% { transform: translateX(0) translateY(0); }
+    75% { transform: translateX(-6px) translateY(-5px); }
   }
 
   .logo {
@@ -41,13 +127,34 @@
   }
 
   .logo span {
-    color: var(--accent);
+    color: var(--gold);
+    text-shadow: 0 0 24px rgba(240,194,70,0.3);
   }
 
   .tagline {
     color: var(--text2);
     font-size: 1.1rem;
-    margin-bottom: 2.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .cny-greeting {
+    font-size: 0.9rem;
+    color: var(--gold-dim);
+    margin-bottom: 0.5rem;
+    letter-spacing: 0.08em;
+  }
+
+  .cny-greeting .horse-char {
+    font-size: 1.1rem;
+    color: var(--gold);
+  }
+
+  .cny-calligraphy {
+    font-size: 1.6rem;
+    color: var(--gold);
+    margin-bottom: 1.5rem;
+    letter-spacing: 0.15em;
+    text-shadow: 0 0 16px rgba(240,194,70,0.3);
   }
 
   .badge {
@@ -65,15 +172,16 @@
     display: inline-block;
     width: 8px;
     height: 8px;
-    background: var(--accent);
+    background: var(--red);
     border-radius: 50%;
     margin-right: 0.5rem;
     animation: pulse 2s ease-in-out infinite;
+    box-shadow: 0 0 6px var(--red-glow);
   }
 
   @keyframes pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.4; }
+    0%, 100% { opacity: 1; box-shadow: 0 0 6px var(--red-glow); }
+    50% { opacity: 0.4; box-shadow: 0 0 2px var(--red-glow); }
   }
 
   .links {
@@ -81,6 +189,7 @@
     display: flex;
     gap: 1.5rem;
     justify-content: center;
+    flex-wrap: wrap;
   }
 
   .links a {
@@ -91,17 +200,66 @@
   }
 
   .links a:hover {
-    color: var(--accent);
+    color: var(--gold);
   }
+
+  .links .coming-soon-link {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  /* Corner ornaments */
+  .ornament {
+    position: fixed;
+    font-size: 1.4rem;
+    opacity: 0.2;
+    pointer-events: none;
+    color: var(--gold);
+  }
+  .ornament.tl { top: 1.5rem; left: 1.5rem; }
+  .ornament.tr { top: 1.5rem; right: 1.5rem; }
+  .ornament.bl { bottom: 1.5rem; left: 1.5rem; }
+  .ornament.br { bottom: 1.5rem; right: 1.5rem; }
 </style>
 </head>
 <body>
+  <!-- Lanterns -->
+  <div class="lantern">&#x1F3EE;</div>
+  <div class="lantern">&#x1F3EE;</div>
+  <div class="lantern">&#x1F3EE;</div>
+  <div class="lantern">&#x1F3EE;</div>
+
+  <!-- Gold sparkles (12 particles) -->
+  <div class="sparkle"></div>
+  <div class="sparkle"></div>
+  <div class="sparkle"></div>
+  <div class="sparkle"></div>
+  <div class="sparkle"></div>
+  <div class="sparkle"></div>
+  <div class="sparkle"></div>
+  <div class="sparkle"></div>
+  <div class="sparkle"></div>
+  <div class="sparkle"></div>
+  <div class="sparkle"></div>
+  <div class="sparkle"></div>
+
+  <!-- Corner ornaments -->
+  <div class="ornament tl">&#x2726; &#x1F3EE;</div>
+  <div class="ornament tr">&#x1F3EE; &#x2726;</div>
+  <div class="ornament bl">&#x2726; &#x1F3EE;</div>
+  <div class="ornament br">&#x1F3EE; &#x2726;</div>
+
   <div class="container">
+    <div class="zodiac">&#x1F40E;</div>
     <div class="logo">Shy<span>Talk</span></div>
     <p class="tagline">Voice chat rooms, reimagined.</p>
+    <p class="cny-greeting"><span class="horse-char">&#x99AC;</span> Year of the Horse 2026 <span class="horse-char">&#x99AC;</span></p>
+    <p class="cny-calligraphy">&#x606D;&#x559C;&#x767C;&#x8CA1;</p>
     <div class="badge"><span class="dot"></span>Coming Soon</div>
     <div class="links">
       <a href="https://play.google.com/store/apps/details?id=com.shyden.shytalk">Google Play</a>
+      <a class="coming-soon-link" title="Coming soon to iOS">App Store (Coming Soon)</a>
+      <a href="/lunar-new-year.html">Learn about Lunar New Year</a>
     </div>
   </div>
 </body>

--- a/public/lunar-new-year.html
+++ b/public/lunar-new-year.html
@@ -1,0 +1,686 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Lunar New Year — ShyTalk</title>
+<style>
+  :root {
+    --bg: #1a0a0a;
+    --surface: #2a1215;
+    --card: #301418;
+    --border: #5c2028;
+    --text: #fde8d0;
+    --text2: #c9a87c;
+    --text-dim: #9a7a5e;
+    --red: #d4263e;
+    --red-soft: #b8202e;
+    --gold: #f0c246;
+    --gold-dim: #c9973a;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  html {
+    scroll-behavior: smooth;
+  }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.7;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  /* Hero section */
+  .hero {
+    text-align: center;
+    padding: 3rem 1.5rem 2rem;
+    background: linear-gradient(180deg, var(--surface) 0%, var(--bg) 100%);
+    border-bottom: 2px solid var(--border);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .hero::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 400px;
+    height: 400px;
+    transform: translate(-50%, -50%);
+    background: radial-gradient(circle, rgba(212,38,62,0.12) 0%, transparent 70%);
+    pointer-events: none;
+  }
+
+  .hero-emoji {
+    font-size: 4rem;
+    display: block;
+    margin-bottom: 0.5rem;
+    filter: drop-shadow(0 0 16px rgba(240,194,70,0.3));
+  }
+
+  .hero h1 {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: var(--gold);
+    margin-bottom: 0.25rem;
+  }
+
+  .hero .subtitle {
+    font-size: 1rem;
+    color: var(--text2);
+    margin-bottom: 0.5rem;
+  }
+
+  .hero .calligraphy {
+    font-size: 1.5rem;
+    color: var(--gold);
+    letter-spacing: 0.1em;
+    text-shadow: 0 0 12px rgba(240,194,70,0.25);
+  }
+
+  /* Content container */
+  .content {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 0 1.25rem 3rem;
+  }
+
+  /* Section */
+  section {
+    margin-top: 2.5rem;
+  }
+
+  section h2 {
+    font-size: 1.4rem;
+    color: var(--gold);
+    margin-bottom: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  section h2 .emoji {
+    font-size: 1.5rem;
+  }
+
+  section h3 {
+    font-size: 1.1rem;
+    color: var(--text);
+    margin-top: 1.25rem;
+    margin-bottom: 0.5rem;
+  }
+
+  p {
+    color: var(--text2);
+    margin-bottom: 1rem;
+    font-size: 0.95rem;
+  }
+
+  /* Cards */
+  .card-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    margin-top: 1rem;
+  }
+
+  @media (min-width: 520px) {
+    .card-grid {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  .card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.25rem;
+  }
+
+  .card .card-emoji {
+    font-size: 2rem;
+    display: block;
+    margin-bottom: 0.5rem;
+  }
+
+  .card h4 {
+    color: var(--text);
+    font-size: 1rem;
+    margin-bottom: 0.4rem;
+  }
+
+  .card p {
+    font-size: 0.85rem;
+    margin-bottom: 0;
+  }
+
+  /* Zodiac table */
+  .zodiac-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+    font-size: 0.9rem;
+  }
+
+  .zodiac-table th {
+    background: var(--surface);
+    color: var(--gold);
+    padding: 0.6rem 0.75rem;
+    text-align: left;
+    border-bottom: 2px solid var(--border);
+    font-weight: 600;
+  }
+
+  .zodiac-table td {
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text2);
+  }
+
+  .zodiac-table tr.highlight {
+    background: rgba(212,38,62,0.12);
+  }
+
+  .zodiac-table tr.highlight td {
+    color: var(--gold);
+    font-weight: 600;
+  }
+
+  .zodiac-table .emoji-col {
+    font-size: 1.2rem;
+    text-align: center;
+    width: 3rem;
+  }
+
+  /* Timeline */
+  .timeline {
+    margin-top: 1rem;
+    padding-left: 1.5rem;
+    border-left: 2px solid var(--border);
+  }
+
+  .timeline-item {
+    position: relative;
+    margin-bottom: 1.25rem;
+    padding-left: 1rem;
+  }
+
+  .timeline-item::before {
+    content: "";
+    position: absolute;
+    left: -1.75rem;
+    top: 0.35rem;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--red);
+    border: 2px solid var(--gold-dim);
+  }
+
+  .timeline-item .day {
+    font-size: 0.8rem;
+    color: var(--gold-dim);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .timeline-item .desc {
+    font-size: 0.9rem;
+    color: var(--text2);
+    margin-top: 0.2rem;
+  }
+
+  /* Info banner */
+  .info-banner {
+    background: linear-gradient(135deg, var(--red-soft) 0%, var(--surface) 100%);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    margin-top: 2rem;
+    text-align: center;
+  }
+
+  .info-banner p {
+    color: var(--text);
+    font-size: 0.95rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .info-banner .cta {
+    color: var(--gold);
+    font-weight: 600;
+  }
+
+  /* Country list */
+  .country-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+  }
+
+  .country-tag {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.8rem;
+    color: var(--text2);
+  }
+
+  /* Fun facts */
+  .fact-box {
+    background: var(--surface);
+    border-left: 3px solid var(--gold);
+    padding: 1rem 1.25rem;
+    border-radius: 0 8px 8px 0;
+    margin: 1rem 0;
+  }
+
+  .fact-box p {
+    margin-bottom: 0;
+    font-size: 0.9rem;
+  }
+
+  .fact-box .label {
+    font-size: 0.75rem;
+    color: var(--gold-dim);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.3rem;
+  }
+
+  /* Footer */
+  footer {
+    text-align: center;
+    padding: 2rem 1.5rem;
+    border-top: 1px solid var(--border);
+    margin-top: 2rem;
+  }
+
+  footer p {
+    font-size: 0.8rem;
+    color: var(--text-dim);
+  }
+
+  footer a {
+    color: var(--gold-dim);
+    text-decoration: none;
+  }
+
+  footer a:hover {
+    color: var(--gold);
+  }
+
+  /* Scroll indicator */
+  .scroll-top {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    width: 40px;
+    height: 40px;
+    background: var(--red);
+    color: var(--gold);
+    border: none;
+    border-radius: 50%;
+    font-size: 1.2rem;
+    cursor: pointer;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+    z-index: 10;
+  }
+
+  /* Responsive tweaks */
+  @media (max-width: 400px) {
+    .hero h1 { font-size: 1.5rem; }
+    .hero-emoji { font-size: 3rem; }
+    .hero .calligraphy { font-size: 1.2rem; }
+    section h2 { font-size: 1.2rem; }
+  }
+</style>
+</head>
+<body>
+
+<div class="hero">
+  <span class="hero-emoji">🐴</span>
+  <h1>The Lunar New Year</h1>
+  <p class="subtitle">Understanding the world's most celebrated festival</p>
+  <p class="calligraphy">&#x8FB2;&#x66C6;&#x65B0;&#x5E74;</p>
+</div>
+
+<div class="content">
+
+  <!-- What is Lunar New Year -->
+  <section>
+    <h2><span class="emoji">🌙</span> What is Lunar New Year?</h2>
+    <p>
+      The Lunar New Year, also known as the Spring Festival (&#x6625;&#x7BC0;), is the most important traditional holiday
+      in many East and Southeast Asian cultures. It marks the beginning of a new year on the lunisolar calendar,
+      which follows the cycles of the moon and the sun.
+    </p>
+    <p>
+      Unlike the Gregorian (Western) calendar, which starts on January 1st every year, the Lunar New Year falls
+      on a different date each year — typically between January 21st and February 20th. The celebrations often
+      last for 15 days, culminating with the Lantern Festival.
+    </p>
+    <div class="fact-box">
+      <p class="label">Did you know?</p>
+      <p>The Lunar New Year is celebrated by over 2 billion people worldwide, making it the largest annual human migration as people travel home to be with family.</p>
+    </div>
+  </section>
+
+  <!-- The Lunar Calendar -->
+  <section>
+    <h2><span class="emoji">📅</span> The Lunar Calendar</h2>
+    <p>
+      The lunisolar calendar has been used in China for thousands of years, dating back to at least the Shang Dynasty
+      (1600-1046 BC). Unlike a purely lunar calendar (like the Islamic calendar), the Chinese lunisolar calendar
+      incorporates both the moon's phases and the sun's position to keep seasons aligned.
+    </p>
+    <h3>How it works</h3>
+    <p>
+      Each month begins with a new moon and lasts about 29.5 days. A regular year has 12 months (354 days),
+      but because this is shorter than the solar year (365.25 days), a leap month (&#x958F;&#x6708;) is inserted roughly
+      every three years to keep the calendar synchronized with the seasons. This ensures that the Spring Festival
+      always falls in late winter or early spring.
+    </p>
+    <h3>The 24 Solar Terms</h3>
+    <p>
+      The calendar also divides the year into 24 solar terms (&#x7BC0;&#x6C23;) that guide agricultural activities.
+      These include terms like "Rain Water," "Awakening of Insects," and "Grain Rain" — reflecting the deep
+      connection between the calendar and farming life that sustained ancient civilizations.
+    </p>
+  </section>
+
+  <!-- The Chinese Zodiac -->
+  <section>
+    <h2><span class="emoji">🐉</span> The Chinese Zodiac</h2>
+    <p>
+      The Chinese zodiac is a repeating 12-year cycle, with each year represented by an animal. According to legend,
+      the Jade Emperor organized a race across a river, and the order in which the animals finished determined their
+      place in the cycle. The clever Rat hitched a ride on the Ox and jumped off at the last moment to finish first!
+    </p>
+
+    <table class="zodiac-table">
+      <thead>
+        <tr>
+          <th></th>
+          <th>Animal</th>
+          <th>Traits</th>
+          <th>Years</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="emoji-col">🐀</td>
+          <td>Rat</td>
+          <td>Quick-witted, resourceful</td>
+          <td>2020, 2032</td>
+        </tr>
+        <tr>
+          <td class="emoji-col">🐂</td>
+          <td>Ox</td>
+          <td>Diligent, dependable</td>
+          <td>2021, 2033</td>
+        </tr>
+        <tr>
+          <td class="emoji-col">🐅</td>
+          <td>Tiger</td>
+          <td>Brave, competitive</td>
+          <td>2022, 2034</td>
+        </tr>
+        <tr>
+          <td class="emoji-col">🐇</td>
+          <td>Rabbit</td>
+          <td>Gentle, elegant</td>
+          <td>2023, 2035</td>
+        </tr>
+        <tr>
+          <td class="emoji-col">🐉</td>
+          <td>Dragon</td>
+          <td>Confident, ambitious</td>
+          <td>2024, 2036</td>
+        </tr>
+        <tr>
+          <td class="emoji-col">🐍</td>
+          <td>Snake</td>
+          <td>Wise, enigmatic</td>
+          <td>2025, 2037</td>
+        </tr>
+        <tr class="highlight">
+          <td class="emoji-col">🐴</td>
+          <td>Horse</td>
+          <td>Energetic, free-spirited</td>
+          <td>2026, 2038</td>
+        </tr>
+        <tr>
+          <td class="emoji-col">🐐</td>
+          <td>Goat</td>
+          <td>Calm, creative</td>
+          <td>2027, 2039</td>
+        </tr>
+        <tr>
+          <td class="emoji-col">🐒</td>
+          <td>Monkey</td>
+          <td>Sharp, curious</td>
+          <td>2028, 2040</td>
+        </tr>
+        <tr>
+          <td class="emoji-col">🐓</td>
+          <td>Rooster</td>
+          <td>Observant, hardworking</td>
+          <td>2029, 2041</td>
+        </tr>
+        <tr>
+          <td class="emoji-col">🐕</td>
+          <td>Dog</td>
+          <td>Loyal, honest</td>
+          <td>2030, 2042</td>
+        </tr>
+        <tr>
+          <td class="emoji-col">🐖</td>
+          <td>Pig</td>
+          <td>Compassionate, generous</td>
+          <td>2031, 2043</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="fact-box">
+      <p class="label">2026 — Year of the Horse</p>
+      <p>The Horse symbolizes energy, freedom, and adventure. People born in Horse years are said to be animated,
+      active, and love being in the spotlight. The Horse year encourages boldness and pursuing new horizons.</p>
+    </div>
+  </section>
+
+  <!-- Cultures and Countries -->
+  <section>
+    <h2><span class="emoji">🌏</span> Who Celebrates?</h2>
+    <p>
+      While most commonly associated with China, the Lunar New Year is celebrated across many cultures,
+      each with their own unique traditions, foods, and customs.
+    </p>
+
+    <div class="country-list">
+      <span class="country-tag">🇨🇳 China</span>
+      <span class="country-tag">🇻🇳 Vietnam (T&#x1EBF;t)</span>
+      <span class="country-tag">🇰🇷 Korea (Seollal)</span>
+      <span class="country-tag">🇸🇬 Singapore</span>
+      <span class="country-tag">🇲🇾 Malaysia</span>
+      <span class="country-tag">🇮🇩 Indonesia</span>
+      <span class="country-tag">🇹🇼 Taiwan</span>
+      <span class="country-tag">🇭🇰 Hong Kong</span>
+      <span class="country-tag">🇵🇭 Philippines</span>
+      <span class="country-tag">🇹🇭 Thailand</span>
+      <span class="country-tag">🇲🇲 Myanmar</span>
+      <span class="country-tag">🇧🇳 Brunei</span>
+      <span class="country-tag">🇲🇳 Mongolia (Tsagaan Sar)</span>
+    </div>
+
+    <h3>Different Names, Same Spirit</h3>
+    <p>
+      In Vietnam, it's called <strong>T&#x1EBF;t Nguy&#xEA;n &#x110;&#xE1;n</strong>, and celebrations revolve around
+      peach blossoms and kumquat trees. In Korea, <strong>Seollal</strong> features the traditional bowing ceremony
+      (sebae) where children pay respect to elders and receive lucky money. In Mongolia,
+      <strong>Tsagaan Sar</strong> ("White Moon") involves elaborate feasts and exchanging snuff bottles.
+    </p>
+  </section>
+
+  <!-- Traditions and Customs -->
+  <section>
+    <h2><span class="emoji">🧧</span> Traditions & Customs</h2>
+
+    <div class="card-grid">
+      <div class="card">
+        <span class="card-emoji">🧧</span>
+        <h4>Red Envelopes (&#x7D05;&#x5305;)</h4>
+        <p>Money is given in red envelopes to children and unmarried adults, symbolizing good luck and warding off evil spirits. The amount is often an even number, as odd numbers are associated with funerals.</p>
+      </div>
+      <div class="card">
+        <span class="card-emoji">🧨</span>
+        <h4>Firecrackers & Fireworks</h4>
+        <p>Legend says that a monster called Nian feared loud noises and the color red. Setting off firecrackers at midnight drives away evil spirits and bad luck for the coming year.</p>
+      </div>
+      <div class="card">
+        <span class="card-emoji">🏮</span>
+        <h4>Lanterns & Decorations</h4>
+        <p>Red lanterns, couplets (&#x5C0D;&#x806F;), and paper cut-outs adorn homes and streets. Red symbolizes good fortune and joy. The character &#x798F; (fortune) is often hung upside-down, as the word for "upside-down" sounds like "arrived" in Chinese.</p>
+      </div>
+      <div class="card">
+        <span class="card-emoji">🍜</span>
+        <h4>Reunion Dinner</h4>
+        <p>On New Year's Eve, families gather for a lavish dinner. Dishes carry symbolic meanings: fish (&#x9B5A;) for surplus, dumplings (&#x9903;&#x5B50;) for wealth (they resemble gold ingots), and noodles for longevity.</p>
+      </div>
+      <div class="card">
+        <span class="card-emoji">🧹</span>
+        <h4>Spring Cleaning</h4>
+        <p>Homes are thoroughly cleaned before New Year's Day to sweep away bad luck. However, sweeping on New Year's Day itself is avoided, as it might sweep away the incoming good fortune!</p>
+      </div>
+      <div class="card">
+        <span class="card-emoji">🐉</span>
+        <h4>Lion & Dragon Dances</h4>
+        <p>Performed by trained dancers in elaborate costumes, these dances are believed to bring prosperity and chase away evil spirits. The longer the dragon, the more luck it brings.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- The 15 Days -->
+  <section>
+    <h2><span class="emoji">🎆</span> The 15 Days of Celebration</h2>
+    <p>
+      The Lunar New Year isn't just one day — it's a 15-day festival, with each day carrying its own traditions and significance.
+    </p>
+
+    <div class="timeline">
+      <div class="timeline-item">
+        <p class="day">Day 1 — New Year's Day</p>
+        <p class="desc">Families gather, firecrackers are lit at midnight, and children receive red envelopes. Many visit temples to pray for a good year.</p>
+      </div>
+      <div class="timeline-item">
+        <p class="day">Day 2 — Married daughters visit parents</p>
+        <p class="desc">Traditionally, married women return to their birth families. It's also believed to be the birthday of all dogs, so dogs are treated extra kindly.</p>
+      </div>
+      <div class="timeline-item">
+        <p class="day">Day 3-4 — Rest & remembrance</p>
+        <p class="desc">Families rest and visit graves of ancestors. These days were traditionally considered unlucky for visiting or hosting guests.</p>
+      </div>
+      <div class="timeline-item">
+        <p class="day">Day 5 — Welcome the God of Wealth</p>
+        <p class="desc">Businesses reopen and firecrackers are set off to welcome the God of Wealth (&#x8CA1;&#x795E;). It's considered the best day to start new ventures.</p>
+      </div>
+      <div class="timeline-item">
+        <p class="day">Day 7 — Everyone's Birthday</p>
+        <p class="desc">Known as "Renri" (&#x4EBA;&#x65E5;), this is considered the common birthday of all humans. A special seven-vegetable soup is prepared in some regions.</p>
+      </div>
+      <div class="timeline-item">
+        <p class="day">Day 8 — Jade Emperor's Eve</p>
+        <p class="desc">Families prepare offerings for the Jade Emperor's birthday on Day 9. In Hokkien culture, this is one of the most important days.</p>
+      </div>
+      <div class="timeline-item">
+        <p class="day">Day 9 — Jade Emperor's Birthday</p>
+        <p class="desc">Prayers and offerings are made to the Jade Emperor, ruler of heaven. Sugarcane is a traditional offering, symbolizing reaching high.</p>
+      </div>
+      <div class="timeline-item">
+        <p class="day">Day 15 — Lantern Festival (&#x5143;&#x5BB5;&#x7BC0;)</p>
+        <p class="desc">The grand finale! Colorful lanterns light up the night, riddles are written on lanterns for people to solve, and tangyuan (sweet rice balls) are eaten to symbolize family unity. Many consider this the Chinese Valentine's Day.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Significance -->
+  <section>
+    <h2><span class="emoji">❤️</span> Why It Matters</h2>
+    <p>
+      At its heart, the Lunar New Year is about <strong>family, renewal, and hope</strong>. In a world that moves
+      ever faster, this ancient festival reminds us to pause, gather with loved ones, express gratitude for the
+      past year, and look forward with optimism.
+    </p>
+    <p>
+      For diaspora communities around the world, it's a vital connection to cultural heritage — a time to share
+      stories, pass down traditions, and teach the next generation about their roots. The festival has also become
+      increasingly celebrated globally, with major cities from London to Sydney hosting spectacular events.
+    </p>
+    <p>
+      The greeting <strong>"&#x606D;&#x559C;&#x767C;&#x8CA1;" (Gong Xi Fa Cai)</strong> — meaning "Wishing you
+      prosperity" — captures the spirit perfectly. It's not just about wealth, but about wishing each other
+      fullness of life, good health, and happiness.
+    </p>
+
+    <div class="info-banner">
+      <p>🐴 2026 is the Year of the Horse 🐴</p>
+      <p>May this year bring you the <span class="cta">energy, freedom, and joy</span> that the Horse represents.</p>
+      <p class="calligraphy" style="color: var(--gold); font-size: 1.3rem; margin-top: 0.5rem;">&#x606D;&#x559C;&#x767C;&#x8CA1;</p>
+    </div>
+  </section>
+
+  <!-- Common Greetings -->
+  <section>
+    <h2><span class="emoji">💬</span> New Year Greetings</h2>
+    <p>Here are some popular greetings you can use to wish others a happy Lunar New Year:</p>
+
+    <div class="card-grid">
+      <div class="card">
+        <h4>&#x606D;&#x559C;&#x767C;&#x8CA1;</h4>
+        <p><strong>Gong Xi Fa Cai</strong> (Mandarin) — Wishing you prosperity</p>
+      </div>
+      <div class="card">
+        <h4>&#x65B0;&#x5E74;&#x5FEB;&#x6A02;</h4>
+        <p><strong>Xin Nian Kuai Le</strong> (Mandarin) — Happy New Year</p>
+      </div>
+      <div class="card">
+        <h4>Chuc Mung Nam Moi</h4>
+        <p><strong>Vietnamese</strong> — Happy New Year</p>
+      </div>
+      <div class="card">
+        <h4>&#xC0C8;&#xD574; &#xBCF5; &#xB9CE;&#xC774; &#xBC1B;&#xC73C;&#xC138;&#xC694;</h4>
+        <p><strong>Saehae bok mani badeuseyo</strong> (Korean) — Receive lots of blessings in the new year</p>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+<footer>
+  <p>&#x1F40E; ShyTalk — Happy Year of the Horse 2026</p>
+  <p style="margin-top: 0.5rem;"><a href="/">Back to ShyTalk</a></p>
+</footer>
+
+<button class="scroll-top" id="scrollTop" onclick="window.scrollTo({top:0,behavior:'smooth'})">&#x2191;</button>
+
+<script>
+  const btn = document.getElementById('scrollTop');
+  window.addEventListener('scroll', () => {
+    btn.style.display = window.scrollY > 300 ? 'flex' : 'none';
+  });
+</script>
+
+</body>
+</html>

--- a/shared/src/androidMain/kotlin/com/shyden/shytalk/ui/theme/Theme.android.kt
+++ b/shared/src/androidMain/kotlin/com/shyden/shytalk/ui/theme/Theme.android.kt
@@ -1,12 +1,7 @@
 package com.shyden.shytalk.ui.theme
 
-import android.os.Build
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 
 @Composable
 actual fun ShyTalkTheme(
@@ -14,14 +9,8 @@ actual fun ShyTalkTheme(
     dynamicColor: Boolean,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
-    }
+    // CNY 2026: Always use our festive red/gold palette (skip dynamic colors)
+    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
 
     MaterialTheme(
         colorScheme = colorScheme,

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeScreen.kt
@@ -1,11 +1,22 @@
 package com.shyden.shytalk.feature.home
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -16,19 +27,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import org.koin.compose.viewmodel.koinViewModel
 import androidx.compose.runtime.collectAsState
-import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.ui.theme.CnyGold
+
+private val BannerBackground = Color(0xFF2A0808)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RoomListContent(
     onNavigateToRoom: (String) -> Unit,
+    onNavigateToLunarNewYear: () -> Unit = {},
     snackbarHostState: SnackbarHostState,
     showCreateDialog: Boolean,
     onDismissCreateDialog: () -> Unit,
@@ -74,6 +87,75 @@ fun RoomListContent(
                 state = listState,
                 modifier = Modifier.fillMaxSize()
             ) {
+                item(key = "cny_banner") {
+                    Card(
+                        shape = RoundedCornerShape(12.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = BannerBackground
+                        ),
+                        border = BorderStroke(1.dp, CnyGold),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .clickable(onClick = onNavigateToLunarNewYear)
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = "\uD83C\uDFEE",
+                                    style = MaterialTheme.typography.headlineMedium
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = "\uD83D\uDC0E",
+                                    style = MaterialTheme.typography.headlineLarge
+                                )
+                                Spacer(modifier = Modifier.width(4.dp))
+                                Text(
+                                    text = "\uD83E\uDDE8",
+                                    style = MaterialTheme.typography.headlineMedium
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = "Happy New Year!",
+                                        style = MaterialTheme.typography.titleSmall,
+                                        color = CnyGold
+                                    )
+                                    Text(
+                                        text = "Year of the Horse 2026",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = CnyGold.copy(alpha = 0.85f)
+                                    )
+                                }
+                                Text(
+                                    text = "\uD83C\uDFEE",
+                                    style = MaterialTheme.typography.headlineMedium
+                                )
+                            }
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = "\u606D\u559C\u767C\u8CA1",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = CnyGold
+                            )
+                            Text(
+                                text = "Gong Xi Fa Cai! \u2022 Tap to learn more",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = CnyGold.copy(alpha = 0.7f)
+                            )
+                        }
+                    }
+                }
+
                 if (uiState.rooms.isEmpty()) {
                     item {
                         Box(

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/RoomListItem.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/RoomListItem.kt
@@ -1,5 +1,6 @@
 package com.shyden.shytalk.feature.home
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -10,10 +11,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -30,6 +33,7 @@ import com.shyden.shytalk.core.model.ChatRoom
 import com.shyden.shytalk.core.model.SeatState
 import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.util.flagEmojiForCode
+import com.shyden.shytalk.ui.theme.CnyGold
 
 private val BottomGradient = Brush.verticalGradient(
     colors = listOf(Color.Transparent, Color.Black.copy(alpha = 0.7f)),
@@ -37,6 +41,7 @@ private val BottomGradient = Brush.verticalGradient(
 )
 
 private val WhiteAlpha80 = Color.White.copy(alpha = 0.8f)
+private val GoldBorder = BorderStroke(1.dp, CnyGold.copy(alpha = 0.5f))
 
 @Composable
 fun RoomListItem(
@@ -72,6 +77,8 @@ fun RoomListItem(
     }
 
     Card(
+        border = GoldBorder,
+        colors = CardDefaults.cardColors(),
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 4.dp)
@@ -171,6 +178,15 @@ fun RoomListItem(
                     }
                 }
             }
+
+            // Lantern corner decoration
+            Text(
+                text = "\uD83C\uDFEE",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset(x = (-6).dp, y = 4.dp)
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/main/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/main/MainScreen.kt
@@ -1,6 +1,11 @@
 package com.shyden.shytalk.feature.main
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -11,6 +16,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
@@ -25,7 +31,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.unit.dp
 import com.shyden.shytalk.feature.home.RoomListContent
+import com.shyden.shytalk.ui.theme.CnyGold
 
 enum class BottomNavTab(val label: String) {
     Rooms("Rooms"),
@@ -39,6 +48,7 @@ fun MainScreen(
     onNavigateToUserProfile: (String) -> Unit,
     onNavigateToFollowList: (String, String) -> Unit,
     onNavigateToSettings: () -> Unit,
+    onNavigateToLunarNewYear: () -> Unit = {},
     profileContent: @Composable (Modifier) -> Unit
 ) {
     var selectedTabName by rememberSaveable { mutableStateOf(BottomNavTab.Rooms.name) }
@@ -46,26 +56,40 @@ fun MainScreen(
     var showCreateDialog by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
 
+    val primaryColor = MaterialTheme.colorScheme.primary
+    val topBarGradient = remember(primaryColor) {
+        Brush.horizontalGradient(listOf(primaryColor, CnyGold, primaryColor))
+    }
+
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        when (selectedTab) {
-                            BottomNavTab.Rooms -> "ShyTalk"
-                            BottomNavTab.Profile -> "Profile"
-                        }
-                    )
-                },
-                actions = {
-                    if (selectedTab == BottomNavTab.Profile) {
-                        IconButton(onClick = onNavigateToSettings) {
-                            Icon(Icons.Default.Settings, contentDescription = "Settings")
+            Column {
+                TopAppBar(
+                    title = {
+                        Text(
+                            when (selectedTab) {
+                                BottomNavTab.Rooms -> "ShyTalk \uD83D\uDC0E\uD83C\uDFEE"
+                                BottomNavTab.Profile -> "Profile"
+                            }
+                        )
+                    },
+                    actions = {
+                        if (selectedTab == BottomNavTab.Profile) {
+                            IconButton(onClick = onNavigateToSettings) {
+                                Icon(Icons.Default.Settings, contentDescription = "Settings")
+                            }
                         }
                     }
-                }
-            )
+                )
+                // Red-gold gradient decoration strip
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(2.dp)
+                        .background(topBarGradient)
+                )
+            }
         },
         bottomBar = {
             NavigationBar {
@@ -85,7 +109,10 @@ fun MainScreen(
         },
         floatingActionButton = {
             if (selectedTab == BottomNavTab.Rooms) {
-                FloatingActionButton(onClick = { showCreateDialog = true }) {
+                FloatingActionButton(
+                    onClick = { showCreateDialog = true },
+                    containerColor = MaterialTheme.colorScheme.primary
+                ) {
                     Icon(Icons.Default.Add, contentDescription = "Create Room")
                 }
             }
@@ -95,6 +122,7 @@ fun MainScreen(
             BottomNavTab.Rooms -> {
                 RoomListContent(
                     onNavigateToRoom = onNavigateToRoom,
+                    onNavigateToLunarNewYear = onNavigateToLunarNewYear,
                     snackbarHostState = snackbarHostState,
                     showCreateDialog = showCreateDialog,
                     onDismissCreateDialog = { showCreateDialog = false },

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/navigation/Screen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/navigation/Screen.kt
@@ -15,5 +15,6 @@ sealed class Screen(val route: String) {
     }
     data object RequiredDOB : Screen("required_dob")
     data object PrivacyPolicy : Screen("privacy_policy")
+    data object LunarNewYear : Screen("lunar_new_year")
     data object Settings : Screen("settings")
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/ui/components/CnyRoomBackground.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/ui/components/CnyRoomBackground.kt
@@ -1,0 +1,250 @@
+package com.shyden.shytalk.ui.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.sp
+import kotlin.math.sin
+
+private const val TWO_PI = 2 * kotlin.math.PI
+
+private val DeepRedTop = Color(0xFF1A0505)
+private val DeepRedBottom = Color(0xFF2A0808)
+private val LanternRed = Color(0xFFD4263E)
+private val Gold = Color(0xFFF0C246)
+private val CloudWhite = Color(0xFFFFFFFF)
+
+// Pre-computed alpha variants to avoid per-frame Color.copy() allocations
+private val LanternBodyColor = LanternRed.copy(alpha = 0.5f)
+private val GoldRimColor = Gold.copy(alpha = 0.6f)
+private val GoldTasselColor = Gold.copy(alpha = 0.4f)
+private val GoldHandleColor = Gold.copy(alpha = 0.5f)
+private val RadialGlowColor = Color(0x15D4263E)
+private val BackgroundGradient = Brush.verticalGradient(listOf(DeepRedTop, DeepRedBottom))
+private val HorseWatermarkColor = Color.White.copy(alpha = 0.04f)
+
+private data class LanternConfig(
+    val xFraction: Float,
+    val yFraction: Float,
+    val size: Float,
+    val phaseOffset: Float
+)
+
+private data class SparkleConfig(
+    val xFraction: Float,
+    val speedFactor: Float,
+    val phaseOffset: Float,
+    val radius: Float
+)
+
+@Composable
+fun CnyRoomBackground(modifier: Modifier = Modifier) {
+    val infiniteTransition = rememberInfiniteTransition(label = "cny_bg")
+
+    // Master sway animation for lanterns (0..1 over 4s)
+    val swayProgress by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(4000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "sway"
+    )
+
+    // Sparkle fall animation (0..1 over 8s)
+    val sparkleProgress by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(8000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "sparkle"
+    )
+
+    val lanterns = remember {
+        listOf(
+            LanternConfig(0.12f, 0.08f, 40f, 0f),
+            LanternConfig(0.85f, 0.05f, 35f, 0.3f),
+            LanternConfig(0.30f, 0.12f, 30f, 0.6f),
+            LanternConfig(0.70f, 0.10f, 32f, 0.15f),
+            LanternConfig(0.50f, 0.06f, 38f, 0.45f),
+            LanternConfig(0.20f, 0.18f, 28f, 0.75f)
+        )
+    }
+
+    val sparkles = remember {
+        listOf(
+            SparkleConfig(0.08f, 0.7f, 0.0f, 2.5f),
+            SparkleConfig(0.15f, 0.9f, 0.15f, 2f),
+            SparkleConfig(0.25f, 0.6f, 0.3f, 3f),
+            SparkleConfig(0.35f, 0.8f, 0.45f, 2.5f),
+            SparkleConfig(0.45f, 1.0f, 0.6f, 2f),
+            SparkleConfig(0.55f, 0.65f, 0.1f, 3f),
+            SparkleConfig(0.62f, 0.85f, 0.5f, 2.5f),
+            SparkleConfig(0.72f, 0.75f, 0.25f, 2f),
+            SparkleConfig(0.80f, 0.95f, 0.7f, 3f),
+            SparkleConfig(0.88f, 0.6f, 0.35f, 2.5f),
+            SparkleConfig(0.93f, 0.8f, 0.55f, 2f),
+            SparkleConfig(0.05f, 0.7f, 0.8f, 2.5f),
+            SparkleConfig(0.40f, 0.9f, 0.9f, 2f),
+            SparkleConfig(0.68f, 0.65f, 0.05f, 3f),
+            SparkleConfig(0.50f, 0.75f, 0.65f, 2.5f)
+        )
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            // Base gradient
+            drawRect(brush = BackgroundGradient)
+
+            // Radial glow from center
+            drawCircle(
+                brush = Brush.radialGradient(
+                    colors = listOf(RadialGlowColor, Color.Transparent),
+                    center = Offset(size.width / 2, size.height / 2),
+                    radius = size.minDimension * 0.6f
+                )
+            )
+
+            // Floating lanterns
+            lanterns.forEach { lantern ->
+                val swayOffset = sin((swayProgress + lantern.phaseOffset) * TWO_PI).toFloat() * 8f
+                val cx = size.width * lantern.xFraction + swayOffset
+                val cy = size.height * lantern.yFraction
+                drawLantern(cx, cy, lantern.size)
+            }
+
+            // Gold sparkles
+            sparkles.forEach { sparkle ->
+                val rawProgress = (sparkleProgress * sparkle.speedFactor + sparkle.phaseOffset) % 1f
+                val y = rawProgress * (size.height + 40f) - 20f
+                val x = size.width * sparkle.xFraction
+                val alpha = when {
+                    rawProgress < 0.1f -> rawProgress / 0.1f
+                    rawProgress > 0.9f -> (1f - rawProgress) / 0.1f
+                    else -> 1f
+                } * 0.6f
+                drawCircle(
+                    color = Gold.copy(alpha = alpha),
+                    radius = sparkle.radius,
+                    center = Offset(x, y)
+                )
+            }
+
+            // Cloud wisps near bottom
+            drawCloudWisp(
+                startX = 0f,
+                y = size.height * 0.88f,
+                width = size.width * 0.35f,
+                alpha = 0.03f
+            )
+            drawCloudWisp(
+                startX = size.width * 0.65f,
+                y = size.height * 0.92f,
+                width = size.width * 0.35f,
+                alpha = 0.03f
+            )
+            drawCloudWisp(
+                startX = size.width * 0.3f,
+                y = size.height * 0.95f,
+                width = size.width * 0.4f,
+                alpha = 0.025f
+            )
+        }
+
+        // Horse watermark
+        Text(
+            text = "\uD83D\uDC0E",
+            fontSize = 200.sp,
+            color = HorseWatermarkColor,
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}
+
+private fun DrawScope.drawLantern(cx: Float, cy: Float, bodySize: Float) {
+    val halfBody = bodySize / 2
+    val bodyHeight = bodySize * 0.6f
+
+    // Lantern body (oval)
+    drawOval(
+        color = LanternBodyColor,
+        topLeft = Offset(cx - halfBody, cy - bodyHeight),
+        size = Size(bodySize, bodySize * 1.2f)
+    )
+
+    // Gold rim top
+    drawOval(
+        color = GoldRimColor,
+        topLeft = Offset(cx - halfBody - 2, cy - bodyHeight - 2),
+        size = Size(bodySize + 4, 6f),
+    )
+
+    // Gold rim bottom
+    drawOval(
+        color = GoldRimColor,
+        topLeft = Offset(cx - halfBody - 2, cy + bodyHeight - 4),
+        size = Size(bodySize + 4, 6f),
+    )
+
+    // Tassel lines
+    val tasselTop = cy + bodyHeight
+    for (i in -1..1) {
+        drawLine(
+            color = GoldTasselColor,
+            start = Offset(cx + i * 3f, tasselTop),
+            end = Offset(cx + i * 4f, tasselTop + bodySize * 0.5f),
+            strokeWidth = 1.5f
+        )
+    }
+
+    // Handle on top
+    drawLine(
+        color = GoldHandleColor,
+        start = Offset(cx, cy - bodyHeight),
+        end = Offset(cx, cy - bodySize * 0.85f),
+        strokeWidth = 2f
+    )
+}
+
+private fun DrawScope.drawCloudWisp(startX: Float, y: Float, width: Float, alpha: Float) {
+    val path = Path().apply {
+        moveTo(startX, y)
+        cubicTo(
+            startX + width * 0.25f, y - 30f,
+            startX + width * 0.5f, y - 25f,
+            startX + width * 0.75f, y - 15f
+        )
+        cubicTo(
+            startX + width * 0.85f, y - 10f,
+            startX + width, y - 5f,
+            startX + width, y
+        )
+    }
+    drawPath(
+        path = path,
+        color = CloudWhite.copy(alpha = alpha),
+        style = Stroke(width = 20f)
+    )
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/ui/theme/Color.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/ui/theme/Color.kt
@@ -2,20 +2,21 @@ package com.shyden.shytalk.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-// Light theme
-val ShyTalkPrimary = Color(0xFF6750A4)
+// Light theme — CNY Red/Gold
+val ShyTalkPrimary = Color(0xFFC62828)
 val ShyTalkOnPrimary = Color(0xFFFFFFFF)
-val ShyTalkPrimaryContainer = Color(0xFFEADDFF)
-val ShyTalkSecondary = Color(0xFF625B71)
-val ShyTalkTertiary = Color(0xFF7D5260)
+val ShyTalkPrimaryContainer = Color(0xFFFFDAD5)
+val ShyTalkSecondary = Color(0xFF8D6E63)
+val ShyTalkTertiary = Color(0xFFC9973A)
 val ShyTalkError = Color(0xFFB3261E)
 
-// Dark theme
-val ShyTalkPrimaryDark = Color(0xFFD0BCFF)
-val ShyTalkOnPrimaryDark = Color(0xFF381E72)
-val ShyTalkPrimaryContainerDark = Color(0xFF4F378B)
-val ShyTalkSecondaryDark = Color(0xFFCCC2DC)
-val ShyTalkTertiaryDark = Color(0xFFEFB8C8)
+// Dark theme — CNY Red/Gold
+val ShyTalkPrimaryDark = Color(0xFFFFB4AB)
+val ShyTalkOnPrimaryDark = Color(0xFF690005)
+val ShyTalkPrimaryContainerDark = Color(0xFF930009)
+val ShyTalkSecondaryDark = Color(0xFFEFCEC5)
+val ShyTalkTertiaryDark = Color(0xFFF0C246)
 
 // Semantic colors
 val SpeakingGreen = Color(0xFF4CAF50)
+val CnyGold = Color(0xFFF0C246)


### PR DESCRIPTION
## Summary
- Full Chinese New Year 2026 (Year of the Horse) festive UI overhaul across all screens
- New animated Canvas-based room background replacing 54MB GIF with lightweight ~250-line Kotlin composable
- Lunar New Year education web page with zodiac, traditions, and cultural information
- Comprehensive GitHub README and MIT License added
- 10 optimization passes: pre-computed colors, cached gradients, deduplicated constants, removed unused imports
- 27 new unit tests (603 total, all passing)

## Changes
- **CnyRoomBackground.kt** (NEW): Animated Canvas with floating lanterns, gold sparkles, horse watermark, cloud wisps
- **RoomScreen.kt**: Replaced AsyncImage GIF with Canvas background
- **GoogleSignInScreen.kt**: Festive overhaul with CNY greetings and decorations
- **HomeScreen.kt**: Enhanced CNY banner with dark background for contrast, links to education page
- **RoomListItem.kt**: Gold borders and lantern corner decorations
- **MainScreen.kt**: Updated title, red-gold gradient strip, cached gradient brush
- **ProfileScreen.kt**: CNY badge, SpeakingGreen constant usage
- **index.html**: Galloping horse animation, more sparkles, iOS placeholder link
- **lunar-new-year.html** (NEW): Comprehensive Lunar New Year education page
- **LunarNewYearScreen.kt** (NEW): WebView screen for education page
- **README.md** (NEW): Comprehensive GitHub README
- **LICENSE** (NEW): MIT License

## Test plan
- [x] All 603 unit tests pass
- [x] Build succeeds (`assembleDebug`)
- [x] Installed and verified on both test devices
- [x] Room background shows animated lanterns and sparkles
- [x] Sign-in screen displays festive decorations
- [x] Home screen banner links to education page
- [x] Landing page shows enhanced animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)