### PR TITLE
Fix sign-in button contrast v0.30

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 29
-        versionName = "0.29"
+        versionCode = 30
+        versionName = "0.30"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/shyden/shytalk/feature/auth/GoogleSignInScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/auth/GoogleSignInScreen.kt
@@ -177,8 +177,8 @@ fun GoogleSignInScreen(
                         },
                         modifier = Modifier.fillMaxWidth(),
                         colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.primary,
-                            contentColor = CnyGold
+                            containerColor = CnyGold,
+                            contentColor = Color.Black
                         )
                     ) {
                         Text("Sign in with Google")

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,10 +1,4 @@
-v0.29 - Chinese New Year 2026 celebration
+v0.30 - Sign-in button contrast fix
 
-- Full CNY Year of the Horse festive UI overhaul
-- Animated Canvas room background replaces heavy GIF
-- Festive sign-in screen with CNY greetings
-- CNY banner links to new Lunar New Year education page
-- Gold-bordered room cards with lantern decorations
-- Red-gold gradient strip on navigation bar
-- Enhanced landing page with galloping horse animation
-- Performance: cached gradients, pre-computed colors
+- Fixed sign-in button readability: now gold background with black text
+- Previously gold text on red was difficult to read


### PR DESCRIPTION
## Summary
- Fixed sign-in button readability: changed from gold text on red to black text on gold background
- Bumped version to v0.30

## Test plan
- [x] Build succeeds
- [x] Installed and verified on both test devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)