### PR TITLE
Voice overhaul, chat limits & UX improvements v0.31

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 30
-        versionName = "0.30"
+        versionCode = 31
+        versionName = "0.31"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/shyden/shytalk/MainActivity.kt
+++ b/app/src/main/java/com/shyden/shytalk/MainActivity.kt
@@ -46,7 +46,7 @@ class MainActivity : ComponentActivity() {
         val prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
 
         setContent {
-            ShyTalkTheme {
+            ShyTalkTheme(darkTheme = true) {
                 var privacyAccepted by remember {
                     mutableStateOf(prefs.getBoolean(KEY_PRIVACY_ACCEPTED, false))
                 }

--- a/app/src/main/java/com/shyden/shytalk/core/room/ActiveRoomManager.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/room/ActiveRoomManager.kt
@@ -270,21 +270,24 @@ class ActiveRoomManager(
                     // Switch mic based on seat status (single lookup)
                     val mySeat = findMySeat(room, userId)
                     val currentlySeated = mySeat != null
-                    if (currentlySeated != isSeated) {
-                        voiceService.setMicrophoneEnabled(currentlySeated)
+                    if (currentlySeated != isSeated && !currentlySeated) {
+                        voiceService.setMicrophoneEnabled(false)
+                        voiceService.setAudioMode(false)
                     }
+                    // When becoming seated: do NOT enable mic. User starts muted (Bug #6).
                     isSeated = currentlySeated
 
                     if (mySeat != null) {
-                        // Sync mute state
-                        voiceService.setMicrophoneEnabled(!mySeat.isMuted)
+                        // Sync mute state and audio mode
+                        val shouldUnmute = !mySeat.isMuted
+                        voiceService.setMicrophoneEnabled(shouldUnmute)
+                        voiceService.setAudioMode(shouldUnmute)
 
                         // Ensure connected to voice room
                         if (!voiceService.isJoined.value && room.voiceRoomName.isNotEmpty()) {
                             voiceService.joinRoom(room.voiceRoomName, currentUserId)
-                            if (mySeat.isMuted) {
-                                voiceService.setMicrophoneEnabled(false)
-                            }
+                            voiceService.setMicrophoneEnabled(shouldUnmute)
+                            voiceService.setAudioMode(shouldUnmute)
                         }
                     }
 
@@ -340,8 +343,11 @@ class ActiveRoomManager(
                         graceJob?.cancel()
                         graceJob = scope.launch {
                             delay(Constants.VOICE_DISCONNECT_GRACE_PERIOD_MS)
-                            if (_activeRoomId.value != null) {
-                                leaveRoom()
+                            val currentRoom = _activeRoom.value ?: return@launch
+                            val seatEntry = currentRoom.findUserSeat(currentUserId)
+                            if (seatEntry != null && _activeRoomId.value != null) {
+                                Log.d(TAG, "connectionMonitor: non-owner voice disconnect timeout — removing from seat ${seatEntry.key}")
+                                roomRepository.leaveSeat(_activeRoomId.value!!, seatEntry.key.toInt())
                             }
                         }
                     }
@@ -372,7 +378,7 @@ class ActiveRoomManager(
                     val room = _activeRoom.value ?: return@collect
                     val participantIds = room.participantIds
 
-                    // Users in room but not present in RTDB
+                    // Users in room but not present in RTDB (include seated users for dimming)
                     val absentUsers = participantIds - presentUserIds - currentUserId
 
                     // Cancel timers for users who reappeared
@@ -475,6 +481,12 @@ class ActiveRoomManager(
         if (seat.userId != currentUserId) return
 
         val newMuteState = !seat.isMuted
+        // Block unmute when voice is not connected — muting is always allowed
+        if (!newMuteState && voiceService.connectionState.value != VoiceConnectionState.CONNECTED) {
+            _error.value = "Voice not connected yet"
+            return
+        }
+
         roomRepository.toggleMute(roomId, seatIndex, newMuteState)
         voiceService.setMicrophoneEnabled(!newMuteState)
     }
@@ -490,7 +502,9 @@ class ActiveRoomManager(
         if (targetUserId == room.ownerId) return
         if (role == RoomRole.HOST && targetUserId in room.hostIds) return
 
-        roomRepository.toggleMute(roomId, seatIndex, !seat.isMuted)
+        // Only mute, never unmute — only the user themselves can unmute
+        if (seat.isMuted) return
+        roomRepository.toggleMute(roomId, seatIndex, true)
     }
 
     suspend fun moveSeat(fromIndex: Int, toIndex: Int) {
@@ -504,9 +518,7 @@ class ActiveRoomManager(
         val targetUserId = fromSeat.userId ?: return
         if (role == RoomRole.HOST && (targetUserId == room.ownerId || targetUserId in room.hostIds)) return
 
-        val toSeat = room.seats[toIndex.toString()] ?: return
-        if (toSeat.state == SeatState.OCCUPIED) return
-
+        // Destination can be empty or occupied (swap)
         roomRepository.moveSeat(roomId, fromIndex, toIndex, targetUserId)
     }
 

--- a/app/src/main/java/com/shyden/shytalk/data/remote/LiveKitVoiceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/LiveKitVoiceService.kt
@@ -32,9 +32,19 @@ class LiveKitVoiceService(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-    private var room: Room? = null
     private var currentRoomName: String? = null
     private val joinMutex = Mutex()
+
+    // Pre-create LiveKit Room object on service init (app start) so joining a
+    // voice room later only needs a token fetch + connect — no SDK init delay.
+    private val room: Room = LiveKit.create(
+        appContext = context,
+        overrides = LiveKitOverrides(
+            audioOptions = AudioOptions(
+                audioOutputType = AudioType.MediaAudioType()
+            )
+        )
+    )
 
     private val _speakingUsers = MutableStateFlow<Set<String>>(emptySet())
     override val speakingUsers: StateFlow<Set<String>> = _speakingUsers.asStateFlow()
@@ -50,46 +60,21 @@ class LiveKitVoiceService(
 
     override fun clearError() { _error.value = null }
 
-    override suspend fun joinRoom(roomName: String, userId: String) = joinMutex.withLock {
-        // Already in this room — no-op
-        if (_isJoined.value && currentRoomName == roomName) {
-            Log.d(TAG, "Already joined room=$roomName, skipping rejoin")
-            return@withLock
-        }
-
-        // Leave any existing room first
-        if (room != null) {
-            Log.d(TAG, "Already in a room, leaving first")
-            room?.disconnect()
-            room?.release()
-            room = null
-            _isJoined.value = false
-            currentRoomName = null
-        }
-
-        val newRoom = LiveKit.create(
-            appContext = context,
-            overrides = LiveKitOverrides(
-                audioOptions = AudioOptions(
-                    audioOutputType = AudioType.MediaAudioType()
-                )
-            )
-        )
-        room = newRoom
-        currentRoomName = roomName
-
-        // Collect room events
+    init {
+        Log.d(TAG, "LiveKit Room pre-initialized")
+        // Collect events once — the Room's SharedFlow persists across disconnect/connect cycles
         scope.launch {
-            newRoom.events.collect { event ->
+            room.events.collect { event ->
                 when (event) {
                     is RoomEvent.Connected -> {
-                        Log.d(TAG, "Connected to room=$roomName")
+                        Log.d(TAG, "Connected to room=$currentRoomName")
                         _isJoined.value = true
                         _connectionState.value = VoiceConnectionState.CONNECTED
                     }
                     is RoomEvent.Disconnected -> {
                         Log.d(TAG, "Disconnected from room")
-                        currentRoomName = null
+                        // Don't clear currentRoomName here — managed by joinRoom/leaveChannel
+                        // to avoid race conditions with back-to-back disconnect+connect
                         _isJoined.value = false
                         _connectionState.value = VoiceConnectionState.DISCONNECTED
                         _speakingUsers.value = emptySet()
@@ -125,6 +110,24 @@ class LiveKitVoiceService(
                 }
             }
         }
+    }
+
+    override suspend fun joinRoom(roomName: String, userId: String) = joinMutex.withLock {
+        // Already in this room — no-op
+        if (_isJoined.value && currentRoomName == roomName) {
+            Log.d(TAG, "Already joined room=$roomName, skipping rejoin")
+            return@withLock
+        }
+
+        // Disconnect from current room if needed (Room object stays alive)
+        if (currentRoomName != null) {
+            Log.d(TAG, "Already in a room, disconnecting first")
+            room.disconnect()
+            _isJoined.value = false
+            currentRoomName = null
+        }
+
+        currentRoomName = roomName
 
         // Fetch token and connect
         val token: String? = try {
@@ -136,8 +139,6 @@ class LiveKitVoiceService(
         }
 
         if (token == null) {
-            room?.release()
-            room = null
             currentRoomName = null
             return@withLock
         }
@@ -146,19 +147,15 @@ class LiveKitVoiceService(
             val serverUrl = BuildConfig.LIVEKIT_SERVER_URL
             if (serverUrl.isBlank()) {
                 _error.value = "LiveKit server URL not configured"
-                room?.release()
-                room = null
                 currentRoomName = null
                 return@withLock
             }
             Log.d(TAG, "Connecting to room=$roomName identity=$userId")
-            newRoom.connect(serverUrl, token)
+            room.connect(serverUrl, token)
             Log.d(TAG, "Connected successfully")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to connect", e)
             _error.value = "Voice connection failed: ${e.message}"
-            room?.release()
-            room = null
             currentRoomName = null
         }
     }
@@ -168,44 +165,51 @@ class LiveKitVoiceService(
         _isJoined.value = false
         _speakingUsers.value = emptySet()
         currentRoomName = null
+        audioManager.isSpeakerphoneOn = false
         audioManager.mode = AudioManager.MODE_NORMAL
         try {
-            room?.disconnect()
-            room?.release()
+            room.disconnect()
         } catch (e: Exception) {
             Log.e(TAG, "leaveChannel failed", e)
         }
-        room = null
         _connectionState.value = VoiceConnectionState.DISCONNECTED
     }
 
     override fun setMicrophoneEnabled(enabled: Boolean) {
-        Log.d(TAG, "setMicrophoneEnabled enabled=$enabled")
-        // Switch audio routing: call mode for mic, media mode otherwise
-        if (enabled) {
-            audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
-            audioManager.isSpeakerphoneOn = true
-        } else {
-            audioManager.mode = AudioManager.MODE_NORMAL
+        Log.d(TAG, "setMicrophoneEnabled enabled=$enabled isJoined=${_isJoined.value}")
+        if (!_isJoined.value) {
+            Log.w(TAG, "setMicrophoneEnabled called but not joined, ignoring")
+            return
         }
         scope.launch {
             try {
-                room?.localParticipant?.setMicrophoneEnabled(enabled)
+                room.localParticipant.setMicrophoneEnabled(enabled)
             } catch (e: Exception) {
                 Log.e(TAG, "setMicrophoneEnabled failed", e)
             }
         }
     }
 
+    override fun setAudioMode(voiceMode: Boolean) {
+        Log.d(TAG, "setAudioMode voiceMode=$voiceMode")
+        if (voiceMode) {
+            audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+            audioManager.isSpeakerphoneOn = true
+        } else {
+            audioManager.isSpeakerphoneOn = false
+            audioManager.mode = AudioManager.MODE_NORMAL
+        }
+    }
+
     fun destroy() {
+        audioManager.isSpeakerphoneOn = false
         audioManager.mode = AudioManager.MODE_NORMAL
         try {
-            room?.disconnect()
-            room?.release()
+            room.disconnect()
+            room.release()
         } catch (e: Exception) {
             Log.e(TAG, "destroy failed", e)
         }
-        room = null
         _isJoined.value = false
         _speakingUsers.value = emptySet()
         _connectionState.value = VoiceConnectionState.DISCONNECTED

--- a/app/src/main/java/com/shyden/shytalk/data/repository/MessageRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/MessageRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.shyden.shytalk.data.repository
 
 import com.shyden.shytalk.core.model.Message
 import com.shyden.shytalk.core.model.MessageType
+import com.shyden.shytalk.core.util.Constants
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.core.util.firebaseCall
 import com.shyden.shytalk.core.util.currentTimeMillis
@@ -24,7 +25,7 @@ class MessageRepositoryImpl(
     override fun getMessages(roomId: String): Flow<List<Message>> = callbackFlow {
         val listener = messagesCollection(roomId)
             .orderBy("createdAt", Query.Direction.ASCENDING)
-            .limitToLast(200)
+            .limitToLast(Constants.MAX_ROOM_MESSAGES.toLong())
             .addSnapshotListener { snapshot, error ->
                 if (error != null) {
                     close(error)
@@ -55,6 +56,21 @@ class MessageRepositoryImpl(
             type = type
         )
         messagesCollection(roomId).document(messageId).set(message.toMap()).await()
+        trimOldMessages(roomId)
+    }
+
+    private suspend fun trimOldMessages(roomId: String) {
+        val collection = messagesCollection(roomId)
+        val snapshot = collection
+            .orderBy("createdAt", Query.Direction.ASCENDING)
+            .get()
+            .await()
+        val excess = snapshot.documents.size - Constants.MAX_ROOM_MESSAGES
+        if (excess > 0) {
+            val batch = firestore.batch()
+            snapshot.documents.take(excess).forEach { batch.delete(it.reference) }
+            batch.commit().await()
+        }
     }
 
     override suspend fun sendMessage(

--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
@@ -68,7 +68,7 @@ class RoomRepositoryImpl(
         val roomId = UUID.randomUUID().toString()
         val seats = (0 until Constants.MAX_SEATS).associate { i ->
             i.toString() to if (i == Constants.OWNER_SEAT_INDEX) {
-                Seat(userId = ownerId, state = SeatState.OCCUPIED)
+                Seat(userId = ownerId, state = SeatState.OCCUPIED, isMuted = true)
             } else {
                 Seat()
             }
@@ -122,8 +122,15 @@ class RoomRepositoryImpl(
             val room = snapshot.data?.let { ChatRoom.fromMap(it, snapshot.id) }
                 ?: throw Exception("Room not found")
 
+            // User already in a seat — no-op (prevents duplicate seating)
+            if (room.findUserSeat(userId) != null) return@runTransaction
+
+            // Target seat occupied — abort
+            val seat = room.seats[seatIndex.toString()]
+            if (seat?.state == SeatState.OCCUPIED) return@runTransaction
+
             val updates = clearUserSeats(room, userId)
-            updates["seats.$seatIndex"] = Seat(userId = userId, state = SeatState.OCCUPIED).toMap()
+            updates["seats.$seatIndex"] = Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = true).toMap()
             updates["allTimeSeatUserIds"] = FieldValue.arrayUnion(userId)
             transaction.update(docRef, updates)
         }.await()
@@ -145,11 +152,24 @@ class RoomRepositoryImpl(
             val snapshot = transaction.get(docRef)
             val room = snapshot.data?.let { ChatRoom.fromMap(it, snapshot.id) }
                 ?: throw Exception("Room not found")
-            val currentMuted = room.seats[fromIndex.toString()]?.isMuted ?: false
-            transaction.update(docRef, mapOf(
-                "seats.$fromIndex" to Seat.EMPTY_MAP,
-                "seats.$toIndex" to Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = currentMuted).toMap()
-            ))
+            val fromSeat = room.seats[fromIndex.toString()]
+            val toSeat = room.seats[toIndex.toString()]
+            val fromMuted = fromSeat?.isMuted ?: false
+
+            if (toSeat?.state == SeatState.OCCUPIED && toSeat.userId != null) {
+                // Swap: move both users, preserving each user's mute state
+                val toMuted = toSeat.isMuted
+                transaction.update(docRef, mapOf(
+                    "seats.$fromIndex" to Seat(userId = toSeat.userId, state = SeatState.OCCUPIED, isMuted = toMuted).toMap(),
+                    "seats.$toIndex" to Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = fromMuted).toMap()
+                ))
+            } else {
+                // Move to empty seat
+                transaction.update(docRef, mapOf(
+                    "seats.$fromIndex" to Seat.EMPTY_MAP,
+                    "seats.$toIndex" to Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = fromMuted).toMap()
+                ))
+            }
         }.await()
     }
 
@@ -254,7 +274,24 @@ class RoomRepositoryImpl(
 
             val updates = clearUserSeats(room, userId)
             updates["pendingInvites.$userId"] = FieldValue.delete()
-            updates["seats.$seatIndex"] = Seat(userId = userId, state = SeatState.OCCUPIED).toMap()
+
+            // User already seated — just clear the invite, don't add another seat
+            if (room.findUserSeat(userId) != null) {
+                transaction.update(docRef, updates)
+                return@runTransaction
+            }
+
+            // Find actual empty seat from transactional read (local state may be stale)
+            val actualSeatIndex = if (room.seats[seatIndex.toString()]?.state != SeatState.OCCUPIED) {
+                seatIndex
+            } else {
+                (1 until Constants.MAX_SEATS).firstOrNull { i ->
+                    val s = room.seats[i.toString()]
+                    s != null && s.state != SeatState.OCCUPIED
+                } ?: return@runTransaction // No seats available
+            }
+
+            updates["seats.$actualSeatIndex"] = Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = true).toMap()
             updates["allTimeSeatUserIds"] = FieldValue.arrayUnion(userId)
             transaction.update(docRef, updates)
         }.await()
@@ -350,22 +387,27 @@ class RoomRepositoryImpl(
             // Owner keeps seat 0 for reconnection — only clear non-owner seats
             val updates = if (isOwner) mutableMapOf() else clearUserSeats(room, userId)
 
-            val remainingParticipants = room.participantIds - userId
-
-            if (remainingParticipants.isEmpty() && !isOwner) {
-                // Room is now empty — close it
-                updates.putAll(closeRoomUpdates())
-            } else if (isOwner) {
-                // Owner disconnected — mark away, keep in participants, and guarantee seat 0
+            if (isOwner) {
+                // Owner disconnected — mark away, keep in participants, guarantee seat 0
                 val currentMuted = room.seats[Constants.OWNER_SEAT_INDEX.toString()]?.isMuted ?: false
                 updates["state"] = RoomState.OWNER_AWAY.name
                 updates["ownerLeftAt"] = Timestamp.now()
                 updates["seats.${Constants.OWNER_SEAT_INDEX}"] =
                     Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = currentMuted).toMap()
             } else {
-                updates["participantIds"] = FieldValue.arrayRemove(userId)
-                // If only the owner remains and they're away, close the room
-                if (remainingParticipants.singleOrNull() == room.ownerId && room.state == RoomState.OWNER_AWAY) {
+                // Non-owner: clear seat only, keep in participantIds
+                // (seat clearing already done by clearUserSeats above)
+                // If no one is seated anymore and owner is away, close the room
+                val seatsAfterClear = room.seats.toMutableMap()
+                val userSeatKey = room.findUserSeat(userId)?.key
+                if (userSeatKey != null) {
+                    seatsAfterClear[userSeatKey] = Seat()
+                }
+                val anyoneOnMic = seatsAfterClear.any { (key, seat) ->
+                    key != Constants.OWNER_SEAT_INDEX.toString() &&
+                    seat.userId != null && seat.state == SeatState.OCCUPIED
+                }
+                if (!anyoneOnMic && room.state == RoomState.OWNER_AWAY) {
                     updates.putAll(closeRoomUpdates())
                 }
             }
@@ -388,10 +430,14 @@ class RoomRepositoryImpl(
     )
 
     private fun clearUserSeats(room: ChatRoom, userId: String): MutableMap<String, Any> {
-        // Short-circuit: a user can only occupy one seat, so find it directly
-        val entry = room.findUserSeat(userId) ?: return mutableMapOf()
-        // Owner must never be removed from seat 0
-        if (entry.key == Constants.OWNER_SEAT_INDEX.toString() && userId == room.ownerId) return mutableMapOf()
-        return mutableMapOf("seats.${entry.key}" to Seat.EMPTY_MAP)
+        val updates = mutableMapOf<String, Any>()
+        for ((key, seat) in room.seats) {
+            if (seat.userId == userId && seat.state == SeatState.OCCUPIED) {
+                // Owner must never be removed from seat 0
+                if (key == Constants.OWNER_SEAT_INDEX.toString() && userId == room.ownerId) continue
+                updates["seats.$key"] = Seat.EMPTY_MAP
+            }
+        }
+        return updates
     }
 }

--- a/app/src/main/java/com/shyden/shytalk/data/repository/SeatRequestRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/SeatRequestRepositoryImpl.kt
@@ -42,14 +42,24 @@ class SeatRequestRepositoryImpl(
         userName: String,
         seatIndex: Int
     ): Resource<Unit> = firebaseCall("Failed to create seat request") {
-        // Check if user already has a pending request (limit 1 — only need existence)
+        // Check if user already has a pending request
         val existing = requestsCollection(roomId)
             .whereEqualTo("userId", userId)
             .whereEqualTo("status", SeatRequestStatus.PENDING.name)
             .limit(1)
             .get()
             .await()
-        if (!existing.isEmpty) return@firebaseCall
+        if (!existing.isEmpty) {
+            // Refresh the stale request so snapshot listeners re-fire for observers
+            existing.documents.first().reference.update(
+                mapOf(
+                    "seatIndex" to seatIndex,
+                    "userName" to userName,
+                    "createdAt" to Timestamp.now()
+                )
+            ).await()
+            return@firebaseCall
+        }
 
         val requestId = UUID.randomUUID().toString()
         val request = SeatRequest(

--- a/app/src/main/java/com/shyden/shytalk/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/UserRepositoryImpl.kt
@@ -10,7 +10,15 @@ import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withTimeout
 
@@ -20,11 +28,34 @@ class UserRepositoryImpl(
 
     private val usersCollection = firestore.collection("users")
 
+    private val _userUpdates = MutableSharedFlow<User>(replay = 1, extraBufferCapacity = 5)
+    override val userUpdates: SharedFlow<User> = _userUpdates.asSharedFlow()
+
+    private suspend fun emitUserUpdate(userId: String) {
+        try {
+            val doc = usersCollection.document(userId).get().await()
+            if (doc.exists()) {
+                val data = doc.data
+                if (data != null) {
+                    _userUpdates.tryEmit(User.fromMap(data, doc.id))
+                }
+            }
+        } catch (_: Exception) {
+            // Best-effort: don't fail the parent operation if re-fetch fails
+        }
+    }
+
+    private val profileVisibleFields = setOf(
+        "displayName", "description", "nationality", "profilePhotoUrl",
+        "coverPhotoUrl", "avatarUrl", "hideFollowing", "hideOnlineStatus", "hideAge"
+    )
+
     override suspend fun createOrUpdateUser(user: User): Resource<Unit> = firebaseCall("Failed to create/update user") {
         try {
             withTimeout(10_000L) {
                 usersCollection.document(user.uid).set(user.toMap()).await()
             }
+            _userUpdates.tryEmit(user)
         } catch (_: TimeoutCancellationException) {
             throw Exception("Server not responding — please try again")
         }
@@ -44,10 +75,12 @@ class UserRepositoryImpl(
 
     override suspend fun updateDisplayName(userId: String, displayName: String): Resource<Unit> = firebaseCall("Failed to update display name") {
         usersCollection.document(userId).update("displayName", displayName).await()
+        emitUserUpdate(userId)
     }
 
     override suspend fun updateAvatar(userId: String, avatarUrl: String): Resource<Unit> = firebaseCall("Failed to update avatar") {
         usersCollection.document(userId).update("avatarUrl", avatarUrl).await()
+        emitUserUpdate(userId)
     }
 
     override suspend fun updateLastSeen(userId: String): Resource<Unit> = firebaseCall("Failed to update last seen") {
@@ -56,6 +89,9 @@ class UserRepositoryImpl(
 
     override suspend fun updateProfile(userId: String, fields: Map<String, Any?>): Resource<Unit> = firebaseCall("Failed to update profile") {
         usersCollection.document(userId).update(fields).await()
+        if (fields.keys.any { it in profileVisibleFields }) {
+            emitUserUpdate(userId)
+        }
     }
 
     override suspend fun generateUniqueId(userId: String): Resource<Long> = firebaseCall("Failed to generate unique ID") {
@@ -113,6 +149,14 @@ class UserRepositoryImpl(
             batch.commit().await()
         }
 
+    override suspend fun removeFollower(userId: String, followerId: String): Resource<Unit> =
+        firebaseCall("Failed to remove follower") {
+            val batch = firestore.batch()
+            batch.update(usersCollection.document(userId), "followerIds", FieldValue.arrayRemove(followerId))
+            batch.update(usersCollection.document(followerId), "followingIds", FieldValue.arrayRemove(userId))
+            batch.commit().await()
+        }
+
     override suspend fun getUsers(userIds: List<String>): Resource<List<User>> =
         firebaseCall("Failed to get users") {
             if (userIds.isEmpty()) return@firebaseCall emptyList()
@@ -127,4 +171,18 @@ class UserRepositoryImpl(
                 }.awaitAll().flatMap { it }
             }
         }
+
+    override fun observeUsers(userIds: Set<String>): Flow<User> {
+        if (userIds.isEmpty()) return emptyFlow()
+        return userIds.map { userId ->
+            callbackFlow {
+                val listener = usersCollection.document(userId)
+                    .addSnapshotListener { snapshot, error ->
+                        if (error != null || snapshot == null || !snapshot.exists()) return@addSnapshotListener
+                        snapshot.data?.let { trySend(User.fromMap(it, snapshot.id)) }
+                    }
+                awaitClose { listener.remove() }
+            }
+        }.merge()
+    }
 }

--- a/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
@@ -74,6 +74,7 @@ import coil3.compose.AsyncImage
 import com.shyden.shytalk.core.util.calculateAge
 import com.shyden.shytalk.core.util.countryNameForCode
 import com.shyden.shytalk.core.util.flagEmojiForCode
+import com.shyden.shytalk.ui.components.FlagBadge
 import com.shyden.shytalk.ui.theme.CnyGold
 import com.shyden.shytalk.ui.theme.SpeakingGreen
 
@@ -350,7 +351,7 @@ private fun ProfileContent(
         return
     }
 
-    // Blocked by target - show blocked message
+    // Blocked by target - show blocked message with name and ID
     if (uiState.isBlockedByTarget) {
         Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -361,6 +362,22 @@ private fun ProfileContent(
                     tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Spacer(modifier = Modifier.height(16.dp))
+                if (user != null) {
+                    Text(
+                        text = user.displayName,
+                        style = MaterialTheme.typography.titleLarge,
+                        textAlign = TextAlign.Center
+                    )
+                    if (user.uniqueId != 0L) {
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = "ID: ${user.uniqueId}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
                 Text(
                     text = "This profile is not available",
                     style = MaterialTheme.typography.titleMedium,
@@ -447,7 +464,7 @@ private fun ProfileContent(
             }
         }
 
-        // Profile photo (overlapping cover)
+        // Profile photo + follow stats (overlapping cover)
         val activeRoomId = uiState.activeRoomId
         Box(
             modifier = Modifier
@@ -456,6 +473,50 @@ private fun ProfileContent(
                 .padding(horizontal = 16.dp),
             contentAlignment = Alignment.CenterStart
         ) {
+            // Follow stats — positioned slightly below center to sit under the cover edge
+            if (!uiState.isEditing) {
+                val followingHidden = !isOwn && uiState.hideFollowing
+                Row(
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .padding(top = 24.dp),
+                    horizontalArrangement = Arrangement.spacedBy(24.dp)
+                ) {
+                    Column(
+                        modifier = Modifier.clickable(enabled = !followingHidden) {
+                            onNavigateToFollowList?.invoke(user.uid, "following")
+                        },
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = if (followingHidden) "-" else "${uiState.followingCount}",
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Text(
+                            text = if (followingHidden) "Following (Private)" else "Following",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Column(
+                        modifier = Modifier.clickable {
+                            onNavigateToFollowList?.invoke(user.uid, "followers")
+                        },
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = "${uiState.followerCount}",
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Text(
+                            text = "Followers",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
             Box(
                 modifier = Modifier
                     .then(
@@ -533,6 +594,15 @@ private fun ProfileContent(
                         color = MaterialTheme.colorScheme.primary
                     )
                 }
+
+                // Nationality flag badge on profile photo
+                if (!uiState.isEditing && user.nationality != null) {
+                    FlagBadge(
+                        countryCode = user.nationality!!,
+                        badgeSize = 28.dp,
+                        modifier = Modifier.align(Alignment.BottomEnd)
+                    )
+                }
             }
         }
 
@@ -557,10 +627,11 @@ private fun ProfileContent(
                 // Edit mode
                 OutlinedTextField(
                     value = editDisplayName,
-                    onValueChange = onEditDisplayNameChange,
+                    onValueChange = { if (it.length <= 20) onEditDisplayNameChange(it) },
                     label = { Text("Display Name") },
                     modifier = Modifier.fillMaxWidth(),
-                    singleLine = true
+                    singleLine = true,
+                    supportingText = { Text("${editDisplayName.length}/20") }
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -667,14 +738,6 @@ private fun ProfileContent(
                     )
                 }
 
-                user.nationality?.let { nat ->
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        text = "${flagEmojiForCode(nat)} ${countryNameForCode(nat) ?: ""}",
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                }
-
                 val age = user.dateOfBirth?.let { calculateAge(it) }
                 val shouldShowAge = age != null && (isOwn || !user.hideAge)
                 if (shouldShowAge) {
@@ -693,47 +756,6 @@ private fun ProfileContent(
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                }
-
-                // Follower / Following counts
-                Spacer(modifier = Modifier.height(12.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(24.dp)
-                ) {
-                    Column(
-                        modifier = Modifier.clickable {
-                            onNavigateToFollowList?.invoke(user.uid, "followers")
-                        },
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Text(
-                            text = "${uiState.followerCount}",
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        Text(
-                            text = "Followers",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    val followingHidden = !isOwn && uiState.hideFollowing
-                    Column(
-                        modifier = Modifier.clickable(enabled = !followingHidden) {
-                            onNavigateToFollowList?.invoke(user.uid, "following")
-                        },
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Text(
-                            text = if (followingHidden) "-" else "${uiState.followingCount}",
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        Text(
-                            text = if (followingHidden) "Following (Private)" else "Following",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
                 }
 
                 Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -77,10 +78,10 @@ fun RoomScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    var showSettings by remember { mutableStateOf(false) }
-    var showUserCardForId by remember { mutableStateOf<String?>(null) }
-    var showParticipantPanel by remember { mutableStateOf(false) }
-    var showRoomNameDialog by remember { mutableStateOf(false) }
+    var showSettings by remember(roomId) { mutableStateOf(false) }
+    var showUserCardForId by remember(roomId) { mutableStateOf<String?>(null) }
+    var showParticipantPanel by remember(roomId) { mutableStateOf(false) }
+    var showRoomNameDialog by remember(roomId) { mutableStateOf(false) }
 
     // Track room screen visibility for chathead
     DisposableEffect(Unit) {
@@ -179,6 +180,18 @@ fun RoomScreen(
     // Block warning dialogs
     uiState.blockWarning?.let { warning ->
         val (title, message, showEnterOption) = when (warning) {
+            is BlockWarning.Banned -> {
+                val reason = buildString {
+                    append("You were banned from this room.")
+                    if (warning.kickerName != null) {
+                        append("\nBanned by: ${warning.kickerName}")
+                    }
+                    if (!warning.reason.isNullOrBlank()) {
+                        append("\nReason: ${warning.reason}")
+                    }
+                }
+                Triple("Banned from Room", reason, false)
+            }
             is BlockWarning.BlockedByRoomOwner -> Triple(
                 "Cannot Enter Room",
                 "You are not allowed to enter this room.",
@@ -265,9 +278,9 @@ fun RoomScreen(
         }
     }
 
-    // Merged user map for ChatPanel (memoized)
-    val userMap = remember(uiState.seatUsers, uiState.participantUsers) {
-        uiState.seatUsers + uiState.participantUsers
+    // Merged user map for ChatPanel — use allKnownUsers so departed users keep their avatars
+    val userMap = remember(uiState.allKnownUsers) {
+        uiState.allKnownUsers
     }
 
     Box(
@@ -278,16 +291,28 @@ fun RoomScreen(
         // Animated CNY Canvas background
         CnyRoomBackground(modifier = Modifier.fillMaxSize())
 
-        // Semi-transparent scrim so text remains readable
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background.copy(alpha = 0.85f))
-        )
-
         Scaffold(
             containerColor = Color.Transparent,
-            snackbarHost = { SnackbarHost(snackbarHostState) },
+            snackbarHost = {
+                SnackbarHost(
+                    hostState = snackbarHostState,
+                    modifier = Modifier.padding(bottom = 56.dp),
+                    snackbar = { data ->
+                        Surface(
+                            shape = MaterialTheme.shapes.small,
+                            color = MaterialTheme.colorScheme.inverseSurface.copy(alpha = 0.75f),
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                        ) {
+                            Text(
+                                text = data.visuals.message,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.inverseOnSurface,
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+                            )
+                        }
+                    }
+                )
+            },
             topBar = {
                 if (!uiState.roomClosed) {
                     RoomToolbar(
@@ -347,6 +372,27 @@ fun RoomScreen(
                     contentAlignment = Alignment.Center
                 ) {
                     CircularProgressIndicator()
+                }
+            } else if (uiState.hasJoined && !uiState.isVoiceReady) {
+                // Loading screen while connecting to voice
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = uiState.room?.name ?: "Room",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = MaterialTheme.colorScheme.onBackground
+                    )
+                    Spacer(modifier = Modifier.height(24.dp))
+                    CircularProgressIndicator()
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "Connecting...",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
             } else if (uiState.hasJoined) {
                 Column(modifier = Modifier.fillMaxSize()) {
@@ -538,12 +584,12 @@ fun RoomScreen(
 
         // User card popup when tapping a user
         showUserCardForId?.let { userId ->
-            val emptySeats = remember(uiState.room?.seats) {
+            val movableSeats = remember(uiState.room?.seats, userId) {
                 uiState.room?.seats?.entries
-                    ?.filter { it.value.state != SeatState.OCCUPIED && it.key.toInt() != Constants.OWNER_SEAT_INDEX }
+                    ?.filter { it.key.toInt() != Constants.OWNER_SEAT_INDEX && it.value.userId != userId }
                     ?.map { it.key.toInt() } ?: emptyList()
             }
-            val user = uiState.seatUsers[userId] ?: uiState.participantUsers[userId]
+            val user = uiState.seatUsers[userId] ?: uiState.participantUsers[userId] ?: uiState.allKnownUsers[userId]
             if (user != null) {
                 val targetSeatEntry = uiState.room?.findUserSeat(userId)
                 val isTargetSeated = targetSeatEntry != null
@@ -589,7 +635,8 @@ fun RoomScreen(
                             showUserCardForId = null
                         }
                     } else null,
-                    onMuteToggle = if (canModerate && targetSeatIndex != null) {
+                    onMuteToggle = if (canModerate && targetSeatIndex != null
+                        && targetSeatEntry?.value?.isMuted != true) {
                         { viewModel.forceMuteUser(targetSeatIndex) }
                     } else null,
                     isTargetMuted = targetSeatEntry?.value?.isMuted ?: false,
@@ -600,11 +647,18 @@ fun RoomScreen(
                     onKickFromRoom = if (canKick) {
                         { reason -> viewModel.kickUser(userId, targetSeatIndex, reason) }
                     } else null,
-                    onMoveSeat = if (canModerate && targetSeatIndex != null && emptySeats.isNotEmpty()
+                    onMoveSeat = if (canModerate && targetSeatIndex != null && movableSeats.isNotEmpty()
                         && targetSeatIndex != Constants.OWNER_SEAT_INDEX) {
                         { toIndex -> viewModel.moveSeat(targetSeatIndex, toIndex) }
                     } else null,
-                    emptySeats = emptySeats,
+                    emptySeats = movableSeats,
+                    seatOccupantNames = remember(uiState.room?.seats, uiState.seatUsers) {
+                        uiState.room?.seats?.entries
+                            ?.filter { it.value.state == SeatState.OCCUPIED && it.value.userId != null }
+                            ?.associate { (key, seat) ->
+                                key.toInt() to (uiState.seatUsers[seat.userId]?.displayName ?: "User")
+                            } ?: emptyMap()
+                    },
                     onMakeHost = if (isOwner && isNotSelf && isTargetSeated
                         && targetRole == RoomRole.ATTENDEE) {
                         { viewModel.addHost(userId) }

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,4 +1,12 @@
-v0.30 - Sign-in button contrast fix
+v0.31 - Voice overhaul, chat limits & UX improvements
 
-- Fixed sign-in button readability: now gold background with black text
-- Previously gold text on red was difficult to read
+- Voice disconnect: non-owners keep room access, only seat cleared
+- Speakerphone auto-enabled when unmuted, earpiece routing fixed
+- Unmute blocked until voice fully connected
+- Re-entry skips block dialogs, joins fresh session
+- Seat request fixes: stale requests refreshed, re-entry race resolved
+- Duplicate sit invites prevented
+- Chat capped at 50 messages, oldest auto-trimmed
+- Follower removal now shows Undo button (5s grace period)
+- Room name persisted across sessions
+- Country flag badges on user cards

--- a/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
@@ -66,10 +66,10 @@ class UserToMapTest {
     }
 
     @Test
-    fun `toMap contains exactly 20 keys`() {
+    fun `toMap contains exactly 21 keys`() {
         val user = TestData.createTestUser()
         val map = user.toMap()
-        assertEquals(20, map.size)
+        assertEquals(21, map.size)
     }
 
     @Test
@@ -79,7 +79,7 @@ class UserToMapTest {
             "description", "nationality", "uniqueId", "blockedUserIds",
             "followingIds", "followerIds", "dateOfBirth", "hideFollowing",
             "hideOnlineStatus", "hideAge", "email",
-            "currentRoomId", "userType", "createdAt", "lastSeenAt"
+            "currentRoomId", "lastRoomName", "userType", "createdAt", "lastSeenAt"
         )
         val user = TestData.createTestUser()
         assertEquals(expectedKeys, user.toMap().keys)

--- a/app/src/test/java/com/shyden/shytalk/core/room/ActiveRoomManagerTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/room/ActiveRoomManagerTest.kt
@@ -23,6 +23,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -72,6 +73,7 @@ class ActiveRoomManagerTest {
         every { presenceService.observeRoomPresence(any()) } returns presenceFlow
 
         every { authRepository.currentUserId } returns currentUserId
+        every { userRepository.userUpdates } returns MutableSharedFlow()
 
         manager = ActiveRoomManager(
             roomRepository = roomRepository,
@@ -462,6 +464,39 @@ class ActiveRoomManagerTest {
         val room = TestData.createTestRoom(ownerId = "owner", seats = seats)
         manager.updateTrackedRoom(room)
 
+        // Voice must be connected for unmute, but muting (isMuted=false→true) is always allowed
+        manager.toggleSelfMute(3)
+
+        coVerify { roomRepository.toggleMute("room-1", 3, true) }
+        verify { voiceService.setMicrophoneEnabled(false) }
+    }
+
+    @Test
+    fun `toggleSelfMute - rejects unmute when voice not connected`() = runTest {
+        manager.trackRoom("room-1")
+        val seats = TestData.createDefaultSeats().toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = currentUserId, isMuted = true)
+        val room = TestData.createTestRoom(ownerId = "owner", seats = seats)
+        manager.updateTrackedRoom(room)
+
+        // connectionState starts as DISCONNECTED
+        manager.toggleSelfMute(3)
+
+        // Should NOT call toggleMute or setMicrophoneEnabled
+        coVerify(exactly = 0) { roomRepository.toggleMute(any(), any(), any()) }
+        verify(exactly = 0) { voiceService.setMicrophoneEnabled(true) }
+        assertEquals("Voice not connected yet", manager.error.value)
+    }
+
+    @Test
+    fun `toggleSelfMute - allows mute when voice disconnected`() = runTest {
+        manager.trackRoom("room-1")
+        val seats = TestData.createDefaultSeats().toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = currentUserId, isMuted = false)
+        val room = TestData.createTestRoom(ownerId = "owner", seats = seats)
+        manager.updateTrackedRoom(room)
+
+        // connectionState is DISCONNECTED — muting (isMuted=false→true) should still work
         manager.toggleSelfMute(3)
 
         coVerify { roomRepository.toggleMute("room-1", 3, true) }
@@ -504,20 +539,21 @@ class ActiveRoomManagerTest {
     }
 
     @Test
-    fun `moveSeat - cannot move to occupied seat`() = runTest {
+    fun `moveSeat - occupied destination triggers swap`() = runTest {
         manager.trackRoom("room-1")
         val seats = TestData.createDefaultSeats().toMutableMap()
         seats["2"] = TestData.createTestSeat(userId = "target")
         seats["3"] = TestData.createTestSeat(userId = "occupied")
         val room = TestData.createTestRoom(
             ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "target", "occupied"),
             seats = seats
         )
         manager.updateTrackedRoom(room)
 
         manager.moveSeat(2, 3)
 
-        coVerify(exactly = 0) { roomRepository.moveSeat(any(), any(), any(), any()) }
+        coVerify { roomRepository.moveSeat("room-1", 2, 3, "target") }
     }
 
     // --- leaveRoom ---
@@ -664,7 +700,7 @@ class ActiveRoomManagerTest {
     }
 
     @Test
-    fun `connection monitor - non-owner disconnect triggers leaveRoom after grace period`() = runTest {
+    fun `connection monitor - non-owner disconnect removes from seat after grace period`() = runTest {
         manager.trackRoom("room-1")
         val seats = TestData.createSeatsWithOwner("other-owner").toMutableMap()
         seats["3"] = TestData.createTestSeat(userId = currentUserId)
@@ -684,9 +720,10 @@ class ActiveRoomManagerTest {
         // Advance past the grace period
         testScheduler.advanceTimeBy(Constants.VOICE_DISCONNECT_GRACE_PERIOD_MS + 1000)
 
-        // Non-owner should have left the room
+        // Non-owner should have seat cleared but NOT full leaveRoom
         coVerify { roomRepository.leaveSeat("room-1", 3) }
-        coVerify { voiceService.leaveChannel() }
+        coVerify(exactly = 0) { voiceService.leaveChannel() }
+        coVerify(exactly = 0) { roomRepository.leaveRoom(any(), any()) }
     }
 
     // --- presence monitor ---
@@ -739,20 +776,27 @@ class ActiveRoomManagerTest {
         presenceFlow.value = setOf(currentUserId, "other-owner")
 
         manager.trackRoom("room-1")
+        // Use default seats (owner on seat 0) but make "other-owner" NOT seated
+        // so the presence monitor considers them for removal
+        val seats = TestData.createDefaultSeats().toMutableMap()
+        seats["0"] = TestData.createTestSeat(userId = "other-owner") // owner is seated
         val room = TestData.createTestRoom(
             ownerId = "other-owner",
-            participantIds = setOf("other-owner", currentUserId)
+            participantIds = setOf("other-owner", currentUserId, "unseated-participant"),
+            seats = seats
         )
         manager.updateTrackedRoom(room)
 
-        // Both disappear from presence
+        // Both disappear from presence, plus unseated-participant
         presenceFlow.value = setOf("nobody")
 
         testScheduler.advanceTimeBy(Constants.PRESENCE_TIMEOUT_MS + 100)
 
-        // Should only try to remove other-owner, not self
+        // Should not try to remove self; seated users and unseated participants are sent to
+        // removeDisconnectedUser (Firestore transaction handles owner protection server-side)
         coVerify(exactly = 0) { roomRepository.removeDisconnectedUser("room-1", currentUserId) }
         coVerify { roomRepository.removeDisconnectedUser("room-1", "other-owner") }
+        coVerify { roomRepository.removeDisconnectedUser("room-1", "unseated-participant") }
     }
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/data/repository/MessageRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/MessageRepositoryImplTest.kt
@@ -4,6 +4,8 @@ import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
 import com.shyden.shytalk.core.util.Resource
 import io.mockk.every
 import io.mockk.mockk
@@ -36,6 +38,12 @@ class MessageRepositoryImplTest {
         every { roomDoc.collection("messages") } returns messagesCollection
         every { messagesCollection.document(any<String>()) } returns messageDoc
         every { messageDoc.set(any()) } returns Tasks.forResult(null)
+
+        // Mock trimOldMessages query (returns empty snapshot — no excess messages)
+        val trimQuery = mockk<Query>(relaxed = true)
+        val emptySnapshot = mockk<QuerySnapshot> { every { documents } returns emptyList() }
+        every { messagesCollection.orderBy("createdAt", Query.Direction.ASCENDING) } returns trimQuery
+        every { trimQuery.get() } returns Tasks.forResult(emptySnapshot)
 
         repo = MessageRepositoryImpl(firestore)
     }

--- a/app/src/test/java/com/shyden/shytalk/data/repository/SeatRequestRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/SeatRequestRepositoryImplTest.kt
@@ -62,19 +62,29 @@ class SeatRequestRepositoryImplTest {
     }
 
     @Test
-    fun `createRequest is no-op when pending request already exists`() = runTest {
+    fun `createRequest refreshes existing pending request instead of creating new`() = runTest {
+        val existingDocRef = mockk<DocumentReference>(relaxed = true)
+        val existingDoc = mockk<DocumentSnapshot> {
+            every { reference } returns existingDocRef
+        }
         val query = mockk<Query>(relaxed = true)
-        val querySnapshot = mockk<QuerySnapshot> { every { isEmpty } returns false }
+        val querySnapshot = mockk<QuerySnapshot> {
+            every { isEmpty } returns false
+            every { documents } returns listOf(existingDoc)
+        }
         every { requestsCollection.whereEqualTo("userId", "user-1") } returns query
         every { query.whereEqualTo("status", SeatRequestStatus.PENDING.name) } returns query
         every { query.limit(1) } returns query
         every { query.get() } returns Tasks.forResult(querySnapshot)
+        every { existingDocRef.update(any<Map<String, Any>>()) } returns Tasks.forResult(null)
 
         val result = repo.createRequest("room-1", "user-1", "Alice", 2)
 
         assertTrue(result is Resource.Success)
-        // Should NOT have written a new document
+        // Should NOT have created a new document
         verify(exactly = 0) { requestDoc.set(any()) }
+        // Should have updated the existing one
+        verify(exactly = 1) { existingDocRef.update(any<Map<String, Any>>()) }
     }
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/data/repository/UserRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/UserRepositoryImplTest.kt
@@ -32,6 +32,11 @@ class UserRepositoryImplTest {
         docRef = mockk(relaxed = true)
         every { firestore.collection("users") } returns usersCollection
         every { usersCollection.document(any<String>()) } returns docRef
+        // Default get() to return non-existent doc so emitUserUpdate() completes quickly
+        val emptySnapshot = mockk<DocumentSnapshot> {
+            every { exists() } returns false
+        }
+        every { docRef.get() } returns Tasks.forResult(emptySnapshot)
         repo = UserRepositoryImpl(firestore)
     }
 

--- a/app/src/test/java/com/shyden/shytalk/feature/home/HomeUiStateTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/home/HomeUiStateTest.kt
@@ -69,6 +69,17 @@ class HomeUiStateTest {
     }
 
     @Test
+    fun `default state has empty lastRoomName`() {
+        assertEquals("", HomeUiState().lastRoomName)
+    }
+
+    @Test
+    fun `copy updates lastRoomName`() {
+        val state = HomeUiState().copy(lastRoomName = "My Room")
+        assertEquals("My Room", state.lastRoomName)
+    }
+
+    @Test
     fun `REFRESH_INTERVAL_MS is 30 seconds`() {
         assertEquals(30_000L, HomeViewModel.REFRESH_INTERVAL_MS)
     }

--- a/app/src/test/java/com/shyden/shytalk/feature/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/home/HomeViewModelTest.kt
@@ -44,6 +44,7 @@ class HomeViewModelTest {
     fun setup() {
         every { authRepository.currentUserId } returns currentUserId
         every { roomRepository.getActiveRooms() } returns roomsFlow
+        every { userRepository.userUpdates } returns MutableSharedFlow()
         coEvery { userRepository.getBlockedUserIds(currentUserId) } returns Resource.Success(emptySet())
     }
 
@@ -205,6 +206,26 @@ class HomeViewModelTest {
         advanceUntilIdle()
 
         assertFalse(vm.uiState.value.isRefreshing)
+    }
+
+    @Test
+    fun `createRoom stores lastRoomName in state`() = runTest {
+        val vm = createViewModel()
+        advanceUntilIdle()
+        coEvery { roomRepository.createRoom(any(), any()) } returns Resource.Success("new-room-id")
+
+        vm.createRoom("My Cool Room")
+        advanceUntilIdle()
+
+        assertEquals("My Cool Room", vm.uiState.value.lastRoomName)
+    }
+
+    @Test
+    fun `lastRoomName defaults to empty`() = runTest {
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        assertEquals("", vm.uiState.value.lastRoomName)
     }
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/feature/profile/FollowListViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/profile/FollowListViewModelTest.kt
@@ -1,0 +1,245 @@
+package com.shyden.shytalk.feature.profile
+
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.data.repository.AuthRepository
+import com.shyden.shytalk.data.repository.UserRepository
+import com.shyden.shytalk.testutil.MainDispatcherRule
+import com.shyden.shytalk.testutil.TestData
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FollowListViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val authRepository = mockk<AuthRepository>(relaxed = true)
+    private val userRepository = mockk<UserRepository>(relaxed = true)
+
+    private val currentUserId = "current-user"
+    private val profileUserId = "current-user" // viewing own list
+
+    @Before
+    fun setup() {
+        every { authRepository.currentUserId } returns currentUserId
+        every { userRepository.userUpdates } returns MutableSharedFlow()
+    }
+
+    private fun createViewModel(
+        profileUid: String = profileUserId,
+        initialTab: String = "followers"
+    ): FollowListViewModel {
+        return FollowListViewModel(
+            profileUserId = profileUid,
+            initialTab = initialTab,
+            authRepository = authRepository,
+            userRepository = userRepository
+        )
+    }
+
+    private fun setupProfileWithFollowers() {
+        val followerA = TestData.createTestUser(uid = "follower-a", displayName = "Alice")
+        val followerB = TestData.createTestUser(uid = "follower-b", displayName = "Bob")
+        val profileUser = TestData.createTestUser(
+            uid = currentUserId,
+            displayName = "Current User",
+            followerIds = setOf("follower-a", "follower-b"),
+            followingIds = setOf("following-1")
+        )
+        coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(profileUser)
+        coEvery { userRepository.getUsers(any()) } returns Resource.Success(listOf(followerA, followerB))
+    }
+
+    // ===== Remove Follower Tests =====
+
+    @Test
+    fun `removeFollower - keeps user in list with pending state`() = runTest {
+        setupProfileWithFollowers()
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        assertEquals(2, vm.uiState.value.followers.size)
+
+        vm.removeFollower("follower-a")
+
+        // User stays in list so Undo button is visible
+        assertEquals(2, vm.uiState.value.followers.size)
+        assertEquals("follower-a", vm.uiState.value.pendingRemoveFollowerId)
+    }
+
+    @Test
+    fun `removeFollower - sets pendingRemoveFollowerId`() = runTest {
+        setupProfileWithFollowers()
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.removeFollower("follower-a")
+
+        assertEquals("follower-a", vm.uiState.value.pendingRemoveFollowerId)
+    }
+
+    @Test
+    fun `undoRemoveFollower - clears pending state`() = runTest {
+        setupProfileWithFollowers()
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.removeFollower("follower-a")
+        assertEquals("follower-a", vm.uiState.value.pendingRemoveFollowerId)
+
+        vm.undoRemoveFollower()
+
+        assertEquals(2, vm.uiState.value.followers.size)
+        assertNull(vm.uiState.value.pendingRemoveFollowerId)
+    }
+
+    @Test
+    fun `removeFollower - auto-confirms after timeout`() = runTest {
+        setupProfileWithFollowers()
+        coEvery { userRepository.removeFollower(any(), any()) } returns Resource.Success(Unit)
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.removeFollower("follower-a")
+        advanceTimeBy(5001L)
+
+        assertNull(vm.uiState.value.pendingRemoveFollowerId)
+        coVerify { userRepository.removeFollower(currentUserId, "follower-a") }
+    }
+
+    @Test
+    fun `undoRemoveFollower - cancels auto-confirm`() = runTest {
+        setupProfileWithFollowers()
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.removeFollower("follower-a")
+        vm.undoRemoveFollower()
+        advanceTimeBy(5001L)
+
+        // Should NOT have called removeFollower since we cancelled
+        coVerify(exactly = 0) { userRepository.removeFollower(any(), any()) }
+    }
+
+    @Test
+    fun `removeFollower - non-own list is no-op`() = runTest {
+        val otherUser = "other-user"
+        val profileUser = TestData.createTestUser(
+            uid = otherUser,
+            displayName = "Other",
+            followerIds = setOf("follower-a")
+        )
+        coEvery { userRepository.getUser(otherUser) } returns Resource.Success(profileUser)
+        coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(
+            TestData.createTestUser(uid = currentUserId)
+        )
+        coEvery { userRepository.getUsers(any()) } returns Resource.Success(
+            listOf(TestData.createTestUser(uid = "follower-a", displayName = "Alice"))
+        )
+
+        val vm = createViewModel(profileUid = otherUser)
+        advanceUntilIdle()
+
+        vm.removeFollower("follower-a")
+
+        // Should still have the follower — removeFollower is a no-op for non-own lists
+        assertEquals(1, vm.uiState.value.followers.size)
+    }
+
+    // ===== Tab Selection Tests =====
+
+    @Test
+    fun `initial tab followers`() = runTest {
+        setupProfileWithFollowers()
+        val vm = createViewModel(initialTab = "followers")
+        advanceUntilIdle()
+
+        assertEquals(FollowTab.FOLLOWERS, vm.uiState.value.selectedTab)
+    }
+
+    @Test
+    fun `initial tab following`() = runTest {
+        setupProfileWithFollowers()
+        val vm = createViewModel(initialTab = "following")
+        advanceUntilIdle()
+
+        assertEquals(FollowTab.FOLLOWING, vm.uiState.value.selectedTab)
+    }
+
+    @Test
+    fun `selectTab changes tab`() = runTest {
+        setupProfileWithFollowers()
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.selectTab(FollowTab.FOLLOWING)
+
+        assertEquals(FollowTab.FOLLOWING, vm.uiState.value.selectedTab)
+    }
+
+    // ===== toggleFollow Tests =====
+
+    @Test
+    fun `toggleFollow - follow adds to followingIds optimistically`() = runTest {
+        setupProfileWithFollowers()
+        coEvery { userRepository.followUser(any(), any()) } returns Resource.Success(Unit)
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.toggleFollow("target-user")
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.currentUserFollowingIds.contains("target-user"))
+    }
+
+    @Test
+    fun `toggleFollow - blocked user is rejected`() = runTest {
+        val profileUser = TestData.createTestUser(
+            uid = currentUserId,
+            blockedUserIds = setOf("blocked-user"),
+            followerIds = setOf("follower-a")
+        )
+        coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(profileUser)
+        coEvery { userRepository.getUsers(any()) } returns Resource.Success(
+            listOf(TestData.createTestUser(uid = "follower-a"))
+        )
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.toggleFollow("blocked-user")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { userRepository.followUser(any(), any()) }
+    }
+
+    @Test
+    fun `clearError clears error`() = runTest {
+        setupProfileWithFollowers()
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // Force an error via removeFollower failure
+        coEvery { userRepository.removeFollower(any(), any()) } returns Resource.Error("fail")
+        vm.removeFollower("follower-a")
+        advanceTimeBy(5001L)
+        assertNotNull(vm.uiState.value.error)
+
+        vm.clearError()
+        assertNull(vm.uiState.value.error)
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/feature/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/profile/ProfileViewModelTest.kt
@@ -11,6 +11,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -39,6 +40,7 @@ class ProfileViewModelTest {
     fun setup() {
         every { authRepository.currentUserId } returns currentUserId
         every { authRepository.currentUserEmail } returns "test@example.com"
+        every { userRepository.userUpdates } returns MutableSharedFlow()
     }
 
     private fun createViewModel(): ProfileViewModel {

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -14,6 +14,7 @@ import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.room.RoomLifecycleManager
 import com.shyden.shytalk.core.util.Constants
 import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.data.remote.VoiceConnectionState
 import com.shyden.shytalk.data.remote.VoiceService
 import com.shyden.shytalk.data.remote.PresenceService
 import com.shyden.shytalk.data.repository.AuthRepository
@@ -30,6 +31,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
@@ -64,6 +66,7 @@ class RoomViewModelTest {
     private val speakingFlow = MutableStateFlow<Set<String>>(emptySet())
     private val joinedFlow = MutableStateFlow(false)
     private val voiceErrorFlow = MutableStateFlow<String?>(null)
+    private val connectionStateFlow = MutableStateFlow(VoiceConnectionState.CONNECTED)
     private val pendingRequestsFlow = MutableStateFlow<List<SeatRequest>>(emptyList())
     private val myRequestsFlow = MutableStateFlow<List<SeatRequest>>(emptyList())
 
@@ -75,11 +78,13 @@ class RoomViewModelTest {
     @Before
     fun setup() {
         every { authRepository.currentUserId } returns currentUserId
+        every { userRepository.userUpdates } returns MutableSharedFlow()
         every { roomRepository.getRoomFlow(any()) } returns roomFlow
         every { messageRepository.getMessages(any()) } returns messagesFlow
         every { voiceService.speakingUsers } returns speakingFlow
         every { voiceService.isJoined } returns joinedFlow
         every { voiceService.error } returns voiceErrorFlow
+        every { voiceService.connectionState } returns connectionStateFlow
         coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(
             TestData.createTestUser(uid = currentUserId, displayName = "Current User")
         )
@@ -517,13 +522,14 @@ class RoomViewModelTest {
     }
 
     @Test
-    fun `moveSeat - destination occupied is rejected`() = roomTest {
+    fun `moveSeat - destination occupied triggers swap`() = roomTest {
         viewModel = createViewModel()
         val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
         seats["2"] = TestData.createTestSeat(userId = "attendee-1")
         seats["5"] = TestData.createTestSeat(userId = "attendee-2")
         emitRoomAsOwner(TestData.createTestRoom(
             ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "attendee-1", "attendee-2"),
             seats = seats
         ))
         advanceUntilIdle()
@@ -531,7 +537,7 @@ class RoomViewModelTest {
         viewModel.moveSeat(2, 5)
         advanceUntilIdle()
 
-        coVerify(exactly = 0) { roomRepository.moveSeat(any(), any(), any(), any()) }
+        coVerify { roomRepository.moveSeat("room-1", 2, 5, "attendee-1") }
     }
 
     @Test
@@ -937,14 +943,21 @@ class RoomViewModelTest {
     }
 
     @Test
-    fun `leaveRoom - non-owner just leaves`() = roomTest {
+    fun `leaveRoom - non-owner clears seat and leaves`() = roomTest {
         viewModel = createViewModel()
-        emitRoomAsAttendee()
+        val seats = TestData.createSeatsWithOwner(ownerId).toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = currentUserId)
+        emitRoomAsAttendee(TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId),
+            seats = seats
+        ))
         advanceUntilIdle()
 
         viewModel.leaveRoom()
         advanceUntilIdle()
 
+        coVerify { roomRepository.leaveSeat("room-1", 3) }
         coVerify { roomRepository.leaveRoom("room-1", currentUserId) }
         coVerify(exactly = 0) { roomRepository.setOwnerAway(any()) }
         coVerify(exactly = 0) { roomRepository.closeRoom(any()) }
@@ -1079,7 +1092,8 @@ class RoomViewModelTest {
         viewModel.toggleSelfMute(3) // not our seat
         advanceUntilIdle()
 
-        coVerify(exactly = 0) { roomRepository.toggleMute(any(), any(), any()) }
+        // toggleMute for seat 3 should not be called (not our seat)
+        coVerify(exactly = 0) { roomRepository.toggleMute(any(), eq(3), any()) }
     }
 
     @Test
@@ -1093,6 +1107,65 @@ class RoomViewModelTest {
         advanceUntilIdle()
 
         coVerify { roomRepository.toggleMute("room-1", 0, true) } // was false, toggled to true
+    }
+
+    @Test
+    fun `toggleSelfMute - rejects unmute when voice not connected`() = roomTest {
+        viewModel = createViewModel()
+        val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
+        // Owner is on seat 0, muted
+        seats["0"] = TestData.createTestSeat(userId = currentUserId, isMuted = true)
+        emitRoomAsOwner(TestData.createTestRoom(ownerId = currentUserId, seats = seats))
+        advanceUntilIdle()
+
+        // Set voice to disconnected
+        connectionStateFlow.value = VoiceConnectionState.DISCONNECTED
+
+        viewModel.toggleSelfMute(0) // try to unmute
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.toggleMute(any(), any(), any()) }
+        assertEquals("Voice not connected yet", viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `toggleSelfMute - allows mute when voice disconnected`() = roomTest {
+        viewModel = createViewModel()
+        val seats = TestData.createSeatsWithOwner(currentUserId)
+        emitRoomAsOwner(TestData.createTestRoom(ownerId = currentUserId, seats = seats))
+        advanceUntilIdle()
+
+        // Set voice to disconnected
+        connectionStateFlow.value = VoiceConnectionState.DISCONNECTED
+
+        viewModel.toggleSelfMute(0) // muting (isMuted=false→true) should work
+        advanceUntilIdle()
+
+        coVerify { roomRepository.toggleMute("room-1", 0, true) }
+    }
+
+    // ===== Re-entry Tests =====
+
+    @Test
+    fun `re-entry skips block check when user already in participantIds`() = roomTest {
+        viewModel = createViewModel()
+
+        // User is in participantIds but lifecycle manager is NOT tracking
+        every { roomLifecycleManager.isInRoom("room-1") } returns false
+
+        val room = TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId)
+        )
+        coEvery { userRepository.getUser(ownerId) } returns Resource.Success(
+            TestData.createTestUser(uid = ownerId, displayName = "Owner")
+        )
+        roomFlow.value = room
+        advanceUntilIdle()
+
+        // Should have joined (hasJoined=true) without showing block warning
+        assertTrue(viewModel.uiState.value.hasJoined)
+        assertNull(viewModel.uiState.value.blockWarning)
     }
 
     // ===== confirmJoinDespiteBlock / cancelJoin Tests =====
@@ -1299,24 +1372,26 @@ class RoomViewModelTest {
     }
 
     @Test
-    fun `owner already seated without permission joins then enables mic on permission grant`() = roomTest {
+    fun `owner already seated without permission joins but does not auto-enable mic on permission grant`() = roomTest {
         viewModel = createViewModel()
         // Emit room with owner on seat 0, but NO audio permission yet
         emitRoomAsOwner()
         advanceUntilIdle()
 
-        // Should join voice (mic disabled since no permission yet)
+        // Should join voice (mic disabled since always starting muted)
         coVerify { voiceService.joinRoom("channel-1", any()) }
 
-        // Grant permission — should enable mic since isSeated was set in joinRoom()
+        // Grant permission — Bug #6: should NOT enable mic, user must manually unmute
+        // The state should have hasAudioPermission=true but onAudioPermissionResult
+        // no longer calls setMicrophoneEnabled
         viewModel.onAudioPermissionResult(true)
         advanceUntilIdle()
 
-        verify { voiceService.setMicrophoneEnabled(true) }
+        assertTrue(viewModel.uiState.value.hasAudioPermission)
     }
 
     @Test
-    fun `alreadyInRoom path sets isSeated and does not trigger redundant seat transition`() = roomTest {
+    fun `alreadyInRoom path sets isSeated but does not auto-enable mic on permission grant`() = roomTest {
         // Simulate ViewModel recreation: roomLifecycleManager reports already in room
         every { roomLifecycleManager.isInRoom("room-1") } returns true
 
@@ -1328,11 +1403,11 @@ class RoomViewModelTest {
         viewModel = createViewModel()
         advanceUntilIdle()
 
-        // Grant permission — since isSeated is set in alreadyInRoom path, this should enable mic
+        // Grant permission — Bug #6: should NOT enable mic, user must manually unmute
         viewModel.onAudioPermissionResult(true)
         advanceUntilIdle()
 
-        verify { voiceService.setMicrophoneEnabled(true) }
+        assertTrue(viewModel.uiState.value.hasAudioPermission)
     }
 
     @Test
@@ -1511,10 +1586,16 @@ class RoomViewModelTest {
         emitRoomAsAttendee()
         advanceUntilIdle()
 
+        // First emission (no approved requests) — seeds the suppression snapshot
+        myRequestsFlow.value = emptyList()
+        advanceUntilIdle()
+
+        // Second emission — freshly approved request triggers notification
         val approvedRequest = TestData.createTestSeatRequest(
             userId = currentUserId,
             userName = "Current User",
-            status = SeatRequestStatus.APPROVED
+            status = SeatRequestStatus.APPROVED,
+            createdAt = System.currentTimeMillis() - 10_000L
         )
         myRequestsFlow.value = listOf(approvedRequest)
         advanceUntilIdle()
@@ -2497,5 +2578,177 @@ class RoomViewModelTest {
         assertTrue(viewModel.uiState.value.roomClosed)
         // Verify batch loading was used for host users
         coVerify { userRepository.getUsers(any()) }
+    }
+
+    // ===== Bug 1: Mic sync on join for already-seated owner =====
+
+    @Test
+    fun `joinRoom - owner already seated with isMuted true disables mic`() = roomTest {
+        viewModel = createViewModel()
+        // Owner is seated at index 0 with isMuted = true (default for new rooms)
+        val seats = TestData.createDefaultSeats().toMutableMap()
+        seats["0"] = TestData.createTestSeat(userId = currentUserId, isMuted = true)
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            seats = seats
+        ))
+        advanceUntilIdle()
+
+        // Mic should be disabled because seat.isMuted == true
+        verify { voiceService.setMicrophoneEnabled(false) }
+    }
+
+    @Test
+    fun `joinRoom - always starts muted even with isMuted false`() = roomTest {
+        viewModel = createViewModel()
+        viewModel.onAudioPermissionResult(true)
+        advanceUntilIdle()
+
+        val seats = TestData.createDefaultSeats().toMutableMap()
+        seats["0"] = TestData.createTestSeat(userId = currentUserId, isMuted = false)
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            seats = seats
+        ))
+        advanceUntilIdle()
+
+        // Bug #6: joinRoom always starts muted — mic is disabled on join
+        verify { voiceService.setMicrophoneEnabled(false) }
+    }
+
+    // ===== Bug 2: allKnownUsers persists user data after they leave =====
+
+    @Test
+    fun `allKnownUsers accumulates and retains departed users`() = roomTest {
+        val departedUser = TestData.createTestUser(uid = "departed-1", displayName = "Departed")
+        coEvery { userRepository.getUser("departed-1") } returns Resource.Success(departedUser)
+        coEvery { userRepository.getUsers(any()) } coAnswers {
+            val ids = firstArg<List<String>>()
+            val users = ids.mapNotNull { id ->
+                when (id) {
+                    currentUserId -> TestData.createTestUser(uid = currentUserId, displayName = "Current User")
+                    ownerId -> TestData.createTestUser(uid = ownerId, displayName = "Owner")
+                    "departed-1" -> departedUser
+                    else -> null
+                }
+            }
+            Resource.Success(users)
+        }
+
+        viewModel = createViewModel()
+        // Emit room with departed-1 as participant
+        emitRoomAsAttendee(TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId, "departed-1")
+        ))
+        advanceUntilIdle()
+
+        // Verify departed-1 is in allKnownUsers
+        assertTrue(viewModel.uiState.value.allKnownUsers.containsKey("departed-1"))
+
+        // Now departed-1 leaves (no longer in participantIds)
+        roomFlow.value = TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId)
+        )
+        advanceUntilIdle()
+
+        // departed-1 should still be in allKnownUsers
+        assertTrue(viewModel.uiState.value.allKnownUsers.containsKey("departed-1"))
+        assertEquals("Departed", viewModel.uiState.value.allKnownUsers["departed-1"]?.displayName)
+    }
+
+    // ===== Non-owner seat cleared on explicit leave =====
+
+    @Test
+    fun `leaveRoom - non-owner clears seat on explicit leave`() = roomTest {
+        viewModel = createViewModel()
+        val seats = TestData.createSeatsWithOwner(ownerId).toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = currentUserId)
+        emitRoomAsAttendee(TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId),
+            seats = seats
+        ))
+        advanceUntilIdle()
+
+        viewModel.leaveRoom()
+        advanceUntilIdle()
+
+        // Non-owner explicit leave clears seat AND leaves participant list
+        coVerify { roomRepository.leaveSeat("room-1", 3) }
+        coVerify { roomRepository.leaveRoom("room-1", currentUserId) }
+    }
+
+    // ===== Bug 5: Banned block warning with reason and kickerName =====
+
+    @Test
+    fun `checkBlockConflicts - banned user sees Banned warning with reason`() = roomTest {
+        viewModel = createViewModel()
+
+        // Emit room where current user is banned
+        val room = TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId),
+            bannedUserIds = setOf(currentUserId),
+            kickInfo = mapOf(
+                currentUserId to mapOf(
+                    "kickerName" to "RoomOwner",
+                    "reason" to "Spamming"
+                )
+            )
+        )
+        coEvery { userRepository.getUser(ownerId) } returns Resource.Success(
+            TestData.createTestUser(uid = ownerId, displayName = "Owner")
+        )
+        roomFlow.value = room
+        advanceUntilIdle()
+
+        val warning = viewModel.uiState.value.blockWarning
+        assertTrue("Expected Banned warning but was $warning", warning is BlockWarning.Banned)
+        assertEquals("Spamming", (warning as BlockWarning.Banned).reason)
+        assertEquals("RoomOwner", warning.kickerName)
+    }
+
+    @Test
+    fun `checkBlockConflicts - banned user without kickInfo sees null reason`() = roomTest {
+        viewModel = createViewModel()
+
+        val room = TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId),
+            bannedUserIds = setOf(currentUserId)
+        )
+        coEvery { userRepository.getUser(ownerId) } returns Resource.Success(
+            TestData.createTestUser(uid = ownerId, displayName = "Owner")
+        )
+        roomFlow.value = room
+        advanceUntilIdle()
+
+        val warning = viewModel.uiState.value.blockWarning
+        assertTrue("Expected Banned warning but was $warning", warning is BlockWarning.Banned)
+        assertNull((warning as BlockWarning.Banned).reason)
+        assertNull(warning.kickerName)
+    }
+
+    // ===== Seat swap: moveSeat to owner seat still blocked =====
+
+    @Test
+    fun `moveSeat - swap cannot target owner seat`() = roomTest {
+        viewModel = createViewModel()
+        val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
+        seats["3"] = TestData.createTestSeat(userId = "attendee-1")
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "attendee-1"),
+            seats = seats
+        ))
+        advanceUntilIdle()
+
+        // Try to swap attendee onto owner seat — should be blocked
+        viewModel.moveSeat(3, 0)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.moveSeat(any(), any(), any(), any()) }
     }
 }

--- a/app/src/test/java/com/shyden/shytalk/testutil/TestData.kt
+++ b/app/src/test/java/com/shyden/shytalk/testutil/TestData.kt
@@ -23,7 +23,10 @@ object TestData {
         coverPhotoUrl: String? = null,
         uniqueId: Long = 12345L,
         dateOfBirth: Long? = null,
-        hideAge: Boolean = false
+        hideAge: Boolean = false,
+        followerIds: Set<String> = emptySet(),
+        followingIds: Set<String> = emptySet(),
+        hideFollowing: Boolean = false
     ) = User(
         uid = uid,
         displayName = displayName,
@@ -33,6 +36,9 @@ object TestData {
         uniqueId = uniqueId,
         dateOfBirth = dateOfBirth,
         hideAge = hideAge,
+        followerIds = followerIds,
+        followingIds = followingIds,
+        hideFollowing = hideFollowing,
         createdAt = BASE_TIMESTAMP,
         lastSeenAt = BASE_TIMESTAMP
     )

--- a/functions/index.js
+++ b/functions/index.js
@@ -138,34 +138,40 @@ exports.onPresenceRemoved = onValueDeleted(
           }
         } else {
           // --- Non-owner disconnected ---
-          // Remove from participants and clear their seats.
-
-          // Clear any seats occupied by this user
+          // Clear their seat but keep them in participantIds.
+          // They may reconnect; seat is the only thing removed on disconnect.
           for (let i = 0; i < MAX_SEATS; i++) {
+            if (i === OWNER_SEAT_INDEX) continue;
             const key = i.toString();
             const seat = seats[key];
             if (seat && seat.userId === userId && seat.state === "OCCUPIED") {
-              updates[`seats.${key}`] = {
-                userId: null,
-                state: "EMPTY",
-                isMuted: false,
-              };
+              updates[`seats.${key}`] = { userId: null, state: "EMPTY", isMuted: false };
+              break;
             }
           }
 
-          const remainingParticipants = participantIds.filter((id) => id !== userId);
-
-          // If only the owner remains and they're away, close the room
-          if (remainingParticipants.length === 1 && remainingParticipants[0] === room.ownerId && room.state === "OWNER_AWAY") {
-            updates.state = "CLOSED";
-            updates.closedAt = require("firebase-admin/firestore").Timestamp.now();
-            updates.participantIds = [];
+          // If no one is on mic anymore and owner is away, close the room
+          if (room.state === "OWNER_AWAY") {
+            let anyoneOnMic = false;
             for (let i = 0; i < MAX_SEATS; i++) {
-              updates[`seats.${i.toString()}`] = { userId: null, state: "EMPTY", isMuted: false };
+              if (i === OWNER_SEAT_INDEX) continue;
+              const key = i.toString();
+              // Check the seat AFTER our clear (use updates if we just cleared it)
+              const seat = updates[`seats.${key}`] || seats[key];
+              if (seat && seat.userId && seat.userId !== userId && seat.state === "OCCUPIED") {
+                anyoneOnMic = true;
+                break;
+              }
             }
-            console.log(`Last non-owner left room ${roomId} (owner away) - closing`);
-          } else {
-            updates.participantIds = remainingParticipants;
+            if (!anyoneOnMic) {
+              updates.state = "CLOSED";
+              updates.closedAt = require("firebase-admin/firestore").Timestamp.now();
+              updates.participantIds = [];
+              for (let i = 0; i < MAX_SEATS; i++) {
+                updates[`seats.${i.toString()}`] = { userId: null, state: "EMPTY", isMuted: false };
+              }
+              console.log(`No one on mic in OWNER_AWAY room ${roomId} — closing`);
+            }
           }
         }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
@@ -22,6 +22,7 @@ data class User(
     val hideAge: Boolean = false,
     val email: String? = null,
     val currentRoomId: String? = null,
+    val lastRoomName: String? = null,
     val createdAt: Long = currentTimeMillis(),
     val userType: UserType = UserType.MEMBER,
     val lastSeenAt: Long = currentTimeMillis()
@@ -47,6 +48,7 @@ data class User(
         "hideAge" to hideAge,
         "email" to email,
         "currentRoomId" to currentRoomId,
+        "lastRoomName" to lastRoomName,
         "userType" to userType.name,
         "createdAt" to millisToTimestamp(createdAt),
         "lastSeenAt" to millisToTimestamp(lastSeenAt)
@@ -74,6 +76,7 @@ data class User(
             hideAge = map["hideAge"] as? Boolean ?: false,
             email = map["email"] as? String,
             currentRoomId = map["currentRoomId"] as? String,
+            lastRoomName = map["lastRoomName"] as? String,
             userType = (map["userType"] as? String)?.let {
                 try { UserType.valueOf(it) } catch (_: Exception) { UserType.MEMBER }
             } ?: UserType.MEMBER,

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/Constants.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/Constants.kt
@@ -4,8 +4,8 @@ object Constants {
     const val MAX_SEATS = 8
     const val OWNER_LEAVE_TIMEOUT_MS = 300_000L // 5 minutes
     const val OWNER_SEAT_INDEX = 0
-    const val VOICE_DISCONNECT_GRACE_PERIOD_MS = 30_000L // 30 seconds
-    const val PRESENCE_TIMEOUT_MS = 30_000L // 30 seconds
+    const val VOICE_DISCONNECT_GRACE_PERIOD_MS = 15_000L // 15 seconds
+    const val PRESENCE_TIMEOUT_MS = 15_000L // 15 seconds
     const val ROOM_NOTIFICATION_ID = 1001
     const val ROOM_NOTIFICATION_CHANNEL_ID = "room_service_channel"
     const val MAX_ROOM_DURATION_MS = 3 * 60 * 60 * 1000L // 3 hours
@@ -18,6 +18,9 @@ object Constants {
 
     // Online status
     const val ONLINE_THRESHOLD_MS = 300_000L // 5 minutes
+
+    // Chat messages
+    const val MAX_ROOM_MESSAGES = 50
 
     // Message flood protection
     const val FLOOD_COOLDOWN_MS = 1_000L       // 1 second between messages

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/remote/VoiceService.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/remote/VoiceService.kt
@@ -12,5 +12,6 @@ interface VoiceService {
     suspend fun joinRoom(roomName: String, userId: String)
     fun leaveChannel()
     fun setMicrophoneEnabled(enabled: Boolean)
+    fun setAudioMode(voiceMode: Boolean)
     fun clearError()
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/UserRepository.kt
@@ -2,8 +2,11 @@ package com.shyden.shytalk.data.repository
 
 import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.util.Resource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
 
 interface UserRepository {
+    val userUpdates: SharedFlow<User>
     suspend fun createOrUpdateUser(user: User): Resource<Unit>
     suspend fun getUser(userId: String): Resource<User>
     suspend fun userExists(userId: String): Resource<Boolean>
@@ -18,4 +21,6 @@ interface UserRepository {
     suspend fun followUser(currentUserId: String, targetUserId: String): Resource<Unit>
     suspend fun unfollowUser(currentUserId: String, targetUserId: String): Resource<Unit>
     suspend fun getUsers(userIds: List<String>): Resource<List<User>>
+    suspend fun removeFollower(userId: String, followerId: String): Resource<Unit>
+    fun observeUsers(userIds: Set<String>): Flow<User>
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/CreateRoomDialog.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/CreateRoomDialog.kt
@@ -19,9 +19,10 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun CreateRoomDialog(
     onDismiss: () -> Unit,
-    onCreate: (String) -> Unit
+    onCreate: (String) -> Unit,
+    initialRoomName: String = ""
 ) {
-    var roomName by remember { mutableStateOf("") }
+    var roomName by remember { mutableStateOf(initialRoomName) }
 
     AlertDialog(
         onDismissRequest = onDismiss,

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeScreen.kt
@@ -197,7 +197,8 @@ fun RoomListContent(
             onCreate = { name ->
                 onDismissCreateDialog()
                 viewModel.createRoom(name)
-            }
+            },
+            initialRoomName = uiState.lastRoomName
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeViewModel.kt
@@ -24,7 +24,8 @@ data class HomeUiState(
     val isLoading: Boolean = true,
     val isRefreshing: Boolean = false,
     val error: String? = null,
-    val createdRoomId: String? = null
+    val createdRoomId: String? = null,
+    val lastRoomName: String = ""
 )
 
 class HomeViewModel(
@@ -48,7 +49,24 @@ class HomeViewModel(
 
     init {
         loadBlockedUsersAndFilter()
+        loadLastRoomName()
         observeRooms()
+        observeUserUpdates()
+    }
+
+    private fun loadLastRoomName() {
+        val userId = currentUserId ?: return
+        viewModelScope.launch {
+            when (val result = userRepository.getUser(userId)) {
+                is Resource.Success -> {
+                    val name = result.data.lastRoomName
+                    if (!name.isNullOrBlank()) {
+                        _uiState.update { it.copy(lastRoomName = name) }
+                    }
+                }
+                else -> {}
+            }
+        }
     }
 
     private fun loadBlockedUsersAndFilter() {
@@ -74,6 +92,23 @@ class HomeViewModel(
                     allRooms = rooms
                     filterAndEmitRooms()
                 }
+        }
+    }
+
+    private fun observeUserUpdates() {
+        viewModelScope.launch {
+            userRepository.userUpdates.collect { updatedUser ->
+                if (updatedUser.uid in userCache) {
+                    userCache[updatedUser.uid] = updatedUser
+                    _uiState.update { state ->
+                        state.copy(
+                            seatUsers = state.seatUsers.let { map ->
+                                if (updatedUser.uid in map) map + (updatedUser.uid to updatedUser) else map
+                            }
+                        )
+                    }
+                }
+            }
         }
     }
 
@@ -178,7 +213,8 @@ class HomeViewModel(
     fun createRoom(name: String) {
         val userId = authRepository.currentUserId ?: return
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, error = null) }
+            _uiState.update { it.copy(isLoading = true, error = null, lastRoomName = name) }
+            userRepository.updateProfile(userId, mapOf("lastRoomName" to name))
             // Close any existing rooms owned by this user
             roomRepository.closeAllRoomsByOwner(userId)
             when (val result = roomRepository.createRoom(name, userId)) {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/main/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/main/MainScreen.kt
@@ -69,7 +69,7 @@ fun MainScreen(
                     title = {
                         Text(
                             when (selectedTab) {
-                                BottomNavTab.Rooms -> "ShyTalk \uD83D\uDC0E\uD83C\uDFEE"
+                                BottomNavTab.Rooms -> "\uD83D\uDC0E\uD83C\uDFEE"
                                 BottomNavTab.Profile -> "Profile"
                             }
                         )

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/FollowListScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/FollowListScreen.kt
@@ -16,9 +16,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.automirrored.filled.Undo
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -152,7 +154,10 @@ fun FollowListScreen(
                                 selectedTab = uiState.selectedTab,
                                 iFollowThisUser = user.uid in uiState.currentUserFollowingIds,
                                 thisUserFollowsMe = user.uid in uiState.currentUserFollowerIds,
+                                isPendingRemove = user.uid == uiState.pendingRemoveFollowerId,
                                 onToggleFollow = { viewModel.toggleFollow(user.uid) },
+                                onRemoveFollower = { viewModel.removeFollower(user.uid) },
+                                onUndoRemove = { viewModel.undoRemoveFollower() },
                                 onClick = { onNavigateToUserProfile(user.uid) }
                             )
                         }
@@ -170,7 +175,10 @@ private fun FollowUserRow(
     selectedTab: FollowTab,
     iFollowThisUser: Boolean,
     thisUserFollowsMe: Boolean,
+    isPendingRemove: Boolean = false,
     onToggleFollow: () -> Unit,
+    onRemoveFollower: () -> Unit = {},
+    onUndoRemove: () -> Unit = {},
     onClick: () -> Unit
 ) {
     Row(
@@ -217,13 +225,11 @@ private fun FollowUserRow(
             )
         }
 
-        // Action button (only on own lists)
+        // Action buttons (only on own lists)
         if (isOwnList) {
-            IconButton(onClick = onToggleFollow) {
-                when (selectedTab) {
-                    FollowTab.FOLLOWING -> {
-                        // Shows mutual status: People if they follow me back, Person if one-way
-                        // After unfollowing: PersonAdd to re-follow
+            when (selectedTab) {
+                FollowTab.FOLLOWING -> {
+                    IconButton(onClick = onToggleFollow) {
                         val icon = when {
                             !iFollowThisUser -> Icons.Default.PersonAdd
                             thisUserFollowsMe -> Icons.Default.People
@@ -236,8 +242,10 @@ private fun FollowUserRow(
                                 else MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
-                    FollowTab.FOLLOWERS -> {
-                        // Shows if I follow them back: People if yes, PersonAdd if no
+                }
+                FollowTab.FOLLOWERS -> {
+                    // Follow back button
+                    IconButton(onClick = onToggleFollow) {
                         Icon(
                             imageVector = if (iFollowThisUser) Icons.Default.People
                                 else Icons.Default.PersonAdd,
@@ -245,6 +253,24 @@ private fun FollowUserRow(
                             tint = if (iFollowThisUser) MaterialTheme.colorScheme.primary
                                 else MaterialTheme.colorScheme.onSurfaceVariant
                         )
+                    }
+                    // Remove follower / Undo button
+                    if (isPendingRemove) {
+                        IconButton(onClick = onUndoRemove) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.Undo,
+                                contentDescription = "Undo remove",
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    } else {
+                        IconButton(onClick = onRemoveFollower) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = "Remove follower",
+                                tint = MaterialTheme.colorScheme.error
+                            )
+                        }
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/FollowListViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/FollowListViewModel.kt
@@ -6,6 +6,8 @@ import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.UserRepository
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -24,7 +26,8 @@ data class FollowListUiState(
     val currentUserFollowingIds: Set<String> = emptySet(),
     val currentUserFollowerIds: Set<String> = emptySet(),
     val currentUserBlockedIds: Set<String> = emptySet(),
-    val followingHidden: Boolean = false
+    val followingHidden: Boolean = false,
+    val pendingRemoveFollowerId: String? = null
 )
 
 enum class FollowTab { FOLLOWERS, FOLLOWING }
@@ -49,6 +52,20 @@ class FollowListViewModel(
             selectedTab = tab
         )
         loadData()
+        observeUserUpdates()
+    }
+
+    private fun observeUserUpdates() {
+        viewModelScope.launch {
+            userRepository.userUpdates.collect { updatedUser ->
+                _uiState.update { state ->
+                    state.copy(
+                        followers = state.followers.map { if (it.uid == updatedUser.uid) updatedUser else it },
+                        following = state.following.map { if (it.uid == updatedUser.uid) updatedUser else it }
+                    )
+                }
+            }
+        }
     }
 
     fun selectTab(tab: FollowTab) {
@@ -144,7 +161,52 @@ class FollowListViewModel(
         }
     }
 
+    private var removeFollowerJob: Job? = null
+    private var pendingRemoveUser: User? = null
+
+    fun removeFollower(followerId: String) {
+        val currentUid = _uiState.value.profileUserId
+        if (!_uiState.value.isOwnList) return
+
+        // Mark as pending remove — keep in list so Undo button is visible
+        pendingRemoveUser = _uiState.value.followers.find { it.uid == followerId }
+        _uiState.update { it.copy(pendingRemoveFollowerId = followerId) }
+
+        // Auto-confirm after delay
+        removeFollowerJob?.cancel()
+        removeFollowerJob = viewModelScope.launch {
+            delay(UNDO_TIMEOUT_MS)
+            confirmRemoveFollower(followerId, currentUid)
+        }
+    }
+
+    fun undoRemoveFollower() {
+        removeFollowerJob?.cancel()
+        pendingRemoveUser = null
+        _uiState.update { it.copy(pendingRemoveFollowerId = null) }
+    }
+
+    private fun confirmRemoveFollower(followerId: String, userId: String) {
+        pendingRemoveUser = null
+        _uiState.update {
+            it.copy(
+                followers = it.followers.filter { u -> u.uid != followerId },
+                pendingRemoveFollowerId = null
+            )
+        }
+        viewModelScope.launch {
+            val result = userRepository.removeFollower(userId, followerId)
+            if (result is Resource.Error) {
+                _uiState.update { it.copy(error = result.message) }
+            }
+        }
+    }
+
     fun clearError() {
         _uiState.update { it.copy(error = null) }
+    }
+
+    companion object {
+        private const val UNDO_TIMEOUT_MS = 5000L
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileSetupScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileSetupScreen.kt
@@ -83,11 +83,11 @@ fun ProfileSetupScreen(
 
             OutlinedTextField(
                 value = displayName,
-                onValueChange = { if (it.length <= 30) displayName = it },
+                onValueChange = { if (it.length <= 20) displayName = it },
                 label = { Text("Display Name") },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
-                supportingText = { Text("${displayName.length}/30") }
+                supportingText = { Text("${displayName.length}/20") }
             )
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
@@ -48,6 +48,24 @@ class ProfileViewModel(
     init {
         val currentUid = authRepository.currentUserId ?: ""
         _uiState.update { it.copy(currentUserId = currentUid) }
+        observeUserUpdates()
+    }
+
+    private fun observeUserUpdates() {
+        viewModelScope.launch {
+            userRepository.userUpdates.collect { updatedUser ->
+                val currentUser = _uiState.value.user ?: return@collect
+                if (updatedUser.uid == currentUser.uid) {
+                    _uiState.update { state ->
+                        state.copy(
+                            user = updatedUser,
+                            followerCount = updatedUser.followerIds.size,
+                            followingCount = updatedUser.followingIds.size
+                        )
+                    }
+                }
+            }
+        }
     }
 
     fun loadProfile(userId: String?) {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -17,6 +17,7 @@ import com.shyden.shytalk.core.util.logD
 import com.shyden.shytalk.core.util.logE
 import com.shyden.shytalk.core.util.logW
 import com.shyden.shytalk.core.room.RoomLifecycleManager
+import com.shyden.shytalk.data.remote.VoiceConnectionState
 import com.shyden.shytalk.data.remote.VoiceService
 import com.shyden.shytalk.data.remote.PresenceService
 import com.shyden.shytalk.data.repository.AuthRepository
@@ -44,6 +45,7 @@ sealed class BlockWarning {
     data object BlockedByRoomOwner : BlockWarning()
     data object BlockedUserInRoom : BlockWarning()
     data object BlockedByUserInRoom : BlockWarning()
+    data class Banned(val reason: String?, val kickerName: String?) : BlockWarning()
 }
 
 data class RoomClosedSummary(
@@ -75,9 +77,11 @@ data class RoomUiState(
     val roomExpiryRemainingMs: Long = 0L,
     val speakingUserIds: Set<String> = emptySet(),
     val isVoiceJoined: Boolean = false,
+    val isVoiceReady: Boolean = false,
     val pendingInvite: String? = null,
     val seatUsers: Map<String, User> = emptyMap(),
     val participantUsers: Map<String, User> = emptyMap(),
+    val allKnownUsers: Map<String, User> = emptyMap(),
     val blockedUserIds: Set<String> = emptySet(),
     val blockWarning: BlockWarning? = null,
     val hasJoined: Boolean = false,
@@ -125,6 +129,9 @@ class RoomViewModel(
     private var lastOwnerAwayState: Pair<RoomState, Long?>? = null
     private var lastFilteredMessages: List<Message> = emptyList()
     private var seatActionResetJob: Job? = null
+    private var autoRejoinAttempted = false
+    private var userObserverJob: Job? = null
+    private var observedUserIds: Set<String> = emptySet()
 
     // Message flood protection
     private val recentMessageTimestamps = ArrayDeque<Long>()
@@ -134,10 +141,14 @@ class RoomViewModel(
     private var autoDismissJob: Job? = null
     private val processedRequestIds = mutableSetOf<String>()
     private val processedApprovalIds = mutableSetOf<String>()
+    private var rawPendingRequests: List<SeatRequest> = emptyList()
 
     init {
         val userId = authRepository.currentUserId ?: ""
-        _uiState.value = _uiState.value.copy(currentUserId = userId)
+        _uiState.value = _uiState.value.copy(
+            currentUserId = userId,
+            isVoiceReady = voiceService.connectionState.value == VoiceConnectionState.CONNECTED
+        )
         loadUserName()
         loadBlockedUsers()
         observeRoom()
@@ -146,6 +157,61 @@ class RoomViewModel(
         observeDisconnectedUsers()
         observePendingRequests()
         observeMyRequest()
+        observeUserUpdates()
+    }
+
+    private fun observeUserUpdates() {
+        viewModelScope.launch {
+            userRepository.userUpdates.collect { updatedUser ->
+                val uid = updatedUser.uid
+                if (uid in userCache) {
+                    userCache[uid] = updatedUser
+                    _uiState.update { state ->
+                        state.copy(
+                            seatUsers = state.seatUsers.replaceUser(updatedUser),
+                            participantUsers = state.participantUsers.replaceUser(updatedUser),
+                            allKnownUsers = state.allKnownUsers.replaceUser(updatedUser),
+                            currentUserName = if (uid == state.currentUserId) updatedUser.displayName else state.currentUserName
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun Map<String, User>.replaceUser(user: User): Map<String, User> =
+        if (user.uid in this) this + (user.uid to user) else this
+
+    private fun observeRemoteUserChanges(userIds: Set<String>) {
+        if (userIds == observedUserIds) return
+        observedUserIds = userIds
+        userObserverJob?.cancel()
+        if (userIds.isEmpty()) return
+        userObserverJob = viewModelScope.launch {
+            userRepository.observeUsers(userIds).collect { updatedUser ->
+                val uid = updatedUser.uid
+                val cached = userCache[uid]
+                if (cached != null && cached != updatedUser) {
+                    userCache[uid] = updatedUser
+                    _uiState.update { state ->
+                        state.copy(
+                            seatUsers = state.seatUsers.replaceUser(updatedUser),
+                            participantUsers = state.participantUsers.replaceUser(updatedUser),
+                            allKnownUsers = state.allKnownUsers.replaceUser(updatedUser),
+                            currentUserName = if (uid == state.currentUserId) updatedUser.displayName else state.currentUserName
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun collectRoomUserIds(room: ChatRoom, currentUserId: String): Set<String> {
+        val seatUserIds = room.seats.values.asSequence()
+            .filter { it.state == SeatState.OCCUPIED && it.userId != null }
+            .mapNotNull { it.userId }
+            .toSet()
+        return (seatUserIds + room.participantIds).filter { it != currentUserId }.toSet()
     }
 
     private fun loadUserName() {
@@ -238,10 +304,22 @@ class RoomViewModel(
             return true
         }
         if (userId !in room.participantIds) {
+            // If not banned and room is active, attempt one auto-rejoin
+            // (handles race between join write and stale Firestore emission)
+            if (!autoRejoinAttempted && room.state == RoomState.ACTIVE) {
+                autoRejoinAttempted = true
+                logW(TAG, "User not in participantIds but not banned — attempting auto-rejoin")
+                viewModelScope.launch {
+                    roomRepository.joinRoom(roomId, userId)
+                    presenceService.setPresence(roomId, userId)
+                }
+                return false
+            }
             disconnectFromRoom()
             _uiState.update { it.copy(isLoading = false, shouldNavigateBack = true) }
             return true
         }
+        autoRejoinAttempted = false
         return false
     }
 
@@ -252,17 +330,18 @@ class RoomViewModel(
         val alreadyInRoom = userId in room.participantIds && roomLifecycleManager.isInRoom(roomId)
         if (alreadyInRoom) {
             _uiState.update { it.copy(room = room, currentRole = role, isLoading = false, hasJoined = true) }
+            refilterPendingRequests()
             // Track seat state so handleNormalUpdate detects transitions correctly
             isSeated = room.findUserSeat(userId) != null
             // Rejoin voice if not already connected (ViewModel recreated)
             if (room.voiceRoomName.isNotEmpty() && !voiceService.isJoined.value) {
                 viewModelScope.launch {
                     voiceService.joinRoom(room.voiceRoomName, userId)
-                    // If seated and muted, disable mic after joining
+                    // Sync mic and audio mode to seat's mute state after joining
                     val mySeat = room.findUserSeat(userId)?.value
-                    if (mySeat?.isMuted == true) {
-                        voiceService.setMicrophoneEnabled(false)
-                    }
+                    val shouldUnmute = mySeat != null && !mySeat.isMuted
+                    voiceService.setMicrophoneEnabled(shouldUnmute)
+                    voiceService.setAudioMode(shouldUnmute)
                 }
             }
             // Detect owner return on first emission — without this, the ViewModel
@@ -271,8 +350,29 @@ class RoomViewModel(
             roomLifecycleManager.updateTrackedRoom(room)
             loadSeatUsers(room)
             loadParticipantUsers(room)
+            observeRemoteUserChanges(collectRoomUserIds(room, userId))
             handleOwnerAwayCountdown(room)
             handleRoomExpiryCountdown(room)
+            return
+        }
+
+        // Re-entry: user is in participantIds but lifecycle manager is not tracking
+        // (e.g., app was backgrounded, process killed, or previous session cleaned up).
+        // Treat as a completely new session — skip block dialogs, join fresh.
+        val isReEntry = userId in room.participantIds && !roomLifecycleManager.isInRoom(roomId)
+        if (isReEntry) {
+            _uiState.update { it.copy(room = room, currentRole = role, isLoading = false) }
+            joinRoom()
+            loadSeatUsers(room)
+            loadParticipantUsers(room)
+            observeRemoteUserChanges(collectRoomUserIds(room, userId))
+            handleOwnerAwayCountdown(room)
+            handleRoomExpiryCountdown(room)
+            // Owner re-entering OWNER_AWAY room
+            if (room.ownerId == userId && room.state == RoomState.OWNER_AWAY) {
+                ownerReturnTriggered = true
+                ownerReturn()
+            }
             return
         }
 
@@ -284,6 +384,7 @@ class RoomViewModel(
         }
         loadSeatUsers(room)
         loadParticipantUsers(room)
+        observeRemoteUserChanges(collectRoomUserIds(room, userId))
         handleOwnerAwayCountdown(room)
         handleRoomExpiryCountdown(room)
 
@@ -327,27 +428,28 @@ class RoomViewModel(
         val hasAudio = _uiState.value.hasAudioPermission
 
         if (currentlySeated != isSeated) {
-            if (currentlySeated) {
-                logD(TAG, "User became seated, hasAudioPermission=$hasAudio")
-                if (hasAudio) voiceService.setMicrophoneEnabled(true)
-            } else {
+            if (!currentlySeated) {
                 logD(TAG, "User left seat, disabling mic")
                 voiceService.setMicrophoneEnabled(false)
+                voiceService.setAudioMode(false)
             }
+            // When becoming seated: do NOT enable mic. User starts muted (Bug #6).
         }
         isSeated = currentlySeated
 
         if (mySeat != null) {
-            // Sync mute state
-            voiceService.setMicrophoneEnabled(!mySeat.isMuted)
+            // Sync mute state and audio mode to seat's isMuted
+            val shouldUnmute = !mySeat.isMuted
+            voiceService.setMicrophoneEnabled(shouldUnmute)
+            voiceService.setAudioMode(shouldUnmute)
 
             // Ensure connected to voice room
             if (!voiceService.isJoined.value && hasAudio && room.voiceRoomName.isNotEmpty()) {
                 viewModelScope.launch {
                     voiceService.joinRoom(room.voiceRoomName, userId)
-                    if (mySeat.isMuted) {
-                        voiceService.setMicrophoneEnabled(false)
-                    }
+                    // Re-sync after connection established
+                    voiceService.setMicrophoneEnabled(shouldUnmute)
+                    voiceService.setAudioMode(shouldUnmute)
                 }
             }
         }
@@ -375,7 +477,9 @@ class RoomViewModel(
         roomLifecycleManager.updateTrackedRoom(room)
         loadSeatUsers(room)
         loadParticipantUsers(room)
+        observeRemoteUserChanges(collectRoomUserIds(room, _uiState.value.currentUserId))
         handleOwnerAwayCountdown(room)
+        refilterPendingRequests()
     }
 
     private fun checkBlockConflicts(room: ChatRoom) {
@@ -385,7 +489,13 @@ class RoomViewModel(
 
             // Check if user is banned from this room (kicked previously)
             if (userId in room.bannedUserIds) {
-                _uiState.update { it.copy(blockWarning = BlockWarning.BlockedByRoomOwner) }
+                val kickInfo = room.kickInfo[userId]
+                _uiState.update {
+                    it.copy(blockWarning = BlockWarning.Banned(
+                        reason = kickInfo?.get("reason"),
+                        kickerName = kickInfo?.get("kickerName")
+                    ))
+                }
                 return@launch
             }
 
@@ -492,6 +602,14 @@ class RoomViewModel(
                 if (errorMsg != null) voiceService.clearError()
             }
         }
+        // Latch isVoiceReady — once connected, never hide the room again
+        viewModelScope.launch {
+            voiceService.connectionState.collect { connState ->
+                if (connState == VoiceConnectionState.CONNECTED) {
+                    _uiState.update { it.copy(isVoiceReady = true) }
+                }
+            }
+        }
     }
 
     private fun observeDisconnectedUsers() {
@@ -513,6 +631,7 @@ class RoomViewModel(
             // Already in this room (e.g., returned after pressing back)
             if (room != null && userId in room.participantIds && roomLifecycleManager.isInRoom(roomId)) {
                 _uiState.update { it.copy(hasJoined = true) }
+                refilterPendingRequests()
                 roomLifecycleManager.trackRoom(roomId)
                 return@launch
             }
@@ -533,20 +652,28 @@ class RoomViewModel(
             presenceService.setPresence(roomId, userId)
             userRepository.updateProfile(userId, mapOf("currentRoomId" to roomId))
             _uiState.update { it.copy(hasJoined = true) }
+            refilterPendingRequests()
 
             // Start foreground service via RoomLifecycleManager
             roomLifecycleManager.trackRoom(roomId)
 
-            // Join voice room
+            // Join voice room — always start muted (Bug #6)
             val voiceRoom = room?.voiceRoomName
             if (!voiceRoom.isNullOrEmpty()) {
-                val alreadySeated = room.findUserSeat(userId) != null
-                if (alreadySeated) isSeated = true
-                voiceService.joinRoom(voiceRoom, userId)
-                // If not seated, disable mic (audience mode)
-                if (!alreadySeated || !_uiState.value.hasAudioPermission) {
-                    voiceService.setMicrophoneEnabled(false)
+                val seatEntry = room.findUserSeat(userId)
+                if (seatEntry != null) {
+                    isSeated = true
+                    // Ensure Firestore seat shows muted so the icon is correct
+                    if (!seatEntry.value.isMuted) {
+                        roomRepository.toggleMute(roomId, seatEntry.key.toInt(), true)
+                    }
                 }
+                voiceService.joinRoom(voiceRoom, userId)
+                voiceService.setMicrophoneEnabled(false)
+                voiceService.setAudioMode(false)
+            } else {
+                // No voice room — mark ready so the room UI is shown immediately
+                _uiState.update { it.copy(isVoiceReady = true) }
             }
 
             if (userName.isNotEmpty()) {
@@ -644,6 +771,8 @@ class RoomViewModel(
     }
 
     fun takeSeat(seatIndex: Int) {
+        // Block rapid successive taps while a seat action is in flight
+        if (_uiState.value.seatActionStatus is SeatActionStatus.Loading) return
         val userId = _uiState.value.currentUserId
         val room = _uiState.value.room ?: return
         val role = _uiState.value.currentRole
@@ -723,6 +852,11 @@ class RoomViewModel(
         if (seat.userId != userId) return
 
         val newMuteState = !seat.isMuted
+        // Block unmute when voice is not connected — muting is always allowed
+        if (!newMuteState && voiceService.connectionState.value != VoiceConnectionState.CONNECTED) {
+            _uiState.update { it.copy(error = "Voice not connected yet") }
+            return
+        }
         val loadingMsg = if (newMuteState) "Muting..." else "Unmuting..."
         val successMsg = if (newMuteState) "Muted" else "Unmuted"
 
@@ -730,6 +864,7 @@ class RoomViewModel(
             val result = roomRepository.toggleMute(roomId, seatIndex, newMuteState)
             if (result is Resource.Success) {
                 voiceService.setMicrophoneEnabled(!newMuteState)
+                voiceService.setAudioMode(!newMuteState)
             }
             result
         }
@@ -748,7 +883,9 @@ class RoomViewModel(
             if (targetUserId == room.ownerId) return@launch
             if (role == RoomRole.HOST && targetUserId in room.hostIds) return@launch
 
-            roomRepository.toggleMute(roomId, seatIndex, !seat.isMuted)
+            // Only mute, never unmute — only the user themselves can unmute
+            if (seat.isMuted) return@launch
+            roomRepository.toggleMute(roomId, seatIndex, true)
         }
     }
 
@@ -769,10 +906,7 @@ class RoomViewModel(
             val isTargetHost = targetUserId in room.hostIds
             if (role == RoomRole.HOST && (isTargetOwner || isTargetHost)) return@launch
 
-            // Destination must be empty
-            val toSeat = room.seats[toIndex.toString()] ?: return@launch
-            if (toSeat.state == SeatState.OCCUPIED) return@launch
-
+            // If destination is occupied, swap the two users
             roomRepository.moveSeat(roomId, fromIndex, toIndex, targetUserId)
         }
     }
@@ -818,8 +952,9 @@ class RoomViewModel(
             val room = _uiState.value.room ?: return@launch
             val role = _uiState.value.currentRole
 
-            // Don't invite someone who is already seated
+            // Don't invite someone who is already seated or already invited
             if (room.findUserSeat(userId) != null) return@launch
+            if (userId in room.pendingInvites) return@launch
 
             // Owner can always invite; hosts only when requireApproval is OFF
             if (role == RoomRole.ATTENDEE) return@launch
@@ -834,6 +969,7 @@ class RoomViewModel(
     }
 
     fun acceptInvite() {
+        if (_uiState.value.seatActionStatus is SeatActionStatus.Loading) return
         dismissCurrentNotification()
         val userId = _uiState.value.currentUserId
         val room = _uiState.value.room ?: return
@@ -917,11 +1053,10 @@ class RoomViewModel(
                             roomRepository.closeRoom(roomId)
                         }
                     } else {
-                        // Non-owner: clear their seat
-                        val mySeatIndex = room.findUserSeat(userId)?.key?.toInt()
-                        if (mySeatIndex != null) {
-                            logD(TAG, "leaveRoom (VM): clearing seat $mySeatIndex")
-                            roomRepository.leaveSeat(roomId, mySeatIndex)
+                        // Non-owner: clear seat on explicit leave
+                        val mySeatEntry = room.findUserSeat(userId)
+                        if (mySeatEntry != null) {
+                            roomRepository.leaveSeat(roomId, mySeatEntry.key.toInt())
                         }
                     }
 
@@ -961,15 +1096,16 @@ class RoomViewModel(
                     roomLifecycleManager.trackRoom(roomId)
                 }
 
-                // Rejoin voice if needed
+                // Rejoin voice if needed — sync to seat's actual mute state
                 val voiceRoom = room.voiceRoomName
                 if (voiceRoom.isNotEmpty()) {
                     if (!voiceService.isJoined.value) {
                         voiceService.joinRoom(voiceRoom, userId)
                     }
-                    if (_uiState.value.hasAudioPermission) {
-                        voiceService.setMicrophoneEnabled(true)
-                    }
+                    val mySeat = room.findUserSeat(userId)?.value
+                    val shouldUnmute = mySeat != null && !mySeat.isMuted && _uiState.value.hasAudioPermission
+                    voiceService.setMicrophoneEnabled(shouldUnmute)
+                    voiceService.setAudioMode(shouldUnmute)
                 }
             } catch (e: Exception) {
                 logE(TAG, "ownerReturn failed, will retry on next room update", e)
@@ -1023,7 +1159,9 @@ class RoomViewModel(
     private fun loadUsersForIds(userIds: Set<String>, onLoaded: (Map<String, User>) -> Unit) {
         val newUserIds = userIds.filter { it !in userCache }
         if (newUserIds.isEmpty()) {
-            onLoaded(userCache.filterKeys { it in userIds })
+            val filtered = userCache.filterKeys { it in userIds }
+            onLoaded(filtered)
+            accumulateKnownUsers(filtered)
             return
         }
 
@@ -1034,7 +1172,18 @@ class RoomViewModel(
                 }
                 else -> {}
             }
-            onLoaded(userCache.filterKeys { it in userIds })
+            val filtered = userCache.filterKeys { it in userIds }
+            onLoaded(filtered)
+            accumulateKnownUsers(filtered)
+        }
+    }
+
+    private fun accumulateKnownUsers(newUsers: Map<String, User>) {
+        if (newUsers.isEmpty()) return
+        val current = _uiState.value.allKnownUsers
+        val hasNew = newUsers.any { it.key !in current }
+        if (hasNew) {
+            _uiState.update { it.copy(allKnownUsers = it.allKnownUsers + newUsers) }
         }
     }
 
@@ -1167,32 +1316,39 @@ class RoomViewModel(
 
     // --- Observe Seat Requests ---
 
+    /** Re-filter raw requests against latest room state and enqueue new notifications. */
+    private fun refilterPendingRequests() {
+        val room = _uiState.value.room
+        val validRequests = rawPendingRequests.filter { req ->
+            val alreadySeated = room?.findUserSeat(req.userId) != null
+            val leftRoom = room != null && req.userId !in room.participantIds
+            !alreadySeated && !leftRoom
+        }
+        _uiState.update { it.copy(pendingRequestsForPanel = validRequests) }
+
+        val role = _uiState.value.currentRole
+        val isHostOrOwner = role == RoomRole.OWNER || role == RoomRole.HOST
+        if (isHostOrOwner && _uiState.value.hasJoined) {
+            for (request in validRequests) {
+                if (request.requestId !in processedRequestIds) {
+                    enqueueNotification(RoomNotification.SeatRequestReceived(request))
+                }
+            }
+        }
+    }
+
     private fun observePendingRequests() {
         viewModelScope.launch {
             seatRequestRepository.getPendingRequests(roomId)
                 .catch { /* ignore */ }
                 .collect { requests ->
-                    val room = _uiState.value.room
-                    // Filter out stale requests: user already seated or left the room
-                    val validRequests = requests.filter { req ->
-                        val alreadySeated = room?.findUserSeat(req.userId) != null
-                        val leftRoom = room != null && req.userId !in room.participantIds
-                        !alreadySeated && !leftRoom
-                    }
-                    _uiState.update { it.copy(pendingRequestsForPanel = validRequests) }
-
-                    val role = _uiState.value.currentRole
-                    val isHostOrOwner = role == RoomRole.OWNER || role == RoomRole.HOST
-                    if (isHostOrOwner && _uiState.value.hasJoined) {
-                        for (request in validRequests) {
-                            if (request.requestId !in processedRequestIds) {
-                                enqueueNotification(RoomNotification.SeatRequestReceived(request))
-                            }
-                        }
-                    }
+                    rawPendingRequests = requests
+                    refilterPendingRequests()
                 }
         }
     }
+
+    private var initialApprovalsSuppressed = false
 
     private fun observeMyRequest() {
         viewModelScope.launch {
@@ -1200,6 +1356,16 @@ class RoomViewModel(
             seatRequestRepository.getRequestsByUser(roomId, userId)
                 .catch { /* ignore */ }
                 .collect { requests ->
+                    // On the first emission, suppress all existing approved requests.
+                    // Only approvals that arrive in later emissions (freshly approved
+                    // during this session) will trigger notifications.
+                    if (!initialApprovalsSuppressed) {
+                        initialApprovalsSuppressed = true
+                        requests.filter { it.status == SeatRequestStatus.APPROVED }
+                            .forEach { processedApprovalIds.add(it.requestId) }
+                        return@collect
+                    }
+
                     val approvedRequest = requests.firstOrNull {
                         it.status == SeatRequestStatus.APPROVED
                     } ?: return@collect
@@ -1256,6 +1422,7 @@ class RoomViewModel(
     }
 
     fun acceptApprovedRequest(request: SeatRequest) {
+        if (_uiState.value.seatActionStatus is SeatActionStatus.Loading) return
         val room = _uiState.value.room ?: return
         val userId = _uiState.value.currentUserId
         val seat = room.seats[request.seatIndex.toString()]
@@ -1288,9 +1455,7 @@ class RoomViewModel(
     fun onAudioPermissionResult(granted: Boolean) {
         logD(TAG, "onAudioPermissionResult granted=$granted isSeated=$isSeated")
         _uiState.update { it.copy(hasAudioPermission = granted) }
-        if (granted && isSeated) {
-            voiceService.setMicrophoneEnabled(true)
-        }
+        // Do NOT enable mic here. User must explicitly unmute via toggleSelfMute (Bug #6).
     }
 
     fun setRoomScreenVisible(visible: Boolean) {
@@ -1302,6 +1467,7 @@ class RoomViewModel(
         ownerAwayCountdownJob?.cancel()
         roomExpiryCountdownJob?.cancel()
         seatActionResetJob?.cancel()
+        userObserverJob?.cancel()
         userCache.clear()
         // DO NOT call presenceService.removePresence() or voiceService.leaveChannel()
         // Voice/presence survive ViewModel destruction; explicit leaveRoom() handles cleanup.

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/MessageBubble.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/MessageBubble.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Icon
@@ -36,6 +37,7 @@ import com.shyden.shytalk.core.model.MessageType
 import com.shyden.shytalk.core.model.RoomRole
 import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.util.flagEmojiForCode
+import com.shyden.shytalk.ui.components.FlagBadge
 
 private val BubbleShape = RoundedCornerShape(
     topStart = 4.dp,
@@ -80,18 +82,11 @@ private fun UserAvatar(
             }
         }
         if (nationality != null && size >= 32.dp) {
-            val flagSize = size * 0.4f
-            Box(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .size(flagSize),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = flagEmojiForCode(nationality),
-                    style = MaterialTheme.typography.labelSmall.copy(fontSize = (size.value * 0.28f).sp)
-                )
-            }
+            FlagBadge(
+                countryCode = nationality,
+                badgeSize = size * 0.4f,
+                modifier = Modifier.align(Alignment.BottomEnd)
+            )
         }
     }
 }
@@ -144,21 +139,31 @@ fun MessageBubble(
                     text = message.text,
                     style = MaterialTheme.typography.bodySmall,
                     fontStyle = FontStyle.Italic,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.weight(1f)
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
 
                 if (canInvite) {
+                    Spacer(modifier = Modifier.width(4.dp))
                     IconButton(
                         onClick = onInvite,
                         modifier = Modifier.size(28.dp)
                     ) {
-                        Icon(
-                            Icons.Default.Mic,
-                            contentDescription = "Invite to mic",
-                            modifier = Modifier.size(16.dp),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                Icons.Default.Mic,
+                                contentDescription = "Invite to mic",
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                            Icon(
+                                Icons.Default.Add,
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(10.dp)
+                                    .align(Alignment.BottomEnd),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/SeatGrid.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/SeatGrid.kt
@@ -189,7 +189,8 @@ private fun SeatRow(
                     user = seatUser,
                     seatSize = seatSize,
                     onClick = { onSeatClick(seatIndex) },
-                    onTapUser = seatUserId?.let { uid -> { onTapUser(uid) } }
+                    onTapUser = seatUserId?.let { uid -> { onTapUser(uid) } },
+                    modifier = Modifier.weight(1f)
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/SeatItem.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/SeatItem.kt
@@ -57,6 +57,7 @@ import com.shyden.shytalk.core.model.Seat
 import com.shyden.shytalk.core.model.SeatState
 import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.util.flagEmojiForCode
+import com.shyden.shytalk.ui.components.FlagBadge
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -193,17 +194,11 @@ fun SeatItem(
 
             // Nationality flag badge (overlapping avatar border, bottom-end)
             if (seat.state == SeatState.OCCUPIED && user?.nationality != null) {
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .size(badgeSize),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = flagEmojiForCode(user.nationality!!),
-                        style = MaterialTheme.typography.labelSmall.copy(fontSize = flagFontSize.sp)
-                    )
-                }
+                FlagBadge(
+                    countryCode = user.nationality!!,
+                    badgeSize = badgeSize,
+                    modifier = Modifier.align(Alignment.BottomEnd)
+                )
             }
 
             // Context menu (only leave seat for current user)
@@ -264,7 +259,8 @@ fun SeatItem(
                     style = textShadowStyle,
                     color = MaterialTheme.colorScheme.onBackground,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false)
                 )
                 Spacer(modifier = Modifier.width(3.dp))
                 Icon(

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/UserCardPopup.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/UserCardPopup.kt
@@ -62,6 +62,7 @@ fun UserCardPopup(
     onKickFromRoom: ((String) -> Unit)? = null,
     onMoveSeat: ((Int) -> Unit)? = null,
     emptySeats: List<Int> = emptyList(),
+    seatOccupantNames: Map<Int, String> = emptyMap(),
     onMakeHost: (() -> Unit)? = null,
     onRemoveHost: (() -> Unit)? = null,
     isHost: Boolean = false
@@ -115,6 +116,15 @@ fun UserCardPopup(
                     text = user.displayName,
                     style = MaterialTheme.typography.titleMedium
                 )
+
+                if (user.uniqueId != 0L) {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = "ID: ${user.uniqueId}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
 
                 user.nationality?.let { nat ->
                     Spacer(modifier = Modifier.height(4.dp))
@@ -183,7 +193,7 @@ fun UserCardPopup(
                 }
 
                 // Moderation actions
-                if (onMuteToggle != null || onRemoveFromSeat != null || onMoveSeat != null || onKickFromRoom != null || onMakeHost != null || onRemoveHost != null) {
+                if ((onMuteToggle != null && !isTargetMuted) || onRemoveFromSeat != null || onMoveSeat != null || onKickFromRoom != null || onMakeHost != null || onRemoveHost != null) {
                     Spacer(modifier = Modifier.height(12.dp))
                     Text(
                         text = "Moderation",
@@ -193,7 +203,7 @@ fun UserCardPopup(
                     Spacer(modifier = Modifier.height(4.dp))
                 }
 
-                if (onMuteToggle != null) {
+                if (onMuteToggle != null && !isTargetMuted) {
                     OutlinedButton(
                         onClick = {
                             onMuteToggle()
@@ -202,12 +212,12 @@ fun UserCardPopup(
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         Icon(
-                            if (isTargetMuted) Icons.Default.Mic else Icons.Default.MicOff,
+                            Icons.Default.MicOff,
                             contentDescription = null,
                             modifier = Modifier.size(16.dp)
                         )
                         Spacer(modifier = Modifier.width(4.dp))
-                        Text(if (isTargetMuted) "Unmute User" else "Mute User")
+                        Text("Mute User")
                     }
                 }
 
@@ -280,7 +290,7 @@ fun UserCardPopup(
                             modifier = Modifier.size(16.dp)
                         )
                         Spacer(modifier = Modifier.width(4.dp))
-                        Text("Remove from Seat")
+                        Text("Move to Audience")
                     }
                 }
 
@@ -381,12 +391,18 @@ fun UserCardPopup(
             text = {
                 Column {
                     emptySeats.forEach { targetIndex ->
+                        val occupantName = seatOccupantNames[targetIndex]
+                        val label = if (occupantName != null) {
+                            "Seat ${targetIndex + 1} (swap with $occupantName)"
+                        } else {
+                            "Seat ${targetIndex + 1}"
+                        }
                         TextButton(onClick = {
                             showMoveDialog = false
                             onMoveSeat?.invoke(targetIndex)
                             onDismiss()
                         }) {
-                            Text("Seat ${targetIndex + 1}")
+                            Text(label)
                         }
                     }
                 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/settings/RoomSettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/settings/RoomSettingsViewModel.kt
@@ -122,6 +122,9 @@ class RoomSettingsViewModel(
         val room = _uiState.value.room ?: return
         // Owner can always invite; hosts only when requireApproval is OFF
         if (currentUserId != room.ownerId && (currentUserId !in room.hostIds || room.requireApproval)) return
+        // Don't invite someone already invited or already seated
+        if (userId in room.pendingInvites) return
+        if (room.findUserSeat(userId) != null) return
         viewModelScope.launch {
             roomRepository.sendInvite(currentRoomId, userId, currentUserId)
         }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/ui/components/CnyRoomBackground.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/ui/components/CnyRoomBackground.kt
@@ -34,13 +34,13 @@ private val Gold = Color(0xFFF0C246)
 private val CloudWhite = Color(0xFFFFFFFF)
 
 // Pre-computed alpha variants to avoid per-frame Color.copy() allocations
-private val LanternBodyColor = LanternRed.copy(alpha = 0.5f)
-private val GoldRimColor = Gold.copy(alpha = 0.6f)
-private val GoldTasselColor = Gold.copy(alpha = 0.4f)
-private val GoldHandleColor = Gold.copy(alpha = 0.5f)
-private val RadialGlowColor = Color(0x15D4263E)
+private val LanternBodyColor = LanternRed.copy(alpha = 0.7f)
+private val GoldRimColor = Gold.copy(alpha = 0.8f)
+private val GoldTasselColor = Gold.copy(alpha = 0.6f)
+private val GoldHandleColor = Gold.copy(alpha = 0.7f)
+private val RadialGlowColor = Color(0x30D4263E)
 private val BackgroundGradient = Brush.verticalGradient(listOf(DeepRedTop, DeepRedBottom))
-private val HorseWatermarkColor = Color.White.copy(alpha = 0.04f)
+private val HorseWatermarkColor = Color.White.copy(alpha = 0.07f)
 
 private data class LanternConfig(
     val xFraction: Float,
@@ -144,7 +144,7 @@ fun CnyRoomBackground(modifier: Modifier = Modifier) {
                     rawProgress < 0.1f -> rawProgress / 0.1f
                     rawProgress > 0.9f -> (1f - rawProgress) / 0.1f
                     else -> 1f
-                } * 0.6f
+                } * 0.8f
                 drawCircle(
                     color = Gold.copy(alpha = alpha),
                     radius = sparkle.radius,
@@ -157,19 +157,19 @@ fun CnyRoomBackground(modifier: Modifier = Modifier) {
                 startX = 0f,
                 y = size.height * 0.88f,
                 width = size.width * 0.35f,
-                alpha = 0.03f
+                alpha = 0.06f
             )
             drawCloudWisp(
                 startX = size.width * 0.65f,
                 y = size.height * 0.92f,
                 width = size.width * 0.35f,
-                alpha = 0.03f
+                alpha = 0.06f
             )
             drawCloudWisp(
                 startX = size.width * 0.3f,
                 y = size.height * 0.95f,
                 width = size.width * 0.4f,
-                alpha = 0.025f
+                alpha = 0.05f
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/ui/components/FlagBadge.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/ui/components/FlagBadge.kt
@@ -1,0 +1,70 @@
+package com.shyden.shytalk.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import com.shyden.shytalk.core.util.countryNameForCode
+import com.shyden.shytalk.core.util.flagEmojiForCode
+
+@Composable
+fun FlagBadge(
+    countryCode: String,
+    badgeSize: Dp = 24.dp,
+    modifier: Modifier = Modifier
+) {
+    var showTooltip by remember { mutableStateOf(false) }
+    val flag = flagEmojiForCode(countryCode)
+    val countryName = countryNameForCode(countryCode)
+
+    Box(modifier = modifier) {
+        Box(
+            modifier = Modifier
+                .size(badgeSize)
+                .clickable { showTooltip = !showTooltip },
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = flag,
+                style = MaterialTheme.typography.labelSmall.copy(
+                    fontSize = (badgeSize.value * 0.65f).sp
+                )
+            )
+        }
+
+        if (showTooltip && countryName != null) {
+            Popup(
+                alignment = Alignment.TopCenter,
+                onDismissRequest = { showTooltip = false }
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(6.dp),
+                    color = MaterialTheme.colorScheme.inverseSurface,
+                    shadowElevation = 4.dp
+                ) {
+                    Text(
+                        text = countryName,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.inverseOnSurface,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Voice disconnect overhaul**: Non-owners stay in room on disconnect, only seat cleared (15s grace period). Speakerphone auto-enabled on unmute. Unmute gated until voice fully connected. Re-entry joins fresh session without block dialogs.
- **Seat request fixes**: Stale PENDING requests refreshed so snapshot listeners re-fire. Re-entry race condition resolved by storing raw requests and re-filtering on room updates. Duplicate sit invites prevented.
- **Chat message limit**: Capped at 50 messages per room with auto-trim of oldest on each send.
- **Follower removal UX**: Shows Undo button for 5 seconds instead of immediately removing.
- **Room name persistence**: Last room name saved to user profile and pre-filled on next creation.
- **Country flag badges**: Flag emoji displayed on user cards based on country code.
- **Cloud function update**: `onPresenceRemoved` clears seat only for non-owners, keeps in participantIds.
- **43 files changed**, comprehensive test updates for all new behaviors.

## Test plan
- [x] All unit tests pass (631+)
- [x] Built and installed on both test devices
- [x] Cloud function deployed
- [ ] Manual: non-owner disconnect clears seat after 15s, stays in participant list
- [ ] Manual: unmute blocked before voice connected, works after
- [ ] Manual: re-entry shows no dialogs, joins fresh
- [ ] Manual: chat auto-trims at 50 messages
- [ ] Manual: follower removal shows Undo, reverts on tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)