### PR TITLE
Seat safety, chathead UX & bug fixes v0.32

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 31
-        versionName = "0.31"
+        versionCode = 32
+        versionName = "0.32"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/shyden/shytalk/MainActivity.kt
+++ b/app/src/main/java/com/shyden/shytalk/MainActivity.kt
@@ -5,6 +5,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -13,6 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.navigation.compose.rememberNavController
 import com.google.firebase.firestore.FirebaseFirestore
 import com.shyden.shytalk.core.room.ActiveRoomManager
+import com.shyden.shytalk.core.room.RoomService
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.UserRepository
 import kotlinx.coroutines.CoroutineScope
@@ -33,6 +37,7 @@ class MainActivity : ComponentActivity() {
     private val activeRoomManager: ActiveRoomManager by inject()
 
     private val _navigateToRoom = mutableStateOf<String?>(null)
+    private val _showLeaveConfirmation = mutableStateOf(false)
 
     companion object {
         private const val PREFS_NAME = "shytalk_prefs"
@@ -107,6 +112,34 @@ class MainActivity : ComponentActivity() {
                         }
                     }
                 }
+
+                // Leave room confirmation dialog (triggered by chathead X tap)
+                val showLeaveDialog by _showLeaveConfirmation
+                if (showLeaveDialog) {
+                    val isOwner = activeRoomManager.activeRoom.value?.ownerId == activeRoomManager.currentUserId
+                    AlertDialog(
+                        onDismissRequest = { _showLeaveConfirmation.value = false },
+                        title = { Text(if (isOwner) "Close Room?" else "Leave Room?") },
+                        text = { Text(
+                            if (isOwner) "This will close the room for everyone."
+                            else "You will leave the voice room."
+                        ) },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                _showLeaveConfirmation.value = false
+                                val intent = Intent(this@MainActivity, RoomService::class.java).apply {
+                                    action = "CONFIRM_DISMISS"
+                                }
+                                startService(intent)
+                            }) { Text("Leave") }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { _showLeaveConfirmation.value = false }) {
+                                Text("Cancel")
+                            }
+                        }
+                    )
+                }
             }
         }
 
@@ -139,6 +172,9 @@ class MainActivity : ComponentActivity() {
                 if (roomId != null) {
                     _navigateToRoom.value = roomId
                 }
+            }
+            "CONFIRM_LEAVE_ROOM" -> {
+                _showLeaveConfirmation.value = true
             }
             "FINISH_APP" -> {
                 finishAffinity()

--- a/app/src/main/java/com/shyden/shytalk/core/chathead/ChatHeadManager.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/chathead/ChatHeadManager.kt
@@ -43,12 +43,12 @@ class ChatHeadManager(
 
     fun show(ownerPhotoUrl: String?) {
         if (isShowing) return
+        isShowing = true
 
         handler.post {
             try {
                 createCloseZoneView()
                 createBubbleView(ownerPhotoUrl)
-                isShowing = true
             } catch (e: Exception) {
                 // Permission not granted or window manager error
                 destroy()
@@ -58,10 +58,10 @@ class ChatHeadManager(
 
     fun hide() {
         if (!isShowing) return
+        isShowing = false
         handler.post {
             removeBubble()
             removeCloseZone()
-            isShowing = false
         }
     }
 

--- a/app/src/main/java/com/shyden/shytalk/core/room/RoomService.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/room/RoomService.kt
@@ -66,28 +66,29 @@ class RoomService : Service() {
                 startActivity(intent)
             },
             onBubbleDismissed = {
-                serviceScope.launch {
-                    val isOwner = activeRoomManager.activeRoom.value?.ownerId == activeRoomManager.currentUserId
-                    if (isOwner) {
-                        activeRoomManager.closeRoom()
-                    } else {
-                        activeRoomManager.leaveRoom()
-                    }
-                }
-                if (!activeRoomManager.isAppInForeground) {
-                    val finishIntent = Intent(this, MainActivity::class.java).apply {
-                        action = "FINISH_APP"
+                if (activeRoomManager.isAppInForeground) {
+                    // App is open — ask for confirmation via MainActivity dialog
+                    val confirmIntent = Intent(this, MainActivity::class.java).apply {
+                        action = "CONFIRM_LEAVE_ROOM"
                         flags = Intent.FLAG_ACTIVITY_NEW_TASK or
-                                Intent.FLAG_ACTIVITY_CLEAR_TOP
+                                Intent.FLAG_ACTIVITY_SINGLE_TOP
                     }
-                    startActivity(finishIntent)
+                    startActivity(confirmIntent)
+                } else {
+                    // App in background — leave/close immediately
+                    performDismiss()
                 }
-                stopSelf()
             }
         )
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Handle confirmed dismiss from MainActivity dialog
+        if (intent?.action == "CONFIRM_DISMISS") {
+            performDismiss()
+            return START_NOT_STICKY
+        }
+
         val roomId = intent?.getStringExtra("roomId") ?: run {
             stopSelf()
             return START_NOT_STICKY
@@ -99,6 +100,26 @@ class RoomService : Service() {
         observeRoomClosed()
 
         return START_STICKY
+    }
+
+    private fun performDismiss() {
+        serviceScope.launch {
+            val isOwner = activeRoomManager.activeRoom.value?.ownerId == activeRoomManager.currentUserId
+            if (isOwner) {
+                activeRoomManager.closeRoom()
+            } else {
+                activeRoomManager.leaveRoom()
+            }
+        }
+        if (!activeRoomManager.isAppInForeground) {
+            val finishIntent = Intent(this, MainActivity::class.java).apply {
+                action = "FINISH_APP"
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                        Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+            startActivity(finishIntent)
+        }
+        stopSelf()
     }
 
     private fun observeRoom() {

--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
@@ -154,38 +154,44 @@ class RoomRepositoryImpl(
                 ?: throw Exception("Room not found")
             val fromSeat = room.seats[fromIndex.toString()]
             val toSeat = room.seats[toIndex.toString()]
-            val fromMuted = fromSeat?.isMuted ?: false
+
+            // Verify user is still in the source seat (another host may have already moved them)
+            if (fromSeat?.userId != userId) return@runTransaction
+
+            val fromMuted = fromSeat.isMuted
+
+            // Clear user from ALL seats first (prevents ending up in multiple seats)
+            val updates = clearUserSeats(room, userId)
 
             if (toSeat?.state == SeatState.OCCUPIED && toSeat.userId != null) {
-                // Swap: move both users, preserving each user's mute state
+                // Swap: move the other user to the source seat, preserving their mute state
                 val toMuted = toSeat.isMuted
-                transaction.update(docRef, mapOf(
-                    "seats.$fromIndex" to Seat(userId = toSeat.userId, state = SeatState.OCCUPIED, isMuted = toMuted).toMap(),
-                    "seats.$toIndex" to Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = fromMuted).toMap()
-                ))
+                updates["seats.$fromIndex"] = Seat(userId = toSeat.userId, state = SeatState.OCCUPIED, isMuted = toMuted).toMap()
+                updates["seats.$toIndex"] = Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = fromMuted).toMap()
             } else {
-                // Move to empty seat
-                transaction.update(docRef, mapOf(
-                    "seats.$fromIndex" to Seat.EMPTY_MAP,
-                    "seats.$toIndex" to Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = fromMuted).toMap()
-                ))
+                // Move to empty seat (clearUserSeats already cleared the source)
+                updates["seats.$toIndex"] = Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = fromMuted).toMap()
             }
+            transaction.update(docRef, updates)
         }.await()
     }
 
     override suspend fun kickUser(roomId: String, userId: String, seatIndex: Int?, kickerName: String, reason: String): Resource<Unit> = firebaseCall("Failed to kick user") {
-        val updates = mutableMapOf<String, Any>(
-            "participantIds" to FieldValue.arrayRemove(userId),
-            "bannedUserIds" to FieldValue.arrayUnion(userId),
-            "kickInfo.$userId" to mapOf(
+        val docRef = roomsCollection.document(roomId)
+        firestore.runTransaction { transaction ->
+            val snapshot = transaction.get(docRef)
+            val room = snapshot.data?.let { ChatRoom.fromMap(it, snapshot.id) }
+                ?: throw Exception("Room not found")
+
+            val updates = clearUserSeats(room, userId)
+            updates["participantIds"] = FieldValue.arrayRemove(userId)
+            updates["bannedUserIds"] = FieldValue.arrayUnion(userId)
+            updates["kickInfo.$userId"] = mapOf(
                 "kickerName" to kickerName,
                 "reason" to reason.ifBlank { "No reason given" }
             )
-        )
-        if (seatIndex != null) {
-            updates["seats.$seatIndex"] = Seat.EMPTY_MAP
-        }
-        roomsCollection.document(roomId).update(updates).await()
+            transaction.update(docRef, updates)
+        }.await()
     }
 
     override suspend fun toggleMute(roomId: String, seatIndex: Int, isMuted: Boolean): Resource<Unit> = firebaseCall("Failed to toggle mute") {

--- a/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
@@ -479,7 +479,7 @@ private fun ProfileContent(
                 Row(
                     modifier = Modifier
                         .align(Alignment.CenterEnd)
-                        .padding(top = 24.dp),
+                        .padding(top = 32.dp),
                     horizontalArrangement = Arrangement.spacedBy(24.dp)
                 ) {
                     Column(

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -417,6 +417,7 @@ fun RoomScreen(
                         speakingUserIds = uiState.speakingUserIds,
                         seatUsers = uiState.seatUsers,
                         disconnectedUserIds = uiState.disconnectedUserIds,
+                        isOwnerAway = uiState.room?.state == RoomState.OWNER_AWAY,
                         showRequestSeat = showRequestSeat,
                         onSeatClick = { seatIndex ->
                             val seat = uiState.room?.seats?.get(seatIndex.toString())
@@ -502,6 +503,7 @@ fun RoomScreen(
                     audienceUsers = audienceUsers,
                     pendingRequests = uiState.pendingRequestsForPanel,
                     pendingInviteUserIds = uiState.room?.pendingInvites?.keys ?: emptySet(),
+                    seatedUserIds = seatedUserIds,
                     isOwnerOrHost = isOwnerOrHost,
                     onUserClick = { userId ->
                         showParticipantPanel = false
@@ -597,9 +599,12 @@ fun RoomScreen(
 
                 val targetRole = uiState.room?.resolveRole(userId) ?: RoomRole.ATTENDEE
 
+                val isInRoom = userId in (uiState.room?.participantIds ?: emptyList())
                 val canInviteFromCard = (uiState.currentRole == RoomRole.OWNER || uiState.currentRole == RoomRole.HOST)
                         && userId != uiState.currentUserId
+                        && isInRoom
                         && !isTargetSeated
+                        && userId !in (uiState.room?.pendingInvites?.keys ?: emptySet())
 
                 // Mod capabilities: owner can act on hosts + attendees; hosts can act on attendees only
                 val isNotSelf = userId != uiState.currentUserId

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,12 +1,12 @@
-v0.31 - Voice overhaul, chat limits & UX improvements
+v0.32 - Seat safety, chathead UX & bug fixes
 
-- Voice disconnect: non-owners keep room access, only seat cleared
-- Speakerphone auto-enabled when unmuted, earpiece routing fixed
-- Unmute blocked until voice fully connected
-- Re-entry skips block dialogs, joins fresh session
-- Seat request fixes: stale requests refreshed, re-entry race resolved
-- Duplicate sit invites prevented
-- Chat capped at 50 messages, oldest auto-trimmed
-- Follower removal now shows Undo button (5s grace period)
-- Room name persisted across sessions
-- Country flag badges on user cards
+- Seat race condition fixed: users can no longer end up in multiple seats when hosts move them simultaneously
+- Chathead X button now shows confirmation dialog when app is open; dismisses immediately when in background
+- Chathead show/hide race condition fixed
+- Owner dimmed during OWNER_AWAY countdown (UI-layer rendering)
+- Dimming no longer lost when another user moves seats
+- Seat grid always fills top row of 4 before second row
+- "Invite to Mic" hidden for seated users and users not in room
+- JOIN message avatars and user cards now persist after room re-entry
+- Connections page: Following tab now appears first
+- Profile follow stats spacing adjusted

--- a/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
@@ -132,6 +132,33 @@ class RoomRepositoryImplTest {
 
     // --- moveSeat ---
 
+    private fun setupMoveSeatTransaction(
+        seats: Map<String, Map<String, Any?>> = mapOf(
+            "0" to mapOf("userId" to "owner-1", "state" to "OCCUPIED", "isMuted" to false),
+            "2" to mapOf("userId" to "user-a", "state" to "OCCUPIED", "isMuted" to true),
+            "5" to mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false)
+        )
+    ): Pair<Transaction, MutableList<Map<String, Any>>> {
+        val transaction = mockk<Transaction>(relaxed = true)
+        val snapshot = mockk<DocumentSnapshot>(relaxed = true)
+        every { snapshot.data } returns mapOf(
+            "ownerId" to "owner-1",
+            "state" to "ACTIVE",
+            "participantIds" to listOf("owner-1", "user-a"),
+            "seats" to seats
+        )
+        every { snapshot.id } returns "room-1"
+        every { transaction.get(docRef) } returns snapshot
+        val updateSlots = mutableListOf<Map<String, Any>>()
+        every { transaction.update(docRef, capture(updateSlots)) } returns transaction
+        every { firestore.runTransaction(any<Transaction.Function<*>>()) } answers {
+            val fn = firstArg<Transaction.Function<*>>()
+            fn.apply(transaction)
+            Tasks.forResult(null)
+        }
+        return transaction to updateSlots
+    }
+
     @Test
     fun `moveSeat returns Success`() = runTest {
         every { firestore.runTransaction(any<Transaction.Function<Any?>>()) } returns Tasks.forResult(null)
@@ -141,54 +168,129 @@ class RoomRepositoryImplTest {
         assertTrue(result is Resource.Success)
     }
 
-    // --- kickUser ---
+    @Test
+    fun `moveSeat clears user from all seats before placing in destination`() = runTest {
+        val (_, updateSlots) = setupMoveSeatTransaction()
+
+        val result = repo.moveSeat("room-1", 2, 5, "user-a")
+
+        assertTrue(result is Resource.Success)
+        val updates = updateSlots.first()
+        // clearUserSeats should have set seat 2 to empty, then destination seat 5 gets the user
+        assertTrue(updates.containsKey("seats.5"))
+        @Suppress("UNCHECKED_CAST")
+        val destSeat = updates["seats.5"] as Map<String, Any?>
+        assertEquals("user-a", destSeat["userId"])
+    }
 
     @Test
-    fun `kickUser with seatIndex clears seat`() = runTest {
-        val mapSlot = slot<Map<String, Any>>()
-        every { docRef.update(capture(mapSlot)) } returns Tasks.forResult(null)
+    fun `moveSeat aborts if user not in source seat`() = runTest {
+        val (_, updateSlots) = setupMoveSeatTransaction()
+
+        // Try to move "user-b" from seat 2, but seat 2 has "user-a"
+        val result = repo.moveSeat("room-1", 2, 5, "user-b")
+
+        assertTrue(result is Resource.Success) // transaction still succeeds, just no-op
+        assertTrue(updateSlots.isEmpty()) // no updates were made
+    }
+
+    @Test
+    fun `moveSeat swap preserves mute states`() = runTest {
+        val (_, updateSlots) = setupMoveSeatTransaction(
+            seats = mapOf(
+                "0" to mapOf("userId" to "owner-1", "state" to "OCCUPIED", "isMuted" to false),
+                "2" to mapOf("userId" to "user-a", "state" to "OCCUPIED", "isMuted" to true),
+                "5" to mapOf("userId" to "user-b", "state" to "OCCUPIED", "isMuted" to false)
+            )
+        )
+
+        val result = repo.moveSeat("room-1", 2, 5, "user-a")
+
+        assertTrue(result is Resource.Success)
+        val updates = updateSlots.first()
+        // user-a moves to seat 5 with their original mute state (true)
+        @Suppress("UNCHECKED_CAST")
+        val destSeat = updates["seats.5"] as Map<String, Any?>
+        assertEquals("user-a", destSeat["userId"])
+        assertEquals(true, destSeat["isMuted"])
+        // user-b swaps to seat 2 with their original mute state (false)
+        @Suppress("UNCHECKED_CAST")
+        val srcSeat = updates["seats.2"] as Map<String, Any?>
+        assertEquals("user-b", srcSeat["userId"])
+        assertEquals(false, srcSeat["isMuted"])
+    }
+
+    // --- kickUser ---
+
+    private fun setupKickUserTransaction(): Pair<Transaction, MutableList<Map<String, Any>>> {
+        val transaction = mockk<Transaction>(relaxed = true)
+        val snapshot = mockk<DocumentSnapshot>(relaxed = true)
+        every { snapshot.data } returns mapOf(
+            "ownerId" to "owner-1",
+            "state" to "ACTIVE",
+            "participantIds" to listOf("owner-1", "bad-user"),
+            "seats" to mapOf(
+                "0" to mapOf("userId" to "owner-1", "state" to "OCCUPIED", "isMuted" to false),
+                "2" to mapOf("userId" to "bad-user", "state" to "OCCUPIED", "isMuted" to false)
+            )
+        )
+        every { snapshot.id } returns "room-1"
+        every { transaction.get(docRef) } returns snapshot
+        val updateSlots = mutableListOf<Map<String, Any>>()
+        every { transaction.update(docRef, capture(updateSlots)) } returns transaction
+        every { firestore.runTransaction(any<Transaction.Function<*>>()) } answers {
+            val fn = firstArg<Transaction.Function<*>>()
+            fn.apply(transaction)
+            Tasks.forResult(null)
+        }
+        return transaction to updateSlots
+    }
+
+    @Test
+    fun `kickUser clears all seats for user`() = runTest {
+        val (_, updateSlots) = setupKickUserTransaction()
 
         val result = repo.kickUser("room-1", "bad-user", 2)
 
         assertTrue(result is Resource.Success)
-        assertTrue(mapSlot.captured.containsKey("seats.2"))
+        val updates = updateSlots.first()
+        assertTrue(updates.containsKey("seats.2"))
     }
 
     @Test
-    fun `kickUser without seatIndex does not clear seat`() = runTest {
-        val mapSlot = slot<Map<String, Any>>()
-        every { docRef.update(capture(mapSlot)) } returns Tasks.forResult(null)
+    fun `kickUser without seatIndex still clears occupied seat`() = runTest {
+        val (_, updateSlots) = setupKickUserTransaction()
 
         val result = repo.kickUser("room-1", "bad-user", null)
 
         assertTrue(result is Resource.Success)
-        assertTrue(mapSlot.captured.keys.none { it.startsWith("seats.") })
+        val updates = updateSlots.first()
+        // clearUserSeats finds seat 2 and clears it even without explicit seatIndex
+        assertTrue(updates.containsKey("seats.2"))
     }
 
     @Test
     fun `kickUser stores kickInfo with kicker name and reason`() = runTest {
-        val mapSlot = slot<Map<String, Any>>()
-        every { docRef.update(capture(mapSlot)) } returns Tasks.forResult(null)
+        val (_, updateSlots) = setupKickUserTransaction()
 
         val result = repo.kickUser("room-1", "bad-user", 2, "Admin", "Spamming")
 
         assertTrue(result is Resource.Success)
         @Suppress("UNCHECKED_CAST")
-        val kickInfo = mapSlot.captured["kickInfo.bad-user"] as Map<String, String>
+        val kickInfo = updateSlots.first()["kickInfo.bad-user"] as Map<String, String>
         assertEquals("Admin", kickInfo["kickerName"])
         assertEquals("Spamming", kickInfo["reason"])
     }
 
     @Test
     fun `kickUser with blank reason defaults to No reason given`() = runTest {
-        val mapSlot = slot<Map<String, Any>>()
-        every { docRef.update(capture(mapSlot)) } returns Tasks.forResult(null)
+        val (_, updateSlots) = setupKickUserTransaction()
 
         val result = repo.kickUser("room-1", "bad-user", 2, "Admin", "")
 
         assertTrue(result is Resource.Success)
         @Suppress("UNCHECKED_CAST")
-        val kickInfo = mapSlot.captured["kickInfo.bad-user"] as Map<String, String>
+        val kickInfo = updateSlots.first()["kickInfo.bad-user"] as Map<String, String>
         assertEquals("No reason given", kickInfo["reason"])
     }
 

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -855,6 +855,21 @@ class RoomViewModelTest {
         coVerify(exactly = 0) { roomRepository.sendInvite(any(), any(), any()) }
     }
 
+    @Test
+    fun `inviteUser - already pending invite is rejected`() = roomTest {
+        viewModel = createViewModel()
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            pendingInvites = mapOf("target-user" to currentUserId)
+        ))
+        advanceUntilIdle()
+
+        viewModel.inviteUser("target-user", "Target")
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { roomRepository.sendInvite(any(), any(), any()) }
+    }
+
     // ===== acceptInvite Tests =====
 
     @Test
@@ -2750,5 +2765,65 @@ class RoomViewModelTest {
         advanceUntilIdle()
 
         coVerify(exactly = 0) { roomRepository.moveSeat(any(), any(), any(), any()) }
+    }
+
+    // ===== Message sender user loading (v0.32 fix) =====
+
+    @Test
+    fun `loadMessageSenderUsers - loads users for JOIN message senders`() = roomTest {
+        val joinUser = TestData.createTestUser(uid = "joiner-1", displayName = "Joiner")
+        coEvery { userRepository.getUser("joiner-1") } returns Resource.Success(joinUser)
+        coEvery { userRepository.getUsers(any()) } coAnswers {
+            val ids = firstArg<List<String>>()
+            val users = ids.mapNotNull { id ->
+                when (id) {
+                    currentUserId -> TestData.createTestUser(uid = currentUserId, displayName = "Current User")
+                    "joiner-1" -> joinUser
+                    else -> null
+                }
+            }
+            Resource.Success(users)
+        }
+
+        viewModel = createViewModel()
+        emitRoomAsOwner()
+        advanceUntilIdle()
+
+        // Emit a JOIN message from joiner-1 (who is no longer in the room)
+        val joinMessage = TestData.createTestMessage(
+            messageId = "msg-join",
+            senderId = "joiner-1",
+            senderName = "Joiner",
+            text = "Joiner joined the room",
+            type = MessageType.JOIN,
+            createdAt = TestData.BASE_TIMESTAMP
+        )
+        messagesFlow.value = listOf(joinMessage)
+        advanceUntilIdle()
+
+        // joiner-1 should be loaded into allKnownUsers via loadMessageSenderUsers
+        assertTrue(viewModel.uiState.value.allKnownUsers.containsKey("joiner-1"))
+        assertEquals("Joiner", viewModel.uiState.value.allKnownUsers["joiner-1"]?.displayName)
+    }
+
+    @Test
+    fun `disconnectedUserIds - does not include owner during OWNER_AWAY`() = roomTest {
+        val disconnectedFlow = MutableStateFlow<Set<String>>(emptySet())
+        every { roomLifecycleManager.disconnectedUserIds } returns disconnectedFlow
+
+        viewModel = createViewModel()
+        // Emit OWNER_AWAY room as attendee
+        val awayRoom = TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId),
+            state = RoomState.OWNER_AWAY,
+            ownerLeftAt = System.currentTimeMillis()
+        )
+        emitRoomAsAttendee(awayRoom)
+        // Use advanceTimeBy instead of advanceUntilIdle to avoid the infinite countdown loop
+        advanceTimeBy(100)
+
+        // disconnectedUserIds should NOT contain the owner (dimming handled in UI layer now)
+        assertFalse(viewModel.uiState.value.disconnectedUserIds.contains(ownerId))
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/FollowListScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/FollowListScreen.kt
@@ -89,17 +89,17 @@ fun FollowListScreen(
                 .padding(padding)
         ) {
             PrimaryTabRow(
-                selectedTabIndex = if (uiState.selectedTab == FollowTab.FOLLOWERS) 0 else 1
+                selectedTabIndex = if (uiState.selectedTab == FollowTab.FOLLOWING) 0 else 1
             ) {
-                Tab(
-                    selected = uiState.selectedTab == FollowTab.FOLLOWERS,
-                    onClick = { viewModel.selectTab(FollowTab.FOLLOWERS) },
-                    text = { Text("Followers (${uiState.followers.size})") }
-                )
                 Tab(
                     selected = uiState.selectedTab == FollowTab.FOLLOWING,
                     onClick = { viewModel.selectTab(FollowTab.FOLLOWING) },
                     text = { Text("Following (${uiState.following.size})") }
+                )
+                Tab(
+                    selected = uiState.selectedTab == FollowTab.FOLLOWERS,
+                    onClick = { viewModel.selectTab(FollowTab.FOLLOWERS) },
+                    text = { Text("Followers (${uiState.followers.size})") }
                 )
             }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -579,7 +579,15 @@ class RoomViewModel(
         if (filtered !== lastFilteredMessages) {
             lastFilteredMessages = filtered
             _uiState.update { it.copy(messages = filtered) }
+            loadMessageSenderUsers(filtered)
         }
+    }
+
+    private fun loadMessageSenderUsers(messages: List<Message>) {
+        val senderIds = messages.mapTo(mutableSetOf()) { it.senderId }
+        senderIds.remove("system")
+        if (senderIds.isEmpty()) return
+        loadUsersForIds(senderIds) { /* accumulateKnownUsers handles the UI update */ }
     }
 
     private fun observeVoiceState() {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ParticipantListPanel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ParticipantListPanel.kt
@@ -53,6 +53,7 @@ fun ParticipantListPanel(
     audienceUsers: List<ParticipantInfo>,
     pendingRequests: List<SeatRequest> = emptyList(),
     pendingInviteUserIds: Set<String> = emptySet(),
+    seatedUserIds: Set<String> = emptySet(),
     isOwnerOrHost: Boolean = false,
     onUserClick: (String) -> Unit,
     onApproveRequest: (SeatRequest) -> Unit = {},
@@ -130,6 +131,7 @@ fun ParticipantListPanel(
                     val pendingRequest = requestByUserId[participant.user.uid]
                     val hasPendingInvite = participant.user.uid in pendingInviteUserIds
                     val canInvite = isOwnerOrHost && pendingRequest == null && !hasPendingInvite
+                        && participant.user.uid !in seatedUserIds
                     ParticipantRow(
                         participant = participant,
                         pendingRequest = pendingRequest,

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/SeatGrid.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/SeatGrid.kt
@@ -31,6 +31,7 @@ fun SeatGrid(
     speakingUserIds: Set<String>,
     seatUsers: Map<String, User> = emptyMap(),
     disconnectedUserIds: Set<String> = emptySet(),
+    isOwnerAway: Boolean = false,
     showRequestSeat: Boolean = false,
     onSeatClick: (Int) -> Unit,
     onTapUser: (String) -> Unit = {},
@@ -76,13 +77,12 @@ fun SeatGrid(
         label = "seatSize"
     )
 
-    // Split into 2 rows: row1 gets first half (ceil), row2 gets remainder
+    // Split into 2 rows: top row always fills up to 4 seats first, overflow goes to row 2
     val (row1, row2) = remember(displaySeats) {
         if (count <= 4) {
             displaySeats to emptyList()
         } else {
-            val splitAt = (count + 1) / 2 // ceil division — top row gets more if odd
-            displaySeats.take(splitAt) to displaySeats.drop(splitAt)
+            displaySeats.take(4) to displaySeats.drop(4)
         }
     }
 
@@ -90,7 +90,7 @@ fun SeatGrid(
         modifier = modifier,
         contentAlignment = Alignment.Center
     ) {
-        val maxItemsPerRow = if (count <= 4) count.coerceAtLeast(1) else (count + 1) / 2
+        val maxItemsPerRow = if (count <= 4) count.coerceAtLeast(1) else 4
         val maxSeatSize = (maxWidth / maxItemsPerRow) - 24.dp
         val cappedSeatSize = seatSize.coerceAtMost(maxSeatSize)
 
@@ -107,6 +107,7 @@ fun SeatGrid(
                 speakingUserIds = speakingUserIds,
                 seatUsers = seatUsers,
                 disconnectedUserIds = disconnectedUserIds,
+                isOwnerAway = isOwnerAway,
                 seatSize = cappedSeatSize,
                 requestSeatIndex = requestSeatIndex,
                 onSeatClick = onSeatClick,
@@ -122,6 +123,7 @@ fun SeatGrid(
                     speakingUserIds = speakingUserIds,
                     seatUsers = seatUsers,
                     disconnectedUserIds = disconnectedUserIds,
+                    isOwnerAway = isOwnerAway,
                     seatSize = cappedSeatSize,
                     requestSeatIndex = requestSeatIndex,
                     onSeatClick = onSeatClick,
@@ -142,6 +144,7 @@ private fun SeatRow(
     speakingUserIds: Set<String>,
     seatUsers: Map<String, User>,
     disconnectedUserIds: Set<String>,
+    isOwnerAway: Boolean,
     seatSize: Dp,
     requestSeatIndex: Int? = null,
     onSeatClick: (Int) -> Unit,
@@ -169,7 +172,8 @@ private fun SeatRow(
                     !(seatUserId == currentUserId && seat.isMuted) &&
                     seatUserId in speakingUserIds
 
-                val isDisconnected = seatUserId != null && seatUserId in disconnectedUserIds
+                val isDisconnected = (seatUserId != null && seatUserId in disconnectedUserIds)
+                    || (isOwnerAway && seatUserId == ownerId)
 
                 val isOwnerOnOwnSeat = seatUserId == currentUserId
                     && seatIndex == Constants.OWNER_SEAT_INDEX


### PR DESCRIPTION
## Summary
- Fix seat race condition: `clearUserSeats()` in `moveSeat`/`kickUser` transactions prevents users ending up in multiple seats
- Chathead X button shows confirmation dialog when app is in foreground; dismisses immediately in background
- Fix chathead show/hide race condition (synchronous `isShowing` flag updates)
- Owner dimmed during OWNER_AWAY via UI-layer `isOwnerAway` param on SeatGrid (no longer overwritten by seat moves)
- Seat grid always fills top row of 4 before moving to second row
- Hide "Invite to Mic" for seated users, pending invites, and users not in room
- JOIN message avatars and user cards persist after room re-entry via `loadMessageSenderUsers()`
- Connections page: Following tab now appears first
- Profile follow stats spacing adjusted
- 7 new unit tests for moveSeat transactions, invite guards, message sender loading, OWNER_AWAY dimming

## Test plan
- [x] All 637 unit tests pass
- [ ] Verify seated users cannot be invited (user card + participant panel)
- [ ] Verify chathead X shows dialog when app is open, dismisses when in background
- [ ] Verify owner dimmed during OWNER_AWAY, dimming persists through seat moves
- [ ] Verify JOIN message avatars persist after room re-entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)