### PR TITLE
Voice indicator fix & stalker UX v0.34

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 33
-        versionName = "0.33"
+        versionCode = 34
+        versionName = "0.34"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,8 +1,5 @@
-v0.33 - Profile Stalkers
+v0.34 - Bug Fixes & Stalker UX
 
-- See who visited your profile in the last 3 months
-- New "Stalkers" stat on your profile with red badge for new visitors
-- Third "Stalkers" tab on Connections page shows visit counts
-- Badge pulses to draw attention to new stalkers
-- Badge clears when you open the Stalkers tab
-- Profile stats layout: labels now appear above numbers
+- Fixed voice room indicator showing on offline users' profile photos
+- Stalkers tab now shows "Stalked you X ago, X time(s) in last 3 months"
+- Voice room overlay only appears when the user is actually online

--- a/app/src/test/java/com/shyden/shytalk/core/util/DateUtilsTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/util/DateUtilsTest.kt
@@ -76,4 +76,48 @@ class DateUtilsTest {
         }
         assertFalse(isAtLeast13(cal.timeInMillis))
     }
+
+    // ===== formatRelativeTime =====
+
+    @Test
+    fun `formatRelativeTime - just now for less than 1 minute ago`() {
+        val ts = System.currentTimeMillis() - 30_000L // 30 seconds ago
+        assertEquals("just now", formatRelativeTime(ts))
+    }
+
+    @Test
+    fun `formatRelativeTime - singular minute`() {
+        val ts = System.currentTimeMillis() - 90_000L // 1.5 minutes ago
+        assertEquals("1 min ago", formatRelativeTime(ts))
+    }
+
+    @Test
+    fun `formatRelativeTime - plural minutes`() {
+        val ts = System.currentTimeMillis() - 5 * 60_000L // 5 minutes ago
+        assertEquals("5 mins ago", formatRelativeTime(ts))
+    }
+
+    @Test
+    fun `formatRelativeTime - singular hour`() {
+        val ts = System.currentTimeMillis() - 90 * 60_000L // 1.5 hours ago
+        assertEquals("1 hour ago", formatRelativeTime(ts))
+    }
+
+    @Test
+    fun `formatRelativeTime - plural hours`() {
+        val ts = System.currentTimeMillis() - 5 * 3600_000L // 5 hours ago
+        assertEquals("5 hours ago", formatRelativeTime(ts))
+    }
+
+    @Test
+    fun `formatRelativeTime - singular day`() {
+        val ts = System.currentTimeMillis() - 36 * 3600_000L // 1.5 days ago
+        assertEquals("1 day ago", formatRelativeTime(ts))
+    }
+
+    @Test
+    fun `formatRelativeTime - plural days`() {
+        val ts = System.currentTimeMillis() - 3 * 24 * 3600_000L // 3 days ago
+        assertEquals("3 days ago", formatRelativeTime(ts))
+    }
 }

--- a/app/src/test/java/com/shyden/shytalk/feature/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/profile/ProfileViewModelTest.kt
@@ -636,6 +636,63 @@ class ProfileViewModelTest {
         assertFalse(vm.uiState.value.isOnline)
     }
 
+    // ===== activeRoomId gated by online status =====
+
+    @Test
+    fun `loadProfile - offline user with currentRoomId has null activeRoomId`() = runTest {
+        val oldTs = System.currentTimeMillis() - 600_000L
+        val user = TestData.createTestUser(uid = otherUserId).copy(
+            lastSeenAt = oldTs,
+            currentRoomId = "room-123"
+        )
+        coEvery { userRepository.getUser(otherUserId) } returns Resource.Success(user)
+        coEvery { userRepository.getBlockedUserIds(currentUserId) } returns Resource.Success(emptySet())
+
+        val vm = createViewModel()
+        vm.loadProfile(otherUserId)
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.isOnline)
+        assertNull(vm.uiState.value.activeRoomId)
+    }
+
+    @Test
+    fun `loadProfile - online user with currentRoomId has activeRoomId set`() = runTest {
+        val recentTs = System.currentTimeMillis() - 60_000L
+        val user = TestData.createTestUser(uid = otherUserId).copy(
+            lastSeenAt = recentTs,
+            currentRoomId = "room-123"
+        )
+        coEvery { userRepository.getUser(otherUserId) } returns Resource.Success(user)
+        coEvery { userRepository.getBlockedUserIds(currentUserId) } returns Resource.Success(emptySet())
+
+        val vm = createViewModel()
+        vm.loadProfile(otherUserId)
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.isOnline)
+        assertEquals("room-123", vm.uiState.value.activeRoomId)
+    }
+
+    @Test
+    fun `loadProfile - hidden online status with currentRoomId has null activeRoomId`() = runTest {
+        val recentTs = System.currentTimeMillis() - 60_000L
+        val user = TestData.createTestUser(uid = otherUserId).copy(
+            lastSeenAt = recentTs,
+            hideOnlineStatus = true,
+            currentRoomId = "room-123"
+        )
+        coEvery { userRepository.getUser(otherUserId) } returns Resource.Success(user)
+        coEvery { userRepository.getBlockedUserIds(currentUserId) } returns Resource.Success(emptySet())
+
+        val vm = createViewModel()
+        vm.loadProfile(otherUserId)
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.isOnline)
+        assertNull(vm.uiState.value.activeRoomId)
+    }
+
     // ===== hideFollowing =====
 
     @Test

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/DateUtils.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/DateUtils.kt
@@ -22,6 +22,19 @@ fun isAtLeast13(dateOfBirthMillis: Long): Boolean {
     return calculateAge(dateOfBirthMillis) >= 13
 }
 
+fun formatRelativeTime(timestampMs: Long): String {
+    val diffMs = currentTimeMillis() - timestampMs
+    val minutes = diffMs / 60_000
+    val hours = minutes / 60
+    val days = hours / 24
+    return when {
+        minutes < 1 -> "just now"
+        minutes < 60 -> "$minutes min${if (minutes != 1L) "s" else ""} ago"
+        hours < 24 -> "$hours hour${if (hours != 1L) "s" else ""} ago"
+        else -> "$days day${if (days != 1L) "s" else ""} ago"
+    }
+}
+
 fun formatDateForDisplay(millis: Long): String {
     val tz = TimeZone.currentSystemDefault()
     val date = Instant.fromEpochMilliseconds(millis).toLocalDateTime(tz).date

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/FollowListScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/FollowListScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.runtime.collectAsState
 import coil3.compose.AsyncImage
 import com.shyden.shytalk.core.model.ProfileVisitor
 import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.util.formatRelativeTime
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -384,8 +385,11 @@ private fun StalkerUserRow(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
+            val agoText = remember(visitor.lastVisitedAt) {
+                formatRelativeTime(visitor.lastVisitedAt)
+            }
             Text(
-                text = "Visited ${visitor.visitCount} time${if (visitor.visitCount != 1L) "s" else ""} in the last 3 months",
+                text = "Stalked you $agoText, ${visitor.visitCount} time${if (visitor.visitCount != 1L) "s" else ""} in the last 3 months",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
@@ -59,10 +59,14 @@ class ProfileViewModel(
                 val currentUser = _uiState.value.user ?: return@collect
                 if (updatedUser.uid == currentUser.uid) {
                     _uiState.update { state ->
+                        val isOnline = !updatedUser.hideOnlineStatus &&
+                            (currentTimeMillis() - updatedUser.lastSeenAt) < Constants.ONLINE_THRESHOLD_MS
                         state.copy(
                             user = updatedUser,
                             followerCount = updatedUser.followerIds.size,
                             followingCount = updatedUser.followingIds.size,
+                            isOnline = isOnline,
+                            activeRoomId = if (isOnline) updatedUser.currentRoomId else null,
                             stalkerCount = if (state.isOwnProfile) updatedUser.stalkerCount.toInt() else state.stalkerCount,
                             newStalkerCount = if (state.isOwnProfile) updatedUser.newStalkerCount.toInt() else state.newStalkerCount
                         )
@@ -112,7 +116,7 @@ class ProfileViewModel(
                                 followingCount = followingCount,
                                 isOnline = isOnline,
                                 hideFollowing = user.hideFollowing,
-                                activeRoomId = user.currentRoomId
+                                activeRoomId = if (isOnline) user.currentRoomId else null
                             )
                         }
                         // Record profile visit (fire-and-forget)
@@ -130,7 +134,7 @@ class ProfileViewModel(
                                 followingCount = followingCount,
                                 isOnline = isOnline,
                                 hideFollowing = user.hideFollowing,
-                                activeRoomId = user.currentRoomId,
+                                activeRoomId = if (isOnline) user.currentRoomId else null,
                                 stalkerCount = user.stalkerCount.toInt(),
                                 newStalkerCount = user.newStalkerCount.toInt()
                             )


### PR DESCRIPTION
## Summary

- **Fix**: Voice room indicator no longer shows on offline users' profile photos. `activeRoomId` is now gated behind the `isOnline` check in `ProfileViewModel` (both `loadProfile()` and `observeUserUpdates()`).
- **UX**: Stalkers tab text changed from "Visited X time(s) in the last 3 months" to "Stalked you X ago, X time(s) in the last 3 months" with relative time formatting.
- **Util**: Added `formatRelativeTime()` to `DateUtils.kt` with full unit test coverage.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — all tests pass
- [ ] Install on device, view profile of offline user who was previously in a room → no voice wave overlay
- [ ] View profile of online user currently in a room → voice wave overlay shows
- [ ] Open Stalkers tab → verify "Stalked you X ago" text format

🤖 Generated with [Claude Code](https://claude.com/claude-code)