### PR TITLE
Add daily orphaned-storage cleanup cron job

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,56 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="MultiplatformPreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="MultiplatformPreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewParameterProviderOnFirstParameter" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <option name="previewPanelProviderInfo">
+      <ProviderInfo name="Compose (experimental)" className="com.intellij.markdown.compose.preview.ComposePanelProvider" />
+    </option>
+  </component>
+</project>

--- a/functions/admin.js
+++ b/functions/admin.js
@@ -2,6 +2,7 @@ const express = require("express");
 const cors = require("cors");
 const { getAuth } = require("firebase-admin/auth");
 const { getFirestore, Timestamp, FieldValue } = require("firebase-admin/firestore");
+const { getStorage } = require("firebase-admin/storage");
 
 const app = express();
 
@@ -391,6 +392,81 @@ app.get("/api/appeals", async (req, res) => {
       return tb - ta;
     });
 
+    // Enrich each appeal with user suspension info and reports
+    const userIds = [...new Set(appeals.map((a) => a.userId).filter(Boolean))];
+    const userMap = {};
+    for (let i = 0; i < userIds.length; i += 30) {
+      const batch = userIds.slice(i, i + 30);
+      const refs = batch.map((uid) => db.collection("users").doc(uid));
+      const docs = await db.getAll(...refs);
+      for (const doc of docs) {
+        if (doc.exists) {
+          const ud = doc.data();
+          const convertTs = (v) => v && typeof v.toDate === "function" ? v.toDate().toISOString() : v;
+          userMap[doc.id] = {
+            displayName: ud.displayName || "",
+            profilePhotoUrl: ud.profilePhotoUrl || null,
+            uniqueId: ud.uniqueId || 0,
+            suspensionReason: ud.suspensionReason || null,
+            suspensionStartDate: convertTs(ud.suspensionStartDate),
+            suspensionEndDate: convertTs(ud.suspensionEndDate),
+            suspendedBy: ud.suspendedBy || null,
+            preSuspension: ud._preSuspension || null,
+          };
+        }
+      }
+    }
+
+    // Fetch reports for each user
+    const reportsMap = {};
+    for (const uid of userIds) {
+      try {
+        const reportsSnap = await db.collection("reports")
+          .where("reportedUserId", "==", uid)
+          .orderBy("timestamp", "desc")
+          .limit(20)
+          .get();
+        reportsMap[uid] = reportsSnap.docs.map((doc) => {
+          const rd = doc.data();
+          for (const [key, val] of Object.entries(rd)) {
+            if (val && typeof val.toDate === "function") {
+              rd[key] = val.toDate().toISOString();
+            }
+          }
+          return { reportId: doc.id, ...rd };
+        });
+      } catch (e) {
+        // If composite index doesn't exist, fall back without ordering
+        const reportsSnap = await db.collection("reports")
+          .where("reportedUserId", "==", uid)
+          .limit(20)
+          .get();
+        reportsMap[uid] = reportsSnap.docs.map((doc) => {
+          const rd = doc.data();
+          for (const [key, val] of Object.entries(rd)) {
+            if (val && typeof val.toDate === "function") {
+              rd[key] = val.toDate().toISOString();
+            }
+          }
+          return { reportId: doc.id, ...rd };
+        });
+      }
+    }
+
+    // Attach user info and reports to each appeal
+    for (const appeal of appeals) {
+      const userInfo = userMap[appeal.userId];
+      if (userInfo) {
+        appeal.userInfo = userInfo;
+        // Use original name from preSuspension if available
+        if (userInfo.preSuspension) {
+          appeal.originalDisplayName = userInfo.preSuspension.displayName;
+          appeal.originalProfilePhotoUrl = userInfo.preSuspension.profilePhotoUrl;
+        }
+      }
+      appeal.reports = reportsMap[appeal.userId] || [];
+    }
+
     return res.json({ appeals });
   } catch (err) {
     console.error("GET /api/appeals error:", err);
@@ -448,6 +524,1238 @@ app.patch("/api/appeals/:id", async (req, res) => {
   } catch (err) {
     console.error("PATCH /api/appeals/:id error:", err);
     return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// --- GCS Helper ---
+function computeDisplayScore(floor, lastDeductionAt) {
+  if (lastDeductionAt == null) return Math.min(100, floor);
+  const now = Date.now();
+  const deductionTime = lastDeductionAt.toDate ? lastDeductionAt.toDate().getTime() : new Date(lastDeductionAt).getTime();
+  const monthsSince = (now - deductionTime) / (30 * 24 * 60 * 60 * 1000);
+  return Math.min(100, Math.floor(floor + 2 * monthsSince));
+}
+
+// --- Timestamp Formatting Helper ---
+function formatTimestamp(firestoreTimestamp) {
+  if (!firestoreTimestamp) return "an unknown date";
+  const date = firestoreTimestamp.toDate ? firestoreTimestamp.toDate() : new Date(firestoreTimestamp);
+  if (isNaN(date.getTime())) return "an unknown date";
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  const day = date.getUTCDate();
+  const month = months[date.getUTCMonth()];
+  const year = date.getUTCFullYear();
+  const hours = String(date.getUTCHours()).padStart(2, "0");
+  const minutes = String(date.getUTCMinutes()).padStart(2, "0");
+  return `${day} ${month} ${year} at ${hours}:${minutes} UTC`;
+}
+
+// --- Audit Log Helper ---
+async function writeAuditLog(db, { adminUid, action, targetUserId, reportId, severity, note }) {
+  await db.collection("admin_audit_log").add({
+    adminUid,
+    action,
+    targetUserId: targetUserId || null,
+    reportId: reportId || null,
+    severity: severity || null,
+    note: note || null,
+    timestamp: Timestamp.now(),
+  });
+}
+
+// --- sendSystemPm (imported from index.js at runtime) ---
+async function sendSystemPm(recipientUid, text) {
+  // Re-implement inline to avoid circular dependency with index.js
+  const SYSTEM_UID = "SHYTALK_SYSTEM";
+  const SYSTEM_NAME = "ShyTalk";
+  const db = getFirestore();
+
+  const systemUserRef = db.collection("users").doc(SYSTEM_UID);
+  const systemDoc = await systemUserRef.get();
+  if (!systemDoc.exists) {
+    await systemUserRef.set({
+      displayName: SYSTEM_NAME,
+      userType: "SYSTEM",
+      profilePhotoUrl: "https://firebasestorage.googleapis.com/v0/b/shytalk-7ba69.firebasestorage.app/o/system%2Fshytalk_icon.webp?alt=media&token=30b0256e-3bd6-4cae-ac50-31b596df98e8",
+      uniqueId: 0,
+      createdAt: FieldValue.serverTimestamp(),
+      lastSeenAt: FieldValue.serverTimestamp(),
+    });
+  }
+
+  // Use deterministic ID matching app's Conversation.generateId()
+  const participantIds = [SYSTEM_UID, recipientUid].sort();
+  const conversationId = participantIds.join("_");
+  const convRef = db.collection("conversations").doc(conversationId);
+  const convDoc = await convRef.get();
+
+  const lastMessagePreview = {
+    text: text.substring(0, 100),
+    senderId: SYSTEM_UID,
+    senderName: SYSTEM_NAME,
+    createdAt: FieldValue.serverTimestamp(),
+    type: "TEXT",
+  };
+
+  if (!convDoc.exists) {
+    await convRef.set({
+      participantIds,
+      isGroup: false,
+      createdAt: FieldValue.serverTimestamp(),
+      lastMessage: lastMessagePreview,
+      lastMessageAt: FieldValue.serverTimestamp(),
+    });
+    // Create default settings for both participants
+    const settingsCol = convRef.collection("settings");
+    await settingsCol.doc(SYSTEM_UID).set({ unreadCount: 0, isMuted: false, isPinned: false, isHidden: false });
+    await settingsCol.doc(recipientUid).set({ unreadCount: 0, isMuted: false, isPinned: false, isHidden: false });
+  }
+
+  const msgRef = convRef.collection("messages").doc();
+  await msgRef.set({
+    senderId: SYSTEM_UID,
+    senderName: SYSTEM_NAME,
+    text,
+    type: "TEXT",
+    createdAt: FieldValue.serverTimestamp(),
+  });
+
+  await convRef.update({
+    lastMessage: lastMessagePreview,
+    lastMessageAt: FieldValue.serverTimestamp(),
+  });
+}
+
+// --- GET /api/reports ---
+app.get("/api/reports", async (req, res) => {
+  try {
+    const status = req.query.status || "pending";
+    const search = req.query.search || null;
+    const userId = req.query.userId || null;
+
+    if (!["pending", "resolved", "archived"].includes(status)) {
+      return res.status(400).json({ error: "status must be pending, resolved, or archived" });
+    }
+
+    const db = getFirestore();
+    const collection = status === "archived" ? "reports_archive" : "reports";
+
+    let query = db.collection(collection).where("status", "==", status === "archived" ? "resolved" : status);
+
+    if (userId) {
+      query = query.where("reportedUserId", "==", userId);
+    }
+
+    const snapshot = await query.limit(200).get();
+
+    // Group by reportedUserId
+    const grouped = {};
+    for (const doc of snapshot.docs) {
+      const data = doc.data();
+      // Convert timestamps
+      for (const [key, val] of Object.entries(data)) {
+        if (val && typeof val.toDate === "function") {
+          data[key] = val.toDate().toISOString();
+        }
+      }
+      data.reportId = doc.id;
+
+      const reportedUid = data.reportedUserId;
+      if (!grouped[reportedUid]) {
+        grouped[reportedUid] = { uid: reportedUid, reports: [] };
+      }
+      grouped[reportedUid].reports.push(data);
+    }
+
+    // Fetch user docs for all reported users
+    const reportedUids = Object.keys(grouped);
+    for (let i = 0; i < reportedUids.length; i += 30) {
+      const batch = reportedUids.slice(i, i + 30);
+      const refs = batch.map((uid) => db.collection("users").doc(uid));
+      const docs = await db.getAll(...refs);
+      for (const doc of docs) {
+        if (doc.exists && grouped[doc.id]) {
+          const userData = doc.data();
+          // For suspended users, show original name/photo from _preSuspension
+          const preSus = userData._preSuspension;
+          grouped[doc.id].displayName = (preSus && preSus.displayName) || userData.displayName || "";
+          grouped[doc.id].uniqueId = userData.uniqueId || 0;
+          grouped[doc.id].profilePhotoUrl = (preSus && preSus.profilePhotoUrl) || userData.profilePhotoUrl || null;
+          grouped[doc.id].warningCount = userData.warningCount || 0;
+          grouped[doc.id].isSuspended = userData.isSuspended || false;
+
+          const floor = userData.goodCharacterScore ?? 100;
+          const lastDeduction = userData.goodCharacterLastDeductionAt || null;
+          grouped[doc.id].gcs = {
+            floor,
+            displayScore: computeDisplayScore(floor, lastDeduction),
+            lastDeductionAt: lastDeduction && typeof lastDeduction.toDate === "function"
+              ? lastDeduction.toDate().toISOString() : lastDeduction,
+          };
+        }
+      }
+    }
+
+    // Enrich reporter info for reports missing reporterName (backfill old reports)
+    const allReporterUids = new Set();
+    for (const group of Object.values(grouped)) {
+      for (const r of group.reports) {
+        if (!r.reporterName && r.reporterId) allReporterUids.add(r.reporterId);
+      }
+    }
+    const reporterUids = [...allReporterUids];
+    const reporterMap = {};
+    for (let i = 0; i < reporterUids.length; i += 30) {
+      const batch = reporterUids.slice(i, i + 30);
+      const refs = batch.map((uid) => db.collection("users").doc(uid));
+      const docs = await db.getAll(...refs);
+      for (const doc of docs) {
+        if (doc.exists) {
+          const d = doc.data();
+          reporterMap[doc.id] = { name: d.displayName || "", uniqueId: d.uniqueId || 0 };
+        }
+      }
+    }
+    // Backfill reporter names
+    for (const group of Object.values(grouped)) {
+      for (const r of group.reports) {
+        if (!r.reporterName && reporterMap[r.reporterId]) {
+          r.reporterName = reporterMap[r.reporterId].name;
+          r.reporterUniqueId = reporterMap[r.reporterId].uniqueId;
+        }
+      }
+    }
+
+    let users = Object.values(grouped);
+
+    // Search filter
+    if (search) {
+      const searchNum = Number(search);
+      users = users.filter((u) => {
+        if (Number.isFinite(searchNum) && u.uniqueId === searchNum) return true;
+        // Also check reporter uniqueIds
+        return u.reports.some((r) => {
+          if (r.reporterUniqueId === searchNum) return true;
+          return false;
+        });
+      });
+    }
+
+    // Sort by most recent report first (newest at top)
+    users.sort((a, b) => {
+      const aLatest = a.reports.reduce((max, r) => {
+        const t = r.timestamp ? new Date(r.timestamp).getTime() : 0;
+        return t > max ? t : max;
+      }, 0);
+      const bLatest = b.reports.reduce((max, r) => {
+        const t = r.timestamp ? new Date(r.timestamp).getTime() : 0;
+        return t > max ? t : max;
+      }, 0);
+      return bLatest - aLatest;
+    });
+
+    // Sort reports within each user (most recent first) and count
+    users.forEach((u) => {
+      u.reports.sort((a, b) => {
+        const aTime = a.timestamp ? new Date(a.timestamp).getTime() : 0;
+        const bTime = b.timestamp ? new Date(b.timestamp).getTime() : 0;
+        return bTime - aTime;
+      });
+      u.reportCount = u.reports.length;
+    });
+
+    // Fetch active review locks
+    const locksSnap = await db.collection("report_locks").get();
+    const fiveMinAgo = Date.now() - 5 * 60 * 1000;
+    const lockMap = {};
+    for (const lockDoc of locksSnap.docs) {
+      const ld = lockDoc.data();
+      const lockTime = ld.timestamp?.toDate?.()?.getTime() || 0;
+      if (lockTime > fiveMinAgo) {
+        lockMap[lockDoc.id] = {
+          adminUid: ld.adminUid,
+          displayName: ld.displayName || "Admin",
+          lockedAt: ld.timestamp?.toDate?.()?.toISOString(),
+        };
+      }
+    }
+    users.forEach((u) => { u.lock = lockMap[u.uid] || null; });
+
+    return res.json({ users });
+  } catch (err) {
+    console.error("GET /api/reports error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// --- GET /api/conversations/:id/messages ---
+// Fetch messages from a conversation for admin review
+app.get("/api/conversations/:id/messages", async (req, res) => {
+  try {
+    const conversationId = req.params.id;
+    const limit = Math.min(Number(req.query.limit) || 50, 100);
+    const db = getFirestore();
+
+    const snapshot = await db.collection("conversations").doc(conversationId)
+      .collection("messages")
+      .orderBy("timestamp", "desc")
+      .limit(limit)
+      .get();
+
+    const messages = snapshot.docs.map((doc) => {
+      const data = doc.data();
+      // Convert timestamps
+      for (const [key, val] of Object.entries(data)) {
+        if (val && typeof val.toDate === "function") {
+          data[key] = val.toDate().toISOString();
+        }
+      }
+      data.messageId = doc.id;
+      return data;
+    }).reverse(); // chronological order
+
+    return res.json({ messages });
+  } catch (err) {
+    console.error("GET /api/conversations/:id/messages error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// --- POST /api/reports/:id/resolve ---
+app.post("/api/reports/:id/resolve", async (req, res) => {
+  try {
+    const { action, severity, adminNote, suspensionDays, canAppeal } = req.body;
+
+    if (!["warn", "suspend", "dismiss"].includes(action)) {
+      return res.status(400).json({ error: "action must be warn, suspend, or dismiss" });
+    }
+    if (action !== "dismiss" && (typeof severity !== "number" || severity < 1 || severity > 5)) {
+      return res.status(400).json({ error: "severity must be 1-5 for warn/suspend" });
+    }
+
+    const db = getFirestore();
+    const reportRef = db.collection("reports").doc(req.params.id);
+    const reportDoc = await reportRef.get();
+    if (!reportDoc.exists) {
+      return res.status(404).json({ error: "Report not found" });
+    }
+    const report = reportDoc.data();
+    if (report.status !== "pending") {
+      return res.status(400).json({ error: "Report is already resolved" });
+    }
+
+    const reportedUserId = report.reportedUserId;
+    const reporterId = report.reporterId;
+    const reportType = (report.reason && report.reason.toLowerCase() !== "other") ? report.reason : "a policy violation";
+
+    // Update report status
+    await reportRef.update({
+      status: "resolved",
+      resolvedAction: action,
+      resolvedBy: req.admin.uid,
+      resolvedAt: Timestamp.now(),
+      severity: action !== "dismiss" ? severity : null,
+      adminNote: adminNote || null,
+    });
+
+    let autoEscalateSuggested = false;
+
+    if (action === "warn" || action === "suspend") {
+      // GCS deduction
+      const userRef = db.collection("users").doc(reportedUserId);
+      const userDoc = await userRef.get();
+      if (userDoc.exists) {
+        const userData = userDoc.data();
+        const currentFloor = userData.goodCharacterScore ?? 100;
+        const lastDeduction = userData.goodCharacterLastDeductionAt || null;
+        const currentDisplay = computeDisplayScore(currentFloor, lastDeduction);
+        const deduction = severity * 5;
+        const newFloor = Math.max(0, currentDisplay - deduction);
+
+        const updates = {
+          goodCharacterScore: newFloor,
+          goodCharacterLastDeductionAt: Timestamp.now(),
+        };
+
+        if (action === "warn") {
+          updates.warningCount = FieldValue.increment(1);
+          updates.hasActiveWarning = true;
+          updates.warningReason = reportType;
+          updates.warningIssuedAt = Timestamp.now();
+
+          const newWarningCount = (userData.warningCount || 0) + 1;
+          if (newWarningCount >= 5) {
+            autoEscalateSuggested = true;
+          }
+
+          // Revoke tokens to force logout
+          try {
+            await getAuth().revokeRefreshTokens(reportedUserId);
+          } catch (err) {
+            console.error(`Failed to revoke tokens for ${reportedUserId}:`, err);
+          }
+        }
+
+        await userRef.update(updates);
+      }
+
+      // Suspend action
+      if (action === "suspend") {
+        let endDate = null;
+        if (suspensionDays && suspensionDays > 0) {
+          endDate = new Date(Date.now() + suspensionDays * 86400000).toISOString();
+        }
+
+        // Reuse the suspend endpoint logic
+        const userRef2 = db.collection("users").doc(reportedUserId);
+        const userDoc2 = await userRef2.get();
+        if (userDoc2.exists) {
+          const userData2 = userDoc2.data();
+          const preSuspension = {
+            displayName: userData2.displayName || "",
+            profilePhotoUrl: userData2.profilePhotoUrl || null,
+            coverPhotoUrl: userData2.coverPhotoUrl || null,
+          };
+
+          await userRef2.update({
+            isSuspended: true,
+            suspensionReason: reportType,
+            suspensionStartDate: Timestamp.now(),
+            suspensionEndDate: endDate ? Timestamp.fromDate(new Date(endDate)) : null,
+            suspensionCanAppeal: canAppeal === true,
+            suspendedBy: req.admin.uid,
+            _preSuspension: preSuspension,
+          });
+        }
+      }
+    }
+
+    // Send system PMs
+    const reporterName = report.reporterName || "there";
+    const reportedUserName = report.reportedUserName || "a user";
+    const reportedUserUniqueId = report.reportedUserUniqueId || "unknown";
+    const reportDate = formatTimestamp(report.timestamp);
+    const evidenceLine = (Array.isArray(report.evidenceUrls) && report.evidenceUrls.length > 0)
+      ? " Your attached evidence was reviewed as part of our investigation."
+      : "";
+
+    if (action === "warn") {
+      await sendSystemPm(reporterId,
+        `Hi ${reporterName},\n\nWe've reviewed your report against ${reportedUserName} (ID: ${reportedUserUniqueId}), submitted on ${reportDate} regarding ${reportType}.${evidenceLine}\n\nAction has been taken against this user. If they continue to violate our Community Guidelines (available in Settings > About), please don't hesitate to report them again. You can also block them from their profile if you'd prefer not to interact with them.\n\nThank you for helping keep ShyTalk safe.`);
+      await sendSystemPm(reportedUserId,
+        `Your account has been reviewed for ${reportType}. Please ensure your behaviour follows our community guidelines.`);
+    } else if (action === "suspend") {
+      await sendSystemPm(reporterId,
+        `Hi ${reporterName},\n\nWe've reviewed your report against ${reportedUserName} (ID: ${reportedUserUniqueId}), submitted on ${reportDate} regarding ${reportType}.${evidenceLine}\n\nThe reported user has been suspended. If you encounter similar issues with other users, please report them — it helps us keep the community safe. You can review our Community Guidelines in Settings > About.\n\nThank you for your report.`);
+      // Suspended user already gets the suspension notice on login, no PM needed
+    } else if (action === "dismiss") {
+      await sendSystemPm(reporterId,
+        `Hi ${reporterName},\n\nWe've reviewed your report against ${reportedUserName} (ID: ${reportedUserUniqueId}), submitted on ${reportDate} regarding ${reportType}.${evidenceLine}\n\nAfter careful investigation, no action was taken at this time. This may be because the reported behaviour didn't meet the threshold for action under our Community Guidelines (available in Settings > About), but your report has been noted. If this user's behaviour continues or escalates, please report them again.\n\nThank you for bringing this to our attention.`);
+    }
+
+    // Audit log
+    await writeAuditLog(db, {
+      adminUid: req.admin.uid,
+      action: `report_${action}`,
+      targetUserId: reportedUserId,
+      reportId: req.params.id,
+      severity: action !== "dismiss" ? severity : null,
+      note: adminNote,
+    });
+
+    return res.json({ success: true, autoEscalateSuggested });
+  } catch (err) {
+    console.error("POST /api/reports/:id/resolve error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// --- POST /api/reports/resolve-all/:reportedUserId ---
+app.post("/api/reports/resolve-all/:reportedUserId", async (req, res) => {
+  try {
+    const { action, severity, adminNote, suspensionDays, canAppeal } = req.body;
+    const reportedUserId = req.params.reportedUserId;
+
+    if (!["warn", "suspend", "dismiss"].includes(action)) {
+      return res.status(400).json({ error: "action must be warn, suspend, or dismiss" });
+    }
+    if (action !== "dismiss" && (typeof severity !== "number" || severity < 1 || severity > 5)) {
+      return res.status(400).json({ error: "severity must be 1-5 for warn/suspend" });
+    }
+
+    const db = getFirestore();
+
+    // Get all pending reports for this user
+    const reportsSnap = await db.collection("reports")
+      .where("reportedUserId", "==", reportedUserId)
+      .where("status", "==", "pending")
+      .get();
+
+    if (reportsSnap.empty) {
+      return res.status(404).json({ error: "No pending reports found for this user" });
+    }
+
+    // Resolve all reports
+    const batch = db.batch();
+    const reportIds = [];
+    let reportType = "a policy violation";
+    let reporterId = null;
+
+    for (const doc of reportsSnap.docs) {
+      reportIds.push(doc.id);
+      const data = doc.data();
+      if (!reporterId) reporterId = data.reporterId;
+      if (data.reason && data.reason.toLowerCase() !== "other") reportType = data.reason;
+
+      batch.update(doc.ref, {
+        status: "resolved",
+        resolvedAction: action,
+        resolvedBy: req.admin.uid,
+        resolvedAt: Timestamp.now(),
+        severity: action !== "dismiss" ? severity : null,
+        adminNote: adminNote || null,
+      });
+    }
+    await batch.commit();
+
+    let autoEscalateSuggested = false;
+
+    // Single GCS deduction for all reports
+    if (action === "warn" || action === "suspend") {
+      const userRef = db.collection("users").doc(reportedUserId);
+      const userDoc = await userRef.get();
+      if (userDoc.exists) {
+        const userData = userDoc.data();
+        const currentFloor = userData.goodCharacterScore ?? 100;
+        const lastDeduction = userData.goodCharacterLastDeductionAt || null;
+        const currentDisplay = computeDisplayScore(currentFloor, lastDeduction);
+        const deduction = severity * 5;
+        const newFloor = Math.max(0, currentDisplay - deduction);
+
+        const updates = {
+          goodCharacterScore: newFloor,
+          goodCharacterLastDeductionAt: Timestamp.now(),
+        };
+
+        if (action === "warn") {
+          updates.warningCount = FieldValue.increment(1);
+          updates.hasActiveWarning = true;
+          updates.warningReason = reportType;
+          updates.warningIssuedAt = Timestamp.now();
+
+          if ((userData.warningCount || 0) + 1 >= 5) {
+            autoEscalateSuggested = true;
+          }
+
+          try {
+            await getAuth().revokeRefreshTokens(reportedUserId);
+          } catch (err) {
+            console.error(`Failed to revoke tokens: ${err}`);
+          }
+        }
+
+        await userRef.update(updates);
+      }
+
+      if (action === "suspend") {
+        let endDate = null;
+        if (suspensionDays && suspensionDays > 0) {
+          endDate = new Date(Date.now() + suspensionDays * 86400000).toISOString();
+        }
+
+        const userRef2 = db.collection("users").doc(reportedUserId);
+        const userDoc2 = await userRef2.get();
+        if (userDoc2.exists) {
+          const userData2 = userDoc2.data();
+          await userRef2.update({
+            isSuspended: true,
+            suspensionReason: reportType,
+            suspensionStartDate: Timestamp.now(),
+            suspensionEndDate: endDate ? Timestamp.fromDate(new Date(endDate)) : null,
+            suspensionCanAppeal: canAppeal === true,
+            suspendedBy: req.admin.uid,
+            _preSuspension: {
+              displayName: userData2.displayName || "",
+              profilePhotoUrl: userData2.profilePhotoUrl || null,
+              coverPhotoUrl: userData2.coverPhotoUrl || null,
+            },
+          });
+        }
+      }
+    }
+
+    // System PMs (send to each unique reporter + reported user)
+    const sentReporters = new Set();
+    for (const doc of reportsSnap.docs) {
+      const data = doc.data();
+      const rid = data.reporterId;
+      if (!rid || sentReporters.has(rid)) continue;
+      sentReporters.add(rid);
+
+      const rName = data.reporterName || "there";
+      const ruName = data.reportedUserName || "a user";
+      const ruId = data.reportedUserUniqueId || "unknown";
+      const rDate = formatTimestamp(data.timestamp);
+      const rType = (data.reason && data.reason.toLowerCase() !== "other") ? data.reason : "a policy violation";
+      const eLine = (Array.isArray(data.evidenceUrls) && data.evidenceUrls.length > 0)
+        ? " Your attached evidence was reviewed as part of our investigation."
+        : "";
+
+      if (action === "warn") {
+        await sendSystemPm(rid,
+          `Hi ${rName},\n\nWe've reviewed your report against ${ruName} (ID: ${ruId}), submitted on ${rDate} regarding ${rType}.${eLine}\n\nAction has been taken against this user. If they continue to violate our Community Guidelines (available in Settings > About), please don't hesitate to report them again. You can also block them from their profile if you'd prefer not to interact with them.\n\nThank you for helping keep ShyTalk safe.`);
+      } else if (action === "suspend") {
+        await sendSystemPm(rid,
+          `Hi ${rName},\n\nWe've reviewed your report against ${ruName} (ID: ${ruId}), submitted on ${rDate} regarding ${rType}.${eLine}\n\nThe reported user has been suspended. If you encounter similar issues with other users, please report them — it helps us keep the community safe. You can review our Community Guidelines in Settings > About.\n\nThank you for your report.`);
+      } else if (action === "dismiss") {
+        await sendSystemPm(rid,
+          `Hi ${rName},\n\nWe've reviewed your report against ${ruName} (ID: ${ruId}), submitted on ${rDate} regarding ${rType}.${eLine}\n\nAfter careful investigation, no action was taken at this time. This may be because the reported behaviour didn't meet the threshold for action under our Community Guidelines (available in Settings > About), but your report has been noted. If this user's behaviour continues or escalates, please report them again.\n\nThank you for bringing this to our attention.`);
+      }
+    }
+    // Warn PM to the reported user
+    if (action === "warn") {
+      await sendSystemPm(reportedUserId,
+        `Your account has been reviewed for ${reportType}. Please ensure your behaviour follows our community guidelines.`);
+    }
+
+    // Audit log
+    await writeAuditLog(db, {
+      adminUid: req.admin.uid,
+      action: `bulk_report_${action}`,
+      targetUserId: reportedUserId,
+      reportId: reportIds.join(","),
+      severity: action !== "dismiss" ? severity : null,
+      note: adminNote,
+    });
+
+    return res.json({ success: true, resolvedCount: reportIds.length, autoEscalateSuggested });
+  } catch (err) {
+    console.error("POST /api/reports/resolve-all error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// --- POST /api/user/:uid/reset-gcs ---
+app.post("/api/user/:uid/reset-gcs", async (req, res) => {
+  try {
+    const db = getFirestore();
+    const userRef = db.collection("users").doc(req.params.uid);
+    const userDoc = await userRef.get();
+    if (!userDoc.exists) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    await userRef.update({
+      goodCharacterScore: 100,
+      goodCharacterLastDeductionAt: null,
+      warningCount: 0,
+    });
+
+    await writeAuditLog(db, {
+      adminUid: req.admin.uid,
+      action: "reset_gcs",
+      targetUserId: req.params.uid,
+    });
+
+    return res.json({ success: true });
+  } catch (err) {
+    console.error("POST /api/user/:uid/reset-gcs error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// --- Review lock endpoints ---
+app.post("/api/report-locks/:reportedUserId/lock", async (req, res) => {
+  try {
+    const db = getFirestore();
+    const lockRef = db.collection("report_locks").doc(req.params.reportedUserId);
+    const lockDoc = await lockRef.get();
+
+    if (lockDoc.exists) {
+      const lockData = lockDoc.data();
+      const lockAge = Date.now() - (lockData.timestamp?.toDate?.()?.getTime() || 0);
+      // Lock expires after 5 minutes
+      if (lockAge < 5 * 60 * 1000 && lockData.adminUid !== req.admin.uid) {
+        return res.json({
+          locked: true,
+          lockedBy: lockData.displayName || "Another admin",
+          lockedAt: lockData.timestamp?.toDate?.()?.toISOString(),
+        });
+      }
+    }
+
+    await lockRef.set({
+      adminUid: req.admin.uid,
+      displayName: req.admin.name || req.admin.email || "Admin",
+      timestamp: Timestamp.now(),
+    });
+
+    return res.json({ locked: false });
+  } catch (err) {
+    console.error("POST /api/report-locks/:id/lock error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+app.delete("/api/report-locks/:reportedUserId", async (req, res) => {
+  try {
+    const db = getFirestore();
+    await db.collection("report_locks").doc(req.params.reportedUserId).delete();
+    return res.json({ success: true });
+  } catch (err) {
+    console.error("DELETE /api/report-locks error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// --- GET /api/reports/export ---
+app.get("/api/reports/export", async (req, res) => {
+  try {
+    const { from, to } = req.query;
+    if (!from || !to) {
+      return res.status(400).json({ error: "from and to query params required (ISO dates)" });
+    }
+
+    const fromDate = new Date(from);
+    const toDate = new Date(to);
+    if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
+      return res.status(400).json({ error: "Invalid date format" });
+    }
+
+    const db = getFirestore();
+    const snapshot = await db.collection("reports")
+      .where("status", "==", "resolved")
+      .where("resolvedAt", ">=", Timestamp.fromDate(fromDate))
+      .where("resolvedAt", "<=", Timestamp.fromDate(toDate))
+      .limit(5000)
+      .get();
+
+    const header = "Report ID,Reporter,Reported User,Type,Reason,Action Taken,Severity,Admin Note,Created At,Resolved At";
+    const rows = snapshot.docs.map((doc) => {
+      const d = doc.data();
+      const escape = (v) => `"${String(v || "").replace(/"/g, '""')}"`;
+      const ts = (v) => v && typeof v.toDate === "function" ? v.toDate().toISOString() : (v || "");
+      return [
+        escape(doc.id),
+        escape(d.reporterName),
+        escape(d.reportedUserName),
+        escape(d.type),
+        escape(d.reason),
+        escape(d.resolvedAction),
+        d.severity || "",
+        escape(d.adminNote),
+        escape(ts(d.timestamp)),
+        escape(ts(d.resolvedAt)),
+      ].join(",");
+    });
+
+    const csv = [header, ...rows].join("\n");
+
+    res.setHeader("Content-Type", "text/csv");
+    res.setHeader("Content-Disposition", `attachment; filename="reports_${from}_${to}.csv"`);
+    return res.send(csv);
+  } catch (err) {
+    console.error("GET /api/reports/export error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// --- GET /api/reports/stats ---
+app.get("/api/reports/stats", async (req, res) => {
+  try {
+    const db = getFirestore();
+    const period = req.query.period || "7d";
+
+    let daysBack = 7;
+    if (period === "30d") daysBack = 30;
+    else if (period === "all") daysBack = 3650;
+
+    const cutoff = new Date(Date.now() - daysBack * 86400000);
+
+    const pendingSnap = await db.collection("reports").where("status", "==", "pending").get();
+    const pendingCount = pendingSnap.size;
+
+    // Resolved today
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+    const resolvedTodaySnap = await db.collection("reports")
+      .where("status", "==", "resolved")
+      .where("resolvedAt", ">=", Timestamp.fromDate(todayStart))
+      .get();
+
+    // Average response time in the period
+    const resolvedInPeriodSnap = await db.collection("reports")
+      .where("status", "==", "resolved")
+      .where("resolvedAt", ">=", Timestamp.fromDate(cutoff))
+      .limit(500)
+      .get();
+
+    let totalResponseMs = 0;
+    let countWithTimes = 0;
+    for (const doc of resolvedInPeriodSnap.docs) {
+      const d = doc.data();
+      if (d.timestamp && d.resolvedAt) {
+        const created = d.timestamp.toDate ? d.timestamp.toDate().getTime() : new Date(d.timestamp).getTime();
+        const resolved = d.resolvedAt.toDate ? d.resolvedAt.toDate().getTime() : new Date(d.resolvedAt).getTime();
+        if (resolved > created) {
+          totalResponseMs += resolved - created;
+          countWithTimes++;
+        }
+      }
+    }
+
+    const avgResponseHours = countWithTimes > 0
+      ? Math.round(totalResponseMs / countWithTimes / 3600000 * 10) / 10
+      : null;
+
+    // Active reviewers (locks in last 5 min)
+    const locksSnap = await db.collection("report_locks").get();
+    const fiveMinAgo = Date.now() - 5 * 60 * 1000;
+    const activeReviewers = locksSnap.docs.filter((doc) => {
+      const data = doc.data();
+      const lockTime = data.timestamp?.toDate?.()?.getTime() || 0;
+      return lockTime > fiveMinAgo;
+    }).length;
+
+    return res.json({
+      pendingCount,
+      resolvedToday: resolvedTodaySnap.size,
+      avgResponseHours,
+      activeReviewers,
+    });
+  } catch (err) {
+    console.error("GET /api/reports/stats error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// --- POST /api/cleanup/system-conversations ---
+// One-off: delete duplicate system conversations with auto-generated IDs
+app.post("/api/cleanup/system-conversations", async (req, res) => {
+  try {
+    const db = getFirestore();
+    const snap = await db.collection("conversations")
+      .where("participantIds", "array-contains", "SHYTALK_SYSTEM")
+      .get();
+
+    const deleted = [];
+    for (const doc of snap.docs) {
+      const data = doc.data();
+      const parts = data.participantIds || [];
+      const otherUid = parts.find(id => id !== "SHYTALK_SYSTEM");
+      const expectedId = [otherUid, "SHYTALK_SYSTEM"].sort().join("_");
+
+      if (doc.id !== expectedId) {
+        // Delete subcollections first
+        const msgSnap = await doc.ref.collection("messages").get();
+        const settingsSnap = await doc.ref.collection("settings").get();
+        const batch = db.batch();
+        msgSnap.docs.forEach(d => batch.delete(d.ref));
+        settingsSnap.docs.forEach(d => batch.delete(d.ref));
+        batch.delete(doc.ref);
+        await batch.commit();
+        deleted.push(doc.id);
+      }
+    }
+
+    // Also delete empty deterministic-ID conversations
+    const remainSnap = await db.collection("conversations")
+      .where("participantIds", "array-contains", "SHYTALK_SYSTEM")
+      .get();
+
+    for (const doc of remainSnap.docs) {
+      const msgSnap = await doc.ref.collection("messages").limit(1).get();
+      if (msgSnap.empty) {
+        const settingsSnap = await doc.ref.collection("settings").get();
+        const batch = db.batch();
+        settingsSnap.docs.forEach(d => batch.delete(d.ref));
+        batch.delete(doc.ref);
+        await batch.commit();
+        deleted.push(doc.id + " (empty)");
+      }
+    }
+
+    return res.json({ deleted, count: deleted.length });
+  } catch (err) {
+    console.error("Cleanup error:", err);
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+// --- POST /api/user/:uid/warn --- Direct warning without a report ---
+app.post("/api/user/:uid/warn", async (req, res) => {
+  try {
+    const { reason, severity, adminNote } = req.body;
+    const uid = req.params.uid;
+
+    if (!reason || typeof reason !== "string" || reason.trim().length === 0) {
+      return res.status(400).json({ error: "reason is required" });
+    }
+    if (typeof severity !== "number" || severity < 1 || severity > 5) {
+      return res.status(400).json({ error: "severity must be 1-5" });
+    }
+
+    const db = getFirestore();
+    const userRef = db.collection("users").doc(uid);
+    const userDoc = await userRef.get();
+    if (!userDoc.exists) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    const userData = userDoc.data();
+    const reportType = reason.toLowerCase() !== "other" ? reason : "a policy violation";
+
+    // GCS deduction
+    const currentFloor = userData.goodCharacterScore ?? 100;
+    const lastDeduction = userData.goodCharacterLastDeductionAt || null;
+    const currentDisplay = computeDisplayScore(currentFloor, lastDeduction);
+    const deduction = severity * 5;
+    const newFloor = Math.max(0, currentDisplay - deduction);
+
+    const updates = {
+      goodCharacterScore: newFloor,
+      goodCharacterLastDeductionAt: Timestamp.now(),
+      warningCount: FieldValue.increment(1),
+      hasActiveWarning: true,
+      warningReason: reportType,
+      warningIssuedAt: Timestamp.now(),
+    };
+
+    await userRef.update(updates);
+
+    const newWarningCount = (userData.warningCount || 0) + 1;
+    let autoEscalateSuggested = false;
+    if (newWarningCount >= 5) {
+      autoEscalateSuggested = true;
+    }
+
+    // Revoke tokens to force logout
+    try {
+      await getAuth().revokeRefreshTokens(uid);
+    } catch (err) {
+      console.error(`Failed to revoke tokens for ${uid}:`, err);
+    }
+
+    // Send system PM
+    await sendSystemPm(uid,
+      `Your account has been reviewed for ${reportType}. Please ensure your behaviour follows our community guidelines.`);
+
+    // Audit log
+    await writeAuditLog(db, {
+      adminUid: req.admin.uid,
+      action: "direct_warn",
+      targetUserId: uid,
+      reportId: null,
+      severity,
+      note: adminNote || null,
+    });
+
+    return res.json({
+      success: true,
+      autoEscalateSuggested,
+      newGCS: newFloor,
+      warningCount: newWarningCount,
+    });
+  } catch (err) {
+    console.error("POST /api/user/:uid/warn error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// --- Storage helpers ---
+function extractStoragePath(url) {
+  if (!url) return null;
+  const match = url.match(/\/o\/(.+?)\?/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+async function deleteStorageFolder(prefix) {
+  const bucket = getStorage().bucket();
+  const [files] = await bucket.getFiles({ prefix });
+  let deleted = 0;
+  for (const file of files) {
+    await file.delete();
+    deleted++;
+  }
+  return deleted;
+}
+
+async function auditStorageFolder(prefix) {
+  const bucket = getStorage().bucket();
+  const [files] = await bucket.getFiles({ prefix });
+  let totalBytes = 0;
+  for (const file of files) {
+    const [metadata] = await file.getMetadata();
+    totalBytes += parseInt(metadata.size || "0", 10);
+  }
+  return { files: files.length, bytes: totalBytes };
+}
+
+// --- POST /api/cleanup/all-system-conversations ---
+// Delete ALL conversations with SHYTALK_SYSTEM (and their subcollections)
+app.post("/api/cleanup/all-system-conversations", async (req, res) => {
+  try {
+    const db = getFirestore();
+    const snap = await db.collection("conversations")
+      .where("participantIds", "array-contains", "SHYTALK_SYSTEM")
+      .get();
+
+    let deleted = 0;
+    const storagePaths = [];
+    const bucket = getStorage().bucket();
+    for (const doc of snap.docs) {
+      const msgSnap = await doc.ref.collection("messages").get();
+      // Collect storage paths from messages with imageUrls
+      for (const msgDoc of msgSnap.docs) {
+        const urls = msgDoc.data().imageUrls || [];
+        for (const url of urls) {
+          const match = url.match(/\/o\/(.+?)\?/);
+          if (match) storagePaths.push(decodeURIComponent(match[1]));
+        }
+      }
+      const settingsSnap = await doc.ref.collection("settings").get();
+      const batch = db.batch();
+      msgSnap.docs.forEach(d => batch.delete(d.ref));
+      settingsSnap.docs.forEach(d => batch.delete(d.ref));
+      batch.delete(doc.ref);
+      await batch.commit();
+      deleted++;
+    }
+
+    // Delete collected storage files
+    let storageFilesDeleted = 0;
+    for (const path of storagePaths) {
+      try {
+        await bucket.file(path).delete();
+        storageFilesDeleted++;
+      } catch (_) { /* file may already be gone */ }
+    }
+
+    await writeAuditLog(db, {
+      adminUid: req.admin.uid,
+      action: "cleanup_all_system_conversations",
+      note: `Deleted ${deleted} system conversations, ${storageFilesDeleted} storage files`,
+    });
+
+    return res.json({ success: true, deleted, storageFilesDeleted });
+  } catch (err) {
+    console.error("Cleanup all system conversations error:", err);
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+// --- POST /api/cleanup/all-reports ---
+// Delete all reports, archived reports, and report locks
+app.post("/api/cleanup/all-reports", async (req, res) => {
+  try {
+    const db = getFirestore();
+    let deleted = 0;
+
+    // Delete from reports collection
+    const reportsSnap = await db.collection("reports").get();
+    for (let i = 0; i < reportsSnap.docs.length; i += 500) {
+      const batch = db.batch();
+      reportsSnap.docs.slice(i, i + 500).forEach(doc => batch.delete(doc.ref));
+      await batch.commit();
+      deleted += Math.min(500, reportsSnap.docs.length - i);
+    }
+
+    // Delete from reports_archive collection
+    const archiveSnap = await db.collection("reports_archive").get();
+    for (let i = 0; i < archiveSnap.docs.length; i += 500) {
+      const batch = db.batch();
+      archiveSnap.docs.slice(i, i + 500).forEach(doc => batch.delete(doc.ref));
+      await batch.commit();
+    }
+    const archivedCount = archiveSnap.docs.length;
+
+    // Delete all report locks
+    const locksSnap = await db.collection("report_locks").get();
+    if (!locksSnap.empty) {
+      const batch = db.batch();
+      locksSnap.docs.forEach(doc => batch.delete(doc.ref));
+      await batch.commit();
+    }
+
+    // Delete report evidence files from Storage
+    const storageFilesDeleted = await deleteStorageFolder("report_evidence/");
+
+    await writeAuditLog(db, {
+      adminUid: req.admin.uid,
+      action: "cleanup_all_reports",
+      note: `Deleted ${deleted} reports, ${archivedCount} archived, ${locksSnap.docs.length} locks, ${storageFilesDeleted} storage files`,
+    });
+
+    return res.json({
+      success: true,
+      reports: deleted,
+      archived: archivedCount,
+      locks: locksSnap.docs.length,
+      storageFilesDeleted,
+    });
+  } catch (err) {
+    console.error("Cleanup all reports error:", err);
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+// --- POST /api/cleanup/all-warnings ---
+// Reset warning fields on ALL users who have active warnings
+app.post("/api/cleanup/all-warnings", async (req, res) => {
+  try {
+    const db = getFirestore();
+    const snap = await db.collection("users")
+      .where("warningCount", ">", 0)
+      .get();
+
+    let cleared = 0;
+    for (let i = 0; i < snap.docs.length; i += 500) {
+      const batch = db.batch();
+      snap.docs.slice(i, i + 500).forEach(doc => {
+        batch.update(doc.ref, {
+          warningCount: 0,
+          hasActiveWarning: false,
+          warningReason: null,
+          warningIssuedAt: null,
+          goodCharacterScore: 100,
+          goodCharacterLastDeductionAt: null,
+        });
+      });
+      await batch.commit();
+      cleared += Math.min(500, snap.docs.length - i);
+    }
+
+    // Also clear any users with hasActiveWarning but warningCount == 0
+    const activeSnap = await db.collection("users")
+      .where("hasActiveWarning", "==", true)
+      .get();
+
+    let extraCleared = 0;
+    for (const doc of activeSnap.docs) {
+      await doc.ref.update({
+        hasActiveWarning: false,
+        warningReason: null,
+        warningIssuedAt: null,
+      });
+      extraCleared++;
+    }
+
+    await writeAuditLog(db, {
+      adminUid: req.admin.uid,
+      action: "cleanup_all_warnings",
+      note: `Cleared warnings on ${cleared + extraCleared} users`,
+    });
+
+    return res.json({ success: true, cleared: cleared + extraCleared });
+  } catch (err) {
+    console.error("Cleanup all warnings error:", err);
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+// --- GET /api/storage/audit ---
+// Audit all storage folders: file counts and total sizes
+app.get("/api/storage/audit", async (req, res) => {
+  try {
+    const folders = ["pm_images/", "stickers/", "report_evidence/", "profile_photos/", "cover_photos/"];
+    const results = {};
+    for (const folder of folders) {
+      results[folder.replace("/", "")] = await auditStorageFolder(folder);
+    }
+    return res.json({ success: true, ...results });
+  } catch (err) {
+    console.error("GET /api/storage/audit error:", err);
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+// --- POST /api/cleanup/orphaned-storage ---
+// Smart cross-referencing: delete only files not referenced in Firestore
+app.post("/api/cleanup/orphaned-storage", async (req, res) => {
+  try {
+    const db = getFirestore();
+    const referencedPaths = new Set();
+
+    // Hardcoded system asset
+    referencedPaths.add("system/shytalk_icon.webp");
+
+    // Users → profilePhotoUrl, coverPhotoUrl, _preSuspension.*
+    const usersSnap = await db.collection("users").get();
+    for (const doc of usersSnap.docs) {
+      const data = doc.data();
+      for (const url of [
+        data.profilePhotoUrl,
+        data.coverPhotoUrl,
+        data._preSuspension && data._preSuspension.profilePhotoUrl,
+        data._preSuspension && data._preSuspension.coverPhotoUrl,
+      ]) {
+        const p = extractStoragePath(url);
+        if (p) referencedPaths.add(p);
+      }
+    }
+
+    // Conversations → groupPhotoUrl + messages (IMAGE → imageUrls, STICKER → stickerUrl)
+    const convsSnap = await db.collection("conversations").get();
+    for (const doc of convsSnap.docs) {
+      const data = doc.data();
+      const gp = extractStoragePath(data.groupPhotoUrl);
+      if (gp) referencedPaths.add(gp);
+
+      const imageSnap = await doc.ref.collection("messages").where("type", "==", "IMAGE").get();
+      for (const msgDoc of imageSnap.docs) {
+        for (const url of (msgDoc.data().imageUrls || [])) {
+          const p = extractStoragePath(url);
+          if (p) referencedPaths.add(p);
+        }
+      }
+
+      const stickerSnap = await doc.ref.collection("messages").where("type", "==", "STICKER").get();
+      for (const msgDoc of stickerSnap.docs) {
+        const p = extractStoragePath(msgDoc.data().stickerUrl);
+        if (p) referencedPaths.add(p);
+      }
+    }
+
+    // Reports + archive → evidenceUrls[]
+    for (const col of ["reports", "reports_archive"]) {
+      const snap = await db.collection(col).get();
+      for (const doc of snap.docs) {
+        for (const url of (doc.data().evidenceUrls || [])) {
+          const p = extractStoragePath(url);
+          if (p) referencedPaths.add(p);
+        }
+      }
+    }
+
+    // List and delete orphaned files across all storage folders
+    const bucket = getStorage().bucket();
+    const folders = ["pm_images/", "stickers/", "report_evidence/", "profile_photos/", "cover_photos/", "group_photos/"];
+    const results = {};
+    let totalDeleted = 0;
+
+    for (const folder of folders) {
+      const [files] = await bucket.getFiles({ prefix: folder });
+      let deleted = 0;
+      for (const file of files) {
+        if (!referencedPaths.has(file.name)) {
+          await file.delete();
+          deleted++;
+        }
+      }
+      results[folder.replace("/", "")] = { total: files.length, deleted };
+      totalDeleted += deleted;
+    }
+
+    await writeAuditLog(db, {
+      adminUid: req.admin.uid,
+      action: "cleanup_orphaned_storage",
+      note: `Smart cleanup: ${totalDeleted} orphaned files deleted`,
+    });
+
+    return res.json({ success: true, totalDeleted, results });
+  } catch (err) {
+    console.error("POST /api/cleanup/orphaned-storage error:", err);
+    return res.status(500).json({ error: err.message });
   }
 });
 

--- a/functions/admin.test.js
+++ b/functions/admin.test.js
@@ -1,0 +1,1004 @@
+/**
+ * Tests for admin.js — ShyTalk Admin API
+ *
+ * Mocks firebase-admin so tests run without a real project.
+ */
+
+// ── Mock data stores (must be prefixed with "mock") ─────────────────
+let mockUsers = {};
+let mockReports = {};
+let mockReportsArchive = {};
+let mockConversations = {};
+let mockMessages = {};
+let mockAuditLog = {};
+let mockReportLocks = {};
+let mockAdminTokens = {};
+let mockSuspensionAppeals = {};
+let mockStorageFiles = {};
+let mockDocIdCounter = 0;
+
+// Helper to build Firestore Timestamp-like object
+function mockFakeTimestamp(date) {
+  const d = date instanceof Date ? date : new Date(date);
+  return { toDate: () => d, _seconds: Math.floor(d.getTime() / 1000) };
+}
+
+function mockGetStore(path) {
+  if (path === "users") return mockUsers;
+  if (path === "reports") return mockReports;
+  if (path === "reports_archive") return mockReportsArchive;
+  if (path === "conversations") return mockConversations;
+  if (path === "admin_audit_log") return mockAuditLog;
+  if (path === "report_locks") return mockReportLocks;
+  if (path === "admin_tokens") return mockAdminTokens;
+  if (path === "suspensionAppeals") return mockSuspensionAppeals;
+  if (path.includes("/messages")) return mockMessages;
+  return {};
+}
+
+function mockBuildQuerySnapshot(docs) {
+  return {
+    empty: docs.length === 0,
+    size: docs.length,
+    docs: docs.map((d) => ({
+      id: d._id,
+      data: () => {
+        const copy = { ...d };
+        delete copy._id;
+        delete copy._collection;
+        return copy;
+      },
+      ref: mockBuildDocRef(d._collection || "unknown", d._id),
+    })),
+  };
+}
+
+function mockBuildDocRef(collection, docId) {
+  return {
+    id: docId,
+    get: jest.fn(async () => {
+      const store = mockGetStore(collection);
+      const data = store[docId];
+      return {
+        exists: !!data,
+        id: docId,
+        data: () => (data ? { ...data } : undefined),
+        ref: mockBuildDocRef(collection, docId),
+      };
+    }),
+    set: jest.fn(async (data, opts) => {
+      const store = mockGetStore(collection);
+      if (opts && opts.merge) {
+        store[docId] = { ...(store[docId] || {}), ...data };
+      } else {
+        store[docId] = { ...data };
+      }
+    }),
+    update: jest.fn(async (updates) => {
+      const store = mockGetStore(collection);
+      if (!store[docId]) throw new Error(`Doc ${collection}/${docId} not found`);
+      for (const [k, v] of Object.entries(updates)) {
+        if (v && v._type === "increment") {
+          store[docId][k] = (store[docId][k] || 0) + v._value;
+        } else if (v && v._type === "delete") {
+          delete store[docId][k];
+        } else {
+          store[docId][k] = v;
+        }
+      }
+    }),
+    delete: jest.fn(async () => {
+      const store = mockGetStore(collection);
+      delete store[docId];
+    }),
+    collection: (subCol) => mockBuildCollectionRef(`${collection}/${docId}/${subCol}`),
+  };
+}
+
+function mockBuildQuery(path, filters) {
+  return {
+    where: (...args) => mockBuildQuery(path, [...filters, args]),
+    limit: () => mockBuildQuery(path, filters),
+    get: jest.fn(async () => {
+      const store = mockGetStore(path);
+      let entries = Object.entries(store).map(([id, data]) => ({
+        _id: id,
+        _collection: path,
+        ...data,
+      }));
+
+      for (const [field, op, value] of filters) {
+        entries = entries.filter((entry) => {
+          const fieldValue = entry[field];
+          switch (op) {
+            case "==": return JSON.stringify(fieldValue) === JSON.stringify(value);
+            case ">=": return fieldValue >= value;
+            case "<=": return fieldValue <= value;
+            case "<": return fieldValue < value;
+            case "in": return value.includes(fieldValue);
+            case "array-contains": return Array.isArray(fieldValue) && fieldValue.includes(value);
+            default: return true;
+          }
+        });
+      }
+
+      return mockBuildQuerySnapshot(entries);
+    }),
+  };
+}
+
+function mockBuildCollectionRef(path) {
+  return {
+    doc: (id) => {
+      const docId = id || `auto_${++mockDocIdCounter}`;
+      return mockBuildDocRef(path, docId);
+    },
+    where: (...args) => mockBuildQuery(path, [args]),
+    add: jest.fn(async (data) => {
+      const store = mockGetStore(path);
+      const id = `auto_${++mockDocIdCounter}`;
+      store[id] = { ...data };
+      return { id };
+    }),
+    get: jest.fn(async () => {
+      const store = mockGetStore(path);
+      const docs = Object.entries(store).map(([id, data]) => ({
+        _id: id,
+        _collection: path,
+        ...data,
+      }));
+      return mockBuildQuerySnapshot(docs);
+    }),
+    limit: () => mockBuildQuery(path, []),
+  };
+}
+
+const mockBatch = {
+  update: jest.fn(),
+  set: jest.fn(),
+  delete: jest.fn(),
+  commit: jest.fn().mockResolvedValue(),
+};
+
+// ── Mock firebase-admin/auth ────────────────────────────────────────
+const mockVerifyIdToken = jest.fn();
+const mockRevokeRefreshTokens = jest.fn().mockResolvedValue();
+
+jest.mock("firebase-admin/auth", () => ({
+  getAuth: () => ({
+    verifyIdToken: mockVerifyIdToken,
+    revokeRefreshTokens: mockRevokeRefreshTokens,
+  }),
+}));
+
+// ── Mock firebase-admin/firestore ───────────────────────────────────
+jest.mock("firebase-admin/firestore", () => ({
+  getFirestore: () => ({
+    collection: (name) => mockBuildCollectionRef(name),
+    batch: () => mockBatch,
+    getAll: jest.fn(async (...refs) => {
+      return refs.map((ref) => {
+        const data = mockUsers[ref.id];
+        return {
+          exists: !!data,
+          id: ref.id,
+          data: () => (data ? { ...data } : undefined),
+        };
+      });
+    }),
+  }),
+  Timestamp: {
+    now: () => mockFakeTimestamp(new Date()),
+    fromDate: (d) => mockFakeTimestamp(d),
+  },
+  FieldValue: {
+    increment: (n) => ({ _type: "increment", _value: n }),
+    delete: () => ({ _type: "delete" }),
+    serverTimestamp: () => mockFakeTimestamp(new Date()),
+  },
+}));
+
+// ── Mock firebase-admin/storage ─────────────────────────────────────
+jest.mock("firebase-admin/storage", () => ({
+  getStorage: () => ({
+    bucket: () => ({
+      getFiles: jest.fn(async ({ prefix }) => {
+        const files = Object.entries(mockStorageFiles)
+          .filter(([k]) => k.startsWith(prefix))
+          .map(([k]) => ({
+            name: k,
+            delete: jest.fn(async () => { delete mockStorageFiles[k]; }),
+            getMetadata: jest.fn(async () => [{ size: "1024" }]),
+          }));
+        return [files];
+      }),
+      file: (path) => ({
+        delete: jest.fn(async () => { delete mockStorageFiles[path]; }),
+      }),
+    }),
+  }),
+}));
+
+// ── Load admin app after mocks ──────────────────────────────────────
+const http = require("http");
+let app;
+let server;
+
+function request(method, path, body, token) {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    const options = {
+      hostname: "127.0.0.1",
+      port: addr.port,
+      path,
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        ...(token !== null ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    };
+
+    const req = http.request(options, (res) => {
+      let data = "";
+      res.on("data", (chunk) => (data += chunk));
+      res.on("end", () => {
+        let parsed;
+        try {
+          parsed = JSON.parse(data);
+        } catch {
+          parsed = data;
+        }
+        resolve({ status: res.statusCode, body: parsed, headers: res.headers });
+      });
+    });
+
+    req.on("error", reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+// ── Setup / Teardown ────────────────────────────────────────────────
+beforeAll((done) => {
+  app = require("./admin");
+  server = http.createServer(app);
+  server.listen(0, "127.0.0.1", done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  mockUsers = {};
+  mockReports = {};
+  mockReportsArchive = {};
+  mockConversations = {};
+  mockMessages = {};
+  mockAuditLog = {};
+  mockReportLocks = {};
+  mockAdminTokens = {};
+  mockSuspensionAppeals = {};
+  mockStorageFiles = {};
+  mockDocIdCounter = 0;
+
+  mockVerifyIdToken.mockResolvedValue({ uid: "admin-1", admin: true, name: "Admin One", email: "admin@test.com" });
+  mockRevokeRefreshTokens.mockResolvedValue();
+  mockBatch.commit.mockResolvedValue();
+  mockBatch.update.mockReset();
+  mockBatch.set.mockReset();
+  mockBatch.delete.mockReset();
+});
+
+// ── Auth Middleware Tests ────────────────────────────────────────────
+describe("Auth Middleware", () => {
+  test("returns 401 when no Authorization header", async () => {
+    const res = await request("GET", "/api/user/test-uid", null, null);
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/Missing/i);
+  });
+
+  test("returns 401 when invalid token", async () => {
+    mockVerifyIdToken.mockRejectedValueOnce(new Error("invalid token"));
+    const res = await request("GET", "/api/user/test-uid", null, "bad-token");
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/Invalid/i);
+  });
+
+  test("returns 403 when not admin", async () => {
+    mockVerifyIdToken.mockResolvedValueOnce({ uid: "user-1", admin: false });
+    const res = await request("GET", "/api/user/test-uid", null, "valid-non-admin");
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/Not an admin/i);
+  });
+});
+
+// ── GCS Reset ───────────────────────────────────────────────────────
+describe("POST /api/user/:uid/reset-gcs", () => {
+  test("sets score to 100 and clears warning count", async () => {
+    mockUsers["user-1"] = {
+      displayName: "Bad User",
+      goodCharacterScore: 40,
+      goodCharacterLastDeductionAt: mockFakeTimestamp(new Date()),
+      warningCount: 3,
+    };
+
+    const res = await request("POST", "/api/user/user-1/reset-gcs", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockUsers["user-1"].goodCharacterScore).toBe(100);
+    expect(mockUsers["user-1"].goodCharacterLastDeductionAt).toBeNull();
+    expect(mockUsers["user-1"].warningCount).toBe(0);
+  });
+
+  test("returns 404 for non-existent user", async () => {
+    const res = await request("POST", "/api/user/no-one/reset-gcs", {}, "valid");
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── GET /api/reports ────────────────────────────────────────────────
+describe("GET /api/reports", () => {
+  test("returns empty list when no reports", async () => {
+    const res = await request("GET", "/api/reports?status=pending", null, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.users).toEqual([]);
+  });
+
+  test("groups reports by reportedUserId", async () => {
+    mockReports["r1"] = {
+      reportedUserId: "user-1",
+      reporterId: "reporter-1",
+      reason: "Spam",
+      status: "pending",
+    };
+    mockReports["r2"] = {
+      reportedUserId: "user-1",
+      reporterId: "reporter-2",
+      reason: "Harassment",
+      status: "pending",
+    };
+    mockUsers["user-1"] = {
+      displayName: "Bad User",
+      uniqueId: 42,
+      goodCharacterScore: 80,
+      warningCount: 1,
+    };
+
+    const res = await request("GET", "/api/reports?status=pending", null, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.users.length).toBe(1);
+    expect(res.body.users[0].uid).toBe("user-1");
+    expect(res.body.users[0].reportCount).toBe(2);
+    expect(res.body.users[0].warningCount).toBe(1);
+  });
+
+  test("rejects invalid status", async () => {
+    const res = await request("GET", "/api/reports?status=invalid", null, "valid");
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── POST /api/reports/:id/resolve ───────────────────────────────────
+describe("POST /api/reports/:id/resolve", () => {
+  beforeEach(() => {
+    mockReports["report-1"] = {
+      reportedUserId: "user-1",
+      reporterId: "reporter-1",
+      reason: "Harassment",
+      status: "pending",
+    };
+    mockUsers["user-1"] = {
+      displayName: "Offender",
+      goodCharacterScore: 100,
+      goodCharacterLastDeductionAt: null,
+      warningCount: 0,
+    };
+  });
+
+  test("rejects invalid action", async () => {
+    const res = await request("POST", "/api/reports/report-1/resolve", { action: "ban" }, "valid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/action/i);
+  });
+
+  test("rejects missing severity for warn", async () => {
+    const res = await request("POST", "/api/reports/report-1/resolve", { action: "warn" }, "valid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/severity/i);
+  });
+
+  test("rejects severity out of range", async () => {
+    const res = await request("POST", "/api/reports/report-1/resolve", { action: "warn", severity: 6 }, "valid");
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 404 for non-existent report", async () => {
+    const res = await request("POST", "/api/reports/fake/resolve", { action: "dismiss" }, "valid");
+    expect(res.status).toBe(404);
+  });
+
+  test("rejects already resolved report", async () => {
+    mockReports["report-1"].status = "resolved";
+    const res = await request("POST", "/api/reports/report-1/resolve", { action: "dismiss" }, "valid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/already resolved/i);
+  });
+
+  test("dismiss resolves report without GCS deduction", async () => {
+    const res = await request("POST", "/api/reports/report-1/resolve", {
+      action: "dismiss",
+      adminNote: "False report",
+    }, "valid");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockReports["report-1"].status).toBe("resolved");
+    expect(mockReports["report-1"].resolvedAction).toBe("dismiss");
+    expect(mockUsers["user-1"].goodCharacterScore).toBe(100);
+  });
+
+  test("warn deducts GCS, sets warning fields, revokes tokens", async () => {
+    const res = await request("POST", "/api/reports/report-1/resolve", {
+      action: "warn",
+      severity: 3,
+      adminNote: "Warned for harassment",
+    }, "valid");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    expect(mockReports["report-1"].status).toBe("resolved");
+    expect(mockReports["report-1"].resolvedAction).toBe("warn");
+    expect(mockReports["report-1"].severity).toBe(3);
+
+    // GCS: 100 - (3*5) = 85
+    expect(mockUsers["user-1"].goodCharacterScore).toBe(85);
+    expect(mockUsers["user-1"].hasActiveWarning).toBe(true);
+    expect(mockUsers["user-1"].warningReason).toBe("Harassment");
+    expect(mockRevokeRefreshTokens).toHaveBeenCalledWith("user-1");
+  });
+
+  test("warn severity 5 deducts 25 points", async () => {
+    const res = await request("POST", "/api/reports/report-1/resolve", {
+      action: "warn",
+      severity: 5,
+    }, "valid");
+    expect(res.status).toBe(200);
+    expect(mockUsers["user-1"].goodCharacterScore).toBe(75);
+  });
+
+  test("GCS does not go below 0", async () => {
+    mockUsers["user-1"].goodCharacterScore = 10;
+    const res = await request("POST", "/api/reports/report-1/resolve", {
+      action: "warn",
+      severity: 5,
+    }, "valid");
+    expect(res.status).toBe(200);
+    expect(mockUsers["user-1"].goodCharacterScore).toBe(0);
+  });
+
+  test("auto-escalation suggested when warningCount reaches 5", async () => {
+    mockUsers["user-1"].warningCount = 4;
+    const res = await request("POST", "/api/reports/report-1/resolve", {
+      action: "warn",
+      severity: 1,
+    }, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.autoEscalateSuggested).toBe(true);
+  });
+
+  test("no auto-escalation when warningCount below 5", async () => {
+    mockUsers["user-1"].warningCount = 2;
+    const res = await request("POST", "/api/reports/report-1/resolve", {
+      action: "warn",
+      severity: 1,
+    }, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.autoEscalateSuggested).toBe(false);
+  });
+
+  test("suspend triggers suspension and GCS deduction", async () => {
+    const res = await request("POST", "/api/reports/report-1/resolve", {
+      action: "suspend",
+      severity: 4,
+      suspensionDays: 7,
+      canAppeal: true,
+    }, "valid");
+
+    expect(res.status).toBe(200);
+    expect(mockUsers["user-1"].goodCharacterScore).toBe(80);
+    expect(mockUsers["user-1"].isSuspended).toBe(true);
+    expect(mockUsers["user-1"].suspensionCanAppeal).toBe(true);
+  });
+
+  test("dismiss does not require severity", async () => {
+    const res = await request("POST", "/api/reports/report-1/resolve", {
+      action: "dismiss",
+    }, "valid");
+    expect(res.status).toBe(200);
+  });
+});
+
+// ── POST /api/reports/resolve-all/:reportedUserId ───────────────────
+describe("POST /api/reports/resolve-all/:reportedUserId", () => {
+  beforeEach(() => {
+    mockReports["r1"] = {
+      reportedUserId: "user-1",
+      reporterId: "reporter-1",
+      reason: "Spam",
+      status: "pending",
+    };
+    mockReports["r2"] = {
+      reportedUserId: "user-1",
+      reporterId: "reporter-2",
+      reason: "Harassment",
+      status: "pending",
+    };
+    mockUsers["user-1"] = {
+      displayName: "Offender",
+      goodCharacterScore: 100,
+      goodCharacterLastDeductionAt: null,
+      warningCount: 0,
+    };
+  });
+
+  test("returns 404 when no pending reports", async () => {
+    const res = await request("POST", "/api/reports/resolve-all/user-999", {
+      action: "dismiss",
+    }, "valid");
+    expect(res.status).toBe(404);
+  });
+
+  test("rejects invalid action", async () => {
+    const res = await request("POST", "/api/reports/resolve-all/user-1", {
+      action: "nuke",
+    }, "valid");
+    expect(res.status).toBe(400);
+  });
+
+  test("bulk warn applies single GCS deduction", async () => {
+    const res = await request("POST", "/api/reports/resolve-all/user-1", {
+      action: "warn",
+      severity: 2,
+    }, "valid");
+
+    expect(res.status).toBe(200);
+    expect(res.body.resolvedCount).toBe(2);
+    // Single deduction: 100 - (2*5) = 90
+    expect(mockUsers["user-1"].goodCharacterScore).toBe(90);
+    expect(mockUsers["user-1"].hasActiveWarning).toBe(true);
+    expect(mockRevokeRefreshTokens).toHaveBeenCalledWith("user-1");
+  });
+});
+
+// ── Review Lock Endpoints ───────────────────────────────────────────
+describe("Review Lock Endpoints", () => {
+  test("POST lock creates a new lock", async () => {
+    const res = await request("POST", "/api/report-locks/user-1/lock", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.locked).toBe(false);
+  });
+
+  test("POST lock returns locked=true when another admin holds it", async () => {
+    mockReportLocks["user-1"] = {
+      adminUid: "admin-2",
+      displayName: "Other Admin",
+      timestamp: mockFakeTimestamp(new Date()),
+    };
+
+    const res = await request("POST", "/api/report-locks/user-1/lock", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.locked).toBe(true);
+    expect(res.body.lockedBy).toBe("Other Admin");
+  });
+
+  test("POST lock allows same admin to re-acquire", async () => {
+    mockReportLocks["user-1"] = {
+      adminUid: "admin-1",
+      displayName: "Admin One",
+      timestamp: mockFakeTimestamp(new Date()),
+    };
+
+    const res = await request("POST", "/api/report-locks/user-1/lock", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.locked).toBe(false);
+  });
+
+  test("POST lock allows acquisition after expired lock", async () => {
+    const tenMinAgo = new Date(Date.now() - 10 * 60 * 1000);
+    mockReportLocks["user-1"] = {
+      adminUid: "admin-2",
+      displayName: "Other",
+      timestamp: mockFakeTimestamp(tenMinAgo),
+    };
+
+    const res = await request("POST", "/api/report-locks/user-1/lock", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.locked).toBe(false);
+  });
+
+  test("DELETE lock removes it", async () => {
+    mockReportLocks["user-1"] = {
+      adminUid: "admin-1",
+      displayName: "Admin One",
+      timestamp: mockFakeTimestamp(new Date()),
+    };
+
+    const res = await request("DELETE", "/api/report-locks/user-1", null, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+
+// ── GET /api/reports/export ─────────────────────────────────────────
+describe("GET /api/reports/export", () => {
+  test("returns 400 when from/to missing", async () => {
+    const res = await request("GET", "/api/reports/export", null, "valid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/from and to/i);
+  });
+
+  test("returns 400 for invalid date format", async () => {
+    const res = await request("GET", "/api/reports/export?from=bad&to=worse", null, "valid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid date/i);
+  });
+
+  test("returns CSV with correct headers", async () => {
+    const ts = mockFakeTimestamp(new Date("2025-06-01"));
+    mockReports["r1"] = {
+      status: "resolved",
+      resolvedAt: ts,
+      timestamp: ts,
+      reporterName: "Reporter",
+      reportedUserName: "Offender",
+      type: "message",
+      reason: "Spam",
+      resolvedAction: "warn",
+      severity: 2,
+      adminNote: "Warned",
+    };
+
+    const from = "2025-01-01";
+    const to = "2025-12-31";
+    const res = await request("GET", `/api/reports/export?from=${from}&to=${to}`, null, "valid");
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/text\/csv/);
+    expect(res.headers["content-disposition"]).toMatch(/attachment/);
+
+    const lines = res.body.split("\n");
+    expect(lines[0]).toBe("Report ID,Reporter,Reported User,Type,Reason,Action Taken,Severity,Admin Note,Created At,Resolved At");
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ── GET /api/reports/stats ──────────────────────────────────────────
+describe("GET /api/reports/stats", () => {
+  test("returns stats with default period", async () => {
+    mockReports["r1"] = { status: "pending" };
+    mockReports["r2"] = { status: "pending" };
+
+    const res = await request("GET", "/api/reports/stats", null, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.pendingCount).toBe(2);
+    expect(typeof res.body.resolvedToday).toBe("number");
+    expect(typeof res.body.activeReviewers).toBe("number");
+  });
+
+  test("returns zero stats when empty", async () => {
+    const res = await request("GET", "/api/reports/stats?period=30d", null, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.pendingCount).toBe(0);
+    expect(res.body.resolvedToday).toBe(0);
+    expect(res.body.activeReviewers).toBe(0);
+  });
+});
+
+// ── Existing Endpoints (regression) ─────────────────────────────────
+describe("Existing Endpoints Regression", () => {
+  test("GET /api/user/:uid returns user data", async () => {
+    mockUsers["user-1"] = { displayName: "Alice", uniqueId: 123 };
+    const res = await request("GET", "/api/user/user-1", null, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.displayName).toBe("Alice");
+    expect(res.body.uid).toBe("user-1");
+  });
+
+  test("GET /api/user/:uid returns 404 for missing user", async () => {
+    const res = await request("GET", "/api/user/nobody", null, "valid");
+    expect(res.status).toBe(404);
+  });
+
+  test("PATCH /api/user/:uid updates user fields", async () => {
+    mockUsers["user-1"] = { displayName: "Alice", uniqueId: 123 };
+    const res = await request("PATCH", "/api/user/user-1", { displayName: "Bob" }, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockUsers["user-1"].displayName).toBe("Bob");
+  });
+
+  test("PATCH /api/user/:uid rejects unknown fields", async () => {
+    mockUsers["user-1"] = { displayName: "Alice" };
+    const res = await request("PATCH", "/api/user/user-1", { badField: "value" }, "valid");
+    expect(res.status).toBe(400);
+  });
+
+  test("PATCH /api/user/:uid rejects uid mutation", async () => {
+    mockUsers["user-1"] = { displayName: "Alice" };
+    const res = await request("PATCH", "/api/user/user-1", { uid: "new-id" }, "valid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/uid is immutable/i);
+  });
+
+  test("POST /api/user/:uid/suspend sets suspension fields", async () => {
+    mockUsers["user-1"] = { displayName: "Alice", profilePhotoUrl: "url", coverPhotoUrl: "cover" };
+    const futureDate = new Date(Date.now() + 7 * 86400000).toISOString();
+
+    const res = await request("POST", "/api/user/user-1/suspend", {
+      reason: "Bad behavior",
+      endDate: futureDate,
+      canAppeal: true,
+    }, "valid");
+
+    expect(res.status).toBe(200);
+    expect(mockUsers["user-1"].isSuspended).toBe(true);
+    expect(mockUsers["user-1"].suspensionReason).toBe("Bad behavior");
+    expect(mockUsers["user-1"].suspensionCanAppeal).toBe(true);
+  });
+
+  test("POST /api/user/:uid/suspend rejects missing reason", async () => {
+    mockUsers["user-1"] = { displayName: "Alice" };
+    const res = await request("POST", "/api/user/user-1/suspend", { canAppeal: true }, "valid");
+    expect(res.status).toBe(400);
+  });
+
+  test("POST /api/user/:uid/unsuspend restores profile", async () => {
+    mockUsers["user-1"] = {
+      displayName: "Suspended Account",
+      isSuspended: true,
+      _preSuspension: { displayName: "Alice", profilePhotoUrl: "url", coverPhotoUrl: "cover" },
+    };
+
+    const res = await request("POST", "/api/user/user-1/unsuspend", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(mockUsers["user-1"].isSuspended).toBe(false);
+    expect(mockUsers["user-1"].displayName).toBe("Alice");
+  });
+
+  test("GET /api/search/uniqueId/:id finds user", async () => {
+    mockUsers["user-1"] = { displayName: "Alice", uniqueId: 42 };
+    const res = await request("GET", "/api/search/uniqueId/42", null, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.displayName).toBe("Alice");
+  });
+});
+
+// ── Direct Warning (POST /api/user/:uid/warn) ──────────────────────
+describe("POST /api/user/:uid/warn", () => {
+  beforeEach(() => {
+    mockUsers["target-1"] = {
+      displayName: "TargetUser",
+      uniqueId: 42,
+      goodCharacterScore: 100,
+      warningCount: 0,
+    };
+  });
+
+  test("returns 404 for non-existent user", async () => {
+    const res = await request("POST", "/api/user/ghost/warn", { reason: "Spam", severity: 2 }, "valid");
+    expect(res.status).toBe(404);
+  });
+
+  test("rejects missing reason", async () => {
+    const res = await request("POST", "/api/user/target-1/warn", { severity: 2 }, "valid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/reason/i);
+  });
+
+  test("rejects invalid severity", async () => {
+    const res = await request("POST", "/api/user/target-1/warn", { reason: "Spam", severity: 0 }, "valid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/severity/i);
+  });
+
+  test("warns user, deducts GCS, sets warning fields", async () => {
+    const res = await request("POST", "/api/user/target-1/warn", { reason: "Harassment", severity: 3, adminNote: "test" }, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.newGCS).toBe(85); // 100 - 15
+    expect(res.body.warningCount).toBe(1);
+    expect(mockUsers["target-1"].hasActiveWarning).toBe(true);
+    expect(mockUsers["target-1"].warningReason).toBe("Harassment");
+    expect(mockUsers["target-1"].goodCharacterScore).toBe(85);
+  });
+
+  test("auto-escalation suggested at 5 warnings", async () => {
+    mockUsers["target-1"].warningCount = 4;
+    const res = await request("POST", "/api/user/target-1/warn", { reason: "Spam", severity: 1 }, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.autoEscalateSuggested).toBe(true);
+  });
+
+  test("GCS does not go below 0", async () => {
+    mockUsers["target-1"].goodCharacterScore = 10;
+    const res = await request("POST", "/api/user/target-1/warn", { reason: "Spam", severity: 5 }, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.newGCS).toBe(0);
+  });
+
+  test("filters 'other' reason to 'a policy violation'", async () => {
+    const res = await request("POST", "/api/user/target-1/warn", { reason: "Other", severity: 1 }, "valid");
+    expect(res.status).toBe(200);
+    expect(mockUsers["target-1"].warningReason).toBe("a policy violation");
+  });
+});
+
+// ── Field Validation ────────────────────────────────────────────────
+describe("Field Validation", () => {
+  beforeEach(() => {
+    mockUsers["user-1"] = { displayName: "Test", uniqueId: 1 };
+  });
+
+  test("rejects non-boolean for boolean fields", async () => {
+    const res = await request("PATCH", "/api/user/user-1", { hideFollowing: "yes" }, "valid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/hideFollowing must be a boolean/);
+  });
+
+  test("rejects invalid userType enum", async () => {
+    const res = await request("PATCH", "/api/user/user-1", { userType: "HACKER" }, "valid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/userType must be one of/);
+  });
+
+  test("accepts valid userType enum", async () => {
+    const res = await request("PATCH", "/api/user/user-1", { userType: "MC_SINGER" }, "valid");
+    expect(res.status).toBe(200);
+    expect(mockUsers["user-1"].userType).toBe("MC_SINGER");
+  });
+
+  test("rejects non-string for string fields", async () => {
+    const res = await request("PATCH", "/api/user/user-1", { displayName: 123 }, "valid");
+    expect(res.status).toBe(400);
+  });
+
+  test("accepts null for nullable fields", async () => {
+    const res = await request("PATCH", "/api/user/user-1", { profilePhotoUrl: null }, "valid");
+    expect(res.status).toBe(200);
+  });
+
+  test("rejects null for non-nullable fields", async () => {
+    const res = await request("PATCH", "/api/user/user-1", { displayName: null }, "valid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/cannot be null/);
+  });
+
+  test("validates timestamp fields as ISO-8601", async () => {
+    const res = await request("PATCH", "/api/user/user-1", { createdAt: "not-a-date" }, "valid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/not a valid date/);
+  });
+
+  test("accepts valid ISO-8601 timestamp", async () => {
+    const res = await request("PATCH", "/api/user/user-1", { createdAt: "2025-01-15T10:00:00Z" }, "valid");
+    expect(res.status).toBe(200);
+  });
+});
+
+// ── Storage Cleanup ─────────────────────────────────────────────────
+describe("Storage Cleanup", () => {
+  test("cleanup all-reports also deletes report_evidence storage", async () => {
+    mockReports["r1"] = { status: "pending", reportedUserId: "u1" };
+    mockStorageFiles["report_evidence/u1/screenshot.png"] = true;
+    mockStorageFiles["report_evidence/u2/video.mp4"] = true;
+
+    const res = await request("POST", "/api/cleanup/all-reports", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.storageFilesDeleted).toBe(2);
+    expect(mockStorageFiles["report_evidence/u1/screenshot.png"]).toBeUndefined();
+    expect(mockStorageFiles["report_evidence/u2/video.mp4"]).toBeUndefined();
+  });
+
+  test("cleanup all-system-conversations deletes PM images from storage", async () => {
+    const imgUrl = "https://firebasestorage.googleapis.com/v0/b/shytalk-7ba69.firebasestorage.app/o/pm_images%2Fuser1%2Fimg.jpg?alt=media&token=abc";
+    mockConversations["SHYTALK_SYSTEM_user1"] = {
+      participantIds: ["SHYTALK_SYSTEM", "user1"],
+    };
+    mockMessages["msg1"] = {
+      senderId: "user1",
+      text: "",
+      imageUrls: [imgUrl],
+    };
+    mockStorageFiles["pm_images/user1/img.jpg"] = true;
+
+    const res = await request("POST", "/api/cleanup/all-system-conversations", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.storageFilesDeleted).toBe(1);
+  });
+
+  test("GET /api/storage/audit returns folder stats", async () => {
+    mockStorageFiles["pm_images/u1/img.jpg"] = true;
+    mockStorageFiles["pm_images/u2/img2.jpg"] = true;
+    mockStorageFiles["stickers/u1/sticker.webp"] = true;
+
+    const res = await request("GET", "/api/storage/audit", null, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.pm_images.files).toBe(2);
+    expect(res.body.pm_images.bytes).toBe(2048);
+    expect(res.body.stickers.files).toBe(1);
+    expect(res.body.stickers.bytes).toBe(1024);
+    expect(res.body.report_evidence.files).toBe(0);
+    expect(res.body.profile_photos.files).toBe(0);
+    expect(res.body.cover_photos.files).toBe(0);
+  });
+
+  test("orphaned-storage deletes only unreferenced files", async () => {
+    // Referenced: user profile photo
+    const profileUrl = "https://firebasestorage.googleapis.com/v0/b/shytalk-7ba69.firebasestorage.app/o/profile_photos%2Fu1%2Fphoto.jpg?alt=media&token=abc";
+    mockUsers["u1"] = { displayName: "User", profilePhotoUrl: profileUrl };
+    mockStorageFiles["profile_photos/u1/photo.jpg"] = true;
+
+    // Orphaned files (no Firestore reference)
+    mockStorageFiles["pm_images/u2/old.jpg"] = true;
+    mockStorageFiles["stickers/u3/stale.webp"] = true;
+
+    const res = await request("POST", "/api/cleanup/orphaned-storage", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    // Referenced file preserved
+    expect(mockStorageFiles["profile_photos/u1/photo.jpg"]).toBe(true);
+    // Orphaned files deleted
+    expect(mockStorageFiles["pm_images/u2/old.jpg"]).toBeUndefined();
+    expect(mockStorageFiles["stickers/u3/stale.webp"]).toBeUndefined();
+    expect(res.body.totalDeleted).toBe(2);
+  });
+
+  test("orphaned-storage preserves files still referenced in Firestore", async () => {
+    // IMAGE message reference
+    const imgUrl = "https://firebasestorage.googleapis.com/v0/b/shytalk-7ba69.firebasestorage.app/o/pm_images%2Fu1%2Fimg.jpg?alt=media&token=abc";
+    mockConversations["conv1"] = { participantIds: ["u1", "u2"] };
+    mockMessages["msg1"] = { senderId: "u1", type: "IMAGE", imageUrls: [imgUrl] };
+    mockStorageFiles["pm_images/u1/img.jpg"] = true;
+
+    // STICKER message reference
+    const stickerUrl = "https://firebasestorage.googleapis.com/v0/b/shytalk-7ba69.firebasestorage.app/o/stickers%2Fu1%2Fsticker.webp?alt=media&token=def";
+    mockMessages["msg2"] = { senderId: "u1", type: "STICKER", stickerUrl };
+    mockStorageFiles["stickers/u1/sticker.webp"] = true;
+
+    // Report evidence reference
+    const evUrl = "https://firebasestorage.googleapis.com/v0/b/shytalk-7ba69.firebasestorage.app/o/report_evidence%2Fu1%2Fev.png?alt=media&token=xyz";
+    mockReports["r1"] = { status: "pending", evidenceUrls: [evUrl] };
+    mockStorageFiles["report_evidence/u1/ev.png"] = true;
+
+    // Cover photo in _preSuspension
+    const coverUrl = "https://firebasestorage.googleapis.com/v0/b/shytalk-7ba69.firebasestorage.app/o/cover_photos%2Fu1%2Fcover.jpg?alt=media&token=ghi";
+    mockUsers["u1"] = { displayName: "User", _preSuspension: { coverPhotoUrl: coverUrl } };
+    mockStorageFiles["cover_photos/u1/cover.jpg"] = true;
+
+    const res = await request("POST", "/api/cleanup/orphaned-storage", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.totalDeleted).toBe(0);
+    expect(mockStorageFiles["pm_images/u1/img.jpg"]).toBe(true);
+    expect(mockStorageFiles["stickers/u1/sticker.webp"]).toBe(true);
+    expect(mockStorageFiles["report_evidence/u1/ev.png"]).toBe(true);
+    expect(mockStorageFiles["cover_photos/u1/cover.jpg"]).toBe(true);
+  });
+
+  test("orphaned-storage deletes unreferenced files from all folders", async () => {
+    mockStorageFiles["pm_images/orphan1.jpg"] = true;
+    mockStorageFiles["stickers/orphan2.webp"] = true;
+    mockStorageFiles["report_evidence/orphan3.png"] = true;
+    mockStorageFiles["profile_photos/orphan4.jpg"] = true;
+    mockStorageFiles["cover_photos/orphan5.jpg"] = true;
+    mockStorageFiles["group_photos/orphan6.jpg"] = true;
+
+    const res = await request("POST", "/api/cleanup/orphaned-storage", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.totalDeleted).toBe(6);
+    expect(Object.keys(mockStorageFiles).length).toBe(0);
+  });
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -6,6 +6,7 @@ const { initializeApp } = require("firebase-admin/app");
 const { getAuth } = require("firebase-admin/auth");
 const { getFirestore, FieldValue } = require("firebase-admin/firestore");
 const { getDatabase } = require("firebase-admin/database");
+const { getStorage } = require("firebase-admin/storage");
 const { AccessToken } = require("livekit-server-sdk");
 
 initializeApp();
@@ -15,6 +16,13 @@ const livekitApiSecret = defineSecret("LIVEKIT_API_SECRET");
 
 const MAX_SEATS = 8;
 const OWNER_SEAT_INDEX = 0;
+
+// Extract a storage path from a Firebase Storage download URL
+function extractStoragePath(url) {
+  if (!url) return null;
+  const match = url.match(/\/o\/(.+?)\?/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
 
 exports.generateLiveKitToken = onCall({ secrets: [livekitApiKey, livekitApiSecret] }, async (request) => {
   const { roomName, identity } = request.data;
@@ -304,83 +312,251 @@ exports.sendPmNotification = onDocumentCreated(
     const message = event.data.data();
     const conversationId = event.params.conversationId;
 
-    if (!message || !message.senderId) return;
+    if (!message || !message.senderId) {
+      console.log("No message data or senderId, skipping");
+      return;
+    }
+
+    console.log(`PM notification: conversation=${conversationId} sender=${message.senderId}`);
 
     const db = getFirestore();
 
     // Get conversation to find the other participant
     const convDoc = await db.collection("conversations").doc(conversationId).get();
-    if (!convDoc.exists) return;
+    if (!convDoc.exists) {
+      console.log("Conversation doc not found");
+      return;
+    }
 
     const conv = convDoc.data();
-    const recipientId = (conv.participantIds || []).find((id) => id !== message.senderId);
-    if (!recipientId) return;
-
-    // Check recipient's notification settings
-    const recipientDoc = await db.collection("users").doc(recipientId).get();
-    if (!recipientDoc.exists) return;
-
-    const recipient = recipientDoc.data();
-    if (recipient.pmNotificationsEnabled === false) return;
-
-    // Check DND schedule
-    if (recipient.dndEnabled) {
-      const now = new Date();
-      const currentHour = now.getHours();
-      const currentMinute = now.getMinutes();
-      const currentTime = currentHour * 60 + currentMinute;
-      const startTime = (recipient.dndStartHour || 22) * 60 + (recipient.dndStartMinute || 0);
-      const endTime = (recipient.dndEndHour || 8) * 60 + (recipient.dndEndMinute || 0);
-
-      let isDnd = false;
-      if (startTime <= endTime) {
-        isDnd = currentTime >= startTime && currentTime < endTime;
-      } else {
-        // Wraps midnight (e.g. 22:00 - 08:00)
-        isDnd = currentTime >= startTime || currentTime < endTime;
-      }
-      if (isDnd) return;
+    // Notify all participants except the sender (supports both 1-on-1 and group)
+    const recipientIds = (conv.participantIds || []).filter((id) => id !== message.senderId);
+    if (recipientIds.length === 0) {
+      console.log("No recipients found in participantIds");
+      return;
     }
 
-    // Check if conversation is muted
-    const settingsDoc = await db
-      .collection("conversations")
-      .doc(conversationId)
-      .collection("settings")
-      .doc(recipientId)
-      .get();
+    console.log(`Recipients: ${recipientIds.join(", ")}`);
 
-    if (settingsDoc.exists) {
-      const settings = settingsDoc.data();
-      if (settings.isMuted || settings.isSilent) return;
-    }
-
-    // Get sender info
+    // Get sender info once
     const senderDoc = await db.collection("users").doc(message.senderId).get();
     const senderName = senderDoc.exists ? senderDoc.data().displayName || "Someone" : "Someone";
 
-    // Build notification body
-    const showPreview = recipient.pmNotificationPreview !== false;
-    let body;
-    if (showPreview) {
-      body = message.type === "IMAGE" ? "Sent an image" : (message.text || "").substring(0, 100);
-    } else {
-      body = "New message";
+    // Process each recipient
+    for (const recipientId of recipientIds) {
+      console.log(`Processing recipient: ${recipientId}`);
+
+      // Check recipient's notification settings
+      const recipientDoc = await db.collection("users").doc(recipientId).get();
+      if (!recipientDoc.exists) continue;
+
+      const recipient = recipientDoc.data();
+      if (recipient.pmNotificationsEnabled === false) continue;
+
+      // Check DND schedule
+      if (recipient.dndEnabled) {
+        const now = new Date();
+        const currentHour = now.getHours();
+        const currentMinute = now.getMinutes();
+        const currentTime = currentHour * 60 + currentMinute;
+        const startTime = (recipient.dndStartHour || 22) * 60 + (recipient.dndStartMinute || 0);
+        const endTime = (recipient.dndEndHour || 8) * 60 + (recipient.dndEndMinute || 0);
+
+        let isDnd = false;
+        if (startTime <= endTime) {
+          isDnd = currentTime >= startTime && currentTime < endTime;
+        } else {
+          // Wraps midnight (e.g. 22:00 - 08:00)
+          isDnd = currentTime >= startTime || currentTime < endTime;
+        }
+        if (isDnd) continue;
+      }
+
+      // Check if conversation is muted
+      const settingsRef = db
+        .collection("conversations")
+        .doc(conversationId)
+        .collection("settings")
+        .doc(recipientId);
+      const settingsDoc = await settingsRef.get();
+
+      if (settingsDoc.exists) {
+        const settings = settingsDoc.data();
+        if (settings.isMuted) {
+          // Still increment unread count even if muted
+          await settingsRef.update({ unreadCount: FieldValue.increment(1) });
+          continue;
+        }
+      }
+
+      // Increment unread count for recipient
+      await settingsRef.set({ unreadCount: FieldValue.increment(1) }, { merge: true });
+
+      // Build notification body
+      const showPreview = recipient.pmNotificationPreview !== false;
+      let body;
+      if (showPreview) {
+        if (message.type === "IMAGE") body = "Sent an image";
+        else if (message.type === "STICKER") body = "Sent a sticker";
+        else if (message.type === "ROOM_INVITE") body = "Invited you to a room";
+        else body = (message.text || "").substring(0, 100);
+      } else {
+        body = "New message";
+      }
+
+      // For groups, prefix with group name
+      const notifTitle = conv.isGroup
+        ? `${senderName} in ${conv.groupName || "Group"}`
+        : senderName;
+
+      // Send to all FCM tokens
+      const tokens = recipient.fcmTokens || [];
+      console.log(`FCM tokens for ${recipientId}: ${tokens.length}`);
+      if (tokens.length === 0) continue;
+
+      const payload = {
+        data: {
+          type: "PM",
+          senderName: notifTitle,
+          messageText: body,
+          senderId: message.senderId,
+          conversationId: conversationId,
+          isGroup: String(conv.isGroup || false),
+          showPreview: String(showPreview),
+        },
+      };
+
+      const tokensToRemove = [];
+      await Promise.all(
+        tokens.map(async (token) => {
+          try {
+            await getMessaging().send({ ...payload, token });
+          } catch (err) {
+            if (
+              err.code === "messaging/invalid-registration-token" ||
+              err.code === "messaging/registration-token-not-registered"
+            ) {
+              tokensToRemove.push(token);
+            }
+          }
+        })
+      );
+
+      // Clean up invalid tokens
+      if (tokensToRemove.length > 0) {
+        await db.collection("users").doc(recipientId).update({
+          fcmTokens: FieldValue.arrayRemove(...tokensToRemove),
+        });
+        console.log(`Removed ${tokensToRemove.length} invalid FCM tokens for ${recipientId}`);
+      }
+    }
+  }
+);
+
+// --- System PM helper ---
+// Sends a private message from the SHYTALK_SYSTEM account to a recipient.
+// Auto-creates the system user doc and conversation if needed.
+async function sendSystemPm(recipientUid, text) {
+  const SYSTEM_UID = "SHYTALK_SYSTEM";
+  const SYSTEM_NAME = "ShyTalk";
+  const db = getFirestore();
+
+  // Auto-create system user doc if it doesn't exist
+  const systemUserRef = db.collection("users").doc(SYSTEM_UID);
+  const systemDoc = await systemUserRef.get();
+  if (!systemDoc.exists) {
+    await systemUserRef.set({
+      displayName: SYSTEM_NAME,
+      userType: "SYSTEM",
+      profilePhotoUrl: "https://firebasestorage.googleapis.com/v0/b/shytalk-7ba69.firebasestorage.app/o/system%2Fshytalk_icon.webp?alt=media&token=30b0256e-3bd6-4cae-ac50-31b596df98e8",
+      uniqueId: 0,
+      createdAt: FieldValue.serverTimestamp(),
+      lastSeenAt: FieldValue.serverTimestamp(),
+    });
+  }
+
+  // Get or create 1-on-1 conversation using deterministic ID
+  // Must match app's Conversation.generateId(): listOf(uid1, uid2).sorted().joinToString("_")
+  const participantIds = [SYSTEM_UID, recipientUid].sort();
+  const conversationId = participantIds.join("_");
+  const convRef = db.collection("conversations").doc(conversationId);
+  const convDoc = await convRef.get();
+
+  const lastMessagePreview = {
+    text: text.substring(0, 100),
+    senderId: SYSTEM_UID,
+    senderName: SYSTEM_NAME,
+    createdAt: FieldValue.serverTimestamp(),
+    type: "TEXT",
+  };
+
+  if (!convDoc.exists) {
+    await convRef.set({
+      participantIds,
+      isGroup: false,
+      createdAt: FieldValue.serverTimestamp(),
+      lastMessage: lastMessagePreview,
+      lastMessageAt: FieldValue.serverTimestamp(),
+    });
+    // Create default settings for both participants
+    const settingsCol = convRef.collection("settings");
+    await settingsCol.doc(SYSTEM_UID).set({ unreadCount: 0, isMuted: false, isPinned: false, isHidden: false });
+    await settingsCol.doc(recipientUid).set({ unreadCount: 0, isMuted: false, isPinned: false, isHidden: false });
+  }
+
+  // Write message
+  const msgRef = convRef.collection("messages").doc();
+  await msgRef.set({
+    senderId: SYSTEM_UID,
+    senderName: SYSTEM_NAME,
+    text,
+    type: "TEXT",
+    createdAt: FieldValue.serverTimestamp(),
+  });
+
+  // Update conversation last message preview
+  await convRef.update({
+    lastMessage: lastMessagePreview,
+    lastMessageAt: FieldValue.serverTimestamp(),
+  });
+
+  return conversationId;
+}
+
+// Export for use in admin.js
+exports._sendSystemPm = sendSystemPm;
+
+// --- Admin push notification on new report ---
+exports.onNewReport = onDocumentCreated(
+  { document: "reports/{reportId}", region: "asia-southeast1" },
+  async (event) => {
+    const report = event.data.data();
+    if (!report) return;
+
+    const reportType = report.reason || "Unknown";
+    const reportedUserName = report.reportedUserName || "a user";
+
+    console.log(`New report: ${reportType} against ${reportedUserName}`);
+
+    // Find all admin users via custom claims
+    const db = getFirestore();
+    const auth = getAuth();
+
+    // Query admin tokens collection
+    const tokensSnap = await db.collection("admin_tokens").get();
+    if (tokensSnap.empty) {
+      console.log("No admin tokens registered");
+      return;
     }
 
-    // Send to all FCM tokens
-    const tokens = recipient.fcmTokens || [];
+    const tokens = tokensSnap.docs.map((doc) => doc.data().token).filter(Boolean);
     if (tokens.length === 0) return;
 
     const payload = {
-      notification: {
-        title: senderName,
-        body: body,
-      },
       data: {
-        type: "pm",
-        otherUserId: message.senderId,
-        conversationId: conversationId,
+        type: "ADMIN_NEW_REPORT",
+        title: "New Report",
+        body: `${reportType} report against ${reportedUserName}`,
       },
     };
 
@@ -402,10 +578,248 @@ exports.sendPmNotification = onDocumentCreated(
 
     // Clean up invalid tokens
     if (tokensToRemove.length > 0) {
-      await db.collection("users").doc(recipientId).update({
-        fcmTokens: FieldValue.arrayRemove(...tokensToRemove),
-      });
-      console.log(`Removed ${tokensToRemove.length} invalid FCM tokens for ${recipientId}`);
+      const batch = db.batch();
+      const invalidSnaps = await db.collection("admin_tokens")
+        .where("token", "in", tokensToRemove.slice(0, 30))
+        .get();
+      invalidSnaps.docs.forEach((doc) => batch.delete(doc.ref));
+      await batch.commit();
+      console.log(`Removed ${invalidSnaps.size} invalid admin tokens`);
+    }
+  }
+);
+
+// --- Scheduled: Archive old resolved reports (runs weekly) ---
+const { onSchedule } = require("firebase-functions/v2/scheduler");
+
+exports.archiveOldReports = onSchedule(
+  { schedule: "every sunday 03:00", region: "asia-southeast1", timeZone: "UTC" },
+  async () => {
+    const db = getFirestore();
+    const sixMonthsAgo = new Date();
+    sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+
+    const snapshot = await db.collection("reports")
+      .where("status", "==", "resolved")
+      .where("resolvedAt", "<", sixMonthsAgo)
+      .limit(500)
+      .get();
+
+    if (snapshot.empty) {
+      console.log("No reports to archive");
+      return;
+    }
+
+    const batch = db.batch();
+    for (const doc of snapshot.docs) {
+      batch.set(db.collection("reports_archive").doc(doc.id), doc.data());
+      batch.delete(doc.ref);
+    }
+    await batch.commit();
+    console.log(`Archived ${snapshot.size} old reports`);
+  }
+);
+
+// --- Scheduled: Daily orphaned-storage cleanup ---
+async function cleanupOrphanedFiles() {
+  const db = getFirestore();
+  const referencedPaths = new Set();
+
+  // Hardcoded system asset
+  referencedPaths.add("system/shytalk_icon.webp");
+
+  // Users → profilePhotoUrl, coverPhotoUrl, _preSuspension.*
+  const usersSnap = await db.collection("users").get();
+  for (const doc of usersSnap.docs) {
+    const data = doc.data();
+    const urls = [
+      data.profilePhotoUrl,
+      data.coverPhotoUrl,
+      data._preSuspension && data._preSuspension.profilePhotoUrl,
+      data._preSuspension && data._preSuspension.coverPhotoUrl,
+    ];
+    for (const url of urls) {
+      const path = extractStoragePath(url);
+      if (path) referencedPaths.add(path);
+    }
+  }
+
+  // Conversations → groupPhotoUrl + messages (IMAGE → imageUrls, STICKER → stickerUrl)
+  const convsSnap = await db.collection("conversations").get();
+  for (const doc of convsSnap.docs) {
+    const data = doc.data();
+    const gPath = extractStoragePath(data.groupPhotoUrl);
+    if (gPath) referencedPaths.add(gPath);
+
+    const imageSnap = await doc.ref.collection("messages").where("type", "==", "IMAGE").get();
+    for (const msgDoc of imageSnap.docs) {
+      for (const url of (msgDoc.data().imageUrls || [])) {
+        const p = extractStoragePath(url);
+        if (p) referencedPaths.add(p);
+      }
+    }
+
+    const stickerSnap = await doc.ref.collection("messages").where("type", "==", "STICKER").get();
+    for (const msgDoc of stickerSnap.docs) {
+      const p = extractStoragePath(msgDoc.data().stickerUrl);
+      if (p) referencedPaths.add(p);
+    }
+  }
+
+  // Reports + archive → evidenceUrls[]
+  for (const col of ["reports", "reports_archive"]) {
+    const snap = await db.collection(col).get();
+    for (const doc of snap.docs) {
+      for (const url of (doc.data().evidenceUrls || [])) {
+        const p = extractStoragePath(url);
+        if (p) referencedPaths.add(p);
+      }
+    }
+  }
+
+  // List and delete orphaned files across all storage folders
+  const bucket = getStorage().bucket();
+  const folders = ["pm_images/", "stickers/", "report_evidence/", "profile_photos/", "cover_photos/", "group_photos/"];
+  const results = {};
+  let totalDeleted = 0;
+
+  for (const folder of folders) {
+    const [files] = await bucket.getFiles({ prefix: folder });
+    let deleted = 0;
+    for (const file of files) {
+      if (!referencedPaths.has(file.name)) {
+        await file.delete();
+        deleted++;
+      }
+    }
+    results[folder.replace("/", "")] = { total: files.length, deleted };
+    totalDeleted += deleted;
+    console.log(`${folder}: ${deleted}/${files.length} files deleted`);
+  }
+
+  console.log(`Orphaned storage cleanup complete: ${totalDeleted} files deleted`);
+  return { totalDeleted, results };
+}
+
+exports.cleanupOrphanedStorage = onSchedule(
+  {
+    schedule: "every day 04:00",
+    region: "asia-southeast1",
+    timeZone: "UTC",
+    timeoutSeconds: 540,
+    memory: "512MiB",
+  },
+  async () => {
+    const result = await cleanupOrphanedFiles();
+    console.log("Scheduled orphan cleanup result:", JSON.stringify(result));
+  }
+);
+
+exports.purgeOrphanedStorageNow = onCall(
+  { region: "asia-southeast1", timeoutSeconds: 540, memory: "512MiB" },
+  async (request) => {
+    if (!request.auth || request.auth.token.admin !== true) {
+      throw new HttpsError("permission-denied", "Admin access required");
+    }
+    return await cleanupOrphanedFiles();
+  }
+);
+
+// Export for admin.js to reuse
+exports._cleanupOrphanedFiles = cleanupOrphanedFiles;
+
+// --- Mod action notification trigger ---
+exports.onModAction = onDocumentCreated(
+  { document: "conversations/{conversationId}/mod_log/{logId}", region: "asia-southeast1" },
+  async (event) => {
+    const logEntry = event.data.data();
+    const conversationId = event.params.conversationId;
+
+    if (!logEntry) return;
+
+    console.log(`Mod action: ${logEntry.action} in conversation=${conversationId} by ${logEntry.modName}`);
+
+    const db = getFirestore();
+
+    // Get conversation to determine notify mode and admin/owner list
+    const convDoc = await db.collection("conversations").doc(conversationId).get();
+    if (!convDoc.exists) {
+      console.log("Conversation not found");
+      return;
+    }
+
+    const conv = convDoc.data();
+    const modNotifyMode = conv.modNotifyMode || "ALL_ADMINS";
+    const groupName = conv.groupName || "Group";
+
+    // Determine recipients based on notify mode
+    let recipientIds;
+    if (modNotifyMode === "OWNER_ONLY") {
+      recipientIds = conv.createdBy ? [conv.createdBy] : [];
+    } else {
+      // ALL_ADMINS — notify owner + all admins
+      const adminIds = conv.groupAdminIds || [];
+      recipientIds = [...new Set([conv.createdBy, ...adminIds].filter(Boolean))];
+    }
+
+    // Exclude the mod who performed the action
+    recipientIds = recipientIds.filter((id) => id !== logEntry.modId);
+
+    if (recipientIds.length === 0) {
+      console.log("No recipients for mod action notification");
+      return;
+    }
+
+    // Build notification text
+    const actionText = {
+      MUTE: `muted ${logEntry.targetUserName}`,
+      UNMUTE: `unmuted ${logEntry.targetUserName}`,
+      HIDE_MESSAGE: `hid a message from ${logEntry.targetUserName}`,
+    }[logEntry.action] || `performed ${logEntry.action} on ${logEntry.targetUserName}`;
+
+    const body = `${logEntry.modName} ${actionText} in ${groupName}`;
+
+    // Send push to each recipient
+    for (const recipientId of recipientIds) {
+      const userDoc = await db.collection("users").doc(recipientId).get();
+      if (!userDoc.exists) continue;
+
+      const tokens = userDoc.data().fcmTokens || [];
+      if (tokens.length === 0) continue;
+
+      const payload = {
+        data: {
+          type: "MOD_ACTION",
+          title: `Mod Action in ${groupName}`,
+          body: body,
+          conversationId: conversationId,
+          action: logEntry.action || "",
+          modName: logEntry.modName || "",
+        },
+      };
+
+      const tokensToRemove = [];
+      await Promise.all(
+        tokens.map(async (token) => {
+          try {
+            await getMessaging().send({ ...payload, token });
+          } catch (err) {
+            if (
+              err.code === "messaging/invalid-registration-token" ||
+              err.code === "messaging/registration-token-not-registered"
+            ) {
+              tokensToRemove.push(token);
+            }
+          }
+        })
+      );
+
+      if (tokensToRemove.length > 0) {
+        await db.collection("users").doc(recipientId).update({
+          fcmTokens: FieldValue.arrayRemove(...tokensToRemove),
+        });
+        console.log(`Removed ${tokensToRemove.length} invalid FCM tokens for ${recipientId}`);
+      }
     }
   }
 );


### PR DESCRIPTION
## Summary
- Add scheduled Cloud Function (`cleanupOrphanedStorage`) that runs daily at 04:00 UTC to cross-reference Firebase Storage files against Firestore and delete orphans across all 6 storage folders (`pm_images/`, `stickers/`, `report_evidence/`, `profile_photos/`, `cover_photos/`, `group_photos/`)
- Add `purgeOrphanedStorageNow` callable function for manual admin trigger
- Replace blind folder-delete logic in admin API `POST /api/cleanup/orphaned-storage` with smart cross-referencing that preserves referenced files

## Test plan
- [x] All 64 tests pass (`cd functions && npm test`), including 3 new smart-detection tests
- [ ] Deploy with `npx firebase deploy --only functions`
- [ ] Trigger `purgeOrphanedStorageNow` from Firebase console to verify first run
- [ ] Check Firebase logs to confirm orphaned files deleted, referenced files preserved
- [ ] Verify cron appears in GCP Cloud Scheduler at 04:00 UTC daily

🤖 Generated with [Claude Code](https://claude.com/claude-code)