### PR TITLE
v0.38 — Lucky Spin & Virtual Economy

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 37
-        versionName = "0.37"
+        versionCode = 38
+        versionName = "0.38"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -130,6 +130,12 @@ dependencies {
 
     // LiveKit
     implementation(libs.livekit.android)
+
+    // Lottie
+    implementation(libs.lottie.compose)
+
+    // Google Play Billing
+    implementation(libs.billing)
 
     // Testing
     testImplementation(libs.junit)

--- a/app/src/main/java/com/shyden/shytalk/core/di/AppKoinModule.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/di/AppKoinModule.kt
@@ -38,7 +38,19 @@ import com.shyden.shytalk.data.repository.StorageRepository
 import com.shyden.shytalk.data.repository.StorageRepositoryImpl
 import com.shyden.shytalk.data.repository.UserRepository
 import com.shyden.shytalk.data.repository.UserRepositoryImpl
+import com.shyden.shytalk.data.repository.GiftRepository
+import com.shyden.shytalk.data.repository.GiftRepositoryImpl
+import com.shyden.shytalk.data.repository.EconomyRepository
+import com.shyden.shytalk.data.repository.EconomyRepositoryImpl
+import com.shyden.shytalk.data.remote.BillingService
+import com.google.firebase.functions.FirebaseFunctions
 import com.shyden.shytalk.feature.auth.AuthViewModel
+import com.shyden.shytalk.feature.daily.DailyRewardViewModel
+import com.shyden.shytalk.feature.gacha.GachaViewModel
+import com.shyden.shytalk.feature.gifting.GiftingViewModel
+import com.shyden.shytalk.feature.profile.GiftWallViewModel
+import com.shyden.shytalk.feature.shop.TransactionHistoryViewModel
+import com.shyden.shytalk.feature.shop.WalletViewModel
 import com.shyden.shytalk.feature.home.HomeViewModel
 import com.shyden.shytalk.feature.messaging.ConversationListViewModel
 import com.shyden.shytalk.feature.messaging.GroupSetupViewModel
@@ -70,11 +82,15 @@ val appModule = module {
         Settings.Secure.getString(androidContext().contentResolver, Settings.Secure.ANDROID_ID)
     }
 
+    // Firebase Functions
+    single { FirebaseFunctions.getInstance("asia-southeast1") }
+
     // Services
     single<TokenService> { LiveKitTokenService() }
     single<VoiceService> { LiveKitVoiceService(androidContext(), get()) }
     single<PresenceService> { FirebasePresenceService(get()) }
     single<AppConfigService> { AndroidAppConfigService(androidContext(), get()) }
+    single { BillingService(androidContext()) }
 
     // Repositories
     singleOf(::AuthRepositoryImpl) bind AuthRepository::class
@@ -88,6 +104,8 @@ val appModule = module {
     singleOf(::ReportRepositoryImpl) bind ReportRepository::class
     singleOf(::TypingRepositoryImpl) bind TypingRepository::class
     singleOf(::NotificationRepositoryImpl) bind NotificationRepository::class
+    singleOf(::GiftRepositoryImpl) bind GiftRepository::class
+    single<EconomyRepository> { EconomyRepositoryImpl(get(), get()) }
     single { StickerStorage(androidContext()) }
 
     // ActiveRoomManager
@@ -97,7 +115,7 @@ val appModule = module {
     // ViewModels
     viewModel { AuthViewModel(get(), get(), get(), get(named("deviceId"))) }
     viewModel { HomeViewModel(get(), get(), get()) }
-    viewModel { ProfileViewModel(get(), get(), get(), get(), get()) }
+    viewModel { ProfileViewModel(get(), get(), get(), get(), get(), get()) }
     viewModel { RequiredDOBViewModel(get(), get()) }
     viewModel { params -> FollowListViewModel(params[0], params[1], get(), get()) }
     viewModel { params -> RoomViewModel(params[0], get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
@@ -121,4 +139,12 @@ val appModule = module {
     viewModel { ReportReviewViewModel(get(), get()) }
     viewModel { NewMessageViewModel(get(), get(), get()) }
     viewModel { params -> GroupSetupViewModel(params[0], get(), get(), get(), get()) }
+
+    // Monetization ViewModels
+    viewModel { GachaViewModel(get(), get()) }
+    viewModel { WalletViewModel(get(), get(), get()) }
+    viewModel { TransactionHistoryViewModel(get()) }
+    viewModel { GiftingViewModel(get(), get(), get()) }
+    viewModel { params -> GiftWallViewModel(params[0], get()) }
+    viewModel { DailyRewardViewModel(get(), get()) }
 }

--- a/app/src/main/java/com/shyden/shytalk/data/remote/BillingService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/BillingService.kt
@@ -1,0 +1,166 @@
+package com.shyden.shytalk.data.remote
+
+import android.app.Activity
+import android.content.Context
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClientStateListener
+import com.android.billingclient.api.BillingFlowParams
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.PurchasesUpdatedListener
+import com.android.billingclient.api.QueryProductDetailsParams
+import com.android.billingclient.api.QueryPurchasesParams
+import com.android.billingclient.api.AcknowledgePurchaseParams
+import com.android.billingclient.api.PendingPurchasesParams
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+data class PurchaseResult(
+    val productId: String,
+    val purchaseToken: String,
+    val isSubscription: Boolean,
+    val success: Boolean,
+    val errorMessage: String? = null
+)
+
+class BillingService(context: Context) {
+
+    private val _purchaseEvents = MutableSharedFlow<PurchaseResult>(extraBufferCapacity = 5)
+    val purchaseEvents: SharedFlow<PurchaseResult> = _purchaseEvents.asSharedFlow()
+
+    private val purchasesUpdatedListener = PurchasesUpdatedListener { billingResult, purchases ->
+        if (billingResult.responseCode == BillingClient.BillingResponseCode.OK && purchases != null) {
+            for (purchase in purchases) {
+                if (purchase.purchaseState == Purchase.PurchaseState.PURCHASED) {
+                    val productId = purchase.products.firstOrNull() ?: continue
+                    val isSub = purchase.products.any { it.startsWith("super_shy") }
+                    _purchaseEvents.tryEmit(
+                        PurchaseResult(
+                            productId = productId,
+                            purchaseToken = purchase.purchaseToken,
+                            isSubscription = isSub,
+                            success = true
+                        )
+                    )
+                    // Acknowledge the purchase
+                    if (!purchase.isAcknowledged) {
+                        val params = AcknowledgePurchaseParams.newBuilder()
+                            .setPurchaseToken(purchase.purchaseToken)
+                            .build()
+                        billingClient.acknowledgePurchase(params) { /* result logged */ }
+                    }
+                }
+            }
+        } else if (billingResult.responseCode != BillingClient.BillingResponseCode.USER_CANCELED) {
+            _purchaseEvents.tryEmit(
+                PurchaseResult(
+                    productId = "",
+                    purchaseToken = "",
+                    isSubscription = false,
+                    success = false,
+                    errorMessage = billingResult.debugMessage
+                )
+            )
+        }
+    }
+
+    private val billingClient: BillingClient = BillingClient.newBuilder(context)
+        .setListener(purchasesUpdatedListener)
+        .enablePendingPurchases(PendingPurchasesParams.newBuilder().enableOneTimeProducts().build())
+        .build()
+
+    private var isConnected = false
+
+    suspend fun connect(): Boolean = suspendCancellableCoroutine { cont ->
+        if (isConnected) {
+            cont.resume(true)
+            return@suspendCancellableCoroutine
+        }
+        billingClient.startConnection(object : BillingClientStateListener {
+            override fun onBillingSetupFinished(result: BillingResult) {
+                isConnected = result.responseCode == BillingClient.BillingResponseCode.OK
+                if (cont.isActive) cont.resume(isConnected)
+            }
+
+            override fun onBillingServiceDisconnected() {
+                isConnected = false
+            }
+        })
+    }
+
+    fun disconnect() {
+        billingClient.endConnection()
+        isConnected = false
+    }
+
+    suspend fun queryProducts(
+        productIds: List<String>,
+        type: String = BillingClient.ProductType.INAPP
+    ): List<ProductDetails> {
+        if (!connect()) return emptyList()
+
+        val params = productIds.map { productId ->
+            QueryProductDetailsParams.Product.newBuilder()
+                .setProductId(productId)
+                .setProductType(type)
+                .build()
+        }
+
+        val queryParams = QueryProductDetailsParams.newBuilder()
+            .setProductList(params)
+            .build()
+
+        return suspendCancellableCoroutine { cont ->
+            billingClient.queryProductDetailsAsync(queryParams) { result, detailsList ->
+                if (result.responseCode == BillingClient.BillingResponseCode.OK) {
+                    cont.resume(detailsList ?: emptyList())
+                } else {
+                    cont.resume(emptyList())
+                }
+            }
+        }
+    }
+
+    fun launchPurchaseFlow(
+        activity: Activity,
+        productDetails: ProductDetails,
+        offerToken: String? = null
+    ): BillingResult {
+        val productDetailsParams = BillingFlowParams.ProductDetailsParams.newBuilder()
+            .setProductDetails(productDetails)
+            .apply { if (offerToken != null) setOfferToken(offerToken) }
+            .build()
+
+        val flowParams = BillingFlowParams.newBuilder()
+            .setProductDetailsParamsList(listOf(productDetailsParams))
+            .build()
+
+        return billingClient.launchBillingFlow(activity, flowParams)
+    }
+
+    suspend fun queryExistingPurchases(): List<Purchase> {
+        if (!connect()) return emptyList()
+
+        val inAppPurchases = suspendCancellableCoroutine<List<Purchase>> { cont ->
+            billingClient.queryPurchasesAsync(
+                QueryPurchasesParams.newBuilder()
+                    .setProductType(BillingClient.ProductType.INAPP)
+                    .build()
+            ) { _, purchases -> cont.resume(purchases) }
+        }
+
+        val subPurchases = suspendCancellableCoroutine<List<Purchase>> { cont ->
+            billingClient.queryPurchasesAsync(
+                QueryPurchasesParams.newBuilder()
+                    .setProductType(BillingClient.ProductType.SUBS)
+                    .build()
+            ) { _, purchases -> cont.resume(purchases) }
+        }
+
+        return inAppPurchases + subPurchases
+    }
+}

--- a/app/src/main/java/com/shyden/shytalk/data/repository/EconomyRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/EconomyRepositoryImpl.kt
@@ -1,0 +1,141 @@
+package com.shyden.shytalk.data.repository
+
+import com.google.firebase.auth.FirebaseAuth
+import com.shyden.shytalk.core.model.CoinPackage
+import com.shyden.shytalk.core.model.DailyRewardResult
+import com.shyden.shytalk.core.model.GachaResult
+import com.shyden.shytalk.core.model.Transaction
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.core.util.firebaseCall
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.google.firebase.functions.FirebaseFunctions
+import kotlinx.coroutines.tasks.await
+
+class EconomyRepositoryImpl(
+    private val firestore: FirebaseFirestore,
+    private val functions: FirebaseFunctions
+) : EconomyRepository {
+
+    override suspend fun claimDailyReward(): Resource<DailyRewardResult> = firebaseCall("Failed to claim daily reward") {
+        val result = functions.getHttpsCallable("claimDailyReward")
+            .call()
+            .await()
+        @Suppress("UNCHECKED_CAST")
+        val data = result.data as Map<String, Any?>
+        DailyRewardResult.fromMap(data)
+    }
+
+    override suspend fun pullGacha(pullCount: Int): Resource<GachaResult> = firebaseCall("Failed to pull gacha") {
+        val result = functions.getHttpsCallable("pullGacha")
+            .call(mapOf("pullCount" to pullCount))
+            .await()
+        @Suppress("UNCHECKED_CAST")
+        val data = result.data as Map<String, Any?>
+        GachaResult.fromMap(data)
+    }
+
+    override suspend fun sendGift(recipientId: String, giftId: String): Resource<Map<String, Any?>> =
+        firebaseCall("Failed to send gift") {
+            val result = functions.getHttpsCallable("sendGift")
+                .call(mapOf("recipientId" to recipientId, "giftId" to giftId))
+                .await()
+            @Suppress("UNCHECKED_CAST")
+            result.data as Map<String, Any?>
+        }
+
+    override suspend fun redeemBeans(amount: Int): Resource<Map<String, Any?>> =
+        firebaseCall("Failed to redeem beans") {
+            val result = functions.getHttpsCallable("redeemBeans")
+                .call(mapOf("amount" to amount))
+                .await()
+            @Suppress("UNCHECKED_CAST")
+            result.data as Map<String, Any?>
+        }
+
+    override suspend fun purchaseCoins(productId: String, purchaseToken: String): Resource<Map<String, Any?>> =
+        firebaseCall("Failed to validate purchase") {
+            val result = functions.getHttpsCallable("validatePurchase")
+                .call(mapOf(
+                    "productId" to productId,
+                    "purchaseToken" to purchaseToken,
+                    "isSubscription" to false
+                ))
+                .await()
+            @Suppress("UNCHECKED_CAST")
+            result.data as Map<String, Any?>
+        }
+
+    override suspend fun purchaseSubscription(productId: String, purchaseToken: String): Resource<Map<String, Any?>> =
+        firebaseCall("Failed to validate subscription") {
+            val result = functions.getHttpsCallable("validatePurchase")
+                .call(mapOf(
+                    "productId" to productId,
+                    "purchaseToken" to purchaseToken,
+                    "isSubscription" to true
+                ))
+                .await()
+            @Suppress("UNCHECKED_CAST")
+            result.data as Map<String, Any?>
+        }
+
+    override suspend fun getCoinPackages(): Resource<List<CoinPackage>> = firebaseCall("Failed to get coin packages") {
+        val snapshot = firestore.collection("coinPackages")
+            .whereEqualTo("isActive", true)
+            .get()
+            .await()
+        snapshot.documents.mapNotNull { doc ->
+            val data = doc.data ?: return@mapNotNull null
+            CoinPackage.fromMap(data, doc.id)
+        }.sortedBy { it.order }
+    }
+
+    override suspend fun getRecentTransactions(limit: Int): Resource<List<Transaction>> = firebaseCall("Failed to load transactions") {
+        val userId = FirebaseAuth.getInstance().currentUser?.uid
+            ?: throw Exception("Not authenticated")
+        val snapshot = firestore.collection("users").document(userId)
+            .collection("transactions")
+            .orderBy("timestamp", Query.Direction.DESCENDING)
+            .limit(limit.toLong())
+            .get()
+            .await()
+        snapshot.documents.mapNotNull { doc ->
+            val data = doc.data ?: return@mapNotNull null
+            Transaction.fromMap(data, doc.id)
+        }
+    }
+
+    override suspend fun getAllTransactions(filterType: String?): Resource<List<Transaction>> = firebaseCall("Failed to load transactions") {
+        val userId = FirebaseAuth.getInstance().currentUser?.uid
+            ?: throw Exception("Not authenticated")
+        var query = firestore.collection("users").document(userId)
+            .collection("transactions")
+            .orderBy("timestamp", Query.Direction.DESCENDING)
+        if (filterType != null) {
+            query = query.whereEqualTo("type", filterType)
+        }
+        val snapshot = query.get().await()
+        snapshot.documents.mapNotNull { doc ->
+            val data = doc.data ?: return@mapNotNull null
+            Transaction.fromMap(data, doc.id)
+        }
+    }
+
+    override suspend fun addTestCoins(amount: Int): Resource<Map<String, Any?>> =
+        firebaseCall("Failed to add test coins") {
+            val userId = FirebaseAuth.getInstance().currentUser?.uid
+                ?: throw Exception("Not authenticated")
+            val userRef = firestore.collection("users").document(userId)
+            userRef.update("shyCoins", FieldValue.increment(amount.toLong())).await()
+            val txData = mapOf(
+                "type" to "PURCHASE",
+                "amount" to amount,
+                "currency" to "COINS",
+                "timestamp" to System.currentTimeMillis(),
+                "details" to "Test purchase (+$amount coins)"
+            )
+            userRef.collection("transactions").add(txData).await()
+            mapOf("success" to true, "coinsAdded" to amount)
+        }
+}

--- a/app/src/main/java/com/shyden/shytalk/data/repository/GiftRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/GiftRepositoryImpl.kt
@@ -1,0 +1,117 @@
+package com.shyden.shytalk.data.repository
+
+import com.shyden.shytalk.core.model.BackpackItem
+import com.shyden.shytalk.core.model.Broadcast
+import com.shyden.shytalk.core.model.Gift
+import com.shyden.shytalk.core.model.GiftRankEntry
+import com.shyden.shytalk.core.model.GiftSender
+import com.shyden.shytalk.core.model.GiftWallEntry
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.tasks.await
+
+class GiftRepositoryImpl(
+    private val firestore: FirebaseFirestore
+) : GiftRepository {
+
+    override fun observeGiftCatalog(): Flow<List<Gift>> = callbackFlow {
+        val listener = firestore.collection("gifts")
+            .orderBy("order")
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    close(error)
+                    return@addSnapshotListener
+                }
+                val gifts = snapshot?.documents?.mapNotNull { doc ->
+                    val data = doc.data ?: return@mapNotNull null
+                    Gift.fromMap(data, doc.id)
+                } ?: emptyList()
+                trySend(gifts)
+            }
+        awaitClose { listener.remove() }
+    }
+
+    override fun observeBackpack(userId: String): Flow<List<BackpackItem>> = callbackFlow {
+        val listener = firestore.collection("users").document(userId)
+            .collection("backpack")
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    close(error)
+                    return@addSnapshotListener
+                }
+                val items = snapshot?.documents?.mapNotNull { doc ->
+                    val data = doc.data ?: return@mapNotNull null
+                    BackpackItem.fromMap(data, doc.id)
+                } ?: emptyList()
+                trySend(items)
+            }
+        awaitClose { listener.remove() }
+    }
+
+    override fun observeGiftWall(userId: String): Flow<List<GiftWallEntry>> = callbackFlow {
+        val listener = firestore.collection("users").document(userId)
+            .collection("giftWall")
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    close(error)
+                    return@addSnapshotListener
+                }
+                val entries = snapshot?.documents?.mapNotNull { doc ->
+                    val data = doc.data ?: return@mapNotNull null
+                    GiftWallEntry.fromMap(data, doc.id)
+                } ?: emptyList()
+                trySend(entries)
+            }
+        awaitClose { listener.remove() }
+    }
+
+    override fun observeBroadcasts(): Flow<List<Broadcast>> = callbackFlow {
+        val listener = firestore.collection("broadcasts")
+            .orderBy("timestamp", Query.Direction.DESCENDING)
+            .limit(10)
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    close(error)
+                    return@addSnapshotListener
+                }
+                val broadcasts = snapshot?.documents?.mapNotNull { doc ->
+                    val data = doc.data ?: return@mapNotNull null
+                    Broadcast.fromMap(data, doc.id)
+                } ?: emptyList()
+                trySend(broadcasts)
+            }
+        awaitClose { listener.remove() }
+    }
+
+    override suspend fun getGiftWallSenders(userId: String, giftId: String): List<GiftSender> {
+        val doc = firestore.collection("users").document(userId)
+            .collection("giftWall").document(giftId).get().await()
+        if (!doc.exists()) return emptyList()
+        val data = doc.data ?: return emptyList()
+        val senders = data["senders"] as? Map<*, *> ?: return emptyList()
+        return senders.mapNotNull { (k, v) ->
+            val key = k as? String ?: return@mapNotNull null
+            val value = (v as? Long)?.toInt() ?: return@mapNotNull null
+            GiftSender(userId = key, count = value)
+        }.sortedByDescending { it.count }
+    }
+
+    override suspend fun getGiftRanking(giftId: String): List<GiftRankEntry> {
+        val doc = firestore.collection("giftRankings").document(giftId).get().await()
+        if (!doc.exists()) return emptyList()
+        val data = doc.data ?: return emptyList()
+        val rankings = data["rankings"] as? List<*> ?: return emptyList()
+        return rankings.mapNotNull { item ->
+            val m = item as? Map<*, *> ?: return@mapNotNull null
+            GiftRankEntry(
+                userId = m["userId"] as? String ?: return@mapNotNull null,
+                count = (m["count"] as? Long)?.toInt() ?: 0,
+                displayName = m["displayName"] as? String ?: "",
+                profilePhotoUrl = m["profilePhotoUrl"] as? String
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -29,6 +30,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -43,7 +45,13 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.PersonRemove
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.AccountBalanceWallet
+import android.app.Activity
 import android.content.Intent
+import com.android.billingclient.api.BillingClient
+import com.shyden.shytalk.data.remote.BillingService
+import org.koin.compose.koinInject
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -56,16 +64,19 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -80,12 +91,18 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.koin.compose.viewmodel.koinViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import com.shyden.shytalk.core.ui.StyledDisplayName
+import com.shyden.shytalk.core.ui.SuperShyGold
 import com.shyden.shytalk.core.util.calculateAge
+import com.shyden.shytalk.core.util.currentTimeMillis
 import com.shyden.shytalk.feature.messaging.ReportUserDialog
+import com.shyden.shytalk.feature.shop.SuperShyBottomSheet
 import com.shyden.shytalk.core.util.Constants
 import com.shyden.shytalk.core.util.countryNameForCode
 import com.shyden.shytalk.core.util.flagEmojiForCode
@@ -105,6 +122,7 @@ fun ProfileScreen(
     onNavigateToSettings: (() -> Unit)? = null,
     onNavigateToRoom: ((String) -> Unit)? = null,
     onNavigateToChat: ((String) -> Unit)? = null,
+    onNavigateToWallet: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     viewModel: ProfileViewModel = koinViewModel()
 ) {
@@ -223,6 +241,44 @@ fun ProfileScreen(
     val user = uiState.user
     val isOwn = uiState.isOwnProfile
 
+    // Billing setup for Super Shy purchases
+    val billingService: BillingService = koinInject()
+    val billingScope = rememberCoroutineScope()
+    val activity = LocalContext.current as? Activity
+
+    LaunchedEffect(Unit) {
+        billingService.purchaseEvents.collect { result ->
+            if (result.success) {
+                viewModel.validateSuperShyPurchase(result.productId, result.purchaseToken)
+            } else if (result.errorMessage != null) {
+                snackbarHostState.showSnackbar(result.errorMessage!!)
+            }
+        }
+    }
+
+    val onPurchaseSuperShy: (String) -> Unit = { productId ->
+        if (activity != null) {
+            billingScope.launch {
+                val type = if (productId == "super_shy_lifetime")
+                    BillingClient.ProductType.INAPP
+                else BillingClient.ProductType.SUBS
+
+                val products = billingService.queryProducts(listOf(productId), type)
+                val details = products.firstOrNull()
+                if (details == null) {
+                    snackbarHostState.showSnackbar("Product not available")
+                    return@launch
+                }
+
+                val offerToken = if (type == BillingClient.ProductType.SUBS) {
+                    details.subscriptionOfferDetails?.firstOrNull()?.offerToken
+                } else null
+
+                billingService.launchPurchaseFlow(activity, details, offerToken)
+            }
+        }
+    }
+
     // If this is embedded in a tab (no scaffold needed), just render the content
     if (!showBackButton) {
         Box(modifier = modifier) {
@@ -252,6 +308,8 @@ fun ProfileScreen(
                 onNavigateToFollowList = onNavigateToFollowList,
                 onNavigateToRoom = onNavigateToRoom,
                 onNavigateToChat = onNavigateToChat,
+                onNavigateToWallet = onNavigateToWallet,
+                onPurchaseSuperShy = onPurchaseSuperShy,
                 snackbarHostState = snackbarHostState,
                 modifier = Modifier.fillMaxSize()
             )
@@ -315,6 +373,8 @@ fun ProfileScreen(
                 onNavigateToFollowList = onNavigateToFollowList,
                 onNavigateToRoom = onNavigateToRoom,
                 onNavigateToChat = onNavigateToChat,
+                onNavigateToWallet = onNavigateToWallet,
+                onPurchaseSuperShy = onPurchaseSuperShy,
                 snackbarHostState = snackbarHostState,
                 modifier = Modifier
                     .fillMaxSize()
@@ -436,6 +496,7 @@ fun ProfileScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ProfileContent(
     uiState: ProfileUiState,
@@ -457,10 +518,13 @@ private fun ProfileContent(
     onNavigateToFollowList: ((String, String) -> Unit)? = null,
     onNavigateToRoom: ((String) -> Unit)? = null,
     onNavigateToChat: ((String) -> Unit)? = null,
+    onNavigateToWallet: (() -> Unit)? = null,
+    onPurchaseSuperShy: (String) -> Unit = {},
     snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier
 ) {
     val user = uiState.user
+    var showSuperShySheet by remember { mutableStateOf(false) }
 
     if (uiState.isLoading) {
         Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -564,6 +628,12 @@ private fun ProfileContent(
         return
     }
 
+    // Gift Wall ViewModel for tab
+    val giftWallViewModel: GiftWallViewModel = koinViewModel(
+        key = user.uid
+    ) { org.koin.core.parameter.parametersOf(user.uid) }
+    val giftWallState by giftWallViewModel.uiState.collectAsStateWithLifecycle()
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -623,26 +693,18 @@ private fun ProfileContent(
                     }
                 }
             }
-        }
 
-        // Profile photo + follow stats (overlapping cover)
-        val activeRoomId = uiState.activeRoomId
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .offset(y = (-50).dp)
-                .padding(horizontal = 16.dp),
-            contentAlignment = Alignment.CenterStart
-        ) {
-            // Follow stats — positioned slightly below center to sit under the cover edge
+            // Follow stats overlay at bottom of cover photo
             if (!uiState.isEditing) {
                 val followingHidden = !isOwn && uiState.hideFollowing
                 Row(
                     modifier = Modifier
-                        .align(Alignment.CenterEnd)
-                        .padding(top = 32.dp),
+                        .align(Alignment.BottomEnd)
+                        .background(Color.Black.copy(alpha = 0.45f))
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
                     horizontalArrangement = Arrangement.spacedBy(24.dp)
                 ) {
+                    // Following
                     Column(
                         modifier = Modifier.clickable(enabled = !followingHidden) {
                             onNavigateToFollowList?.invoke(user.uid, "following")
@@ -650,15 +712,17 @@ private fun ProfileContent(
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         Text(
-                            text = if (followingHidden) "Following (Private)" else "Following",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            text = if (followingHidden) "-" else "${uiState.followingCount}",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = Color.White
                         )
                         Text(
-                            text = if (followingHidden) "-" else "${uiState.followingCount}",
-                            style = MaterialTheme.typography.titleMedium
+                            text = if (followingHidden) "Following (Private)" else "Following",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.White.copy(alpha = 0.8f)
                         )
                     }
+                    // Followers
                     Column(
                         modifier = Modifier.clickable {
                             onNavigateToFollowList?.invoke(user.uid, "followers")
@@ -666,15 +730,17 @@ private fun ProfileContent(
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         Text(
-                            text = "Followers",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            text = "${uiState.followerCount}",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = Color.White
                         )
                         Text(
-                            text = "${uiState.followerCount}",
-                            style = MaterialTheme.typography.titleMedium
+                            text = "Followers",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.White.copy(alpha = 0.8f)
                         )
                     }
+                    // Stalkers (own profile only)
                     if (isOwn) {
                         Column(
                             modifier = Modifier.clickable {
@@ -709,20 +775,31 @@ private fun ProfileContent(
                                 }
                             ) {
                                 Text(
-                                    text = "Stalkers",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    text = "${uiState.stalkerCount}",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = Color.White
                                 )
                             }
                             Text(
-                                text = "${uiState.stalkerCount}",
-                                style = MaterialTheme.typography.titleMedium
+                                text = "Stalkers",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.White.copy(alpha = 0.8f)
                             )
                         }
                     }
                 }
             }
+        }
 
+        // Profile photo (overlapping cover)
+        val activeRoomId = uiState.activeRoomId
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .offset(y = (-50).dp)
+                .padding(horizontal = 16.dp),
+            contentAlignment = Alignment.CenterStart
+        ) {
             Box(
                 modifier = Modifier
                     .then(
@@ -810,6 +887,7 @@ private fun ProfileContent(
                     )
                 }
             }
+
         }
 
         // CNY badge
@@ -919,19 +997,42 @@ private fun ProfileContent(
                 // View mode
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text(
-                        text = user.displayName,
+                    StyledDisplayName(
+                        displayName = user.displayName,
+                        isSuperShy = user.isSuperShy,
                         style = MaterialTheme.typography.headlineMedium
                     )
                     if (uiState.isOnline) {
+                        Spacer(modifier = Modifier.width(8.dp))
                         Box(
                             modifier = Modifier
                                 .size(10.dp)
                                 .clip(CircleShape)
                                 .background(SpeakingGreen)
                         )
+                    }
+                    Spacer(modifier = Modifier.weight(1f))
+                    if (isOwn) {
+                        Surface(
+                            modifier = Modifier
+                                .size(36.dp)
+                                .clip(CircleShape)
+                                .clickable { onToggleEditing() },
+                            shape = CircleShape,
+                            color = MaterialTheme.colorScheme.primaryContainer,
+                            shadowElevation = 2.dp
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Icon(
+                                    Icons.Default.Edit,
+                                    contentDescription = "Edit profile",
+                                    modifier = Modifier.size(18.dp),
+                                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                                )
+                            }
+                        }
                     }
                 }
 
@@ -955,29 +1056,103 @@ private fun ProfileContent(
                     )
                 }
 
+                // Collapsible description
                 user.description?.takeIf { it.isNotBlank() }?.let { desc ->
                     Spacer(modifier = Modifier.height(12.dp))
-                    Text(
-                        text = desc,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                    var expanded by rememberSaveable { mutableStateOf(false) }
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .animateContentSize()
+                    ) {
+                        Text(
+                            text = desc,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = if (expanded) Int.MAX_VALUE else 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        if (desc.length > 80) {
+                            Text(
+                                text = if (expanded) "less" else "more",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.primary,
+                                fontWeight = FontWeight.Bold,
+                                modifier = Modifier.clickable { expanded = !expanded }
+                            )
+                        }
+                    }
                 }
 
-                Spacer(modifier = Modifier.height(24.dp))
-
+                // Super Shy + Wallet buttons (own profile only)
                 if (isOwn) {
-                    // Edit profile button
-                    OutlinedButton(
-                        onClick = onToggleEditing,
-                        modifier = Modifier.fillMaxWidth()
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text("Edit Profile")
-                    }
+                        // Super Shy button
+                        val superShyActive = user.isSuperShy
+                        Button(
+                            onClick = { showSuperShySheet = true },
+                            modifier = Modifier.weight(1f),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = if (superShyActive) SuperShyGold
+                                else MaterialTheme.colorScheme.surfaceVariant,
+                                contentColor = if (superShyActive) Color.Black
+                                else MaterialTheme.colorScheme.onSurfaceVariant
+                            ),
+                            shape = RoundedCornerShape(12.dp)
+                        ) {
+                            Icon(
+                                Icons.Filled.Star,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp)
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            if (superShyActive) {
+                                val label = if (user.superShyTier == "lifetime") {
+                                    "Super Shy \u2726 Lifetime"
+                                } else {
+                                    val daysLeft = user.superShyExpiry?.let {
+                                        ((it - currentTimeMillis()) / 86_400_000).toInt()
+                                    }
+                                    if (daysLeft != null && daysLeft > 0) "Super Shy \u2726 ${daysLeft}d"
+                                    else "Super Shy"
+                                }
+                                Text(label, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                            } else {
+                                Text("Get Super Shy")
+                            }
+                        }
 
-                } else {
+                        // Wallet button
+                        Button(
+                            onClick = { onNavigateToWallet?.invoke() },
+                            modifier = Modifier.weight(1f),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.primary
+                            ),
+                            shape = RoundedCornerShape(12.dp)
+                        ) {
+                            Icon(
+                                Icons.Filled.AccountBalanceWallet,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp)
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                "Wallet \u00B7 ${formatBalance(user.shyCoins)}",
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                if (!isOwn) {
                     // Follow/Unfollow + Message buttons
                     Row(
                         modifier = Modifier.fillMaxWidth(),
@@ -1054,9 +1229,44 @@ private fun ProfileContent(
                         Text("Report")
                     }
                 }
+
+                // Gift Wall Tab
+                Spacer(modifier = Modifier.height(16.dp))
+                var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+                PrimaryTabRow(selectedTabIndex = selectedTab) {
+                    Tab(
+                        selected = selectedTab == 0,
+                        onClick = { selectedTab = 0 },
+                        text = { Text("Gift Wall") }
+                    )
+                }
+
+                // Gift Wall content inline (non-scrolling since parent scrolls)
+                GiftWallContent(
+                    state = giftWallState,
+                    onSelectGift = { giftWallViewModel.selectGift(it) },
+                    onDismissDetails = { giftWallViewModel.dismissDetails() },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(400.dp)
+                )
             }
         }
 
         Spacer(modifier = Modifier.height(16.dp))
     }
+
+    // Super Shy bottom sheet
+    if (showSuperShySheet) {
+        SuperShyBottomSheet(
+            user = user,
+            onPurchase = { productId ->
+                showSuperShySheet = false
+                onPurchaseSuperShy(productId)
+            },
+            onDismiss = { showSuperShySheet = false }
+        )
+    }
 }
+
+private fun formatBalance(value: Long): String = "%,d".format(value)

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -50,6 +50,7 @@ import com.shyden.shytalk.ui.components.CnyRoomBackground
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -68,9 +69,20 @@ import com.shyden.shytalk.feature.room.components.RoomToolbar
 import com.shyden.shytalk.feature.room.components.SeatGrid
 import com.shyden.shytalk.feature.room.components.UserCardPopup
 import androidx.activity.result.PickVisualMediaRequest
+import com.shyden.shytalk.core.model.Broadcast
+import com.shyden.shytalk.core.ui.BroadcastBanner
+import com.shyden.shytalk.core.ui.GiftEffectOverlay
+import com.shyden.shytalk.data.repository.GiftRepository
+import com.shyden.shytalk.feature.gacha.GachaViewModel
+import com.shyden.shytalk.feature.gacha.LuckySpinOverlay
+import com.shyden.shytalk.feature.gifting.GiftingViewModel
 import com.shyden.shytalk.feature.messaging.ConversationListViewModel
 import com.shyden.shytalk.feature.messaging.PmBottomSheet
 import com.shyden.shytalk.feature.messaging.PrivateChatViewModel
+import com.shyden.shytalk.feature.room.components.BackpackSheet
+import com.shyden.shytalk.feature.room.components.RoomActionCarousel
+import com.shyden.shytalk.feature.daily.DailyRewardDialog
+import com.shyden.shytalk.feature.daily.DailyRewardViewModel
 import com.shyden.shytalk.feature.settings.RoomSettingsSheet
 import org.koin.compose.koinInject
 
@@ -85,6 +97,13 @@ fun RoomScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val conversationListViewModel: ConversationListViewModel = koinInject()
     val convListState by conversationListViewModel.uiState.collectAsStateWithLifecycle()
+    val gachaViewModel: GachaViewModel = koinInject()
+    val giftingViewModel: GiftingViewModel = koinInject()
+    val dailyRewardViewModel: DailyRewardViewModel = koinInject()
+    val giftRepository: GiftRepository = koinInject()
+    val gachaState by gachaViewModel.uiState.collectAsStateWithLifecycle()
+    val giftingState by giftingViewModel.uiState.collectAsStateWithLifecycle()
+    var latestBroadcast by remember { mutableStateOf<Broadcast?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
     var showSettings by remember(roomId) { mutableStateOf(false) }
     var showUserCardForId by remember(roomId) { mutableStateOf<String?>(null) }
@@ -92,6 +111,14 @@ fun RoomScreen(
     var showRoomNameDialog by remember(roomId) { mutableStateOf(false) }
     var showPmSheet by remember(roomId) { mutableStateOf(false) }
     var pmSheetPreOpenUserId by remember(roomId) { mutableStateOf<String?>(null) }
+    var showGachaWheel by remember(roomId) { mutableStateOf(false) }
+    var showDailyReward by remember(roomId) { mutableStateOf(false) }
+    var showBackpackSheet by remember(roomId) { mutableStateOf(false) }
+    var backpackRecipientId by remember(roomId) { mutableStateOf("") }
+    var backpackRecipientName by remember(roomId) { mutableStateOf("") }
+    var showGiftEffect by remember { mutableStateOf(false) }
+    var giftEffectAnimUrl by remember { mutableStateOf("") }
+    var giftEffectSoundUrl by remember { mutableStateOf("") }
     var pmImageResultHandler by remember { mutableStateOf<((List<ByteArray>) -> Unit)?>(null) }
     var pmStickerResultHandler by remember { mutableStateOf<((ByteArray) -> Unit)?>(null) }
     val reportEvidenceList = remember { mutableListOf<Pair<ByteArray, String>>() }
@@ -155,6 +182,67 @@ fun RoomScreen(
             if (bytes != null) {
                 pmStickerResultHandler?.invoke(bytes)
             }
+        }
+    }
+
+    // Sync gacha balance from user data
+    val currentUser = uiState.allKnownUsers[uiState.currentUserId]
+    LaunchedEffect(currentUser?.shyCoins, currentUser?.pityCounter, currentUser?.luckScore) {
+        currentUser?.let { user ->
+            gachaViewModel.updateBalance(user.shyCoins, user.pityCounter, user.luckScore)
+        }
+    }
+
+    // Observe broadcasts
+    LaunchedEffect(Unit) {
+        giftRepository.observeBroadcasts()
+            .catch { /* ignore errors */ }
+            .collect { broadcasts ->
+                latestBroadcast = broadcasts.firstOrNull()
+            }
+    }
+
+    // Handle gift sending success - trigger effect
+    LaunchedEffect(giftingState.sentGiftId) {
+        val giftId = giftingState.sentGiftId ?: return@LaunchedEffect
+        val gift = giftingState.giftCatalog.find { it.id == giftId }
+        if (gift != null) {
+            giftEffectAnimUrl = gift.animationUrl ?: ""
+            giftEffectSoundUrl = gift.soundUrl ?: ""
+            showGiftEffect = giftEffectAnimUrl.isNotBlank()
+            showBackpackSheet = false
+        }
+        giftingViewModel.clearSentGift()
+    }
+
+    // Handle gacha win — trigger GiftEffectOverlay for RARE+ single wins
+    LaunchedEffect(gachaState.currentWin) {
+        val win = gachaState.currentWin ?: return@LaunchedEffect
+        if (win.bracket.ordinal >= com.shyden.shytalk.core.model.GiftBracket.RARE.ordinal) {
+            val gift = gachaState.giftCatalog.find { it.id == win.giftId }
+            if (gift != null && gift.animationUrl.isNotBlank()) {
+                // Delay so the wheel celebration finishes first
+                kotlinx.coroutines.delay(2600)
+                giftEffectAnimUrl = gift.animationUrl
+                giftEffectSoundUrl = gift.soundUrl
+                showGiftEffect = true
+            }
+        }
+    }
+
+    // Handle gacha errors
+    LaunchedEffect(gachaState.error) {
+        gachaState.error?.let {
+            snackbarHostState.showSnackbar(it)
+            gachaViewModel.clearError()
+        }
+    }
+
+    // Handle gifting errors
+    LaunchedEffect(giftingState.error) {
+        giftingState.error?.let {
+            snackbarHostState.showSnackbar(it)
+            giftingViewModel.clearError()
         }
     }
 
@@ -542,6 +630,11 @@ fun RoomScreen(
                             showPmSheet = true
                         },
                         unreadCount = convListState.totalUnreadCount.toInt(),
+                        onOpenBackpack = {
+                            backpackRecipientId = uiState.currentUserId
+                            backpackRecipientName = ""
+                            showBackpackSheet = true
+                        },
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f)
@@ -608,6 +701,16 @@ fun RoomScreen(
                         .fillMaxHeight()
                         .fillMaxWidth(0.7f)
                 )
+            // Floating action carousel (bottom-right, inside scaffold content to respect padding)
+            if (uiState.hasJoined && !uiState.roomClosed) {
+                RoomActionCarousel(
+                    onOpenGacha = { showGachaWheel = true },
+                    onOpenDailyReward = { showDailyReward = true },
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(bottom = 64.dp, end = 8.dp)
+                )
+            }
             }
         }
 
@@ -722,6 +825,14 @@ fun RoomScreen(
                             showPmSheet = true
                         }
                     } else null,
+                    onSendGift = if (userId != uiState.currentUserId) {
+                        {
+                            showUserCardForId = null
+                            backpackRecipientId = userId
+                            backpackRecipientName = user.displayName
+                            showBackpackSheet = true
+                        }
+                    } else null,
                     onBlock = {
                         viewModel.blockUser(userId)
                         showUserCardForId = null
@@ -819,6 +930,65 @@ fun RoomScreen(
                 },
                 activeRoomId = roomId,
                 activeRoomName = uiState.room?.name
+            )
+        }
+
+        // Backpack Sheet for sending/viewing gifts
+        if (showBackpackSheet) {
+            BackpackSheet(
+                viewModel = giftingViewModel,
+                recipientId = backpackRecipientId,
+                recipientName = backpackRecipientName,
+                currentUserId = uiState.currentUserId,
+                onDismiss = { showBackpackSheet = false }
+            )
+        }
+
+        // Spin-the-Wheel overlay
+        if (showGachaWheel && uiState.hasJoined) {
+            LuckySpinOverlay(
+                gachaState = gachaState,
+                onSpin = gachaViewModel::pullSingle,
+                onQuickSpin = { count ->
+                    when (count) {
+                        10 -> gachaViewModel.pullTen()
+                        100 -> gachaViewModel.pullHundred()
+                    }
+                },
+                onAdvanceMultiSpin = gachaViewModel::advanceMultiSpin,
+                onSkipMultiSpin = gachaViewModel::skipMultiSpin,
+                onDismissResults = gachaViewModel::dismissResults,
+                onDismiss = { showGachaWheel = false }
+            )
+        }
+
+        // Daily Reward Dialog
+        if (showDailyReward) {
+            currentUser?.let { user ->
+                LaunchedEffect(Unit) {
+                    dailyRewardViewModel.checkAndShowDialog(user)
+                }
+                DailyRewardDialog(
+                    viewModel = dailyRewardViewModel,
+                    onDismiss = { showDailyReward = false }
+                )
+            }
+        }
+
+        // Broadcast Banner (top overlay)
+        BroadcastBanner(
+            broadcast = latestBroadcast,
+            modifier = Modifier.align(Alignment.TopCenter)
+        )
+
+        // Full-screen gift effect overlay
+        if (showGiftEffect) {
+            GiftEffectOverlay(
+                animationUrl = giftEffectAnimUrl,
+                soundUrl = giftEffectSoundUrl,
+                isVisible = true,
+                onFinished = { showGiftEffect = false },
+                modifier = Modifier.fillMaxSize()
             )
         }
         }

--- a/app/src/main/java/com/shyden/shytalk/feature/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/settings/AppSettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Security
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -311,7 +312,7 @@ private fun SettingsMainPage(
             )
             HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
             SettingsMenuItem(
-                icon = Icons.Default.Notifications,
+                icon = Icons.Default.Security,
                 title = "Permissions",
                 onClick = { onNavigateToPage(SettingsPage.Permissions) }
             )

--- a/app/src/main/java/com/shyden/shytalk/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shyden/shytalk/navigation/NavGraph.kt
@@ -58,8 +58,17 @@ import com.shyden.shytalk.feature.privacy.PrivacyPolicyScreen
 import com.shyden.shytalk.feature.settings.AppSettingsScreen
 import com.shyden.shytalk.feature.profile.FollowListScreen
 import com.shyden.shytalk.feature.profile.ProfileScreen
+import com.shyden.shytalk.feature.profile.GiftWallScreen
+import com.shyden.shytalk.feature.profile.GiftWallViewModel
 import com.shyden.shytalk.feature.profile.ProfileSetupScreen
 import com.shyden.shytalk.feature.profile.RequiredDOBScreen
+import com.shyden.shytalk.feature.shop.TransactionHistoryScreen
+import com.shyden.shytalk.feature.shop.TransactionHistoryViewModel
+import com.shyden.shytalk.feature.shop.WalletScreen
+import com.shyden.shytalk.feature.shop.WalletViewModel
+import com.shyden.shytalk.feature.daily.DailyRewardDialog
+import com.shyden.shytalk.feature.daily.DailyRewardViewModel
+import com.shyden.shytalk.data.remote.BillingService
 import com.shyden.shytalk.feature.room.RoomScreen
 import com.shyden.shytalk.feature.warning.WarningScreen
 import kotlinx.coroutines.launch
@@ -272,6 +281,15 @@ fun NavGraph(
             }
 
             val conversationListViewModel: ConversationListViewModel = koinInject()
+            val dailyRewardViewModel: DailyRewardViewModel = org.koin.compose.viewmodel.koinViewModel()
+            var showDailyRewardDialog by rememberSaveable { mutableStateOf(true) }
+
+            if (showDailyRewardDialog) {
+                DailyRewardDialog(
+                    viewModel = dailyRewardViewModel,
+                    onDismiss = { showDailyRewardDialog = false }
+                )
+            }
 
             MainScreen(
                 onNavigateToRoom = { roomId ->
@@ -291,6 +309,9 @@ fun NavGraph(
                 },
                 onNavigateToNewMessage = {
                     navController.navigate(Screen.NewMessage.route)
+                },
+                onNavigateToWallet = {
+                    navController.navigate(Screen.Wallet.route)
                 },
                 messagesContent = { modifier ->
                     ConversationListScreen(
@@ -318,6 +339,9 @@ fun NavGraph(
                         onNavigateToRoom = { roomId -> navigateToRoom(roomId) },
                         onNavigateToChat = { otherUserId ->
                             navController.navigate(Screen.PrivateChat.createRoute(otherUserId))
+                        },
+                        onNavigateToWallet = {
+                            navController.navigate(Screen.Wallet.route)
                         },
                         modifier = modifier
                     )
@@ -359,6 +383,9 @@ fun NavGraph(
                 onNavigateToRoom = { roomId -> navigateToRoom(roomId) },
                 onNavigateToChat = { otherUserId ->
                     navController.navigate(Screen.PrivateChat.createRoute(otherUserId))
+                },
+                onNavigateToWallet = {
+                    navController.navigate(Screen.Wallet.route)
                 }
             )
         }
@@ -653,6 +680,47 @@ fun NavGraph(
                     )
                 },
                 viewModel = groupSetupViewModel
+            )
+        }
+
+        composable(Screen.Wallet.route) {
+            val walletViewModel: WalletViewModel = org.koin.compose.viewmodel.koinViewModel()
+            val billingService: BillingService = koinInject()
+
+            WalletScreen(
+                viewModel = walletViewModel,
+                onNavigateBack = { navController.safePopBackStack() },
+                onNavigateToTransactions = { navController.navigate(Screen.Transactions.route) },
+                onPurchasePackage = { pkg ->
+                    // TODO: Launch billing flow for coin package
+                },
+                onPurchaseSubscription = { productId ->
+                    // TODO: Launch billing flow for subscription
+                }
+            )
+        }
+
+        composable(Screen.Transactions.route) {
+            val transactionHistoryViewModel: TransactionHistoryViewModel =
+                org.koin.compose.viewmodel.koinViewModel()
+            TransactionHistoryScreen(
+                viewModel = transactionHistoryViewModel,
+                onNavigateBack = { navController.safePopBackStack() }
+            )
+        }
+
+        composable(
+            route = Screen.GiftWall.route,
+            arguments = listOf(navArgument("userId") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val userId = backStackEntry.arguments?.getString("userId") ?: return@composable
+            val giftWallViewModel: GiftWallViewModel = org.koin.compose.viewmodel.koinViewModel(
+                key = userId
+            ) { org.koin.core.parameter.parametersOf(userId) }
+
+            GiftWallScreen(
+                viewModel = giftWallViewModel,
+                onNavigateBack = { navController.safePopBackStack() }
             )
         }
 

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,12 +1,13 @@
-v0.37 - Group Messaging & Moderation
+v0.38 - Lucky Spin & Virtual Economy
 
-- Group chats with admin roles, permissions & mod actions
-- New message screen for starting conversations
-- In-app user reporting in conversations
-- Warning system with emergency tone alerts
-- Video compression and thumbnail support
-- Sticker storage (KMP: Android & iOS)
-- Community Guidelines & Terms via in-app WebView
-- Orphaned storage cleanup (daily cron + admin purge)
-- Expanded admin panel with moderation tools
-- Bug fixes and performance improvements
+- Lucky Spin dual-ring wheel game replaces old gacha
+- Light-chase animations with 1x, 10x, 100x spin tiers
+- Confetti bursts and screen shake for rare wins
+- Gift catalogue with 27 gifts across 5 rarity tiers
+- Shy Coins wallet with test purchase buttons
+- Shy Beans redemption with 10% bonus at 2000+
+- Transaction history with friendly labels
+- Daily reward system with streak milestones
+- Animated mini-wheel icon in room carousel
+- Firestore PITR and delete protection enabled
+- Bug fixes and UI improvements

--- a/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
@@ -69,7 +69,7 @@ class UserToMapTest {
     fun `toMap contains exactly 44 keys`() {
         val user = TestData.createTestUser()
         val map = user.toMap()
-        assertEquals(44, map.size)
+        assertEquals(54, map.size)
     }
 
     @Test
@@ -88,7 +88,9 @@ class UserToMapTest {
             "pmSoundEnabled", "pmShowTimestamps", "pmShowDateSeparators",
             "pmNotificationPreview", "acceptedLegalVersion",
             "dndEnabled", "dndStartHour", "dndStartMinute",
-            "dndEndHour", "dndEndMinute"
+            "dndEndHour", "dndEndMinute",
+            "shyCoins", "shyBeans", "isSuperShy", "superShyExpiry", "superShyTier",
+            "luckScore", "pityCounter", "loginStreak", "lastLoginDate", "lastLoginRewardDate"
         )
         val user = TestData.createTestUser()
         assertEquals(expectedKeys, user.toMap().keys)

--- a/app/src/test/java/com/shyden/shytalk/feature/gacha/GachaViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/gacha/GachaViewModelTest.kt
@@ -1,0 +1,222 @@
+package com.shyden.shytalk.feature.gacha
+
+import com.shyden.shytalk.core.model.GachaGift
+import com.shyden.shytalk.core.model.GachaResult
+import com.shyden.shytalk.core.model.Gift
+import com.shyden.shytalk.core.model.GiftBracket
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.data.repository.EconomyRepository
+import com.shyden.shytalk.data.repository.GiftRepository
+import com.shyden.shytalk.testutil.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GachaViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val economyRepository = mockk<EconomyRepository>(relaxed = true)
+    private val giftRepository = mockk<GiftRepository>(relaxed = true)
+
+    private val giftsFlow = MutableSharedFlow<List<Gift>>()
+
+    private val sampleGifts = listOf(
+        Gift(id = "g1", name = "Rose", baseDropRate = 40.0, bracket = GiftBracket.COMMON),
+        Gift(id = "g2", name = "Crown", baseDropRate = 5.0, bracket = GiftBracket.RARE),
+        Gift(id = "g3", name = "Display", baseDropRate = 0.0, bracket = GiftBracket.EPIC)
+    )
+
+    private val singleResult = GachaResult(
+        gifts = listOf(GachaGift(giftId = "g1", giftName = "Rose", bracket = GiftBracket.COMMON)),
+        coinsSpent = 10,
+        newBalance = 90,
+        newPityCounter = 1,
+        newLuckScore = 0
+    )
+
+    private val multiResult = GachaResult(
+        gifts = listOf(
+            GachaGift(giftId = "g1", giftName = "Rose", bracket = GiftBracket.COMMON),
+            GachaGift(giftId = "g2", giftName = "Crown", bracket = GiftBracket.RARE),
+            GachaGift(giftId = "g1", giftName = "Rose", bracket = GiftBracket.COMMON),
+            GachaGift(giftId = "g1", giftName = "Rose", bracket = GiftBracket.COMMON),
+            GachaGift(giftId = "g1", giftName = "Rose", bracket = GiftBracket.COMMON),
+            GachaGift(giftId = "g1", giftName = "Rose", bracket = GiftBracket.COMMON),
+            GachaGift(giftId = "g1", giftName = "Rose", bracket = GiftBracket.COMMON),
+            GachaGift(giftId = "g1", giftName = "Rose", bracket = GiftBracket.COMMON),
+            GachaGift(giftId = "g1", giftName = "Rose", bracket = GiftBracket.COMMON),
+            GachaGift(giftId = "g1", giftName = "Rose", bracket = GiftBracket.COMMON)
+        ),
+        coinsSpent = 100,
+        newBalance = 900,
+        newPityCounter = 10,
+        newLuckScore = 0
+    )
+
+    @Before
+    fun setup() {
+        every { giftRepository.observeGiftCatalog() } returns giftsFlow
+    }
+
+    private fun createViewModel(): GachaViewModel {
+        return GachaViewModel(economyRepository, giftRepository)
+    }
+
+    @Test
+    fun `winnableGifts filters out zero drop rate`() = runTest {
+        val vm = createViewModel()
+        giftsFlow.emit(sampleGifts)
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertEquals(2, state.winnableGifts.size)
+        assertTrue(state.winnableGifts.all { it.baseDropRate > 0 })
+        assertEquals(3, state.giftCatalog.size)
+    }
+
+    @Test
+    fun `single pull sets currentWin`() = runTest {
+        coEvery { economyRepository.pullGacha(1) } returns Resource.Success(singleResult)
+
+        val vm = createViewModel()
+        vm.updateBalance(100, 0, 0)
+        vm.pullSingle()
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertNotNull(state.currentWin)
+        assertEquals("g1", state.currentWin?.giftId)
+        assertFalse(state.isMultiSpin)
+        assertFalse(state.showResults)
+        assertEquals(90L, state.coinBalance)
+    }
+
+    @Test
+    fun `multi pull sets isMultiSpin and multiSpinResults`() = runTest {
+        coEvery { economyRepository.pullGacha(10) } returns Resource.Success(multiResult)
+
+        val vm = createViewModel()
+        vm.updateBalance(1000, 0, 0)
+        vm.pullTen()
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state.isMultiSpin)
+        assertEquals(10, state.multiSpinResults.size)
+        assertEquals(0, state.multiSpinIndex)
+        assertTrue(state.showResults)
+        assertEquals(900L, state.coinBalance)
+    }
+
+    @Test
+    fun `advanceMultiSpin increments index`() = runTest {
+        coEvery { economyRepository.pullGacha(10) } returns Resource.Success(multiResult)
+
+        val vm = createViewModel()
+        vm.updateBalance(1000, 0, 0)
+        vm.pullTen()
+        advanceUntilIdle()
+
+        vm.advanceMultiSpin()
+        assertEquals(1, vm.uiState.value.multiSpinIndex)
+        vm.advanceMultiSpin()
+        assertEquals(2, vm.uiState.value.multiSpinIndex)
+    }
+
+    @Test
+    fun `skipMultiSpin jumps to end`() = runTest {
+        coEvery { economyRepository.pullGacha(10) } returns Resource.Success(multiResult)
+
+        val vm = createViewModel()
+        vm.updateBalance(1000, 0, 0)
+        vm.pullTen()
+        advanceUntilIdle()
+
+        vm.skipMultiSpin()
+
+        val state = vm.uiState.value
+        assertEquals(10, state.multiSpinIndex)
+        assertTrue(state.showResults)
+    }
+
+    @Test
+    fun `dismissResults resets all spin state`() = runTest {
+        coEvery { economyRepository.pullGacha(1) } returns Resource.Success(singleResult)
+
+        val vm = createViewModel()
+        vm.updateBalance(100, 0, 0)
+        vm.pullSingle()
+        advanceUntilIdle()
+
+        vm.dismissResults()
+
+        val state = vm.uiState.value
+        assertNull(state.currentWin)
+        assertFalse(state.isMultiSpin)
+        assertTrue(state.multiSpinResults.isEmpty())
+        assertEquals(0, state.multiSpinIndex)
+        assertFalse(state.showResults)
+        assertTrue(state.pullResults.isEmpty())
+    }
+
+    @Test
+    fun `pull fails with insufficient coins`() = runTest {
+        val vm = createViewModel()
+        vm.updateBalance(5, 0, 0)
+        vm.pullSingle()
+        advanceUntilIdle()
+
+        assertEquals("Not enough coins", vm.uiState.value.error)
+        assertNull(vm.uiState.value.currentWin)
+    }
+
+    @Test
+    fun `pull error from server sets error state`() = runTest {
+        coEvery { economyRepository.pullGacha(1) } returns Resource.Error("Server error")
+
+        val vm = createViewModel()
+        vm.updateBalance(100, 0, 0)
+        vm.pullSingle()
+        advanceUntilIdle()
+
+        assertEquals("Server error", vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isPulling)
+    }
+
+    @Test
+    fun `hundred pull requires 1000 coins`() = runTest {
+        val vm = createViewModel()
+        vm.updateBalance(999, 0, 0)
+        vm.pullHundred()
+        advanceUntilIdle()
+
+        assertEquals("Not enough coins", vm.uiState.value.error)
+    }
+
+    @Test
+    fun `clearError clears error`() = runTest {
+        val vm = createViewModel()
+        vm.updateBalance(5, 0, 0)
+        vm.pullSingle()
+        advanceUntilIdle()
+
+        assertNotNull(vm.uiState.value.error)
+        vm.clearError()
+        assertNull(vm.uiState.value.error)
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/feature/gacha/SpinWheelSegmentTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/gacha/SpinWheelSegmentTest.kt
@@ -1,0 +1,104 @@
+package com.shyden.shytalk.feature.gacha
+
+import com.shyden.shytalk.core.model.Gift
+import com.shyden.shytalk.core.model.GiftBracket
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpinWheelSegmentTest {
+
+    private val testGifts = listOf(
+        Gift(id = "c1", name = "Rose", baseDropRate = 20.0, bracket = GiftBracket.COMMON, order = 1),
+        Gift(id = "c2", name = "Heart", baseDropRate = 20.0, bracket = GiftBracket.COMMON, order = 2),
+        Gift(id = "u1", name = "Gift Box", baseDropRate = 15.0, bracket = GiftBracket.UNCOMMON, order = 3),
+        Gift(id = "u2", name = "Potion", baseDropRate = 15.0, bracket = GiftBracket.UNCOMMON, order = 4),
+        Gift(id = "r1", name = "Crown", baseDropRate = 10.0, bracket = GiftBracket.RARE, order = 5),
+        Gift(id = "r2", name = "Treasure", baseDropRate = 10.0, bracket = GiftBracket.RARE, order = 6),
+        Gift(id = "e1", name = "Mystery", baseDropRate = 5.0, bracket = GiftBracket.EPIC, order = 7),
+        Gift(id = "l1", name = "Jackpot", baseDropRate = 5.0, bracket = GiftBracket.LEGENDARY, order = 8)
+    )
+
+    @Test
+    fun `buildRingLayout puts COMMON and UNCOMMON in outer ring`() {
+        val (outer, _) = buildRingLayout(testGifts)
+        assertTrue(outer.all { it.bracket == GiftBracket.COMMON || it.bracket == GiftBracket.UNCOMMON })
+        assertEquals(4, outer.size)
+    }
+
+    @Test
+    fun `buildRingLayout puts RARE EPIC LEGENDARY in inner ring`() {
+        val (_, inner) = buildRingLayout(testGifts)
+        assertTrue(inner.all {
+            it.bracket == GiftBracket.RARE || it.bracket == GiftBracket.EPIC || it.bracket == GiftBracket.LEGENDARY
+        })
+        assertEquals(4, inner.size)
+    }
+
+    @Test
+    fun `buildRingLayout sorts by order field`() {
+        val shuffled = testGifts.shuffled()
+        val (outer, inner) = buildRingLayout(shuffled)
+        assertEquals(listOf(1, 2, 3, 4), outer.map { it.order })
+        assertEquals(listOf(5, 6, 7, 8), inner.map { it.order })
+    }
+
+    @Test
+    fun `buildRingLayout returns empty lists for empty input`() {
+        val (outer, inner) = buildRingLayout(emptyList())
+        assertTrue(outer.isEmpty())
+        assertTrue(inner.isEmpty())
+    }
+
+    @Test
+    fun `buildRingLayout handles only COMMON gifts`() {
+        val commonOnly = testGifts.filter { it.bracket == GiftBracket.COMMON }
+        val (outer, inner) = buildRingLayout(commonOnly)
+        assertEquals(2, outer.size)
+        assertTrue(inner.isEmpty())
+    }
+
+    @Test
+    fun `buildRingLayout handles only RARE gifts`() {
+        val rareOnly = testGifts.filter { it.bracket == GiftBracket.RARE }
+        val (outer, inner) = buildRingLayout(rareOnly)
+        assertTrue(outer.isEmpty())
+        assertEquals(2, inner.size)
+    }
+
+    @Test
+    fun `resolveWinPosition finds gift in outer ring`() {
+        val (outer, inner) = buildRingLayout(testGifts)
+        val result = resolveWinPosition("c1", outer, inner)
+        assertNotNull(result)
+        assertEquals(Ring.OUTER, result!!.first)
+        assertEquals(0, result.second) // first in sorted outer list
+    }
+
+    @Test
+    fun `resolveWinPosition finds gift in inner ring`() {
+        val (outer, inner) = buildRingLayout(testGifts)
+        val result = resolveWinPosition("r1", outer, inner)
+        assertNotNull(result)
+        assertEquals(Ring.INNER, result!!.first)
+        assertEquals(0, result.second) // first in sorted inner list
+    }
+
+    @Test
+    fun `resolveWinPosition returns null for unknown ID`() {
+        val (outer, inner) = buildRingLayout(testGifts)
+        val result = resolveWinPosition("nonexistent", outer, inner)
+        assertNull(result)
+    }
+
+    @Test
+    fun `resolveWinPosition returns correct index for later gift`() {
+        val (outer, inner) = buildRingLayout(testGifts)
+        val result = resolveWinPosition("l1", outer, inner)
+        assertNotNull(result)
+        assertEquals(Ring.INNER, result!!.first)
+        assertEquals(3, result.second) // 4th item in inner (r1, r2, e1, l1)
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/feature/messaging/PrivateChatViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/messaging/PrivateChatViewModelTest.kt
@@ -34,6 +34,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -58,7 +59,14 @@ class PrivateChatViewModelTest {
 
     private val messagesFlow = MutableSharedFlow<List<PrivateMessage>>()
     private val settingsFlow = MutableSharedFlow<ConversationSettings>()
+    private val activeViewModels = mutableListOf<PrivateChatViewModel>()
     private val typingFlow = MutableSharedFlow<Boolean>()
+
+    @After
+    fun tearDown() {
+        activeViewModels.forEach { it.viewModelScope.cancel() }
+        activeViewModels.clear()
+    }
 
     @Before
     fun setup() {
@@ -94,7 +102,7 @@ class PrivateChatViewModelTest {
             typingRepository = typingRepository,
             reportRepository = reportRepository,
             storageRepository = storageRepository
-        )
+        ).also { activeViewModels.add(it) }
     }
 
     // ===== Init =====

--- a/app/src/test/java/com/shyden/shytalk/feature/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/profile/ProfileViewModelTest.kt
@@ -4,6 +4,7 @@ import com.shyden.shytalk.core.model.ChatRoom
 import com.shyden.shytalk.core.model.RoomState
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.data.repository.AuthRepository
+import com.shyden.shytalk.data.repository.EconomyRepository
 import com.shyden.shytalk.data.repository.ReportRepository
 import com.shyden.shytalk.data.repository.RoomRepository
 import com.shyden.shytalk.data.repository.StorageRepository
@@ -39,6 +40,7 @@ class ProfileViewModelTest {
     private val storageRepository = mockk<StorageRepository>(relaxed = true)
     private val roomRepository = mockk<RoomRepository>(relaxed = true)
     private val reportRepository = mockk<ReportRepository>(relaxed = true)
+    private val economyRepository = mockk<EconomyRepository>(relaxed = true)
 
     private val currentUserId = "current-user"
     private val otherUserId = "other-user"
@@ -56,7 +58,8 @@ class ProfileViewModelTest {
             userRepository = userRepository,
             storageRepository = storageRepository,
             roomRepository = roomRepository,
-            reportRepository = reportRepository
+            reportRepository = reportRepository,
+            economyRepository = economyRepository
         )
     }
 

--- a/firebase.json
+++ b/firebase.json
@@ -10,6 +10,7 @@
     }
   ],
   "firestore": {
+    "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
   "database": {

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,113 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // Users
+    match /users/{uid} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null && request.auth.uid == uid;
+
+      // Backpack — read own, write only via Cloud Functions
+      match /backpack/{giftId} {
+        allow read: if request.auth != null && request.auth.uid == uid;
+        allow write: if false;
+      }
+
+      // Gift Wall — auth read, write only via Cloud Functions
+      match /giftWall/{giftId} {
+        allow read: if request.auth != null;
+        allow write: if false;
+      }
+
+      // Transactions — owner read only, write only via Cloud Functions
+      match /transactions/{txId} {
+        allow read: if request.auth != null && request.auth.uid == uid;
+        allow write: if false;
+      }
+    }
+
+    // Rooms
+    match /rooms/{roomId} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null;
+    }
+
+    // Conversations
+    match /conversations/{conversationId} {
+      allow read: if request.auth != null
+                  && request.auth.uid in resource.data.participantIds;
+      allow create: if request.auth != null;
+      allow update: if request.auth != null
+                    && request.auth.uid in resource.data.participantIds;
+
+      match /messages/{messageId} {
+        allow read: if request.auth != null;
+        allow write: if request.auth != null;
+      }
+      match /settings/{userId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+      match /mod_log/{logId} {
+        allow read: if request.auth != null;
+        allow create: if request.auth != null;
+      }
+    }
+
+    // Gift catalog — auth read, admin write only
+    match /gifts/{giftId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+
+    // Gift rankings — auth read, server write only
+    match /giftRankings/{giftId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+
+    // Broadcasts — auth read, server write only
+    match /broadcasts/{broadcastId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+
+    // Coin packages — auth read, admin write only
+    match /coinPackages/{packageId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+
+    // Reports
+    match /reports/{reportId} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null;
+      allow update: if false;
+    }
+
+    // Suspension appeals
+    match /suspensionAppeals/{appealId} {
+      allow read: if request.auth != null && request.auth.uid == resource.data.userId;
+      allow create: if request.auth != null;
+    }
+
+    // Seat requests
+    match /seatRequests/{requestId} {
+      allow read, write: if request.auth != null;
+    }
+
+    // Admin tokens
+    match /admin_tokens/{tokenId} {
+      allow read, write: if false;
+    }
+
+    // Admin audit log
+    match /admin_audit_log/{logId} {
+      allow read, write: if false;
+    }
+
+    // Report locks
+    match /report_locks/{lockId} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/functions/admin.js
+++ b/functions/admin.js
@@ -57,6 +57,16 @@ const FIELD_SCHEMA = {
   suspensionEndDate:     { type: "timestamp", nullable: true },
   suspensionCanAppeal:   { type: "boolean" },
   suspendedBy:           { type: "string", nullable: true },
+  shyCoins:              { type: "number" },
+  shyBeans:              { type: "number" },
+  isSuperShy:            { type: "boolean" },
+  superShyExpiry:        { type: "timestamp", nullable: true },
+  superShyTier:          { type: "string", nullable: true },
+  luckScore:             { type: "number" },
+  pityCounter:           { type: "number" },
+  loginStreak:           { type: "number" },
+  lastLoginDate:         { type: "string", nullable: true },
+  lastLoginRewardDate:   { type: "string", nullable: true },
 };
 
 function validateAndConvert(field, value) {
@@ -364,13 +374,14 @@ app.post("/api/user/:uid/unsuspend", async (req, res) => {
 // --- GET /api/appeals ---
 app.get("/api/appeals", async (req, res) => {
   try {
+    const db = getFirestore();
     const status = req.query.status || "pending";
     if (!["pending", "approved", "rejected"].includes(status)) {
       return res.status(400).json({ error: "status must be pending, approved, or rejected" });
     }
 
     // Single-field query avoids composite index requirement
-    const snapshot = await getFirestore().collection("suspensionAppeals")
+    const snapshot = await db.collection("suspensionAppeals")
       .where("status", "==", status)
       .limit(50)
       .get();
@@ -1756,6 +1767,348 @@ app.post("/api/cleanup/orphaned-storage", async (req, res) => {
   } catch (err) {
     console.error("POST /api/cleanup/orphaned-storage error:", err);
     return res.status(500).json({ error: err.message });
+  }
+});
+
+// ─── Gift Catalog ─────────────────────────────────────────────
+
+// GET /api/gifts — List all gifts in the catalog
+app.get("/api/gifts", async (req, res) => {
+  try {
+    const db = getFirestore();
+    const snap = await db.collection("gifts").orderBy("order").get();
+    const gifts = snap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    return res.json({ gifts });
+  } catch (err) {
+    console.error("GET gifts error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// POST /api/gifts/seed — Seed the 27-gift catalog (idempotent)
+app.post("/api/gifts/seed", async (req, res) => {
+  try {
+    const db = getFirestore();
+    const catalog = [
+      { name: "Rose", coinValue: 8, baseDropRate: 0.70, bracket: "COMMON", order: 1 },
+      { name: "Heart", coinValue: 10, baseDropRate: 0.70, bracket: "COMMON", order: 2 },
+      { name: "Thumbs Up", coinValue: 12, baseDropRate: 0.70, bracket: "COMMON", order: 3 },
+      { name: "Star", coinValue: 15, baseDropRate: 0.70, bracket: "COMMON", order: 4 },
+      { name: "Smiley", coinValue: 18, baseDropRate: 0.70, bracket: "COMMON", order: 5 },
+      { name: "Coffee", coinValue: 20, baseDropRate: 0.70, bracket: "COMMON", order: 6 },
+      { name: "Candy", coinValue: 25, baseDropRate: 0.70, bracket: "COMMON", order: 7 },
+      { name: "Balloon", coinValue: 30, baseDropRate: 0.70, bracket: "COMMON", order: 8 },
+      { name: "Teddy Bear", coinValue: 50, baseDropRate: 0.20, bracket: "UNCOMMON", order: 9 },
+      { name: "Perfume", coinValue: 80, baseDropRate: 0.20, bracket: "UNCOMMON", order: 10 },
+      { name: "Diamond Ring", coinValue: 120, baseDropRate: 0.20, bracket: "UNCOMMON", order: 11 },
+      { name: "Bouquet", coinValue: 150, baseDropRate: 0.20, bracket: "UNCOMMON", order: 12 },
+      { name: "Fireworks", coinValue: 200, baseDropRate: 0.20, bracket: "UNCOMMON", order: 13 },
+      { name: "Music Box", coinValue: 300, baseDropRate: 0.20, bracket: "UNCOMMON", order: 14 },
+      { name: "Treasure Chest", coinValue: 500, baseDropRate: 0.08, bracket: "RARE", order: 15 },
+      { name: "Crown", coinValue: 800, baseDropRate: 0.08, bracket: "RARE", order: 16 },
+      { name: "Sports Car", coinValue: 1200, baseDropRate: 0.08, bracket: "RARE", order: 17 },
+      { name: "Yacht", coinValue: 1800, baseDropRate: 0.08, bracket: "RARE", order: 18 },
+      { name: "Dragon", coinValue: 2500, baseDropRate: 0.08, bracket: "RARE", order: 19 },
+      { name: "Phoenix", coinValue: 3500, baseDropRate: 0.08, bracket: "RARE", order: 20 },
+      { name: "Crystal Ball", coinValue: 5000, baseDropRate: 0.018, bracket: "EPIC", order: 21 },
+      { name: "Castle", coinValue: 8000, baseDropRate: 0.018, bracket: "EPIC", order: 22 },
+      { name: "Spaceship", coinValue: 12000, baseDropRate: 0.018, bracket: "EPIC", order: 23 },
+      { name: "Aurora", coinValue: 16000, baseDropRate: 0.018, bracket: "EPIC", order: 24 },
+      { name: "Galaxy Unicorn", coinValue: 20000, baseDropRate: 0.018, bracket: "EPIC", order: 25 },
+      { name: "ShyTalk Emblem", coinValue: 35000, baseDropRate: 0.002, bracket: "LEGENDARY", order: 26 },
+      { name: "Celestial Throne", coinValue: 52000, baseDropRate: 0.002, bracket: "LEGENDARY", order: 27 },
+    ];
+
+    const batch = db.batch();
+    for (const gift of catalog) {
+      const docId = gift.name.toLowerCase().replace(/\s+/g, "_");
+      const ref = db.collection("gifts").doc(docId);
+      batch.set(ref, {
+        ...gift,
+        beanValue: Math.floor(gift.coinValue * 0.6),
+        broadcastEnabled: gift.bracket === "LEGENDARY",
+        animationUrl: "",
+        soundUrl: "",
+        iconUrl: "",
+      }, { merge: true });
+    }
+    await batch.commit();
+
+    await writeAuditLog(db, {
+      adminUid: req.admin.uid,
+      action: "seed_gifts",
+      note: `Seeded ${catalog.length} gifts`,
+    });
+
+    return res.json({ success: true, count: catalog.length });
+  } catch (err) {
+    console.error("POST gifts/seed error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// ─── Economy Admin Endpoints ───────────────────────────────────
+
+// GET /api/users/:uid/economy — Full economy snapshot
+app.get("/api/users/:uid/economy", async (req, res) => {
+  try {
+    const db = getFirestore();
+    const userDoc = await db.collection("users").doc(req.params.uid).get();
+    if (!userDoc.exists) return res.status(404).json({ error: "User not found" });
+    const u = userDoc.data();
+
+    return res.json({
+      shyCoins: u.shyCoins || 0,
+      shyBeans: u.shyBeans || 0,
+      isSuperShy: u.isSuperShy || false,
+      superShyExpiry: u.superShyExpiry?.toDate?.()?.toISOString() || null,
+      superShyTier: u.superShyTier || null,
+      luckScore: u.luckScore || 0,
+      pityCounter: u.pityCounter || 0,
+      loginStreak: u.loginStreak || 0,
+      lastLoginDate: u.lastLoginDate || null,
+      lastLoginRewardDate: u.lastLoginRewardDate || null,
+    });
+  } catch (err) {
+    console.error("GET economy error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// GET /api/users/:uid/backpack — List user's backpack items (enriched with gift catalog info)
+app.get("/api/users/:uid/backpack", async (req, res) => {
+  try {
+    const db = getFirestore();
+    const [bpSnap, giftSnap] = await Promise.all([
+      db.collection("users").doc(req.params.uid).collection("backpack").get(),
+      db.collection("gifts").get(),
+    ]);
+    const giftMap = {};
+    giftSnap.docs.forEach((doc) => { giftMap[doc.id] = doc.data(); });
+
+    const items = bpSnap.docs.map((doc) => {
+      const gift = giftMap[doc.id] || {};
+      return {
+        giftId: doc.id,
+        ...doc.data(),
+        giftName: gift.name || doc.id,
+        bracket: gift.bracket || "",
+        coinValue: gift.coinValue || 0,
+        lastAcquired: doc.data().lastAcquired?.toDate?.()?.toISOString() || null,
+      };
+    });
+    return res.json({ items });
+  } catch (err) {
+    console.error("GET backpack error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// POST /api/users/:uid/backpack — Set gift quantity (0 = remove), with transaction audit
+app.post("/api/users/:uid/backpack", async (req, res) => {
+  try {
+    const { giftId, quantity } = req.body;
+    if (!giftId || typeof quantity !== "number") {
+      return res.status(400).json({ error: "giftId and quantity required" });
+    }
+
+    const db = getFirestore();
+    const userRef = db.collection("users").doc(req.params.uid);
+    const bpRef = userRef.collection("backpack").doc(giftId);
+
+    // Get current quantity for audit delta
+    const bpDoc = await bpRef.get();
+    const previousQty = bpDoc.exists ? (bpDoc.data().quantity || 0) : 0;
+    const delta = quantity - previousQty;
+
+    const batch = db.batch();
+
+    if (quantity <= 0) {
+      batch.delete(bpRef);
+    } else {
+      batch.set(bpRef, { quantity, lastAcquired: Timestamp.now() }, { merge: true });
+    }
+
+    // Write transaction record for audit
+    const action = quantity <= 0 ? "removed" : (delta > 0 ? "added" : "set");
+    const txRef = userRef.collection("transactions").doc();
+    batch.set(txRef, {
+      type: "ADMIN_BACKPACK",
+      amount: Math.abs(delta),
+      currency: "COINS",
+      balanceAfter: 0,
+      giftId,
+      details: `Admin ${action} backpack item ${giftId}: ${previousQty} -> ${Math.max(0, quantity)} (by ShyTalk Official)`,
+      timestamp: Timestamp.now(),
+    });
+
+    await batch.commit();
+
+    await writeAuditLog(db, {
+      adminUid: req.admin.uid,
+      action: "edit_backpack",
+      targetUserId: req.params.uid,
+      note: `${action} ${giftId}: ${previousQty} -> ${Math.max(0, quantity)}`,
+    });
+
+    return res.json({ success: true });
+  } catch (err) {
+    console.error("POST backpack error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// GET /api/users/:uid/luck — Get luck score + pity counter
+app.get("/api/users/:uid/luck", async (req, res) => {
+  try {
+    const db = getFirestore();
+    const userDoc = await db.collection("users").doc(req.params.uid).get();
+    if (!userDoc.exists) return res.status(404).json({ error: "User not found" });
+    const u = userDoc.data();
+    return res.json({
+      luckScore: u.luckScore || 0,
+      pityCounter: u.pityCounter || 0,
+    });
+  } catch (err) {
+    console.error("GET luck error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// POST /api/users/:uid/adjust-balance — Add/deduct coins or beans with audit
+app.post("/api/users/:uid/adjust-balance", async (req, res) => {
+  try {
+    const { currency, amount, operation } = req.body;
+    if (!["COINS", "BEANS"].includes(currency)) {
+      return res.status(400).json({ error: "currency must be COINS or BEANS" });
+    }
+    if (typeof amount !== "number" || amount <= 0) {
+      return res.status(400).json({ error: "amount must be a positive number" });
+    }
+    if (!["add", "deduct"].includes(operation)) {
+      return res.status(400).json({ error: "operation must be add or deduct" });
+    }
+
+    const db = getFirestore();
+    const userRef = db.collection("users").doc(req.params.uid);
+    const userDoc = await userRef.get();
+    if (!userDoc.exists) return res.status(404).json({ error: "User not found" });
+
+    const userData = userDoc.data();
+    const field = currency === "COINS" ? "shyCoins" : "shyBeans";
+    const currentBalance = userData[field] || 0;
+    const delta = operation === "deduct" ? -amount : amount;
+    const newBalance = Math.max(0, currentBalance + delta);
+
+    const batch = db.batch();
+
+    // Update balance
+    batch.update(userRef, { [field]: newBalance });
+
+    // Write transaction record
+    const txRef = userRef.collection("transactions").doc();
+    batch.set(txRef, {
+      type: "ADMIN_ADJUSTMENT",
+      amount: delta,
+      currency,
+      balanceAfter: newBalance,
+      details: `Admin ${operation} ${amount} ${currency.toLowerCase()} (by ShyTalk Official)`,
+      timestamp: Timestamp.now(),
+    });
+
+    await batch.commit();
+
+    await writeAuditLog(db, {
+      adminUid: req.admin.uid,
+      action: "adjust_balance",
+      targetUserId: req.params.uid,
+      note: `${operation} ${amount} ${currency.toLowerCase()} (${currentBalance} -> ${newBalance})`,
+    });
+
+    return res.json({ success: true, newBalance });
+  } catch (err) {
+    console.error("POST adjust-balance error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// POST /api/users/:uid/luck — Update luck score / pity counter
+app.post("/api/users/:uid/luck", async (req, res) => {
+  try {
+    const { luckScore, pityCounter } = req.body;
+    const updates = {};
+
+    if (typeof luckScore === "number") {
+      if (luckScore < 0 || luckScore > 100) {
+        return res.status(400).json({ error: "luckScore must be 0-100" });
+      }
+      updates.luckScore = luckScore;
+    }
+    if (typeof pityCounter === "number") {
+      if (pityCounter < 0 || pityCounter > 80) {
+        return res.status(400).json({ error: "pityCounter must be 0-80" });
+      }
+      updates.pityCounter = pityCounter;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({ error: "Provide luckScore and/or pityCounter" });
+    }
+
+    const db = getFirestore();
+    const userRef = db.collection("users").doc(req.params.uid);
+    const userDoc = await userRef.get();
+    if (!userDoc.exists) return res.status(404).json({ error: "User not found" });
+
+    await userRef.update(updates);
+
+    await writeAuditLog(db, {
+      adminUid: req.admin.uid,
+      action: "edit_luck",
+      targetUserId: req.params.uid,
+      note: JSON.stringify(updates),
+    });
+
+    return res.json({ success: true, ...updates });
+  } catch (err) {
+    console.error("POST luck error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// GET /api/users/:uid/transactions — Paginated transaction audit
+app.get("/api/users/:uid/transactions", async (req, res) => {
+  try {
+    const db = getFirestore();
+    const limit = Math.min(Number(req.query.limit) || 50, 200);
+    const typeFilter = req.query.type || null;
+
+    let query = db.collection("users").doc(req.params.uid)
+      .collection("transactions")
+      .orderBy("timestamp", "desc")
+      .limit(limit);
+
+    if (typeFilter) {
+      query = db.collection("users").doc(req.params.uid)
+        .collection("transactions")
+        .where("type", "==", typeFilter)
+        .orderBy("timestamp", "desc")
+        .limit(limit);
+    }
+
+    const snap = await query.get();
+    const transactions = snap.docs.map((doc) => {
+      const data = doc.data();
+      if (data.timestamp && typeof data.timestamp.toDate === "function") {
+        data.timestamp = data.timestamp.toDate().toISOString();
+      }
+      return { id: doc.id, ...data };
+    });
+
+    return res.json({ transactions });
+  } catch (err) {
+    console.error("GET transactions error:", err);
+    return res.status(500).json({ error: "Internal server error" });
   }
 });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -824,6 +824,633 @@ exports.onModAction = onDocumentCreated(
   }
 );
 
+// ─── Monetization ───────────────────────────────────────────────
+
+const DAILY_BASE = 50;
+const MILESTONE_REWARDS = {
+  7: 100, 14: 200, 30: 500, 60: 1000, 90: 2000
+};
+function getDailyReward(day) {
+  return MILESTONE_REWARDS[day] || DAILY_BASE;
+}
+const MILESTONES = new Set([7, 14, 30, 60, 90]);
+const PULL_COSTS = { 1: 10, 10: 100, 100: 1000 };
+
+// Base drop rates: [Common, Uncommon, Rare, Epic, Legendary]
+const BASE_RATES = [0.70, 0.20, 0.08, 0.018, 0.002];
+const BRACKETS = ["COMMON", "UNCOMMON", "RARE", "EPIC", "LEGENDARY"];
+
+exports.claimDailyReward = onCall({ region: "asia-southeast1" }, async (request) => {
+  if (!request.auth) throw new HttpsError("unauthenticated", "Must be signed in");
+  const uid = request.auth.uid;
+  const db = getFirestore();
+  const userRef = db.collection("users").doc(uid);
+
+  return await db.runTransaction(async (tx) => {
+    const userDoc = await tx.get(userRef);
+    if (!userDoc.exists) throw new HttpsError("not-found", "User not found");
+    const user = userDoc.data();
+
+    const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
+    if (user.lastLoginRewardDate === today) {
+      throw new HttpsError("already-exists", "Already claimed today");
+    }
+
+    const yesterday = new Date(Date.now() - 86400000).toISOString().split("T")[0];
+    const lastDate = user.lastLoginDate || "";
+    const newStreak = (lastDate === yesterday) ? (user.loginStreak || 0) + 1 : 1;
+
+    let reward = getDailyReward(newStreak);
+    const isMilestone = MILESTONES.has(newStreak);
+
+    // Super Shy 10% bonus (rounded up)
+    if (user.isSuperShy) {
+      reward = Math.ceil(reward * 1.1);
+    }
+
+    const newBalance = (user.shyCoins || 0) + reward;
+
+    tx.update(userRef, {
+      shyCoins: newBalance,
+      loginStreak: newStreak,
+      lastLoginDate: today,
+      lastLoginRewardDate: today,
+    });
+
+    // Write transaction record
+    const txRef = userRef.collection("transactions").doc();
+    tx.set(txRef, {
+      type: "DAILY_REWARD",
+      amount: reward,
+      currency: "COINS",
+      balanceAfter: newBalance,
+      details: `Day ${newStreak}${isMilestone ? " (milestone)" : ""}`,
+      timestamp: FieldValue.serverTimestamp(),
+    });
+
+    return { coinsAwarded: reward, newStreak, isMilestone, newBalance };
+  });
+});
+
+exports.pullGacha = onCall({ region: "asia-southeast1" }, async (request) => {
+  if (!request.auth) throw new HttpsError("unauthenticated", "Must be signed in");
+  const uid = request.auth.uid;
+  const pullCount = request.data.pullCount;
+
+  if (![1, 10, 100].includes(pullCount)) {
+    throw new HttpsError("invalid-argument", "pullCount must be 1, 10, or 100");
+  }
+
+  const cost = PULL_COSTS[pullCount];
+  const db = getFirestore();
+  const userRef = db.collection("users").doc(uid);
+
+  // Load gift catalog
+  const giftsSnap = await db.collection("gifts").orderBy("order").get();
+  if (giftsSnap.empty) throw new HttpsError("failed-precondition", "Gift catalog not configured");
+
+  const giftsByBracket = {};
+  for (const b of BRACKETS) giftsByBracket[b] = [];
+  giftsSnap.docs.forEach((doc) => {
+    const g = { id: doc.id, ...doc.data() };
+    if (giftsByBracket[g.bracket]) giftsByBracket[g.bracket].push(g);
+  });
+
+  return await db.runTransaction(async (tx) => {
+    const userDoc = await tx.get(userRef);
+    if (!userDoc.exists) throw new HttpsError("not-found", "User not found");
+    const user = userDoc.data();
+
+    if ((user.shyCoins || 0) < cost) {
+      throw new HttpsError("failed-precondition", "Insufficient coins");
+    }
+
+    let pity = user.pityCounter || 0;
+    let luck = user.luckScore || 0;
+    const results = [];
+
+    for (let i = 0; i < pullCount; i++) {
+      // Calculate effective rates
+      const rates = [...BASE_RATES];
+
+      // Pity system
+      if (pity >= 80) {
+        // Hard pity: force Epic+
+        rates[0] = 0; rates[1] = 0; rates[2] = 0;
+        const epicLeg = BASE_RATES[3] + BASE_RATES[4];
+        rates[3] = BASE_RATES[3] / epicLeg;
+        rates[4] = BASE_RATES[4] / epicLeg;
+      } else if (pity >= 60) {
+        const pityBoost = (pity - 60) / 20; // 0→1 linear
+        const shift = 0.15 * pityBoost;
+        rates[0] -= shift;
+        rates[3] += shift;
+      }
+
+      // Luck boost (up to 5%)
+      const luckBoost = (luck / 100) * 0.05;
+      if (luckBoost > 0 && rates[0] > luckBoost) {
+        rates[0] -= luckBoost;
+        // Distribute proportionally across higher brackets
+        const higherTotal = rates[1] + rates[2] + rates[3] + rates[4];
+        if (higherTotal > 0) {
+          for (let b = 1; b < 5; b++) {
+            rates[b] += luckBoost * (rates[b] / higherTotal);
+          }
+        }
+      }
+
+      // Normalize rates
+      const total = rates.reduce((s, r) => s + r, 0);
+      for (let b = 0; b < 5; b++) rates[b] /= total;
+
+      // Roll
+      const roll = Math.random();
+      let cumulative = 0;
+      let bracketIndex = 0;
+      for (let b = 0; b < 5; b++) {
+        cumulative += rates[b];
+        if (roll <= cumulative) { bracketIndex = b; break; }
+      }
+
+      const bracket = BRACKETS[bracketIndex];
+      const gifts = giftsByBracket[bracket];
+      if (!gifts || gifts.length === 0) {
+        // Fallback to common
+        const fallback = giftsByBracket["COMMON"];
+        const gift = fallback[Math.floor(Math.random() * fallback.length)];
+        results.push(gift);
+        pity++;
+        continue;
+      }
+
+      const gift = gifts[Math.floor(Math.random() * gifts.length)];
+      results.push(gift);
+
+      // Reset pity on Epic+
+      if (bracketIndex >= 3) {
+        pity = 0;
+      } else {
+        pity++;
+      }
+    }
+
+    // 100-pull luck bonus
+    if (pullCount === 100) {
+      luck = Math.min(100, luck + 2);
+    }
+
+    const newBalance = (user.shyCoins || 0) - cost;
+
+    // Update user
+    tx.update(userRef, {
+      shyCoins: newBalance,
+      pityCounter: pity,
+      luckScore: luck,
+    });
+
+    // Add gifts to backpack
+    for (const gift of results) {
+      const bpRef = userRef.collection("backpack").doc(gift.id);
+      tx.set(bpRef, {
+        quantity: FieldValue.increment(1),
+        lastAcquired: FieldValue.serverTimestamp(),
+      }, { merge: true });
+    }
+
+    // Write transaction
+    const txRef = userRef.collection("transactions").doc();
+    tx.set(txRef, {
+      type: "GACHA_PULL",
+      amount: -cost,
+      currency: "COINS",
+      balanceAfter: newBalance,
+      pullCount,
+      details: results.map((g) => g.name).join(", "),
+      timestamp: FieldValue.serverTimestamp(),
+    });
+
+    return {
+      gifts: results.map((g) => ({
+        giftId: g.id,
+        giftName: g.name,
+        bracket: g.bracket,
+        coinValue: g.coinValue,
+        iconUrl: g.iconUrl || "",
+      })),
+      coinsSpent: cost,
+      newBalance,
+      newPityCounter: pity,
+      newLuckScore: luck,
+    };
+  });
+});
+
+exports.sendGift = onCall({ region: "asia-southeast1" }, async (request) => {
+  if (!request.auth) throw new HttpsError("unauthenticated", "Must be signed in");
+  const senderUid = request.auth.uid;
+  const { recipientId, giftId } = request.data;
+
+  if (!recipientId || !giftId) {
+    throw new HttpsError("invalid-argument", "recipientId and giftId required");
+  }
+  if (senderUid === recipientId) {
+    throw new HttpsError("invalid-argument", "Cannot send gift to yourself");
+  }
+
+  const db = getFirestore();
+  const senderRef = db.collection("users").doc(senderUid);
+  const recipientRef = db.collection("users").doc(recipientId);
+  const giftRef = db.collection("gifts").doc(giftId);
+
+  const giftDoc = await giftRef.get();
+  if (!giftDoc.exists) throw new HttpsError("not-found", "Gift not found");
+  const gift = giftDoc.data();
+
+  return await db.runTransaction(async (tx) => {
+    const bpRef = senderRef.collection("backpack").doc(giftId);
+    const bpDoc = await tx.get(bpRef);
+
+    if (!bpDoc.exists || (bpDoc.data().quantity || 0) < 1) {
+      throw new HttpsError("failed-precondition", "Gift not in backpack");
+    }
+
+    const senderDoc = await tx.get(senderRef);
+    const recipientDoc = await tx.get(recipientRef);
+    if (!recipientDoc.exists) throw new HttpsError("not-found", "Recipient not found");
+
+    const sender = senderDoc.data();
+    const recipient = recipientDoc.data();
+    const beanReward = Math.floor(gift.coinValue * 0.6);
+
+    // Decrement sender backpack
+    const newQty = (bpDoc.data().quantity || 0) - 1;
+    if (newQty <= 0) {
+      tx.delete(bpRef);
+    } else {
+      tx.update(bpRef, { quantity: newQty });
+    }
+
+    // Update recipient gift wall
+    const wallRef = recipientRef.collection("giftWall").doc(giftId);
+    tx.set(wallRef, {
+      receivedCount: FieldValue.increment(1),
+      [`senders.${senderUid}`]: FieldValue.increment(1),
+    }, { merge: true });
+
+    // Credit beans to recipient
+    tx.update(recipientRef, {
+      shyBeans: FieldValue.increment(beanReward),
+    });
+
+    // Transaction records
+    const senderTxRef = senderRef.collection("transactions").doc();
+    tx.set(senderTxRef, {
+      type: "GIFT_SENT",
+      amount: -1,
+      currency: "COINS",
+      balanceAfter: sender.shyCoins || 0,
+      giftId, giftName: gift.name,
+      recipientId,
+      timestamp: FieldValue.serverTimestamp(),
+    });
+
+    const recipientTxRef = recipientRef.collection("transactions").doc();
+    tx.set(recipientTxRef, {
+      type: "GIFT_RECEIVED",
+      amount: beanReward,
+      currency: "BEANS",
+      balanceAfter: (recipient.shyBeans || 0) + beanReward,
+      giftId, giftName: gift.name,
+      senderId: senderUid,
+      timestamp: FieldValue.serverTimestamp(),
+    });
+
+    return { success: true, beanReward, giftName: gift.name };
+  }).then(async (result) => {
+    // Broadcast if eligible (outside transaction)
+    if (gift.broadcastEnabled) {
+      const senderDoc = await senderRef.get();
+      const recipientDoc = await recipientRef.get();
+      const senderData = senderDoc.data();
+      const recipientData = recipientDoc.data();
+
+      const broadcastsRef = db.collection("broadcasts");
+      await broadcastsRef.add({
+        senderName: senderData.displayName || "",
+        senderPhotoUrl: senderData.profilePhotoUrl || null,
+        recipientName: recipientData.displayName || "",
+        giftName: gift.name,
+        giftIconUrl: gift.iconUrl || "",
+        giftCoinValue: gift.coinValue,
+        timestamp: FieldValue.serverTimestamp(),
+      });
+
+      // Keep only last 50 broadcasts
+      const oldBroadcasts = await broadcastsRef
+        .orderBy("timestamp", "desc")
+        .offset(50)
+        .get();
+      const batch = db.batch();
+      oldBroadcasts.docs.forEach((doc) => batch.delete(doc.ref));
+      if (!oldBroadcasts.empty) await batch.commit();
+    }
+
+    return result;
+  });
+});
+
+exports.redeemBeans = onCall({ region: "asia-southeast1" }, async (request) => {
+  if (!request.auth) throw new HttpsError("unauthenticated", "Must be signed in");
+  const uid = request.auth.uid;
+  const amount = request.data.amount;
+
+  if (!amount || typeof amount !== "number" || amount < 1) {
+    throw new HttpsError("invalid-argument", "amount must be a positive number");
+  }
+
+  const db = getFirestore();
+  const userRef = db.collection("users").doc(uid);
+
+  return await db.runTransaction(async (tx) => {
+    const userDoc = await tx.get(userRef);
+    if (!userDoc.exists) throw new HttpsError("not-found", "User not found");
+    const user = userDoc.data();
+
+    if ((user.shyBeans || 0) < amount) {
+      throw new HttpsError("failed-precondition", "Insufficient beans");
+    }
+
+    const coins = amount >= 2000 ? Math.floor(amount * 1.1) : amount;
+    const newBeans = (user.shyBeans || 0) - amount;
+    const newCoins = (user.shyCoins || 0) + coins;
+
+    tx.update(userRef, {
+      shyBeans: newBeans,
+      shyCoins: newCoins,
+    });
+
+    const txRef = userRef.collection("transactions").doc();
+    tx.set(txRef, {
+      type: "BEAN_REDEEM",
+      amount: coins,
+      currency: "COINS",
+      balanceAfter: newCoins,
+      details: `Redeemed ${amount} beans${amount >= 2000 ? " (10% bonus)" : ""}`,
+      timestamp: FieldValue.serverTimestamp(),
+    });
+
+    return { coinsReceived: coins, newCoinBalance: newCoins, newBeanBalance: newBeans };
+  });
+});
+
+exports.validatePurchase = onCall({ region: "asia-southeast1" }, async (request) => {
+  if (!request.auth) throw new HttpsError("unauthenticated", "Must be signed in");
+  const uid = request.auth.uid;
+  const { productId, purchaseToken, isSubscription } = request.data;
+
+  if (!productId || !purchaseToken) {
+    throw new HttpsError("invalid-argument", "productId and purchaseToken required");
+  }
+
+  const db = getFirestore();
+  const userRef = db.collection("users").doc(uid);
+
+  // TODO: Add Google Play Developer API verification of purchaseToken here
+  // For now, trust the client (acceptable during development/testing)
+
+  if (isSubscription) {
+    const tierMap = {
+      super_shy_monthly: { tier: "monthly", days: 30 },
+      super_shy_yearly: { tier: "yearly", days: 365 },
+      super_shy_lifetime: { tier: "lifetime", days: null },
+    };
+
+    const sub = tierMap[productId];
+    if (!sub) throw new HttpsError("invalid-argument", "Unknown subscription product");
+
+    const expiry = sub.days ? new Date(Date.now() + sub.days * 86400000) : null;
+
+    await userRef.update({
+      isSuperShy: true,
+      superShyExpiry: expiry ? require("firebase-admin/firestore").Timestamp.fromDate(expiry) : null,
+      superShyTier: sub.tier,
+    });
+
+    const txRef = userRef.collection("transactions").doc();
+    await txRef.set({
+      type: "SUBSCRIPTION",
+      amount: 0,
+      currency: "COINS",
+      balanceAfter: 0,
+      details: `Super Shy ${sub.tier}`,
+      timestamp: FieldValue.serverTimestamp(),
+    });
+
+    return { success: true, tier: sub.tier };
+  } else {
+    // Coin package
+    const packagesSnap = await db.collection("coinPackages")
+      .where("productId", "==", productId)
+      .limit(1)
+      .get();
+
+    if (packagesSnap.empty) throw new HttpsError("not-found", "Unknown coin package");
+
+    const pkg = packagesSnap.docs[0].data();
+    const totalCoins = (pkg.coins || 0) + (pkg.bonusCoins || 0);
+
+    return await db.runTransaction(async (tx) => {
+      const userDoc = await tx.get(userRef);
+      if (!userDoc.exists) throw new HttpsError("not-found", "User not found");
+      const user = userDoc.data();
+      const newBalance = (user.shyCoins || 0) + totalCoins;
+
+      tx.update(userRef, { shyCoins: newBalance });
+
+      const txDocRef = userRef.collection("transactions").doc();
+      tx.set(txDocRef, {
+        type: "PURCHASE",
+        amount: totalCoins,
+        currency: "COINS",
+        balanceAfter: newBalance,
+        details: `${pkg.coins} + ${pkg.bonusCoins} bonus coins`,
+        timestamp: FieldValue.serverTimestamp(),
+      });
+
+      return { success: true, coinsAdded: totalCoins, newBalance };
+    });
+  }
+});
+
+exports.checkSubscriptionStatus = onSchedule(
+  { schedule: "every day 00:00", region: "asia-southeast1", timeZone: "UTC" },
+  async () => {
+    const db = getFirestore();
+    const now = require("firebase-admin/firestore").Timestamp.now();
+
+    const expiredSnap = await db.collection("users")
+      .where("isSuperShy", "==", true)
+      .where("superShyExpiry", "<=", now)
+      .get();
+
+    let expired = 0;
+    for (const doc of expiredSnap.docs) {
+      const data = doc.data();
+      if (data.superShyTier === "lifetime") continue;
+      await doc.ref.update({
+        isSuperShy: false,
+        superShyExpiry: null,
+        superShyTier: null,
+      });
+      expired++;
+    }
+    console.log(`Expired ${expired} Super Shy subscriptions`);
+  }
+);
+
+exports.updateGiftRankings = onSchedule(
+  { schedule: "every 1 hours", region: "asia-southeast1", timeZone: "UTC", memory: "512MiB" },
+  async () => {
+    const db = getFirestore();
+    const giftsSnap = await db.collection("gifts").get();
+
+    for (const giftDoc of giftsSnap.docs) {
+      const giftId = giftDoc.id;
+
+      // Query all users who have this gift on their wall
+      const wallSnap = await db.collectionGroup("giftWall")
+        .where(require("firebase-admin/firestore").FieldPath.documentId(), "==", giftId)
+        .get();
+
+      // Not feasible with collectionGroup by doc ID directly, so we iterate all users
+      // Alternative approach: aggregate from giftWall subcollections
+      // For now, we'll use a simpler approach based on the data we have
+    }
+
+    // Simplified: scan users' giftWall for each gift
+    const usersSnap = await db.collection("users").select().get(); // Just get IDs
+
+    for (const giftDoc of giftsSnap.docs) {
+      const giftId = giftDoc.id;
+      const entries = [];
+      let totalSent = 0;
+
+      for (const userDoc of usersSnap.docs) {
+        const wallDoc = await db.collection("users").doc(userDoc.id)
+          .collection("giftWall").doc(giftId).get();
+        if (wallDoc.exists) {
+          const data = wallDoc.data();
+          const count = data.receivedCount || 0;
+          totalSent += count;
+          entries.push({ userId: userDoc.id, count });
+        }
+      }
+
+      entries.sort((a, b) => b.count - a.count);
+      const top100 = entries.slice(0, 100);
+
+      // Fetch display names for top 100
+      const rankings = [];
+      for (const entry of top100) {
+        const uDoc = await db.collection("users").doc(entry.userId).get();
+        const uData = uDoc.exists ? uDoc.data() : {};
+        rankings.push({
+          userId: entry.userId,
+          count: entry.count,
+          displayName: uData.displayName || "",
+          profilePhotoUrl: uData.profilePhotoUrl || null,
+        });
+      }
+
+      await db.collection("giftRankings").doc(giftId).set({
+        rankings,
+        totalSent,
+        lastUpdated: FieldValue.serverTimestamp(),
+      });
+    }
+
+    console.log("Gift rankings updated");
+  }
+);
+
+// --- Seed gift & coin package catalogs ---
+exports.seedCatalog = onCall({ region: "asia-southeast1" }, async (request) => {
+  if (!request.auth || request.auth.token.admin !== true) {
+    throw new HttpsError("permission-denied", "Admin access required");
+  }
+
+  const db = getFirestore();
+
+  const giftCatalog = [
+    { name: "Rose", coinValue: 8, baseDropRate: 0.70, bracket: "COMMON", order: 1 },
+    { name: "Heart", coinValue: 10, baseDropRate: 0.70, bracket: "COMMON", order: 2 },
+    { name: "Thumbs Up", coinValue: 12, baseDropRate: 0.70, bracket: "COMMON", order: 3 },
+    { name: "Star", coinValue: 15, baseDropRate: 0.70, bracket: "COMMON", order: 4 },
+    { name: "Smiley", coinValue: 18, baseDropRate: 0.70, bracket: "COMMON", order: 5 },
+    { name: "Coffee", coinValue: 20, baseDropRate: 0.70, bracket: "COMMON", order: 6 },
+    { name: "Candy", coinValue: 25, baseDropRate: 0.70, bracket: "COMMON", order: 7 },
+    { name: "Balloon", coinValue: 30, baseDropRate: 0.70, bracket: "COMMON", order: 8 },
+    { name: "Teddy Bear", coinValue: 50, baseDropRate: 0.20, bracket: "UNCOMMON", order: 9 },
+    { name: "Perfume", coinValue: 80, baseDropRate: 0.20, bracket: "UNCOMMON", order: 10 },
+    { name: "Diamond Ring", coinValue: 120, baseDropRate: 0.20, bracket: "UNCOMMON", order: 11 },
+    { name: "Bouquet", coinValue: 150, baseDropRate: 0.20, bracket: "UNCOMMON", order: 12 },
+    { name: "Fireworks", coinValue: 200, baseDropRate: 0.20, bracket: "UNCOMMON", order: 13 },
+    { name: "Music Box", coinValue: 300, baseDropRate: 0.20, bracket: "UNCOMMON", order: 14 },
+    { name: "Treasure Chest", coinValue: 500, baseDropRate: 0.08, bracket: "RARE", order: 15 },
+    { name: "Crown", coinValue: 800, baseDropRate: 0.08, bracket: "RARE", order: 16 },
+    { name: "Sports Car", coinValue: 1200, baseDropRate: 0.08, bracket: "RARE", order: 17 },
+    { name: "Yacht", coinValue: 1800, baseDropRate: 0.08, bracket: "RARE", order: 18 },
+    { name: "Dragon", coinValue: 2500, baseDropRate: 0.08, bracket: "RARE", order: 19 },
+    { name: "Phoenix", coinValue: 3500, baseDropRate: 0.08, bracket: "RARE", order: 20 },
+    { name: "Crystal Ball", coinValue: 5000, baseDropRate: 0.018, bracket: "EPIC", order: 21 },
+    { name: "Castle", coinValue: 8000, baseDropRate: 0.018, bracket: "EPIC", order: 22 },
+    { name: "Spaceship", coinValue: 12000, baseDropRate: 0.018, bracket: "EPIC", order: 23 },
+    { name: "Aurora", coinValue: 16000, baseDropRate: 0.018, bracket: "EPIC", order: 24 },
+    { name: "Galaxy Unicorn", coinValue: 20000, baseDropRate: 0.018, bracket: "EPIC", order: 25 },
+    { name: "ShyTalk Emblem", coinValue: 35000, baseDropRate: 0.002, bracket: "LEGENDARY", order: 26 },
+    { name: "Celestial Throne", coinValue: 52000, baseDropRate: 0.002, bracket: "LEGENDARY", order: 27 },
+  ];
+
+  const coinPackages = [
+    { productId: "coins_100", coins: 100, bonusCoins: 0, displayPrice: "$0.99", order: 1, isActive: true },
+    { productId: "coins_500", coins: 500, bonusCoins: 50, displayPrice: "$4.99", order: 2, isActive: true },
+    { productId: "coins_1200", coins: 1200, bonusCoins: 200, displayPrice: "$9.99", order: 3, isActive: true },
+    { productId: "coins_2500", coins: 2500, bonusCoins: 500, displayPrice: "$19.99", order: 4, isActive: true },
+    { productId: "coins_6500", coins: 6500, bonusCoins: 1500, displayPrice: "$49.99", order: 5, isActive: true },
+    { productId: "coins_14000", coins: 14000, bonusCoins: 4000, displayPrice: "$99.99", order: 6, isActive: true },
+  ];
+
+  const batch = db.batch();
+
+  for (const gift of giftCatalog) {
+    const docId = gift.name.toLowerCase().replace(/\s+/g, "_");
+    batch.set(db.collection("gifts").doc(docId), {
+      ...gift,
+      beanValue: Math.floor(gift.coinValue * 0.6),
+      broadcastEnabled: gift.bracket === "LEGENDARY",
+      animationUrl: "",
+      soundUrl: "",
+      iconUrl: "",
+    }, { merge: true });
+  }
+
+  for (const pkg of coinPackages) {
+    batch.set(db.collection("coinPackages").doc(pkg.productId), pkg, { merge: true });
+  }
+
+  // App config (force update minimum version, etc.)
+  batch.set(db.collection("config").doc("app"), {
+    minVersionCode: 1,
+  }, { merge: true });
+
+  await batch.commit();
+  return { giftsSeeded: giftCatalog.length, packagesSeeded: coinPackages.length, configSeeded: true };
+});
+
+
 // --- Admin API ---
 const adminApp = require("./admin");
 exports.adminApi = onRequest({ region: "asia-southeast1" }, adminApp);
+
+// deploy 1771560904

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,8 @@ turbine = "1.2.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
+lottieCompose = "6.7.1"
+billing = "7.1.1"
 
 [libraries]
 # AndroidX Core
@@ -89,6 +91,12 @@ google-id = { group = "com.google.android.libraries.identity.googleid", name = "
 
 # LiveKit
 livekit-android = { group = "io.livekit", name = "livekit-android", version.ref = "livekit" }
+
+# Lottie
+lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottieCompose" }
+
+# Google Play Billing
+billing = { group = "com.android.billingclient", name = "billing-ktx", version.ref = "billing" }
 
 # Testing
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1341,8 +1341,8 @@
 <div id="login-screen" class="screen">
   <div class="login-box">
     <h2>ShyTalk Admin</h2>
-    <input type="email" id="login-email" placeholder="Email" autocomplete="email">
-    <input type="password" id="login-password" placeholder="Password" autocomplete="current-password">
+    <input type="email" id="login-email" placeholder="Email" autocomplete="email" aria-label="Email">
+    <input type="password" id="login-password" placeholder="Password" autocomplete="current-password" aria-label="Password">
     <button id="login-btn">Sign In</button>
     <div class="login-error" id="login-error"></div>
   </div>
@@ -1363,7 +1363,7 @@
 
   <div class="main-content">
     <div class="search-bar">
-      <input type="number" id="search-uid" placeholder="Enter ShyTalk User ID">
+      <input type="number" id="search-uid" placeholder="Enter ShyTalk User ID" aria-label="ShyTalk User ID">
       <button id="search-btn">Search</button>
     </div>
 
@@ -1377,23 +1377,23 @@
         </div>
         <div class="field-group">
           <label>Display Name</label>
-          <input type="text" data-field="displayName">
+          <input type="text" data-field="displayName" aria-label="Display Name">
         </div>
         <div class="field-group">
           <label>Email</label>
           <div class="field-row">
-            <input type="text" data-field="email" id="email-input">
+            <input type="text" data-field="email" id="email-input" aria-label="Email">
             <button class="btn-clear" id="email-toggle" type="button">Show</button>
             <button class="btn-clear" data-clear="email">Clear</button>
           </div>
         </div>
         <div class="field-group">
           <label>Unique ID</label>
-          <input type="number" data-field="uniqueId">
+          <input type="number" data-field="uniqueId" aria-label="Unique ID">
         </div>
         <div class="field-group">
           <label>User Type</label>
-          <select data-field="userType">
+          <select data-field="userType" aria-label="User Type">
             <option value="MEMBER">MEMBER</option>
             <option value="SHYTALK_OFFICIAL">SHYTALK_OFFICIAL</option>
             <option value="MC_SINGER">MC_SINGER</option>
@@ -1404,7 +1404,7 @@
         <div class="field-group">
           <label>Nationality</label>
           <div class="field-row">
-            <select data-field="nationality" id="nationality-select"></select>
+            <select data-field="nationality" id="nationality-select" aria-label="Nationality"></select>
             <button class="btn-clear" data-clear="nationality">Clear</button>
           </div>
         </div>
@@ -1416,21 +1416,21 @@
         <div class="field-group">
           <label>Description</label>
           <div class="field-row">
-            <textarea data-field="description" rows="3"></textarea>
+            <textarea data-field="description" rows="3" aria-label="Description"></textarea>
             <button class="btn-clear" data-clear="description">Clear</button>
           </div>
         </div>
         <div class="field-group">
           <label>Profile Photo URL</label>
           <div class="field-row">
-            <input type="text" data-field="profilePhotoUrl">
+            <input type="text" data-field="profilePhotoUrl" aria-label="Profile Photo URL">
             <button class="btn-clear" data-clear="profilePhotoUrl">Clear</button>
           </div>
         </div>
         <div class="field-group">
           <label>Cover Photo URL</label>
           <div class="field-row">
-            <input type="text" data-field="coverPhotoUrl">
+            <input type="text" data-field="coverPhotoUrl" aria-label="Cover Photo URL">
             <button class="btn-clear" data-clear="coverPhotoUrl">Clear</button>
           </div>
         </div>
@@ -1460,7 +1460,7 @@
         <div id="pre-suspension-info" style="display:none;margin-top:12px;padding:12px;background:var(--surface2);border-radius:8px;border:1px solid var(--border);">
           <div style="font-size:12px;color:var(--text2);margin-bottom:8px;">Original Profile (before suspension)</div>
           <div style="display:flex;align-items:center;gap:12px;">
-            <img id="pre-suspension-photo" src="" style="width:40px;height:40px;border-radius:50%;object-fit:cover;display:none;" />
+            <img id="pre-suspension-photo" src="" alt="Pre-suspension profile photo" style="width:40px;height:40px;border-radius:50%;object-fit:cover;display:none;" />
             <div>
               <div id="pre-suspension-name" style="font-weight:600;"></div>
               <div id="pre-suspension-cover" style="font-size:12px;color:var(--text2);display:none;">Has cover photo</div>
@@ -1469,7 +1469,7 @@
         </div>
         <div class="field-group">
           <label>Reason</label>
-          <textarea id="suspend-reason" rows="2" placeholder="Reason for suspension"></textarea>
+          <textarea id="suspend-reason" rows="2" placeholder="Reason for suspension" aria-label="Suspension Reason"></textarea>
         </div>
         <div class="field-group">
           <label>Duration</label>
@@ -1480,7 +1480,7 @@
             <button type="button" data-days="30">30 Days</button>
             <button type="button" data-days="0">Permanent</button>
           </div>
-          <input type="datetime-local" id="suspend-end-date">
+          <input type="datetime-local" id="suspend-end-date" aria-label="Suspension End Date">
         </div>
         <div class="checkbox-row">
           <input type="checkbox" id="suspend-can-appeal">
@@ -1509,7 +1509,7 @@
       <div class="form-section" id="direct-warn-section" style="display:none;">
         <h3>Issue Warning</h3>
         <div style="display:flex;flex-direction:column;gap:10px;">
-          <select id="direct-warn-reason" style="padding:8px;background:var(--surface);color:var(--text1);border:1px solid var(--border);border-radius:6px;">
+          <select id="direct-warn-reason" aria-label="Warning Reason" style="padding:8px;background:var(--surface);color:var(--text1);border:1px solid var(--border);border-radius:6px;">
             <option value="">Select reason...</option>
             <option value="Spam">Spam</option>
             <option value="Harassment">Harassment</option>
@@ -1524,7 +1524,7 @@
             <label style="color:var(--text2);font-size:13px;cursor:pointer;"><input type="radio" name="direct-warn-severity" value="4"> 4 (-20)</label>
             <label style="color:var(--text2);font-size:13px;cursor:pointer;"><input type="radio" name="direct-warn-severity" value="5"> 5 (-25)</label>
           </div>
-          <textarea id="direct-warn-note" rows="2" placeholder="Admin note (optional)" style="padding:8px;background:var(--surface);color:var(--text1);border:1px solid var(--border);border-radius:6px;resize:vertical;font-family:inherit;"></textarea>
+          <textarea id="direct-warn-note" rows="2" placeholder="Admin note (optional)" aria-label="Warning Note" style="padding:8px;background:var(--surface);color:var(--text1);border:1px solid var(--border);border-radius:6px;resize:vertical;font-family:inherit;"></textarea>
           <button type="button" id="direct-warn-btn" class="btn-warn" style="align-self:flex-start;">Issue Warning</button>
         </div>
       </div>
@@ -1541,7 +1541,7 @@
         <div class="field-group">
           <label>Date of Birth</label>
           <div class="field-row">
-            <input type="datetime-local" data-field="dateOfBirth">
+            <input type="datetime-local" data-field="dateOfBirth" aria-label="Date of Birth">
             <button class="btn-clear" data-clear="dateOfBirth">Clear</button>
           </div>
         </div>
@@ -1564,7 +1564,7 @@
           <div class="list-widget" id="list-blockedUserIds">
             <div class="list-items"></div>
             <div class="list-add">
-              <input type="number" placeholder="ShyTalk User ID">
+              <input type="number" placeholder="ShyTalk User ID" aria-label="Add blocked user ID">
               <button type="button">Add</button>
             </div>
           </div>
@@ -1574,7 +1574,7 @@
           <div class="list-widget" id="list-followingIds">
             <div class="list-items"></div>
             <div class="list-add">
-              <input type="number" placeholder="ShyTalk User ID">
+              <input type="number" placeholder="ShyTalk User ID" aria-label="Add following user ID">
               <button type="button">Add</button>
             </div>
           </div>
@@ -1584,11 +1584,113 @@
           <div class="list-widget" id="list-followerIds">
             <div class="list-items"></div>
             <div class="list-add">
-              <input type="number" placeholder="ShyTalk User ID">
+              <input type="number" placeholder="ShyTalk User ID" aria-label="Add follower user ID">
               <button type="button">Add</button>
             </div>
           </div>
         </div>
+      </div>
+
+      <!-- Economy -->
+      <div class="form-section">
+        <h3>Economy</h3>
+        <div class="field-group">
+          <label>Shy Coins</label>
+          <div style="display:flex;align-items:center;gap:8px">
+            <span id="eco-coins-display" style="font-weight:bold;min-width:60px">0</span>
+            <select id="eco-coins-op" aria-label="Coins operation" style="width:80px">
+              <option value="add">Add</option>
+              <option value="deduct">Deduct</option>
+            </select>
+            <input type="number" id="eco-coins-amount" placeholder="Amount" min="0" aria-label="Coins amount" style="width:100px">
+            <button type="button" id="eco-coins-apply" class="btn-sm">Apply</button>
+          </div>
+        </div>
+        <div class="field-group">
+          <label>Shy Beans</label>
+          <div style="display:flex;align-items:center;gap:8px">
+            <span id="eco-beans-display" style="font-weight:bold;min-width:60px">0</span>
+            <select id="eco-beans-op" aria-label="Beans operation" style="width:80px">
+              <option value="add">Add</option>
+              <option value="deduct">Deduct</option>
+            </select>
+            <input type="number" id="eco-beans-amount" placeholder="Amount" min="0" aria-label="Beans amount" style="width:100px">
+            <button type="button" id="eco-beans-apply" class="btn-sm">Apply</button>
+          </div>
+        </div>
+        <div class="field-group">
+          <label>Super Shy</label>
+          <select id="eco-super-shy" aria-label="Super Shy">
+            <option value="false">No</option>
+            <option value="true">Yes</option>
+          </select>
+        </div>
+        <div class="field-group">
+          <label>Super Shy Tier</label>
+          <select id="eco-super-shy-tier" aria-label="Super Shy Tier" disabled>
+            <option value="">None</option>
+            <option value="monthly">Monthly</option>
+            <option value="yearly">Yearly</option>
+            <option value="lifetime">Lifetime</option>
+          </select>
+        </div>
+        <div class="field-group">
+          <label>Login Streak</label>
+          <input type="number" id="eco-streak" value="0" min="0" aria-label="Login Streak">
+        </div>
+        <div class="field-group">
+          <label>Luck Score (0-100)</label>
+          <input type="number" id="eco-luck" value="0" min="0" max="100" aria-label="Luck Score">
+        </div>
+        <div class="field-group">
+          <label>Pity Counter (0-80)</label>
+          <input type="number" id="eco-pity" value="0" min="0" max="80" aria-label="Pity Counter">
+        </div>
+      </div>
+
+      <!-- Backpack -->
+      <div class="form-section">
+        <h3>Backpack</h3>
+        <div style="display:flex;gap:8px;margin-bottom:8px">
+          <input type="text" id="backpack-search" placeholder="Search by name, type, or ID..." aria-label="Search backpack" style="flex:1">
+          <select id="backpack-filter-type" aria-label="Filter by type" style="width:120px">
+            <option value="">All Types</option>
+            <option value="COMMON">Common</option>
+            <option value="UNCOMMON">Uncommon</option>
+            <option value="RARE">Rare</option>
+            <option value="EPIC">Epic</option>
+            <option value="LEGENDARY">Legendary</option>
+          </select>
+        </div>
+        <div id="backpack-container">
+          <p style="color:var(--text2)">Loading backpack...</p>
+        </div>
+        <div style="margin-top:8px;display:flex;gap:8px">
+          <select id="backpack-gift-select" aria-label="Select gift" style="flex:1"><option value="">Select gift...</option></select>
+          <input type="number" id="backpack-qty" placeholder="Qty" min="1" aria-label="Quantity" style="width:80px">
+          <button type="button" id="backpack-add-btn" class="btn-sm">Add</button>
+        </div>
+      </div>
+
+      <!-- Transactions -->
+      <div class="form-section">
+        <h3>Transaction History</h3>
+        <div style="display:flex;gap:8px;margin-bottom:8px">
+          <select id="tx-type-filter" aria-label="Transaction type filter" style="flex:1">
+            <option value="">All Types</option>
+            <option value="PURCHASE">Purchase</option>
+            <option value="GACHA_PULL">Gacha Pull</option>
+            <option value="GIFT_SENT">Gift Sent</option>
+            <option value="GIFT_RECEIVED">Gift Received</option>
+            <option value="BEAN_REDEEM">Bean Redeem</option>
+            <option value="DAILY_REWARD">Daily Reward</option>
+            <option value="SUBSCRIPTION">Subscription</option>
+            <option value="ADMIN_ADJUSTMENT">Admin Adjustment</option>
+            <option value="ADMIN_BACKPACK">Admin Backpack</option>
+          </select>
+          <button type="button" id="tx-load-btn" class="btn-sm">Load</button>
+        </div>
+        <div id="tx-list" style="max-height:300px;overflow-y:auto"></div>
       </div>
 
       <!-- Save -->
@@ -3544,6 +3646,234 @@
     }
     btn.disabled = false;
     btn.textContent = "Purge Orphaned Files";
+  });
+
+  // --- Economy Admin ---
+  let _ecoCoins = 0;
+  let _ecoBeans = 0;
+
+  function populateEconomySection(data) {
+    _ecoCoins = data.shyCoins || 0;
+    _ecoBeans = data.shyBeans || 0;
+    $("#eco-coins-display").textContent = _ecoCoins;
+    $("#eco-beans-display").textContent = _ecoBeans;
+    $("#eco-coins-amount").value = "";
+    $("#eco-beans-amount").value = "";
+    $("#eco-super-shy").value = data.isSuperShy ? "true" : "false";
+    const isSuperShy = data.isSuperShy === true;
+    $("#eco-super-shy-tier").disabled = !isSuperShy;
+    $("#eco-super-shy-tier").value = isSuperShy ? (data.superShyTier || "") : "";
+    $("#eco-streak").value = data.loginStreak || 0;
+    $("#eco-luck").value = data.luckScore || 0;
+    $("#eco-pity").value = data.pityCounter || 0;
+  }
+
+  // Toggle Super Shy Tier enabled/disabled based on Super Shy value
+  $("#eco-super-shy").addEventListener("change", () => {
+    const isSuperShy = $("#eco-super-shy").value === "true";
+    $("#eco-super-shy-tier").disabled = !isSuperShy;
+    if (!isSuperShy) {
+      $("#eco-super-shy-tier").value = "";
+    }
+  });
+
+  // Apply coins add/deduct (uses dedicated audit endpoint)
+  $("#eco-coins-apply").addEventListener("click", async () => {
+    if (!currentUid) return;
+    const op = $("#eco-coins-op").value;
+    const amount = parseInt($("#eco-coins-amount").value) || 0;
+    if (amount <= 0) { showToast("Enter a positive amount", "error"); return; }
+    try {
+      const result = await apiCall("POST", `/api/users/${currentUid}/adjust-balance`, {
+        currency: "COINS", amount, operation: op
+      });
+      _ecoCoins = result.newBalance;
+      $("#eco-coins-display").textContent = _ecoCoins;
+      $("#eco-coins-amount").value = "";
+      showToast(`${op === "add" ? "Added" : "Deducted"} ${amount} coins (now ${_ecoCoins})`);
+    } catch (err) {
+      showToast(err.message, "error");
+    }
+  });
+
+  // Apply beans add/deduct (uses dedicated audit endpoint)
+  $("#eco-beans-apply").addEventListener("click", async () => {
+    if (!currentUid) return;
+    const op = $("#eco-beans-op").value;
+    const amount = parseInt($("#eco-beans-amount").value) || 0;
+    if (amount <= 0) { showToast("Enter a positive amount", "error"); return; }
+    try {
+      const result = await apiCall("POST", `/api/users/${currentUid}/adjust-balance`, {
+        currency: "BEANS", amount, operation: op
+      });
+      _ecoBeans = result.newBalance;
+      $("#eco-beans-display").textContent = _ecoBeans;
+      $("#eco-beans-amount").value = "";
+      showToast(`${op === "add" ? "Added" : "Deducted"} ${amount} beans (now ${_ecoBeans})`);
+    } catch (err) {
+      showToast(err.message, "error");
+    }
+  });
+
+  // Hook economy into full populate
+  const _origPopulateFull = populateFormFull;
+  populateFormFull = async function(data) {
+    await _origPopulateFull(data);
+    populateEconomySection(data);
+    loadBackpack(data.uid);
+    populateGiftSelect();
+  };
+
+  // Include economy fields in save (coins/beans excluded — managed via add/deduct buttons)
+  const _origGetModified = getModifiedFields;
+  getModifiedFields = function() {
+    const modified = _origGetModified();
+    const isSuperShy = $("#eco-super-shy").value === "true";
+    const ecoFields = {
+      isSuperShy,
+      superShyTier: isSuperShy ? ($("#eco-super-shy-tier").value || null) : null,
+      loginStreak: parseInt($("#eco-streak").value) || 0,
+      luckScore: parseInt($("#eco-luck").value) || 0,
+      pityCounter: parseInt($("#eco-pity").value) || 0,
+    };
+    for (const [k, v] of Object.entries(ecoFields)) {
+      if (v !== (loadedData[k] ?? (typeof v === "boolean" ? false : typeof v === "number" ? 0 : null))) {
+        modified[k] = v;
+      }
+    }
+    return modified;
+  };
+
+  // Backpack management
+  let _backpackItems = [];
+  let _giftCatalog = [];
+
+  async function loadBackpack(uid) {
+    const container = $("#backpack-container");
+    container.innerHTML = '<p style="color:var(--text2)">Loading...</p>';
+    try {
+      const data = await apiCall("GET", `/api/users/${uid}/backpack`);
+      _backpackItems = data.items || [];
+      renderBackpack();
+    } catch (err) {
+      container.innerHTML = `<p style="color:var(--danger)">${escapeHtml(err.message)}</p>`;
+    }
+  }
+
+  function renderBackpack() {
+    const container = $("#backpack-container");
+    const searchText = ($("#backpack-search").value || "").toLowerCase();
+    const filterType = $("#backpack-filter-type").value;
+
+    let filtered = _backpackItems;
+    if (searchText) {
+      filtered = filtered.filter(item => {
+        const name = (item.giftName || item.giftId || "").toLowerCase();
+        const id = (item.giftId || "").toLowerCase();
+        const bracket = (item.bracket || "").toLowerCase();
+        return name.includes(searchText) || id.includes(searchText) || bracket.includes(searchText);
+      });
+    }
+    if (filterType) {
+      filtered = filtered.filter(item => (item.bracket || "").toUpperCase() === filterType);
+    }
+
+    if (_backpackItems.length === 0) {
+      container.innerHTML = '<p style="color:var(--text2)">Backpack is empty</p>';
+    } else if (filtered.length === 0) {
+      container.innerHTML = '<p style="color:var(--text2)">No items match your search</p>';
+    } else {
+      container.innerHTML = filtered.map(item =>
+        `<div style="display:flex;justify-content:space-between;align-items:center;padding:4px 0;border-bottom:1px solid var(--border)">
+          <span>
+            ${escapeHtml(item.giftName || item.giftId)}
+            <span style="color:var(--text2)">x${item.quantity}</span>
+            ${item.bracket ? `<span style="color:var(--text2);font-size:0.8em">[${escapeHtml(item.bracket)}]</span>` : ""}
+            <span style="color:var(--text2);font-size:0.75em">(${escapeHtml(item.giftId)})</span>
+          </span>
+          <div style="display:flex;gap:4px">
+            <button type="button" class="btn-sm" style="background:var(--danger)" onclick="removeBackpackItem('${escapeHtml(item.giftId)}')">Remove</button>
+          </div>
+        </div>`
+      ).join("");
+    }
+  }
+
+  // Search & filter triggers
+  $("#backpack-search").addEventListener("input", renderBackpack);
+  $("#backpack-filter-type").addEventListener("change", renderBackpack);
+
+  async function populateGiftSelect() {
+    const select = $("#backpack-gift-select");
+    try {
+      const data = await apiCall("GET", "/api/gifts");
+      _giftCatalog = data.gifts || [];
+      select.innerHTML = '<option value="">Select gift...</option>' +
+        _giftCatalog.map(g => `<option value="${g.id}">${escapeHtml(g.name)} (${g.bracket})</option>`).join("");
+    } catch (err) {
+      // Gift catalog not available
+    }
+  }
+
+  window.removeBackpackItem = async function(giftId) {
+    if (!currentUid || !confirm("Remove this gift from backpack?")) return;
+    try {
+      await apiCall("POST", `/api/users/${currentUid}/backpack`, { giftId, quantity: 0 });
+      showToast("Removed from backpack");
+      loadBackpack(currentUid);
+    } catch (err) {
+      showToast(err.message, "error");
+    }
+  };
+
+  $("#backpack-add-btn").addEventListener("click", async () => {
+    const giftId = $("#backpack-gift-select").value;
+    const qty = parseInt($("#backpack-qty").value) || 0;
+    if (!giftId || !currentUid || qty <= 0) { showToast("Select a gift and enter a quantity", "error"); return; }
+    try {
+      // Find current quantity and add to it
+      const existing = _backpackItems.find(i => i.giftId === giftId);
+      const newQty = (existing ? existing.quantity : 0) + qty;
+      await apiCall("POST", `/api/users/${currentUid}/backpack`, { giftId, quantity: newQty });
+      showToast(`Added ${qty} (total now ${newQty})`);
+      loadBackpack(currentUid);
+      $("#backpack-qty").value = "";
+    } catch (err) {
+      showToast(err.message, "error");
+    }
+  });
+
+  // Transaction history
+  $("#tx-load-btn").addEventListener("click", async () => {
+    if (!currentUid) return;
+    const typeFilter = $("#tx-type-filter").value;
+    const txList = $("#tx-list");
+    txList.innerHTML = '<p style="color:var(--text2)">Loading...</p>';
+    try {
+      const url = typeFilter
+        ? `/api/users/${currentUid}/transactions?type=${typeFilter}`
+        : `/api/users/${currentUid}/transactions`;
+      const data = await apiCall("GET", url);
+      const txs = data.transactions || [];
+      if (txs.length === 0) {
+        txList.innerHTML = '<p style="color:var(--text2)">No transactions found</p>';
+      } else {
+        txList.innerHTML = txs.map(tx => {
+          const date = tx.timestamp ? new Date(tx.timestamp).toLocaleString() : "—";
+          const details = tx.details || tx.giftName || "";
+          return `<div style="padding:6px 0;border-bottom:1px solid var(--border);font-size:13px">
+            <div style="display:flex;justify-content:space-between">
+              <span style="color:var(--accent)">${escapeHtml(tx.type)}</span>
+              <span style="color:var(--text2)">${date}</span>
+            </div>
+            <div>${tx.amount > 0 ? "+" : ""}${tx.amount} ${tx.currency || "COINS"} → Balance: ${tx.balanceAfter ?? "?"}</div>
+            ${details ? `<div style="color:var(--text2)">${escapeHtml(details)}</div>` : ""}
+          </div>`;
+        }).join("");
+      }
+    } catch (err) {
+      txList.innerHTML = `<p style="color:var(--danger)">${escapeHtml(err.message)}</p>`;
+    }
   });
 </script>
 </body>

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -50,6 +50,7 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.firebase.common)
             implementation(libs.ktor.client.okhttp)
+            implementation(libs.lottie.compose)
         }
 
         iosMain.dependencies {

--- a/shared/src/androidMain/kotlin/com/shyden/shytalk/core/ui/GiftEffectOverlay.android.kt
+++ b/shared/src/androidMain/kotlin/com/shyden/shytalk/core/ui/GiftEffectOverlay.android.kt
@@ -1,0 +1,94 @@
+package com.shyden.shytalk.core.ui
+
+import android.media.MediaPlayer
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.LottieCompositionSpec
+import com.airbnb.lottie.compose.animateLottieCompositionAsState
+import com.airbnb.lottie.compose.rememberLottieComposition
+import kotlinx.coroutines.delay
+
+@Composable
+actual fun GiftEffectOverlay(
+    animationUrl: String,
+    soundUrl: String,
+    isVisible: Boolean,
+    onFinished: () -> Unit,
+    modifier: Modifier
+) {
+    AnimatedVisibility(
+        visible = isVisible,
+        enter = fadeIn(),
+        exit = fadeOut(),
+        modifier = modifier
+    ) {
+        val context = LocalContext.current
+        val composition by rememberLottieComposition(LottieCompositionSpec.Url(animationUrl))
+        val progress by animateLottieCompositionAsState(
+            composition = composition,
+            iterations = 1,
+            isPlaying = isVisible
+        )
+
+        // Play sound effect
+        if (isVisible && soundUrl.isNotBlank()) {
+            val mediaPlayer = remember(soundUrl) {
+                try {
+                    MediaPlayer().apply {
+                        setDataSource(soundUrl)
+                        prepareAsync()
+                        setOnPreparedListener { start() }
+                    }
+                } catch (_: Exception) { null }
+            }
+
+            DisposableEffect(soundUrl) {
+                onDispose {
+                    try {
+                        mediaPlayer?.release()
+                    } catch (_: Exception) {}
+                }
+            }
+        }
+
+        // Auto-dismiss after animation completes
+        LaunchedEffect(progress) {
+            if (progress >= 1f) {
+                delay(300)
+                onFinished()
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.3f))
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() }
+                ) { onFinished() },
+            contentAlignment = Alignment.Center
+        ) {
+            LottieAnimation(
+                composition = composition,
+                progress = { progress }
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/BackpackItem.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/BackpackItem.kt
@@ -1,0 +1,22 @@
+package com.shyden.shytalk.core.model
+
+import com.shyden.shytalk.core.util.timestampToMillis
+
+data class BackpackItem(
+    val giftId: String = "",
+    val quantity: Int = 0,
+    val lastAcquired: Long = 0
+) {
+    fun toMap(): Map<String, Any?> = mapOf(
+        "quantity" to quantity,
+        "lastAcquired" to lastAcquired
+    )
+
+    companion object {
+        fun fromMap(map: Map<String, Any?>, giftId: String): BackpackItem = BackpackItem(
+            giftId = giftId,
+            quantity = (map["quantity"] as? Long)?.toInt() ?: 0,
+            lastAcquired = map["lastAcquired"]?.let { timestampToMillis(it) } ?: 0
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/Broadcast.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/Broadcast.kt
@@ -1,0 +1,27 @@
+package com.shyden.shytalk.core.model
+
+import com.shyden.shytalk.core.util.timestampToMillis
+
+data class Broadcast(
+    val id: String = "",
+    val senderName: String = "",
+    val senderPhotoUrl: String? = null,
+    val recipientName: String = "",
+    val giftName: String = "",
+    val giftIconUrl: String = "",
+    val giftCoinValue: Int = 0,
+    val timestamp: Long = 0
+) {
+    companion object {
+        fun fromMap(map: Map<String, Any?>, id: String): Broadcast = Broadcast(
+            id = id,
+            senderName = map["senderName"] as? String ?: "",
+            senderPhotoUrl = map["senderPhotoUrl"] as? String,
+            recipientName = map["recipientName"] as? String ?: "",
+            giftName = map["giftName"] as? String ?: "",
+            giftIconUrl = map["giftIconUrl"] as? String ?: "",
+            giftCoinValue = (map["giftCoinValue"] as? Long)?.toInt() ?: 0,
+            timestamp = map["timestamp"]?.let { timestampToMillis(it) } ?: 0
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/CoinPackage.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/CoinPackage.kt
@@ -1,0 +1,25 @@
+package com.shyden.shytalk.core.model
+
+data class CoinPackage(
+    val id: String = "",
+    val productId: String = "",
+    val coins: Int = 0,
+    val bonusCoins: Int = 0,
+    val displayPrice: String = "",
+    val order: Int = 0,
+    val isActive: Boolean = true
+) {
+    val totalCoins: Int get() = coins + bonusCoins
+
+    companion object {
+        fun fromMap(map: Map<String, Any?>, id: String): CoinPackage = CoinPackage(
+            id = id,
+            productId = map["productId"] as? String ?: "",
+            coins = (map["coins"] as? Long)?.toInt() ?: 0,
+            bonusCoins = (map["bonusCoins"] as? Long)?.toInt() ?: 0,
+            displayPrice = map["displayPrice"] as? String ?: "",
+            order = (map["order"] as? Long)?.toInt() ?: 0,
+            isActive = map["isActive"] as? Boolean ?: true
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/DailyRewardResult.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/DailyRewardResult.kt
@@ -1,0 +1,17 @@
+package com.shyden.shytalk.core.model
+
+data class DailyRewardResult(
+    val coinsAwarded: Int = 0,
+    val newStreak: Int = 0,
+    val isMilestone: Boolean = false,
+    val newBalance: Long = 0
+) {
+    companion object {
+        fun fromMap(map: Map<String, Any?>): DailyRewardResult = DailyRewardResult(
+            coinsAwarded = (map["coinsAwarded"] as? Long)?.toInt() ?: 0,
+            newStreak = (map["newStreak"] as? Long)?.toInt() ?: 0,
+            isMilestone = map["isMilestone"] as? Boolean ?: false,
+            newBalance = (map["newBalance"] as? Long) ?: 0
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/GachaResult.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/GachaResult.kt
@@ -1,0 +1,38 @@
+package com.shyden.shytalk.core.model
+
+data class GachaGift(
+    val giftId: String = "",
+    val giftName: String = "",
+    val bracket: GiftBracket = GiftBracket.COMMON,
+    val coinValue: Int = 0,
+    val iconUrl: String = ""
+)
+
+data class GachaResult(
+    val gifts: List<GachaGift> = emptyList(),
+    val coinsSpent: Int = 0,
+    val newBalance: Long = 0,
+    val newPityCounter: Int = 0,
+    val newLuckScore: Int = 0
+) {
+    companion object {
+        fun fromMap(map: Map<String, Any?>): GachaResult = GachaResult(
+            gifts = (map["gifts"] as? List<*>)?.mapNotNull { item ->
+                val m = item as? Map<*, *> ?: return@mapNotNull null
+                GachaGift(
+                    giftId = m["giftId"] as? String ?: "",
+                    giftName = m["giftName"] as? String ?: "",
+                    bracket = (m["bracket"] as? String)?.let {
+                        try { GiftBracket.valueOf(it) } catch (_: Exception) { GiftBracket.COMMON }
+                    } ?: GiftBracket.COMMON,
+                    coinValue = (m["coinValue"] as? Long)?.toInt() ?: 0,
+                    iconUrl = m["iconUrl"] as? String ?: ""
+                )
+            } ?: emptyList(),
+            coinsSpent = (map["coinsSpent"] as? Long)?.toInt() ?: 0,
+            newBalance = (map["newBalance"] as? Long) ?: 0,
+            newPityCounter = (map["newPityCounter"] as? Long)?.toInt() ?: 0,
+            newLuckScore = (map["newLuckScore"] as? Long)?.toInt() ?: 0
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/Gift.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/Gift.kt
@@ -1,0 +1,50 @@
+package com.shyden.shytalk.core.model
+
+enum class GiftBracket {
+    COMMON, UNCOMMON, RARE, EPIC, LEGENDARY
+}
+
+data class Gift(
+    val id: String = "",
+    val name: String = "",
+    val coinValue: Int = 0,
+    val beanValue: Int = 0,
+    val baseDropRate: Double = 0.0,
+    val bracket: GiftBracket = GiftBracket.COMMON,
+    val animationUrl: String = "",
+    val soundUrl: String = "",
+    val iconUrl: String = "",
+    val order: Int = 0,
+    val broadcastEnabled: Boolean = false
+) {
+    fun toMap(): Map<String, Any?> = mapOf(
+        "name" to name,
+        "coinValue" to coinValue,
+        "beanValue" to beanValue,
+        "baseDropRate" to baseDropRate,
+        "bracket" to bracket.name,
+        "animationUrl" to animationUrl,
+        "soundUrl" to soundUrl,
+        "iconUrl" to iconUrl,
+        "order" to order,
+        "broadcastEnabled" to broadcastEnabled
+    )
+
+    companion object {
+        fun fromMap(map: Map<String, Any?>, id: String): Gift = Gift(
+            id = id,
+            name = map["name"] as? String ?: "",
+            coinValue = (map["coinValue"] as? Long)?.toInt() ?: 0,
+            beanValue = (map["beanValue"] as? Long)?.toInt() ?: 0,
+            baseDropRate = (map["baseDropRate"] as? Double) ?: 0.0,
+            bracket = (map["bracket"] as? String)?.let {
+                try { GiftBracket.valueOf(it) } catch (_: Exception) { GiftBracket.COMMON }
+            } ?: GiftBracket.COMMON,
+            animationUrl = map["animationUrl"] as? String ?: "",
+            soundUrl = map["soundUrl"] as? String ?: "",
+            iconUrl = map["iconUrl"] as? String ?: "",
+            order = (map["order"] as? Long)?.toInt() ?: 0,
+            broadcastEnabled = map["broadcastEnabled"] as? Boolean ?: false
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/GiftWallEntry.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/GiftWallEntry.kt
@@ -1,0 +1,35 @@
+package com.shyden.shytalk.core.model
+
+data class GiftSender(
+    val userId: String = "",
+    val count: Int = 0
+)
+
+data class GiftWallEntry(
+    val giftId: String = "",
+    val receivedCount: Int = 0,
+    val senders: Map<String, Int> = emptyMap(),
+    val topSenderId: String? = null,
+    val topSenderCount: Int = 0
+) {
+    companion object {
+        fun fromMap(map: Map<String, Any?>, giftId: String): GiftWallEntry = GiftWallEntry(
+            giftId = giftId,
+            receivedCount = (map["receivedCount"] as? Long)?.toInt() ?: 0,
+            senders = (map["senders"] as? Map<*, *>)?.mapNotNull { (k, v) ->
+                val key = k as? String ?: return@mapNotNull null
+                val value = (v as? Long)?.toInt() ?: return@mapNotNull null
+                key to value
+            }?.toMap() ?: emptyMap(),
+            topSenderId = map["topSenderId"] as? String,
+            topSenderCount = (map["topSenderCount"] as? Long)?.toInt() ?: 0
+        )
+    }
+}
+
+data class GiftRankEntry(
+    val userId: String = "",
+    val count: Int = 0,
+    val displayName: String = "",
+    val profilePhotoUrl: String? = null
+)

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/Transaction.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/Transaction.kt
@@ -1,0 +1,48 @@
+package com.shyden.shytalk.core.model
+
+import com.shyden.shytalk.core.util.timestampToMillis
+
+enum class TransactionType {
+    PURCHASE, GACHA_PULL, GIFT_SENT, GIFT_RECEIVED, BEAN_REDEEM, DAILY_REWARD, SUBSCRIPTION,
+    ADMIN_ADJUSTMENT, ADMIN_BACKPACK
+}
+
+enum class CurrencyType {
+    COINS, BEANS
+}
+
+data class Transaction(
+    val id: String = "",
+    val type: TransactionType = TransactionType.PURCHASE,
+    val amount: Long = 0,
+    val currency: CurrencyType = CurrencyType.COINS,
+    val balanceAfter: Long = 0,
+    val giftId: String? = null,
+    val giftName: String? = null,
+    val recipientId: String? = null,
+    val senderId: String? = null,
+    val pullCount: Int? = null,
+    val details: String? = null,
+    val timestamp: Long = 0
+) {
+    companion object {
+        fun fromMap(map: Map<String, Any?>, id: String): Transaction = Transaction(
+            id = id,
+            type = (map["type"] as? String)?.let {
+                try { TransactionType.valueOf(it) } catch (_: Exception) { TransactionType.PURCHASE }
+            } ?: TransactionType.PURCHASE,
+            amount = (map["amount"] as? Long) ?: 0,
+            currency = (map["currency"] as? String)?.let {
+                try { CurrencyType.valueOf(it) } catch (_: Exception) { CurrencyType.COINS }
+            } ?: CurrencyType.COINS,
+            balanceAfter = (map["balanceAfter"] as? Long) ?: 0,
+            giftId = map["giftId"] as? String,
+            giftName = map["giftName"] as? String,
+            recipientId = map["recipientId"] as? String,
+            senderId = map["senderId"] as? String,
+            pullCount = (map["pullCount"] as? Long)?.toInt(),
+            details = map["details"] as? String,
+            timestamp = map["timestamp"]?.let { timestampToMillis(it) } ?: 0
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
@@ -50,7 +50,18 @@ data class User(
     val dndStartHour: Int = 22,
     val dndStartMinute: Int = 0,
     val dndEndHour: Int = 8,
-    val dndEndMinute: Int = 0
+    val dndEndMinute: Int = 0,
+    // Monetization
+    val shyCoins: Long = 0,
+    val shyBeans: Long = 0,
+    val isSuperShy: Boolean = false,
+    val superShyExpiry: Long? = null,
+    val superShyTier: String? = null,
+    val luckScore: Int = 0,
+    val pityCounter: Int = 0,
+    val loginStreak: Int = 0,
+    val lastLoginDate: String? = null,
+    val lastLoginRewardDate: String? = null
 ) {
     val isActivelySuspended: Boolean
         get() {
@@ -106,7 +117,17 @@ data class User(
         "dndStartHour" to dndStartHour,
         "dndStartMinute" to dndStartMinute,
         "dndEndHour" to dndEndHour,
-        "dndEndMinute" to dndEndMinute
+        "dndEndMinute" to dndEndMinute,
+        "shyCoins" to shyCoins,
+        "shyBeans" to shyBeans,
+        "isSuperShy" to isSuperShy,
+        "superShyExpiry" to superShyExpiry?.let { millisToTimestamp(it) },
+        "superShyTier" to superShyTier,
+        "luckScore" to luckScore,
+        "pityCounter" to pityCounter,
+        "loginStreak" to loginStreak,
+        "lastLoginDate" to lastLoginDate,
+        "lastLoginRewardDate" to lastLoginRewardDate
     )
 
     companion object {
@@ -162,7 +183,17 @@ data class User(
             dndStartHour = (map["dndStartHour"] as? Long)?.toInt() ?: 22,
             dndStartMinute = (map["dndStartMinute"] as? Long)?.toInt() ?: 0,
             dndEndHour = (map["dndEndHour"] as? Long)?.toInt() ?: 8,
-            dndEndMinute = (map["dndEndMinute"] as? Long)?.toInt() ?: 0
+            dndEndMinute = (map["dndEndMinute"] as? Long)?.toInt() ?: 0,
+            shyCoins = (map["shyCoins"] as? Long) ?: 0,
+            shyBeans = (map["shyBeans"] as? Long) ?: 0,
+            isSuperShy = map["isSuperShy"] as? Boolean ?: false,
+            superShyExpiry = map["superShyExpiry"]?.let { timestampToMillis(it) },
+            superShyTier = map["superShyTier"] as? String,
+            luckScore = (map["luckScore"] as? Long)?.toInt() ?: 0,
+            pityCounter = (map["pityCounter"] as? Long)?.toInt() ?: 0,
+            loginStreak = (map["loginStreak"] as? Long)?.toInt() ?: 0,
+            lastLoginDate = map["lastLoginDate"] as? String,
+            lastLoginRewardDate = map["lastLoginRewardDate"] as? String
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/BroadcastBanner.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/BroadcastBanner.kt
@@ -1,0 +1,99 @@
+package com.shyden.shytalk.core.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CardGiftcard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.shyden.shytalk.core.model.Broadcast
+import kotlinx.coroutines.delay
+
+@Composable
+fun BroadcastBanner(
+    broadcast: Broadcast?,
+    modifier: Modifier = Modifier
+) {
+    var visible by remember { mutableStateOf(false) }
+    var currentBroadcast by remember { mutableStateOf<Broadcast?>(null) }
+
+    LaunchedEffect(broadcast) {
+        if (broadcast != null && broadcast != currentBroadcast) {
+            currentBroadcast = broadcast
+            visible = true
+            delay(5000)
+            visible = false
+        }
+    }
+
+    AnimatedVisibility(
+        visible = visible,
+        enter = slideInVertically(initialOffsetY = { -it }),
+        exit = slideOutVertically(targetOffsetY = { -it }),
+        modifier = modifier
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .background(
+                    brush = Brush.horizontalGradient(
+                        colors = listOf(
+                            Color(0xFFFF6B35),
+                            Color(0xFFFFD700),
+                            Color(0xFFFF6B35)
+                        )
+                    ),
+                    shape = RoundedCornerShape(12.dp)
+                )
+                .padding(horizontal = 16.dp, vertical = 10.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.CardGiftcard,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                currentBroadcast?.let { b ->
+                    Text(
+                        text = "${b.senderName} sent ${b.giftName} to ${b.recipientName}!",
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            color = Color.White,
+                            fontWeight = FontWeight.Bold
+                        ),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/GiftEffectOverlay.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/GiftEffectOverlay.kt
@@ -1,0 +1,13 @@
+package com.shyden.shytalk.core.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+expect fun GiftEffectOverlay(
+    animationUrl: String,
+    soundUrl: String,
+    isVisible: Boolean,
+    onFinished: () -> Unit,
+    modifier: Modifier = Modifier
+)

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/StyledDisplayName.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/StyledDisplayName.kt
@@ -1,0 +1,63 @@
+package com.shyden.shytalk.core.ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+val SuperShyGold = Color(0xFFFFD700)
+
+@Composable
+fun StyledDisplayName(
+    displayName: String,
+    isSuperShy: Boolean,
+    modifier: Modifier = Modifier,
+    style: TextStyle = LocalTextStyle.current,
+    maxLines: Int = 1,
+    overflow: TextOverflow = TextOverflow.Ellipsis
+) {
+    if (isSuperShy) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Star,
+                contentDescription = "Super Shy",
+                tint = SuperShyGold,
+                modifier = Modifier.size(style.fontSize.value.dp * 1.1f)
+            )
+            Spacer(modifier = Modifier.width(3.dp))
+            Text(
+                text = displayName,
+                style = style.copy(
+                    color = SuperShyGold,
+                    fontWeight = FontWeight.Bold
+                ),
+                maxLines = maxLines,
+                overflow = overflow
+            )
+        }
+    } else {
+        Text(
+            text = displayName,
+            style = style,
+            maxLines = maxLines,
+            overflow = overflow,
+            modifier = modifier
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/EconomyRepository.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/EconomyRepository.kt
@@ -1,0 +1,20 @@
+package com.shyden.shytalk.data.repository
+
+import com.shyden.shytalk.core.model.CoinPackage
+import com.shyden.shytalk.core.model.DailyRewardResult
+import com.shyden.shytalk.core.model.GachaResult
+import com.shyden.shytalk.core.model.Transaction
+import com.shyden.shytalk.core.util.Resource
+
+interface EconomyRepository {
+    suspend fun claimDailyReward(): Resource<DailyRewardResult>
+    suspend fun pullGacha(pullCount: Int): Resource<GachaResult>
+    suspend fun sendGift(recipientId: String, giftId: String): Resource<Map<String, Any?>>
+    suspend fun redeemBeans(amount: Int): Resource<Map<String, Any?>>
+    suspend fun purchaseCoins(productId: String, purchaseToken: String): Resource<Map<String, Any?>>
+    suspend fun purchaseSubscription(productId: String, purchaseToken: String): Resource<Map<String, Any?>>
+    suspend fun getCoinPackages(): Resource<List<CoinPackage>>
+    suspend fun getRecentTransactions(limit: Int = 10): Resource<List<Transaction>>
+    suspend fun getAllTransactions(filterType: String? = null): Resource<List<Transaction>>
+    suspend fun addTestCoins(amount: Int): Resource<Map<String, Any?>>
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/GiftRepository.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/GiftRepository.kt
@@ -1,0 +1,18 @@
+package com.shyden.shytalk.data.repository
+
+import com.shyden.shytalk.core.model.BackpackItem
+import com.shyden.shytalk.core.model.Broadcast
+import com.shyden.shytalk.core.model.Gift
+import com.shyden.shytalk.core.model.GiftRankEntry
+import com.shyden.shytalk.core.model.GiftSender
+import com.shyden.shytalk.core.model.GiftWallEntry
+import kotlinx.coroutines.flow.Flow
+
+interface GiftRepository {
+    fun observeGiftCatalog(): Flow<List<Gift>>
+    fun observeBackpack(userId: String): Flow<List<BackpackItem>>
+    fun observeGiftWall(userId: String): Flow<List<GiftWallEntry>>
+    fun observeBroadcasts(): Flow<List<Broadcast>>
+    suspend fun getGiftWallSenders(userId: String, giftId: String): List<GiftSender>
+    suspend fun getGiftRanking(giftId: String): List<GiftRankEntry>
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/daily/DailyRewardDialog.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/daily/DailyRewardDialog.kt
@@ -1,0 +1,168 @@
+package com.shyden.shytalk.feature.daily
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.shyden.shytalk.core.ui.SuperShyGold
+
+@Composable
+fun DailyRewardDialog(
+    viewModel: DailyRewardViewModel,
+    onDismiss: () -> Unit
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    if (!state.showDialog) return
+
+    AlertDialog(
+        onDismissRequest = {
+            viewModel.dismissDialog()
+            onDismiss()
+        },
+        icon = {
+            Icon(
+                imageVector = Icons.Filled.CalendarMonth,
+                contentDescription = null,
+                tint = SuperShyGold,
+                modifier = Modifier.size(32.dp)
+            )
+        },
+        title = {
+            Text(
+                text = if (state.reward != null) "Reward Claimed!" else "Daily Reward",
+                fontWeight = FontWeight.Bold
+            )
+        },
+        text = {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                if (state.reward != null) {
+                    val reward = state.reward!!
+                    Text(
+                        text = "+${reward.coinsAwarded} coins!",
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = SuperShyGold
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text("Day ${reward.newStreak} streak")
+                    if (reward.isMilestone) {
+                        Text(
+                            "Milestone bonus!",
+                            color = Color(0xFFFF6B35),
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                } else {
+                    Text("Day ${state.currentStreak + 1}")
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        "Claim your daily login reward!",
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center
+                    )
+
+                    // Mini streak preview (next 7 days)
+                    Spacer(modifier = Modifier.height(12.dp))
+                    LazyVerticalGrid(
+                        columns = GridCells.Fixed(7),
+                        contentPadding = PaddingValues(0.dp),
+                        horizontalArrangement = Arrangement.spacedBy(2.dp),
+                        modifier = Modifier.height(50.dp)
+                    ) {
+                        val currentDay = state.currentStreak
+                        items(7) { index ->
+                            val day = currentDay + index + 1
+                            val isToday = index == 0
+                            Box(
+                                modifier = Modifier
+                                    .size(32.dp)
+                                    .clip(CircleShape)
+                                    .background(
+                                        if (isToday) SuperShyGold
+                                        else MaterialTheme.colorScheme.surfaceVariant
+                                    )
+                                    .then(
+                                        if (isToday) Modifier.border(2.dp, SuperShyGold, CircleShape)
+                                        else Modifier
+                                    ),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = "$day",
+                                    fontSize = 10.sp,
+                                    fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
+                                    color = if (isToday) Color.White else MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            if (state.reward != null) {
+                Button(onClick = {
+                    viewModel.dismissDialog()
+                    onDismiss()
+                }) {
+                    Text("Yay!")
+                }
+            } else {
+                Button(
+                    onClick = { viewModel.claimReward() },
+                    enabled = !state.isClaiming && !state.hasClaimedToday
+                ) {
+                    if (state.isClaiming) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Text("Claim")
+                    }
+                }
+            }
+        },
+        dismissButton = {
+            if (state.reward == null) {
+                TextButton(onClick = {
+                    viewModel.dismissDialog()
+                    onDismiss()
+                }) {
+                    Text("Later")
+                }
+            }
+        }
+    )
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/daily/DailyRewardViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/daily/DailyRewardViewModel.kt
@@ -1,0 +1,76 @@
+package com.shyden.shytalk.feature.daily
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.shyden.shytalk.core.model.DailyRewardResult
+import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.data.repository.AuthRepository
+import com.shyden.shytalk.data.repository.EconomyRepository
+import com.shyden.shytalk.data.repository.UserRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+data class DailyRewardUiState(
+    val reward: DailyRewardResult? = null,
+    val hasClaimedToday: Boolean = false,
+    val currentStreak: Int = 0,
+    val isClaiming: Boolean = false,
+    val showDialog: Boolean = false,
+    val error: String? = null
+)
+
+class DailyRewardViewModel(
+    private val economyRepository: EconomyRepository,
+    private val authRepository: AuthRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(DailyRewardUiState())
+    val uiState: StateFlow<DailyRewardUiState> = _uiState.asStateFlow()
+
+    fun checkAndShowDialog(user: User) {
+        val today = Clock.System.now()
+            .toLocalDateTime(TimeZone.currentSystemDefault())
+            .date.toString()
+        val alreadyClaimed = user.lastLoginRewardDate == today
+        _uiState.update {
+            it.copy(
+                hasClaimedToday = alreadyClaimed,
+                currentStreak = user.loginStreak,
+                showDialog = !alreadyClaimed
+            )
+        }
+    }
+
+    fun claimReward() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isClaiming = true, error = null) }
+            when (val result = economyRepository.claimDailyReward()) {
+                is Resource.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            reward = result.data,
+                            hasClaimedToday = true,
+                            currentStreak = result.data.newStreak,
+                            isClaiming = false
+                        )
+                    }
+                }
+                is Resource.Error -> {
+                    _uiState.update { it.copy(isClaiming = false, error = result.message) }
+                }
+                is Resource.Loading -> {}
+            }
+        }
+    }
+
+    fun dismissDialog() {
+        _uiState.update { it.copy(showDialog = false) }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/GachaViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/GachaViewModel.kt
@@ -1,0 +1,148 @@
+package com.shyden.shytalk.feature.gacha
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.shyden.shytalk.core.model.GachaGift
+import com.shyden.shytalk.core.model.GachaResult
+import com.shyden.shytalk.core.model.Gift
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.data.repository.EconomyRepository
+import com.shyden.shytalk.data.repository.GiftRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class GachaUiState(
+    val giftCatalog: List<Gift> = emptyList(),
+    val winnableGifts: List<Gift> = emptyList(),
+    val pullResults: List<GachaGift> = emptyList(),
+    val coinBalance: Long = 0,
+    val pityCounter: Int = 0,
+    val luckScore: Int = 0,
+    val isPulling: Boolean = false,
+    val error: String? = null,
+    val showResults: Boolean = false,
+    val currentWin: GachaGift? = null,
+    val isMultiSpin: Boolean = false,
+    val multiSpinResults: List<GachaGift> = emptyList(),
+    val multiSpinIndex: Int = 0
+)
+
+class GachaViewModel(
+    private val economyRepository: EconomyRepository,
+    private val giftRepository: GiftRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(GachaUiState())
+    val uiState: StateFlow<GachaUiState> = _uiState.asStateFlow()
+
+    init {
+        observeGiftCatalog()
+    }
+
+    private fun observeGiftCatalog() {
+        viewModelScope.launch {
+            giftRepository.observeGiftCatalog()
+                .catch { e -> _uiState.update { it.copy(error = e.message) } }
+                .collect { gifts ->
+                    _uiState.update {
+                        it.copy(
+                            giftCatalog = gifts,
+                            winnableGifts = gifts.filter { g -> g.baseDropRate > 0 }
+                        )
+                    }
+                }
+        }
+    }
+
+    fun updateBalance(coins: Long, pity: Int, luck: Int) {
+        _uiState.update { it.copy(coinBalance = coins, pityCounter = pity, luckScore = luck) }
+    }
+
+    fun pullSingle() = pull(1)
+    fun pullTen() = pull(10)
+    fun pullHundred() = pull(100)
+
+    private fun pull(count: Int) {
+        val cost = when (count) { 1 -> 10; 10 -> 100; 100 -> 1000; else -> return }
+        if (_uiState.value.coinBalance < cost) {
+            _uiState.update { it.copy(error = "Not enough coins") }
+            return
+        }
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPulling = true, error = null, currentWin = null) }
+            when (val result = economyRepository.pullGacha(count)) {
+                is Resource.Success -> {
+                    if (count == 1) {
+                        _uiState.update {
+                            it.copy(
+                                pullResults = result.data.gifts,
+                                coinBalance = result.data.newBalance,
+                                pityCounter = result.data.newPityCounter,
+                                luckScore = result.data.newLuckScore,
+                                isPulling = false,
+                                currentWin = result.data.gifts.firstOrNull(),
+                                isMultiSpin = false,
+                                showResults = false
+                            )
+                        }
+                    } else {
+                        _uiState.update {
+                            it.copy(
+                                pullResults = result.data.gifts,
+                                coinBalance = result.data.newBalance,
+                                pityCounter = result.data.newPityCounter,
+                                luckScore = result.data.newLuckScore,
+                                isPulling = false,
+                                isMultiSpin = true,
+                                multiSpinResults = result.data.gifts,
+                                multiSpinIndex = 0,
+                                showResults = true
+                            )
+                        }
+                    }
+                }
+                is Resource.Error -> {
+                    _uiState.update { it.copy(isPulling = false, error = result.message) }
+                }
+                is Resource.Loading -> {}
+            }
+        }
+    }
+
+    fun advanceMultiSpin() {
+        _uiState.update {
+            val nextIndex = it.multiSpinIndex + 1
+            it.copy(multiSpinIndex = nextIndex)
+        }
+    }
+
+    fun skipMultiSpin() {
+        _uiState.update {
+            it.copy(
+                multiSpinIndex = it.multiSpinResults.size,
+                showResults = true
+            )
+        }
+    }
+
+    fun dismissResults() {
+        _uiState.update {
+            it.copy(
+                showResults = false,
+                pullResults = emptyList(),
+                currentWin = null,
+                isMultiSpin = false,
+                multiSpinResults = emptyList(),
+                multiSpinIndex = 0
+            )
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinConfetti.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinConfetti.kt
@@ -1,0 +1,123 @@
+package com.shyden.shytalk.feature.gacha
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameMillis
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import kotlin.random.Random
+
+private data class ConfettiParticle(
+    var x: Float,
+    var y: Float,
+    var vx: Float,
+    var vy: Float,
+    val gravity: Float,
+    var rotation: Float,
+    val rotationSpeed: Float,
+    var opacity: Float,
+    val color: Color,
+    val particleSize: Float,
+    val shape: Int // 0=rect, 1=circle, 2=strip
+)
+
+private val ConfettiColors = listOf(
+    Color(0xFFFF1744), Color(0xFFFFD600), Color(0xFF00E676),
+    Color(0xFF2979FF), Color(0xFFD500F9), Color(0xFFFF9100),
+    Color(0xFF00BFA5), Color(0xFFFF6D00)
+)
+
+@Composable
+fun LuckySpinConfetti(
+    active: Boolean,
+    particleCount: Int = 80,
+    modifier: Modifier = Modifier
+) {
+    var particles by remember { mutableStateOf<List<ConfettiParticle>>(emptyList()) }
+
+    LaunchedEffect(active) {
+        if (!active) {
+            particles = emptyList()
+            return@LaunchedEffect
+        }
+        // Create burst of particles
+        particles = List(particleCount) {
+            ConfettiParticle(
+                x = 0.5f + (Random.nextFloat() - 0.5f) * 0.15f,  // normalized coords
+                y = 0.5f + 0.05f,
+                vx = (Random.nextFloat() - 0.5f) * 0.04f,
+                vy = -Random.nextFloat() * 0.04f - 0.012f,
+                gravity = 0.0004f + Random.nextFloat() * 0.0002f,
+                rotation = Random.nextFloat() * 6.28f,
+                rotationSpeed = (Random.nextFloat() - 0.5f) * 0.06f,
+                opacity = 1f,
+                color = ConfettiColors.random(),
+                particleSize = 3f + Random.nextFloat() * 9f,
+                shape = Random.nextInt(3)
+            )
+        }
+
+        // Physics loop
+        var lastFrame = 0L
+        while (true) {
+            withFrameMillis { frameTime ->
+                if (lastFrame == 0L) lastFrame = frameTime
+                val dt = ((frameTime - lastFrame).coerceIn(0, 32)).toFloat()
+                lastFrame = frameTime
+
+                var anyAlive = false
+                particles = particles.map { p ->
+                    if (p.opacity <= 0f) return@map p
+                    anyAlive = true
+                    p.copy(
+                        x = p.x + p.vx * dt * 0.06f,
+                        y = p.y + p.vy * dt * 0.06f,
+                        vx = p.vx * 0.995f,
+                        vy = p.vy + p.gravity * dt * 0.06f,
+                        rotation = p.rotation + p.rotationSpeed * dt * 0.06f,
+                        opacity = if (p.y > 1f) (p.opacity - 0.02f).coerceAtLeast(0f) else p.opacity
+                    )
+                }
+                if (!anyAlive) {
+                    particles = emptyList()
+                }
+            }
+            if (particles.isEmpty()) break
+        }
+    }
+
+    Canvas(modifier = modifier) {
+        val w = size.width
+        val h = size.height
+        for (p in particles) {
+            if (p.opacity <= 0f) continue
+            val px = p.x * w
+            val py = p.y * h
+            val s = p.particleSize
+            when (p.shape) {
+                0 -> drawRect(
+                    color = p.color.copy(alpha = p.opacity.coerceIn(0f, 1f)),
+                    topLeft = Offset(px - s / 2, py - s * 0.3f),
+                    size = Size(s, s * 0.6f)
+                )
+                1 -> drawCircle(
+                    color = p.color.copy(alpha = p.opacity.coerceIn(0f, 1f)),
+                    radius = s / 2,
+                    center = Offset(px, py)
+                )
+                else -> drawRect(
+                    color = p.color.copy(alpha = p.opacity.coerceIn(0f, 1f)),
+                    topLeft = Offset(px - s / 2, py - 1f),
+                    size = Size(s, 2.5f)
+                )
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinOverlay.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinOverlay.kt
@@ -1,0 +1,634 @@
+package com.shyden.shytalk.feature.gacha
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.shyden.shytalk.core.model.GachaGift
+import com.shyden.shytalk.core.model.GiftBracket
+import com.shyden.shytalk.core.ui.SuperShyGold
+import kotlinx.coroutines.delay
+import kotlin.math.pow
+
+private enum class SpinPhase {
+    IDLE, ANIMATING, CELEBRATING, SHOW_SUMMARY
+}
+
+@Composable
+fun LuckySpinOverlay(
+    gachaState: GachaUiState,
+    onSpin: () -> Unit,
+    onQuickSpin: (Int) -> Unit,
+    onAdvanceMultiSpin: () -> Unit,
+    onSkipMultiSpin: () -> Unit,
+    onDismissResults: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val winnableGifts = gachaState.winnableGifts
+    val (outerGifts, innerGifts) = remember(winnableGifts) { buildRingLayout(winnableGifts) }
+
+    var phase by remember { mutableStateOf(SpinPhase.IDLE) }
+    var outerLitIndex by remember { mutableIntStateOf(-1) }
+    var innerLitIndex by remember { mutableIntStateOf(-1) }
+    var wonSegments by remember { mutableStateOf(emptySet<String>()) }
+    var lastWin by remember { mutableStateOf<GachaGift?>(null) }
+    var showConfetti by remember { mutableStateOf(false) }
+    var confettiCount by remember { mutableIntStateOf(60) }
+    var showFlash by remember { mutableStateOf(false) }
+    var flashColor by remember { mutableStateOf(Color.White) }
+    var spinProgress by remember { mutableStateOf<Pair<Int, Int>?>(null) }
+    var activeTier by remember { mutableStateOf(SpinTiers[0]) }
+    var skipAnimation by remember { mutableStateOf(false) }
+    var showSummary by remember { mutableStateOf(false) }
+    var allWins by remember { mutableStateOf<List<GachaGift>>(emptyList()) }
+
+    // Screen shake
+    val shakeX = remember { Animatable(0f) }
+    val shakeY = remember { Animatable(0f) }
+
+    suspend fun triggerShake(intensity: Float) {
+        if (intensity <= 0f) return
+        shakeX.snapTo(intensity)
+        shakeY.snapTo(-intensity)
+        shakeX.animateTo(0f, spring(dampingRatio = Spring.DampingRatioHighBouncy, stiffness = Spring.StiffnessMediumLow))
+    }
+
+    suspend fun celebrate(results: List<GachaGift>, midSpin: Boolean = false) {
+        val bestBracket = results.maxByOrNull { it.bracket.ordinal }?.bracket ?: GiftBracket.COMMON
+        val config = RarityConfigs[bestBracket] ?: return
+        confettiCount = if (midSpin) config.burstCount / 2 else config.burstCount
+        showConfetti = true
+        if (config.flash) {
+            flashColor = config.glowColor.copy(alpha = 0.3f)
+            showFlash = true
+            delay(600)
+            showFlash = false
+        }
+        triggerShake(config.shakeIntensity)
+        delay(if (midSpin) 400 else 3000)
+        showConfetti = false
+    }
+
+    fun resetBoard() {
+        outerLitIndex = -1
+        innerLitIndex = -1
+        wonSegments = emptySet()
+        lastWin = null
+        showSummary = false
+        spinProgress = null
+        phase = SpinPhase.IDLE
+    }
+
+    // Handle single spin result (1x)
+    LaunchedEffect(gachaState.currentWin) {
+        val win = gachaState.currentWin ?: return@LaunchedEffect
+        if (phase != SpinPhase.ANIMATING) return@LaunchedEffect
+        if (gachaState.isMultiSpin) return@LaunchedEffect
+
+        allWins = listOf(win)
+
+        if (skipAnimation) {
+            val pos = resolveWinPosition(win.giftId, outerGifts, innerGifts)
+            if (pos != null) {
+                val key = "${if (pos.first == Ring.OUTER) "outer" else "inner"}-${pos.second}"
+                wonSegments = setOf(key)
+                if (pos.first == Ring.OUTER) { outerLitIndex = pos.second; innerLitIndex = -1 }
+                else { innerLitIndex = pos.second; outerLitIndex = -1 }
+            }
+            lastWin = win
+            phase = SpinPhase.CELEBRATING
+            celebrate(listOf(win))
+            showSummary = true
+            phase = SpinPhase.SHOW_SUMMARY
+            return@LaunchedEffect
+        }
+
+        val pos = resolveWinPosition(win.giftId, outerGifts, innerGifts)
+            ?: run { phase = SpinPhase.IDLE; return@LaunchedEffect }
+
+        // Chase phase (~2.8s) — light chase around both rings
+        val totalDuration = 2800L
+        val minInterval = 30L
+        val maxInterval = 280L
+        val startTime = System.currentTimeMillis()
+        var step = 0
+
+        while (true) {
+            val elapsed = System.currentTimeMillis() - startTime
+            val progress = (elapsed.toFloat() / totalDuration).coerceIn(0f, 1f)
+            val interval = minInterval + ((maxInterval - minInterval) * progress.pow(3)).toLong()
+
+            if (progress < 0.92f) {
+                outerLitIndex = if (outerGifts.isNotEmpty()) step % outerGifts.size else -1
+                innerLitIndex = if (innerGifts.isNotEmpty()) (innerGifts.size - (step % innerGifts.size)) % innerGifts.size else -1
+            } else {
+                // Lock to winner
+                if (pos.first == Ring.OUTER) { outerLitIndex = pos.second; innerLitIndex = -1 }
+                else { innerLitIndex = pos.second; outerLitIndex = -1 }
+            }
+
+            step++
+            if (progress >= 1f) break
+            delay(interval)
+        }
+
+        // Final lock
+        if (pos.first == Ring.OUTER) { outerLitIndex = pos.second; innerLitIndex = -1 }
+        else { innerLitIndex = pos.second; outerLitIndex = -1 }
+
+        // Blink phase (3 cycles)
+        repeat(3) {
+            if (pos.first == Ring.OUTER) outerLitIndex = -1 else innerLitIndex = -1
+            delay(130)
+            if (pos.first == Ring.OUTER) outerLitIndex = pos.second else innerLitIndex = pos.second
+            delay(130)
+        }
+
+        val key = "${if (pos.first == Ring.OUTER) "outer" else "inner"}-${pos.second}"
+        wonSegments = setOf(key)
+        lastWin = win
+        phase = SpinPhase.CELEBRATING
+        celebrate(listOf(win))
+        showSummary = true
+        phase = SpinPhase.SHOW_SUMMARY
+    }
+
+    // Handle multi-spin results (10x / 100x)
+    LaunchedEffect(gachaState.isMultiSpin, gachaState.multiSpinResults) {
+        if (!gachaState.isMultiSpin) return@LaunchedEffect
+        if (gachaState.multiSpinResults.isEmpty()) return@LaunchedEffect
+        if (phase != SpinPhase.ANIMATING) return@LaunchedEffect
+
+        val results = gachaState.multiSpinResults
+        allWins = results
+
+        if (skipAnimation) {
+            // Instant: populate all won segments
+            val newWon = mutableSetOf<String>()
+            for (r in results) {
+                val pos = resolveWinPosition(r.giftId, outerGifts, innerGifts) ?: continue
+                val key = "${if (pos.first == Ring.OUTER) "outer" else "inner"}-${pos.second}"
+                newWon.add(key)
+            }
+            wonSegments = newWon
+            outerLitIndex = -1
+            innerLitIndex = -1
+            onSkipMultiSpin()
+            phase = SpinPhase.CELEBRATING
+            celebrate(results)
+            showSummary = true
+            phase = SpinPhase.SHOW_SUMMARY
+            return@LaunchedEffect
+        }
+
+        val is100x = results.size >= 100
+
+        if (is100x) {
+            // Bulk sweep animation (~2s)
+            spinProgress = results.size to results.size
+            val totalSteps = 60
+            val intervalMs = 2000L / totalSteps
+            val sweepPhase = (totalSteps * 0.65f).toInt()
+
+            // Compute unique wins for reveal phase
+            val uniqueWins = mutableListOf<Pair<Ring, Int>>()
+            val seen = mutableSetOf<String>()
+            val allWonSet = mutableSetOf<String>()
+            for (r in results) {
+                val pos = resolveWinPosition(r.giftId, outerGifts, innerGifts) ?: continue
+                val key = "${if (pos.first == Ring.OUTER) "outer" else "inner"}-${pos.second}"
+                allWonSet.add(key)
+                if (key !in seen) { seen.add(key); uniqueWins.add(pos) }
+            }
+
+            for (step in 0..totalSteps) {
+                if (step < sweepPhase) {
+                    outerLitIndex = if (outerGifts.isNotEmpty()) step % outerGifts.size else -1
+                    innerLitIndex = if (innerGifts.isNotEmpty()) (innerGifts.size - (step % innerGifts.size)) % innerGifts.size else -1
+                } else {
+                    val revealStep = step - sweepPhase
+                    val revealIndex = ((revealStep.toFloat() / (totalSteps - sweepPhase)) * uniqueWins.size).toInt()
+                        .coerceAtMost(uniqueWins.size - 1)
+                    val revealed = mutableSetOf<String>()
+                    for (i in 0..revealIndex) {
+                        val p = uniqueWins[i]
+                        revealed.add("${if (p.first == Ring.OUTER) "outer" else "inner"}-${p.second}")
+                    }
+                    wonSegments = revealed
+                    val current = uniqueWins[revealIndex]
+                    if (current.first == Ring.OUTER) { outerLitIndex = current.second; innerLitIndex = -1 }
+                    else { innerLitIndex = current.second; outerLitIndex = -1 }
+                }
+                delay(intervalMs)
+            }
+
+            wonSegments = allWonSet
+            outerLitIndex = -1
+            innerLitIndex = -1
+            onSkipMultiSpin()
+        } else {
+            // 10x: per-result quick chase
+            val newWon = mutableSetOf<String>()
+            for (i in results.indices) {
+                spinProgress = (i + 1) to results.size
+                val result = results[i]
+                val pos = resolveWinPosition(result.giftId, outerGifts, innerGifts) ?: continue
+
+                // Quick chase (260ms per result)
+                val chaseDuration = 260L
+                val startTime2 = System.currentTimeMillis()
+                var chaseStep = 0
+                while (true) {
+                    val p = ((System.currentTimeMillis() - startTime2).toFloat() / chaseDuration).coerceIn(0f, 1f)
+                    if (p < 0.75f) {
+                        outerLitIndex = if (outerGifts.isNotEmpty()) chaseStep % outerGifts.size else -1
+                        innerLitIndex = if (innerGifts.isNotEmpty()) (innerGifts.size - (chaseStep % innerGifts.size)) % innerGifts.size else -1
+                    } else {
+                        if (pos.first == Ring.OUTER) { outerLitIndex = pos.second; innerLitIndex = -1 }
+                        else { innerLitIndex = pos.second; outerLitIndex = -1 }
+                    }
+                    chaseStep++
+                    if (p >= 1f) break
+                    delay(25)
+                }
+
+                // Lock on winner
+                if (pos.first == Ring.OUTER) outerLitIndex = pos.second else innerLitIndex = pos.second
+                val key = "${if (pos.first == Ring.OUTER) "outer" else "inner"}-${pos.second}"
+                newWon.add(key)
+                wonSegments = newWon.toSet()
+
+                // Brief celebration for RARE+
+                if (result.bracket.ordinal >= GiftBracket.RARE.ordinal) {
+                    lastWin = result
+                    celebrate(listOf(result), midSpin = true)
+                }
+
+                if (i < results.size - 1) delay(30)
+                onAdvanceMultiSpin()
+            }
+            onSkipMultiSpin()
+        }
+
+        phase = SpinPhase.CELEBRATING
+        celebrate(results)
+        spinProgress = null
+        showSummary = true
+        phase = SpinPhase.SHOW_SUMMARY
+    }
+
+    // Main overlay layout
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ) { /* consume taps on scrim */ }
+            .graphicsLayer {
+                translationX = shakeX.value
+                translationY = shakeY.value
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp)
+        ) {
+            // Close + coin balance header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = {
+                    if (phase == SpinPhase.IDLE || phase == SpinPhase.SHOW_SUMMARY) {
+                        resetBoard()
+                        onDismissResults()
+                        onDismiss()
+                    }
+                }) {
+                    Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.White)
+                }
+
+                Surface(
+                    shape = RoundedCornerShape(30.dp),
+                    color = Color(0xFFFFD700).copy(alpha = 0.06f)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(horizontal = 18.dp, vertical = 5.dp)
+                    ) {
+                        Text("\uD83E\uDE99", fontSize = 16.sp)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "${gachaState.coinBalance}",
+                            color = SuperShyGold,
+                            fontWeight = FontWeight.ExtraBold,
+                            fontSize = 18.sp,
+                            letterSpacing = 1.sp
+                        )
+                    }
+                }
+            }
+
+            // Title
+            Text(
+                text = "LUCKY SPIN",
+                fontSize = 26.sp,
+                fontWeight = FontWeight.Black,
+                letterSpacing = 2.sp,
+                style = androidx.compose.ui.text.TextStyle(
+                    brush = Brush.linearGradient(
+                        listOf(
+                            Color(0xFFFFD700), Color(0xFFFF6B00), Color(0xFFFF1744),
+                            Color(0xFFD500F9), Color(0xFF2979FF), Color(0xFF00E676)
+                        )
+                    )
+                )
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            // Skip animation toggle
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Switch(
+                    checked = skipAnimation,
+                    onCheckedChange = { skipAnimation = it },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = Color(0xFF1A1A2E),
+                        checkedTrackColor = Color(0xFFFFD700),
+                        uncheckedThumbColor = Color(0xFF777777),
+                        uncheckedTrackColor = Color(0xFF333333)
+                    ),
+                    modifier = Modifier.height(24.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "SKIP ANIMATION",
+                    color = Color.White.copy(alpha = 0.3f),
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    letterSpacing = 1.sp
+                )
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            // Progress bar for multi-spin
+            spinProgress?.let { (current, total) ->
+                if (total > 1) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center,
+                        modifier = Modifier.padding(horizontal = 32.dp)
+                    ) {
+                        LinearProgressIndicator(
+                            progress = { current.toFloat() / total },
+                            modifier = Modifier.weight(1f).height(6.dp),
+                            color = activeTier.color,
+                            trackColor = Color.White.copy(alpha = 0.07f)
+                        )
+                        Spacer(modifier = Modifier.width(10.dp))
+                        Text(
+                            text = "$current/$total",
+                            color = Color.White.copy(alpha = 0.35f),
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+            }
+
+            // The dual-ring wheel
+            LuckySpinWheel(
+                outerGifts = outerGifts,
+                innerGifts = innerGifts,
+                outerLitIndex = outerLitIndex,
+                innerLitIndex = innerLitIndex,
+                wonSegments = wonSegments,
+                modifier = Modifier.size(300.dp)
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Last win display
+            lastWin?.let { win ->
+                if (phase != SpinPhase.IDLE && !showSummary) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        Text(giftEmoji(win.giftName), fontSize = 22.sp)
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = "${win.giftName} — \uD83E\uDE99${win.coinValue}",
+                            color = Color(0xFFFFD700),
+                            fontWeight = FontWeight.ExtraBold,
+                            fontSize = 14.sp
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
+
+            // Spin tier buttons
+            if (phase == SpinPhase.IDLE) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    SpinTiers.forEach { tier ->
+                        val canAfford = gachaState.coinBalance >= tier.cost
+                        val enabled = canAfford && !gachaState.isPulling
+
+                        Button(
+                            onClick = {
+                                activeTier = tier
+                                phase = SpinPhase.ANIMATING
+                                wonSegments = emptySet()
+                                outerLitIndex = -1
+                                innerLitIndex = -1
+                                lastWin = null
+                                showConfetti = false
+                                allWins = emptyList()
+                                when (tier.count) {
+                                    1 -> onSpin()
+                                    else -> onQuickSpin(tier.count)
+                                }
+                            },
+                            enabled = enabled,
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = tier.color.copy(alpha = 0.15f),
+                                disabledContainerColor = Color(0xFF222222)
+                            ),
+                            shape = RoundedCornerShape(20.dp),
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(80.dp)
+                        ) {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(
+                                    text = tier.label,
+                                    fontSize = 22.sp,
+                                    fontWeight = FontWeight.Black,
+                                    color = if (enabled) tier.color else Color.Gray,
+                                    letterSpacing = 1.sp,
+                                    lineHeight = 24.sp
+                                )
+                                Text(
+                                    text = "SPIN",
+                                    fontSize = 10.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = if (enabled) Color.White.copy(alpha = 0.55f) else Color.Gray.copy(alpha = 0.4f),
+                                    letterSpacing = 1.sp
+                                )
+                                Surface(
+                                    shape = RoundedCornerShape(12.dp),
+                                    color = if (enabled) tier.color.copy(alpha = 0.12f) else Color.White.copy(alpha = 0.03f)
+                                ) {
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 3.dp)
+                                    ) {
+                                        Text("\uD83E\uDE99", fontSize = 11.sp)
+                                        Text(
+                                            text = "${tier.cost}",
+                                            fontSize = 13.sp,
+                                            fontWeight = FontWeight.ExtraBold,
+                                            color = if (enabled) tier.color else Color.Gray
+                                        )
+                                    }
+                                }
+                                if (tier.boostedDrop) {
+                                    Text(
+                                        text = "BOOSTED",
+                                        fontSize = 8.sp,
+                                        fontWeight = FontWeight.ExtraBold,
+                                        letterSpacing = 1.5.sp,
+                                        color = if (enabled) tier.color else Color.Gray
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            } else if (phase == SpinPhase.ANIMATING) {
+                Text(
+                    text = "Spinning...",
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp
+                )
+            }
+
+            // Collect All button when celebrating (pre-summary)
+            if (phase == SpinPhase.CELEBRATING && wonSegments.isNotEmpty() && !showSummary) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = { showSummary = true; phase = SpinPhase.SHOW_SUMMARY },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFFFFD700).copy(alpha = 0.08f)
+                    ),
+                    shape = RoundedCornerShape(50)
+                ) {
+                    Text(
+                        text = "COLLECT ALL (${allWins.size})",
+                        color = Color(0xFFFFD700),
+                        fontWeight = FontWeight.ExtraBold,
+                        fontSize = 14.sp,
+                        letterSpacing = 2.sp
+                    )
+                }
+            }
+        }
+
+        // Confetti overlay
+        LuckySpinConfetti(
+            active = showConfetti,
+            particleCount = confettiCount,
+            modifier = Modifier.fillMaxSize()
+        )
+
+        // Screen flash overlay
+        if (showFlash) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(flashColor)
+            )
+        }
+
+        // Summary popup
+        if (showSummary && allWins.isNotEmpty()) {
+            LuckySpinSummaryPopup(
+                wins = allWins,
+                spinTier = activeTier,
+                canAffordSpinAgain = gachaState.coinBalance >= activeTier.cost,
+                onClose = {
+                    resetBoard()
+                    onDismissResults()
+                },
+                onSpinAgain = {
+                    val tier = activeTier
+                    resetBoard()
+                    onDismissResults()
+                    // Trigger new spin
+                    phase = SpinPhase.ANIMATING
+                    activeTier = tier
+                    when (tier.count) {
+                        1 -> onSpin()
+                        else -> onQuickSpin(tier.count)
+                    }
+                }
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinSummaryPopup.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinSummaryPopup.kt
@@ -1,0 +1,307 @@
+package com.shyden.shytalk.feature.gacha
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.shyden.shytalk.core.model.GachaGift
+import com.shyden.shytalk.core.model.GiftBracket
+
+private data class GroupedWin(
+    val giftId: String,
+    val giftName: String,
+    val bracket: GiftBracket,
+    val coinValue: Int,
+    val count: Int
+)
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun LuckySpinSummaryPopup(
+    wins: List<GachaGift>,
+    spinTier: SpinTier,
+    canAffordSpinAgain: Boolean,
+    onClose: () -> Unit,
+    onSpinAgain: () -> Unit
+) {
+    val grouped = remember(wins) {
+        val map = mutableMapOf<String, GroupedWin>()
+        for (w in wins) {
+            val existing = map[w.giftId]
+            if (existing != null) {
+                map[w.giftId] = existing.copy(count = existing.count + 1)
+            } else {
+                map[w.giftId] = GroupedWin(w.giftId, w.giftName, w.bracket, w.coinValue, 1)
+            }
+        }
+        map.values
+            .sortedWith(compareByDescending<GroupedWin> { it.bracket.ordinal }.thenByDescending { it.coinValue })
+            .toList()
+    }
+
+    val totalCoins = remember(wins) { wins.sumOf { it.coinValue } }
+    val bestBracket = remember(wins) {
+        wins.maxByOrNull { it.bracket.ordinal }?.bracket ?: GiftBracket.COMMON
+    }
+    val rarityConfig = RarityConfigs[bestBracket] ?: RarityConfigs[GiftBracket.COMMON]!!
+    val isRarePlus = bestBracket.ordinal >= GiftBracket.RARE.ordinal
+
+    // Animated entrance
+    var appeared by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { appeared = true }
+    val scale by animateFloatAsState(
+        targetValue = if (appeared) 1f else 0.5f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow),
+        label = "summaryScale"
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ) { /* consume taps */ },
+        contentAlignment = Alignment.Center
+    ) {
+        Surface(
+            modifier = Modifier
+                .widthIn(max = 420.dp)
+                .fillMaxWidth(0.94f)
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                },
+            shape = RoundedCornerShape(28.dp),
+            color = Color(0xFF1A1A3E),
+            shadowElevation = 16.dp
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 32.dp)
+            ) {
+                // Title
+                Text(
+                    text = if (isRarePlus) rarityConfig.title else "Spin Results",
+                    fontSize = if (isRarePlus) 26.sp else 22.sp,
+                    fontWeight = FontWeight.Black,
+                    color = rarityConfig.glowColor,
+                    letterSpacing = 2.sp
+                )
+
+                Text(
+                    text = "${wins.size} SPIN${if (wins.size > 1) "S" else ""}${if (spinTier.boostedDrop) "  ★ BOOSTED" else ""}",
+                    color = Color.White.copy(alpha = 0.35f),
+                    fontSize = 11.sp,
+                    letterSpacing = 2.sp
+                )
+
+                Spacer(modifier = Modifier.height(14.dp))
+
+                // Gift cards grid
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(if (grouped.size > 8) 200.dp else 140.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    grouped.forEachIndexed { index, win ->
+                        WinCard(win = win, index = index)
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Total coins
+                Text(
+                    text = "\uD83E\uDE99 ${totalCoins.formatWithCommas()} Coins",
+                    fontSize = if (isRarePlus) 34.sp else 26.sp,
+                    fontWeight = FontWeight.Black,
+                    style = MaterialTheme.typography.headlineLarge.copy(
+                        brush = if (bestBracket == GiftBracket.LEGENDARY) {
+                            Brush.linearGradient(
+                                listOf(Color(0xFFFFD700), Color(0xFFFF6B00), Color(0xFFFF1744), Color(0xFFFFD700))
+                            )
+                        } else {
+                            Brush.linearGradient(
+                                listOf(Color(0xFFFFD700), Color(0xFFFF9100))
+                            )
+                        }
+                    )
+                )
+
+                Spacer(modifier = Modifier.height(18.dp))
+
+                // Spin again button
+                Button(
+                    onClick = onSpinAgain,
+                    enabled = canAffordSpinAgain,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = spinTier.color,
+                        disabledContainerColor = Color(0xFF333333)
+                    ),
+                    shape = RoundedCornerShape(50),
+                    modifier = Modifier
+                        .fillMaxWidth(0.8f)
+                        .height(48.dp)
+                ) {
+                    Text(
+                        text = "${spinTier.label} SPIN AGAIN · \uD83E\uDE99${spinTier.cost}",
+                        fontWeight = FontWeight.ExtraBold,
+                        fontSize = 15.sp,
+                        letterSpacing = 2.sp,
+                        color = if (canAffordSpinAgain) Color.White else Color.Gray
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Close button
+                Button(
+                    onClick = onClose,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color.White.copy(alpha = 0.08f)
+                    ),
+                    shape = RoundedCornerShape(50),
+                    modifier = Modifier
+                        .fillMaxWidth(0.6f)
+                        .height(40.dp)
+                ) {
+                    Text(
+                        text = "Close",
+                        color = Color.White.copy(alpha = 0.6f),
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 13.sp
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WinCard(win: GroupedWin, index: Int) {
+    val bracketColor = BracketColors[win.bracket] ?: Color.Gray
+    val isRarePlus = win.bracket.ordinal >= GiftBracket.RARE.ordinal
+
+    // Staggered entrance
+    var appeared by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { appeared = true }
+    val scale by animateFloatAsState(
+        targetValue = if (appeared) 1f else 0f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "cardScale$index"
+    )
+
+    Box(
+        modifier = Modifier
+            .graphicsLayer { scaleX = scale; scaleY = scale }
+            .clip(RoundedCornerShape(16.dp))
+            .background(bracketColor.copy(alpha = 0.1f))
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .widthIn(min = 80.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            // Count badge
+            if (win.count > 1) {
+                Text(
+                    text = "x${win.count}",
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Black,
+                    color = Color(0xFF1A1A2E),
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(
+                            Brush.linearGradient(listOf(Color(0xFFFFD700), Color(0xFFFF9100)))
+                        )
+                        .padding(horizontal = 7.dp, vertical = 1.dp)
+                )
+            }
+
+            Text(
+                text = giftEmoji(win.giftName),
+                fontSize = 28.sp
+            )
+
+            Text(
+                text = win.giftName,
+                color = Color.White,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+                maxLines = 1
+            )
+
+            Text(
+                text = "\uD83E\uDE99 ${(win.coinValue * win.count).formatWithCommas()}",
+                color = Color(0xFFFFD700),
+                fontSize = 11.sp,
+                fontWeight = FontWeight.ExtraBold
+            )
+
+            if (isRarePlus) {
+                Text(
+                    text = win.bracket.name,
+                    fontSize = 7.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    letterSpacing = 1.5.sp,
+                    color = (RarityConfigs[win.bracket] ?: RarityConfigs[GiftBracket.COMMON]!!).glowColor
+                )
+            }
+        }
+    }
+}
+
+private fun Int.formatWithCommas(): String {
+    val s = this.toString()
+    val result = StringBuilder()
+    for ((i, c) in s.reversed().withIndex()) {
+        if (i > 0 && i % 3 == 0) result.append(',')
+        result.append(c)
+    }
+    return result.reverse().toString()
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinWheel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinWheel.kt
@@ -1,0 +1,367 @@
+package com.shyden.shytalk.feature.gacha
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.sp
+import com.shyden.shytalk.core.model.Gift
+import com.shyden.shytalk.core.model.GiftBracket
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
+
+val BracketColors = mapOf(
+    GiftBracket.COMMON to Color(0xFF9E9E9E),
+    GiftBracket.UNCOMMON to Color(0xFF4CAF50),
+    GiftBracket.RARE to Color(0xFF2196F3),
+    GiftBracket.EPIC to Color(0xFF9C27B0),
+    GiftBracket.LEGENDARY to Color(0xFFFFD700)
+)
+
+private val BracketAccentColors = mapOf(
+    GiftBracket.COMMON to Color(0xFF757575),
+    GiftBracket.UNCOMMON to Color(0xFF388E3C),
+    GiftBracket.RARE to Color(0xFF1976D2),
+    GiftBracket.EPIC to Color(0xFF7B1FA2),
+    GiftBracket.LEGENDARY to Color(0xFFFFC107)
+)
+
+enum class Ring { OUTER, INNER }
+
+/**
+ * Splits winnable gifts into outer (COMMON + UNCOMMON) and inner (RARE + EPIC + LEGENDARY)
+ * rings, sorted by [Gift.order].
+ */
+fun buildRingLayout(gifts: List<Gift>): Pair<List<Gift>, List<Gift>> {
+    val outer = gifts
+        .filter { it.bracket == GiftBracket.COMMON || it.bracket == GiftBracket.UNCOMMON }
+        .sortedBy { it.order }
+    val inner = gifts
+        .filter { it.bracket == GiftBracket.RARE || it.bracket == GiftBracket.EPIC || it.bracket == GiftBracket.LEGENDARY }
+        .sortedBy { it.order }
+    return outer to inner
+}
+
+/**
+ * Finds which ring and segment index a gift with [giftId] occupies.
+ */
+fun resolveWinPosition(
+    giftId: String,
+    outerGifts: List<Gift>,
+    innerGifts: List<Gift>
+): Pair<Ring, Int>? {
+    val outerIndex = outerGifts.indexOfFirst { it.id == giftId }
+    if (outerIndex >= 0) return Ring.OUTER to outerIndex
+    val innerIndex = innerGifts.indexOfFirst { it.id == giftId }
+    if (innerIndex >= 0) return Ring.INNER to innerIndex
+    return null
+}
+
+private val GiftEmojiMap = mapOf(
+    "Rose" to "\uD83C\uDF39",
+    "Candy" to "\uD83C\uDF6C",
+    "Heart" to "\u2764\uFE0F",
+    "Star" to "\u2B50",
+    "Clover" to "\uD83C\uDF40",
+    "Fire" to "\uD83D\uDD25",
+    "Moon" to "\uD83C\uDF19",
+    "Bolt" to "\u26A1",
+    "Gift Box" to "\uD83C\uDF81",
+    "Potion" to "\uD83E\uDDEA",
+    "Crown" to "\uD83D\uDC51",
+    "Treasure" to "\uD83D\uDCB0",
+    "Mystery" to "\uD83D\uDD2E",
+    "Jackpot" to "\uD83C\uDFB0",
+    "Multiplier" to "\u2716\uFE0F",
+    "Bonus" to "\uD83C\uDFAF",
+    "Ruby" to "\uD83D\uDC8E",
+    "Sunflower" to "\uD83C\uDF3B",
+    "Coffee" to "\u2615",
+    "Music Note" to "\uD83C\uDFB5",
+    "Balloon" to "\uD83C\uDF88",
+    "Cake" to "\uD83C\uDF82",
+    "Diamond" to "\uD83D\uDC8E",
+    "Rocket" to "\uD83D\uDE80",
+    "Trophy" to "\uD83C\uDFC6",
+    "Rainbow" to "\uD83C\uDF08",
+    "Unicorn" to "\uD83E\uDD84"
+)
+
+fun giftEmoji(name: String): String = GiftEmojiMap[name] ?: name.take(2)
+
+private fun formatCoins(n: Int): String = when {
+    n >= 1000 -> "${n / 1000}${if (n % 1000 != 0) ".${(n % 1000) / 100}" else ""}K"
+    else -> "$n"
+}
+
+@Composable
+fun LuckySpinWheel(
+    outerGifts: List<Gift>,
+    innerGifts: List<Gift>,
+    outerLitIndex: Int,
+    innerLitIndex: Int,
+    wonSegments: Set<String>,
+    modifier: Modifier = Modifier
+) {
+    val textMeasurer = rememberTextMeasurer()
+    val outerAngle = remember(outerGifts.size) {
+        if (outerGifts.isNotEmpty()) 360f / outerGifts.size else 0f
+    }
+    val innerAngle = remember(innerGifts.size) {
+        if (innerGifts.isNotEmpty()) 360f / innerGifts.size else 0f
+    }
+
+    Canvas(
+        modifier = modifier
+            .fillMaxSize()
+            .aspectRatio(1f)
+    ) {
+        val diameter = min(size.width, size.height)
+        val radius = diameter / 2f
+        val center = Offset(size.width / 2f, size.height / 2f)
+
+        // Outer border ring
+        drawCircle(Color(0xFFFFD600).copy(alpha = 0.07f), radius = radius, center = center)
+        drawCircle(Color(0xFFFFD600).copy(alpha = 0.12f), radius = radius, center = center, style = Stroke(3f))
+
+        // Outer ring: from radius to ~62% radius
+        val outerRingOuter = radius - 6f
+        val outerRingInner = radius * 0.62f
+        drawRing(
+            gifts = outerGifts,
+            segmentAngle = outerAngle,
+            rOuter = outerRingOuter,
+            rInner = outerRingInner,
+            litIndex = outerLitIndex,
+            ringName = "outer",
+            wonSegments = wonSegments,
+            center = center,
+            textMeasurer = textMeasurer
+        )
+
+        // Divider between rings
+        drawCircle(Color(0xFF0D0D1A), radius = outerRingInner + 2f, center = center, style = Stroke(5f))
+        drawCircle(Color(0xFFFFD700).copy(alpha = 0.08f), radius = outerRingInner, center = center, style = Stroke(1f))
+
+        // Inner ring: from ~60% to ~28% radius
+        val innerRingOuter = outerRingInner - 3f
+        val innerRingInner = radius * 0.28f
+        drawRing(
+            gifts = innerGifts,
+            segmentAngle = innerAngle,
+            rOuter = innerRingOuter,
+            rInner = innerRingInner,
+            litIndex = innerLitIndex,
+            ringName = "inner",
+            wonSegments = wonSegments,
+            center = center,
+            textMeasurer = textMeasurer
+        )
+
+        // Center hub
+        drawCircle(Color(0xFF0D0D1A), radius = innerRingInner, center = center)
+        drawCircle(Color(0xFFFFD700).copy(alpha = 0.1f), radius = innerRingInner, center = center, style = Stroke(1.5f))
+
+        // Center "SPIN" text
+        val spinLabel = textMeasurer.measure(
+            text = "SPIN",
+            style = TextStyle(
+                color = Color(0xFFFFD700).copy(alpha = 0.3f),
+                fontSize = 10.sp,
+                letterSpacing = 2.sp
+            ),
+            constraints = Constraints(maxWidth = (innerRingInner * 2).toInt().coerceAtLeast(1))
+        )
+        drawText(
+            textLayoutResult = spinLabel,
+            topLeft = Offset(
+                center.x - spinLabel.size.width / 2f,
+                center.y - spinLabel.size.height / 2f + 12f
+            )
+        )
+
+        // Center emoji
+        val centerEmoji = textMeasurer.measure(
+            text = "\uD83C\uDFB0",
+            style = TextStyle(fontSize = 22.sp),
+            constraints = Constraints(maxWidth = (innerRingInner * 2).toInt().coerceAtLeast(1))
+        )
+        drawText(
+            textLayoutResult = centerEmoji,
+            topLeft = Offset(
+                center.x - centerEmoji.size.width / 2f,
+                center.y - centerEmoji.size.height / 2f - 4f
+            )
+        )
+    }
+}
+
+private fun DrawScope.drawRing(
+    gifts: List<Gift>,
+    segmentAngle: Float,
+    rOuter: Float,
+    rInner: Float,
+    litIndex: Int,
+    ringName: String,
+    wonSegments: Set<String>,
+    center: Offset,
+    textMeasurer: TextMeasurer
+) {
+    if (gifts.isEmpty() || segmentAngle <= 0f) return
+
+    for ((index, gift) in gifts.withIndex()) {
+        val isLit = litIndex == index
+        val wonKey = "$ringName-$index"
+        val isPrevWon = wonKey in wonSegments
+        val isActive = isLit || isPrevWon
+
+        val baseColor = BracketColors[gift.bracket] ?: Color.Gray
+        val accentColor = BracketAccentColors[gift.bracket] ?: Color.DarkGray
+
+        val startAngleDeg = index * segmentAngle - 90f - segmentAngle / 2f
+        val startAngleRad = startAngleDeg * (PI.toFloat() / 180f)
+        val endAngleRad = (startAngleDeg + segmentAngle) * (PI.toFloat() / 180f)
+        val midAngleRad = (startAngleDeg + segmentAngle / 2f) * (PI.toFloat() / 180f)
+
+        // Draw filled arc segment
+        val fillColor = when {
+            isLit -> baseColor
+            isPrevWon -> baseColor.copy(alpha = 0.7f)
+            else -> baseColor.copy(alpha = 0.3f)
+        }
+
+        drawArc(
+            color = fillColor,
+            startAngle = startAngleDeg,
+            sweepAngle = segmentAngle,
+            useCenter = true,
+            topLeft = Offset(center.x - rOuter, center.y - rOuter),
+            size = Size(rOuter * 2, rOuter * 2)
+        )
+
+        // Cut out inner portion to make a ring (draw over with background)
+        drawArc(
+            color = Color(0xFF0D0D1A),
+            startAngle = startAngleDeg,
+            sweepAngle = segmentAngle,
+            useCenter = true,
+            topLeft = Offset(center.x - rInner, center.y - rInner),
+            size = Size(rInner * 2, rInner * 2)
+        )
+
+        // Segment border stroke
+        val strokeColor = when {
+            isLit -> Color.White
+            isPrevWon -> baseColor
+            else -> Color(0xFF0D0D1A)
+        }
+        val strokeWidth = when {
+            isLit -> 3f
+            isPrevWon -> 2f
+            else -> 1.5f
+        }
+        drawArc(
+            color = strokeColor,
+            startAngle = startAngleDeg,
+            sweepAngle = segmentAngle,
+            useCenter = true,
+            topLeft = Offset(center.x - rOuter, center.y - rOuter),
+            size = Size(rOuter * 2, rOuter * 2),
+            style = Stroke(strokeWidth)
+        )
+
+        // Lit glow overlay
+        if (isLit) {
+            drawArc(
+                color = Color.White.copy(alpha = 0.18f),
+                startAngle = startAngleDeg,
+                sweepAngle = segmentAngle,
+                useCenter = true,
+                topLeft = Offset(center.x - rOuter, center.y - rOuter),
+                size = Size(rOuter * 2, rOuter * 2)
+            )
+            drawArc(
+                color = Color(0xFF0D0D1A),
+                startAngle = startAngleDeg,
+                sweepAngle = segmentAngle,
+                useCenter = true,
+                topLeft = Offset(center.x - rInner, center.y - rInner),
+                size = Size(rInner * 2, rInner * 2)
+            )
+        }
+
+        // Won dot marker (green dot on outer edge)
+        if (isPrevWon && !isLit) {
+            val dotR = rOuter - 8f
+            val dotX = center.x + dotR * cos(midAngleRad)
+            val dotY = center.y + dotR * sin(midAngleRad)
+            drawCircle(Color(0xFF00E676), radius = 5f, center = Offset(dotX, dotY))
+            drawCircle(
+                Color(0xFF0D0D1A), radius = 5f, center = Offset(dotX, dotY),
+                style = Stroke(1f)
+            )
+        }
+
+        // Emoji and coin text at segment midpoint
+        val midR = (rOuter + rInner) / 2f
+        val emojiR = midR + (rOuter - rInner) * 0.12f
+        val textR = midR - (rOuter - rInner) * 0.2f
+
+        val emojiX = center.x + emojiR * cos(midAngleRad)
+        val emojiY = center.y + emojiR * sin(midAngleRad)
+        val coinX = center.x + textR * cos(midAngleRad)
+        val coinY = center.y + textR * sin(midAngleRad)
+
+        val emojiSize = if (isLit) 20.sp else 16.sp
+        val emojiText = giftEmoji(gift.name)
+        val emojiMeasured = textMeasurer.measure(
+            text = emojiText,
+            style = TextStyle(fontSize = emojiSize),
+            maxLines = 1,
+            overflow = TextOverflow.Clip,
+            constraints = Constraints(maxWidth = ((rOuter - rInner) * 0.8f).toInt().coerceAtLeast(1))
+        )
+        drawText(
+            textLayoutResult = emojiMeasured,
+            topLeft = Offset(
+                emojiX - emojiMeasured.size.width / 2f,
+                emojiY - emojiMeasured.size.height / 2f
+            ),
+            alpha = if (isActive) 1f else 0.35f
+        )
+
+        val coinText = "\uD83E\uDE99${formatCoins(gift.coinValue)}"
+        val coinMeasured = textMeasurer.measure(
+            text = coinText,
+            style = TextStyle(
+                color = if (isActive) Color.White else Color.White.copy(alpha = 0.2f),
+                fontSize = 9.sp
+            ),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            constraints = Constraints(maxWidth = ((rOuter - rInner) * 0.9f).toInt().coerceAtLeast(1))
+        )
+        drawText(
+            textLayoutResult = coinMeasured,
+            topLeft = Offset(
+                coinX - coinMeasured.size.width / 2f,
+                coinY - coinMeasured.size.height / 2f
+            )
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/SpinTier.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/SpinTier.kt
@@ -1,0 +1,65 @@
+package com.shyden.shytalk.feature.gacha
+
+import androidx.compose.ui.graphics.Color
+import com.shyden.shytalk.core.model.GiftBracket
+
+data class SpinTier(
+    val label: String,
+    val count: Int,
+    val cost: Int,
+    val boostedDrop: Boolean,
+    val color: Color,
+    val accentColor: Color
+)
+
+val SpinTiers = listOf(
+    SpinTier("1x", 1, 10, false, Color(0xFFFFD700), Color(0xFFFF9100)),
+    SpinTier("10x", 10, 100, false, Color(0xFF2979FF), Color(0xFF00B0FF)),
+    SpinTier("100x", 100, 1000, true, Color(0xFFD500F9), Color(0xFFE040FB))
+)
+
+data class RarityConfig(
+    val glowColor: Color,
+    val burstCount: Int,
+    val shakeIntensity: Float,
+    val flash: Boolean,
+    val title: String
+)
+
+val RarityConfigs = mapOf(
+    GiftBracket.COMMON to RarityConfig(
+        glowColor = Color.White,
+        burstCount = 40,
+        shakeIntensity = 0f,
+        flash = false,
+        title = "You Won!"
+    ),
+    GiftBracket.UNCOMMON to RarityConfig(
+        glowColor = Color(0xFF2979FF),
+        burstCount = 70,
+        shakeIntensity = 3f,
+        flash = false,
+        title = "Nice Win!"
+    ),
+    GiftBracket.RARE to RarityConfig(
+        glowColor = Color(0xFFFFD700),
+        burstCount = 130,
+        shakeIntensity = 5f,
+        flash = true,
+        title = "RARE WIN!"
+    ),
+    GiftBracket.EPIC to RarityConfig(
+        glowColor = Color(0xFFD500F9),
+        burstCount = 180,
+        shakeIntensity = 7f,
+        flash = true,
+        title = "EPIC WIN!"
+    ),
+    GiftBracket.LEGENDARY to RarityConfig(
+        glowColor = Color(0xFFFF1744),
+        burstCount = 220,
+        shakeIntensity = 10f,
+        flash = true,
+        title = "LEGENDARY!!"
+    )
+)

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gifting/GiftingViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gifting/GiftingViewModel.kt
@@ -1,0 +1,94 @@
+package com.shyden.shytalk.feature.gifting
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.shyden.shytalk.core.model.BackpackItem
+import com.shyden.shytalk.core.model.Gift
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.data.repository.AuthRepository
+import com.shyden.shytalk.data.repository.EconomyRepository
+import com.shyden.shytalk.data.repository.GiftRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class GiftingUiState(
+    val backpackItems: List<BackpackItem> = emptyList(),
+    val giftCatalog: List<Gift> = emptyList(),
+    val selectedGiftId: String? = null,
+    val isSending: Boolean = false,
+    val sentGiftName: String? = null,
+    val sentGiftId: String? = null,
+    val error: String? = null
+)
+
+class GiftingViewModel(
+    private val giftRepository: GiftRepository,
+    private val economyRepository: EconomyRepository,
+    private val authRepository: AuthRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(GiftingUiState())
+    val uiState: StateFlow<GiftingUiState> = _uiState.asStateFlow()
+
+    init {
+        observeData()
+    }
+
+    private fun observeData() {
+        val userId = authRepository.currentUserId ?: return
+        viewModelScope.launch {
+            combine(
+                giftRepository.observeGiftCatalog(),
+                giftRepository.observeBackpack(userId)
+            ) { catalog, backpack ->
+                catalog to backpack
+            }.catch { e ->
+                _uiState.update { it.copy(error = e.message) }
+            }.collect { (catalog, backpack) ->
+                _uiState.update {
+                    it.copy(giftCatalog = catalog, backpackItems = backpack)
+                }
+            }
+        }
+    }
+
+    fun selectGift(giftId: String?) {
+        _uiState.update { it.copy(selectedGiftId = giftId) }
+    }
+
+    fun sendGift(recipientId: String, giftId: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSending = true, error = null) }
+            when (val result = economyRepository.sendGift(recipientId, giftId)) {
+                is Resource.Success -> {
+                    val giftName = result.data["giftName"] as? String ?: ""
+                    _uiState.update {
+                        it.copy(
+                            isSending = false,
+                            selectedGiftId = null,
+                            sentGiftName = giftName,
+                            sentGiftId = giftId
+                        )
+                    }
+                }
+                is Resource.Error -> {
+                    _uiState.update { it.copy(isSending = false, error = result.message) }
+                }
+                is Resource.Loading -> {}
+            }
+        }
+    }
+
+    fun clearSentGift() {
+        _uiState.update { it.copy(sentGiftName = null, sentGiftId = null) }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/main/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/main/MainScreen.kt
@@ -56,6 +56,7 @@ fun MainScreen(
     onNavigateToSettings: () -> Unit,
     onNavigateToLunarNewYear: () -> Unit = {},
     onNavigateToNewMessage: () -> Unit = {},
+    onNavigateToWallet: () -> Unit = {},
     messagesContent: @Composable (Modifier) -> Unit = {},
     totalUnreadCount: Long = 0,
     profileContent: @Composable (Modifier) -> Unit

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ConversationListItem.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ConversationListItem.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.shyden.shytalk.core.model.GroupRole
+import com.shyden.shytalk.core.ui.StyledDisplayName
 import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.util.Constants
 import com.shyden.shytalk.core.util.currentTimeMillis
@@ -124,11 +125,10 @@ fun ConversationListItem(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp)
             ) {
-                Text(
-                    text = if (isGroup) groupName ?: "Group" else otherUser?.displayName ?: "Unknown",
+                StyledDisplayName(
+                    displayName = if (isGroup) groupName ?: "Group" else otherUser?.displayName ?: "Unknown",
+                    isSuperShy = !isGroup && otherUser?.isSuperShy == true,
                     style = MaterialTheme.typography.bodyLarge,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f, fill = false)
                 )
                 if (isGroup && currentUserRole != GroupRole.MEMBER) {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.shyden.shytalk.core.model.GroupPermissions
+import com.shyden.shytalk.core.ui.StyledDisplayName
 import com.shyden.shytalk.core.model.MessageEdit
 import com.shyden.shytalk.core.model.PrivateMessage
 import com.shyden.shytalk.core.util.Constants
@@ -237,11 +238,10 @@ fun PrivateChatScreen(
                             }
                             Spacer(modifier = Modifier.width(12.dp))
                             Column {
-                                Text(
-                                    text = otherUser?.displayName ?: "Chat",
-                                    style = MaterialTheme.typography.titleMedium,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
+                                StyledDisplayName(
+                                    displayName = otherUser?.displayName ?: "Chat",
+                                    isSuperShy = otherUser?.isSuperShy == true,
+                                    style = MaterialTheme.typography.titleMedium
                                 )
                                 if (uiState.isOtherUserTyping) {
                                     Text(

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/FollowListScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/FollowListScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.runtime.collectAsState
 import coil3.compose.AsyncImage
 import com.shyden.shytalk.core.model.ProfileVisitor
 import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.ui.StyledDisplayName
 import com.shyden.shytalk.core.util.formatRelativeTime
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -274,11 +275,10 @@ private fun FollowUserRow(
 
         // Name
         Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = user.displayName.ifEmpty { "Unknown" },
-                style = MaterialTheme.typography.bodyLarge,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+            StyledDisplayName(
+                displayName = user.displayName.ifEmpty { "Unknown" },
+                isSuperShy = user.isSuperShy,
+                style = MaterialTheme.typography.bodyLarge
             )
         }
 
@@ -379,11 +379,10 @@ private fun StalkerUserRow(
 
         // Name and visit count
         Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = user?.displayName?.ifEmpty { "Unknown" } ?: "Unknown",
-                style = MaterialTheme.typography.bodyLarge,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+            StyledDisplayName(
+                displayName = user?.displayName?.ifEmpty { "Unknown" } ?: "Unknown",
+                isSuperShy = user?.isSuperShy == true,
+                style = MaterialTheme.typography.bodyLarge
             )
             val agoText = remember(visitor.lastVisitedAt) {
                 formatRelativeTime(visitor.lastVisitedAt)

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/GiftWallScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/GiftWallScreen.kt
@@ -1,0 +1,211 @@
+package com.shyden.shytalk.feature.profile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.shyden.shytalk.core.model.Gift
+import com.shyden.shytalk.core.model.GiftBracket
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GiftWallScreen(
+    viewModel: GiftWallViewModel,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Gift Wall") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        modifier = modifier
+    ) { padding ->
+        GiftWallContent(
+            state = state,
+            onSelectGift = { viewModel.selectGift(it) },
+            onDismissDetails = { viewModel.dismissDetails() },
+            modifier = Modifier.fillMaxSize().padding(padding)
+        )
+    }
+}
+
+/**
+ * Reusable gift wall content that can be embedded in ProfileScreen tabs
+ * or used standalone in GiftWallScreen.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GiftWallContent(
+    state: GiftWallUiState,
+    onSelectGift: (String) -> Unit,
+    onDismissDetails: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(4),
+        contentPadding = PaddingValues(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier
+    ) {
+        items(state.giftCatalog) { gift ->
+            val wallEntry = state.wallEntries.find { it.giftId == gift.id }
+            val hasReceived = wallEntry != null && wallEntry.receivedCount > 0
+
+            GiftWallItem(
+                gift = gift,
+                receivedCount = wallEntry?.receivedCount ?: 0,
+                isLit = hasReceived,
+                onClick = { if (hasReceived) onSelectGift(gift.id) }
+            )
+        }
+    }
+
+    // Gift detail bottom sheet
+    state.selectedGiftId?.let { selectedId ->
+        val gift = state.giftCatalog.find { it.id == selectedId }
+        val wallEntry = state.wallEntries.find { it.giftId == selectedId }
+
+        if (gift != null) {
+            ModalBottomSheet(onDismissRequest = onDismissDetails) {
+                Column(
+                    modifier = Modifier.padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(gift.name, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        "Received ${wallEntry?.receivedCount ?: 0} times",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Text(
+                        "Value: ${gift.coinValue} coins",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    if (state.senders.isNotEmpty()) {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text("Top Senders", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                        state.senders.take(5).forEach { sender ->
+                            Text("${sender.userId.take(8)}... - ${sender.count}x",
+                                style = MaterialTheme.typography.bodySmall)
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(24.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GiftWallItem(
+    gift: Gift,
+    receivedCount: Int,
+    isLit: Boolean,
+    onClick: () -> Unit
+) {
+    val bracketColor = when (gift.bracket) {
+        GiftBracket.COMMON -> Color.Gray
+        GiftBracket.UNCOMMON -> Color(0xFF4CAF50)
+        GiftBracket.RARE -> Color(0xFF2196F3)
+        GiftBracket.EPIC -> Color(0xFF9C27B0)
+        GiftBracket.LEGENDARY -> Color(0xFFFFD700)
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(
+                if (isLit) bracketColor.copy(alpha = 0.1f)
+                else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+            )
+            .border(
+                width = if (isLit) 2.dp else 1.dp,
+                color = if (isLit) bracketColor else Color.Gray.copy(alpha = 0.3f),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .clickable(enabled = isLit) { onClick() }
+            .padding(8.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(
+                    if (isLit) bracketColor.copy(alpha = 0.2f)
+                    else Color.Gray.copy(alpha = 0.1f)
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = gift.name.take(2),
+                fontWeight = FontWeight.Bold,
+                color = if (isLit) bracketColor else Color.Gray,
+                fontSize = 14.sp
+            )
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = gift.name,
+            style = MaterialTheme.typography.labelSmall,
+            maxLines = 1,
+            textAlign = TextAlign.Center,
+            color = if (isLit) MaterialTheme.colorScheme.onSurface else Color.Gray
+        )
+        if (receivedCount > 0) {
+            Text(
+                text = "x$receivedCount",
+                style = MaterialTheme.typography.labelSmall,
+                color = bracketColor,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/GiftWallViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/GiftWallViewModel.kt
@@ -1,0 +1,75 @@
+package com.shyden.shytalk.feature.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.shyden.shytalk.core.model.Gift
+import com.shyden.shytalk.core.model.GiftRankEntry
+import com.shyden.shytalk.core.model.GiftSender
+import com.shyden.shytalk.core.model.GiftWallEntry
+import com.shyden.shytalk.data.repository.GiftRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class GiftWallUiState(
+    val wallEntries: List<GiftWallEntry> = emptyList(),
+    val giftCatalog: List<Gift> = emptyList(),
+    val selectedGiftId: String? = null,
+    val senders: List<GiftSender> = emptyList(),
+    val ranking: List<GiftRankEntry> = emptyList(),
+    val isLoadingDetails: Boolean = false,
+    val error: String? = null
+)
+
+class GiftWallViewModel(
+    private val userId: String,
+    private val giftRepository: GiftRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(GiftWallUiState())
+    val uiState: StateFlow<GiftWallUiState> = _uiState.asStateFlow()
+
+    init {
+        observeData()
+    }
+
+    private fun observeData() {
+        viewModelScope.launch {
+            combine(
+                giftRepository.observeGiftCatalog(),
+                giftRepository.observeGiftWall(userId)
+            ) { catalog, wall ->
+                catalog to wall
+            }.catch { e ->
+                _uiState.update { it.copy(error = e.message) }
+            }.collect { (catalog, wall) ->
+                _uiState.update {
+                    it.copy(giftCatalog = catalog, wallEntries = wall)
+                }
+            }
+        }
+    }
+
+    fun selectGift(giftId: String) {
+        _uiState.update { it.copy(selectedGiftId = giftId, isLoadingDetails = true) }
+        viewModelScope.launch {
+            try {
+                val senders = giftRepository.getGiftWallSenders(userId, giftId)
+                val ranking = giftRepository.getGiftRanking(giftId)
+                _uiState.update {
+                    it.copy(senders = senders, ranking = ranking, isLoadingDetails = false)
+                }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(isLoadingDetails = false, error = e.message) }
+            }
+        }
+    }
+
+    fun dismissDetails() {
+        _uiState.update { it.copy(selectedGiftId = null, senders = emptyList(), ranking = emptyList()) }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
@@ -8,6 +8,7 @@ import com.shyden.shytalk.core.util.Constants
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.core.util.currentTimeMillis
 import com.shyden.shytalk.data.repository.AuthRepository
+import com.shyden.shytalk.data.repository.EconomyRepository
 import com.shyden.shytalk.data.repository.ReportRepository
 import com.shyden.shytalk.data.repository.RoomRepository
 import com.shyden.shytalk.data.repository.StorageRepository
@@ -51,7 +52,8 @@ class ProfileViewModel(
     private val userRepository: UserRepository,
     private val storageRepository: StorageRepository,
     private val roomRepository: RoomRepository,
-    private val reportRepository: ReportRepository
+    private val reportRepository: ReportRepository,
+    private val economyRepository: EconomyRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ProfileUiState())
@@ -468,5 +470,20 @@ class ProfileViewModel(
 
     fun clearReportSubmitted() {
         _uiState.update { it.copy(reportSubmitted = false, reportError = null) }
+    }
+
+    fun validateSuperShyPurchase(productId: String, purchaseToken: String) {
+        viewModelScope.launch {
+            when (val result = economyRepository.purchaseSubscription(productId, purchaseToken)) {
+                is Resource.Success -> {
+                    // Reload profile to pick up isSuperShy change
+                    loadProfile(null)
+                }
+                is Resource.Error -> {
+                    _uiState.update { it.copy(error = result.message ?: "Purchase validation failed") }
+                }
+                is Resource.Loading -> {}
+            }
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/BackpackSheet.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/BackpackSheet.kt
@@ -1,0 +1,159 @@
+package com.shyden.shytalk.feature.room.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.shyden.shytalk.core.model.BackpackItem
+import com.shyden.shytalk.core.model.Gift
+import com.shyden.shytalk.core.model.GiftBracket
+import com.shyden.shytalk.feature.gifting.GiftingUiState
+import com.shyden.shytalk.feature.gifting.GiftingViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BackpackSheet(
+    viewModel: GiftingViewModel,
+    recipientId: String = "",
+    recipientName: String = "",
+    currentUserId: String = "",
+    onDismiss: () -> Unit
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val isSelfView = recipientId.isBlank() || recipientId == currentUserId
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                if (isSelfView) "Your Backpack" else "Send a gift to $recipientName",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            if (state.backpackItems.isEmpty()) {
+                Text(
+                    "Your backpack is empty.\nSpin the wheel to get gifts!",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
+            } else {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(4),
+                    contentPadding = PaddingValues(4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.height(250.dp)
+                ) {
+                    items(state.backpackItems) { item ->
+                        val gift = state.giftCatalog.find { it.id == item.giftId }
+                        if (gift != null) {
+                            BackpackGiftItem(
+                                gift = gift,
+                                quantity = item.quantity,
+                                isSelected = !isSelfView && state.selectedGiftId == item.giftId,
+                                onClick = {
+                                    if (!isSelfView) viewModel.selectGift(item.giftId)
+                                }
+                            )
+                        }
+                    }
+                }
+
+                if (!isSelfView) {
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    Button(
+                        onClick = {
+                            state.selectedGiftId?.let { giftId ->
+                                viewModel.sendGift(recipientId, giftId)
+                            }
+                        },
+                        enabled = state.selectedGiftId != null && !state.isSending
+                    ) {
+                        Text(if (state.isSending) "Sending..." else "Send Gift")
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun BackpackGiftItem(
+    gift: Gift,
+    quantity: Int,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    val bracketColor = when (gift.bracket) {
+        GiftBracket.COMMON -> Color.Gray
+        GiftBracket.UNCOMMON -> Color(0xFF4CAF50)
+        GiftBracket.RARE -> Color(0xFF2196F3)
+        GiftBracket.EPIC -> Color(0xFF9C27B0)
+        GiftBracket.LEGENDARY -> Color(0xFFFFD700)
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .border(
+                width = if (isSelected) 3.dp else 1.dp,
+                color = if (isSelected) MaterialTheme.colorScheme.primary else bracketColor.copy(alpha = 0.5f),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .background(bracketColor.copy(alpha = 0.1f))
+            .clickable { onClick() }
+            .padding(6.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(bracketColor.copy(alpha = 0.2f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(gift.name.take(2), fontWeight = FontWeight.Bold, color = bracketColor, fontSize = 12.sp)
+        }
+        Text(gift.name, style = MaterialTheme.typography.labelSmall, maxLines = 1, fontSize = 9.sp)
+        Text("x$quantity", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, color = bracketColor)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ChatPanel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ChatPanel.kt
@@ -1,16 +1,23 @@
 package com.shyden.shytalk.feature.room.components
 
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Backpack
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MicOff
 import androidx.compose.material3.Badge
@@ -29,6 +36,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import com.shyden.shytalk.ui.theme.SpeakingGreen
@@ -52,6 +60,7 @@ fun ChatPanel(
     onInviteUser: (String, String) -> Unit,
     onToggleMessages: (() -> Unit)? = null,
     unreadCount: Int = 0,
+    onOpenBackpack: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     val listState = rememberLazyListState()
@@ -122,9 +131,37 @@ fun ChatPanel(
                 value = messageText,
                 onValueChange = { if (it.length <= 200) messageText = it },
                 placeholder = { Text("Type a message...") },
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(0.6f),
                 singleLine = true
             )
+
+            IconButton(
+                onClick = {
+                    if (messageText.isNotBlank()) {
+                        onSendMessage(messageText)
+                        messageText = ""
+                    }
+                }
+            ) {
+                Icon(
+                    Icons.AutoMirrored.Filled.Send,
+                    contentDescription = "Send",
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+
+            if (isSeated) {
+                IconButton(onClick = {
+                    focusManager.clearFocus()
+                    currentSeatEntry?.key?.toIntOrNull()?.let { onToggleMic(it) }
+                }) {
+                    Icon(
+                        imageVector = if (isSelfMuted) Icons.Default.MicOff else Icons.Default.Mic,
+                        contentDescription = if (isSelfMuted) "Unmute" else "Mute",
+                        tint = if (isSelfMuted) MaterialTheme.colorScheme.error else SpeakingGreen
+                    )
+                }
+            }
 
             if (onToggleMessages != null) {
                 IconButton(onClick = { focusManager.clearFocus(); onToggleMessages() }) {
@@ -149,32 +186,31 @@ fun ChatPanel(
                 }
             }
 
-            if (isSeated) {
-                IconButton(onClick = {
-                    focusManager.clearFocus()
-                    currentSeatEntry?.key?.toIntOrNull()?.let { onToggleMic(it) }
-                }) {
+            Spacer(modifier = Modifier.width(4.dp))
+
+            if (onOpenBackpack != null) {
+                val pulseTransition = rememberInfiniteTransition(label = "backpackPulse")
+                val scale by pulseTransition.animateFloat(
+                    initialValue = 1f,
+                    targetValue = 1.15f,
+                    animationSpec = infiniteRepeatable(
+                        animation = tween(750)
+                    ),
+                    label = "backpackScale"
+                )
+                IconButton(
+                    onClick = { focusManager.clearFocus(); onOpenBackpack() },
+                    modifier = Modifier.graphicsLayer {
+                        scaleX = scale
+                        scaleY = scale
+                    }
+                ) {
                     Icon(
-                        imageVector = if (isSelfMuted) Icons.Default.MicOff else Icons.Default.Mic,
-                        contentDescription = if (isSelfMuted) "Unmute" else "Mute",
-                        tint = if (isSelfMuted) MaterialTheme.colorScheme.error else SpeakingGreen
+                        Icons.Default.Backpack,
+                        contentDescription = "Backpack",
+                        tint = MaterialTheme.colorScheme.primary
                     )
                 }
-            }
-
-            IconButton(
-                onClick = {
-                    if (messageText.isNotBlank()) {
-                        onSendMessage(messageText)
-                        messageText = ""
-                    }
-                }
-            ) {
-                Icon(
-                    Icons.AutoMirrored.Filled.Send,
-                    contentDescription = "Send",
-                    tint = MaterialTheme.colorScheme.primary
-                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/MessageBubble.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/MessageBubble.kt
@@ -36,6 +36,7 @@ import com.shyden.shytalk.core.model.Message
 import com.shyden.shytalk.core.model.MessageType
 import com.shyden.shytalk.core.model.RoomRole
 import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.ui.StyledDisplayName
 import com.shyden.shytalk.core.util.flagEmojiForCode
 import com.shyden.shytalk.ui.components.FlagBadge
 
@@ -187,10 +188,12 @@ fun MessageBubble(
                 Spacer(modifier = Modifier.width(8.dp))
 
                 Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = message.senderName,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.primary
+                    StyledDisplayName(
+                        displayName = message.senderName,
+                        isSuperShy = user?.isSuperShy ?: false,
+                        style = MaterialTheme.typography.labelSmall.copy(
+                            color = MaterialTheme.colorScheme.primary
+                        )
                     )
 
                     Surface(

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ParticipantListPanel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ParticipantListPanel.kt
@@ -36,6 +36,7 @@ import coil3.compose.AsyncImage
 import com.shyden.shytalk.core.model.RoomRole
 import com.shyden.shytalk.core.model.SeatRequest
 import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.ui.StyledDisplayName
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.ui.unit.sp
@@ -219,11 +220,10 @@ private fun ParticipantRow(
         }
 
         // Name
-        Text(
-            text = participant.user.displayName.ifEmpty { "Unknown" },
+        StyledDisplayName(
+            displayName = participant.user.displayName.ifEmpty { "Unknown" },
+            isSuperShy = participant.user.isSuperShy,
             style = MaterialTheme.typography.bodyMedium,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f)
         )
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/RoomActionCarousel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/RoomActionCarousel.kt
@@ -1,0 +1,216 @@
+package com.shyden.shytalk.feature.room.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocalFireDepartment
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.shyden.shytalk.core.ui.SuperShyGold
+import kotlinx.coroutines.delay
+
+private const val PAGE_COUNT = 2
+
+@Composable
+fun RoomActionCarousel(
+    onOpenGacha: () -> Unit,
+    onOpenDailyReward: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val pagerState = rememberPagerState(pageCount = { PAGE_COUNT })
+
+    // Auto-scroll
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(4000)
+            val nextPage = (pagerState.currentPage + 1) % PAGE_COUNT
+            pagerState.animateScrollToPage(
+                page = nextPage,
+                animationSpec = tween(500, easing = LinearEasing)
+            )
+        }
+    }
+
+    Surface(
+        modifier = modifier
+            .size(76.dp),
+        shape = RoundedCornerShape(12.dp),
+        color = Color(0xFF263238).copy(alpha = 0.85f),
+        shadowElevation = 4.dp
+    ) {
+        Box(modifier = Modifier.padding(3.dp)) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize()
+            ) { page ->
+                when (page) {
+                    0 -> SquareCarouselBanner(
+                        icon = { MiniLuckySpinIcon(modifier = Modifier.size(28.dp)) },
+                        title = "Lucky Spin",
+                        gradientColors = listOf(Color(0xFFE53935), Color(0xFFFF6B35)),
+                        onClick = onOpenGacha
+                    )
+                    1 -> SquareCarouselBanner(
+                        icon = {
+                            Icon(
+                                Icons.Default.LocalFireDepartment,
+                                contentDescription = null,
+                                tint = Color(0xFFFF6B35),
+                                modifier = Modifier.size(28.dp)
+                            )
+                        },
+                        title = "Daily",
+                        gradientColors = listOf(Color(0xFFFF6B35), Color(0xFFFFD700)),
+                        onClick = onOpenDailyReward
+                    )
+                }
+            }
+
+            // Page indicator dots (bottom center)
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 1.dp)
+            ) {
+                repeat(PAGE_COUNT) { index ->
+                    val isSelected = pagerState.currentPage == index
+                    Box(
+                        modifier = Modifier
+                            .padding(horizontal = 1.5.dp)
+                            .size(if (isSelected) 5.dp else 3.dp)
+                            .clip(CircleShape)
+                            .background(
+                                if (isSelected) Color.White
+                                else Color.White.copy(alpha = 0.4f)
+                            )
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SquareCarouselBanner(
+    icon: @Composable () -> Unit,
+    title: String,
+    gradientColors: List<Color>,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(RoundedCornerShape(8.dp))
+            .background(
+                brush = Brush.verticalGradient(gradientColors.map { it.copy(alpha = 0.3f) })
+            )
+            .clickable { onClick() }
+            .padding(4.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            icon()
+            Text(
+                text = title,
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+                fontSize = 10.sp,
+                maxLines = 1
+            )
+        }
+    }
+}
+
+@Composable
+private fun MiniLuckySpinIcon(modifier: Modifier = Modifier) {
+    val transition = rememberInfiniteTransition(label = "miniSpin")
+    val litSegment by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 7f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2100, easing = LinearEasing)
+        ),
+        label = "miniSpinLit"
+    )
+    val outerSegments = 4
+    val innerSegments = 3
+    val currentLit = litSegment.toInt()
+
+    Canvas(modifier = modifier) {
+        val ctr = Offset(size.width / 2f, size.height / 2f)
+        val r = size.width / 2f
+
+        // Outer ring arcs (4 segments)
+        val outerOuter = r - 1f
+        val outerInner = r * 0.55f
+        val outerAngle = 360f / outerSegments
+        val outerColors = listOf(Color(0xFF9E9E9E), Color(0xFF4CAF50), Color(0xFF9E9E9E), Color(0xFF4CAF50))
+        for (i in 0 until outerSegments) {
+            val isLit = currentLit == i
+            drawArc(
+                color = outerColors[i].copy(alpha = if (isLit) 1f else 0.3f),
+                startAngle = i * outerAngle - 90f,
+                sweepAngle = outerAngle - 2f,
+                useCenter = true,
+                topLeft = Offset(ctr.x - outerOuter, ctr.y - outerOuter),
+                size = Size(outerOuter * 2, outerOuter * 2)
+            )
+        }
+        // Clear inner for outer ring
+        drawCircle(Color(0xFF263238), radius = outerInner, center = ctr)
+
+        // Inner ring arcs (3 segments)
+        val innerOuter = outerInner - 1f
+        val innerInner = r * 0.22f
+        val innerAngle = 360f / innerSegments
+        val innerColors = listOf(Color(0xFF2196F3), Color(0xFF9C27B0), Color(0xFFFFD700))
+        for (i in 0 until innerSegments) {
+            val isLit = currentLit == (outerSegments + i)
+            drawArc(
+                color = innerColors[i].copy(alpha = if (isLit) 1f else 0.3f),
+                startAngle = i * innerAngle - 90f,
+                sweepAngle = innerAngle - 2f,
+                useCenter = true,
+                topLeft = Offset(ctr.x - innerOuter, ctr.y - innerOuter),
+                size = Size(innerOuter * 2, innerOuter * 2)
+            )
+        }
+        // Center dot
+        drawCircle(Color(0xFF0D0D1A), radius = innerInner, center = ctr)
+        drawCircle(SuperShyGold.copy(alpha = 0.4f), radius = innerInner, center = ctr, style = Stroke(1f))
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/SeatItem.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/SeatItem.kt
@@ -56,6 +56,8 @@ import com.shyden.shytalk.core.model.RoomRole
 import com.shyden.shytalk.core.model.Seat
 import com.shyden.shytalk.core.model.SeatState
 import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.ui.StyledDisplayName
+import com.shyden.shytalk.core.ui.SuperShyGold
 import com.shyden.shytalk.core.util.flagEmojiForCode
 import com.shyden.shytalk.ui.components.FlagBadge
 
@@ -254,12 +256,12 @@ fun SeatItem(
                     )
                 }
                 Spacer(modifier = Modifier.width(3.dp))
-                Text(
-                    text = name,
-                    style = textShadowStyle,
-                    color = MaterialTheme.colorScheme.onBackground,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
+                StyledDisplayName(
+                    displayName = name,
+                    isSuperShy = user.isSuperShy,
+                    style = textShadowStyle.copy(
+                        color = MaterialTheme.colorScheme.onBackground
+                    ),
                     modifier = Modifier.weight(1f, fill = false)
                 )
                 Spacer(modifier = Modifier.width(3.dp))

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/UserCardPopup.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/UserCardPopup.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.CardGiftcard
 import androidx.compose.material.icons.filled.EventSeat
 import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material.icons.filled.Mic
@@ -45,6 +46,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.ui.StyledDisplayName
 import com.shyden.shytalk.core.util.countryNameForCode
 import com.shyden.shytalk.core.util.flagEmojiForCode
 import com.shyden.shytalk.feature.messaging.ReportUserDialog
@@ -72,6 +74,7 @@ fun UserCardPopup(
     onMakeHost: (() -> Unit)? = null,
     onRemoveHost: (() -> Unit)? = null,
     isHost: Boolean = false,
+    onSendGift: (() -> Unit)? = null,
     onReportUser: ((reason: String, description: String) -> Unit)? = null,
     evidenceItems: List<ByteArray> = emptyList(),
     onAddEvidence: (() -> Unit)? = null,
@@ -136,8 +139,9 @@ fun UserCardPopup(
 
                 Spacer(modifier = Modifier.height(12.dp))
 
-                Text(
-                    text = user.displayName,
+                StyledDisplayName(
+                    displayName = user.displayName,
+                    isSuperShy = user.isSuperShy,
                     style = MaterialTheme.typography.titleMedium
                 )
 
@@ -213,6 +217,22 @@ fun UserCardPopup(
                         )
                         Spacer(modifier = Modifier.width(4.dp))
                         Text("Message")
+                    }
+                }
+
+                if (!isSelf && onSendGift != null) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedButton(
+                        onClick = onSendGift,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(
+                            Icons.Default.CardGiftcard,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text("Send Gift")
                     }
                 }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/SuperShyBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/SuperShyBottomSheet.kt
@@ -1,0 +1,269 @@
+package com.shyden.shytalk.feature.shop
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.ui.SuperShyGold
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SuperShyBottomSheet(
+    user: User,
+    onPurchase: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Header
+            Icon(
+                Icons.Filled.Star,
+                contentDescription = null,
+                tint = SuperShyGold,
+                modifier = Modifier.size(40.dp)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                "Super Shy",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = SuperShyGold
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Benefits list
+            val benefits = listOf(
+                "Gold display name everywhere",
+                "Star badge next to name",
+                "+10% daily login coins (rounded up)",
+                "Exclusive profile frame"
+            )
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = SuperShyGold.copy(alpha = 0.08f)
+                )
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(
+                        "Benefits",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    benefits.forEach { benefit ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(vertical = 4.dp)
+                        ) {
+                            Icon(
+                                Icons.Filled.Check,
+                                contentDescription = null,
+                                tint = SuperShyGold,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                benefit,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            if (user.isSuperShy && user.superShyTier == "lifetime") {
+                // Lifetime — congratulations
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = SuperShyGold.copy(alpha = 0.15f)
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier.padding(20.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Icon(
+                            Icons.Filled.AutoAwesome,
+                            contentDescription = null,
+                            tint = SuperShyGold,
+                            modifier = Modifier.size(32.dp)
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            "You're Super Shy for life!",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = SuperShyGold,
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                }
+            } else if (user.isSuperShy) {
+                // Active non-lifetime — show current tier + expiry + upgrade option
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = SuperShyGold.copy(alpha = 0.1f)
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            "Currently Active",
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = SuperShyGold
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            "Tier: ${user.superShyTier ?: "monthly"}",
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        user.superShyExpiry?.let { expiry ->
+                            val daysLeft = ((expiry - com.shyden.shytalk.core.util.currentTimeMillis()) / 86_400_000).toInt()
+                            if (daysLeft > 0) {
+                                Text(
+                                    "$daysLeft days remaining",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    "Upgrade to Lifetime",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                SuperShyPricingCard(
+                    tier = "Lifetime",
+                    price = "$99.99",
+                    description = "One-time payment",
+                    onClick = { onPurchase("super_shy_lifetime") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            } else {
+                // Not Super Shy — show all pricing
+                Text(
+                    "Choose a plan",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    SuperShyPricingCard(
+                        tier = "Monthly",
+                        price = "$4.99",
+                        description = "per month",
+                        onClick = { onPurchase("super_shy_monthly") },
+                        modifier = Modifier.weight(1f)
+                    )
+                    SuperShyPricingCard(
+                        tier = "Yearly",
+                        price = "$39.99",
+                        description = "per year",
+                        onClick = { onPurchase("super_shy_yearly") },
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                SuperShyPricingCard(
+                    tier = "Lifetime",
+                    price = "$99.99",
+                    description = "One-time payment",
+                    onClick = { onPurchase("super_shy_lifetime") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SuperShyPricingCard(
+    tier: String,
+    price: String,
+    description: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier,
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                tier,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                price,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = SuperShyGold
+            )
+            Text(
+                description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/TransactionHistoryScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/TransactionHistoryScreen.kt
@@ -1,0 +1,121 @@
+package com.shyden.shytalk.feature.shop
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+private val FILTERS = listOf("All", "Purchases", "Gifts", "Gacha", "Rewards", "Redemptions")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TransactionHistoryScreen(
+    viewModel: TransactionHistoryViewModel,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Transactions") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        modifier = modifier
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            // Filter chips
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                FILTERS.forEach { filter ->
+                    val selected = if (filter == "All") state.selectedFilter == null
+                    else state.selectedFilter == filter
+                    FilterChip(
+                        selected = selected,
+                        onClick = { viewModel.setFilter(if (filter == "All") null else filter) },
+                        label = { Text(filter) }
+                    )
+                }
+            }
+
+            when {
+                state.isLoading -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+                state.transactions.isEmpty() -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = if (state.selectedFilter != null) "No ${state.selectedFilter?.lowercase()} transactions"
+                            else "No transactions yet",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 16.dp)
+                    ) {
+                        items(state.transactions, key = { it.id }) { transaction ->
+                            TransactionRow(transaction)
+                            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                        }
+                        item { Spacer(modifier = Modifier.height(16.dp)) }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/TransactionHistoryViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/TransactionHistoryViewModel.kt
@@ -1,0 +1,72 @@
+package com.shyden.shytalk.feature.shop
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.shyden.shytalk.core.model.Transaction
+import com.shyden.shytalk.core.model.TransactionType
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.data.repository.EconomyRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class TransactionHistoryUiState(
+    val transactions: List<Transaction> = emptyList(),
+    val isLoading: Boolean = true,
+    val selectedFilter: String? = null, // null = "All"
+    val error: String? = null
+)
+
+class TransactionHistoryViewModel(
+    private val economyRepository: EconomyRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(TransactionHistoryUiState())
+    val uiState: StateFlow<TransactionHistoryUiState> = _uiState.asStateFlow()
+
+    init {
+        loadTransactions()
+    }
+
+    fun setFilter(filter: String?) {
+        _uiState.update { it.copy(selectedFilter = filter) }
+        loadTransactions()
+    }
+
+    private fun loadTransactions() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+
+            val filter = _uiState.value.selectedFilter
+
+            // "Gifts" is a client-side composite filter for GIFT_SENT + GIFT_RECEIVED
+            val serverFilter = when (filter) {
+                "Gifts" -> null // load all, filter client-side
+                "Purchases" -> TransactionType.PURCHASE.name
+                "Gacha" -> TransactionType.GACHA_PULL.name
+                "Rewards" -> TransactionType.DAILY_REWARD.name
+                "Redemptions" -> TransactionType.BEAN_REDEEM.name
+                else -> null // "All"
+            }
+
+            when (val result = economyRepository.getAllTransactions(serverFilter)) {
+                is Resource.Success -> {
+                    val transactions = if (filter == "Gifts") {
+                        result.data.filter {
+                            it.type == TransactionType.GIFT_SENT || it.type == TransactionType.GIFT_RECEIVED
+                        }
+                    } else {
+                        result.data
+                    }
+                    _uiState.update { it.copy(transactions = transactions, isLoading = false) }
+                }
+                is Resource.Error -> {
+                    _uiState.update { it.copy(isLoading = false, error = result.message) }
+                }
+                is Resource.Loading -> {}
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/WalletComponents.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/WalletComponents.kt
@@ -1,0 +1,112 @@
+package com.shyden.shytalk.feature.shop
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.shyden.shytalk.core.model.CurrencyType
+import com.shyden.shytalk.core.model.Transaction
+import com.shyden.shytalk.core.model.TransactionType
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+@Composable
+internal fun TransactionRow(transaction: Transaction) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = transactionIcon(transaction.type),
+            style = MaterialTheme.typography.titleMedium
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = transactionLabel(transaction),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                text = formatTimestamp(transaction.timestamp),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        val isPositive = transaction.amount > 0
+        Text(
+            text = "${if (isPositive) "+" else ""}${transaction.amount}",
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            color = if (isPositive) Color(0xFF4CAF50) else MaterialTheme.colorScheme.error
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = if (transaction.currency == CurrencyType.BEANS) "\uD83E\uDED8" else "\uD83E\uDE99",
+            style = MaterialTheme.typography.bodySmall
+        )
+    }
+}
+
+internal fun transactionIcon(type: TransactionType): String = when (type) {
+    TransactionType.PURCHASE -> "\uD83D\uDCB3"
+    TransactionType.GACHA_PULL -> "\uD83C\uDFB0"
+    TransactionType.GIFT_SENT -> "\uD83C\uDF81"
+    TransactionType.GIFT_RECEIVED -> "\uD83C\uDF89"
+    TransactionType.BEAN_REDEEM -> "\uD83E\uDED8"
+    TransactionType.DAILY_REWARD -> "\uD83D\uDCC5"
+    TransactionType.SUBSCRIPTION -> "\u2B50"
+    TransactionType.ADMIN_ADJUSTMENT -> "\uD83D\uDD27"
+    TransactionType.ADMIN_BACKPACK -> "\uD83C\uDF92"
+}
+
+private val uidPattern = Regex("""\(by [a-zA-Z0-9]{20,}\)""")
+
+internal fun transactionLabel(transaction: Transaction): String {
+    val details = transaction.details
+    if (!details.isNullOrBlank()) {
+        return details.replace(uidPattern, "(by ShyTalk Official)")
+    }
+    return when (transaction.type) {
+        TransactionType.PURCHASE -> "Coin purchase"
+        TransactionType.GACHA_PULL -> "Gacha pull${transaction.pullCount?.let { " (x$it)" } ?: ""}"
+        TransactionType.GIFT_SENT -> "Sent ${transaction.giftName ?: "gift"}"
+        TransactionType.GIFT_RECEIVED -> "Received ${transaction.giftName ?: "gift"}"
+        TransactionType.BEAN_REDEEM -> "Bean redemption"
+        TransactionType.DAILY_REWARD -> "Daily reward"
+        TransactionType.SUBSCRIPTION -> "Super Shy"
+        TransactionType.ADMIN_ADJUSTMENT -> "Adjustment"
+        TransactionType.ADMIN_BACKPACK -> "Backpack item"
+    }
+}
+
+internal fun formatNumber(value: Long): String = "%,d".format(value)
+
+internal fun formatTimestamp(millis: Long): String {
+    if (millis == 0L) return ""
+    val now = com.shyden.shytalk.core.util.currentTimeMillis()
+    val diff = now - millis
+    return when {
+        diff < 60_000 -> "Just now"
+        diff < 3_600_000 -> "${diff / 60_000}m ago"
+        diff < 86_400_000 -> "${diff / 3_600_000}h ago"
+        diff < 604_800_000 -> "${diff / 86_400_000}d ago"
+        else -> {
+            val instant = Instant.fromEpochMilliseconds(millis)
+            val local = instant.toLocalDateTime(TimeZone.currentSystemDefault())
+            "${local.dayOfMonth}/${local.monthNumber}/${local.year}"
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/WalletScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/WalletScreen.kt
@@ -1,0 +1,368 @@
+package com.shyden.shytalk.feature.shop
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ReceiptLong
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.shyden.shytalk.core.model.CoinPackage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WalletScreen(
+    viewModel: WalletViewModel,
+    onNavigateBack: () -> Unit,
+    onNavigateToTransactions: () -> Unit,
+    onPurchasePackage: (CoinPackage) -> Unit,
+    onPurchaseSubscription: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+
+    LaunchedEffect(state.error) {
+        state.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    LaunchedEffect(state.successMessage) {
+        state.successMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearSuccess()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text("Wallet") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onNavigateToTransactions) {
+                        Icon(Icons.AutoMirrored.Filled.ReceiptLong, contentDescription = "Transaction History")
+                    }
+                }
+            )
+        },
+        modifier = modifier
+    ) { padding ->
+        if (state.isLoading) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+            ) {
+                PrimaryTabRow(selectedTabIndex = selectedTab) {
+                    Tab(
+                        selected = selectedTab == 0,
+                        onClick = { selectedTab = 0 },
+                        text = { Text("Shy Coins") }
+                    )
+                    Tab(
+                        selected = selectedTab == 1,
+                        onClick = { selectedTab = 1 },
+                        text = { Text("Shy Beans") }
+                    )
+                }
+
+                when (selectedTab) {
+                    0 -> CoinsTab(
+                        coinBalance = state.coinBalance,
+                        coinPackages = state.coinPackages,
+                        isPurchasing = state.isPurchasing,
+                        onTestPurchase = { coins -> viewModel.testPurchaseCoins(coins) }
+                    )
+                    1 -> BeansTab(
+                        beanBalance = state.beanBalance,
+                        isPurchasing = state.isPurchasing,
+                        onRedeem = { amount -> viewModel.redeemBeans(amount) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CoinsTab(
+    coinBalance: Long,
+    coinPackages: List<CoinPackage>,
+    isPurchasing: Boolean,
+    onTestPurchase: (Int) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        BalanceCard(
+            label = "Shy Coins",
+            amount = coinBalance,
+            icon = "\uD83E\uDE99",
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer
+            )
+        ) {
+            Text(
+                text = "Testing mode — no real money is charged. " +
+                    "Tap a package to instantly receive coins.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                modifier = Modifier.padding(12.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text("Buy Shy Coins", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Spacer(modifier = Modifier.height(8.dp))
+
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            contentPadding = PaddingValues(0.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.height(300.dp)
+        ) {
+            items(coinPackages) { pkg ->
+                val totalCoins = pkg.coins + pkg.bonusCoins
+                CoinPackageCard(
+                    pkg = pkg,
+                    enabled = !isPurchasing,
+                    onClick = { onTestPurchase(totalCoins) }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun BeansTab(
+    beanBalance: Long,
+    isPurchasing: Boolean,
+    onRedeem: (Int) -> Unit
+) {
+    val presets = listOf(100, 500, 1_000, 2_000, 5_000)
+    var confirmAmount by remember { mutableStateOf<Int?>(null) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        BalanceCard(
+            label = "Shy Beans",
+            amount = beanBalance,
+            icon = "\uD83E\uDED8",
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Text("Redeem Shy Beans", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Text(
+            "1 bean = 1 coin. Redeem 2,000+ for a 10% bonus!",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Preset buttons in 2-column grid
+        val rows = (presets + -1).chunked(2) // -1 sentinel for "Redeem All"
+        rows.forEach { row ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                row.forEach { preset ->
+                    val isRedeemAll = preset == -1
+                    val amount = if (isRedeemAll) beanBalance.toInt() else preset
+                    val label = if (isRedeemAll) "Redeem All" else formatNumber(preset.toLong())
+                    val hasBonus = amount >= 2_000
+                    val enabled = !isPurchasing && amount > 0 && amount <= beanBalance
+
+                    Button(
+                        onClick = { confirmAmount = amount },
+                        enabled = enabled,
+                        modifier = Modifier.weight(1f).height(56.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (hasBonus && enabled) Color(0xFF4CAF50)
+                            else MaterialTheme.colorScheme.primary
+                        )
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(label, fontWeight = FontWeight.Bold)
+                            if (hasBonus) {
+                                Text(
+                                    "+10%",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = if (enabled) Color.White else MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+                // Pad last row if odd
+                if (row.size == 1) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+
+    // Confirmation dialog
+    confirmAmount?.let { amount ->
+        val coins = if (amount >= 2_000) (amount * 1.1).toInt() else amount
+        AlertDialog(
+            onDismissRequest = { confirmAmount = null },
+            title = { Text("Confirm Redemption") },
+            text = {
+                Text("Redeem ${formatNumber(amount.toLong())} beans for ${formatNumber(coins.toLong())} coins?")
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    confirmAmount = null
+                    onRedeem(amount)
+                }) {
+                    Text("Redeem")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmAmount = null }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun BalanceCard(
+    label: String,
+    amount: Long,
+    icon: String,
+    containerColor: Color,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = containerColor)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(icon, style = MaterialTheme.typography.headlineMedium)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = formatNumber(amount),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun CoinPackageCard(pkg: CoinPackage, enabled: Boolean = true, onClick: () -> Unit) {
+    Card(
+        onClick = onClick,
+        enabled = enabled,
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text("${pkg.coins}", fontWeight = FontWeight.Bold, style = MaterialTheme.typography.titleLarge)
+            if (pkg.bonusCoins > 0) {
+                Text("+${pkg.bonusCoins} bonus", color = Color(0xFF4CAF50), style = MaterialTheme.typography.bodySmall)
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(pkg.displayPrice, style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/WalletViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/WalletViewModel.kt
@@ -1,0 +1,143 @@
+package com.shyden.shytalk.feature.shop
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.shyden.shytalk.core.model.CoinPackage
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.data.repository.AuthRepository
+import com.shyden.shytalk.data.repository.EconomyRepository
+import com.shyden.shytalk.data.repository.UserRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class WalletUiState(
+    val coinPackages: List<CoinPackage> = emptyList(),
+    val coinBalance: Long = 0,
+    val beanBalance: Long = 0,
+    val isSuperShy: Boolean = false,
+    val superShyTier: String? = null,
+    val superShyExpiry: Long? = null,
+    val isLoading: Boolean = true,
+    val isPurchasing: Boolean = false,
+    val error: String? = null,
+    val successMessage: String? = null
+)
+
+class WalletViewModel(
+    private val economyRepository: EconomyRepository,
+    private val userRepository: UserRepository,
+    private val authRepository: AuthRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(WalletUiState())
+    val uiState: StateFlow<WalletUiState> = _uiState.asStateFlow()
+
+    init {
+        loadData()
+    }
+
+    private fun loadData() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+
+            // Load coin packages
+            when (val result = economyRepository.getCoinPackages()) {
+                is Resource.Success -> _uiState.update { it.copy(coinPackages = result.data) }
+                is Resource.Error -> _uiState.update { it.copy(error = result.message) }
+                is Resource.Loading -> {}
+            }
+
+            // Load user balance
+            val userId = authRepository.currentUserId ?: return@launch
+            when (val result = userRepository.getUser(userId)) {
+                is Resource.Success -> {
+                    val user = result.data
+                    _uiState.update {
+                        it.copy(
+                            coinBalance = user.shyCoins,
+                            beanBalance = user.shyBeans,
+                            isSuperShy = user.isSuperShy,
+                            superShyTier = user.superShyTier,
+                            superShyExpiry = user.superShyExpiry,
+                            isLoading = false
+                        )
+                    }
+                }
+                is Resource.Error -> _uiState.update { it.copy(isLoading = false, error = result.message) }
+                is Resource.Loading -> {}
+            }
+        }
+    }
+
+    fun onPurchaseCompleted(productId: String, purchaseToken: String, isSubscription: Boolean) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPurchasing = true) }
+            val result = if (isSubscription) {
+                economyRepository.purchaseSubscription(productId, purchaseToken)
+            } else {
+                economyRepository.purchaseCoins(productId, purchaseToken)
+            }
+            when (result) {
+                is Resource.Success -> {
+                    _uiState.update { it.copy(isPurchasing = false, successMessage = "Purchase successful!") }
+                    loadData()
+                }
+                is Resource.Error -> {
+                    _uiState.update { it.copy(isPurchasing = false, error = result.message) }
+                }
+                is Resource.Loading -> {}
+            }
+        }
+    }
+
+    fun redeemBeans(amount: Int) {
+        if (amount < 1) return
+        if (amount > _uiState.value.beanBalance) {
+            _uiState.update { it.copy(error = "Not enough beans") }
+            return
+        }
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPurchasing = true) }
+            when (val result = economyRepository.redeemBeans(amount)) {
+                is Resource.Success -> {
+                    val bonus = if (amount >= 2000) " (10% bonus!)" else ""
+                    _uiState.update {
+                        it.copy(
+                            isPurchasing = false,
+                            successMessage = "Redeemed ${formatNumber(amount.toLong())} beans$bonus"
+                        )
+                    }
+                    loadData()
+                }
+                is Resource.Error -> {
+                    _uiState.update { it.copy(isPurchasing = false, error = result.message) }
+                }
+                is Resource.Loading -> {}
+            }
+        }
+    }
+
+    fun testPurchaseCoins(coins: Int) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isPurchasing = true) }
+            when (val result = economyRepository.addTestCoins(coins)) {
+                is Resource.Success -> {
+                    _uiState.update {
+                        it.copy(isPurchasing = false, successMessage = "+${formatNumber(coins.toLong())} coins added!")
+                    }
+                    loadData()
+                }
+                is Resource.Error -> {
+                    _uiState.update { it.copy(isPurchasing = false, error = result.message) }
+                }
+                is Resource.Loading -> {}
+            }
+        }
+    }
+
+    fun clearError() { _uiState.update { it.copy(error = null) } }
+    fun clearSuccess() { _uiState.update { it.copy(successMessage = null) } }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/navigation/Screen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/navigation/Screen.kt
@@ -32,4 +32,9 @@ sealed class Screen(val route: String) {
         fun createRoute(selectedIds: String) = "group_setup/$selectedIds"
     }
     data object Warning : Screen("warning")
+    data object Wallet : Screen("wallet")
+    data object Transactions : Screen("transactions")
+    data object GiftWall : Screen("gift_wall/{userId}") {
+        fun createRoute(userId: String) = "gift_wall/$userId"
+    }
 }

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/ui/GiftEffectOverlay.ios.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/ui/GiftEffectOverlay.ios.kt
@@ -1,0 +1,22 @@
+package com.shyden.shytalk.core.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+actual fun GiftEffectOverlay(
+    animationUrl: String,
+    soundUrl: String,
+    isVisible: Boolean,
+    onFinished: () -> Unit,
+    modifier: Modifier
+) {
+    // TODO: Implement iOS Lottie playback
+    // For now, auto-dismiss after a delay
+    if (isVisible) {
+        androidx.compose.runtime.LaunchedEffect(Unit) {
+            kotlinx.coroutines.delay(2000)
+            onFinished()
+        }
+    }
+}

--- a/storage.rules
+++ b/storage.rules
@@ -48,6 +48,21 @@ service firebase.storage {
                        || request.resource.contentType.matches('video/.*'));
     }
 
+    // Gift assets (Lottie animations, icons, sounds — admin-managed)
+    match /gift_assets/{giftId}/{allPaths=**} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+
+    // Group photos
+    match /group_photos/{userId}/{allPaths=**} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null
+                   && request.auth.uid == userId
+                   && request.resource.size < 5 * 1024 * 1024
+                   && request.resource.contentType.matches('image/.*');
+    }
+
     // Deny everything else
     match /{allPaths=**} {
       allow read, write: if false;


### PR DESCRIPTION
## Summary

- Lucky Spin dual-ring wheel game replaces old gacha with light-chase animations (1x, 10x, 100x spin tiers)
- Full virtual economy: Shy Coins wallet, Shy Beans redemption, daily rewards with streak milestones
- Gift system: 27 gifts across 5 rarity tiers, sending, backpack, gift wall, broadcast notifications
- Shop: coin packages with test purchase buttons, Super Shy subscription sheet, transaction history
- Cloud Functions: gacha pulls, daily rewards, gifting, bean redemption, billing validation, gift rankings
- Admin panel enhancements: user management, reports, storage cleanup
- Animated mini-wheel icon in room action carousel
- Firestore rules, storage rules, PITR and delete protection enabled

## Test plan

- [x] All 990 unit tests pass
- [x] Debug APK installed on both test devices
- [x] Cloud Functions deployed successfully (18 functions)
- [ ] Verify Lucky Spin opens from room carousel
- [ ] Test 1x/10x/100x spin tiers
- [ ] Verify daily reward claim
- [ ] Test gift sending flow
- [ ] Verify wallet and transaction history

🤖 Generated with [Claude Code](https://claude.com/claude-code)