### PR TITLE
v0.39 — Sound effects, bug fixes & balance tuning

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 38
-        versionName = "0.38"
+        versionCode = 39
+        versionName = "0.39"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/shyden/shytalk/data/repository/EconomyRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/EconomyRepositoryImpl.kt
@@ -11,12 +11,26 @@ import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import com.google.firebase.functions.FirebaseFunctions
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 
 class EconomyRepositoryImpl(
     private val firestore: FirebaseFirestore,
     private val functions: FirebaseFunctions
 ) : EconomyRepository {
+
+    override fun observeBalance(): Flow<Long> = callbackFlow {
+        val uid = FirebaseAuth.getInstance().currentUser?.uid
+        if (uid == null) { close(); return@callbackFlow }
+        val reg = firestore.collection("users").document(uid)
+            .addSnapshotListener { snap, _ ->
+                val coins = snap?.getLong("shyCoins")
+                if (coins != null) trySend(coins)
+            }
+        awaitClose { reg.remove() }
+    }
 
     override suspend fun claimDailyReward(): Resource<DailyRewardResult> = firebaseCall("Failed to claim daily reward") {
         val result = functions.getHttpsCallable("claimDailyReward")
@@ -109,9 +123,8 @@ class EconomyRepositoryImpl(
     override suspend fun getAllTransactions(filterType: String?): Resource<List<Transaction>> = firebaseCall("Failed to load transactions") {
         val userId = FirebaseAuth.getInstance().currentUser?.uid
             ?: throw Exception("Not authenticated")
-        var query = firestore.collection("users").document(userId)
+        var query: Query = firestore.collection("users").document(userId)
             .collection("transactions")
-            .orderBy("timestamp", Query.Direction.DESCENDING)
         if (filterType != null) {
             query = query.whereEqualTo("type", filterType)
         }
@@ -119,7 +132,7 @@ class EconomyRepositoryImpl(
         snapshot.documents.mapNotNull { doc ->
             val data = doc.data ?: return@mapNotNull null
             Transaction.fromMap(data, doc.id)
-        }
+        }.sortedByDescending { it.timestamp }
     }
 
     override suspend fun addTestCoins(amount: Int): Resource<Map<String, Any?>> =

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -185,13 +185,7 @@ fun RoomScreen(
         }
     }
 
-    // Sync gacha balance from user data
     val currentUser = uiState.allKnownUsers[uiState.currentUserId]
-    LaunchedEffect(currentUser?.shyCoins, currentUser?.pityCounter, currentUser?.luckScore) {
-        currentUser?.let { user ->
-            gachaViewModel.updateBalance(user.shyCoins, user.pityCounter, user.luckScore)
-        }
-    }
 
     // Observe broadcasts
     LaunchedEffect(Unit) {
@@ -701,6 +695,8 @@ fun RoomScreen(
                         .fillMaxHeight()
                         .fillMaxWidth(0.7f)
                 )
+            }
+
             // Floating action carousel (bottom-right, inside scaffold content to respect padding)
             if (uiState.hasJoined && !uiState.roomClosed) {
                 RoomActionCarousel(
@@ -710,7 +706,6 @@ fun RoomScreen(
                         .align(Alignment.BottomEnd)
                         .padding(bottom = 64.dp, end = 8.dp)
                 )
-            }
             }
         }
 
@@ -958,7 +953,8 @@ fun RoomScreen(
                 onAdvanceMultiSpin = gachaViewModel::advanceMultiSpin,
                 onSkipMultiSpin = gachaViewModel::skipMultiSpin,
                 onDismissResults = gachaViewModel::dismissResults,
-                onDismiss = { showGachaWheel = false }
+                onDismiss = { showGachaWheel = false },
+                onTestPurchase = { coins -> gachaViewModel.testPurchase(coins) }
             )
         }
 

--- a/app/src/main/java/com/shyden/shytalk/feature/update/ForceUpdateScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/update/ForceUpdateScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.SystemUpdate
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,6 +27,10 @@ import androidx.compose.ui.unit.dp
 fun ForceUpdateScreen() {
     val context = LocalContext.current
 
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -68,5 +73,6 @@ fun ForceUpdateScreen() {
         }) {
             Text("Update Now")
         }
+    }
     }
 }

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,12 +1,12 @@
-v0.38 - Lucky Spin & Virtual Economy
+v0.39 - Sound Effects, Bug Fixes & Balance Tuning
 
-- Lucky Spin dual-ring wheel with light-chase animations
-- 1x, 10x, 100x spin tiers with confetti and screen shake
-- 27 gifts across 5 rarity tiers
-- Shy Coins wallet with test purchases
-- Shy Beans redemption (10% bonus at 2000+)
-- Transaction history
-- Daily rewards with streak milestones
-- Animated mini-wheel in room carousel
-- Firestore PITR and delete protection
-- Bug fixes and UI improvements
+- Synthesized sound effects for Lucky Spin (chase ticks, win fanfares, coin purchase)
+- High-tier fanfare for RARE+ wins
+- Backpack shows gift names, coin values, and total value
+- Uniform win card sizes in summary popup
+- Inline coin shop via + button on balance pill
+- Gacha drop rates rebalanced (harder high-tier)
+- Fixed coin balance showing 0 after spinning
+- Fixed daily reward showing 0 coins/streak
+- Fixed spin history not loading
+- Admin panel: partial backpack item removal

--- a/app/src/test/java/com/shyden/shytalk/core/audio/GachaSoundPlayerTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/audio/GachaSoundPlayerTest.kt
@@ -1,0 +1,167 @@
+package com.shyden.shytalk.core.audio
+
+import com.shyden.shytalk.core.model.GiftBracket
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests for GachaSoundPlayer logic. The actual Android AudioTrack-based implementation
+ * cannot be fully tested in JVM unit tests, but we verify the public API contract
+ * and the tick band quantization logic that the player uses.
+ */
+class GachaSoundPlayerTest {
+
+    @Test
+    fun `tick band 0 at progress 0`() {
+        val band = (0f.coerceIn(0f, 1f) * 7).toInt().coerceIn(0, 7)
+        assertEquals(0, band)
+    }
+
+    @Test
+    fun `tick band 7 at progress 1`() {
+        val band = (1f.coerceIn(0f, 1f) * 7).toInt().coerceIn(0, 7)
+        assertEquals(7, band)
+    }
+
+    @Test
+    fun `tick band 3 at progress 0_5`() {
+        val band = (0.5f.coerceIn(0f, 1f) * 7).toInt().coerceIn(0, 7)
+        assertEquals(3, band)
+    }
+
+    @Test
+    fun `tick band clamps negative progress to 0`() {
+        val band = ((-0.5f).coerceIn(0f, 1f) * 7).toInt().coerceIn(0, 7)
+        assertEquals(0, band)
+    }
+
+    @Test
+    fun `tick band clamps progress above 1 to 7`() {
+        val band = (1.5f.coerceIn(0f, 1f) * 7).toInt().coerceIn(0, 7)
+        assertEquals(7, band)
+    }
+
+    @Test
+    fun `tick bands cover all 8 values across progress range`() {
+        val bands = (0..100).map { i ->
+            val progress = i / 100f
+            (progress.coerceIn(0f, 1f) * 7).toInt().coerceIn(0, 7)
+        }.toSet()
+
+        assertEquals(setOf(0, 1, 2, 3, 4, 5, 6, 7), bands)
+    }
+
+    @Test
+    fun `tick frequency calculation covers expected range`() {
+        val minFreq = 180.0 + (740.0 - 180.0) * (0 / 7.0)
+        val maxFreq = 180.0 + (740.0 - 180.0) * (7 / 7.0)
+
+        assertEquals(180.0, minFreq, 0.01)
+        assertEquals(740.0, maxFreq, 0.01)
+    }
+
+    @Test
+    fun `GiftBracket entries count is 5`() {
+        assertEquals(5, GiftBracket.entries.size)
+    }
+
+    @Test
+    fun `GiftBracket ordinal ordering matches rarity`() {
+        assert(GiftBracket.COMMON.ordinal < GiftBracket.UNCOMMON.ordinal)
+        assert(GiftBracket.UNCOMMON.ordinal < GiftBracket.RARE.ordinal)
+        assert(GiftBracket.RARE.ordinal < GiftBracket.EPIC.ordinal)
+        assert(GiftBracket.EPIC.ordinal < GiftBracket.LEGENDARY.ordinal)
+    }
+
+    @Test
+    fun `spin start chirp frequency range`() {
+        // Verify the chirp formula at boundaries
+        val startFreq = 220.0 + (1760.0 - 220.0) * 0.0
+        val endFreq = 220.0 + (1760.0 - 220.0) * 1.0
+        assertEquals(220.0, startFreq, 0.01)
+        assertEquals(1760.0, endFreq, 0.01)
+    }
+
+    @Test
+    fun `coin purchase has two distinct frequency segments`() {
+        val freq1 = 880.0
+        val freq2 = 1108.0
+        assert(freq2 > freq1)
+        // Second ding is higher — ascending purchase confirmation
+    }
+
+    @Test
+    fun `sample count calculation for given duration`() {
+        val sampleRate = 44100
+        // 420ms spin start
+        assertEquals(18522, sampleRate * 420 / 1000)
+        // 28ms tick
+        assertEquals(1234, sampleRate * 28 / 1000)
+        // 22ms blink click
+        assertEquals(970, sampleRate * 22 / 1000)
+        // 330ms coin purchase
+        assertEquals(14553, sampleRate * 330 / 1000)
+    }
+
+    @Test
+    fun `win reveal duration increases with rarity`() {
+        val durations = mapOf(
+            GiftBracket.COMMON to 280,
+            GiftBracket.UNCOMMON to 420,
+            GiftBracket.RARE to 600,
+            GiftBracket.EPIC to 800,
+            GiftBracket.LEGENDARY to 1200
+        )
+
+        var previousDuration = 0
+        for (bracket in GiftBracket.entries) {
+            val duration = durations[bracket]!!
+            assert(duration > previousDuration) {
+                "$bracket duration ($duration) should be > previous ($previousDuration)"
+            }
+            previousDuration = duration
+        }
+    }
+
+    @Test
+    fun `high tier fanfare duration is longer than any win reveal`() {
+        val fanfareDuration = 1800
+        val longestWinReveal = 1200 // LEGENDARY
+        assert(fanfareDuration > longestWinReveal) {
+            "Fanfare ($fanfareDuration ms) should be longer than longest win reveal ($longestWinReveal ms)"
+        }
+    }
+
+    @Test
+    fun `high tier fanfare triggers for RARE and above only`() {
+        val highTierBrackets = GiftBracket.entries.filter { it.ordinal >= GiftBracket.RARE.ordinal }
+        assertEquals(listOf(GiftBracket.RARE, GiftBracket.EPIC, GiftBracket.LEGENDARY), highTierBrackets)
+
+        val lowTierBrackets = GiftBracket.entries.filter { it.ordinal < GiftBracket.RARE.ordinal }
+        assertEquals(listOf(GiftBracket.COMMON, GiftBracket.UNCOMMON), lowTierBrackets)
+    }
+
+    @Test
+    fun `total PCM buffer memory estimate under 550KB`() {
+        val sampleRate = 44100
+        val bytesPerSample = 2 // 16-bit PCM
+
+        val spinStart = sampleRate * 420 / 1000 * bytesPerSample
+        val ticks = 8 * (sampleRate * 28 / 1000 * bytesPerSample)
+        val blinkClick = sampleRate * 22 / 1000 * bytesPerSample
+        val coinPurchase = sampleRate * 330 / 1000 * bytesPerSample
+        val highTierFanfare = sampleRate * 1800 / 1000 * bytesPerSample
+        val winCommon = sampleRate * 280 / 1000 * bytesPerSample
+        val winUncommon = sampleRate * 420 / 1000 * bytesPerSample
+        val winRare = sampleRate * 600 / 1000 * bytesPerSample
+        val winEpic = sampleRate * 800 / 1000 * bytesPerSample
+        val winLegendary = sampleRate * 1200 / 1000 * bytesPerSample
+
+        val totalBytes = spinStart + ticks + blinkClick + coinPurchase + highTierFanfare +
+                winCommon + winUncommon + winRare + winEpic + winLegendary
+
+        assert(totalBytes < 550_000) {
+            "Total PCM buffer size $totalBytes exceeds 550KB limit"
+        }
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/core/model/GachaResultFromMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/GachaResultFromMapTest.kt
@@ -1,0 +1,181 @@
+package com.shyden.shytalk.core.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GachaResultFromMapTest {
+
+    @Test
+    fun `fromMap parses complete result`() {
+        val map = mapOf<String, Any?>(
+            "gifts" to listOf(
+                mapOf(
+                    "giftId" to "g1",
+                    "giftName" to "Rose",
+                    "bracket" to "COMMON",
+                    "coinValue" to 10L,
+                    "iconUrl" to "https://example.com/rose.png"
+                )
+            ),
+            "coinsSpent" to 100L,
+            "newBalance" to 900L,
+            "newPityCounter" to 1L,
+            "newLuckScore" to 5L
+        )
+
+        val result = GachaResult.fromMap(map)
+
+        assertEquals(1, result.gifts.size)
+        assertEquals("g1", result.gifts[0].giftId)
+        assertEquals("Rose", result.gifts[0].giftName)
+        assertEquals(GiftBracket.COMMON, result.gifts[0].bracket)
+        assertEquals(10, result.gifts[0].coinValue)
+        assertEquals("https://example.com/rose.png", result.gifts[0].iconUrl)
+        assertEquals(100, result.coinsSpent)
+        assertEquals(900L, result.newBalance)
+        assertEquals(1, result.newPityCounter)
+        assertEquals(5, result.newLuckScore)
+    }
+
+    @Test
+    fun `fromMap handles empty gifts list`() {
+        val map = mapOf<String, Any?>(
+            "gifts" to emptyList<Any>(),
+            "coinsSpent" to 0L,
+            "newBalance" to 100L,
+            "newPityCounter" to 0L,
+            "newLuckScore" to 0L
+        )
+
+        val result = GachaResult.fromMap(map)
+
+        assertTrue(result.gifts.isEmpty())
+    }
+
+    @Test
+    fun `fromMap handles null gifts`() {
+        val map = mapOf<String, Any?>(
+            "gifts" to null,
+            "coinsSpent" to 0L,
+            "newBalance" to 100L
+        )
+
+        val result = GachaResult.fromMap(map)
+
+        assertTrue(result.gifts.isEmpty())
+    }
+
+    @Test
+    fun `fromMap handles missing fields with defaults`() {
+        val map = emptyMap<String, Any?>()
+
+        val result = GachaResult.fromMap(map)
+
+        assertTrue(result.gifts.isEmpty())
+        assertEquals(0, result.coinsSpent)
+        assertEquals(0L, result.newBalance)
+        assertEquals(0, result.newPityCounter)
+        assertEquals(0, result.newLuckScore)
+    }
+
+    @Test
+    fun `fromMap handles invalid bracket string`() {
+        val map = mapOf<String, Any?>(
+            "gifts" to listOf(
+                mapOf(
+                    "giftId" to "g1",
+                    "giftName" to "Rose",
+                    "bracket" to "INVALID_BRACKET",
+                    "coinValue" to 10L
+                )
+            )
+        )
+
+        val result = GachaResult.fromMap(map)
+
+        assertEquals(GiftBracket.COMMON, result.gifts[0].bracket) // defaults to COMMON
+    }
+
+    @Test
+    fun `fromMap handles all bracket types`() {
+        val brackets = listOf("COMMON", "UNCOMMON", "RARE", "EPIC", "LEGENDARY")
+        val gifts = brackets.mapIndexed { i, bracket ->
+            mapOf(
+                "giftId" to "g$i",
+                "giftName" to "Gift $i",
+                "bracket" to bracket,
+                "coinValue" to (i * 100L)
+            )
+        }
+        val map = mapOf<String, Any?>("gifts" to gifts)
+
+        val result = GachaResult.fromMap(map)
+
+        assertEquals(5, result.gifts.size)
+        assertEquals(GiftBracket.COMMON, result.gifts[0].bracket)
+        assertEquals(GiftBracket.UNCOMMON, result.gifts[1].bracket)
+        assertEquals(GiftBracket.RARE, result.gifts[2].bracket)
+        assertEquals(GiftBracket.EPIC, result.gifts[3].bracket)
+        assertEquals(GiftBracket.LEGENDARY, result.gifts[4].bracket)
+    }
+
+    @Test
+    fun `fromMap handles multi-pull with many gifts`() {
+        val gifts = (1..100).map { i ->
+            mapOf(
+                "giftId" to "g$i",
+                "giftName" to "Gift $i",
+                "bracket" to "COMMON",
+                "coinValue" to 10L
+            )
+        }
+        val map = mapOf<String, Any?>(
+            "gifts" to gifts,
+            "coinsSpent" to 1000L,
+            "newBalance" to 0L
+        )
+
+        val result = GachaResult.fromMap(map)
+
+        assertEquals(100, result.gifts.size)
+        assertEquals(1000, result.coinsSpent)
+    }
+
+    @Test
+    fun `fromMap skips malformed gift entries`() {
+        val map = mapOf<String, Any?>(
+            "gifts" to listOf(
+                mapOf("giftId" to "g1", "giftName" to "Rose", "bracket" to "COMMON"),
+                "not a map",
+                42,
+                null,
+                mapOf("giftId" to "g2", "giftName" to "Crown", "bracket" to "RARE")
+            )
+        )
+
+        val result = GachaResult.fromMap(map)
+
+        assertEquals(2, result.gifts.size)
+        assertEquals("g1", result.gifts[0].giftId)
+        assertEquals("g2", result.gifts[1].giftId)
+    }
+
+    @Test
+    fun `fromMap gift with missing fields uses defaults`() {
+        val map = mapOf<String, Any?>(
+            "gifts" to listOf(
+                mapOf<String, Any?>()  // completely empty gift map
+            )
+        )
+
+        val result = GachaResult.fromMap(map)
+
+        assertEquals(1, result.gifts.size)
+        assertEquals("", result.gifts[0].giftId)
+        assertEquals("", result.gifts[0].giftName)
+        assertEquals(GiftBracket.COMMON, result.gifts[0].bracket)
+        assertEquals(0, result.gifts[0].coinValue)
+        assertEquals("", result.gifts[0].iconUrl)
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/feature/room/BackpackSortingTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/BackpackSortingTest.kt
@@ -1,0 +1,128 @@
+package com.shyden.shytalk.feature.room
+
+import com.shyden.shytalk.core.model.BackpackItem
+import com.shyden.shytalk.core.model.Gift
+import com.shyden.shytalk.core.model.GiftBracket
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BackpackSortingTest {
+
+    private val giftCatalog = listOf(
+        Gift(id = "g1", name = "Rose", coinValue = 10, bracket = GiftBracket.COMMON),
+        Gift(id = "g2", name = "Crown", coinValue = 500, bracket = GiftBracket.RARE),
+        Gift(id = "g3", name = "Diamond", coinValue = 5000, bracket = GiftBracket.LEGENDARY),
+        Gift(id = "g4", name = "Potion", coinValue = 50, bracket = GiftBracket.UNCOMMON),
+        Gift(id = "g5", name = "Amulet", coinValue = 500, bracket = GiftBracket.RARE)
+    )
+
+    /** Reproduces the exact sorting comparator used in BackpackSheet.kt */
+    private fun sortBackpack(items: List<BackpackItem>, catalog: List<Gift>): List<BackpackItem> {
+        return items.sortedWith(
+            compareByDescending<BackpackItem> { item ->
+                catalog.find { it.id == item.giftId }?.coinValue ?: 0
+            }.thenBy { item ->
+                catalog.find { it.id == item.giftId }?.name ?: ""
+            }
+        )
+    }
+
+    @Test
+    fun `items sorted by coin value descending`() {
+        val items = listOf(
+            BackpackItem(giftId = "g1", quantity = 3),
+            BackpackItem(giftId = "g2", quantity = 1),
+            BackpackItem(giftId = "g3", quantity = 1)
+        )
+
+        val sorted = sortBackpack(items, giftCatalog)
+
+        assertEquals("g3", sorted[0].giftId) // 5000
+        assertEquals("g2", sorted[1].giftId) // 500
+        assertEquals("g1", sorted[2].giftId) // 10
+    }
+
+    @Test
+    fun `equal value items sorted alphabetically by name`() {
+        val items = listOf(
+            BackpackItem(giftId = "g2", quantity = 1), // Crown, 500
+            BackpackItem(giftId = "g5", quantity = 2)  // Amulet, 500
+        )
+
+        val sorted = sortBackpack(items, giftCatalog)
+
+        assertEquals("g5", sorted[0].giftId) // Amulet comes before Crown
+        assertEquals("g2", sorted[1].giftId)
+    }
+
+    @Test
+    fun `full sort order is value desc then name asc`() {
+        val items = listOf(
+            BackpackItem(giftId = "g1", quantity = 5),
+            BackpackItem(giftId = "g5", quantity = 1),
+            BackpackItem(giftId = "g4", quantity = 2),
+            BackpackItem(giftId = "g2", quantity = 1),
+            BackpackItem(giftId = "g3", quantity = 1)
+        )
+
+        val sorted = sortBackpack(items, giftCatalog)
+
+        assertEquals(listOf("g3", "g5", "g2", "g4", "g1"), sorted.map { it.giftId })
+        // 5000, 500 (Amulet), 500 (Crown), 50, 10
+    }
+
+    @Test
+    fun `empty backpack returns empty`() {
+        val sorted = sortBackpack(emptyList(), giftCatalog)
+        assertTrue(sorted.isEmpty())
+    }
+
+    @Test
+    fun `single item returns unchanged`() {
+        val items = listOf(BackpackItem(giftId = "g1", quantity = 3))
+        val sorted = sortBackpack(items, giftCatalog)
+        assertEquals(1, sorted.size)
+        assertEquals("g1", sorted[0].giftId)
+    }
+
+    @Test
+    fun `unknown gift ID sorts to beginning of zero-value group`() {
+        val items = listOf(
+            BackpackItem(giftId = "g1", quantity = 1),    // 10 coins
+            BackpackItem(giftId = "unknown", quantity = 1) // 0 coins (not in catalog)
+        )
+
+        val sorted = sortBackpack(items, giftCatalog)
+
+        assertEquals("g1", sorted[0].giftId)      // 10 coins first
+        assertEquals("unknown", sorted[1].giftId)  // 0 coins last
+    }
+
+    @Test
+    fun `quantity is preserved after sorting`() {
+        val items = listOf(
+            BackpackItem(giftId = "g1", quantity = 5),
+            BackpackItem(giftId = "g3", quantity = 2)
+        )
+
+        val sorted = sortBackpack(items, giftCatalog)
+
+        assertEquals(2, sorted[0].quantity) // g3 first (5000 coins), qty 2
+        assertEquals(5, sorted[1].quantity) // g1 second (10 coins), qty 5
+    }
+
+    @Test
+    fun `empty catalog treats all items as zero value`() {
+        val items = listOf(
+            BackpackItem(giftId = "g1", quantity = 1),
+            BackpackItem(giftId = "g2", quantity = 1)
+        )
+
+        val sorted = sortBackpack(items, emptyList())
+
+        // All values 0, sorted alphabetically by name — but name lookup also fails
+        // so all names are "", order is stable
+        assertEquals(2, sorted.size)
+    }
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -837,7 +837,7 @@ const MILESTONES = new Set([7, 14, 30, 60, 90]);
 const PULL_COSTS = { 1: 10, 10: 100, 100: 1000 };
 
 // Base drop rates: [Common, Uncommon, Rare, Epic, Legendary]
-const BASE_RATES = [0.70, 0.20, 0.08, 0.018, 0.002];
+const BASE_RATES = [0.74, 0.18, 0.06, 0.015, 0.005];
 const BRACKETS = ["COMMON", "UNCOMMON", "RARE", "EPIC", "LEGENDARY"];
 
 exports.claimDailyReward = onCall({ region: "asia-southeast1" }, async (request) => {
@@ -934,15 +934,15 @@ exports.pullGacha = onCall({ region: "asia-southeast1" }, async (request) => {
       const rates = [...BASE_RATES];
 
       // Pity system
-      if (pity >= 80) {
+      if (pity >= 150) {
         // Hard pity: force Epic+
         rates[0] = 0; rates[1] = 0; rates[2] = 0;
         const epicLeg = BASE_RATES[3] + BASE_RATES[4];
         rates[3] = BASE_RATES[3] / epicLeg;
         rates[4] = BASE_RATES[4] / epicLeg;
-      } else if (pity >= 60) {
-        const pityBoost = (pity - 60) / 20; // 0→1 linear
-        const shift = 0.15 * pityBoost;
+      } else if (pity >= 100) {
+        const pityBoost = (pity - 100) / 50; // 0→1 linear over 50 pulls
+        const shift = 0.10 * pityBoost;
         rates[0] -= shift;
         rates[3] += shift;
       }

--- a/functions/seedGifts.js
+++ b/functions/seedGifts.js
@@ -1,0 +1,56 @@
+const admin = require("firebase-admin");
+admin.initializeApp();
+const db = admin.firestore();
+
+const catalog = [
+  { name: "Rose", coinValue: 8, baseDropRate: 0.70, bracket: "COMMON", order: 1 },
+  { name: "Heart", coinValue: 10, baseDropRate: 0.70, bracket: "COMMON", order: 2 },
+  { name: "Thumbs Up", coinValue: 12, baseDropRate: 0.70, bracket: "COMMON", order: 3 },
+  { name: "Star", coinValue: 15, baseDropRate: 0.70, bracket: "COMMON", order: 4 },
+  { name: "Smiley", coinValue: 18, baseDropRate: 0.70, bracket: "COMMON", order: 5 },
+  { name: "Coffee", coinValue: 20, baseDropRate: 0.70, bracket: "COMMON", order: 6 },
+  { name: "Candy", coinValue: 25, baseDropRate: 0.70, bracket: "COMMON", order: 7 },
+  { name: "Balloon", coinValue: 30, baseDropRate: 0.70, bracket: "COMMON", order: 8 },
+  { name: "Teddy Bear", coinValue: 50, baseDropRate: 0.20, bracket: "UNCOMMON", order: 9 },
+  { name: "Perfume", coinValue: 80, baseDropRate: 0.20, bracket: "UNCOMMON", order: 10 },
+  { name: "Diamond Ring", coinValue: 120, baseDropRate: 0.20, bracket: "UNCOMMON", order: 11 },
+  { name: "Bouquet", coinValue: 150, baseDropRate: 0.20, bracket: "UNCOMMON", order: 12 },
+  { name: "Fireworks", coinValue: 200, baseDropRate: 0.20, bracket: "UNCOMMON", order: 13 },
+  { name: "Music Box", coinValue: 300, baseDropRate: 0.20, bracket: "UNCOMMON", order: 14 },
+  { name: "Treasure Chest", coinValue: 500, baseDropRate: 0.08, bracket: "RARE", order: 15 },
+  { name: "Crown", coinValue: 800, baseDropRate: 0.08, bracket: "RARE", order: 16 },
+  { name: "Sports Car", coinValue: 1200, baseDropRate: 0.08, bracket: "RARE", order: 17 },
+  { name: "Yacht", coinValue: 1800, baseDropRate: 0.08, bracket: "RARE", order: 18 },
+  { name: "Dragon", coinValue: 2500, baseDropRate: 0.08, bracket: "RARE", order: 19 },
+  { name: "Phoenix", coinValue: 3500, baseDropRate: 0.08, bracket: "RARE", order: 20 },
+  { name: "Crystal Ball", coinValue: 5000, baseDropRate: 0.018, bracket: "EPIC", order: 21 },
+  { name: "Castle", coinValue: 8000, baseDropRate: 0.018, bracket: "EPIC", order: 22 },
+  { name: "Spaceship", coinValue: 12000, baseDropRate: 0.018, bracket: "EPIC", order: 23 },
+  { name: "Aurora", coinValue: 16000, baseDropRate: 0.018, bracket: "EPIC", order: 24 },
+  { name: "Galaxy Unicorn", coinValue: 20000, baseDropRate: 0.018, bracket: "EPIC", order: 25 },
+  { name: "ShyTalk Emblem", coinValue: 35000, baseDropRate: 0.002, bracket: "LEGENDARY", order: 26 },
+  { name: "Celestial Throne", coinValue: 52000, baseDropRate: 0.002, bracket: "LEGENDARY", order: 27 },
+];
+
+async function seed() {
+  const batch = db.batch();
+  for (const gift of catalog) {
+    const docId = gift.name.toLowerCase().replace(/\s+/g, "_");
+    batch.set(db.collection("gifts").doc(docId), {
+      ...gift,
+      beanValue: Math.floor(gift.coinValue * 0.6),
+      broadcastEnabled: gift.bracket === "LEGENDARY",
+      animationUrl: "",
+      soundUrl: "",
+      iconUrl: "",
+    }, { merge: true });
+  }
+  await batch.commit();
+  console.log(`Seeded ${catalog.length} gifts`);
+  process.exit(0);
+}
+
+seed().catch((err) => {
+  console.error("Seed failed:", err);
+  process.exit(1);
+});

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -3791,8 +3791,9 @@
             ${item.bracket ? `<span style="color:var(--text2);font-size:0.8em">[${escapeHtml(item.bracket)}]</span>` : ""}
             <span style="color:var(--text2);font-size:0.75em">(${escapeHtml(item.giftId)})</span>
           </span>
-          <div style="display:flex;gap:4px">
-            <button type="button" class="btn-sm" style="background:var(--danger)" onclick="removeBackpackItem('${escapeHtml(item.giftId)}')">Remove</button>
+          <div style="display:flex;gap:4px;align-items:center">
+            <input type="number" id="bp-rm-qty-${escapeHtml(item.giftId)}" min="1" max="${item.quantity}" value="${item.quantity}" style="width:50px;padding:2px 4px;border:1px solid var(--border);border-radius:4px;background:var(--bg2);color:var(--text1);text-align:center;font-size:0.85em">
+            <button type="button" class="btn-sm" style="background:var(--danger)" onclick="removeBackpackItem('${escapeHtml(item.giftId)}', ${item.quantity})">Remove</button>
           </div>
         </div>`
       ).join("");
@@ -3815,11 +3816,17 @@
     }
   }
 
-  window.removeBackpackItem = async function(giftId) {
-    if (!currentUid || !confirm("Remove this gift from backpack?")) return;
+  window.removeBackpackItem = async function(giftId, currentQty) {
+    if (!currentUid) return;
+    const input = $(`#bp-rm-qty-${giftId}`);
+    const removeQty = parseInt(input?.value) || currentQty;
+    if (removeQty <= 0) return;
+    const label = removeQty >= currentQty ? "all" : removeQty;
+    if (!confirm(`Remove ${label} of this gift from backpack?`)) return;
     try {
-      await apiCall("POST", `/api/users/${currentUid}/backpack`, { giftId, quantity: 0 });
-      showToast("Removed from backpack");
+      const newQty = Math.max(0, currentQty - removeQty);
+      await apiCall("POST", `/api/users/${currentUid}/backpack`, { giftId, quantity: newQty });
+      showToast(removeQty >= currentQty ? "Removed from backpack" : `Removed ${removeQty} (${newQty} remaining)`);
       loadBackpack(currentUid);
     } catch (err) {
       showToast(err.message, "error");

--- a/shared/src/androidMain/kotlin/com/shyden/shytalk/core/audio/GachaSoundPlayer.android.kt
+++ b/shared/src/androidMain/kotlin/com/shyden/shytalk/core/audio/GachaSoundPlayer.android.kt
@@ -1,0 +1,431 @@
+package com.shyden.shytalk.core.audio
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import com.shyden.shytalk.core.model.GiftBracket
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.exp
+import kotlin.math.sin
+
+private const val SAMPLE_RATE = 44100
+
+actual object GachaSoundPlayer {
+
+    private var spinStartTrack: AudioTrack? = null
+    private var blinkClickTrack: AudioTrack? = null
+    private var coinPurchaseTrack: AudioTrack? = null
+    private var highTierFanfareTrack: AudioTrack? = null
+    private val tickTracks = arrayOfNulls<AudioTrack>(8)
+    private val winTracks = mutableMapOf<GiftBracket, AudioTrack>()
+    private var initialized = false
+
+    actual fun init() {
+        if (initialized) return
+        initialized = true
+        spinStartTrack = buildTrack(generateSpinStart())
+        blinkClickTrack = buildTrack(generateBlinkClick())
+        coinPurchaseTrack = buildTrack(generateCoinPurchase())
+        highTierFanfareTrack = buildTrack(generateHighTierFanfare())
+        for (band in 0 until 8) {
+            tickTracks[band] = buildTrack(generateTick(band))
+        }
+        GiftBracket.entries.forEach { bracket ->
+            winTracks[bracket] = buildTrack(generateWinReveal(bracket))
+        }
+    }
+
+    actual fun release() {
+        if (!initialized) return
+        initialized = false
+        spinStartTrack?.release(); spinStartTrack = null
+        blinkClickTrack?.release(); blinkClickTrack = null
+        coinPurchaseTrack?.release(); coinPurchaseTrack = null
+        highTierFanfareTrack?.release(); highTierFanfareTrack = null
+        tickTracks.indices.forEach { tickTracks[it]?.release(); tickTracks[it] = null }
+        winTracks.values.forEach { it.release() }
+        winTracks.clear()
+    }
+
+    actual fun playSpinStart() = replay(spinStartTrack)
+    actual fun playBlinkClick() = replay(blinkClickTrack)
+    actual fun playCoinPurchase() = replay(coinPurchaseTrack)
+    actual fun playHighTierFanfare() = replay(highTierFanfareTrack)
+
+    actual fun playTick(progress: Float) {
+        val band = (progress.coerceIn(0f, 1f) * 7).toInt().coerceIn(0, 7)
+        replay(tickTracks[band])
+    }
+
+    actual fun playWinReveal(bracket: GiftBracket) {
+        replay(winTracks[bracket])
+    }
+
+    // -- Playback helper --
+
+    private fun replay(track: AudioTrack?) {
+        track ?: return
+        try {
+            track.pause()
+            track.reloadStaticData()
+            track.play()
+        } catch (_: Exception) {}
+    }
+
+    // -- Track builder --
+
+    private fun buildTrack(samples: ShortArray): AudioTrack {
+        val bufferSize = samples.size * 2
+        val track = AudioTrack.Builder()
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_GAME)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .build()
+            )
+            .setAudioFormat(
+                AudioFormat.Builder()
+                    .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                    .setSampleRate(SAMPLE_RATE)
+                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                    .build()
+            )
+            .setBufferSizeInBytes(bufferSize)
+            .setTransferMode(AudioTrack.MODE_STATIC)
+            .build()
+        track.write(samples, 0, samples.size)
+        return track
+    }
+
+    // -- Sound generators --
+
+    /** Ascending chirp 220→1760Hz, 420ms, cos² attack/decay */
+    private fun generateSpinStart(): ShortArray {
+        val durationMs = 420
+        val numSamples = SAMPLE_RATE * durationMs / 1000
+        val samples = ShortArray(numSamples)
+        val amplitude = 0.28f
+        val attackMs = 40
+        val decayMs = 80
+        val attackSamples = SAMPLE_RATE * attackMs / 1000
+        val decaySamples = SAMPLE_RATE * decayMs / 1000
+
+        var phase = 0.0
+        for (i in 0 until numSamples) {
+            val t = i.toFloat() / numSamples
+            val freq = 220.0 + (1760.0 - 220.0) * t
+            phase += 2.0 * PI * freq / SAMPLE_RATE
+            var envelope = 1f
+            if (i < attackSamples) {
+                val x = (i.toFloat() / attackSamples * PI / 2).toFloat()
+                envelope = cos(x) * cos(x) // cos² ramp up  — actually this is wrong, cos²(0)=1
+                // cos² attack: starts at 0, ends at 1
+                val at = i.toFloat() / attackSamples
+                envelope = (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+            } else if (i > numSamples - decaySamples) {
+                val dt = (i - (numSamples - decaySamples)).toFloat() / decaySamples
+                envelope = (cos(dt * PI / 2) * cos(dt * PI / 2)).toFloat()
+            }
+            samples[i] = (sin(phase) * amplitude * envelope * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+        }
+        return samples
+    }
+
+    /** Short tick, pitch mapped to 8 bands (180→740Hz), 28ms */
+    private fun generateTick(band: Int): ShortArray {
+        val durationMs = 28
+        val numSamples = SAMPLE_RATE * durationMs / 1000
+        val samples = ShortArray(numSamples)
+        val freq = 180.0 + (740.0 - 180.0) * (band / 7.0)
+        val amplitude = 0.20f
+        val attackSamples = SAMPLE_RATE * 4 / 1000
+        val decaySamples = SAMPLE_RATE * 4 / 1000
+
+        var phase = 0.0
+        for (i in 0 until numSamples) {
+            phase += 2.0 * PI * freq / SAMPLE_RATE
+            var envelope = 1f
+            if (i < attackSamples) {
+                val at = i.toFloat() / attackSamples
+                envelope = (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+            } else if (i > numSamples - decaySamples) {
+                val dt = (i - (numSamples - decaySamples)).toFloat() / decaySamples
+                envelope = (sin((1 - dt) * PI / 2) * sin((1 - dt) * PI / 2)).toFloat()
+            }
+            samples[i] = (sin(phase) * amplitude * envelope * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+        }
+        return samples
+    }
+
+    /** Sharp click at 660Hz, 22ms, exponential decay */
+    private fun generateBlinkClick(): ShortArray {
+        val durationMs = 22
+        val numSamples = SAMPLE_RATE * durationMs / 1000
+        val samples = ShortArray(numSamples)
+        val amplitude = 0.30f
+
+        var phase = 0.0
+        for (i in 0 until numSamples) {
+            phase += 2.0 * PI * 660.0 / SAMPLE_RATE
+            val envelope = exp(-5.0 * i.toDouble() / numSamples).toFloat()
+            samples[i] = (sin(phase) * amplitude * envelope * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+        }
+        return samples
+    }
+
+    /** Win reveal sound — complexity scales with rarity */
+    private fun generateWinReveal(bracket: GiftBracket): ShortArray {
+        return when (bracket) {
+            GiftBracket.COMMON -> generateWinCommon()
+            GiftBracket.UNCOMMON -> generateWinUncommon()
+            GiftBracket.RARE -> generateWinRare()
+            GiftBracket.EPIC -> generateWinEpic()
+            GiftBracket.LEGENDARY -> generateWinLegendary()
+        }
+    }
+
+    /** COMMON: single C5 tone, 280ms */
+    private fun generateWinCommon(): ShortArray {
+        val durationMs = 280
+        val numSamples = SAMPLE_RATE * durationMs / 1000
+        val samples = ShortArray(numSamples)
+        val amplitude = 0.25f
+        val attackSamples = SAMPLE_RATE * 20 / 1000
+
+        var phase = 0.0
+        for (i in 0 until numSamples) {
+            phase += 2.0 * PI * 523.0 / SAMPLE_RATE
+            var envelope = 1f
+            if (i < attackSamples) {
+                val at = i.toFloat() / attackSamples
+                envelope = (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+            } else {
+                val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
+                envelope = (1f - dt * dt)
+            }
+            samples[i] = (sin(phase) * amplitude * envelope * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+        }
+        return samples
+    }
+
+    /** UNCOMMON: C5+E5 chord, 420ms */
+    private fun generateWinUncommon(): ShortArray {
+        val durationMs = 420
+        val numSamples = SAMPLE_RATE * durationMs / 1000
+        val samples = ShortArray(numSamples)
+        val amplitude = 0.25f
+        val attackSamples = SAMPLE_RATE * 25 / 1000
+
+        var phase1 = 0.0
+        var phase2 = 0.0
+        for (i in 0 until numSamples) {
+            phase1 += 2.0 * PI * 523.0 / SAMPLE_RATE
+            phase2 += 2.0 * PI * 659.0 / SAMPLE_RATE
+            var envelope = 1f
+            if (i < attackSamples) {
+                val at = i.toFloat() / attackSamples
+                envelope = (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+            } else {
+                val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
+                envelope = (1f - dt)
+            }
+            val value = (sin(phase1) + sin(phase2)) * 0.5 * amplitude * envelope
+            samples[i] = (value * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+        }
+        return samples
+    }
+
+    /** RARE: C5+E5+G5 triad + shimmer, 600ms */
+    private fun generateWinRare(): ShortArray {
+        val durationMs = 600
+        val numSamples = SAMPLE_RATE * durationMs / 1000
+        val samples = ShortArray(numSamples)
+        val amplitude = 0.28f
+        val attackSamples = SAMPLE_RATE * 25 / 1000
+
+        var phase1 = 0.0
+        var phase2 = 0.0
+        var phase3 = 0.0
+        var shimmerPhase = 0.0
+        for (i in 0 until numSamples) {
+            phase1 += 2.0 * PI * 523.0 / SAMPLE_RATE
+            phase2 += 2.0 * PI * 659.0 / SAMPLE_RATE
+            phase3 += 2.0 * PI * 784.0 / SAMPLE_RATE
+            shimmerPhase += 2.0 * PI * 8.0 / SAMPLE_RATE
+            var envelope = 1f
+            if (i < attackSamples) {
+                val at = i.toFloat() / attackSamples
+                envelope = (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+            } else {
+                val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
+                envelope = (1f - dt * 0.7f)
+            }
+            val shimmer = 1.0 + 0.15 * sin(shimmerPhase)
+            val value = (sin(phase1) + sin(phase2) + sin(phase3)) / 3.0 * amplitude * envelope * shimmer
+            samples[i] = (value * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+        }
+        return samples
+    }
+
+    /** EPIC: A4+C#5+E5 + sub-bass 80Hz, 800ms */
+    private fun generateWinEpic(): ShortArray {
+        val durationMs = 800
+        val numSamples = SAMPLE_RATE * durationMs / 1000
+        val samples = ShortArray(numSamples)
+        val amplitude = 0.30f
+        val attackSamples = SAMPLE_RATE * 30 / 1000
+
+        var phase1 = 0.0
+        var phase2 = 0.0
+        var phase3 = 0.0
+        var subPhase = 0.0
+        for (i in 0 until numSamples) {
+            phase1 += 2.0 * PI * 440.0 / SAMPLE_RATE
+            phase2 += 2.0 * PI * 554.0 / SAMPLE_RATE
+            phase3 += 2.0 * PI * 659.0 / SAMPLE_RATE
+            subPhase += 2.0 * PI * 80.0 / SAMPLE_RATE
+            var envelope = 1f
+            if (i < attackSamples) {
+                val at = i.toFloat() / attackSamples
+                envelope = (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+            } else {
+                val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
+                envelope = (1f - dt * 0.5f)
+            }
+            val chord = (sin(phase1) + sin(phase2) + sin(phase3)) / 3.0
+            val sub = sin(subPhase) * 0.3
+            val value = (chord + sub) * amplitude * envelope / 1.3
+            samples[i] = (value * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+        }
+        return samples
+    }
+
+    /** LEGENDARY: 5-note chord + chirp overlay, 1200ms */
+    private fun generateWinLegendary(): ShortArray {
+        val durationMs = 1200
+        val numSamples = SAMPLE_RATE * durationMs / 1000
+        val samples = ShortArray(numSamples)
+        val amplitude = 0.30f
+        val attackSamples = SAMPLE_RATE * 40 / 1000
+
+        var p1 = 0.0; var p2 = 0.0; var p3 = 0.0; var p4 = 0.0; var p5 = 0.0
+        var chirpPhase = 0.0
+        for (i in 0 until numSamples) {
+            p1 += 2.0 * PI * 220.0 / SAMPLE_RATE
+            p2 += 2.0 * PI * 440.0 / SAMPLE_RATE
+            p3 += 2.0 * PI * 550.0 / SAMPLE_RATE
+            p4 += 2.0 * PI * 660.0 / SAMPLE_RATE
+            p5 += 2.0 * PI * 880.0 / SAMPLE_RATE
+            val t = i.toFloat() / numSamples
+            val chirpFreq = 880.0 + 1760.0 * t
+            chirpPhase += 2.0 * PI * chirpFreq / SAMPLE_RATE
+            var envelope = 1f
+            if (i < attackSamples) {
+                val at = i.toFloat() / attackSamples
+                envelope = (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+            } else {
+                val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
+                envelope = (1f - dt * 0.4f)
+            }
+            val chord = (sin(p1) + sin(p2) + sin(p3) + sin(p4) + sin(p5)) / 5.0
+            val chirp = sin(chirpPhase) * 0.15 * (1.0 - t)
+            val value = (chord + chirp) * amplitude * envelope / 1.15
+            samples[i] = (value * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+        }
+        return samples
+    }
+
+    /** High-tier fanfare: dramatic ascending arpeggio C-E-G-C with layered harmonics, 1800ms */
+    private fun generateHighTierFanfare(): ShortArray {
+        val durationMs = 1800
+        val numSamples = SAMPLE_RATE * durationMs / 1000
+        val samples = ShortArray(numSamples)
+        val amplitude = 0.32f
+
+        // 4-note ascending arpeggio: C4→E4→G4→C5, each ~350ms, overlapping
+        val notes = doubleArrayOf(261.6, 329.6, 392.0, 523.3)
+        val noteOnsets = intArrayOf(0, (numSamples * 0.18).toInt(), (numSamples * 0.36).toInt(), (numSamples * 0.52).toInt())
+        val noteDuration = (numSamples * 0.55)
+
+        // Sub-bass impact at start
+        var subPhase = 0.0
+        // Shimmer oscillator
+        var shimmerPhase = 0.0
+
+        val phases = DoubleArray(notes.size)
+        val octavePhases = DoubleArray(notes.size)
+
+        for (i in 0 until numSamples) {
+            val t = i.toFloat() / numSamples
+            var value = 0.0
+
+            // Sub-bass impact (60Hz, first 400ms, fast decay)
+            subPhase += 2.0 * PI * 60.0 / SAMPLE_RATE
+            val subEnv = if (i < SAMPLE_RATE * 400 / 1000) exp(-4.0 * i.toDouble() / (SAMPLE_RATE * 400 / 1000)) else 0.0
+            value += sin(subPhase) * 0.25 * subEnv
+
+            // Arpeggio notes with octave harmonics
+            for (n in notes.indices) {
+                val onset = noteOnsets[n]
+                if (i < onset) continue
+                val noteT = (i - onset).toDouble()
+                if (noteT > noteDuration) continue
+
+                val noteProgress = noteT / noteDuration
+                phases[n] += 2.0 * PI * notes[n] / SAMPLE_RATE
+                octavePhases[n] += 2.0 * PI * notes[n] * 2.0 / SAMPLE_RATE
+
+                // Attack 20ms, sustain, then decay
+                val attackSamp = SAMPLE_RATE * 20 / 1000
+                val noteEnv = if (noteT < attackSamp) {
+                    val at = noteT / attackSamp
+                    sin(at * PI / 2) * sin(at * PI / 2)
+                } else {
+                    val dt = (noteT - attackSamp) / (noteDuration - attackSamp)
+                    1.0 - dt * 0.6
+                }
+
+                value += (sin(phases[n]) * 0.7 + sin(octavePhases[n]) * 0.3) * noteEnv / notes.size
+            }
+
+            // Shimmer (6Hz amplitude modulation, grows over time)
+            shimmerPhase += 2.0 * PI * 6.0 / SAMPLE_RATE
+            val shimmer = 1.0 + 0.12 * sin(shimmerPhase) * t
+
+            // Global envelope: quick attack, long sustain, gentle decay at end
+            val globalEnv = if (i < SAMPLE_RATE * 30 / 1000) {
+                val at = i.toFloat() / (SAMPLE_RATE * 30 / 1000)
+                (sin(at * PI / 2) * sin(at * PI / 2)).toDouble()
+            } else if (t > 0.85) {
+                val dt = (t - 0.85) / 0.15
+                (1.0 - dt * dt)
+            } else 1.0
+
+            val sample = value * amplitude * shimmer * globalEnv
+            samples[i] = (sample * Short.MAX_VALUE).toInt()
+                .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+        }
+        return samples
+    }
+
+    /** Two sequential dings: 880Hz then 1108Hz, 330ms total */
+    private fun generateCoinPurchase(): ShortArray {
+        val durationMs = 330
+        val numSamples = SAMPLE_RATE * durationMs / 1000
+        val samples = ShortArray(numSamples)
+        val amplitude = 0.28f
+        val halfSamples = numSamples / 2
+
+        var phase = 0.0
+        for (i in 0 until numSamples) {
+            val freq = if (i < halfSamples) 880.0 else 1108.0
+            if (i == halfSamples) phase = 0.0
+            phase += 2.0 * PI * freq / SAMPLE_RATE
+            val localT = if (i < halfSamples) i.toFloat() / halfSamples else (i - halfSamples).toFloat() / (numSamples - halfSamples)
+            val envelope = exp(-3.0 * localT).toFloat()
+            samples[i] = (sin(phase) * amplitude * envelope * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+        }
+        return samples
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/audio/GachaSoundPlayer.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/audio/GachaSoundPlayer.kt
@@ -1,0 +1,14 @@
+package com.shyden.shytalk.core.audio
+
+import com.shyden.shytalk.core.model.GiftBracket
+
+expect object GachaSoundPlayer {
+    fun init()
+    fun release()
+    fun playSpinStart()
+    fun playTick(progress: Float)
+    fun playBlinkClick()
+    fun playWinReveal(bracket: GiftBracket)
+    fun playHighTierFanfare()
+    fun playCoinPurchase()
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/DailyRewardResult.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/DailyRewardResult.kt
@@ -8,10 +8,10 @@ data class DailyRewardResult(
 ) {
     companion object {
         fun fromMap(map: Map<String, Any?>): DailyRewardResult = DailyRewardResult(
-            coinsAwarded = (map["coinsAwarded"] as? Long)?.toInt() ?: 0,
-            newStreak = (map["newStreak"] as? Long)?.toInt() ?: 0,
+            coinsAwarded = (map["coinsAwarded"] as? Number)?.toInt() ?: 0,
+            newStreak = (map["newStreak"] as? Number)?.toInt() ?: 0,
             isMilestone = map["isMilestone"] as? Boolean ?: false,
-            newBalance = (map["newBalance"] as? Long) ?: 0
+            newBalance = (map["newBalance"] as? Number)?.toLong() ?: 0
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/GachaResult.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/GachaResult.kt
@@ -25,14 +25,14 @@ data class GachaResult(
                     bracket = (m["bracket"] as? String)?.let {
                         try { GiftBracket.valueOf(it) } catch (_: Exception) { GiftBracket.COMMON }
                     } ?: GiftBracket.COMMON,
-                    coinValue = (m["coinValue"] as? Long)?.toInt() ?: 0,
+                    coinValue = (m["coinValue"] as? Number)?.toInt() ?: 0,
                     iconUrl = m["iconUrl"] as? String ?: ""
                 )
             } ?: emptyList(),
-            coinsSpent = (map["coinsSpent"] as? Long)?.toInt() ?: 0,
-            newBalance = (map["newBalance"] as? Long) ?: 0,
-            newPityCounter = (map["newPityCounter"] as? Long)?.toInt() ?: 0,
-            newLuckScore = (map["newLuckScore"] as? Long)?.toInt() ?: 0
+            coinsSpent = (map["coinsSpent"] as? Number)?.toInt() ?: 0,
+            newBalance = (map["newBalance"] as? Number)?.toLong() ?: 0,
+            newPityCounter = (map["newPityCounter"] as? Number)?.toInt() ?: 0,
+            newLuckScore = (map["newLuckScore"] as? Number)?.toInt() ?: 0
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/Transaction.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/Transaction.kt
@@ -31,16 +31,16 @@ data class Transaction(
             type = (map["type"] as? String)?.let {
                 try { TransactionType.valueOf(it) } catch (_: Exception) { TransactionType.PURCHASE }
             } ?: TransactionType.PURCHASE,
-            amount = (map["amount"] as? Long) ?: 0,
+            amount = (map["amount"] as? Number)?.toLong() ?: 0,
             currency = (map["currency"] as? String)?.let {
                 try { CurrencyType.valueOf(it) } catch (_: Exception) { CurrencyType.COINS }
             } ?: CurrencyType.COINS,
-            balanceAfter = (map["balanceAfter"] as? Long) ?: 0,
+            balanceAfter = (map["balanceAfter"] as? Number)?.toLong() ?: 0,
             giftId = map["giftId"] as? String,
             giftName = map["giftName"] as? String,
             recipientId = map["recipientId"] as? String,
             senderId = map["senderId"] as? String,
-            pullCount = (map["pullCount"] as? Long)?.toInt(),
+            pullCount = (map["pullCount"] as? Number)?.toInt(),
             details = map["details"] as? String,
             timestamp = map["timestamp"]?.let { timestampToMillis(it) } ?: 0
         )

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/EconomyRepository.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/EconomyRepository.kt
@@ -5,8 +5,10 @@ import com.shyden.shytalk.core.model.DailyRewardResult
 import com.shyden.shytalk.core.model.GachaResult
 import com.shyden.shytalk.core.model.Transaction
 import com.shyden.shytalk.core.util.Resource
+import kotlinx.coroutines.flow.Flow
 
 interface EconomyRepository {
+    fun observeBalance(): Flow<Long>
     suspend fun claimDailyReward(): Resource<DailyRewardResult>
     suspend fun pullGacha(pullCount: Int): Resource<GachaResult>
     suspend fun sendGift(recipientId: String, giftId: String): Resource<Map<String, Any?>>

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/GachaViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/GachaViewModel.kt
@@ -2,9 +2,11 @@ package com.shyden.shytalk.feature.gacha
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.shyden.shytalk.core.model.CoinPackage
 import com.shyden.shytalk.core.model.GachaGift
 import com.shyden.shytalk.core.model.GachaResult
 import com.shyden.shytalk.core.model.Gift
+import com.shyden.shytalk.core.model.Transaction
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.data.repository.EconomyRepository
 import com.shyden.shytalk.data.repository.GiftRepository
@@ -28,7 +30,9 @@ data class GachaUiState(
     val currentWin: GachaGift? = null,
     val isMultiSpin: Boolean = false,
     val multiSpinResults: List<GachaGift> = emptyList(),
-    val multiSpinIndex: Int = 0
+    val multiSpinIndex: Int = 0,
+    val coinPackages: List<CoinPackage> = emptyList(),
+    val spinHistory: List<Transaction> = emptyList()
 )
 
 class GachaViewModel(
@@ -39,8 +43,14 @@ class GachaViewModel(
     private val _uiState = MutableStateFlow(GachaUiState())
     val uiState: StateFlow<GachaUiState> = _uiState.asStateFlow()
 
+    // Guard against stale Firestore snapshots overwriting the pull result balance
+    private var pullBalanceSetAt = 0L
+
     init {
         observeGiftCatalog()
+        observeBalance()
+        loadCoinPackages()
+        loadSpinHistory()
     }
 
     private fun observeGiftCatalog() {
@@ -55,6 +65,44 @@ class GachaViewModel(
                         )
                     }
                 }
+        }
+    }
+
+    private fun observeBalance() {
+        viewModelScope.launch {
+            economyRepository.observeBalance()
+                .catch { /* ignore */ }
+                .collect { coins ->
+                    // Ignore stale Firestore snapshots for 3s after a pull set the balance
+                    val elapsed = System.currentTimeMillis() - pullBalanceSetAt
+                    if (elapsed < 3000 && coins < _uiState.value.coinBalance) return@collect
+                    _uiState.update { it.copy(coinBalance = coins) }
+                }
+        }
+    }
+
+    private fun loadCoinPackages() {
+        viewModelScope.launch {
+            when (val result = economyRepository.getCoinPackages()) {
+                is Resource.Success -> _uiState.update { it.copy(coinPackages = result.data) }
+                else -> {}
+            }
+        }
+    }
+
+    private fun loadSpinHistory(delayMs: Long = 0) {
+        viewModelScope.launch {
+            if (delayMs > 0) kotlinx.coroutines.delay(delayMs)
+            when (val result = economyRepository.getAllTransactions("GACHA_PULL")) {
+                is Resource.Success -> _uiState.update { it.copy(spinHistory = result.data) }
+                else -> {}
+            }
+        }
+    }
+
+    fun testPurchase(amount: Int) {
+        viewModelScope.launch {
+            economyRepository.addTestCoins(amount)
         }
     }
 
@@ -76,6 +124,7 @@ class GachaViewModel(
             _uiState.update { it.copy(isPulling = true, error = null, currentWin = null) }
             when (val result = economyRepository.pullGacha(count)) {
                 is Resource.Success -> {
+                    pullBalanceSetAt = System.currentTimeMillis()
                     if (count == 1) {
                         _uiState.update {
                             it.copy(
@@ -110,6 +159,8 @@ class GachaViewModel(
                 }
                 is Resource.Loading -> {}
             }
+            // Delay to allow cloud function to write transaction doc
+            loadSpinHistory(delayMs = 2000)
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinOverlay.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinOverlay.kt
@@ -9,22 +9,32 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -43,11 +53,21 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.runtime.DisposableEffect
+import com.shyden.shytalk.core.audio.GachaSoundPlayer
+import com.shyden.shytalk.core.model.CoinPackage
 import com.shyden.shytalk.core.model.GachaGift
+import com.shyden.shytalk.core.model.Gift
 import com.shyden.shytalk.core.model.GiftBracket
+import com.shyden.shytalk.core.model.Transaction
 import com.shyden.shytalk.core.ui.SuperShyGold
+import com.shyden.shytalk.feature.shop.CoinPackageCard
+import com.shyden.shytalk.feature.shop.formatNumber
+import com.shyden.shytalk.feature.shop.formatTimestamp
+import com.shyden.shytalk.feature.shop.transactionLabel
 import kotlinx.coroutines.delay
 import kotlin.math.pow
 
@@ -64,6 +84,7 @@ fun LuckySpinOverlay(
     onSkipMultiSpin: () -> Unit,
     onDismissResults: () -> Unit,
     onDismiss: () -> Unit,
+    onTestPurchase: (Int) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val winnableGifts = gachaState.winnableGifts
@@ -83,6 +104,17 @@ fun LuckySpinOverlay(
     var skipAnimation by remember { mutableStateOf(false) }
     var showSummary by remember { mutableStateOf(false) }
     var allWins by remember { mutableStateOf<List<GachaGift>>(emptyList()) }
+
+    // Sound lifecycle
+    DisposableEffect(Unit) {
+        GachaSoundPlayer.init()
+        onDispose { GachaSoundPlayer.release() }
+    }
+
+    // Inline panel states
+    var showCoinShop by remember { mutableStateOf(false) }
+    var showHistory by remember { mutableStateOf(false) }
+    var showPrizeList by remember { mutableStateOf(false) }
 
     // Screen shake
     val shakeX = remember { Animatable(0f) }
@@ -138,8 +170,6 @@ fun LuckySpinOverlay(
                 else { innerLitIndex = pos.second; outerLitIndex = -1 }
             }
             lastWin = win
-            phase = SpinPhase.CELEBRATING
-            celebrate(listOf(win))
             showSummary = true
             phase = SpinPhase.SHOW_SUMMARY
             return@LaunchedEffect
@@ -169,6 +199,7 @@ fun LuckySpinOverlay(
                 else { innerLitIndex = pos.second; outerLitIndex = -1 }
             }
 
+            GachaSoundPlayer.playTick(progress)
             step++
             if (progress >= 1f) break
             delay(interval)
@@ -181,16 +212,21 @@ fun LuckySpinOverlay(
         // Blink phase (3 cycles)
         repeat(3) {
             if (pos.first == Ring.OUTER) outerLitIndex = -1 else innerLitIndex = -1
+            GachaSoundPlayer.playBlinkClick()
             delay(130)
             if (pos.first == Ring.OUTER) outerLitIndex = pos.second else innerLitIndex = pos.second
+            GachaSoundPlayer.playBlinkClick()
             delay(130)
         }
 
         val key = "${if (pos.first == Ring.OUTER) "outer" else "inner"}-${pos.second}"
         wonSegments = setOf(key)
         lastWin = win
-        phase = SpinPhase.CELEBRATING
-        celebrate(listOf(win))
+        GachaSoundPlayer.playWinReveal(win.bracket)
+        if (win.bracket.ordinal >= GiftBracket.RARE.ordinal) {
+            GachaSoundPlayer.playHighTierFanfare()
+        }
+        // Show summary immediately — don't wait for celebration animation
         showSummary = true
         phase = SpinPhase.SHOW_SUMMARY
     }
@@ -216,8 +252,6 @@ fun LuckySpinOverlay(
             outerLitIndex = -1
             innerLitIndex = -1
             onSkipMultiSpin()
-            phase = SpinPhase.CELEBRATING
-            celebrate(results)
             showSummary = true
             phase = SpinPhase.SHOW_SUMMARY
             return@LaunchedEffect
@@ -247,6 +281,7 @@ fun LuckySpinOverlay(
                 if (step < sweepPhase) {
                     outerLitIndex = if (outerGifts.isNotEmpty()) step % outerGifts.size else -1
                     innerLitIndex = if (innerGifts.isNotEmpty()) (innerGifts.size - (step % innerGifts.size)) % innerGifts.size else -1
+                    GachaSoundPlayer.playTick(step.toFloat() / totalSteps)
                 } else {
                     val revealStep = step - sweepPhase
                     val revealIndex = ((revealStep.toFloat() / (totalSteps - sweepPhase)) * uniqueWins.size).toInt()
@@ -289,6 +324,7 @@ fun LuckySpinOverlay(
                         if (pos.first == Ring.OUTER) { outerLitIndex = pos.second; innerLitIndex = -1 }
                         else { innerLitIndex = pos.second; outerLitIndex = -1 }
                     }
+                    GachaSoundPlayer.playTick(p)
                     chaseStep++
                     if (p >= 1f) break
                     delay(25)
@@ -312,33 +348,44 @@ fun LuckySpinOverlay(
             onSkipMultiSpin()
         }
 
-        phase = SpinPhase.CELEBRATING
-        celebrate(results)
         spinProgress = null
+        val bestBracket = allWins.maxByOrNull { it.bracket.ordinal }?.bracket ?: GiftBracket.COMMON
+        GachaSoundPlayer.playWinReveal(bestBracket)
+        if (bestBracket.ordinal >= GiftBracket.RARE.ordinal) {
+            GachaSoundPlayer.playHighTierFanfare()
+        }
+        // Show summary immediately — don't wait for celebration animation
         showSummary = true
         phase = SpinPhase.SHOW_SUMMARY
     }
 
-    // Main overlay layout
+    // Main overlay layout — bottom-aligned opaque panel, room visible above
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(Color.Black)
-            .clickable(
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() }
-            ) { /* consume taps on scrim */ }
             .graphicsLayer {
                 translationX = shakeX.value
                 translationY = shakeY.value
             },
-        contentAlignment = Alignment.Center
+        contentAlignment = Alignment.BottomCenter
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp)
+            verticalArrangement = Arrangement.Bottom,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    Color.Black,
+                    RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+                )
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() }
+                ) { /* consume taps on panel */ }
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp)
         ) {
-            // Close + coin balance header
+            // Header: [X Close] ---- [History] [Prizes] [Balance pill]
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -354,23 +401,75 @@ fun LuckySpinOverlay(
                     Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.White)
                 }
 
+                Spacer(modifier = Modifier.weight(1f))
+
+                // History icon
                 Surface(
-                    shape = RoundedCornerShape(30.dp),
-                    color = Color(0xFFFFD700).copy(alpha = 0.06f)
+                    shape = RoundedCornerShape(20.dp),
+                    color = Color.White.copy(alpha = 0.06f),
+                    modifier = Modifier.clickable { showHistory = true }
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(horizontal = 18.dp, vertical = 5.dp)
+                    Text(
+                        "\uD83D\uDCCB",
+                        fontSize = 18.sp,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                // Prize catalog icon
+                Surface(
+                    shape = RoundedCornerShape(20.dp),
+                    color = Color.White.copy(alpha = 0.06f),
+                    modifier = Modifier.clickable { showPrizeList = true }
+                ) {
+                    Text(
+                        "\uD83C\uDFC6",
+                        fontSize = 18.sp,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                // Coin balance pill + add button
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Surface(
+                        shape = RoundedCornerShape(30.dp),
+                        color = Color(0xFFFFD700).copy(alpha = 0.06f)
                     ) {
-                        Text("\uD83E\uDE99", fontSize = 16.sp)
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = "${gachaState.coinBalance}",
-                            color = SuperShyGold,
-                            fontWeight = FontWeight.ExtraBold,
-                            fontSize = 18.sp,
-                            letterSpacing = 1.sp
-                        )
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(horizontal = 18.dp, vertical = 5.dp)
+                        ) {
+                            Text("\uD83E\uDE99", fontSize = 16.sp)
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = "${gachaState.coinBalance}",
+                                color = SuperShyGold,
+                                fontWeight = FontWeight.ExtraBold,
+                                fontSize = 18.sp,
+                                letterSpacing = 1.sp
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Surface(
+                        shape = CircleShape,
+                        color = Color(0xFFFFD700).copy(alpha = 0.15f),
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clickable { showCoinShop = true }
+                    ) {
+                        Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                            Icon(
+                                Icons.Default.Add,
+                                contentDescription = "Buy coins",
+                                tint = SuperShyGold,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
                     }
                 }
             }
@@ -390,8 +489,6 @@ fun LuckySpinOverlay(
                     )
                 )
             )
-
-            Spacer(modifier = Modifier.height(4.dp))
 
             // Skip animation toggle
             Row(
@@ -419,45 +516,22 @@ fun LuckySpinOverlay(
                 )
             }
 
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(2.dp))
 
-            // Progress bar for multi-spin
-            spinProgress?.let { (current, total) ->
-                if (total > 1) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center,
-                        modifier = Modifier.padding(horizontal = 32.dp)
-                    ) {
-                        LinearProgressIndicator(
-                            progress = { current.toFloat() / total },
-                            modifier = Modifier.weight(1f).height(6.dp),
-                            color = activeTier.color,
-                            trackColor = Color.White.copy(alpha = 0.07f)
-                        )
-                        Spacer(modifier = Modifier.width(10.dp))
-                        Text(
-                            text = "$current/$total",
-                            color = Color.White.copy(alpha = 0.35f),
-                            fontSize = 12.sp,
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(4.dp))
-                }
-            }
-
-            // The dual-ring wheel
+            // The dual-ring wheel — fill available width for a bigger wheel
             LuckySpinWheel(
                 outerGifts = outerGifts,
                 innerGifts = innerGifts,
                 outerLitIndex = outerLitIndex,
                 innerLitIndex = innerLitIndex,
                 wonSegments = wonSegments,
-                modifier = Modifier.size(300.dp)
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp)
+                    .aspectRatio(1f)
             )
 
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(4.dp))
 
             // Last win display
             lastWin?.let { win ->
@@ -475,87 +549,100 @@ fun LuckySpinOverlay(
                             fontSize = 14.sp
                         )
                     }
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(4.dp))
                 }
             }
 
-            // Spin tier buttons
+            // Spin tier buttons — equal height via IntrinsicSize
             if (phase == SpinPhase.IDLE) {
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(IntrinsicSize.Min)
                 ) {
                     SpinTiers.forEach { tier ->
                         val canAfford = gachaState.coinBalance >= tier.cost
-                        val enabled = canAfford && !gachaState.isPulling
 
                         Button(
                             onClick = {
-                                activeTier = tier
-                                phase = SpinPhase.ANIMATING
-                                wonSegments = emptySet()
-                                outerLitIndex = -1
-                                innerLitIndex = -1
-                                lastWin = null
-                                showConfetti = false
-                                allWins = emptyList()
-                                when (tier.count) {
-                                    1 -> onSpin()
-                                    else -> onQuickSpin(tier.count)
+                                if (!canAfford) {
+                                    showCoinShop = true
+                                } else if (!gachaState.isPulling) {
+                                    activeTier = tier
+                                    phase = SpinPhase.ANIMATING
+                                    wonSegments = emptySet()
+                                    outerLitIndex = -1
+                                    innerLitIndex = -1
+                                    lastWin = null
+                                    showConfetti = false
+                                    allWins = emptyList()
+                                    GachaSoundPlayer.playSpinStart()
+                                    when (tier.count) {
+                                        1 -> onSpin()
+                                        else -> onQuickSpin(tier.count)
+                                    }
                                 }
                             },
-                            enabled = enabled,
                             colors = ButtonDefaults.buttonColors(
-                                containerColor = tier.color.copy(alpha = 0.15f),
-                                disabledContainerColor = Color(0xFF222222)
+                                containerColor = if (canAfford) tier.color.copy(alpha = 0.15f)
+                                    else Color(0xFF222222)
                             ),
                             shape = RoundedCornerShape(20.dp),
+                            contentPadding = ButtonDefaults.ContentPadding,
                             modifier = Modifier
                                 .weight(1f)
-                                .height(80.dp)
+                                .heightIn(min = 72.dp)
                         ) {
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
                                 Text(
                                     text = tier.label,
-                                    fontSize = 22.sp,
+                                    fontSize = 18.sp,
                                     fontWeight = FontWeight.Black,
-                                    color = if (enabled) tier.color else Color.Gray,
+                                    color = if (canAfford) tier.color else Color.Gray,
                                     letterSpacing = 1.sp,
-                                    lineHeight = 24.sp
+                                    lineHeight = 20.sp,
+                                    maxLines = 1
                                 )
                                 Text(
                                     text = "SPIN",
                                     fontSize = 10.sp,
                                     fontWeight = FontWeight.Bold,
-                                    color = if (enabled) Color.White.copy(alpha = 0.55f) else Color.Gray.copy(alpha = 0.4f),
-                                    letterSpacing = 1.sp
+                                    color = if (canAfford) Color.White.copy(alpha = 0.55f) else Color.Gray.copy(alpha = 0.4f),
+                                    letterSpacing = 1.sp,
+                                    maxLines = 1
                                 )
                                 Surface(
                                     shape = RoundedCornerShape(12.dp),
-                                    color = if (enabled) tier.color.copy(alpha = 0.12f) else Color.White.copy(alpha = 0.03f)
+                                    color = if (canAfford) tier.color.copy(alpha = 0.12f) else Color.White.copy(alpha = 0.03f)
                                 ) {
                                     Row(
                                         verticalAlignment = Alignment.CenterVertically,
-                                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 3.dp)
+                                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp)
                                     ) {
-                                        Text("\uD83E\uDE99", fontSize = 11.sp)
+                                        Text("\uD83E\uDE99", fontSize = 11.sp, maxLines = 1)
                                         Text(
                                             text = "${tier.cost}",
-                                            fontSize = 13.sp,
+                                            fontSize = 11.sp,
                                             fontWeight = FontWeight.ExtraBold,
-                                            color = if (enabled) tier.color else Color.Gray
+                                            color = if (canAfford) tier.color else Color.Gray,
+                                            maxLines = 1
                                         )
                                     }
                                 }
-                                if (tier.boostedDrop) {
-                                    Text(
-                                        text = "BOOSTED",
-                                        fontSize = 8.sp,
-                                        fontWeight = FontWeight.ExtraBold,
-                                        letterSpacing = 1.5.sp,
-                                        color = if (enabled) tier.color else Color.Gray
-                                    )
-                                }
+                                // All buttons show the drop rate line — visible text only for boosted tier
+                                Text(
+                                    text = if (tier.boostedDrop) "INCREASED DROP RATE" else "",
+                                    fontSize = 7.sp,
+                                    fontWeight = FontWeight.ExtraBold,
+                                    letterSpacing = 0.5.sp,
+                                    color = if (canAfford) tier.color else Color.Gray,
+                                    maxLines = 1,
+                                    lineHeight = 9.sp
+                                )
                             }
                         }
                     }
@@ -623,12 +710,303 @@ fun LuckySpinOverlay(
                     // Trigger new spin
                     phase = SpinPhase.ANIMATING
                     activeTier = tier
+                    GachaSoundPlayer.playSpinStart()
                     when (tier.count) {
                         1 -> onSpin()
                         else -> onQuickSpin(tier.count)
                     }
                 }
             )
+        }
+
+        // Inline Coin Shop overlay
+        if (showCoinShop) {
+            InlineCoinShop(
+                coinPackages = gachaState.coinPackages,
+                onPurchase = { coins ->
+                    GachaSoundPlayer.playCoinPurchase()
+                    onTestPurchase(coins)
+                    showCoinShop = false
+                },
+                onDismiss = { showCoinShop = false }
+            )
+        }
+
+        // Inline Spin History overlay
+        if (showHistory) {
+            InlineSpinHistory(
+                transactions = gachaState.spinHistory,
+                onDismiss = { showHistory = false }
+            )
+        }
+
+        // Inline Prize Catalog overlay
+        if (showPrizeList) {
+            InlinePrizeCatalog(
+                gifts = gachaState.winnableGifts,
+                onDismiss = { showPrizeList = false }
+            )
+        }
+    }
+}
+
+@Composable
+private fun InlineCoinShop(
+    coinPackages: List<CoinPackage>,
+    onPurchase: (Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.85f))
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ) { /* consume taps */ },
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Need more coins!",
+                    color = Color(0xFFFFD700),
+                    fontWeight = FontWeight.ExtraBold,
+                    fontSize = 20.sp
+                )
+                IconButton(onClick = onDismiss) {
+                    Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.White)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (coinPackages.isEmpty()) {
+                Text(
+                    text = "No packages available",
+                    color = Color.White.copy(alpha = 0.5f),
+                    fontSize = 14.sp
+                )
+            } else {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(2),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.heightIn(max = 300.dp)
+                ) {
+                    items(coinPackages) { pkg ->
+                        CoinPackageCard(
+                            pkg = pkg,
+                            onClick = { onPurchase(pkg.totalCoins) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InlineSpinHistory(
+    transactions: List<Transaction>,
+    onDismiss: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.9f))
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ) { /* consume taps */ },
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Spin History",
+                    color = Color.White,
+                    fontWeight = FontWeight.ExtraBold,
+                    fontSize = 20.sp
+                )
+                IconButton(onClick = onDismiss) {
+                    Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.White)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            if (transactions.isEmpty()) {
+                Text(
+                    text = "No spins yet",
+                    color = Color.White.copy(alpha = 0.5f),
+                    fontSize = 14.sp
+                )
+            } else {
+                LazyColumn(
+                    modifier = Modifier.heightIn(max = 400.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    items(transactions) { tx ->
+                        Surface(
+                            shape = RoundedCornerShape(12.dp),
+                            color = Color.White.copy(alpha = 0.05f),
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("\uD83C\uDFB0", fontSize = 18.sp)
+                                Spacer(modifier = Modifier.width(10.dp))
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = tx.pullCount?.let { "x$it pull" } ?: "Pull",
+                                        color = Color.White,
+                                        fontWeight = FontWeight.Bold,
+                                        fontSize = 14.sp,
+                                        maxLines = 1
+                                    )
+                                    Text(
+                                        text = transactionLabel(tx),
+                                        color = Color.White.copy(alpha = 0.5f),
+                                        fontSize = 12.sp,
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                    Text(
+                                        text = formatTimestamp(tx.timestamp),
+                                        color = Color.White.copy(alpha = 0.3f),
+                                        fontSize = 11.sp,
+                                        maxLines = 1
+                                    )
+                                }
+                                Text(
+                                    text = "${tx.amount}",
+                                    color = if (tx.amount < 0) Color(0xFFFF5252) else Color(0xFF4CAF50),
+                                    fontWeight = FontWeight.Bold,
+                                    fontSize = 14.sp
+                                )
+                                Spacer(modifier = Modifier.width(2.dp))
+                                Text("\uD83E\uDE99", fontSize = 12.sp)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InlinePrizeCatalog(
+    gifts: List<Gift>,
+    onDismiss: () -> Unit
+) {
+    val sorted = remember(gifts) {
+        gifts.sortedByDescending { it.coinValue }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.9f))
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ) { /* consume taps */ },
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Prizes",
+                    color = Color.White,
+                    fontWeight = FontWeight.ExtraBold,
+                    fontSize = 20.sp
+                )
+                IconButton(onClick = onDismiss) {
+                    Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.White)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            LazyColumn(
+                modifier = Modifier.heightIn(max = 400.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                items(sorted) { gift ->
+                    Surface(
+                        shape = RoundedCornerShape(10.dp),
+                        color = (BracketColors[gift.bracket] ?: Color.Gray).copy(alpha = 0.08f),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 12.dp, vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            // Bracket color indicator dot
+                            Box(
+                                modifier = Modifier
+                                    .size(8.dp)
+                                    .background(
+                                        BracketColors[gift.bracket] ?: Color.Gray,
+                                        RoundedCornerShape(4.dp)
+                                    )
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(giftEmoji(gift.name), fontSize = 20.sp)
+                            Spacer(modifier = Modifier.width(10.dp))
+                            Text(
+                                text = gift.name,
+                                color = Color.White,
+                                fontWeight = FontWeight.SemiBold,
+                                fontSize = 14.sp,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Text(
+                                text = "\uD83E\uDE99 ${gift.coinValue}",
+                                color = Color(0xFFFFD700),
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 13.sp,
+                                maxLines = 1
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinSummaryPopup.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinSummaryPopup.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -128,7 +130,7 @@ fun LuckySpinSummaryPopup(
                 )
 
                 Text(
-                    text = "${wins.size} SPIN${if (wins.size > 1) "S" else ""}${if (spinTier.boostedDrop) "  ★ BOOSTED" else ""}",
+                    text = "${wins.size} SPIN${if (wins.size > 1) "S" else ""}${if (spinTier.boostedDrop) "  ★ INCREASED DROP RATE" else ""}",
                     color = Color.White.copy(alpha = 0.35f),
                     fontSize = 11.sp,
                     letterSpacing = 2.sp
@@ -177,7 +179,7 @@ fun LuckySpinSummaryPopup(
                     onClick = onSpinAgain,
                     enabled = canAffordSpinAgain,
                     colors = ButtonDefaults.buttonColors(
-                        containerColor = spinTier.color,
+                        containerColor = spinTier.accentColor,
                         disabledContainerColor = Color(0xFF333333)
                     ),
                     shape = RoundedCornerShape(50),
@@ -238,29 +240,33 @@ private fun WinCard(win: GroupedWin, index: Int) {
 
     Box(
         modifier = Modifier
+            .size(width = 80.dp, height = 110.dp)
             .graphicsLayer { scaleX = scale; scaleY = scale }
             .clip(RoundedCornerShape(16.dp))
             .background(bracketColor.copy(alpha = 0.1f))
-            .padding(horizontal = 12.dp, vertical = 8.dp)
-            .widthIn(min = 80.dp),
+            .padding(horizontal = 4.dp, vertical = 6.dp),
         contentAlignment = Alignment.Center
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            // Count badge
-            if (win.count > 1) {
-                Text(
-                    text = "x${win.count}",
-                    fontSize = 10.sp,
-                    fontWeight = FontWeight.Black,
-                    color = Color(0xFF1A1A2E),
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(10.dp))
-                        .background(
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            // Count badge — always reserve space
+            Text(
+                text = if (win.count > 1) "x${win.count}" else "",
+                fontSize = 10.sp,
+                fontWeight = FontWeight.Black,
+                color = if (win.count > 1) Color(0xFF1A1A2E) else Color.Transparent,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(10.dp))
+                    .then(
+                        if (win.count > 1) Modifier.background(
                             Brush.linearGradient(listOf(Color(0xFFFFD700), Color(0xFFFF9100)))
-                        )
-                        .padding(horizontal = 7.dp, vertical = 1.dp)
-                )
-            }
+                        ) else Modifier
+                    )
+                    .padding(horizontal = 7.dp, vertical = 1.dp)
+            )
 
             Text(
                 text = giftEmoji(win.giftName),
@@ -280,18 +286,18 @@ private fun WinCard(win: GroupedWin, index: Int) {
                 text = "\uD83E\uDE99 ${(win.coinValue * win.count).formatWithCommas()}",
                 color = Color(0xFFFFD700),
                 fontSize = 11.sp,
-                fontWeight = FontWeight.ExtraBold
+                fontWeight = FontWeight.ExtraBold,
+                maxLines = 1
             )
 
-            if (isRarePlus) {
-                Text(
-                    text = win.bracket.name,
-                    fontSize = 7.sp,
-                    fontWeight = FontWeight.ExtraBold,
-                    letterSpacing = 1.5.sp,
-                    color = (RarityConfigs[win.bracket] ?: RarityConfigs[GiftBracket.COMMON]!!).glowColor
-                )
-            }
+            // Bracket label — always reserve space
+            Text(
+                text = if (isRarePlus) win.bracket.name else "",
+                fontSize = 7.sp,
+                fontWeight = FontWeight.ExtraBold,
+                letterSpacing = 1.5.sp,
+                color = if (isRarePlus) (RarityConfigs[win.bracket] ?: RarityConfigs[GiftBracket.COMMON]!!).glowColor else Color.Transparent
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/BackpackSheet.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/BackpackSheet.kt
@@ -7,11 +7,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -24,12 +26,14 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -73,6 +77,48 @@ fun BackpackSheet(
                     textAlign = TextAlign.Center
                 )
             } else {
+                val totalValue = remember(state.backpackItems, state.giftCatalog) {
+                    state.backpackItems.sumOf { item ->
+                        val coinValue = state.giftCatalog.find { it.id == item.giftId }?.coinValue ?: 0
+                        coinValue * item.quantity
+                    }
+                }
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        "\uD83E\uDE99",
+                        fontSize = 14.sp
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = "$totalValue",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.ExtraBold,
+                        color = Color(0xFFFFD700)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = "total value",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                val sortedItems = remember(state.backpackItems, state.giftCatalog) {
+                    state.backpackItems.sortedWith(
+                        compareByDescending<BackpackItem> { item ->
+                            state.giftCatalog.find { it.id == item.giftId }?.coinValue ?: 0
+                        }.thenBy { item ->
+                            state.giftCatalog.find { it.id == item.giftId }?.name ?: ""
+                        }
+                    )
+                }
                 LazyVerticalGrid(
                     columns = GridCells.Fixed(4),
                     contentPadding = PaddingValues(4.dp),
@@ -80,7 +126,7 @@ fun BackpackSheet(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                     modifier = Modifier.height(250.dp)
                 ) {
-                    items(state.backpackItems) { item ->
+                    items(sortedItems) { item ->
                         val gift = state.giftCatalog.find { it.id == item.giftId }
                         if (gift != null) {
                             BackpackGiftItem(
@@ -153,7 +199,27 @@ private fun BackpackGiftItem(
         ) {
             Text(gift.name.take(2), fontWeight = FontWeight.Bold, color = bracketColor, fontSize = 12.sp)
         }
-        Text(gift.name, style = MaterialTheme.typography.labelSmall, maxLines = 1, fontSize = 9.sp)
+        Text(
+            gift.name,
+            style = MaterialTheme.typography.labelSmall,
+            maxLines = 1,
+            fontSize = 9.sp,
+            overflow = TextOverflow.Ellipsis
+        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                "\uD83E\uDE99",
+                fontSize = 8.sp
+            )
+            Spacer(modifier = Modifier.width(1.dp))
+            Text(
+                "${gift.coinValue}",
+                style = MaterialTheme.typography.labelSmall,
+                fontSize = 8.sp,
+                color = Color(0xFFFFD700),
+                maxLines = 1
+            )
+        }
         Text("x$quantity", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, color = bracketColor)
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/WalletScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/WalletScreen.kt
@@ -347,7 +347,7 @@ private fun BalanceCard(
 }
 
 @Composable
-private fun CoinPackageCard(pkg: CoinPackage, enabled: Boolean = true, onClick: () -> Unit) {
+internal fun CoinPackageCard(pkg: CoinPackage, enabled: Boolean = true, onClick: () -> Unit) {
     Card(
         onClick = onClick,
         enabled = enabled,

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/audio/GachaSoundPlayer.ios.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/audio/GachaSoundPlayer.ios.kt
@@ -1,0 +1,14 @@
+package com.shyden.shytalk.core.audio
+
+import com.shyden.shytalk.core.model.GiftBracket
+
+actual object GachaSoundPlayer {
+    actual fun init() {}
+    actual fun release() {}
+    actual fun playSpinStart() {}
+    actual fun playTick(progress: Float) {}
+    actual fun playBlinkClick() {}
+    actual fun playWinReveal(bracket: GiftBracket) {}
+    actual fun playHighTierFanfare() {}
+    actual fun playCoinPurchase() {}
+}


### PR DESCRIPTION
## Summary
- **Sound effects**: Synthesized PCM audio for Lucky Spin (chase ticks, blink clicks, rarity-scaled win fanfares, high-tier fanfare, coin purchase ding) via expect/actual KMP pattern
- **Bug fixes**: Fixed coin balance showing 0 after spinning, daily reward showing 0 coins/streak, spin history not loading — root cause was `as? Long` failing for Firebase Cloud Function `Int` responses
- **Backpack improvements**: Shows gift names, coin values, total backpack value; sorted by value descending
- **UI polish**: Opaque bottom panel overlay, uniform 80x110dp win cards, inline coin shop via + button, removed progress bar
- **Balance tuning**: Gacha drop rates rebalanced (COMMON 74%, UNCOMMON 18%, RARE 6%, EPIC 1.5%, LEGENDARY 0.5%), pity at 100/150
- **Admin panel**: Partial backpack item removal (specify quantity)
- **Tests**: 24 new unit tests for sound player, backpack sorting, and GachaResult parsing

## Test plan
- [x] All 1023 unit tests pass (1 pre-existing flaky test excluded)
- [x] Installed and tested on CPH2747 and CPH2653
- [x] Cloud Functions deployed with updated drop rates
- [ ] Verify sound effects play during spin, win, and purchase
- [ ] Verify coin balance persists correctly after spinning
- [ ] Verify daily reward shows correct coins and streak
- [ ] Verify backpack sorting and total value display

🤖 Generated with [Claude Code](https://claude.com/claude-code)