### PR TITLE
v0.42 — Room speed-up, broadcasts, self-destruct alerts & QoL

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 41
-        versionName = "0.41"
+        versionCode = 42
+        versionName = "0.42"
 
         testInstrumentationRunner = "com.shyden.shytalk.ShyTalkTestRunner"
 

--- a/app/src/androidTest/java/com/shyden/shytalk/fake/FakeEconomyRepository.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/fake/FakeEconomyRepository.kt
@@ -50,7 +50,7 @@ class FakeEconomyRepository : EconomyRepository {
     override suspend fun sendEntireBackpack(recipientId: String): Resource<Map<String, Any?>> =
         Resource.Success(mapOf("success" to true, "totalItemsSent" to 0))
 
-    override suspend fun redeemBeans(amount: Int): Resource<Map<String, Any?>> =
+    override suspend fun redeemBeans(amount: Long): Resource<Map<String, Any?>> =
         Resource.Success(mapOf("success" to true))
 
     override suspend fun purchaseCoins(productId: String, purchaseToken: String): Resource<Map<String, Any?>> =

--- a/app/src/androidTest/java/com/shyden/shytalk/fake/FakeVoiceService.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/fake/FakeVoiceService.kt
@@ -24,4 +24,5 @@ class FakeVoiceService : VoiceService {
     override fun setMicrophoneEnabled(enabled: Boolean) { /* no-op */ }
     override fun setAudioMode(voiceMode: Boolean) { /* no-op */ }
     override fun clearError() { /* no-op */ }
+    override fun prewarmToken(roomName: String, userId: String) { /* no-op */ }
 }

--- a/app/src/main/java/com/shyden/shytalk/MainActivity.kt
+++ b/app/src/main/java/com/shyden/shytalk/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.shyden.shytalk
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -59,6 +60,7 @@ class MainActivity : ComponentActivity() {
                 }
                 var updateRequired by remember { mutableStateOf(false) }
                 var checkComplete by remember { mutableStateOf(false) }
+                var softUpdateAvailable by remember { mutableStateOf<String?>(null) }
 
                 LaunchedEffect(Unit) {
                     try {
@@ -69,6 +71,13 @@ class MainActivity : ComponentActivity() {
                             .await()
                         val minVersion = (doc.getLong("minVersionCode") ?: 0).toInt()
                         updateRequired = BuildConfig.VERSION_CODE < minVersion
+                        if (!updateRequired) {
+                            val latestVersion = (doc.getLong("latestVersionCode") ?: 0).toInt()
+                            if (BuildConfig.VERSION_CODE < latestVersion) {
+                                softUpdateAvailable = doc.getString("latestVersionName")
+                                    ?: "v$latestVersion"
+                            }
+                        }
                     } catch (_: Exception) {
                         updateRequired = false
                     }
@@ -141,6 +150,30 @@ class MainActivity : ComponentActivity() {
                                 startDestination = Screen.SignIn.route,
                                 onSignOut = { authRepository.signOut() }
                             )
+
+                            if (softUpdateAvailable != null) {
+                                AlertDialog(
+                                    onDismissRequest = { softUpdateAvailable = null },
+                                    title = { Text("Update Available") },
+                                    text = { Text("A new version ($softUpdateAvailable) of ShyTalk is available.") },
+                                    confirmButton = {
+                                        TextButton(onClick = {
+                                            softUpdateAvailable = null
+                                            startActivity(
+                                                Intent(
+                                                    Intent.ACTION_VIEW,
+                                                    Uri.parse("https://play.google.com/store/apps/details?id=com.shyden.shytalk")
+                                                )
+                                            )
+                                        }) { Text("Update Now") }
+                                    },
+                                    dismissButton = {
+                                        TextButton(onClick = { softUpdateAvailable = null }) {
+                                            Text("Later")
+                                        }
+                                    }
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/shyden/shytalk/data/remote/LiveKitVoiceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/LiveKitVoiceService.kt
@@ -41,6 +41,11 @@ class LiveKitVoiceService(
     private var cachedToken: String? = null
     private val joinMutex = Mutex()
 
+    // Token pre-warming: fetched in background before user navigates to room
+    private var prewarmedToken: String? = null
+    private var prewarmedRoomName: String? = null
+    private var prewarmJob: Job? = null
+
     // Audio type switching: we recreate the Room to swap between
     // CallAudioType (STREAM_VOICE_CALL → loudspeaker) and
     // MediaAudioType (STREAM_MUSIC → media channel).
@@ -181,13 +186,22 @@ class LiveKitVoiceService(
         currentRoomName = roomName
         currentUserId = userId
 
-        // Fetch token and connect
-        val token: String? = try {
-            tokenService.fetchToken(roomName, userId)
-        } catch (e: Exception) {
-            Log.w(TAG, "Token fetch failed", e)
-            _error.value = "Token fetch failed — check Cloud Function deployment"
-            null
+        // Use prewarmed token if available for this room, otherwise fetch
+        prewarmJob?.join() // Wait for in-flight prewarm if running
+        val token: String? = if (prewarmedRoomName == roomName && prewarmedToken != null) {
+            Log.d(TAG, "Using prewarmed token for room=$roomName")
+            prewarmedToken.also {
+                prewarmedToken = null
+                prewarmedRoomName = null
+            }
+        } else {
+            try {
+                tokenService.fetchToken(roomName, userId)
+            } catch (e: Exception) {
+                Log.w(TAG, "Token fetch failed", e)
+                _error.value = "Token fetch failed — check Cloud Function deployment"
+                null
+            }
         }
 
         if (token == null) {
@@ -225,6 +239,9 @@ class LiveKitVoiceService(
         currentRoomName = null
         currentUserId = null
         cachedToken = null
+        prewarmedToken = null
+        prewarmedRoomName = null
+        prewarmJob?.cancel()
         desiredMicEnabled = false
         isVoiceMode = false
         setSpeakerphoneEnabled(false)
@@ -326,6 +343,23 @@ class LiveKitVoiceService(
             isSwitchingAudioType = false
             _isJoined.value = false
             _connectionState.value = VoiceConnectionState.DISCONNECTED
+        }
+    }
+
+    override fun prewarmToken(roomName: String, userId: String) {
+        prewarmJob?.cancel()
+        prewarmedToken = null
+        prewarmedRoomName = null
+        prewarmJob = scope.launch {
+            try {
+                Log.d(TAG, "Pre-warming token for room=$roomName")
+                val token = tokenService.fetchToken(roomName, userId)
+                prewarmedToken = token
+                prewarmedRoomName = roomName
+                Log.d(TAG, "Token pre-warmed for room=$roomName")
+            } catch (e: Exception) {
+                Log.w(TAG, "Token pre-warm failed (joinRoom will retry)", e)
+            }
         }
     }
 

--- a/app/src/main/java/com/shyden/shytalk/data/repository/EconomyRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/EconomyRepositoryImpl.kt
@@ -109,7 +109,7 @@ class EconomyRepositoryImpl(
             result.data as Map<String, Any?>
         }
 
-    override suspend fun redeemBeans(amount: Int): Resource<Map<String, Any?>> =
+    override suspend fun redeemBeans(amount: Long): Resource<Map<String, Any?>> =
         firebaseCall("Failed to redeem beans") {
             val result = functions.getHttpsCallable("redeemBeans")
                 .call(mapOf("amount" to amount))

--- a/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
@@ -1263,10 +1263,10 @@ private fun ProfileContent(
         SuperShyBottomSheet(
             user = user,
             onTestPurchase = if (onTestPurchaseSuperShy != null) { productId ->
-                showSuperShySheet = false
                 onTestPurchaseSuperShy(productId)
             } else null,
             onClaimTrial = onClaimTrial,
+            isPurchasing = uiState.isPurchasingSuperShy,
             onDismiss = { showSuperShySheet = false }
         )
     }

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -2,6 +2,8 @@ package com.shyden.shytalk.feature.room
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.speech.tts.TextToSpeech
+import java.util.Locale
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -36,6 +38,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -72,9 +75,16 @@ import com.shyden.shytalk.feature.room.components.RoomToolbar
 import com.shyden.shytalk.feature.room.components.SeatGrid
 import com.shyden.shytalk.feature.room.components.UserCardPopup
 import androidx.activity.result.PickVisualMediaRequest
+import com.shyden.shytalk.core.model.Broadcast
+import com.shyden.shytalk.core.model.BroadcastType
 import com.shyden.shytalk.core.model.Gift
 import com.shyden.shytalk.core.model.GiftEvent
+import com.shyden.shytalk.core.ui.BroadcastBanner
 import com.shyden.shytalk.core.ui.GiftEffectOverlay
+import com.shyden.shytalk.core.util.currentTimeMillis
+import com.shyden.shytalk.data.repository.GiftRepository
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.drop
 import com.shyden.shytalk.core.ui.GiftPreviewPopup
 import com.shyden.shytalk.feature.gacha.GachaViewModel
 import com.shyden.shytalk.feature.gacha.LuckySpinOverlay
@@ -87,8 +97,12 @@ import com.shyden.shytalk.feature.room.components.RoomActionCarousel
 import com.shyden.shytalk.feature.daily.DailyRewardDialog
 import com.shyden.shytalk.feature.daily.DailyRewardViewModel
 import com.shyden.shytalk.feature.settings.RoomSettingsSheet
+import com.shyden.shytalk.feature.shop.WalletViewModel
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 import org.koin.compose.koinInject
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RoomScreen(
     roomId: String,
@@ -119,7 +133,43 @@ fun RoomScreen(
     var additionalBackpackRecipient by remember(roomId) { mutableStateOf<com.shyden.shytalk.core.model.User?>(null) }
     var previewGift by remember { mutableStateOf<Gift?>(null) }
     var showSuperShySheet by remember(roomId) { mutableStateOf(false) }
+    var showWalletSheet by remember(roomId) { mutableStateOf(false) }
     val currentGiftEvent by viewModel.giftAnimationQueue.currentEvent.collectAsStateWithLifecycle()
+    val giftRepository: GiftRepository = koinInject()
+    val roomBroadcasts = remember { mutableStateListOf<Broadcast>() }
+
+    // Convert room gift events into Broadcast objects for the sliding banner
+    LaunchedEffect(currentGiftEvent) {
+        currentGiftEvent?.let { event ->
+            roomBroadcasts.add(
+                Broadcast(
+                    id = "room_${event.eventId}",
+                    type = BroadcastType.GIFT_SEND,
+                    senderName = event.senderName,
+                    recipientName = event.recipientName,
+                    giftName = event.giftName,
+                    giftCoinValue = event.coinValue,
+                    quantity = event.quantity,
+                    timestamp = currentTimeMillis()
+                )
+            )
+        }
+    }
+
+    // Observe app-wide Firestore broadcasts (high-value gifts & gacha wins from all rooms)
+    LaunchedEffect(Unit) {
+        giftRepository.observeBroadcasts()
+            .drop(1) // Skip the initial snapshot to avoid replaying old broadcasts
+            .catch { /* ignore errors */ }
+            .collect { broadcasts ->
+                for (b in broadcasts) {
+                    if (b.id.isNotEmpty() && roomBroadcasts.none { it.id == b.id }) {
+                        roomBroadcasts.add(b)
+                    }
+                }
+            }
+    }
+
     var pmImageResultHandler by remember { mutableStateOf<((List<ByteArray>) -> Unit)?>(null) }
     var pmStickerResultHandler by remember { mutableStateOf<((ByteArray) -> Unit)?>(null) }
     val reportEvidenceList = remember { mutableListOf<Pair<ByteArray, String>>() }
@@ -240,6 +290,53 @@ fun RoomScreen(
         activity?.window?.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         onDispose {
             activity?.window?.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+
+    // Self-destruct announcement TTS
+    val tts = remember { mutableStateOf<TextToSpeech?>(null) }
+    var selfDestructAnnounced by remember(roomId) { mutableStateOf(false) }
+    DisposableEffect(Unit) {
+        val engine = TextToSpeech(context) { status ->
+            if (status == TextToSpeech.SUCCESS) {
+                tts.value?.language = Locale.US
+                tts.value?.setPitch(0.75f)
+                tts.value?.setSpeechRate(0.85f)
+            }
+        }
+        tts.value = engine
+        onDispose {
+            engine.stop()
+            engine.shutdown()
+            tts.value = null
+        }
+    }
+
+    // Play self-destruct announcement when a 5-minute countdown first appears
+    // (room expiry OR owner-away cooldown), and deactivation when owner returns
+    // Only plays if the user has enabled self-destruct alerts in settings (default: off)
+    val selfDestructEnabled = currentUser?.selfDestructAlertEnabled == true
+    LaunchedEffect(uiState.roomExpiryRemainingMs, uiState.ownerAwayRemainingMs, selfDestructEnabled) {
+        val expiryActive = uiState.roomExpiryRemainingMs in 1..300_000L
+        val ownerAwayActive = uiState.ownerAwayRemainingMs in 1..300_000L
+        if (selfDestructEnabled && !selfDestructAnnounced && (expiryActive || ownerAwayActive)) {
+            selfDestructAnnounced = true
+            tts.value?.speak(
+                "Room self destruct sequence activated. Self destruct in T minus 5 minutes.",
+                TextToSpeech.QUEUE_FLUSH,
+                null,
+                "self_destruct"
+            )
+        } else if (selfDestructAnnounced && !expiryActive && !ownerAwayActive) {
+            selfDestructAnnounced = false
+            if (selfDestructEnabled) {
+                tts.value?.speak(
+                    "Self destruct sequence deactivated.",
+                    TextToSpeech.QUEUE_FLUSH,
+                    null,
+                    "self_destruct_off"
+                )
+            }
         }
     }
 
@@ -737,6 +834,12 @@ fun RoomScreen(
                         .padding(bottom = 64.dp, end = 8.dp)
                 )
             }
+
+            // Sliding gold broadcast banner for room gift events (just above the seat grid)
+            BroadcastBanner(
+                broadcasts = roomBroadcasts.toList(),
+                modifier = Modifier.align(Alignment.TopCenter)
+            )
         }
 
         if (showSettings && uiState.room != null) {
@@ -975,7 +1078,7 @@ fun RoomScreen(
                     showBackpackSheet = false
                     additionalBackpackRecipient = null
                 },
-                onNavigateToWallet = onNavigateToWallet,
+                onNavigateToWallet = { showWalletSheet = true },
                 onLongPressGift = { gift -> previewGift = gift }
             )
         }
@@ -1036,6 +1139,24 @@ fun RoomScreen(
                 user = currentUser,
                 onDismiss = { showSuperShySheet = false }
             )
+        }
+
+        // Coin purchase sheet (shown when user has insufficient coins)
+        if (showWalletSheet) {
+            val walletViewModel: WalletViewModel = org.koin.compose.viewmodel.koinViewModel()
+            val walletState by walletViewModel.uiState.collectAsStateWithLifecycle()
+
+            ModalBottomSheet(
+                onDismissRequest = { showWalletSheet = false }
+            ) {
+                com.shyden.shytalk.feature.shop.CoinPurchaseSheetContent(
+                    coinBalance = walletState.coinBalance,
+                    coinPackages = walletState.coinPackages,
+                    isPurchasing = walletState.isPurchasing,
+                    onTestPurchase = { coins -> walletViewModel.testPurchaseCoins(coins) },
+                    onDismiss = { showWalletSheet = false }
+                )
+            }
         }
 
         // Full-screen gift effect overlay (room-wide via AnimationQueue)

--- a/app/src/main/java/com/shyden/shytalk/feature/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/settings/AppSettingsScreen.kt
@@ -169,6 +169,7 @@ fun AppSettingsScreen(
                 onSetDndEndHour = { viewModel.setDndEndHour(it) },
                 onSetDndEndMinute = { viewModel.setDndEndMinute(it) },
                 onSetMinGiftAnimationValue = { viewModel.setMinGiftAnimationValue(it) },
+                onToggleSelfDestructAlert = { viewModel.toggleSelfDestructAlert() },
                 snackbarHostState = snackbarHostState
             )
             SettingsPage.Permissions -> PermissionsPage(
@@ -650,6 +651,7 @@ private fun NotificationsPage(
     onSetDndEndHour: (Int) -> Unit,
     onSetDndEndMinute: (Int) -> Unit,
     onSetMinGiftAnimationValue: (Int) -> Unit,
+    onToggleSelfDestructAlert: () -> Unit,
     snackbarHostState: SnackbarHostState
 ) {
     SettingsSubPage(
@@ -847,6 +849,23 @@ private fun NotificationsPage(
                 onValueChangeFinished = { onSetMinGiftAnimationValue(sliderValue.toInt()) },
                 valueRange = 0f..5000f,
                 steps = 9
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = "Room Alerts",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            SettingsSwitch(
+                title = "Self-Destruct Countdown",
+                description = "Play a voice announcement when a room's 5-minute self-destruct timer starts or stops.",
+                checked = uiState.selfDestructAlertEnabled,
+                onCheckedChange = { onToggleSelfDestructAlert() }
             )
 
             Spacer(modifier = Modifier.height(32.dp))

--- a/app/src/main/java/com/shyden/shytalk/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shyden/shytalk/navigation/NavGraph.kt
@@ -41,6 +41,7 @@ import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.data.repository.NotificationRepository
 import com.shyden.shytalk.data.repository.UserRepository
 import com.shyden.shytalk.data.remote.PmSyncService
+import com.shyden.shytalk.data.remote.VoiceService
 import com.shyden.shytalk.feature.auth.GoogleSignInScreen
 import com.shyden.shytalk.feature.home.LunarNewYearScreen
 import com.shyden.shytalk.feature.legal.CURRENT_LEGAL_VERSION
@@ -75,12 +76,7 @@ import com.shyden.shytalk.feature.daily.DailyRewardDialog
 import com.shyden.shytalk.feature.daily.DailyRewardViewModel
 import com.shyden.shytalk.data.remote.BillingService
 import com.shyden.shytalk.feature.room.RoomScreen
-import com.shyden.shytalk.core.model.Broadcast
-import com.shyden.shytalk.core.ui.BroadcastBanner
-import com.shyden.shytalk.data.repository.GiftRepository
 import com.shyden.shytalk.feature.warning.WarningScreen
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import org.koin.compose.koinInject
@@ -137,15 +133,6 @@ fun NavGraph(
                 }
             }
         }
-    }
-
-    // App-wide broadcast banner
-    val giftRepository: GiftRepository = koinInject()
-    var broadcastList by remember { mutableStateOf<List<Broadcast>>(emptyList()) }
-    LaunchedEffect(Unit) {
-        giftRepository.observeBroadcasts()
-            .catch { /* ignore errors */ }
-            .collect { broadcastList = it }
     }
 
     fun navigateToRoom(roomId: String) {
@@ -321,9 +308,17 @@ fun NavGraph(
                 )
             }
 
+            val voiceService: VoiceService = koinInject()
+
             MainScreen(
                 onNavigateToRoom = { roomId ->
                     navController.navigate(Screen.Room.createRoute(roomId))
+                },
+                onPrewarmRoom = { room ->
+                    val userId = authRepository.currentUserId
+                    if (userId != null && room.voiceRoomName.isNotEmpty()) {
+                        voiceService.prewarmToken(room.voiceRoomName, userId)
+                    }
                 },
                 onNavigateToUserProfile = { userId ->
                     navController.navigate(Screen.UserProfile.createRoute(userId))
@@ -789,9 +784,5 @@ fun NavGraph(
         }
     }
 
-    BroadcastBanner(
-        broadcasts = broadcastList,
-        modifier = Modifier.align(Alignment.TopCenter).statusBarsPadding()
-    )
     } // Box
 }

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,11 +1,12 @@
-v0.41 - Gacha, Gifting & UI Fixes
+v0.42 - Room Speed-up, Broadcasts & Quality of Life
 
-- Gacha wheel locked to 16 slots (CF + client)
-- Admin: showOnWheel toggle now saves correctly
-- Broadcast banner for ALL gift sends
-- Send-all plays queued animations per gift type
-- Gift wall shows ALL gifts (locked/unlocked)
-- Backpack shows all items regardless of store flag
-- Perfect square cells: gift wall, backpack, profile
-- System/gift messages no longer hidden under carousel
-- Admin UX: keyboard hints, GCS legend, mute, toasts
+- LiveKit token pre-warming for faster room joins
+- Soft update dialog on launch (no extra network call)
+- Broadcast banners show gift quantity (3x Crown)
+- Cross-room broadcast banners restored
+- Super Shy purchase stays on sheet (no blank screen)
+- Self-destruct TTS countdown (opt-in in Settings)
+- ShyBeans redemption supports large balances (Long)
+- Broadcast banner repositioned above seats
+- Buy coins sheet available inside rooms
+- Invite shows error if person left the room

--- a/app/src/test/java/com/shyden/shytalk/core/model/BroadcastFromMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/BroadcastFromMapTest.kt
@@ -111,4 +111,59 @@ class BroadcastFromMapTest {
 
         assertEquals(BroadcastType.GIFT_SEND, broadcast.type)
     }
+
+    // ===== quantity field =====
+
+    @Test
+    fun `fromMap parses quantity from Long`() {
+        val map = mapOf<String, Any?>(
+            "type" to "GIFT_SEND",
+            "senderName" to "Alice",
+            "recipientName" to "Bob",
+            "giftName" to "Crown",
+            "giftCoinValue" to 800L,
+            "quantity" to 3L
+        )
+
+        val broadcast = Broadcast.fromMap(map, "bq1")
+
+        assertEquals(3, broadcast.quantity)
+    }
+
+    @Test
+    fun `fromMap defaults quantity to 1 when missing`() {
+        val map = mapOf<String, Any?>(
+            "senderName" to "Alice",
+            "giftName" to "Crown"
+        )
+
+        val broadcast = Broadcast.fromMap(map, "bq2")
+
+        assertEquals(1, broadcast.quantity)
+    }
+
+    @Test
+    fun `fromMap defaults quantity to 1 when null`() {
+        val map = mapOf<String, Any?>("quantity" to null)
+
+        val broadcast = Broadcast.fromMap(map, "bq3")
+
+        assertEquals(1, broadcast.quantity)
+    }
+
+    @Test
+    fun `fromMap defaults quantity to 1 when wrong type`() {
+        val map = mapOf<String, Any?>("quantity" to "not a number")
+
+        val broadcast = Broadcast.fromMap(map, "bq4")
+
+        assertEquals(1, broadcast.quantity)
+    }
+
+    @Test
+    fun `fromMap empty map defaults quantity to 1`() {
+        val broadcast = Broadcast.fromMap(emptyMap(), "bq5")
+
+        assertEquals(1, broadcast.quantity)
+    }
 }

--- a/app/src/test/java/com/shyden/shytalk/core/model/GiftEventFromMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/GiftEventFromMapTest.kt
@@ -168,4 +168,70 @@ class GiftEventFromMapTest {
 
         assertTrue(event.timestamp in before..after)
     }
+
+    // ===== quantity field =====
+
+    @Test
+    fun `fromMap parses quantity from Long`() {
+        val map = mapOf<String, Any?>("quantity" to 5L)
+        val event = GiftEvent.fromMap(map)
+        assertEquals(5, event.quantity)
+    }
+
+    @Test
+    fun `fromMap defaults quantity to 1 when missing`() {
+        val map = mapOf<String, Any?>(
+            "senderId" to "sender-1",
+            "giftId" to "crown"
+        )
+        val event = GiftEvent.fromMap(map)
+        assertEquals(1, event.quantity)
+    }
+
+    @Test
+    fun `fromMap defaults quantity to 1 when null`() {
+        val map = mapOf<String, Any?>("quantity" to null)
+        val event = GiftEvent.fromMap(map)
+        assertEquals(1, event.quantity)
+    }
+
+    @Test
+    fun `fromMap defaults quantity to 1 when wrong type`() {
+        val map = mapOf<String, Any?>("quantity" to "not a number")
+        val event = GiftEvent.fromMap(map)
+        assertEquals(1, event.quantity)
+    }
+
+    @Test
+    fun `default constructor has quantity 1`() {
+        val event = GiftEvent()
+        assertEquals(1, event.quantity)
+    }
+
+    @Test
+    fun `fromMap parses complete map including quantity`() {
+        val map = mapOf<String, Any?>(
+            "senderId" to "sender-1",
+            "senderName" to "Alice",
+            "recipientId" to "recipient-1",
+            "recipientName" to "Bob",
+            "giftId" to "crown",
+            "giftName" to "Crown",
+            "coinValue" to 800L,
+            "quantity" to 3L,
+            "timestamp" to ts
+        )
+
+        val event = GiftEvent.fromMap(map)
+
+        assertEquals("sender-1", event.senderId)
+        assertEquals("Alice", event.senderName)
+        assertEquals("recipient-1", event.recipientId)
+        assertEquals("Bob", event.recipientName)
+        assertEquals("crown", event.giftId)
+        assertEquals("Crown", event.giftName)
+        assertEquals(800, event.coinValue)
+        assertEquals(3, event.quantity)
+        assertEquals(tsMillis, event.timestamp)
+    }
 }

--- a/app/src/test/java/com/shyden/shytalk/core/model/UserFromMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/UserFromMapTest.kt
@@ -339,6 +339,35 @@ class UserFromMapTest {
         assertEquals(0, map["minGiftAnimationValue"])
     }
 
+    // ===== selfDestructAlertEnabled =====
+
+    @Test
+    fun `fromMap parses selfDestructAlertEnabled`() {
+        val map = mapOf<String, Any?>("selfDestructAlertEnabled" to true)
+        val user = User.fromMap(map, "u1")
+        assertTrue(user.selfDestructAlertEnabled)
+    }
+
+    @Test
+    fun `fromMap defaults selfDestructAlertEnabled to false when missing`() {
+        val user = User.fromMap(emptyMap(), "u1")
+        assertFalse(user.selfDestructAlertEnabled)
+    }
+
+    @Test
+    fun `toMap includes selfDestructAlertEnabled`() {
+        val user = User(selfDestructAlertEnabled = true)
+        val map = user.toMap()
+        assertEquals(true, map["selfDestructAlertEnabled"])
+    }
+
+    @Test
+    fun `toMap defaults selfDestructAlertEnabled to false`() {
+        val user = User()
+        val map = user.toMap()
+        assertEquals(false, map["selfDestructAlertEnabled"])
+    }
+
     @Test
     fun `fromMap of toMap roundtrip preserves suspension fields`() {
         val original = User(

--- a/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
@@ -69,7 +69,7 @@ class UserToMapTest {
     fun `toMap contains exactly 56 keys`() {
         val user = TestData.createTestUser()
         val map = user.toMap()
-        assertEquals(57, map.size)
+        assertEquals(58, map.size)
     }
 
     @Test
@@ -91,7 +91,7 @@ class UserToMapTest {
             "dndEndHour", "dndEndMinute",
             "shyCoins", "shyBeans", "isSuperShy", "superShyExpiry", "superShyTier",
             "luckScore", "pityCounter", "loginStreak", "lastLoginDate", "lastLoginRewardDate",
-            "aliases", "minGiftAnimationValue", "hasClaimedSuperShyTrial"
+            "aliases", "minGiftAnimationValue", "selfDestructAlertEnabled", "hasClaimedSuperShyTrial"
         )
         val user = TestData.createTestUser()
         assertEquals(expectedKeys, user.toMap().keys)

--- a/app/src/test/java/com/shyden/shytalk/feature/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/profile/ProfileViewModelTest.kt
@@ -1403,7 +1403,7 @@ class ProfileViewModelTest {
         advanceUntilIdle()
 
         assertEquals("Test failed", vm.uiState.value.error)
-        assertFalse(vm.uiState.value.isLoading)
+        assertFalse(vm.uiState.value.isPurchasingSuperShy)
     }
 
     // ===== loadProfile - isFollowingTarget set from followerIds =====

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -824,7 +824,7 @@ class RoomViewModelTest {
         viewModel = createViewModel()
         emitRoomAsHost(TestData.createTestRoom(
             ownerId = ownerId,
-            participantIds = setOf(ownerId, currentUserId),
+            participantIds = setOf(ownerId, currentUserId, "target-user"),
             hostIds = setOf(currentUserId),
             requireApproval = false
         ))
@@ -841,6 +841,7 @@ class RoomViewModelTest {
         viewModel = createViewModel()
         emitRoomAsOwner(TestData.createTestRoom(
             ownerId = currentUserId,
+            participantIds = setOf(currentUserId, "target-user"),
             requireApproval = true
         ))
         advanceUntilIdle()
@@ -880,6 +881,22 @@ class RoomViewModelTest {
         viewModel.inviteUser("target-user", "Target")
         advanceUntilIdle()
 
+        coVerify(exactly = 0) { roomRepository.sendInvite(any(), any(), any()) }
+    }
+
+    @Test
+    fun `inviteUser - user who left room shows error`() = roomTest {
+        viewModel = createViewModel()
+        emitRoomAsOwner(TestData.createTestRoom(
+            ownerId = currentUserId,
+            participantIds = setOf(currentUserId) // target-user NOT in participants
+        ))
+        advanceUntilIdle()
+
+        viewModel.inviteUser("target-user", "Target")
+        advanceUntilIdle()
+
+        assertEquals("Target has left the room", viewModel.uiState.value.error)
         coVerify(exactly = 0) { roomRepository.sendInvite(any(), any(), any()) }
     }
 

--- a/app/src/test/java/com/shyden/shytalk/feature/settings/AppSettingsViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/settings/AppSettingsViewModelTest.kt
@@ -629,4 +629,57 @@ class AppSettingsViewModelTest {
 
         assertEquals(PmPrivacy.FOLLOWERS_ONLY, vm.uiState.value.pmPrivacy)
     }
+
+    // ===== selfDestructAlert =====
+
+    @Test
+    fun `init loads selfDestructAlertEnabled from user`() = runTest {
+        val user = TestData.createTestUser(uid = currentUserId).copy(
+            selfDestructAlertEnabled = true
+        )
+        coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(user)
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.selfDestructAlertEnabled)
+    }
+
+    @Test
+    fun `selfDestructAlert defaults to false`() = runTest {
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.selfDestructAlertEnabled)
+    }
+
+    @Test
+    fun `toggleSelfDestructAlert - optimistic toggle on`() = runTest {
+        coEvery { userRepository.updateProfile(currentUserId, any()) } returns Resource.Success(Unit)
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+        assertFalse(vm.uiState.value.selfDestructAlertEnabled)
+
+        vm.toggleSelfDestructAlert()
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.selfDestructAlertEnabled)
+        coVerify { userRepository.updateProfile(currentUserId, mapOf("selfDestructAlertEnabled" to true)) }
+    }
+
+    @Test
+    fun `toggleSelfDestructAlert - error reverts`() = runTest {
+        coEvery { userRepository.updateProfile(currentUserId, any()) } returns Resource.Error("fail")
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+        assertFalse(vm.uiState.value.selfDestructAlertEnabled)
+
+        vm.toggleSelfDestructAlert()
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.selfDestructAlertEnabled)
+        assertEquals("Failed to update privacy setting", vm.uiState.value.error)
+    }
 }

--- a/app/src/test/java/com/shyden/shytalk/feature/shop/WalletViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/shop/WalletViewModelTest.kt
@@ -340,6 +340,25 @@ class WalletViewModelTest {
     }
 
     @Test
+    fun `redeemBeans supports large Long values`() = runTest {
+        val largeBalance = 5_000_000_000L
+        coEvery { userRepository.getUser("u1") } returns Resource.Success(sampleUser.copy(shyBeans = largeBalance))
+        coEvery { economyRepository.redeemBeans(largeBalance) } returns Resource.Success(emptyMap())
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        assertEquals(largeBalance, vm.uiState.value.beanBalance)
+
+        vm.redeemBeans(largeBalance)
+        advanceUntilIdle()
+
+        assertNotNull(vm.uiState.value.successMessage)
+        assertTrue(vm.uiState.value.successMessage!!.contains("bonus"))
+        assertFalse(vm.uiState.value.isPurchasing)
+    }
+
+    @Test
     fun `clearSuccess clears success message`() = runTest {
         coEvery { economyRepository.addTestCoins(100) } returns Resource.Success(emptyMap())
 

--- a/functions/admin.js
+++ b/functions/admin.js
@@ -2287,9 +2287,11 @@ app.post("/api/cleanup/all-spin-history", async (req, res) => {
 app.post("/api/cleanup/all-supershy", async (req, res) => {
   try {
     const db = getFirestore();
-    const snap = await db.collection("users").where("isSuperShy", "==", true).get();
     let usersCleared = 0;
+    let trialsReset = 0;
 
+    // Clear active Super Shy status
+    const snap = await db.collection("users").where("isSuperShy", "==", true).get();
     for (let i = 0; i < snap.docs.length; i += 500) {
       const batch = db.batch();
       snap.docs.slice(i, i + 500).forEach((doc) => {
@@ -2303,13 +2305,24 @@ app.post("/api/cleanup/all-supershy", async (req, res) => {
       usersCleared += Math.min(500, snap.docs.length - i);
     }
 
+    // Reset trial claim flag so users can re-claim after reset
+    const trialSnap = await db.collection("users").where("hasClaimedSuperShyTrial", "==", true).get();
+    for (let i = 0; i < trialSnap.docs.length; i += 500) {
+      const batch = db.batch();
+      trialSnap.docs.slice(i, i + 500).forEach((doc) => {
+        batch.update(doc.ref, { hasClaimedSuperShyTrial: false });
+      });
+      await batch.commit();
+      trialsReset += Math.min(500, trialSnap.docs.length - i);
+    }
+
     await writeAuditLog(db, {
       adminUid: req.admin.uid,
       action: "cleanup_all_supershy",
-      note: `Removed Super Shy from ${usersCleared} users`,
+      note: `Removed Super Shy from ${usersCleared} users, reset ${trialsReset} trial claims`,
     });
 
-    return res.json({ success: true, usersCleared });
+    return res.json({ success: true, usersCleared, trialsReset });
   } catch (err) {
     console.error("POST cleanup/all-supershy error:", err);
     return res.status(500).json({ error: err.message });

--- a/functions/admin.test.js
+++ b/functions/admin.test.js
@@ -1664,6 +1664,21 @@ describe("POST /api/cleanup/all-supershy", () => {
     expect(res.status).toBe(200);
     expect(res.body.usersCleared).toBe(0);
   });
+
+  test("resets hasClaimedSuperShyTrial for users who claimed trial", async () => {
+    mockUsers["user-1"] = { displayName: "A", hasClaimedSuperShyTrial: true };
+    mockUsers["user-2"] = { displayName: "B", hasClaimedSuperShyTrial: true, isSuperShy: true, superShyTier: "trial" };
+    mockUsers["user-3"] = { displayName: "C" };
+
+    const res = await request("POST", "/api/cleanup/all-supershy", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.trialsReset).toBe(2);
+    // Verify batch.update was called with hasClaimedSuperShyTrial: false
+    const trialUpdates = mockBatch.update.mock.calls.filter(
+      ([, data]) => data.hasClaimedSuperShyTrial === false
+    );
+    expect(trialUpdates.length).toBe(2);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════

--- a/functions/index.js
+++ b/functions/index.js
@@ -1257,6 +1257,7 @@ exports.sendGift = onCall({ region: "asia-southeast1" }, async (request) => {
           giftId,
           giftName: gift.name,
           coinValue: gift.coinValue,
+          quantity,
           timestamp: FieldValue.serverTimestamp(),
         },
       });
@@ -1410,6 +1411,7 @@ exports.sendGiftDirect = onCall({ region: "asia-southeast1" }, async (request) =
           giftId,
           giftName: gift.name,
           coinValue: gift.coinValue,
+          quantity,
           timestamp: FieldValue.serverTimestamp(),
         },
       });
@@ -1925,6 +1927,7 @@ exports.sendGiftBatch = onCall({ region: "asia-southeast1" }, async (request) =>
           giftId,
           giftName: gift.name,
           coinValue: gift.coinValue,
+          quantity: quantity * recipientDocs.length,
           timestamp: FieldValue.serverTimestamp(),
         },
       });
@@ -2179,6 +2182,7 @@ exports.sendEntireBackpack = onCall({ region: "asia-southeast1" }, async (reques
             giftId: g.giftId,
             giftName: g.giftName,
             coinValue: details.coinValue,
+            quantity: g.quantity,
             timestamp: FieldValue.serverTimestamp(),
           },
         });

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/Broadcast.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/Broadcast.kt
@@ -13,6 +13,7 @@ data class Broadcast(
     val giftName: String = "",
     val giftIconUrl: String = "",
     val giftCoinValue: Int = 0,
+    val quantity: Int = 1,
     val timestamp: Long = 0
 ) {
     companion object {
@@ -27,6 +28,7 @@ data class Broadcast(
             giftName = map["giftName"] as? String ?: "",
             giftIconUrl = map["giftIconUrl"] as? String ?: "",
             giftCoinValue = (map["giftCoinValue"] as? Long)?.toInt() ?: 0,
+            quantity = (map["quantity"] as? Long)?.toInt() ?: 1,
             timestamp = map["timestamp"]?.let { timestampToMillis(it) } ?: 0
         )
     }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/GiftEvent.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/GiftEvent.kt
@@ -11,6 +11,7 @@ data class GiftEvent(
     val giftId: String = "",
     val giftName: String = "",
     val coinValue: Int = 0,
+    val quantity: Int = 1,
     val timestamp: Long = 0,
     val eventId: Long = Random.nextLong()
 ) {
@@ -23,6 +24,7 @@ data class GiftEvent(
             giftId = map["giftId"] as? String ?: "",
             giftName = map["giftName"] as? String ?: "",
             coinValue = (map["coinValue"] as? Long)?.toInt() ?: 0,
+            quantity = (map["quantity"] as? Long)?.toInt() ?: 1,
             timestamp = map["timestamp"]?.let { timestampToMillis(it) } ?: 0
         )
     }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
@@ -64,6 +64,7 @@ data class User(
     val lastLoginRewardDate: String? = null,
     val aliases: Map<String, String> = emptyMap(),
     val minGiftAnimationValue: Int = 0,
+    val selfDestructAlertEnabled: Boolean = false,
     val hasClaimedSuperShyTrial: Boolean = false
 ) {
     val isActivelySuspended: Boolean
@@ -133,6 +134,7 @@ data class User(
         "lastLoginRewardDate" to lastLoginRewardDate,
         "aliases" to aliases,
         "minGiftAnimationValue" to minGiftAnimationValue,
+        "selfDestructAlertEnabled" to selfDestructAlertEnabled,
         "hasClaimedSuperShyTrial" to hasClaimedSuperShyTrial
     )
 
@@ -205,6 +207,7 @@ data class User(
                 ?.mapNotNull { (k, v) -> (k as? String)?.let { key -> (v as? String)?.let { value -> key to value } } }
                 ?.toMap() ?: emptyMap(),
             minGiftAnimationValue = (map["minGiftAnimationValue"] as? Long)?.toInt() ?: 0,
+            selfDestructAlertEnabled = map["selfDestructAlertEnabled"] as? Boolean ?: false,
             hasClaimedSuperShyTrial = map["hasClaimedSuperShyTrial"] as? Boolean ?: false
         )
     }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/BroadcastBanner.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/BroadcastBanner.kt
@@ -105,13 +105,14 @@ fun BroadcastBanner(
     val isGachaWin = broadcast.type == BroadcastType.GACHA_WIN
     val gradient = if (isGachaWin) gachaWinGradient else giftSendGradient
     val icon = if (isGachaWin) Icons.Filled.Stars else Icons.Filled.CardGiftcard
+    val qtyPrefix = if (broadcast.quantity > 1) "${broadcast.quantity}x " else ""
     val coinText = if (broadcast.giftCoinValue > 0) {
         " (${broadcast.giftCoinValue.formatWithCommas()})"
     } else ""
     val text = if (isGachaWin) {
-        "${broadcast.senderName} won ${broadcast.giftName}$coinText from Lucky Spin!"
+        "${broadcast.senderName} won $qtyPrefix${broadcast.giftName}$coinText from Lucky Spin!"
     } else {
-        "${broadcast.senderName} sent ${broadcast.giftName}$coinText to ${broadcast.recipientName}!"
+        "${broadcast.senderName} sent $qtyPrefix${broadcast.giftName}$coinText to ${broadcast.recipientName}!"
     }
 
     BoxWithConstraints(modifier = modifier.fillMaxWidth()) {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/GiftEffectOverlay.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/GiftEffectOverlay.kt
@@ -29,7 +29,6 @@ fun GiftEffectOverlay(
 ) {
     val coinValue = GiftEffectRegistry.coinValueForGiftId(event.giftId)
     val durationMs = GiftEffectRegistry.durationForValue(coinValue)
-    val label = "${event.senderName} sent ${event.giftName} to ${event.recipientName}"
 
     // Guard against double-firing (tap dismiss + animation timer both call onFinished)
     var dismissed by remember(event) { mutableStateOf(false) }
@@ -51,7 +50,6 @@ fun GiftEffectOverlay(
     ) {
         GiftAnimation(
             giftId = event.giftId,
-            label = label,
             durationMs = durationMs,
             onFinished = dismiss,
             modifier = Modifier.fillMaxSize(),
@@ -71,17 +69,9 @@ fun GiftEffectOverlay(
     isVisible: Boolean,
     onFinished: () -> Unit,
     modifier: Modifier = Modifier,
-    giftId: String = "",
-    senderName: String = "",
-    recipientName: String = "",
-    giftName: String = ""
+    giftId: String = ""
 ) {
     if (!isVisible) return
-    val event = GiftEvent(
-        giftId = giftId,
-        giftName = giftName,
-        senderName = senderName,
-        recipientName = recipientName
-    )
+    val event = GiftEvent(giftId = giftId)
     GiftEffectOverlay(event = event, onFinished = onFinished, modifier = modifier)
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/effects/GiftAnimations.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/effects/GiftAnimations.kt
@@ -6,22 +6,15 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.rotate
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
@@ -30,12 +23,10 @@ import kotlin.random.Random
 /**
  * Renders the gift animation for the given giftId over the specified duration.
  * Calls [onFinished] when the animation completes.
- * The [label] is shown as a text overlay at the top (e.g. "Alice sent Crown to Bob").
  */
 @Composable
 fun GiftAnimation(
     giftId: String,
-    label: String,
     durationMs: Long,
     onFinished: () -> Unit,
     modifier: Modifier = Modifier,
@@ -53,29 +44,8 @@ fun GiftAnimation(
     }
 
     Box(modifier = modifier.fillMaxSize()) {
-        // Animation canvas
         val coinValue = GiftEffectRegistry.coinValueForGiftId(giftId)
         GiftCanvas(giftId = giftId, coinValue = coinValue, progress = progress.value)
-
-        // Label overlay
-        if (label.isNotBlank()) {
-            val labelAlpha = when {
-                progress.value < 0.1f -> progress.value / 0.1f
-                progress.value > 0.85f -> (1f - progress.value) / 0.15f
-                else -> 1f
-            }.coerceIn(0f, 1f)
-
-            Text(
-                text = label,
-                color = Color.White.copy(alpha = labelAlpha),
-                fontSize = 18.sp,
-                fontWeight = FontWeight.Bold,
-                textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .padding(top = 80.dp)
-            )
-        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/remote/VoiceService.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/remote/VoiceService.kt
@@ -14,4 +14,5 @@ interface VoiceService {
     fun setMicrophoneEnabled(enabled: Boolean)
     fun setAudioMode(voiceMode: Boolean)
     fun clearError()
+    fun prewarmToken(roomName: String, userId: String)
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/EconomyRepository.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/EconomyRepository.kt
@@ -17,7 +17,7 @@ interface EconomyRepository {
     suspend fun sendGiftDirect(recipientId: String, giftId: String, quantity: Int = 1): Resource<Map<String, Any?>>
     suspend fun sendGiftBatch(recipientIds: List<String>, giftId: String, quantity: Int, fromBackpack: Boolean): Resource<Map<String, Any?>>
     suspend fun sendEntireBackpack(recipientId: String): Resource<Map<String, Any?>>
-    suspend fun redeemBeans(amount: Int): Resource<Map<String, Any?>>
+    suspend fun redeemBeans(amount: Long): Resource<Map<String, Any?>>
     suspend fun purchaseCoins(productId: String, purchaseToken: String): Resource<Map<String, Any?>>
     suspend fun purchaseSubscription(productId: String, purchaseToken: String): Resource<Map<String, Any?>>
     suspend fun getCoinPackages(): Resource<List<CoinPackage>>

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import org.koin.compose.viewmodel.koinViewModel
 import androidx.compose.runtime.collectAsState
+import com.shyden.shytalk.core.model.ChatRoom
 import com.shyden.shytalk.ui.theme.CnyGold
 
 private val BannerBackground = Color(0xFF2A0808)
@@ -111,6 +112,7 @@ private fun CnyBanner(onClick: () -> Unit) {
 @Composable
 fun RoomListContent(
     onNavigateToRoom: (String) -> Unit,
+    onPrewarmRoom: (ChatRoom) -> Unit = {},
     onNavigateToLunarNewYear: () -> Unit = {},
     snackbarHostState: SnackbarHostState,
     showCreateDialog: Boolean,
@@ -198,7 +200,10 @@ fun RoomListContent(
                         RoomListItem(
                             room = room,
                             seatUsers = uiState.seatUsers,
-                            onClick = { onNavigateToRoom(room.roomId) },
+                            onClick = {
+                                onPrewarmRoom(room)
+                                onNavigateToRoom(room.roomId)
+                            },
                             modifier = Modifier.testTag("roomList_roomCard_${room.roomId}")
                         )
                     }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/main/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/main/MainScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.shyden.shytalk.core.model.ChatRoom
 import com.shyden.shytalk.feature.home.RoomListContent
 import com.shyden.shytalk.ui.theme.CnyGold
 
@@ -52,6 +53,7 @@ enum class BottomNavTab(val label: String) {
 @Composable
 fun MainScreen(
     onNavigateToRoom: (String) -> Unit,
+    onPrewarmRoom: (ChatRoom) -> Unit = {},
     onNavigateToUserProfile: (String) -> Unit,
     onNavigateToFollowList: (String, String) -> Unit,
     onNavigateToSettings: () -> Unit,
@@ -171,6 +173,7 @@ fun MainScreen(
             BottomNavTab.Rooms -> {
                 RoomListContent(
                     onNavigateToRoom = onNavigateToRoom,
+                    onPrewarmRoom = onPrewarmRoom,
                     onNavigateToLunarNewYear = onNavigateToLunarNewYear,
                     snackbarHostState = snackbarHostState,
                     showCreateDialog = showCreateDialog,

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
@@ -44,7 +44,8 @@ data class ProfileUiState(
     val isTargetSuspended: Boolean = false,
     val isSubmittingReport: Boolean = false,
     val reportSubmitted: Boolean = false,
-    val reportError: String? = null
+    val reportError: String? = null,
+    val isPurchasingSuperShy: Boolean = false
 )
 
 class ProfileViewModel(
@@ -509,13 +510,14 @@ class ProfileViewModel(
 
     fun testPurchaseSuperShy(productId: String) {
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
+            _uiState.update { it.copy(isPurchasingSuperShy = true) }
             when (val result = economyRepository.purchaseSubscription(productId, "test_token")) {
                 is Resource.Success -> {
+                    _uiState.update { it.copy(isPurchasingSuperShy = false) }
                     loadProfile(null)
                 }
                 is Resource.Error -> {
-                    _uiState.update { it.copy(isLoading = false, error = result.message ?: "Test purchase failed") }
+                    _uiState.update { it.copy(isPurchasingSuperShy = false, error = result.message ?: "Test purchase failed") }
                 }
                 is Resource.Loading -> {}
             }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -782,33 +782,45 @@ class RoomViewModel(
                 }
             }
             val userName = _uiState.value.currentUserName
-            roomRepository.leaveAllRooms(userId, exceptRoomId = roomId)
-            roomRepository.recordFirstJoinTimestamp(roomId, userId)
-            roomRepository.joinRoom(roomId, userId)
-            presenceService.setPresence(roomId, userId)
-            userRepository.updateProfile(userId, mapOf("currentRoomId" to roomId))
+
+            // Mute setup if already seated (owner re-entering)
+            val voiceRoom = room?.voiceRoomName
+            if (!voiceRoom.isNullOrEmpty()) {
+                val seatEntry = room.findUserSeat(userId)
+                if (seatEntry != null) {
+                    isSeated = true
+                    if (!seatEntry.value.isMuted) {
+                        roomRepository.toggleMute(roomId, seatEntry.key.toInt(), true)
+                    }
+                }
+            }
+
             _uiState.update { it.copy(hasJoined = true) }
             refilterPendingRequests()
 
             // Start foreground service via RoomLifecycleManager
             roomLifecycleManager.trackRoom(roomId)
 
-            // Join voice room — always start muted (Bug #6)
-            val voiceRoom = room?.voiceRoomName
+            // Run all independent operations in parallel for faster room join
+            // Firestore room writes (sequential — same document)
+            launch {
+                roomRepository.leaveAllRooms(userId, exceptRoomId = roomId)
+                roomRepository.recordFirstJoinTimestamp(roomId, userId)
+                roomRepository.joinRoom(roomId, userId)
+            }
+            // RTDB presence (independent)
+            launch { presenceService.setPresence(roomId, userId) }
+            // User profile update (different document)
+            launch { userRepository.updateProfile(userId, mapOf("currentRoomId" to roomId)) }
+            // Voice join — biggest bottleneck, runs in parallel with writes
             if (!voiceRoom.isNullOrEmpty()) {
-                val seatEntry = room.findUserSeat(userId)
-                if (seatEntry != null) {
-                    isSeated = true
-                    // Ensure Firestore seat shows muted so the icon is correct
-                    if (!seatEntry.value.isMuted) {
-                        roomRepository.toggleMute(roomId, seatEntry.key.toInt(), true)
-                    }
+                launch {
+                    voiceService.joinRoom(voiceRoom, userId)
+                    voiceService.setMicrophoneEnabled(false)
+                    voiceService.setAudioMode(false)
                 }
-                voiceService.joinRoom(voiceRoom, userId)
-                voiceService.setMicrophoneEnabled(false)
-                voiceService.setAudioMode(false)
                 // Timeout: unblock room if voice doesn't connect in time
-                viewModelScope.launch {
+                launch {
                     delay(VOICE_CONNECT_TIMEOUT_MS)
                     if (!_uiState.value.isVoiceReady) {
                         _uiState.update { it.copy(isVoiceReady = true, isVoiceUnavailable = true) }
@@ -818,14 +830,16 @@ class RoomViewModel(
                 // No voice room — mark ready so the room UI is shown immediately
                 _uiState.update { it.copy(isVoiceReady = true) }
             }
-
+            // Join message (independent)
             if (userName.isNotEmpty()) {
-                messageRepository.sendJoinMessage(
-                    roomId,
-                    userId,
-                    userName,
-                    "$userName joined the room"
-                )
+                launch {
+                    messageRepository.sendJoinMessage(
+                        roomId,
+                        userId,
+                        userName,
+                        "$userName joined the room"
+                    )
+                }
             }
         }
     }
@@ -1112,6 +1126,12 @@ class RoomViewModel(
             // Don't invite someone who is already seated or already invited
             if (room.findUserSeat(userId) != null) return@launch
             if (userId in room.pendingInvites) return@launch
+
+            // Check the person is still in the room
+            if (userId !in room.participantIds) {
+                _uiState.update { it.copy(error = "$userName has left the room") }
+                return@launch
+            }
 
             // Owner can always invite; hosts only when requireApproval is OFF
             if (role == RoomRole.ATTENDEE) return@launch

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/BackpackSheet.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/BackpackSheet.kt
@@ -214,7 +214,8 @@ fun BackpackSheet(
                     onQuantityClick = {},
                     onSendClick = { viewModel.activateTrial() },
                     onSendAllClick = null,
-                    sendLabel = "Use"
+                    sendLabel = "Use",
+                    isSelfUse = true
                 )
             } else {
                 BottomBar(
@@ -692,11 +693,13 @@ private fun BottomBar(
     onQuantityClick: () -> Unit,
     onSendClick: () -> Unit,
     onSendAllClick: (() -> Unit)? = null,
-    sendLabel: String? = null
+    sendLabel: String? = null,
+    isSelfUse: Boolean = false
 ) {
     val selectedGift = state.selectedGiftId?.let { id -> giftCatalog.find { it.id == id } }
     val hasRecipients = state.selectedRecipientIds.isNotEmpty()
-    val canSend = selectedGift != null && hasRecipients && !state.isSending
+    val canSend = selectedGift != null && !state.isSending &&
+        if (isSelfUse) !hasRecipients else hasRecipients
 
     Row(
         verticalAlignment = Alignment.CenterVertically,

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/settings/AppSettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/settings/AppSettingsViewModel.kt
@@ -40,6 +40,7 @@ data class AppSettingsUiState(
     val dndEndHour: Int = 8,
     val dndEndMinute: Int = 0,
     val minGiftAnimationValue: Int = 0,
+    val selfDestructAlertEnabled: Boolean = false,
     val cacheCleared: Boolean = false,
     val updateCheckResult: UpdateCheckResult? = null,
     val isCheckingUpdate: Boolean = false
@@ -91,7 +92,8 @@ class AppSettingsViewModel(
                             dndStartMinute = user.dndStartMinute,
                             dndEndHour = user.dndEndHour,
                             dndEndMinute = user.dndEndMinute,
-                            minGiftAnimationValue = user.minGiftAnimationValue
+                            minGiftAnimationValue = user.minGiftAnimationValue,
+                            selfDestructAlertEnabled = user.selfDestructAlertEnabled
                         )
                     }
                 }
@@ -233,6 +235,12 @@ class AppSettingsViewModel(
             userRepository.updateProfile(currentUserId, mapOf(key to value))
         }
     }
+
+    fun toggleSelfDestructAlert() = togglePrivacySetting(
+        key = "selfDestructAlertEnabled",
+        currentValue = _uiState.value.selfDestructAlertEnabled,
+        applyOptimistic = { value -> _uiState.update { it.copy(selfDestructAlertEnabled = value) } }
+    )
 
     fun setMinGiftAnimationValue(value: Int) {
         _uiState.update { it.copy(minGiftAnimationValue = value) }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/SuperShyBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/SuperShyBottomSheet.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.material3.CircularProgressIndicator
 import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.ui.SuperShyGold
 
@@ -42,6 +43,7 @@ fun SuperShyBottomSheet(
     onPurchase: (String) -> Unit = {},
     onTestPurchase: ((String) -> Unit)? = null,
     onClaimTrial: (() -> Unit)? = null,
+    isPurchasing: Boolean = false,
     onDismiss: () -> Unit
 ) {
     val effectivePurchase: (String) -> Unit = onTestPurchase ?: onPurchase
@@ -209,8 +211,17 @@ fun SuperShyBottomSheet(
                     price = "$99.99",
                     description = "One-time payment",
                     onClick = { effectivePurchase("super_shy_lifetime") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !isPurchasing
                 )
+                if (isPurchasing) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        color = SuperShyGold,
+                        strokeWidth = 2.dp
+                    )
+                }
             } else {
                 // Not Super Shy — show trial card + all pricing
                 if (onClaimTrial != null && !user.hasClaimedSuperShyTrial) {
@@ -268,14 +279,16 @@ fun SuperShyBottomSheet(
                         price = "$4.99",
                         description = "per month",
                         onClick = { effectivePurchase("super_shy_monthly") },
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
+                        enabled = !isPurchasing
                     )
                     SuperShyPricingCard(
                         tier = "Yearly",
                         price = "$39.99",
                         description = "per year",
                         onClick = { effectivePurchase("super_shy_yearly") },
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
+                        enabled = !isPurchasing
                     )
                 }
                 Spacer(modifier = Modifier.height(8.dp))
@@ -284,8 +297,17 @@ fun SuperShyBottomSheet(
                     price = "$99.99",
                     description = "One-time payment",
                     onClick = { effectivePurchase("super_shy_lifetime") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !isPurchasing
                 )
+                if (isPurchasing) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        color = SuperShyGold,
+                        strokeWidth = 2.dp
+                    )
+                }
             }
         }
     }
@@ -297,10 +319,12 @@ private fun SuperShyPricingCard(
     price: String,
     description: String,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
 ) {
     Card(
         onClick = onClick,
+        enabled = enabled,
         modifier = modifier,
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/WalletScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/WalletScreen.kt
@@ -217,10 +217,10 @@ private fun CoinsTab(
 private fun BeansTab(
     beanBalance: Long,
     isPurchasing: Boolean,
-    onRedeem: (Int) -> Unit
+    onRedeem: (Long) -> Unit
 ) {
-    val presets = listOf(100, 500, 1_000, 2_000, 5_000)
-    var confirmAmount by remember { mutableStateOf<Int?>(null) }
+    val presets = listOf(100L, 500L, 1_000L, 2_000L, 5_000L)
+    var confirmAmount by remember { mutableStateOf<Long?>(null) }
 
     Column(
         modifier = Modifier
@@ -247,16 +247,16 @@ private fun BeansTab(
         Spacer(modifier = Modifier.height(12.dp))
 
         // Preset buttons in 2-column grid
-        val rows = (presets + -1).chunked(2) // -1 sentinel for "Redeem All"
+        val rows = (presets + -1L).chunked(2) // -1 sentinel for "Redeem All"
         rows.forEach { row ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 row.forEach { preset ->
-                    val isRedeemAll = preset == -1
-                    val amount = if (isRedeemAll) beanBalance.toInt() else preset
-                    val label = if (isRedeemAll) "Redeem All" else formatNumber(preset.toLong())
+                    val isRedeemAll = preset == -1L
+                    val amount = if (isRedeemAll) beanBalance else preset
+                    val label = if (isRedeemAll) "Redeem All" else formatNumber(preset)
                     val hasBonus = amount >= 2_000
                     val enabled = !isPurchasing && amount > 0 && amount <= beanBalance
 
@@ -295,12 +295,12 @@ private fun BeansTab(
 
     // Confirmation dialog
     confirmAmount?.let { amount ->
-        val coins = if (amount >= 2_000) (amount * 1.1).toInt() else amount
+        val coins = if (amount >= 2_000) (amount * 1.1).toLong() else amount
         AlertDialog(
             onDismissRequest = { confirmAmount = null },
             title = { Text("Confirm Redemption") },
             text = {
-                Text("Redeem ${formatNumber(amount.toLong())} beans for ${formatNumber(coins.toLong())} coins?")
+                Text("Redeem ${formatNumber(amount)} beans for ${formatNumber(coins)} coins?")
             },
             confirmButton = {
                 TextButton(onClick = {
@@ -371,5 +371,59 @@ internal fun CoinPackageCard(pkg: CoinPackage, enabled: Boolean = true, onClick:
             Spacer(modifier = Modifier.height(4.dp))
             Text(pkg.displayPrice, style = MaterialTheme.typography.bodyMedium)
         }
+    }
+}
+
+/**
+ * Lightweight coin-purchase content for use inside a ModalBottomSheet.
+ * Keeps the user in the room while purchasing coins.
+ */
+@Composable
+fun CoinPurchaseSheetContent(
+    coinBalance: Long,
+    coinPackages: List<CoinPackage>,
+    isPurchasing: Boolean,
+    onTestPurchase: (Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        BalanceCard(
+            label = "Shy Coins",
+            amount = coinBalance,
+            icon = "\uD83E\uDE99",
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text("Buy Shy Coins", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Spacer(modifier = Modifier.height(8.dp))
+
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            contentPadding = PaddingValues(0.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.heightIn(max = 240.dp)
+        ) {
+            items(coinPackages) { pkg ->
+                val totalCoins = pkg.coins + pkg.bonusCoins
+                CoinPackageCard(
+                    pkg = pkg,
+                    enabled = !isPurchasing,
+                    onClick = {
+                        onTestPurchase(totalCoins)
+                        onDismiss()
+                    }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/WalletViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/WalletViewModel.kt
@@ -93,7 +93,7 @@ class WalletViewModel(
         }
     }
 
-    fun redeemBeans(amount: Int) {
+    fun redeemBeans(amount: Long) {
         if (amount < 1) return
         if (amount > _uiState.value.beanBalance) {
             _uiState.update { it.copy(error = "Not enough beans") }
@@ -107,7 +107,7 @@ class WalletViewModel(
                     _uiState.update {
                         it.copy(
                             isPurchasing = false,
-                            successMessage = "Redeemed ${formatNumber(amount.toLong())} beans$bonus"
+                            successMessage = "Redeemed ${formatNumber(amount)} beans$bonus"
                         )
                     }
                     loadData()


### PR DESCRIPTION
## Summary
- **Faster room joins**: LiveKit token pre-warming fetches the token while navigating, saving 1-2s
- **Soft update dialog**: Checks for updates on launch using existing Firestore read (zero extra latency)
- **Broadcast banners**: Show quantity (3x Crown), restored cross-room visibility, repositioned above seats
- **Super Shy purchase UX**: Sheet stays open during purchase instead of showing blank loading screen
- **Self-destruct TTS**: Robotic voice announcement when room 5-min countdown starts/stops (opt-in in Settings)
- **Large ShyBeans support**: Redemption uses Long throughout to handle balances > 2.1 billion
- **In-room coin purchase**: Buy coins sheet available without leaving the room
- **Invite fix**: Shows error message if the target user has left the room
- **CF quantity**: lastGiftEvent includes quantity for all gift send variants

## Test plan
- [x] 1698 Kotlin unit tests pass (including new selfDestructAlert, invite, Long beans, User model tests)
- [x] 450 Cloud Functions tests pass
- [ ] Manual: Launch app → soft update dialog appears if update available → dismiss works
- [ ] Manual: Tap room → joins noticeably faster (token pre-warmed)
- [ ] Manual: Send 3x gift → broadcast shows "3x Crown" in sender's room and other rooms
- [ ] Manual: Settings > Notifications > Room Alerts > toggle Self-Destruct Countdown
- [ ] Manual: Redeem All with large bean balance → succeeds
- [ ] Manual: Invite user who left → snackbar "X has left the room"

🤖 Generated with [Claude Code](https://claude.com/claude-code)