### PR TITLE
Move gift animation slider to room settings

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/feature/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/settings/AppSettingsScreen.kt
@@ -46,7 +46,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -168,7 +167,6 @@ fun AppSettingsScreen(
                 onSetDndStartMinute = { viewModel.setDndStartMinute(it) },
                 onSetDndEndHour = { viewModel.setDndEndHour(it) },
                 onSetDndEndMinute = { viewModel.setDndEndMinute(it) },
-                onSetMinGiftAnimationValue = { viewModel.setMinGiftAnimationValue(it) },
                 onToggleSelfDestructAlert = { viewModel.toggleSelfDestructAlert() },
                 snackbarHostState = snackbarHostState
             )
@@ -650,7 +648,6 @@ private fun NotificationsPage(
     onSetDndStartMinute: (Int) -> Unit,
     onSetDndEndHour: (Int) -> Unit,
     onSetDndEndMinute: (Int) -> Unit,
-    onSetMinGiftAnimationValue: (Int) -> Unit,
     onToggleSelfDestructAlert: () -> Unit,
     snackbarHostState: SnackbarHostState
 ) {
@@ -817,39 +814,6 @@ private fun NotificationsPage(
                     )
                 }
             }
-
-            Spacer(modifier = Modifier.height(16.dp))
-            HorizontalDivider()
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Text(
-                text = "Gift Animations",
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.primary
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = if (uiState.minGiftAnimationValue == 0) "Showing all gift animations"
-                       else "Only showing gift animations worth ${uiState.minGiftAnimationValue}+ coins",
-                style = MaterialTheme.typography.bodyMedium
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = "Filter out animations for cheaper gifts in rooms.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            var sliderValue by remember(uiState.minGiftAnimationValue) {
-                mutableStateOf(uiState.minGiftAnimationValue.toFloat())
-            }
-            Slider(
-                value = sliderValue,
-                onValueChange = { sliderValue = it },
-                onValueChangeFinished = { onSetMinGiftAnimationValue(sliderValue.toInt()) },
-                valueRange = 0f..5000f,
-                steps = 9
-            )
 
             Spacer(modifier = Modifier.height(16.dp))
             HorizontalDivider()

--- a/app/src/test/java/com/shyden/shytalk/feature/settings/RoomSettingsViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/settings/RoomSettingsViewModelTest.kt
@@ -416,8 +416,9 @@ class RoomSettingsViewModelTest {
         )
         advanceUntilIdle()
 
-        // getUser should only be called once for the same ID
-        coVerify(exactly = 1) { userRepository.getUser(currentUserId) }
+        // getUser for resolveUserNames should only be called once for the same ID
+        // (loadRoom also calls getUser once for minGiftAnimationValue, so total is 2)
+        coVerify(exactly = 2) { userRepository.getUser(currentUserId) }
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/settings/RoomSettingsSheet.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/settings/RoomSettingsSheet.kt
@@ -14,12 +14,16 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -120,6 +124,39 @@ fun RoomSettingsSheet(
                 HorizontalDivider()
                 Spacer(modifier = Modifier.height(16.dp))
             }
+
+            // Gift Animations filter (per-user setting)
+            Text(
+                text = "Gift Animations",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = if (uiState.minGiftAnimationValue == 0) "Showing all gift animations"
+                       else "Only showing animations worth ${uiState.minGiftAnimationValue}+ coins",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Filter out animations for cheaper gifts.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            var sliderValue by remember(uiState.minGiftAnimationValue) {
+                mutableStateOf(uiState.minGiftAnimationValue.toFloat())
+            }
+            Slider(
+                value = sliderValue,
+                onValueChange = { sliderValue = it },
+                onValueChangeFinished = { viewModel.setMinGiftAnimationValue(sliderValue.toInt()) },
+                valueRange = 0f..10000f
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(16.dp))
 
             // Close Room Button (owner only)
             if (isOwner) {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/settings/RoomSettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/settings/RoomSettingsViewModel.kt
@@ -26,6 +26,7 @@ data class RoomSettingsUiState(
     val room: ChatRoom? = null,
     val pendingRequests: List<SeatRequest> = emptyList(),
     val userNames: Map<String, String> = emptyMap(),
+    val minGiftAnimationValue: Int = 0,
     val isLoading: Boolean = false,
     val error: String? = null
 )
@@ -47,6 +48,18 @@ class RoomSettingsViewModel(
 
     fun loadRoom(roomId: String) {
         currentRoomId = roomId
+        viewModelScope.launch {
+            // Load the user's gift animation preference
+            val uid = currentUserId
+            if (uid.isNotEmpty()) {
+                when (val result = userRepository.getUser(uid)) {
+                    is Resource.Success -> {
+                        _uiState.update { it.copy(minGiftAnimationValue = result.data.minGiftAnimationValue) }
+                    }
+                    else -> {}
+                }
+            }
+        }
         viewModelScope.launch {
             combine(
                 roomRepository.getRoomFlow(roomId),
@@ -203,6 +216,13 @@ class RoomSettingsViewModel(
         if (currentUserId != room.ownerId) return
         viewModelScope.launch {
             roomRepository.closeRoom(currentRoomId)
+        }
+    }
+
+    fun setMinGiftAnimationValue(value: Int) {
+        _uiState.update { it.copy(minGiftAnimationValue = value) }
+        viewModelScope.launch {
+            userRepository.updateProfile(currentUserId, mapOf("minGiftAnimationValue" to value))
         }
     }
 


### PR DESCRIPTION
## Summary
- Moved gift animation filter slider from Settings > Notifications to Room Settings sheet
- Removed discrete steps for continuous granularity
- Increased maximum from 5,000 to 10,000 coins

## Test plan
- [x] 1698 Kotlin unit tests pass
- [ ] Open room settings → slider visible with 0-10,000 range
- [ ] Adjust slider → setting persists across rooms

🤖 Generated with [Claude Code](https://claude.com/claude-code)