### PR TITLE
v0.43 — Gacha UX overhaul, daily gift rewards & QoL

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 42
-        versionName = "0.42"
+        versionCode = 43
+        versionName = "0.43"
 
         testInstrumentationRunner = "com.shyden.shytalk.ShyTalkTestRunner"
 

--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
@@ -122,15 +122,20 @@ class RoomRepositoryImpl(
             val room = snapshot.data?.let { ChatRoom.fromMap(it, snapshot.id) }
                 ?: throw Exception("Room not found")
 
-            // User already in a seat — no-op (prevents duplicate seating)
+            // User already in a seat — already seated, nothing to do
             if (room.findUserSeat(userId) != null) return@runTransaction
 
-            // Target seat occupied — abort
-            val seat = room.seats[seatIndex.toString()]
-            if (seat?.state == SeatState.OCCUPIED) return@runTransaction
+            // Pick the requested seat, or fall back to any empty seat
+            val targetSeat = seatIndex.takeIf {
+                val s = room.seats[it.toString()]
+                s != null && s.state != SeatState.OCCUPIED
+            } ?: (1 until Constants.MAX_SEATS).firstOrNull { i ->
+                val s = room.seats[i.toString()]
+                s != null && s.state != SeatState.OCCUPIED
+            } ?: return@runTransaction // no seats available at all
 
             val updates = clearUserSeats(room, userId)
-            updates["seats.$seatIndex"] = Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = true).toMap()
+            updates["seats.$targetSeat"] = Seat(userId = userId, state = SeatState.OCCUPIED, isMuted = true).toMap()
             updates["allTimeSeatUserIds"] = FieldValue.arrayUnion(userId)
             transaction.update(docRef, updates)
         }.await()

--- a/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
@@ -996,6 +996,13 @@ private fun ProfileContent(
                                 .clip(CircleShape)
                                 .background(SpeakingGreen)
                         )
+                    } else if (uiState.lastActiveText != null) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = uiState.lastActiveText!!,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                     }
                     Spacer(modifier = Modifier.weight(1f))
                     if (isOwn) {

--- a/app/src/test/java/com/shyden/shytalk/core/model/DailyRewardResultFromMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/DailyRewardResultFromMapTest.kt
@@ -85,4 +85,37 @@ class DailyRewardResultFromMapTest {
         assertFalse(DailyRewardResult.fromMap(mapFalse).isMilestone)
         assertFalse(DailyRewardResult.fromMap(mapMissing).isMilestone)
     }
+
+    @Test
+    fun `gift reward fields parse correctly`() {
+        val map = mapOf<String, Any?>(
+            "coinsAwarded" to 0,
+            "newStreak" to 7,
+            "isMilestone" to true,
+            "newBalance" to 100L,
+            "giftId" to "rose",
+            "giftQuantity" to 3
+        )
+        val result = DailyRewardResult.fromMap(map)
+
+        assertEquals("rose", result.giftId)
+        assertEquals(3, result.giftQuantity)
+        assertTrue(result.isGiftReward)
+        assertEquals(0, result.coinsAwarded)
+    }
+
+    @Test
+    fun `coin reward has no gift fields`() {
+        val map = mapOf<String, Any?>(
+            "coinsAwarded" to 100,
+            "newStreak" to 7,
+            "isMilestone" to true,
+            "newBalance" to 500L
+        )
+        val result = DailyRewardResult.fromMap(map)
+
+        assertFalse(result.isGiftReward)
+        assertEquals(null, result.giftId)
+        assertEquals(0, result.giftQuantity)
+    }
 }

--- a/app/src/test/java/com/shyden/shytalk/core/model/EconomyConfigFromMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/EconomyConfigFromMapTest.kt
@@ -33,6 +33,7 @@ class EconomyConfigFromMapTest {
         assertTrue(config.pullCosts.isEmpty())
         assertEquals(5000, config.broadcastSendThreshold)
         assertEquals(5000, config.broadcastWinThreshold)
+        assertEquals(18888, config.wheelInnerThreshold)
     }
 
     @Test
@@ -79,6 +80,7 @@ class EconomyConfigFromMapTest {
 
         assertEquals(5000, config.broadcastSendThreshold)
         assertEquals(5000, config.broadcastWinThreshold)
+        assertEquals(18888, config.wheelInnerThreshold)
     }
 
     @Test
@@ -123,6 +125,7 @@ class EconomyConfigFromMapTest {
         assertEquals(360, config.maxRoomDurationMinutes)
         assertEquals(720, config.superShyRoomDurationMinutes)
         assertEquals(5, config.normalSeatCount)
+        assertEquals(18888, config.wheelInnerThreshold)
     }
 
     @Test
@@ -149,7 +152,8 @@ class EconomyConfigFromMapTest {
             "broadcastWinThreshold" to null,
             "maxRoomDurationMinutes" to null,
             "superShyRoomDurationMinutes" to null,
-            "normalSeatCount" to null
+            "normalSeatCount" to null,
+            "wheelInnerThreshold" to null
         )
 
         val config = EconomyConfig.fromMap(map)
@@ -161,6 +165,7 @@ class EconomyConfigFromMapTest {
         assertEquals(360, config.maxRoomDurationMinutes)
         assertEquals(720, config.superShyRoomDurationMinutes)
         assertEquals(5, config.normalSeatCount)
+        assertEquals(18888, config.wheelInnerThreshold)
     }
 
     @Test
@@ -171,7 +176,8 @@ class EconomyConfigFromMapTest {
             "broadcastWinThreshold" to true,
             "maxRoomDurationMinutes" to listOf(1),
             "superShyRoomDurationMinutes" to mapOf("a" to "b"),
-            "normalSeatCount" to false
+            "normalSeatCount" to false,
+            "wheelInnerThreshold" to "not a number"
         )
 
         val config = EconomyConfig.fromMap(map)
@@ -182,5 +188,28 @@ class EconomyConfigFromMapTest {
         assertEquals(360, config.maxRoomDurationMinutes)
         assertEquals(720, config.superShyRoomDurationMinutes)
         assertEquals(5, config.normalSeatCount)
+        assertEquals(18888, config.wheelInnerThreshold)
+    }
+
+    @Test
+    fun `fromMap parses wheelInnerThreshold`() {
+        val map = mapOf<String, Any?>(
+            "wheelInnerThreshold" to 5000L
+        )
+
+        val config = EconomyConfig.fromMap(map)
+
+        assertEquals(5000, config.wheelInnerThreshold)
+    }
+
+    @Test
+    fun `fromMap parses wheelInnerThreshold from Int`() {
+        val map = mapOf<String, Any?>(
+            "wheelInnerThreshold" to 10000
+        )
+
+        val config = EconomyConfig.fromMap(map)
+
+        assertEquals(10000, config.wheelInnerThreshold)
     }
 }

--- a/app/src/test/java/com/shyden/shytalk/feature/gacha/SpinTierTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/gacha/SpinTierTest.kt
@@ -76,34 +76,26 @@ class SpinTierTest {
     }
 
     @Test
-    fun `rarityConfigForCoinValue covers all tiers`() {
-        // Each tier boundary returns a config
-        val common = rarityConfigForCoinValue(10)
-        val uncommon = rarityConfigForCoinValue(100)
-        val rare = rarityConfigForCoinValue(500)
-        val epic = rarityConfigForCoinValue(5000)
-        val legendary = rarityConfigForCoinValue(50000)
-
-        assertEquals("You Won!", common.title)
-        assertEquals("Nice Win!", uncommon.title)
-        assertEquals("RARE WIN!", rare.title)
-        assertEquals("EPIC WIN!", epic.title)
-        assertEquals("LEGENDARY!!", legendary.title)
+    fun `rarityConfigForCoinValue all tiers use Spin Results title`() {
+        val values = listOf(10, 100, 500, 5000, 50000)
+        for (v in values) {
+            assertEquals("Spin Results", rarityConfigForCoinValue(v).title)
+        }
     }
 
     @Test
-    fun `rarityConfigForCoinValue LEGENDARY has highest shake intensity`() {
-        val legendary = rarityConfigForCoinValue(50000)
+    fun `rarityConfigForCoinValue highest tier has highest shake intensity`() {
+        val highest = rarityConfigForCoinValue(50000)
         val others = listOf(10, 100, 500, 5000).map { rarityConfigForCoinValue(it) }
         val maxOther = others.maxOf { it.shakeIntensity }
-        assertTrue(legendary.shakeIntensity > maxOther)
+        assertTrue(highest.shakeIntensity > maxOther)
     }
 
     @Test
-    fun `rarityConfigForCoinValue COMMON has no flash and no shake`() {
-        val common = rarityConfigForCoinValue(10)
-        assertFalse(common.flash)
-        assertEquals(0f, common.shakeIntensity)
+    fun `rarityConfigForCoinValue lowest tier has no flash and no shake`() {
+        val lowest = rarityConfigForCoinValue(10)
+        assertFalse(lowest.flash)
+        assertEquals(0f, lowest.shakeIntensity)
     }
 
     @Test
@@ -116,5 +108,43 @@ class SpinTierTest {
                 burstCounts[i] < burstCounts[i + 1]
             )
         }
+    }
+
+    @Test
+    fun `rarityConfigForCoinValue titles contain no rarity terminology`() {
+        val forbidden = listOf("rare", "epic", "legendary", "uncommon", "common", "mythic")
+        val values = listOf(1, 10, 49, 50, 100, 199, 200, 500, 1999, 2000, 5000, 9999, 10000, 50000)
+        for (v in values) {
+            val title = rarityConfigForCoinValue(v).title.lowercase()
+            for (word in forbidden) {
+                assertFalse(
+                    "Title for coinValue=$v ('${rarityConfigForCoinValue(v).title}') contains forbidden word '$word'",
+                    title.contains(word)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `rarityConfigForCoinValue shake intensity increases with value`() {
+        val values = listOf(10, 100, 500, 5000, 50000)
+        val shakes = values.map { rarityConfigForCoinValue(it).shakeIntensity }
+        for (i in 0 until shakes.size - 1) {
+            assertTrue(
+                "shake at ${values[i]} (${shakes[i]}) should be <= shake at ${values[i+1]} (${shakes[i+1]})",
+                shakes[i] <= shakes[i + 1]
+            )
+        }
+    }
+
+    @Test
+    fun `rarityConfigForCoinValue boundary values are in correct tier`() {
+        // Just below each boundary
+        assertEquals(rarityConfigForCoinValue(49).burstCount, rarityConfigForCoinValue(10).burstCount)
+        assertEquals(rarityConfigForCoinValue(199).burstCount, rarityConfigForCoinValue(50).burstCount)
+        assertEquals(rarityConfigForCoinValue(1999).burstCount, rarityConfigForCoinValue(200).burstCount)
+        assertEquals(rarityConfigForCoinValue(9999).burstCount, rarityConfigForCoinValue(2000).burstCount)
+        // At and above top boundary
+        assertEquals(rarityConfigForCoinValue(10000).burstCount, rarityConfigForCoinValue(100000).burstCount)
     }
 }

--- a/app/src/test/java/com/shyden/shytalk/feature/gacha/SpinWheelSegmentTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/gacha/SpinWheelSegmentTest.kt
@@ -22,14 +22,14 @@ class SpinWheelSegmentTest {
 
     @Test
     fun `buildRingLayout puts low value gifts in outer ring`() {
-        val (outer, _) = buildRingLayout(testGifts)
+        val (outer, _) = buildRingLayout(testGifts, innerThreshold = 500)
         assertTrue(outer.all { it.coinValue < 500 })
         assertEquals(4, outer.size)
     }
 
     @Test
     fun `buildRingLayout puts high value gifts in inner ring`() {
-        val (_, inner) = buildRingLayout(testGifts)
+        val (_, inner) = buildRingLayout(testGifts, innerThreshold = 500)
         assertTrue(inner.all { it.coinValue >= 500 })
         assertEquals(4, inner.size)
     }
@@ -37,7 +37,7 @@ class SpinWheelSegmentTest {
     @Test
     fun `buildRingLayout sorts by order field`() {
         val shuffled = testGifts.shuffled()
-        val (outer, inner) = buildRingLayout(shuffled)
+        val (outer, inner) = buildRingLayout(shuffled, innerThreshold = 500)
         assertEquals(listOf(1, 2, 3, 4), outer.map { it.order })
         assertEquals(listOf(5, 6, 7, 8), inner.map { it.order })
     }
@@ -52,7 +52,7 @@ class SpinWheelSegmentTest {
     @Test
     fun `buildRingLayout handles only low value gifts`() {
         val lowOnly = testGifts.filter { it.coinValue < 500 }
-        val (outer, inner) = buildRingLayout(lowOnly)
+        val (outer, inner) = buildRingLayout(lowOnly, innerThreshold = 500)
         assertEquals(4, outer.size)
         assertTrue(inner.isEmpty())
     }
@@ -60,14 +60,14 @@ class SpinWheelSegmentTest {
     @Test
     fun `buildRingLayout handles only high value gifts`() {
         val highOnly = testGifts.filter { it.coinValue >= 500 }
-        val (outer, inner) = buildRingLayout(highOnly)
+        val (outer, inner) = buildRingLayout(highOnly, innerThreshold = 500)
         assertTrue(outer.isEmpty())
         assertEquals(4, inner.size)
     }
 
     @Test
     fun `resolveWinPosition finds gift in outer ring`() {
-        val (outer, inner) = buildRingLayout(testGifts)
+        val (outer, inner) = buildRingLayout(testGifts, innerThreshold = 500)
         val result = resolveWinPosition("c1", outer, inner)
         assertNotNull(result)
         assertEquals(Ring.OUTER, result!!.first)
@@ -76,7 +76,7 @@ class SpinWheelSegmentTest {
 
     @Test
     fun `resolveWinPosition finds gift in inner ring`() {
-        val (outer, inner) = buildRingLayout(testGifts)
+        val (outer, inner) = buildRingLayout(testGifts, innerThreshold = 500)
         val result = resolveWinPosition("r1", outer, inner)
         assertNotNull(result)
         assertEquals(Ring.INNER, result!!.first)
@@ -85,14 +85,14 @@ class SpinWheelSegmentTest {
 
     @Test
     fun `resolveWinPosition returns null for unknown ID`() {
-        val (outer, inner) = buildRingLayout(testGifts)
+        val (outer, inner) = buildRingLayout(testGifts, innerThreshold = 500)
         val result = resolveWinPosition("nonexistent", outer, inner)
         assertNull(result)
     }
 
     @Test
     fun `resolveWinPosition returns correct index for later gift`() {
-        val (outer, inner) = buildRingLayout(testGifts)
+        val (outer, inner) = buildRingLayout(testGifts, innerThreshold = 500)
         val result = resolveWinPosition("l1", outer, inner)
         assertNotNull(result)
         assertEquals(Ring.INNER, result!!.first)

--- a/app/src/test/java/com/shyden/shytalk/feature/gifting/GiftingViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/gifting/GiftingViewModelTest.kt
@@ -647,7 +647,7 @@ class GiftingViewModelTest {
         val state = vm.uiState.value
         assertFalse(state.isSending)
         assertNull(state.selectedGiftId)
-        assertEquals("Super Shy Trial activated!", state.sentGiftName)
+        assertEquals("Super Shy activated! +30 days", state.sentGiftName)
         assertNull(state.error)
     }
 

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -1747,6 +1747,89 @@ class RoomViewModelTest {
         coVerify { roomRepository.cancelInvite("room-1", currentUserId) }
     }
 
+    @Test
+    fun `invite suppressed when approved request is already active`() = roomTest {
+        viewModel = createViewModel()
+        emitRoomAsAttendee()
+        advanceUntilIdle()
+
+        // Seed the suppression snapshot with empty first emission
+        myRequestsFlow.value = emptyList()
+        advanceUntilIdle()
+
+        // Freshly approved request triggers RequestApproved notification
+        val approvedRequest = TestData.createTestSeatRequest(
+            userId = currentUserId,
+            userName = "Current User",
+            status = SeatRequestStatus.APPROVED,
+            createdAt = System.currentTimeMillis() - 10_000L
+        )
+        myRequestsFlow.value = listOf(approvedRequest)
+        advanceUntilIdle()
+
+        // Confirm RequestApproved is showing
+        assertTrue(viewModel.uiState.value.activeNotification is RoomNotification.RequestApproved)
+
+        // Now a room update arrives with a pending invite for the same user
+        val roomWithInvite = TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId),
+            pendingInvites = mapOf(currentUserId to ownerId)
+        )
+        roomFlow.value = roomWithInvite
+        advanceUntilIdle()
+
+        // The active notification should still be RequestApproved (invite suppressed)
+        val notif = viewModel.uiState.value.activeNotification
+        assertTrue(
+            "Expected RequestApproved but got $notif",
+            notif is RoomNotification.RequestApproved
+        )
+    }
+
+    @Test
+    fun `approved request removes queued invite`() = roomTest {
+        viewModel = createViewModel()
+        // First room emit triggers handleFirstJoin (no invite yet)
+        emitRoomAsAttendee()
+        advanceUntilIdle()
+
+        // Second room emit with pending invite — triggers handleNormalUpdate
+        val roomWithInvite = TestData.createTestRoom(
+            ownerId = ownerId,
+            participantIds = setOf(ownerId, currentUserId),
+            pendingInvites = mapOf(currentUserId to ownerId)
+        )
+        roomFlow.value = roomWithInvite
+        advanceUntilIdle()
+
+        // InviteReceived is the active notification
+        assertTrue(
+            "Expected InviteReceived but got ${viewModel.uiState.value.activeNotification}",
+            viewModel.uiState.value.activeNotification is RoomNotification.InviteReceived
+        )
+
+        // Now a freshly approved request arrives
+        val approvedRequest = TestData.createTestSeatRequest(
+            userId = currentUserId,
+            userName = "Current User",
+            status = SeatRequestStatus.APPROVED,
+            createdAt = System.currentTimeMillis() - 10_000L
+        )
+        myRequestsFlow.value = listOf(approvedRequest)
+        advanceUntilIdle()
+
+        // Dismiss the InviteReceived — RequestApproved should be next
+        viewModel.dismissCurrentNotification()
+        advanceUntilIdle()
+
+        val notif = viewModel.uiState.value.activeNotification
+        assertTrue(
+            "Expected RequestApproved after dismissing invite but got $notif",
+            notif is RoomNotification.RequestApproved
+        )
+    }
+
     // ===== Owner Can Kick/Force-Mute Hosts (v0.18 fix) =====
 
     @Test

--- a/functions/admin.js
+++ b/functions/admin.js
@@ -2329,6 +2329,35 @@ app.post("/api/cleanup/all-supershy", async (req, res) => {
   }
 });
 
+// POST /api/cleanup/all-appeals
+app.post("/api/cleanup/all-appeals", async (req, res) => {
+  try {
+    const db = getFirestore();
+    let appealsDeleted = 0;
+
+    const snap = await db.collection("suspensionAppeals").get();
+    for (let i = 0; i < snap.docs.length; i += 500) {
+      const batch = db.batch();
+      snap.docs.slice(i, i + 500).forEach((doc) => {
+        batch.delete(doc.ref);
+      });
+      await batch.commit();
+      appealsDeleted += Math.min(500, snap.docs.length - i);
+    }
+
+    await writeAuditLog(db, {
+      adminUid: req.admin.uid,
+      action: "cleanup_all_appeals",
+      note: `Deleted ${appealsDeleted} suspension appeals`,
+    });
+
+    return res.json({ success: true, appealsDeleted });
+  } catch (err) {
+    console.error("POST cleanup/all-appeals error:", err);
+    return res.status(500).json({ error: err.message });
+  }
+});
+
 // ─── Economy Config Endpoints ─────────────────────────────────
 
 const ECONOMY_CONFIG_FIELDS = {
@@ -2348,6 +2377,7 @@ const ECONOMY_CONFIG_FIELDS = {
   maxRoomDurationMinutes: "number",
   superShyRoomDurationMinutes: "number",
   normalSeatCount: "number",
+  wheelInnerThreshold: "number",
 };
 
 // GET /api/config/economy

--- a/functions/admin.test.js
+++ b/functions/admin.test.js
@@ -1682,6 +1682,29 @@ describe("POST /api/cleanup/all-supershy", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════
+// Cleanup All Appeals
+// ═══════════════════════════════════════════════════════════════
+
+describe("POST /api/cleanup/all-appeals", () => {
+  test("deletes all suspension appeals", async () => {
+    mockSuspensionAppeals["a1"] = { userId: "u1", status: "pending", appealText: "Please unban" };
+    mockSuspensionAppeals["a2"] = { userId: "u2", status: "approved", appealText: "I'm sorry" };
+    mockSuspensionAppeals["a3"] = { userId: "u3", status: "rejected", appealText: "It was unfair" };
+
+    const res = await request("POST", "/api/cleanup/all-appeals", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.appealsDeleted).toBe(3);
+  });
+
+  test("returns 0 when no appeals exist", async () => {
+    const res = await request("POST", "/api/cleanup/all-appeals", {}, "valid");
+    expect(res.status).toBe(200);
+    expect(res.body.appealsDeleted).toBe(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
 // Cleanup System Conversations
 // ═══════════════════════════════════════════════════════════════
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -878,35 +878,74 @@ exports.claimDailyReward = onCall({ region: "asia-southeast1" }, async (request)
 
     const milestoneRewards = config.milestoneRewards || {};
     const milestoneKeys = Object.keys(milestoneRewards).map(Number);
-    let reward = milestoneRewards[String(newStreak)] || config.dailyBase;
+    const rawReward = milestoneRewards[String(newStreak)];
     const isMilestone = milestoneKeys.includes(newStreak);
 
-    // Super Shy 10% bonus (rounded up)
-    if (user.isSuperShy) {
-      reward = Math.ceil(reward * 1.1);
+    // Determine reward type: gift object or coin amount
+    let coinReward = 0;
+    let giftReward = null; // { giftId, quantity }
+
+    if (rawReward && typeof rawReward === "object" && rawReward.type === "gift") {
+      giftReward = { giftId: rawReward.giftId, quantity: rawReward.quantity || 1 };
+    } else {
+      // Number (legacy) or {type:"coins", amount} or fallback to dailyBase
+      coinReward = (typeof rawReward === "number") ? rawReward
+        : (rawReward && rawReward.amount) ? rawReward.amount
+        : config.dailyBase;
+      // Super Shy 10% bonus (rounded up)
+      if (user.isSuperShy) {
+        coinReward = Math.ceil(coinReward * 1.1);
+      }
     }
 
-    const newBalance = (user.shyCoins || 0) + reward;
+    const newBalance = (user.shyCoins || 0) + coinReward;
 
-    tx.update(userRef, {
-      shyCoins: newBalance,
+    const userUpdate = {
       loginStreak: newStreak,
       lastLoginDate: today,
       lastLoginRewardDate: today,
-    });
+    };
+    if (coinReward > 0) userUpdate.shyCoins = newBalance;
+    tx.update(userRef, userUpdate);
+
+    // Add gift to backpack if gift reward
+    let giftName = null;
+    if (giftReward) {
+      const bpRef = userRef.collection("backpack").doc(giftReward.giftId);
+      tx.set(bpRef, {
+        quantity: FieldValue.increment(giftReward.quantity),
+        lastAcquired: FieldValue.serverTimestamp(),
+      }, { merge: true });
+
+      // Look up gift name from gifts collection (outside transaction read)
+      giftName = giftReward.giftId;
+    }
 
     // Write transaction record
     const txRef = userRef.collection("transactions").doc();
-    tx.set(txRef, {
+    const txRecord = {
       type: "DAILY_REWARD",
-      amount: reward,
-      currency: "COINS",
-      balanceAfter: newBalance,
-      details: `Day ${newStreak}${isMilestone ? " (milestone)" : ""}`,
       timestamp: FieldValue.serverTimestamp(),
-    });
+    };
+    if (giftReward) {
+      txRecord.amount = giftReward.quantity;
+      txRecord.currency = "GIFT";
+      txRecord.details = `Day ${newStreak} (milestone) — ${giftReward.quantity}x ${giftReward.giftId}`;
+      txRecord.balanceAfter = newBalance;
+    } else {
+      txRecord.amount = coinReward;
+      txRecord.currency = "COINS";
+      txRecord.balanceAfter = newBalance;
+      txRecord.details = `Day ${newStreak}${isMilestone ? " (milestone)" : ""}`;
+    }
+    tx.set(txRef, txRecord);
 
-    return { coinsAwarded: reward, newStreak, isMilestone, newBalance };
+    const result = { coinsAwarded: coinReward, newStreak, isMilestone, newBalance };
+    if (giftReward) {
+      result.giftId = giftReward.giftId;
+      result.giftQuantity = giftReward.quantity;
+    }
+    return result;
   });
 });
 
@@ -2285,7 +2324,7 @@ exports.claimSuperShyTrial = onCall({ region: "asia-southeast1" }, async (reques
       amount: 0,
       currency: "COINS",
       balanceAfter: userData.shyCoins || 0,
-      details: "Claimed free Super Shy 1-month trial",
+      details: "Claimed 30 days of Super Shy",
       timestamp: FieldValue.serverTimestamp(),
     });
 
@@ -2319,7 +2358,8 @@ exports.activateSuperShyTrial = onCall({ region: "asia-southeast1" }, async (req
     const now = Date.now();
     const thirtyDays = 30 * 24 * 60 * 60 * 1000;
     const currentExpiry = userData.superShyExpiry ? userData.superShyExpiry.toMillis() : 0;
-    const newExpiry = Math.max(currentExpiry, now + thirtyDays);
+    const baseTime = Math.max(currentExpiry, now);
+    const newExpiry = baseTime + thirtyDays;
     const currentTier = userData.superShyTier;
     // Only set trial tier if user has no existing tier or it's already trial
     const newTier = (currentTier && currentTier !== "trial") ? currentTier : "trial";
@@ -2337,7 +2377,7 @@ exports.activateSuperShyTrial = onCall({ region: "asia-southeast1" }, async (req
       amount: 0,
       currency: "COINS",
       balanceAfter: userData.shyCoins || 0,
-      details: "Activated Super Shy 1-month trial",
+      details: "Activated 30 days of Super Shy",
       timestamp: FieldValue.serverTimestamp(),
     });
 

--- a/functions/index.test.js
+++ b/functions/index.test.js
@@ -408,6 +408,56 @@ describe("claimDailyReward", () => {
     // 50 * 1.1 = 55.00000000000001 in JS floating-point, Math.ceil → 56
     expect(result.coinsAwarded).toBe(56);
   });
+
+  test("gift milestone reward adds to backpack", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().split("T")[0];
+    mockUsers["user-1"] = { lastLoginDate: yesterday, loginStreak: 6, shyCoins: 100 };
+    mockConfig["economy"] = {
+      dailyBase: 50,
+      milestoneRewards: { "7": { type: "gift", giftId: "rose", quantity: 3 } }
+    };
+
+    const result = await callOnCall("claimDailyReward", "user-1");
+
+    expect(result.newStreak).toBe(7);
+    expect(result.isMilestone).toBe(true);
+    expect(result.coinsAwarded).toBe(0);
+    expect(result.giftId).toBe("rose");
+    expect(result.giftQuantity).toBe(3);
+    // Balance unchanged (gift reward, no coins)
+    expect(result.newBalance).toBe(100);
+  });
+
+  test("gift milestone reward defaults quantity to 1", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().split("T")[0];
+    mockUsers["user-1"] = { lastLoginDate: yesterday, loginStreak: 13, shyCoins: 50 };
+    mockConfig["economy"] = {
+      dailyBase: 50,
+      milestoneRewards: { "14": { type: "gift", giftId: "crown" } }
+    };
+
+    const result = await callOnCall("claimDailyReward", "user-1");
+
+    expect(result.giftId).toBe("crown");
+    expect(result.giftQuantity).toBe(1);
+    expect(result.coinsAwarded).toBe(0);
+  });
+
+  test("non-milestone day with gift milestones still awards base coins", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().split("T")[0];
+    mockUsers["user-1"] = { lastLoginDate: yesterday, loginStreak: 5, shyCoins: 200 };
+    mockConfig["economy"] = {
+      dailyBase: 50,
+      milestoneRewards: { "7": { type: "gift", giftId: "rose", quantity: 1 } }
+    };
+
+    const result = await callOnCall("claimDailyReward", "user-1");
+
+    expect(result.newStreak).toBe(6);
+    expect(result.coinsAwarded).toBe(50);
+    expect(result.giftId).toBeUndefined();
+    expect(result.newBalance).toBe(250);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -132,10 +132,13 @@
         .main-content {
           flex: 1;
           padding: 24px;
-          max-width: 800px;
-          margin: 0 auto;
           width: 100%;
+          max-width: 1400px;
+          margin: 0 auto;
         }
+
+        /* Narrow panels (form-heavy) get a comfortable reading width */
+        #user-form, .search-bar { max-width: 800px; }
 
         /* --- Search --- */
         .search-bar {
@@ -789,10 +792,204 @@
           vertical-align: middle;
         }
         .gift-modified { background: rgba(108, 92, 231, 0.08) !important; border-left: 4px solid var(--accent) !important; }
+        .gift-new { background: rgba(46, 204, 113, 0.10) !important; border-left: 4px solid var(--success) !important; }
+        .gift-deleted { background: rgba(231, 76, 60, 0.10) !important; border-left: 4px solid var(--danger) !important; }
+        .gift-deleted td { text-decoration: line-through; color: var(--text2); }
+        .gift-deleted input, .gift-deleted select { pointer-events: none; opacity: 0.4; }
+
+        .gift-undo-del-btn { background: var(--warning); color: #fff; }
+        .gift-undo-del-btn:hover { background: #e67e22; }
+        .gift-remove-btn { background: var(--danger); color: #fff; }
+        .gift-remove-btn:hover { background: #c0392b; }
+
+        #gift-apply-btn {
+          background: var(--accent);
+          color: #fff;
+          padding: 8px 18px;
+          border: none;
+          border-radius: 6px;
+          cursor: pointer;
+          font-size: 13px;
+          font-weight: 600;
+          display: none;
+        }
+        #gift-apply-btn:hover { background: var(--accent-hover); }
+        #gift-apply-btn .badge {
+          display: inline-block;
+          background: #fff;
+          color: var(--accent);
+          font-size: 11px;
+          font-weight: 700;
+          padding: 1px 7px;
+          border-radius: 10px;
+          margin-left: 6px;
+        }
+
+        #gift-discard-btn {
+          background: transparent;
+          color: var(--text2);
+          padding: 8px 16px;
+          border: 1px solid var(--border);
+          border-radius: 6px;
+          cursor: pointer;
+          font-size: 13px;
+          font-weight: 600;
+          display: none;
+          margin-left: 8px;
+        }
+        #gift-discard-btn:hover { background: var(--surface2); color: var(--text); }
+
+        .gift-confirm-overlay {
+          display: none;
+          position: fixed;
+          inset: 0;
+          background: rgba(0,0,0,0.75);
+          z-index: 9999;
+          justify-content: center;
+          align-items: center;
+        }
+        .gift-confirm-overlay.visible { display: flex; }
+
+        .gift-confirm-dialog {
+          background: var(--surface);
+          border: 1px solid var(--border);
+          border-radius: 12px;
+          padding: 28px;
+          max-width: 520px;
+          width: 92%;
+          max-height: 80vh;
+          overflow-y: auto;
+        }
+        .gift-confirm-dialog h2 {
+          margin: 0 0 16px;
+          font-size: 18px;
+        }
+        .gift-confirm-warning {
+          background: rgba(231, 76, 60, 0.12);
+          border: 1px solid var(--danger);
+          border-radius: 6px;
+          padding: 10px 14px;
+          color: var(--danger);
+          font-size: 13px;
+          font-weight: 600;
+          margin-bottom: 16px;
+        }
+        .gift-confirm-ok {
+          background: rgba(46, 204, 113, 0.12);
+          border: 1px solid var(--success);
+          border-radius: 6px;
+          padding: 10px 14px;
+          color: var(--success);
+          font-size: 13px;
+          font-weight: 600;
+          margin-bottom: 16px;
+        }
+        .gift-confirm-section {
+          margin-bottom: 14px;
+        }
+        .gift-confirm-section h4 {
+          font-size: 13px;
+          color: var(--text2);
+          text-transform: uppercase;
+          letter-spacing: 0.5px;
+          margin-bottom: 6px;
+          border-bottom: 1px solid var(--border);
+          padding-bottom: 4px;
+        }
+        .gift-confirm-section ul {
+          list-style: none;
+          padding: 0;
+        }
+        .gift-confirm-section li {
+          font-size: 13px;
+          padding: 4px 0;
+          color: var(--text);
+        }
+        .gift-confirm-section li .change-detail {
+          color: var(--text2);
+          font-size: 12px;
+        }
+        .gift-confirm-buttons {
+          display: flex;
+          gap: 12px;
+          justify-content: flex-end;
+          margin-top: 20px;
+        }
+        .gift-confirm-buttons button {
+          padding: 10px 24px;
+          border: none;
+          border-radius: 6px;
+          cursor: pointer;
+          font-size: 14px;
+          font-weight: 600;
+        }
+        .gift-confirm-cancel {
+          background: var(--surface2);
+          color: var(--text2);
+          border: 1px solid var(--border) !important;
+        }
+        .gift-confirm-cancel:hover { background: var(--border); color: var(--text); }
+        .gift-confirm-submit {
+          background: var(--accent);
+          color: #fff;
+        }
+        .gift-confirm-submit:hover { background: var(--accent-hover); }
+        .gift-confirm-submit:disabled { opacity: 0.3; cursor: not-allowed; }
 
         /* --- Economy Panel --- */
         #economy-panel { display: none; }
         #economy-panel.visible { display: block; }
+
+        /* Milestone rewards editor */
+        .milestone-rows { margin-top: 8px; }
+        .milestone-row {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          margin-bottom: 6px;
+          flex-wrap: wrap;
+        }
+        .milestone-row input, .milestone-row select {
+          background: var(--surface2);
+          border: 1px solid var(--border);
+          color: var(--text);
+          padding: 5px 8px;
+          border-radius: 4px;
+          font-size: 13px;
+          outline: none;
+        }
+        .milestone-row input:focus, .milestone-row select:focus { border-color: var(--accent); }
+        .milestone-row .ms-day { width: 65px; }
+        .milestone-row .ms-type { width: 90px; }
+        .milestone-row .ms-amount { width: 80px; }
+        .milestone-row .ms-gift-select { flex: 1; min-width: 120px; }
+        .milestone-row .ms-qty { width: 55px; }
+        .milestone-row .ms-swap-btn,
+        .milestone-row .ms-remove-btn {
+          padding: 4px 8px;
+          border: none;
+          border-radius: 4px;
+          cursor: pointer;
+          font-size: 12px;
+          font-weight: 600;
+          flex-shrink: 0;
+        }
+        .milestone-row .ms-swap-btn { background: var(--surface2); color: var(--text2); border: 1px solid var(--border); }
+        .milestone-row .ms-swap-btn:hover { background: var(--border); color: var(--text); }
+        .milestone-row .ms-remove-btn { background: var(--danger); color: #fff; }
+        .milestone-row .ms-remove-btn:hover { background: #c0392b; }
+        .ms-add-btn {
+          padding: 5px 12px;
+          background: var(--success);
+          color: #fff;
+          border: none;
+          border-radius: 4px;
+          cursor: pointer;
+          font-size: 12px;
+          font-weight: 600;
+          margin-top: 4px;
+        }
+        .ms-add-btn:hover { background: #27ae60; }
 
         /* --- Spin Monitor Panel --- */
         #monitor-panel { display: none; }
@@ -1999,6 +2196,29 @@
           opacity: 0.6;
           margin-left: 4px;
         }
+
+        /* --- Responsive --- */
+        @media (max-width: 768px) {
+          .main-content { padding: 12px; }
+          .header { padding: 12px 16px; }
+          .header h1 { font-size: 16px; }
+          .tab-btn { padding: 5px 10px; font-size: 12px; }
+          .gifts-toolbar { flex-direction: column; align-items: flex-start; gap: 8px; }
+          .gifts-table .gift-name-input { width: 90px; }
+          .gifts-table .gift-url-input { width: 80px; }
+          .gifts-table th, .gifts-table td { padding: 6px 6px; font-size: 12px; }
+          .gift-confirm-dialog { padding: 20px 16px; }
+          .maintenance-grid { grid-template-columns: 1fr; }
+        }
+
+        @media (max-width: 480px) {
+          .main-content { padding: 8px; }
+          .header { padding: 10px 12px; }
+          .tab-btn { padding: 4px 8px; font-size: 11px; }
+          .gifts-table .gift-url-input { width: 60px; font-size: 11px; }
+          .gifts-table .gift-order-input { width: 40px; }
+          .gift-actions button { padding: 3px 6px; font-size: 11px; }
+        }
     </style>
 </head>
 <body>
@@ -2487,19 +2707,21 @@
         <div id="gifts-panel">
             <h2 style="margin-bottom: 16px;">Gift Catalog</h2>
             <p style="color:var(--text2);margin-bottom:12px;">Manage the gift catalog stored in the
-                <code>gifts</code> collection. Changes affect the gacha and gift-sending systems
-                immediately.</p>
+                <code>gifts</code> collection. Edits are staged locally — click <strong>Apply Changes</strong> to commit them.</p>
             <div class="gifts-toolbar">
-                <div>
+                <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
                     <button class="gift-add-btn" id="gift-add-btn">+ Add Gift</button>
                     <button class="gift-add-btn" id="gift-seed-btn"
-                            style="background:var(--warning);margin-left:8px;">Seed Defaults
-                    </button>
+                            style="background:var(--warning);">Seed Defaults</button>
+                    <button id="gift-apply-btn">Apply Changes <span class="badge">0</span></button>
+                    <button id="gift-discard-btn">Discard</button>
                 </div>
-                <span style="color:var(--text2);font-size:13px;" id="gifts-count"></span>
-                <span style="font-size:13px;margin-left:8px;" id="wheel-count"></span>
+                <div style="display:flex;align-items:center;gap:8px;">
+                    <span style="color:var(--text2);font-size:13px;" id="gifts-count"></span>
+                    <span style="font-size:13px;" id="wheel-count"></span>
+                </div>
             </div>
-            <div style="overflow-x:auto;max-height:70vh;overflow-y:auto;border:1px solid var(--border);border-radius:8px;">
+            <div style="overflow-x:auto;max-height:calc(100vh - 220px);overflow-y:auto;border:1px solid var(--border);border-radius:8px;">
                 <table class="gifts-table">
                     <thead>
                     <tr>
@@ -2517,6 +2739,19 @@
                     </thead>
                     <tbody id="gifts-tbody"></tbody>
                 </table>
+            </div>
+        </div>
+
+        <!-- Gift batch-apply confirmation overlay -->
+        <div class="gift-confirm-overlay" id="gift-confirm-overlay">
+            <div class="gift-confirm-dialog">
+                <h2 id="gift-confirm-title">Review Changes</h2>
+                <div id="gift-confirm-wheel-status"></div>
+                <div id="gift-confirm-body"></div>
+                <div class="gift-confirm-buttons">
+                    <button class="gift-confirm-cancel" id="gift-confirm-cancel">Cancel</button>
+                    <button class="gift-confirm-submit" id="gift-confirm-submit">Confirm</button>
+                </div>
             </div>
         </div>
 
@@ -2561,6 +2796,11 @@
                         <label>100 Spins</label>
                         <input type="number" id="eco-pullCost-100" placeholder="1000">
                     </div>
+                    <div class="field-group">
+                        <label>Wheel Inner Ring Threshold</label>
+                        <input type="number" id="eco-wheelInnerThreshold" placeholder="18888">
+                        <small style="color:var(--text2);margin-top:2px;display:block">Gifts with coin value at or above this appear on the inner ring of the gacha wheel.</small>
+                    </div>
                 </div>
                 <div class="maintenance-card">
                     <h3>Pity System</h3>
@@ -2589,9 +2829,9 @@
                         <input type="number" id="eco-dailyBase" placeholder="50">
                     </div>
                     <div class="field-group">
-                        <label>Milestone Rewards (JSON)</label>
-                        <input type="text" id="eco-milestoneRewards"
-                               placeholder='{"7":100,"14":200,"30":500,"60":1000,"90":2000}'>
+                        <label>Milestone Rewards</label>
+                        <div class="milestone-rows" id="milestone-rows"></div>
+                        <button type="button" class="ms-add-btn" id="ms-add-btn">+ Add Milestone</button>
                     </div>
                 </div>
                 <div class="maintenance-card">
@@ -2648,6 +2888,12 @@
                     <div class="maintenance-result" id="clear-warnings-result"></div>
                 </div>
                 <div class="maintenance-card">
+                    <h3>Appeals</h3>
+                    <p>Delete all suspension appeals (pending, approved, rejected).</p>
+                    <button id="clear-appeals-btn">Delete All Appeals</button>
+                    <div class="maintenance-result" id="clear-appeals-result"></div>
+                </div>
+                <div class="maintenance-card">
                     <h3>Storage</h3>
                     <p>Audit storage usage and purge orphaned files (PM images, stickers, report
                         evidence). Profile and cover photos are not affected.</p>
@@ -2697,11 +2943,12 @@
                 <div class="maintenance-card nuclear">
                     <h3>&#9762; RESET ALL</h3>
                     <p>Runs every maintenance action above in sequence. This will wipe system messages,
-                        reports, warnings, orphaned storage, backpacks, gift walls, coins, beans, spin history, and Super Shy.</p>
+                        reports, warnings, orphaned storage, backpacks, gift walls, coins, beans, spin history, Super Shy, and appeals.</p>
                     <div class="nuclear-actions">
                         <span>System Messages</span>
                         <span>Reports</span>
                         <span>Warnings</span>
+                        <span>Appeals</span>
                         <span>Orphaned Storage</span>
                         <span>Backpacks</span>
                         <span>Gift Walls</span>
@@ -2721,9 +2968,9 @@
             <div class="nuclear-dialog">
                 <div class="step-indicator" id="nuclear-step-label">Step 1 of 3</div>
                 <h2 id="nuclear-title">Are you sure?</h2>
-                <p id="nuclear-desc">This will run ALL 10 maintenance actions and permanently delete
+                <p id="nuclear-desc">This will run ALL 11 maintenance actions and permanently delete
                     system messages, reports, warnings, orphaned files, backpacks, gift walls, coins,
-                    beans, spin history, and Super Shy for every user. This cannot be undone.</p>
+                    beans, spin history, Super Shy, and appeals for every user. This cannot be undone.</p>
                 <div id="nuclear-input-wrap" style="display:none;">
                     <input type="text" id="nuclear-confirm-input" placeholder="Type here..." autocomplete="off">
                 </div>
@@ -2746,6 +2993,7 @@
                     <div class="step" id="np-system-msgs">&#9679; Clear system messages</div>
                     <div class="step" id="np-reports">&#9679; Clear reports</div>
                     <div class="step" id="np-warnings">&#9679; Clear warnings</div>
+                    <div class="step" id="np-appeals">&#9679; Delete appeals</div>
                     <div class="step" id="np-storage">&#9679; Purge orphaned storage</div>
                     <div class="step" id="np-backpacks">&#9679; Empty backpacks</div>
                     <div class="step" id="np-giftwalls">&#9679; Empty gift walls</div>
@@ -5053,143 +5301,337 @@
       }
     });
 
-    // --- Gift Catalog Management ---
+    // --- Gift Catalog Management (batch-edit) ---
     let giftsCache = [];
+    let pendingEdits = {};        // { giftId: { field: newValue, ... } }
+    let pendingDeletes = new Set();
+    let pendingAdds = [];         // [{ tempId, name, coinValue, order, ... }]
 
     async function loadGifts() {
       try {
         const data = await apiCall("GET", "/api/gifts");
         giftsCache = data.gifts || [];
+        clearPendingState();
         renderGiftsTable();
       } catch (err) {
         showToast("Failed to load gifts: " + err.message, "error");
       }
     }
 
-    function renderGiftsTable() {
-      const tbody = $("#gifts-tbody");
-      tbody.innerHTML = "";
-      $("#gifts-count").textContent = `${giftsCache.length} gifts`;
-      const wheelCount = giftsCache.filter(g => g.coinValue > 0 && g.showOnWheel !== false).length;
+    function clearPendingState() {
+      pendingEdits = {};
+      pendingDeletes = new Set();
+      pendingAdds = [];
+    }
+
+    /** Build the effective gift list after applying all pending changes */
+    function getEffectiveGifts() {
+      const result = [];
+      for (const g of giftsCache) {
+        if (pendingDeletes.has(g.id)) continue;
+        const edits = pendingEdits[g.id];
+        if (edits) {
+          result.push({ ...g, ...edits });
+        } else {
+          result.push({ ...g });
+        }
+      }
+      for (const a of pendingAdds) {
+        result.push({ ...a });
+      }
+      return result;
+    }
+
+    function getEffectiveWheelCount() {
+      return getEffectiveGifts().filter(g => g.coinValue > 0 && g.showOnWheel !== false).length;
+    }
+
+    function getPendingChangeCount() {
+      return Object.keys(pendingEdits).length + pendingDeletes.size + pendingAdds.length;
+    }
+
+    function updatePendingUI() {
+      const count = getPendingChangeCount();
+      const applyBtn = $("#gift-apply-btn");
+      const discardBtn = $("#gift-discard-btn");
+      applyBtn.style.display = count > 0 ? "inline-block" : "none";
+      discardBtn.style.display = count > 0 ? "inline-block" : "none";
+      applyBtn.querySelector(".badge").textContent = count;
+
+      // Update wheel count from effective gifts
+      const wheelCount = getEffectiveWheelCount();
+      const effective = getEffectiveGifts();
       const wheelEl = $("#wheel-count");
       wheelEl.textContent = `(${wheelCount}/16 on wheel)`;
       wheelEl.style.color = wheelCount === 16 ? "var(--success, #4caf50)" : "var(--danger, #f44336)";
       wheelEl.style.fontWeight = wheelCount === 16 ? "normal" : "bold";
-      wheelEl.title = `Gacha wheel has 16 slots. Gifts with coinValue > 0 and "On Wheel" checked count toward this total. Currently ${wheelCount} qualifying.`;
+      wheelEl.title = `Gacha wheel has 16 slots. Currently ${wheelCount} qualifying.`;
 
+      // Update total count (effective)
+      $("#gifts-count").textContent = `${effective.length} gifts`;
+    }
+
+    function renderGiftsTable() {
+      const tbody = $("#gifts-tbody");
+      tbody.innerHTML = "";
+      updatePendingUI();
+
+      // Existing gifts
       for (const gift of giftsCache) {
+        const isDeleted = pendingDeletes.has(gift.id);
+        const edits = pendingEdits[gift.id];
+        const isModified = !!edits;
+        const effective = isModified ? { ...gift, ...edits } : gift;
+
         const tr = document.createElement("tr");
         tr.dataset.giftId = gift.id;
+        if (isDeleted) tr.classList.add("gift-deleted");
+        else if (isModified) tr.classList.add("gift-modified");
+
         tr.innerHTML = `
-          <td><input type="number" class="gift-order-input" data-field="order" value="${gift.order || 0}"></td>
-          <td style="text-align:center"><input type="checkbox" data-field="showInStore" ${gift.showInStore !== false ? 'checked' : ''}></td>
-          <td style="text-align:center"><input type="checkbox" data-field="showOnWheel" ${gift.showOnWheel !== false ? 'checked' : ''}></td>
-          <td>${gift.iconUrl ? `<img src="${escapeHtml(gift.iconUrl)}" class="gift-icon-preview" onerror="this.style.display='none'">` : '<span style="color:var(--text2)">—</span>'}</td>
-          <td><input type="text" class="gift-name-input" data-field="name" value="${escapeHtml(gift.name || "")}"></td>
-          <td><input type="number" class="gift-value-input" data-field="coinValue" value="${gift.coinValue || 0}"></td>
-          <td><input type="text" class="gift-url-input" data-field="animationUrl" value="${escapeHtml(gift.animationUrl || "")}" placeholder="URL"></td>
-          <td><input type="text" class="gift-url-input" data-field="soundUrl" value="${escapeHtml(gift.soundUrl || "")}" placeholder="URL"></td>
-          <td><input type="text" class="gift-url-input" data-field="iconUrl" value="${escapeHtml(gift.iconUrl || "")}" placeholder="URL"></td>
+          <td><input type="number" class="gift-order-input" data-field="order" value="${effective.order || 0}"></td>
+          <td style="text-align:center"><input type="checkbox" data-field="showInStore" ${effective.showInStore !== false ? 'checked' : ''}></td>
+          <td style="text-align:center"><input type="checkbox" data-field="showOnWheel" ${effective.showOnWheel !== false ? 'checked' : ''}></td>
+          <td>${effective.iconUrl ? `<img src="${escapeHtml(effective.iconUrl)}" class="gift-icon-preview" onerror="this.style.display='none'">` : '<span style="color:var(--text2)">\u2014</span>'}</td>
+          <td><input type="text" class="gift-name-input" data-field="name" value="${escapeHtml(effective.name || "")}"></td>
+          <td><input type="number" class="gift-value-input" data-field="coinValue" value="${effective.coinValue || 0}"></td>
+          <td><input type="text" class="gift-url-input" data-field="animationUrl" value="${escapeHtml(effective.animationUrl || "")}" placeholder="URL"></td>
+          <td><input type="text" class="gift-url-input" data-field="soundUrl" value="${escapeHtml(effective.soundUrl || "")}" placeholder="URL"></td>
+          <td><input type="text" class="gift-url-input" data-field="iconUrl" value="${escapeHtml(effective.iconUrl || "")}" placeholder="URL"></td>
           <td class="gift-actions">
-            <button class="gift-save-btn" data-gift-id="${gift.id}">Save</button>
-            <button class="gift-delete-btn" data-gift-id="${gift.id}">Del</button>
+            ${isDeleted
+              ? `<button class="gift-undo-del-btn" data-gift-id="${gift.id}">Undo</button>`
+              : `<button class="gift-delete-btn" data-gift-id="${gift.id}">Del</button>`
+            }
           </td>
         `;
 
-        // Track modifications
-        const inputs = tr.querySelectorAll("input, select");
-        inputs.forEach(inp => {
-          inp.addEventListener("change", () => tr.classList.add("gift-modified"));
-          inp.addEventListener("input", () => tr.classList.add("gift-modified"));
-        });
+        // Wire input change handlers for existing gifts
+        if (!isDeleted) {
+          for (const inp of tr.querySelectorAll("[data-field]")) {
+            const handler = () => {
+              const field = inp.dataset.field;
+              let newVal;
+              if (inp.type === "checkbox") newVal = inp.checked;
+              else if (inp.type === "number") newVal = Number(inp.value) || 0;
+              else newVal = inp.value;
+
+              // Compare to original
+              let origVal = gift[field];
+              if (origVal === undefined || origVal === null) {
+                origVal = inp.type === "checkbox" ? true : inp.type === "number" ? 0 : "";
+              }
+
+              if (!pendingEdits[gift.id]) pendingEdits[gift.id] = {};
+              if (newVal === origVal) {
+                delete pendingEdits[gift.id][field];
+                if (Object.keys(pendingEdits[gift.id]).length === 0) delete pendingEdits[gift.id];
+              } else {
+                pendingEdits[gift.id][field] = newVal;
+              }
+
+              // Update row styling
+              tr.classList.toggle("gift-modified", !!pendingEdits[gift.id]);
+              updatePendingUI();
+            };
+            inp.addEventListener("change", handler);
+            inp.addEventListener("input", handler);
+          }
+        }
 
         tbody.appendChild(tr);
       }
 
-      // Wire save buttons
-      for (const btn of tbody.querySelectorAll(".gift-save-btn")) {
-        btn.addEventListener("click", () => saveGift(btn.dataset.giftId));
-      }
-      for (const btn of tbody.querySelectorAll(".gift-delete-btn")) {
-        btn.addEventListener("click", () => deleteGift(btn.dataset.giftId));
-      }
-    }
+      // Pending new gifts
+      for (const add of pendingAdds) {
+        const tr = document.createElement("tr");
+        tr.dataset.tempId = add.tempId;
+        tr.classList.add("gift-new");
 
-    async function saveGift(giftId) {
-      const tr = document.querySelector(`tr[data-gift-id="${giftId}"]`);
-      if (!tr) return;
-      const btn = tr.querySelector(".gift-save-btn");
-      btn.disabled = true;
-      btn.textContent = "...";
+        tr.innerHTML = `
+          <td><input type="number" class="gift-order-input" data-field="order" value="${add.order || 0}"></td>
+          <td style="text-align:center"><input type="checkbox" data-field="showInStore" ${add.showInStore !== false ? 'checked' : ''}></td>
+          <td style="text-align:center"><input type="checkbox" data-field="showOnWheel" ${add.showOnWheel !== false ? 'checked' : ''}></td>
+          <td><span style="color:var(--text2)">\u2014</span></td>
+          <td><input type="text" class="gift-name-input" data-field="name" value="${escapeHtml(add.name || "")}" placeholder="Gift name"></td>
+          <td><input type="number" class="gift-value-input" data-field="coinValue" value="${add.coinValue || 0}"></td>
+          <td><input type="text" class="gift-url-input" data-field="animationUrl" value="${escapeHtml(add.animationUrl || "")}" placeholder="URL"></td>
+          <td><input type="text" class="gift-url-input" data-field="soundUrl" value="${escapeHtml(add.soundUrl || "")}" placeholder="URL"></td>
+          <td><input type="text" class="gift-url-input" data-field="iconUrl" value="${escapeHtml(add.iconUrl || "")}" placeholder="URL"></td>
+          <td class="gift-actions">
+            <button class="gift-remove-btn" data-temp-id="${add.tempId}">Remove</button>
+          </td>
+        `;
 
-      try {
-        const updates = {};
+        // Wire input change handlers for new gifts
         for (const inp of tr.querySelectorAll("[data-field]")) {
-          const field = inp.dataset.field;
-          if (inp.type === "checkbox") {
-            updates[field] = inp.checked;
-          } else if (inp.type === "number") {
-            updates[field] = Number(inp.value) || 0;
-          } else {
-            updates[field] = inp.value;
-          }
+          const handler = () => {
+            const field = inp.dataset.field;
+            if (inp.type === "checkbox") add[field] = inp.checked;
+            else if (inp.type === "number") add[field] = Number(inp.value) || 0;
+            else add[field] = inp.value;
+            updatePendingUI();
+          };
+          inp.addEventListener("change", handler);
+          inp.addEventListener("input", handler);
         }
 
-        await apiCall("PUT", `/api/gifts/${giftId}`, updates);
-        tr.classList.remove("gift-modified");
-        showToast(`Gift "${updates.name}" saved`, "success");
-
-        // Refresh icon preview
-        const iconTd = tr.children[3];
-        const iconUrl = updates.iconUrl;
-        if (iconUrl) {
-          iconTd.innerHTML = `<img src="${escapeHtml(iconUrl)}" class="gift-icon-preview" onerror="this.style.display='none'">`;
-        } else {
-          iconTd.innerHTML = '<span style="color:var(--text2)">—</span>';
-        }
-      } catch (err) {
-        showToast("Save failed: " + err.message, "error");
+        tbody.appendChild(tr);
       }
 
-      btn.disabled = false;
-      btn.textContent = "Save";
-    }
-
-    async function deleteGift(giftId) {
-      const gift = giftsCache.find(g => g.id === giftId);
-      if (!confirm(`Delete gift "${gift?.name || giftId}"? This cannot be undone.`)) return;
-
-      try {
-        await apiCall("DELETE", `/api/gifts/${giftId}`);
-        showToast(`Gift "${gift?.name || giftId}" deleted`, "success");
-        loadGifts();
-      } catch (err) {
-        showToast("Delete failed: " + err.message, "error");
-      }
-    }
-
-    // Add new gift
-    $("#gift-add-btn").addEventListener("click", async () => {
-      const name = prompt("Gift name:");
-      if (!name || !name.trim()) return;
-
-      const coinValue = prompt("Coin value:", "10");
-      if (coinValue === null) return;
-
-      try {
-        await apiCall("POST", "/api/gifts", {
-          name: name.trim(),
-          coinValue: Number(coinValue) || 0,
-          order: giftsCache.length + 1,
+      // Wire delete / undo-delete / remove buttons
+      for (const btn of tbody.querySelectorAll(".gift-delete-btn")) {
+        btn.addEventListener("click", () => {
+          pendingDeletes.add(btn.dataset.giftId);
+          renderGiftsTable();
         });
-        showToast(`Gift "${name}" created`, "success");
-        loadGifts();
-      } catch (err) {
-        showToast("Create failed: " + err.message, "error");
       }
+      for (const btn of tbody.querySelectorAll(".gift-undo-del-btn")) {
+        btn.addEventListener("click", () => {
+          pendingDeletes.delete(btn.dataset.giftId);
+          renderGiftsTable();
+        });
+      }
+      for (const btn of tbody.querySelectorAll(".gift-remove-btn")) {
+        btn.addEventListener("click", () => {
+          pendingAdds = pendingAdds.filter(a => a.tempId !== btn.dataset.tempId);
+          renderGiftsTable();
+        });
+      }
+    }
+
+    // --- Add Gift (local) ---
+    $("#gift-add-btn").addEventListener("click", () => {
+      const maxOrder = Math.max(0, ...giftsCache.map(g => g.order || 0), ...pendingAdds.map(a => a.order || 0));
+      pendingAdds.push({
+        tempId: `new_${Date.now()}`,
+        name: "",
+        coinValue: 0,
+        order: maxOrder + 1,
+        showInStore: true,
+        showOnWheel: true,
+        animationUrl: "",
+        soundUrl: "",
+        iconUrl: "",
+      });
+      renderGiftsTable();
     });
 
-    // Seed defaults
+    // --- Discard ---
+    $("#gift-discard-btn").addEventListener("click", () => {
+      clearPendingState();
+      renderGiftsTable();
+      showToast("All pending changes discarded", "info");
+    });
+
+    // --- Apply Changes (show confirmation) ---
+    $("#gift-apply-btn").addEventListener("click", () => {
+      showGiftConfirmation();
+    });
+
+    function showGiftConfirmation() {
+      const wheelCount = getEffectiveWheelCount();
+      const effective = getEffectiveGifts();
+      const wheelOk = wheelCount === 16;
+
+      // Wheel status
+      const statusEl = $("#gift-confirm-wheel-status");
+      if (wheelOk) {
+        statusEl.className = "gift-confirm-ok";
+        statusEl.textContent = `Wheel: ${wheelCount}/16 \u2014 ready`;
+      } else {
+        statusEl.className = "gift-confirm-warning";
+        statusEl.textContent = `\u26A0 Wheel: ${wheelCount}/16 \u2014 need exactly 16 items on the wheel`;
+      }
+
+      // Build body
+      let html = "";
+      // New gifts
+      if (pendingAdds.length > 0) {
+        html += `<div class="gift-confirm-section"><h4>New Gifts (${pendingAdds.length})</h4><ul>`;
+        for (const a of pendingAdds) {
+          html += `<li>+ ${escapeHtml(a.name || "(unnamed)")} <span class="change-detail">(${a.coinValue} coins)</span></li>`;
+        }
+        html += "</ul></div>";
+      }
+
+      // Modified gifts
+      const editIds = Object.keys(pendingEdits);
+      if (editIds.length > 0) {
+        html += `<div class="gift-confirm-section"><h4>Modified Gifts (${editIds.length})</h4><ul>`;
+        for (const id of editIds) {
+          const orig = giftsCache.find(g => g.id === id);
+          const changes = pendingEdits[id];
+          const fieldDescs = Object.entries(changes).map(([field, newVal]) => {
+            let origVal = orig[field];
+            if (origVal === undefined || origVal === null) {
+              origVal = typeof newVal === "boolean" ? true : typeof newVal === "number" ? 0 : "";
+            }
+            return `${field}: ${origVal}\u2192${newVal}`;
+          }).join(", ");
+          html += `<li>\u270E ${escapeHtml(orig?.name || id)} <span class="change-detail">${escapeHtml(fieldDescs)}</span></li>`;
+        }
+        html += "</ul></div>";
+      }
+
+      // Deleted gifts
+      if (pendingDeletes.size > 0) {
+        html += `<div class="gift-confirm-section"><h4>Deleted Gifts (${pendingDeletes.size})</h4><ul>`;
+        for (const id of pendingDeletes) {
+          const orig = giftsCache.find(g => g.id === id);
+          html += `<li>\u2715 ${escapeHtml(orig?.name || id)}</li>`;
+        }
+        html += "</ul></div>";
+      }
+
+      const totalChanges = getPendingChangeCount();
+      $("#gift-confirm-title").textContent = `Review Changes (${totalChanges} total)`;
+      $("#gift-confirm-body").innerHTML = html;
+      $("#gift-confirm-submit").disabled = !wheelOk;
+      $("#gift-confirm-overlay").classList.add("visible");
+    }
+
+    $("#gift-confirm-cancel").addEventListener("click", () => {
+      $("#gift-confirm-overlay").classList.remove("visible");
+    });
+
+    $("#gift-confirm-submit").addEventListener("click", async () => {
+      const submitBtn = $("#gift-confirm-submit");
+      const cancelBtn = $("#gift-confirm-cancel");
+      submitBtn.disabled = true;
+      cancelBtn.disabled = true;
+      submitBtn.textContent = "Applying...";
+
+      try {
+        // 1. Creates
+        for (const add of pendingAdds) {
+          const { tempId, ...payload } = add;
+          await apiCall("POST", "/api/gifts", payload);
+        }
+
+        // 2. Updates
+        for (const [giftId, changes] of Object.entries(pendingEdits)) {
+          await apiCall("PUT", `/api/gifts/${giftId}`, changes);
+        }
+
+        // 3. Deletes
+        for (const giftId of pendingDeletes) {
+          await apiCall("DELETE", `/api/gifts/${giftId}`);
+        }
+
+        showToast(`${getPendingChangeCount()} changes applied successfully`, "success");
+        $("#gift-confirm-overlay").classList.remove("visible");
+        loadGifts(); // refresh from server
+      } catch (err) {
+        showToast("Apply failed: " + err.message + " — pending changes kept for retry", "error");
+      }
+
+      submitBtn.disabled = false;
+      cancelBtn.disabled = false;
+      submitBtn.textContent = "Confirm";
+    });
+
+    // --- Seed defaults (immediate, reloads table) ---
     $("#gift-seed-btn").addEventListener("click", async () => {
       if (!confirm("Seed the default 27-gift catalog? Existing gifts with the same names will be merged.")) return;
       const btn = $("#gift-seed-btn");
@@ -5199,7 +5641,7 @@
       try {
         await apiCall("POST", "/api/gifts/seed");
         showToast("Default gifts seeded", "success");
-        loadGifts();
+        loadGifts(); // loadGifts clears pending state
       } catch (err) {
         showToast("Seed failed: " + err.message, "error");
       }
@@ -5214,9 +5656,10 @@
       "beanConversionRate", "beanRedeemBonusThreshold", "beanRedeemBonusMultiplier",
       "dropRateExponent", "pitySoftStart", "pityHardLimit", "pitySoftMaxShift",
       "pityHighValueThreshold", "dailyBase", "broadcastSendThreshold", "broadcastWinThreshold",
-      "maxRoomDurationMinutes", "superShyRoomDurationMinutes", "normalSeatCount"
+      "maxRoomDurationMinutes", "superShyRoomDurationMinutes", "normalSeatCount",
+      "wheelInnerThreshold"
     ];
-    const ECO_JSON_FIELDS = ["milestoneRewards"];
+    const ECO_JSON_FIELDS = [];
     const PULL_COST_KEYS = ["1", "10", "100"];
 
     async function loadEconomyConfig() {
@@ -5258,10 +5701,127 @@
           const el = $(`#eco-${f}`);
           if (el) el.value = config[f] ? JSON.stringify(config[f]) : "";
         }
+        // Milestone rewards
+        loadMilestoneUI(config.milestoneRewards || {});
       } catch (err) {
         showToast("Failed to load economy config: " + err.message, "error");
       }
     }
+
+    // --- Milestone Rewards Editor ---
+    let milestoneData = []; // [{ day, type, amount, giftId, quantity }]
+
+    function loadMilestoneUI(obj) {
+      milestoneData = [];
+      for (const [day, val] of Object.entries(obj).sort((a, b) => Number(a[0]) - Number(b[0]))) {
+        if (typeof val === "number") {
+          milestoneData.push({ day: Number(day), type: "coins", amount: val, giftId: "", quantity: 1 });
+        } else if (val && typeof val === "object") {
+          if (val.type === "gift") {
+            milestoneData.push({ day: Number(day), type: "gift", amount: 0, giftId: val.giftId || "", quantity: val.quantity || 1 });
+          } else {
+            milestoneData.push({ day: Number(day), type: "coins", amount: val.amount || 0, giftId: "", quantity: 1 });
+          }
+        }
+      }
+      renderMilestoneRows();
+    }
+
+    function buildGiftOptions() {
+      // Use giftsCache from the gift catalog (loaded when gifts tab is visited)
+      return giftsCache.map(g => `<option value="${escapeHtml(g.id)}">${escapeHtml(g.name || g.id)} (${g.coinValue} coins)</option>`).join("");
+    }
+
+    function renderMilestoneRows() {
+      const container = $("#milestone-rows");
+      container.innerHTML = "";
+      const giftOpts = buildGiftOptions();
+      milestoneData.forEach((row, idx) => {
+        const div = document.createElement("div");
+        div.className = "milestone-row";
+        const isGift = row.type === "gift";
+        div.innerHTML = `
+          <span style="color:var(--text2);font-size:12px;width:28px;text-align:right;flex-shrink:0">Day</span>
+          <input type="number" class="ms-day" min="1" value="${row.day}" data-idx="${idx}" data-field="day">
+          <select class="ms-type" data-idx="${idx}" data-field="type">
+            <option value="coins" ${!isGift ? "selected" : ""}>Coins</option>
+            <option value="gift" ${isGift ? "selected" : ""}>Gift</option>
+          </select>
+          ${isGift ? `
+            <select class="ms-gift-select" data-idx="${idx}" data-field="giftId">
+              <option value="">Select gift...</option>
+              ${giftOpts}
+            </select>
+            <span style="color:var(--text2);font-size:12px;flex-shrink:0">&times;</span>
+            <input type="number" class="ms-qty" min="1" value="${row.quantity}" data-idx="${idx}" data-field="quantity">
+          ` : `
+            <input type="number" class="ms-amount" min="0" value="${row.amount}" data-idx="${idx}" data-field="amount" placeholder="Coins">
+          `}
+          ${idx > 0 ? `<button type="button" class="ms-swap-btn" data-idx="${idx}" title="Swap with row above">\u2191</button>` : '<span style="width:28px"></span>'}
+          <button type="button" class="ms-remove-btn" data-idx="${idx}" title="Remove">\u2715</button>
+        `;
+        container.appendChild(div);
+
+        // Set gift select value after DOM insertion
+        if (isGift && row.giftId) {
+          const sel = div.querySelector(".ms-gift-select");
+          if (sel) sel.value = row.giftId;
+        }
+      });
+
+      // Wire events
+      for (const el of container.querySelectorAll("[data-field]")) {
+        el.addEventListener("change", () => {
+          const idx = Number(el.dataset.idx);
+          const field = el.dataset.field;
+          if (field === "type") {
+            milestoneData[idx].type = el.value;
+            renderMilestoneRows(); // re-render to swap input type
+          } else if (field === "day") {
+            milestoneData[idx].day = Number(el.value) || 1;
+          } else if (field === "amount") {
+            milestoneData[idx].amount = Number(el.value) || 0;
+          } else if (field === "giftId") {
+            milestoneData[idx].giftId = el.value;
+          } else if (field === "quantity") {
+            milestoneData[idx].quantity = Math.max(1, Number(el.value) || 1);
+          }
+        });
+      }
+      for (const btn of container.querySelectorAll(".ms-swap-btn")) {
+        btn.addEventListener("click", () => {
+          const idx = Number(btn.dataset.idx);
+          [milestoneData[idx - 1], milestoneData[idx]] = [milestoneData[idx], milestoneData[idx - 1]];
+          renderMilestoneRows();
+        });
+      }
+      for (const btn of container.querySelectorAll(".ms-remove-btn")) {
+        btn.addEventListener("click", () => {
+          milestoneData.splice(Number(btn.dataset.idx), 1);
+          renderMilestoneRows();
+        });
+      }
+    }
+
+    function collectMilestoneRewards() {
+      const obj = {};
+      for (const row of milestoneData) {
+        const key = String(row.day);
+        if (row.type === "gift") {
+          if (!row.giftId) continue; // skip incomplete rows
+          obj[key] = { type: "gift", giftId: row.giftId, quantity: row.quantity || 1 };
+        } else {
+          obj[key] = row.amount;
+        }
+      }
+      return obj;
+    }
+
+    $("#ms-add-btn").addEventListener("click", () => {
+      const maxDay = milestoneData.length > 0 ? Math.max(...milestoneData.map(r => r.day)) : 0;
+      milestoneData.push({ day: maxDay + 7, type: "coins", amount: 100, giftId: "", quantity: 1 });
+      renderMilestoneRows();
+    });
 
     $("#eco-pitySoftMaxShift").addEventListener("input", (e) => {
       $("#eco-pitySoftMaxShift-val").textContent = e.target.value;
@@ -5310,6 +5870,8 @@
             }
           }
         }
+        // Milestone rewards
+        updates.milestoneRewards = collectMilestoneRewards();
 
         if (Object.keys(updates).length === 0) throw new Error("No fields to save");
 
@@ -5515,6 +6077,36 @@
       }
       btn.disabled = false;
       btn.textContent = "Remove All Super Shy";
+    });
+
+    // Clear All Appeals
+    $("#clear-appeals-btn").addEventListener("click", async () => {
+      const btn = $("#clear-appeals-btn");
+      const result = $("#clear-appeals-result");
+      if (!confirm("Delete ALL suspension appeals? This cannot be undone.")) return;
+
+      btn.disabled = true;
+      btn.textContent = "Deleting...";
+      result.style.display = "none";
+
+      try {
+        const token = await auth.currentUser.getIdToken();
+        const resp = await fetch(`${API_BASE}/api/cleanup/all-appeals`, {
+          method: "POST",
+          headers: { "Authorization": `Bearer ${token}`, "Content-Type": "application/json" },
+        });
+        const data = await resp.json();
+        if (!resp.ok) throw new Error(data.error || "Request failed");
+        result.className = "maintenance-result success";
+        result.textContent = `Deleted ${data.appealsDeleted} appeals`;
+        result.style.display = "block";
+      } catch (err) {
+        result.className = "maintenance-result error";
+        result.textContent = err.message;
+        result.style.display = "block";
+      }
+      btn.disabled = false;
+      btn.textContent = "Delete All Appeals";
     });
 
     // =====================================================
@@ -5737,7 +6329,7 @@
           step = 2;
           stepLabel.textContent = "Step 2 of 3";
           title.textContent = "This is your last warning";
-          desc.textContent = "Every user will lose their coins, beans, backpack items, gift wall, spin history, and warnings. All reports and system messages will be deleted. Orphaned files will be purged.";
+          desc.textContent = "Every user will lose their coins, beans, backpack items, gift wall, spin history, and warnings. All reports, system messages, and appeals will be deleted. Orphaned files will be purged.";
           proceedBtn.textContent = "Continue to final step";
           return;
         }
@@ -5768,7 +6360,7 @@
           title.textContent = "Resetting everything";
           desc.textContent = "Do not close this page.";
           progress.classList.add("visible");
-          updateNukeBar(0, 9);
+          updateNukeBar(0, 11);
           startParticles();
           startSirenLights();
 
@@ -5782,6 +6374,7 @@
             { id: "np-system-msgs", endpoint: "all-system-conversations", label: "System messages" },
             { id: "np-reports", endpoint: "all-reports", label: "Reports" },
             { id: "np-warnings", endpoint: "all-warnings", label: "Warnings" },
+            { id: "np-appeals", endpoint: "all-appeals", label: "Appeals" },
             { id: "np-storage", endpoint: "orphaned-storage", label: "Orphaned storage", body: { folders: ["pm_images/", "stickers/", "report_evidence/"] } },
             { id: "np-backpacks", endpoint: "all-backpacks", label: "Backpacks" },
             { id: "np-giftwalls", endpoint: "all-giftwalls", label: "Gift walls" },
@@ -5833,7 +6426,7 @@
           title.textContent = failed ? "Some actions failed" : "All done";
           desc.textContent = failed
             ? `${actions.length - failed} of ${actions.length} actions succeeded. Check the results below.`
-            : "All 9 maintenance actions completed successfully.";
+            : "All 11 maintenance actions completed successfully.";
           btnRow.style.display = "flex";
           proceedBtn.style.display = "none";
           cancelBtn.textContent = "Close";

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/DailyRewardResult.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/DailyRewardResult.kt
@@ -4,14 +4,20 @@ data class DailyRewardResult(
     val coinsAwarded: Int = 0,
     val newStreak: Int = 0,
     val isMilestone: Boolean = false,
-    val newBalance: Long = 0
+    val newBalance: Long = 0,
+    val giftId: String? = null,
+    val giftQuantity: Int = 0
 ) {
+    val isGiftReward: Boolean get() = giftId != null
+
     companion object {
         fun fromMap(map: Map<String, Any?>): DailyRewardResult = DailyRewardResult(
             coinsAwarded = (map["coinsAwarded"] as? Number)?.toInt() ?: 0,
             newStreak = (map["newStreak"] as? Number)?.toInt() ?: 0,
             isMilestone = map["isMilestone"] as? Boolean ?: false,
-            newBalance = (map["newBalance"] as? Number)?.toLong() ?: 0
+            newBalance = (map["newBalance"] as? Number)?.toLong() ?: 0,
+            giftId = map["giftId"] as? String,
+            giftQuantity = (map["giftQuantity"] as? Number)?.toInt() ?: 0
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/EconomyConfig.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/EconomyConfig.kt
@@ -7,7 +7,8 @@ data class EconomyConfig(
     val broadcastWinThreshold: Int = 5000,
     val maxRoomDurationMinutes: Int = 360,
     val superShyRoomDurationMinutes: Int = 720,
-    val normalSeatCount: Int = 5
+    val normalSeatCount: Int = 5,
+    val wheelInnerThreshold: Int = 18888
 ) {
     companion object {
         fun fromMap(map: Map<String, Any?>): EconomyConfig {
@@ -31,7 +32,8 @@ data class EconomyConfig(
                 broadcastWinThreshold = (map["broadcastWinThreshold"] as? Number)?.toInt() ?: 5000,
                 maxRoomDurationMinutes = (map["maxRoomDurationMinutes"] as? Number)?.toInt() ?: 360,
                 superShyRoomDurationMinutes = (map["superShyRoomDurationMinutes"] as? Number)?.toInt() ?: 720,
-                normalSeatCount = (map["normalSeatCount"] as? Number)?.toInt() ?: 5
+                normalSeatCount = (map["normalSeatCount"] as? Number)?.toInt() ?: 5,
+                wheelInnerThreshold = (map["wheelInnerThreshold"] as? Number)?.toInt() ?: 18888
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/daily/DailyRewardDialog.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/daily/DailyRewardDialog.kt
@@ -70,12 +70,21 @@ fun DailyRewardDialog(
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 if (state.reward != null) {
                     val reward = state.reward!!
-                    Text(
-                        text = "+${reward.coinsAwarded} coins!",
-                        style = MaterialTheme.typography.headlineMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = SuperShyGold
-                    )
+                    if (reward.isGiftReward) {
+                        Text(
+                            text = "${reward.giftQuantity}x ${reward.giftId}",
+                            style = MaterialTheme.typography.headlineMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = SuperShyGold
+                        )
+                    } else {
+                        Text(
+                            text = "+${reward.coinsAwarded} coins!",
+                            style = MaterialTheme.typography.headlineMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = SuperShyGold
+                        )
+                    }
                     Spacer(modifier = Modifier.height(8.dp))
                     Text("Day ${reward.newStreak} streak")
                     if (reward.isMilestone) {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/GachaViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/GachaViewModel.kt
@@ -34,7 +34,8 @@ data class GachaUiState(
     val coinPackages: List<CoinPackage> = emptyList(),
     val spinHistory: List<Transaction> = emptyList(),
     val pullCosts: Map<Int, Int> = emptyMap(),
-    val configLoaded: Boolean = false
+    val configLoaded: Boolean = false,
+    val wheelInnerThreshold: Int = 18888
 )
 
 class GachaViewModel(
@@ -95,7 +96,8 @@ class GachaViewModel(
                     _uiState.update {
                         it.copy(
                             pullCosts = config.pullCosts,
-                            configLoaded = config.pullCosts.isNotEmpty()
+                            configLoaded = config.pullCosts.isNotEmpty(),
+                            wheelInnerThreshold = config.wheelInnerThreshold
                         )
                     }
                 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinOverlay.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinOverlay.kt
@@ -88,7 +88,10 @@ fun LuckySpinOverlay(
     modifier: Modifier = Modifier
 ) {
     val winnableGifts = gachaState.winnableGifts
-    val (outerGifts, innerGifts) = remember(winnableGifts) { buildRingLayout(winnableGifts) }
+    val innerThreshold = gachaState.wheelInnerThreshold
+    val (outerGifts, innerGifts) = remember(winnableGifts, innerThreshold) {
+        buildRingLayout(winnableGifts, innerThreshold)
+    }
 
     var phase by remember { mutableStateOf(SpinPhase.IDLE) }
     var outerLitIndex by remember { mutableIntStateOf(-1) }
@@ -375,6 +378,17 @@ fun LuckySpinOverlay(
             .graphicsLayer {
                 translationX = shakeX.value
                 translationY = shakeY.value
+            }
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ) {
+                // Tap outside the panel to close (only when idle)
+                if (phase == SpinPhase.IDLE && !showCoinShop && !showHistory && !showPrizeList && !showSummary) {
+                    resetBoard()
+                    onDismissResults()
+                    onDismiss()
+                }
             },
         contentAlignment = Alignment.BottomCenter
     ) {
@@ -528,49 +542,86 @@ fun LuckySpinOverlay(
 
             Spacer(modifier = Modifier.height(2.dp))
 
-            // The dual-ring wheel — fill available width for a bigger wheel
-            LuckySpinWheel(
-                outerGifts = outerGifts,
-                innerGifts = innerGifts,
-                outerLitIndex = outerLitIndex,
-                innerLitIndex = innerLitIndex,
-                wonSegments = wonSegments,
+            // Fixed-size area: same aspect ratio as the wheel so the panel doesn't resize
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 8.dp)
-                    .aspectRatio(1f)
-            )
-
-            Spacer(modifier = Modifier.height(4.dp))
-
-            // Last win display
-            lastWin?.let { win ->
-                if (phase != SpinPhase.IDLE && !showSummary) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center
+                    .aspectRatio(1f),
+                contentAlignment = Alignment.Center
+            ) {
+                if (showSummary && allWins.isNotEmpty()) {
+                    LuckySpinSummaryPopup(
+                        wins = allWins,
+                        spinTier = activeTier,
+                        canAffordSpinAgain = gachaState.coinBalance >= activeTier.cost,
+                        onClose = {
+                            resetBoard()
+                            onDismissResults()
+                        },
+                        onSpinAgain = {
+                            val tier = activeTier
+                            resetBoard()
+                            onDismissResults()
+                            phase = SpinPhase.ANIMATING
+                            activeTier = tier
+                            GachaSoundPlayer.playSpinStart()
+                            when (tier.count) {
+                                1 -> onSpin()
+                                else -> onQuickSpin(tier.count)
+                            }
+                        }
+                    )
+                } else {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center,
+                        modifier = Modifier.fillMaxSize()
                     ) {
-                        Text(giftEmoji(win.giftName), fontSize = 22.sp)
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Text(
-                            text = "${win.giftName} — \uD83E\uDE99${win.coinValue}",
-                            color = Color(0xFFFFD700),
-                            fontWeight = FontWeight.ExtraBold,
-                            fontSize = 14.sp
+                        LuckySpinWheel(
+                            outerGifts = outerGifts,
+                            innerGifts = innerGifts,
+                            outerLitIndex = outerLitIndex,
+                            innerLitIndex = innerLitIndex,
+                            wonSegments = wonSegments,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1f)
                         )
+
+                        Spacer(modifier = Modifier.height(4.dp))
+
+                        lastWin?.let { win ->
+                            if (phase != SpinPhase.IDLE) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.Center
+                                ) {
+                                    Text(giftEmoji(win.giftName), fontSize = 22.sp)
+                                    Spacer(modifier = Modifier.width(6.dp))
+                                    Text(
+                                        text = "${win.giftName} — \uD83E\uDE99${win.coinValue}",
+                                        color = Color(0xFFFFD700),
+                                        fontWeight = FontWeight.ExtraBold,
+                                        fontSize = 14.sp
+                                    )
+                                }
+                                Spacer(modifier = Modifier.height(4.dp))
+                            }
+                        }
                     }
-                    Spacer(modifier = Modifier.height(4.dp))
                 }
             }
 
             // Spin tier buttons — equal height via IntrinsicSize
-            if (phase == SpinPhase.IDLE && !gachaState.configLoaded) {
+            if (!gachaState.configLoaded && phase == SpinPhase.IDLE) {
                 Text(
                     text = "Loading prices...",
                     color = Color.White.copy(alpha = 0.5f),
                     fontSize = 14.sp
                 )
-            } else if (phase == SpinPhase.IDLE && gachaState.configLoaded) {
+            } else if (gachaState.configLoaded) {
+                val spinning = phase == SpinPhase.ANIMATING || phase == SpinPhase.CELEBRATING
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
                     modifier = Modifier
@@ -582,6 +633,7 @@ fun LuckySpinOverlay(
 
                         Button(
                             onClick = {
+                                if (spinning) return@Button
                                 if (!canAfford) {
                                     showCoinShop = true
                                 } else if (!gachaState.isPulling) {
@@ -601,8 +653,7 @@ fun LuckySpinOverlay(
                                 }
                             },
                             colors = ButtonDefaults.buttonColors(
-                                containerColor = if (canAfford) tier.color.copy(alpha = 0.15f)
-                                    else Color(0xFF222222)
+                                containerColor = tier.color.copy(alpha = 0.15f)
                             ),
                             shape = RoundedCornerShape(20.dp),
                             contentPadding = ButtonDefaults.ContentPadding,
@@ -618,7 +669,7 @@ fun LuckySpinOverlay(
                                     text = tier.label,
                                     fontSize = 18.sp,
                                     fontWeight = FontWeight.Black,
-                                    color = if (canAfford) tier.color else Color.Gray,
+                                    color = tier.color,
                                     letterSpacing = 1.sp,
                                     lineHeight = 20.sp,
                                     maxLines = 1
@@ -627,13 +678,13 @@ fun LuckySpinOverlay(
                                     text = "SPIN",
                                     fontSize = 10.sp,
                                     fontWeight = FontWeight.Bold,
-                                    color = if (canAfford) Color.White.copy(alpha = 0.55f) else Color.Gray.copy(alpha = 0.4f),
+                                    color = Color.White.copy(alpha = 0.55f),
                                     letterSpacing = 1.sp,
                                     maxLines = 1
                                 )
                                 Surface(
                                     shape = RoundedCornerShape(12.dp),
-                                    color = if (canAfford) tier.color.copy(alpha = 0.12f) else Color.White.copy(alpha = 0.03f)
+                                    color = tier.color.copy(alpha = 0.12f)
                                 ) {
                                     Row(
                                         verticalAlignment = Alignment.CenterVertically,
@@ -644,7 +695,7 @@ fun LuckySpinOverlay(
                                             text = "${tier.cost}",
                                             fontSize = 11.sp,
                                             fontWeight = FontWeight.ExtraBold,
-                                            color = if (canAfford) tier.color else Color.Gray,
+                                            color = tier.color,
                                             maxLines = 1
                                         )
                                     }
@@ -654,22 +705,17 @@ fun LuckySpinOverlay(
                                     text = if (tier.boostedDrop) "INCREASED DROP RATE" else "",
                                     fontSize = 7.sp,
                                     fontWeight = FontWeight.ExtraBold,
-                                    letterSpacing = 0.5.sp,
-                                    color = if (canAfford) tier.color else Color.Gray,
+                                    letterSpacing = 0.sp,
+                                    color = tier.color,
                                     maxLines = 1,
-                                    lineHeight = 9.sp
+                                    lineHeight = 9.sp,
+                                    overflow = androidx.compose.ui.text.style.TextOverflow.Visible,
+                                    softWrap = false
                                 )
                             }
                         }
                     }
                 }
-            } else if (phase == SpinPhase.ANIMATING) {
-                Text(
-                    text = "Spinning...",
-                    color = Color.White,
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 16.sp
-                )
             }
 
             // Collect All button when celebrating (pre-summary)
@@ -706,32 +752,6 @@ fun LuckySpinOverlay(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(flashColor)
-            )
-        }
-
-        // Summary popup
-        if (showSummary && allWins.isNotEmpty()) {
-            LuckySpinSummaryPopup(
-                wins = allWins,
-                spinTier = activeTier,
-                canAffordSpinAgain = gachaState.coinBalance >= activeTier.cost,
-                onClose = {
-                    resetBoard()
-                    onDismissResults()
-                },
-                onSpinAgain = {
-                    val tier = activeTier
-                    resetBoard()
-                    onDismissResults()
-                    // Trigger new spin
-                    phase = SpinPhase.ANIMATING
-                    activeTier = tier
-                    GachaSoundPlayer.playSpinStart()
-                    when (tier.count) {
-                        1 -> onSpin()
-                        else -> onQuickSpin(tier.count)
-                    }
-                }
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinSummaryPopup.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinSummaryPopup.kt
@@ -82,8 +82,6 @@ fun LuckySpinSummaryPopup(
     val bestCoinValue = remember(wins) {
         wins.maxByOrNull { it.coinValue }?.coinValue ?: 0
     }
-    val rarityConfig = rarityConfigForCoinValue(bestCoinValue)
-    val isHighValue = bestCoinValue >= 2000
 
     // Animated entrance
     var appeared by remember { mutableStateOf(false) }
@@ -94,38 +92,26 @@ fun LuckySpinSummaryPopup(
         label = "summaryScale"
     )
 
-    Box(
+    Surface(
         modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black)
-            .clickable(
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() }
-            ) { /* consume taps */ },
-        contentAlignment = Alignment.Center
+            .fillMaxWidth()
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            },
+        shape = RoundedCornerShape(20.dp),
+        color = Color(0xFF1A1A3E).copy(alpha = 0.6f),
     ) {
-        Surface(
-            modifier = Modifier
-                .widthIn(max = 420.dp)
-                .fillMaxWidth(0.94f)
-                .graphicsLayer {
-                    scaleX = scale
-                    scaleY = scale
-                },
-            shape = RoundedCornerShape(28.dp),
-            color = Color(0xFF1A1A3E),
-            shadowElevation = 16.dp
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp)
         ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.padding(horizontal = 24.dp, vertical = 32.dp)
-            ) {
                 // Title
                 Text(
-                    text = if (isHighValue) rarityConfig.title else "Spin Results",
-                    fontSize = if (isHighValue) 26.sp else 22.sp,
+                    text = "Spin Results",
+                    fontSize = 22.sp,
                     fontWeight = FontWeight.Black,
-                    color = rarityConfig.glowColor,
+                    color = Color.White,
                     letterSpacing = 2.sp
                 )
 
@@ -157,18 +143,12 @@ fun LuckySpinSummaryPopup(
                 // Total coins
                 Text(
                     text = "\uD83E\uDE99 ${totalCoins.formatWithCommas()} Coins",
-                    fontSize = if (isHighValue) 34.sp else 26.sp,
+                    fontSize = 26.sp,
                     fontWeight = FontWeight.Black,
                     style = MaterialTheme.typography.headlineLarge.copy(
-                        brush = if (bestCoinValue >= 10000) {
-                            Brush.linearGradient(
-                                listOf(Color(0xFFFFD700), Color(0xFFFF6B00), Color(0xFFFF1744), Color(0xFFFFD700))
-                            )
-                        } else {
-                            Brush.linearGradient(
-                                listOf(Color(0xFFFFD700), Color(0xFFFF9100))
-                            )
-                        }
+                        brush = Brush.linearGradient(
+                            listOf(Color(0xFFFFD700), Color(0xFFFF9100))
+                        )
                     )
                 )
 
@@ -218,13 +198,10 @@ fun LuckySpinSummaryPopup(
                 }
             }
         }
-    }
 }
 
 @Composable
 private fun WinCard(win: GroupedWin, index: Int) {
-    val isHighValue = win.coinValue >= 2000
-
     // Staggered entrance
     var appeared by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { appeared = true }
@@ -241,7 +218,7 @@ private fun WinCard(win: GroupedWin, index: Int) {
 
     Box(
         modifier = Modifier
-            .size(width = 80.dp, height = 110.dp)
+            .size(80.dp)
             .graphicsLayer { scaleX = scale; scaleY = scale }
             .clip(RoundedCornerShape(16.dp))
             .background(cardColor.copy(alpha = 0.1f))
@@ -297,15 +274,6 @@ private fun WinCard(win: GroupedWin, index: Int) {
                 fontSize = 11.sp,
                 fontWeight = FontWeight.ExtraBold,
                 maxLines = 1
-            )
-
-            // High-value label — always reserve space
-            Text(
-                text = if (isHighValue) "HIGH VALUE" else "",
-                fontSize = 7.sp,
-                fontWeight = FontWeight.ExtraBold,
-                letterSpacing = 1.5.sp,
-                color = if (isHighValue) rarityConfigForCoinValue(win.coinValue).glowColor else Color.Transparent
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinWheel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinWheel.kt
@@ -31,15 +31,15 @@ private val SegmentAccentColor = Color(0xFF757575)
 enum class Ring { OUTER, INNER }
 
 /**
- * Splits winnable gifts into outer (coinValue < 500) and inner (coinValue >= 500)
+ * Splits winnable gifts into outer (below [innerThreshold]) and inner (at or above)
  * rings, sorted by [Gift.order].
  */
-fun buildRingLayout(gifts: List<Gift>): Pair<List<Gift>, List<Gift>> {
+fun buildRingLayout(gifts: List<Gift>, innerThreshold: Int = 18888): Pair<List<Gift>, List<Gift>> {
     val outer = gifts
-        .filter { it.coinValue < 500 }
+        .filter { it.coinValue < innerThreshold }
         .sortedBy { it.order }
     val inner = gifts
-        .filter { it.coinValue >= 500 }
+        .filter { it.coinValue >= innerThreshold }
         .sortedBy { it.order }
     return outer to inner
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/SpinTier.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/SpinTier.kt
@@ -31,41 +31,41 @@ data class RarityConfig(
     val title: String
 )
 
-/** Coin-value-based rarity configs (replacing GiftBracket-keyed map). */
+/** Coin-value-based celebration configs — effects scale with value. */
 fun rarityConfigForCoinValue(coinValue: Int): RarityConfig = when {
     coinValue < 50 -> RarityConfig(
         glowColor = Color.White,
         burstCount = 40,
         shakeIntensity = 0f,
         flash = false,
-        title = "You Won!"
+        title = "Spin Results"
     )
     coinValue < 200 -> RarityConfig(
         glowColor = Color.White,
         burstCount = 70,
         shakeIntensity = 3f,
         flash = false,
-        title = "Nice Win!"
+        title = "Spin Results"
     )
     coinValue < 2000 -> RarityConfig(
         glowColor = Color.White,
         burstCount = 130,
         shakeIntensity = 5f,
         flash = true,
-        title = "RARE WIN!"
+        title = "Spin Results"
     )
     coinValue < 10000 -> RarityConfig(
         glowColor = Color.White,
         burstCount = 180,
         shakeIntensity = 7f,
         flash = true,
-        title = "EPIC WIN!"
+        title = "Spin Results"
     )
     else -> RarityConfig(
         glowColor = Color.White,
         burstCount = 220,
         shakeIntensity = 10f,
         flash = true,
-        title = "LEGENDARY!!"
+        title = "Spin Results"
     )
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gifting/GiftingViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gifting/GiftingViewModel.kt
@@ -244,7 +244,7 @@ class GiftingViewModel(
                         it.copy(
                             isSending = false,
                             selectedGiftId = null,
-                            sentGiftName = "Super Shy Trial activated!"
+                            sentGiftName = "Super Shy activated! +30 days"
                         )
                     }
                 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
@@ -37,6 +37,7 @@ data class ProfileUiState(
     val followerCount: Int = 0,
     val followingCount: Int = 0,
     val isOnline: Boolean = false,
+    val lastActiveText: String? = null,
     val hideFollowing: Boolean = false,
     val activeRoomId: String? = null,
     val stalkerCount: Int = 0,
@@ -66,6 +67,26 @@ class ProfileViewModel(
         observeUserUpdates()
     }
 
+    /**
+     * Returns a human-readable "last active" string, or null if the user is online
+     * or has hidden their online status.
+     */
+    private fun computeLastActiveText(user: com.shyden.shytalk.core.model.User): String? {
+        if (user.hideOnlineStatus) return null
+        val elapsed = currentTimeMillis() - user.lastSeenAt
+        if (elapsed < Constants.ONLINE_THRESHOLD_MS) return null // currently online
+        val minutes = elapsed / 60_000L
+        val hours = minutes / 60
+        val days = hours / 24
+        return when {
+            days > 30 -> "Active 30+ days ago"
+            days >= 1 -> "Active ${days}d ago"
+            hours >= 1 -> "Active ${hours}h ago"
+            minutes >= 1 -> "Active ${minutes}m ago"
+            else -> "Active just now"
+        }
+    }
+
     private fun observeUserUpdates() {
         viewModelScope.launch {
             userRepository.userUpdates.collect { updatedUser ->
@@ -80,6 +101,7 @@ class ProfileViewModel(
                             followerCount = updatedUser.followerIds.size,
                             followingCount = updatedUser.followingIds.size,
                             isOnline = isOnline,
+                            lastActiveText = computeLastActiveText(updatedUser),
                             activeRoomId = activeRoomId,
                             stalkerCount = if (state.isOwnProfile) updatedUser.stalkerCount.toInt() else state.stalkerCount,
                             newStalkerCount = if (state.isOwnProfile) updatedUser.newStalkerCount.toInt() else state.newStalkerCount
@@ -154,6 +176,7 @@ class ProfileViewModel(
                                 followerCount = followerCount,
                                 followingCount = followingCount,
                                 isOnline = isOnline,
+                                lastActiveText = computeLastActiveText(user),
                                 hideFollowing = user.hideFollowing,
                                 activeRoomId = activeRoomId
                             )
@@ -172,6 +195,7 @@ class ProfileViewModel(
                                 followerCount = followerCount,
                                 followingCount = followingCount,
                                 isOnline = isOnline,
+                                lastActiveText = computeLastActiveText(user),
                                 hideFollowing = user.hideFollowing,
                                 activeRoomId = activeRoomId,
                                 stalkerCount = user.stalkerCount.toInt(),
@@ -490,18 +514,14 @@ class ProfileViewModel(
 
     fun claimSuperShyTrial() {
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
             when (val result = economyRepository.claimSuperShyTrial()) {
                 is Resource.Success -> {
                     _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            user = it.user?.copy(hasClaimedSuperShyTrial = true)
-                        )
+                        it.copy(user = it.user?.copy(hasClaimedSuperShyTrial = true))
                     }
                 }
                 is Resource.Error -> {
-                    _uiState.update { it.copy(isLoading = false, error = result.message ?: "Failed to claim trial") }
+                    _uiState.update { it.copy(error = result.message ?: "Failed to claim trial") }
                 }
                 is Resource.Loading -> {}
             }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -1594,9 +1594,18 @@ class RoomViewModel(
         when (notification) {
             is RoomNotification.SeatRequestReceived ->
                 if (notification.request.requestId in processedRequestIds) return
-            is RoomNotification.RequestApproved ->
+            is RoomNotification.RequestApproved -> {
                 if (notification.request.requestId in processedApprovalIds) return
-            is RoomNotification.InviteReceived -> {}
+                // Approved request supersedes any pending invite — remove it from queue
+                notificationQueue.removeAll { it is RoomNotification.InviteReceived }
+            }
+            is RoomNotification.InviteReceived -> {
+                // Suppress invite if a RequestApproved is already active or queued
+                // (the approved-request dialog already tells the user they can sit)
+                val approvedActive = _uiState.value.activeNotification is RoomNotification.RequestApproved
+                val approvedQueued = notificationQueue.any { it is RoomNotification.RequestApproved }
+                if (approvedActive || approvedQueued) return
+            }
         }
         if (notificationQueue.any { it.id == notification.id }) return
         if (_uiState.value.activeNotification?.id == notification.id) return

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/BackpackSheet.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/BackpackSheet.kt
@@ -782,7 +782,7 @@ private fun BottomBar(
         ) {
             Text(
                 when {
-                    state.isSending -> "Sending..."
+                    state.isSending -> if (isSelfUse) "Using..." else "Sending..."
                     sendLabel != null -> sendLabel
                     else -> "Send"
                 },

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ChatPanel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ChatPanel.kt
@@ -4,7 +4,9 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,12 +14,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
-import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.material.icons.filled.Backpack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Edit
@@ -29,21 +34,27 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.gestures.detectTapGestures
+import kotlinx.coroutines.launch
 import com.shyden.shytalk.ui.theme.SpeakingGreen
 import com.shyden.shytalk.core.model.Message
 import com.shyden.shytalk.core.model.RoomRole
@@ -101,17 +112,29 @@ fun ChatPanel(
     val isSeated = currentSeatEntry != null
     val isSelfMuted = currentSeatEntry?.value?.isMuted ?: false
 
-    // Track whether user is near the bottom continuously via snapshotFlow
-    val isNearBottom = remember { mutableStateOf(true) }
+    // Track whether the user has scrolled away from the bottom
+    var hasNewMessages by remember { mutableStateOf(false) }
+    var lastSeenSize by remember { mutableIntStateOf(messages.size) }
+    val coroutineScope = rememberCoroutineScope()
+
     LaunchedEffect(listState) {
         snapshotFlow { listState.firstVisibleItemIndex }
-            .collect { index -> isNearBottom.value = index <= 2 }
+            .collect { index ->
+                if (index <= 1) hasNewMessages = false
+            }
     }
 
-    // Auto-scroll when new messages arrive and user is near bottom
+    // Auto-scroll when new messages arrive and user is near the bottom.
     LaunchedEffect(messages.size) {
-        if (isNearBottom.value) {
+        if (messages.size <= lastSeenSize) {
+            lastSeenSize = messages.size
+            return@LaunchedEffect
+        }
+        lastSeenSize = messages.size
+        if (listState.firstVisibleItemIndex <= 2) {
             listState.animateScrollToItem(0)
+        } else {
+            hasNewMessages = true
         }
     }
 
@@ -120,32 +143,60 @@ fun ChatPanel(
     val focusManager = LocalFocusManager.current
 
     Column(modifier = modifier) {
-        LazyColumn(
-            state = listState,
-            reverseLayout = true,
-            verticalArrangement = Arrangement.Bottom,
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .padding(start = 8.dp, end = 80.dp)
+        Box(
+            modifier = Modifier.fillMaxWidth().weight(1f)
+                .pointerInput(Unit) { detectTapGestures { focusManager.clearFocus() } }
         ) {
-            items(reversedMessages, key = { it.messageId }) { message ->
-                val senderUser = userMap[message.senderId]
-                val isSelf = message.senderId == currentUserId
-                val isUserSeated = message.senderId in seatedUserIds
-                MessageBubble(
-                    message = message,
-                    user = senderUser,
-                    currentRole = currentRole,
-                    isUserSeated = isUserSeated,
-                    isSelf = isSelf,
-                    onTapUser = { onTapUser(message.senderId) },
-                    onInvite = { onInviteUser(message.senderId, message.senderName) },
-                    onEditMessage = if (isSelf && message.type == com.shyden.shytalk.core.model.MessageType.TEXT) {
-                        { onStartEditMessage(message.messageId, message.text) }
-                    } else null,
-                    aliases = aliases
-                )
+            LazyColumn(
+                state = listState,
+                reverseLayout = true,
+                verticalArrangement = Arrangement.Bottom,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .matchParentSize()
+                    .padding(start = 8.dp, end = 80.dp)
+            ) {
+                items(reversedMessages, key = { it.messageId }) { message ->
+                    val senderUser = userMap[message.senderId]
+                    val isSelf = message.senderId == currentUserId
+                    val isUserSeated = message.senderId in seatedUserIds
+                    MessageBubble(
+                        message = message,
+                        user = senderUser,
+                        currentRole = currentRole,
+                        isUserSeated = isUserSeated,
+                        isSelf = isSelf,
+                        onTapUser = { onTapUser(message.senderId) },
+                        onInvite = { onInviteUser(message.senderId, message.senderName) },
+                        onEditMessage = if (isSelf && message.type == com.shyden.shytalk.core.model.MessageType.TEXT) {
+                            { onStartEditMessage(message.messageId, message.text) }
+                        } else null,
+                        aliases = aliases
+                    )
+                }
+            }
+
+            // "New messages" chip when user has scrolled up
+            if (hasNewMessages) {
+                Surface(
+                    shape = RoundedCornerShape(16.dp),
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    shadowElevation = 4.dp,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 8.dp)
+                        .clickable {
+                            hasNewMessages = false
+                            coroutineScope.launch { listState.animateScrollToItem(0) }
+                        }
+                ) {
+                    Text(
+                        text = "New messages",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+                    )
+                }
             }
         }
 
@@ -173,32 +224,25 @@ fun ChatPanel(
                 value = messageText,
                 onValueChange = { if (it.length <= 200) messageText = it },
                 placeholder = { Text(if (isEditing) "Edit message..." else "Type a message...") },
-                modifier = Modifier.weight(0.6f).testTag("room_chatInput"),
+                modifier = Modifier.weight(1f).testTag("room_chatInput"),
                 singleLine = true,
                 leadingIcon = if (isEditing) {
                     { Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(16.dp)) }
-                } else null
-            )
-
-            IconButton(
-                onClick = {
-                    if (messageText.isNotBlank()) {
-                        if (isEditing) {
-                            onEditMessage(messageText)
-                        } else {
-                            onSendMessage(messageText)
+                } else null,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                keyboardActions = KeyboardActions(
+                    onSend = {
+                        if (messageText.isNotBlank()) {
+                            if (isEditing) {
+                                onEditMessage(messageText)
+                            } else {
+                                onSendMessage(messageText)
+                            }
+                            messageText = ""
                         }
-                        messageText = ""
                     }
-                },
-                modifier = Modifier.testTag("room_sendButton")
-            ) {
-                Icon(
-                    Icons.AutoMirrored.Filled.Send,
-                    contentDescription = if (isEditing) "Save edit" else "Send",
-                    tint = MaterialTheme.colorScheme.primary
                 )
-            }
+            )
 
             if (isSeated) {
                 IconButton(onClick = {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/settings/RoomSettingsSheet.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/settings/RoomSettingsSheet.kt
@@ -126,6 +126,9 @@ fun RoomSettingsSheet(
             }
 
             // Gift Animations filter (per-user setting)
+            var sliderValue by remember(uiState.minGiftAnimationValue) {
+                mutableStateOf(uiState.minGiftAnimationValue.toFloat())
+            }
             Text(
                 text = "Gift Animations",
                 style = MaterialTheme.typography.titleSmall,
@@ -133,8 +136,8 @@ fun RoomSettingsSheet(
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = if (uiState.minGiftAnimationValue == 0) "Showing all gift animations"
-                       else "Only showing animations worth ${uiState.minGiftAnimationValue}+ coins",
+                text = if (sliderValue.toInt() == 0) "Showing all gift animations"
+                       else "Only showing animations worth ${sliderValue.toInt()}+ coins",
                 style = MaterialTheme.typography.bodyMedium
             )
             Spacer(modifier = Modifier.height(4.dp))
@@ -144,14 +147,12 @@ fun RoomSettingsSheet(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             Spacer(modifier = Modifier.height(8.dp))
-            var sliderValue by remember(uiState.minGiftAnimationValue) {
-                mutableStateOf(uiState.minGiftAnimationValue.toFloat())
-            }
             Slider(
                 value = sliderValue,
                 onValueChange = { sliderValue = it },
                 onValueChangeFinished = { viewModel.setMinGiftAnimationValue(sliderValue.toInt()) },
-                valueRange = 0f..10000f
+                valueRange = 0f..10000f,
+                modifier = Modifier.padding(horizontal = 24.dp)
             )
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/SuperShyBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/shop/SuperShyBottomSheet.kt
@@ -25,6 +25,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -224,12 +228,21 @@ fun SuperShyBottomSheet(
                 }
             } else {
                 // Not Super Shy — show trial card + all pricing
-                if (onClaimTrial != null && !user.hasClaimedSuperShyTrial) {
+                var claiming by remember { mutableStateOf(false) }
+                var claimed by remember { mutableStateOf(false) }
+                // Detect when claim succeeds (user object updates while we were claiming)
+                if (claiming && user.hasClaimedSuperShyTrial && !claimed) {
+                    claimed = true
+                }
+                if (onClaimTrial != null && (!user.hasClaimedSuperShyTrial || claimed)) {
                     Card(
                         onClick = {
-                            onClaimTrial()
-                            onDismiss()
+                            if (!claiming && !claimed) {
+                                claiming = true
+                                onClaimTrial()
+                            }
                         },
+                        enabled = !claiming && !claimed,
                         modifier = Modifier.fillMaxWidth(),
                         shape = RoundedCornerShape(12.dp),
                         colors = CardDefaults.cardColors(
@@ -249,17 +262,43 @@ fun SuperShyBottomSheet(
                                 modifier = Modifier.size(24.dp)
                             )
                             Spacer(modifier = Modifier.height(4.dp))
-                            Text(
-                                "Free 1-Month Trial",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = SuperShyGold
-                            )
-                            Text(
-                                "Tap to claim — goes to your backpack",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
+                            when {
+                                claimed -> {
+                                    Text(
+                                        "Claimed!",
+                                        style = MaterialTheme.typography.titleMedium,
+                                        fontWeight = FontWeight.Bold,
+                                        color = SuperShyGold
+                                    )
+                                    Text(
+                                        "To activate it, find it in your backpack while in a chat room.",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        textAlign = TextAlign.Center
+                                    )
+                                }
+                                claiming -> {
+                                    Text(
+                                        "Claiming...",
+                                        style = MaterialTheme.typography.titleMedium,
+                                        fontWeight = FontWeight.Bold,
+                                        color = SuperShyGold
+                                    )
+                                }
+                                else -> {
+                                    Text(
+                                        "Claim 30 Days Free",
+                                        style = MaterialTheme.typography.titleMedium,
+                                        fontWeight = FontWeight.Bold,
+                                        color = SuperShyGold
+                                    )
+                                    Text(
+                                        "Tap to claim — added to your backpack",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
                         }
                     }
                     Spacer(modifier = Modifier.height(12.dp))


### PR DESCRIPTION
## Summary
- **Gacha UX overhaul**: Spin results display inline (not fullscreen), spin buttons stay visible during animation, tap outside to close, configurable inner ring threshold, removed all rarity terminology
- **Daily gift rewards**: Milestone rewards can now grant gifts (not just coins), with backpack integration
- **Notification dedup**: Suppress duplicate seat notifications when RequestApproved and InviteReceived fire together
- **QoL**: Super Shy trial claim shows success message, backpack "Use" shows "Using...", keyboard dismisses on tap outside in chat, admin panel enhancements

## Test plan
- [x] 1708 Kotlin unit tests pass
- [x] 455 Cloud Functions tests pass
- [x] Installed on both devices (CPH2747 + CPH2653)
- [x] Cloud Functions deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)