### PR TITLE
v0.44 — Gacha UX overhaul, daily gift rewards, remove share profile & QoL

### DIFF
--- a/PM_TEST_PLAN.md
+++ b/PM_TEST_PLAN.md
@@ -411,26 +411,6 @@
 
 ---
 
-## Phase 21: Share Profile Link
-
-### TC-21.1: Share button on profile
-- [ ] Navigate to another user's profile
-- [ ] Tap the share icon in the top bar
-- [ ] Verify Android share sheet opens
-- [ ] Verify share text contains: profile name + `https://shytalk.shyden.co.uk/profile/{userId}`
-
-### TC-21.2: Deep link opens profile
-- [ ] Share a profile link to yourself (e.g., via clipboard)
-- [ ] Open the link
-- [ ] Verify ShyTalk opens and navigates to the correct user profile
-
-### TC-21.3: Deep link cold start
-- [ ] Force-close ShyTalk
-- [ ] Tap a profile deep link
-- [ ] Verify app launches and navigates to the profile after auth check
-
----
-
 ## Phase 22: Do Not Disturb Schedule
 
 ### TC-22.1: Enable DND
@@ -530,4 +510,4 @@
 - All Firestore document checks can be done via Firebase Console
 - For DND testing, you may need to adjust device time or set DND window to current time
 - Cloud Function logs viewable via `firebase functions:log`
-- For deep link testing, use `adb shell am start -a android.intent.action.VIEW -d "https://shytalk.shyden.co.uk/profile/USER_ID" com.shyden.shytalk`
+- For deep link testing, use `adb shell am start` with the appropriate intent URI

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 43
-        versionName = "0.43"
+        versionCode = 44
+        versionName = "0.44"
 
         testInstrumentationRunner = "com.shyden.shytalk.ShyTalkTestRunner"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,15 +37,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data
-                    android:scheme="https"
-                    android:host="shytalk.shyden.co.uk"
-                    android:pathPrefix="/profile/" />
-            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/java/com/shyden/shytalk/MainActivity.kt
+++ b/app/src/main/java/com/shyden/shytalk/MainActivity.kt
@@ -38,7 +38,6 @@ class MainActivity : ComponentActivity() {
     private val activeRoomManager: RoomLifecycleManager by inject()
 
     private val _navigateToRoom = mutableStateOf<String?>(null)
-    private val _navigateToProfile = mutableStateOf<String?>(null)
     private val _navigateToChat = mutableStateOf<Pair<String, Boolean>?>(null) // (id, isGroup)
     private val _showLeaveConfirmation = mutableStateOf(false)
 
@@ -105,8 +104,6 @@ class MainActivity : ComponentActivity() {
                             val navController = rememberNavController()
                             val navigateToRoomId by _navigateToRoom
 
-                            val navigateToProfileId by _navigateToProfile
-
                             LaunchedEffect(navigateToRoomId) {
                                 val roomId = navigateToRoomId
                                 if (roomId != null) {
@@ -114,16 +111,6 @@ class MainActivity : ComponentActivity() {
                                         launchSingleTop = true
                                     }
                                     _navigateToRoom.value = null
-                                }
-                            }
-
-                            LaunchedEffect(navigateToProfileId) {
-                                val profileId = navigateToProfileId
-                                if (profileId != null) {
-                                    navController.navigate(Screen.UserProfile.createRoute(profileId)) {
-                                        launchSingleTop = true
-                                    }
-                                    _navigateToProfile.value = null
                                 }
                             }
 
@@ -231,16 +218,6 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun handleRoomIntent(intent: Intent?) {
-        // Handle deep links (https://shytalk.shyden.co.uk/profile/{userId})
-        val data = intent?.data
-        if (data != null && data.host == "shytalk.shyden.co.uk") {
-            val pathSegments = data.pathSegments
-            if (pathSegments.size >= 2 && pathSegments[0] == "profile") {
-                _navigateToProfile.value = pathSegments[1]
-                return
-            }
-        }
-
         // Handle PM notification tap (navigateTo=chat)
         val navigateTo = intent?.getStringExtra("navigateTo")
         if (navigateTo == "chat") {

--- a/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
@@ -304,21 +304,7 @@ fun ProfileScreen(
                             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                         }
                     },
-                    actions = {
-                        val context = LocalContext.current
-                        IconButton(onClick = {
-                            val user = uiState.user ?: return@IconButton
-                            val shareText = "Check out ${user.displayName}'s profile on ShyTalk!\nhttps://shytalk.shyden.co.uk/profile/${user.uid}"
-                            val sendIntent = Intent().apply {
-                                action = Intent.ACTION_SEND
-                                putExtra(Intent.EXTRA_TEXT, shareText)
-                                type = "text/plain"
-                            }
-                            context.startActivity(Intent.createChooser(sendIntent, "Share Profile"))
-                        }) {
-                            Icon(Icons.Default.Share, contentDescription = "Share profile")
-                        }
-                    }
+                    actions = {}
                 )
             }
         ) { padding ->

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,4 +1,4 @@
-v0.43 - Gacha UX Overhaul, Daily Gift Rewards & QoL
+v0.44 - Gacha UX Overhaul, Daily Gift Rewards & QoL
 
 - Gacha spin results now show inline instead of fullscreen
 - Spin buttons stay visible during animation
@@ -10,4 +10,5 @@ v0.43 - Gacha UX Overhaul, Daily Gift Rewards & QoL
 - Keyboard dismisses when tapping outside chat input
 - Fixed duplicate seat notification when access granted
 - Removed all rarity tier terminology from gacha
+- Removed share profile button and deep links
 - Admin panel: wheel threshold, guarantee pull, send backpack


### PR DESCRIPTION
## Summary
- **Gacha UX overhaul**: Inline spin results, buttons stay visible during animation, tap outside to close, configurable inner ring threshold, removed all rarity terminology
- **Daily gift rewards**: Milestone rewards can now grant gifts (not just coins)
- **Notification dedup**: Suppress duplicate seat notifications (RequestApproved + InviteReceived)
- **Remove share profile**: Removed share button, deep link handler, and manifest intent filter
- **QoL**: Super Shy trial claim success message, backpack "Using..." feedback, keyboard dismiss on tap outside, admin panel enhancements

## Test plan
- [x] 1708 Kotlin unit tests pass
- [x] 455 Cloud Functions tests pass
- [ ] E2E tests (devices not connected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)