### PR TITLE
Upgrade Kotlin from 2.2.10 to 2.3.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "9.0.1"
-kotlin = "2.2.10"
+kotlin = "2.3.10"
 composeMultiplatform = "1.10.1"
 composeBom = "2026.01.01"
 coreKtx = "1.17.0"


### PR DESCRIPTION
## Summary
- Upgrade Kotlin from 2.2.10 to 2.3.10 (latest stable)

## Test plan
- [x] 1708 Kotlin unit tests pass
- [x] 455 Cloud Functions tests pass (unaffected)
- [x] Compile succeeds with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)