### PR TITLE
Simplify splash screen and fix conversation list speed

### DIFF
--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,7 +1,7 @@
-v0.48 — Closed Room UX & Chat Fixes
+v0.48 — Performance & UX Polish
 
-- Closed rooms now show speaker photos and visitor count instead of empty cards
-- Room invite previews in chat auto-scroll into view when they load
-- Smoother room closing experience with loading indicator
-- Conversation list loads instantly when returning from a chat
-- Fixed a test stability issue with coroutine lifecycle management
+- Clean splash screen with just logo and app name
+- Conversation list now loads instantly (settings refresh in background)
+- Closed rooms show speaker photos and visitor count instead of empty cards
+- Room invite previews auto-scroll into view when they load
+- Smoother room closing with loading indicator

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ConversationListViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ConversationListViewModel.kt
@@ -112,61 +112,61 @@ class ConversationListViewModel(
             }
         }
 
-        // Fetch settings for each conversation
-        val conversationsWithDetails = conversations.mapNotNull { conversation ->
-            // Fetch settings (always re-fetch to pick up unread count changes)
-            val settings = when (val result = pmRepository.getConversationSettings(conversation.conversationId, currentUserId)) {
-                is Resource.Success -> {
-                    settingsCache[conversation.conversationId] = result.data
-                    result.data
-                }
-                else -> settingsCache[conversation.conversationId]
-            }
+        // Show conversations immediately with cached settings (no blocking network calls)
+        val conversationsWithDetails = buildConversationList(conversations, blockedByMe)
+        emitSortedConversations(conversationsWithDetails)
 
-            // Filter hidden conversations (unless a new message arrived after hiding)
-            if (settings?.isHidden == true) {
-                val hiddenAt = settings.hiddenAt ?: 0
-                if (conversation.lastMessageAt <= hiddenAt) return@mapNotNull null
-            }
+        // Then refresh settings in background for accurate unread counts
+        refreshSettingsInBackground(conversations)
+    }
 
-            if (conversation.isGroup) {
-                // Skip closed groups
-                if (conversation.isClosed) return@mapNotNull null
-                ConversationWithUser(
-                    conversation = conversation,
-                    otherUser = null,
-                    settings = settings,
-                    isBlocked = false,
-                    isGroup = true,
-                    groupName = conversation.groupName,
-                    groupPhotoUrl = conversation.groupPhotoUrl
-                )
-            } else {
-                val otherUserId = conversation.otherUserId(currentUserId) ?: return@mapNotNull null
-                val otherUser = userCache[otherUserId]
+    private fun buildConversationList(
+        conversations: List<Conversation>,
+        blockedByMe: Set<String>
+    ): List<ConversationWithUser> = conversations.mapNotNull { conversation ->
+        val settings = settingsCache[conversation.conversationId]
 
-                // Skip blocking checks for system user
-                val isSystemConversation = otherUserId == Constants.SYSTEM_USER_ID
-                if (!isSystemConversation) {
-                    // Check block status bidirectionally
-                    val blockedByTarget = otherUser?.blockedUserIds?.contains(currentUserId) == true
-                    val isBlocked = otherUserId in blockedByMe || blockedByTarget
-
-                    // Skip blocked conversations
-                    if (isBlocked) return@mapNotNull null
-                }
-
-                ConversationWithUser(
-                    conversation = conversation,
-                    otherUser = otherUser,
-                    settings = settings,
-                    isBlocked = false
-                )
-            }
+        // Filter hidden conversations (unless a new message arrived after hiding)
+        if (settings?.isHidden == true) {
+            val hiddenAt = settings.hiddenAt ?: 0
+            if (conversation.lastMessageAt <= hiddenAt) return@mapNotNull null
         }
 
-        // Sort: system conversations first, then pinned, then by lastMessageAt desc
-        val sorted = conversationsWithDetails.sortedWith(
+        if (conversation.isGroup) {
+            // Skip closed groups
+            if (conversation.isClosed) return@mapNotNull null
+            ConversationWithUser(
+                conversation = conversation,
+                otherUser = null,
+                settings = settings,
+                isBlocked = false,
+                isGroup = true,
+                groupName = conversation.groupName,
+                groupPhotoUrl = conversation.groupPhotoUrl
+            )
+        } else {
+            val otherUserId = conversation.otherUserId(currentUserId) ?: return@mapNotNull null
+            val otherUser = userCache[otherUserId]
+
+            // Skip blocking checks for system user
+            val isSystemConversation = otherUserId == Constants.SYSTEM_USER_ID
+            if (!isSystemConversation) {
+                val blockedByTarget = otherUser?.blockedUserIds?.contains(currentUserId) == true
+                val isBlocked = otherUserId in blockedByMe || blockedByTarget
+                if (isBlocked) return@mapNotNull null
+            }
+
+            ConversationWithUser(
+                conversation = conversation,
+                otherUser = otherUser,
+                settings = settings,
+                isBlocked = false
+            )
+        }
+    }
+
+    private fun emitSortedConversations(list: List<ConversationWithUser>) {
+        val sorted = list.sortedWith(
             compareByDescending<ConversationWithUser> {
                 it.conversation.otherUserId(currentUserId) == Constants.SYSTEM_USER_ID
             }
@@ -184,6 +184,34 @@ class ConversationListViewModel(
                 isLoading = false,
                 totalUnreadCount = totalUnread
             )
+        }
+    }
+
+    private fun refreshSettingsInBackground(conversations: List<Conversation>) {
+        viewModelScope.launch {
+            var anyChanged = false
+            for (conversation in conversations) {
+                val result = pmRepository.getConversationSettings(
+                    conversation.conversationId, currentUserId
+                )
+                if (result is Resource.Success) {
+                    val old = settingsCache[conversation.conversationId]
+                    if (old != result.data) {
+                        settingsCache[conversation.conversationId] = result.data
+                        anyChanged = true
+                    }
+                }
+            }
+            // Re-render once if any settings changed (e.g. unread counts)
+            if (anyChanged) {
+                val currentUser = when (val result = userRepository.getUser(currentUserId)) {
+                    is Resource.Success -> result.data
+                    else -> null
+                }
+                val blockedByMe = currentUser?.blockedUserIds ?: emptySet()
+                val refreshed = buildConversationList(conversations, blockedByMe)
+                emitSortedConversations(refreshed)
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/splash/FunFactSplashScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/splash/FunFactSplashScreen.kt
@@ -1,39 +1,26 @@
 package com.shyden.shytalk.feature.splash
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.shyden.shytalk.core.model.FunFact
-import kotlinx.coroutines.delay
 
 @Composable
 fun FunFactSplashScreen(
@@ -42,201 +29,65 @@ fun FunFactSplashScreen(
     onContinue: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    // Auto-navigate when warmup finishes
+    LaunchedEffect(warmUpComplete) {
+        if (warmUpComplete) onContinue()
+    }
+
+    val primaryColor = MaterialTheme.colorScheme.primary
+    val blushColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)
+
     Surface(
         modifier = modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background
     ) {
         Column(
-            modifier = Modifier.fillMaxSize().padding(24.dp),
+            modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
+            // Speech bubble logo
+            Canvas(modifier = Modifier.size(96.dp)) {
+                val w = size.width
+                val h = size.height
+
+                // Speech bubble body
+                drawRoundRect(
+                    color = primaryColor,
+                    topLeft = Offset(w * 0.12f, w * 0.08f),
+                    size = Size(w * 0.76f, h * 0.52f),
+                    cornerRadius = CornerRadius(w * 0.08f)
+                )
+
+                // Speech bubble tail
+                val tail = Path().apply {
+                    moveTo(w * 0.22f, h * 0.58f)
+                    lineTo(w * 0.14f, h * 0.72f)
+                    lineTo(w * 0.40f, h * 0.58f)
+                    close()
+                }
+                drawPath(tail, color = primaryColor)
+
+                // Three dots
+                val dotY = h * 0.34f
+                val dotRadius = w * 0.035f
+                drawCircle(color = androidx.compose.ui.graphics.Color.White, radius = dotRadius, center = Offset(w * 0.36f, dotY), alpha = 0.9f)
+                drawCircle(color = androidx.compose.ui.graphics.Color.White, radius = dotRadius, center = Offset(w * 0.50f, dotY), alpha = 0.65f)
+                drawCircle(color = androidx.compose.ui.graphics.Color.White, radius = dotRadius, center = Offset(w * 0.64f, dotY), alpha = 0.4f)
+
+                // Blush marks
+                drawOval(color = blushColor, topLeft = Offset(w * 0.18f, h * 0.42f), size = Size(w * 0.14f, h * 0.08f))
+                drawOval(color = blushColor, topLeft = Offset(w * 0.68f, h * 0.42f), size = Size(w * 0.14f, h * 0.08f))
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
             Text(
                 text = "ShyTalk",
                 style = MaterialTheme.typography.headlineLarge,
                 color = MaterialTheme.colorScheme.primary,
                 fontWeight = FontWeight.Bold
             )
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            if (funFacts.isNotEmpty()) {
-                FunFactCarousel(
-                    facts = funFacts,
-                    modifier = Modifier.fillMaxWidth().weight(1f, fill = false)
-                )
-            } else {
-                // Loading state before facts arrive
-                FunFactPlaceholder()
-            }
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            AnimatedContent(
-                targetState = warmUpComplete,
-                transitionSpec = { fadeIn() togetherWith fadeOut() },
-                label = "splash_bottom"
-            ) { ready ->
-                if (ready) {
-                    Button(
-                        onClick = onContinue,
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp)
-                    ) {
-                        Text("Continue")
-                    }
-                } else {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(24.dp),
-                            strokeWidth = 2.dp,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            text = "Warming up...",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-                        )
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-        }
-    }
-}
-
-@Composable
-private fun FunFactCarousel(
-    facts: List<FunFact>,
-    modifier: Modifier = Modifier
-) {
-    val pagerState = rememberPagerState(pageCount = { facts.size })
-
-    // Auto-advance every 5 seconds
-    LaunchedEffect(pagerState, facts.size) {
-        if (facts.size <= 1) return@LaunchedEffect
-        while (true) {
-            delay(5000)
-            val next = (pagerState.currentPage + 1) % facts.size
-            pagerState.animateScrollToPage(next)
-        }
-    }
-
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            text = "Did you know?",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        HorizontalPager(
-            state = pagerState,
-            modifier = Modifier.fillMaxWidth()
-        ) { page ->
-            FunFactCard(fact = facts[page])
-        }
-
-        // Page indicator dots
-        if (facts.size > 1) {
-            Spacer(modifier = Modifier.height(12.dp))
-            PageIndicator(
-                pageCount = facts.size,
-                currentPage = pagerState.currentPage
-            )
-        }
-    }
-}
-
-@Composable
-private fun FunFactCard(fact: FunFact) {
-    Surface(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-        shape = RoundedCornerShape(16.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        tonalElevation = 2.dp
-    ) {
-        Column(
-            modifier = Modifier.padding(24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            if (fact.emoji.isNotBlank()) {
-                Text(
-                    text = fact.emoji,
-                    style = MaterialTheme.typography.displaySmall
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-            }
-
-            Text(
-                text = fact.text,
-                style = MaterialTheme.typography.bodyLarge,
-                textAlign = TextAlign.Center,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            val label = buildString {
-                val categoryLabels = mapOf(
-                    "language" to "Language",
-                    "greeting" to "Greeting",
-                    "culture" to "Culture",
-                    "trivia" to "Trivia"
-                )
-                append(categoryLabels[fact.category] ?: fact.category)
-                if (fact.sourceLanguage.isNotBlank()) {
-                    append(" · ")
-                    append(fact.sourceLanguage)
-                }
-            }
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-            )
-        }
-    }
-}
-
-@Composable
-private fun FunFactPlaceholder() {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        CircularProgressIndicator(
-            modifier = Modifier.size(32.dp),
-            strokeWidth = 3.dp,
-            color = MaterialTheme.colorScheme.primary
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = "Getting things ready...",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center
-        )
-    }
-}
-
-@Composable
-private fun PageIndicator(pageCount: Int, currentPage: Int) {
-    androidx.compose.foundation.layout.Row(
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        repeat(pageCount) { i ->
-            Surface(
-                modifier = Modifier.size(if (i == currentPage) 8.dp else 6.dp),
-                shape = androidx.compose.foundation.shape.CircleShape,
-                color = if (i == currentPage) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
-            ) {}
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Splash screen**: Replaced fun fact carousel with clean logo + "ShyTalk" name only, auto-navigates when warmup completes
- **Conversation list**: Renders instantly using cached settings instead of blocking on N sequential `getConversationSettings` API calls; unread counts refresh in background

## Test plan
- [ ] Launch app → see only logo and "ShyTalk" name on splash, auto-navigates when ready
- [ ] Navigate to messages → conversation list appears instantly
- [ ] Unread badge counts update shortly after list appears
- [x] `./gradlew test` — all 1808 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)