### PR TITLE
Add R2 backup system, fix data loss bug, room lifecycle fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ scripts/migrate-*.mjs
 
 # Archived Cloud Functions (deleted from project)
 functions-archive/
+
+# R2 local backups
+backups/

--- a/app/src/main/java/com/shyden/shytalk/core/room/ActiveRoomManager.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/room/ActiveRoomManager.kt
@@ -223,6 +223,20 @@ class ActiveRoomManager(
         // Non-owners leave the participant list
         if (!isOwner) {
             roomRepository.leaveRoom(roomId, userId)
+
+            // If no non-owner seats remain in an OWNER_AWAY room, close it —
+            // don't count unseated visitors, only seated users matter.
+            if (room.state == RoomState.OWNER_AWAY) {
+                val othersStillSeated = room.seats.any { (_, seat) ->
+                    seat.userId != null && seat.userId != userId
+                        && seat.userId != room.ownerId
+                        && seat.state == SeatState.OCCUPIED
+                }
+                if (!othersStillSeated) {
+                    Log.d(TAG, "leaveRoom: no seated non-owners left in OWNER_AWAY room → closeRoom")
+                    roomRepository.closeRoom(roomId)
+                }
+            }
         }
 
         cleanup()
@@ -330,6 +344,15 @@ class ActiveRoomManager(
                     }
 
                     _activeRoom.value = room
+
+                    // Close OWNER_AWAY room immediately if no non-owner seats remain
+                    if (room.state == RoomState.OWNER_AWAY && !room.hasSeatedNonOwners()) {
+                        Log.d(TAG, "Room observation: OWNER_AWAY with no seated non-owners → closeRoom")
+                        ownerAwayCountdownJob?.cancel()
+                        roomRepository.closeRoom(room.roomId)
+                        return@collect
+                    }
+
                     handleOwnerAwayCountdown(room)
                 }
         }
@@ -430,7 +453,15 @@ class ActiveRoomManager(
                         if (userId in graceTimers) continue
                         graceTimers[userId] = scope.launch {
                             delay(Constants.PRESENCE_TIMEOUT_MS)
-                            roomRepository.removeDisconnectedUser(roomId, userId)
+
+                            // Owner disconnect → transition to OWNER_AWAY instead of removing
+                            val latestRoom = _activeRoom.value
+                            if (userId == latestRoom?.ownerId && latestRoom.state == RoomState.ACTIVE) {
+                                Log.d(TAG, "presenceMonitor: owner absent → setOwnerAway")
+                                roomRepository.setOwnerAway(roomId)
+                            } else {
+                                roomRepository.removeDisconnectedUser(roomId, userId)
+                            }
                             graceTimers.remove(userId)
                             emitDisconnectedIds()
                         }

--- a/app/src/main/java/com/shyden/shytalk/data/remote/AndroidAppConfigService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/AndroidAppConfigService.kt
@@ -27,7 +27,7 @@ class AndroidAppConfigService(
 
     override suspend fun checkBackendHealth(): Resource<BackendHealthStatus> {
         return try {
-            val json = api.get("/api/health")
+            val json = api.getPublic("/api/health")
             val data = json.toMap()
             Resource.Success(BackendHealthStatus(
                 status = data["status"] as? String ?: "ok",

--- a/app/src/main/java/com/shyden/shytalk/data/remote/WorkerApiClient.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/WorkerApiClient.kt
@@ -50,6 +50,19 @@ class WorkerApiClient(
             Request.Builder().url(url).header("Authorization", "Bearer $token").get().build()
         }
 
+    /** GET without authentication — for public endpoints like /api/health. */
+    suspend fun getPublic(path: String): JSONObject {
+        val url = "$baseUrl$path"
+        val request = Request.Builder().url(url).get().build()
+        val response = httpClient.newCall(request).executeAsync()
+        val bodyStr = response.use { it.body?.string() ?: "{}" }
+        if (!response.isSuccessful) {
+            val error = try { JSONObject(bodyStr).optString("error", "Request failed") } catch (_: Exception) { "HTTP ${response.code}" }
+            throw ApiException(response.code, error)
+        }
+        return JSONObject(bodyStr)
+    }
+
     suspend fun getArray(path: String): JSONArray =
         executeArrayWithRetry(path) { url, token ->
             Request.Builder().url(url).header("Authorization", "Bearer $token").get().build()

--- a/app/src/main/java/com/shyden/shytalk/data/repository/BannerRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/BannerRepositoryImpl.kt
@@ -12,15 +12,14 @@ class BannerRepositoryImpl(
         val now = System.currentTimeMillis()
         val snapshot = firestore.collection("banners")
             .whereEqualTo("isActive", true)
-            .whereLessThanOrEqualTo("startDate", now)
             .get()
             .await()
         return snapshot.documents
             .mapNotNull { doc ->
                 val data = doc.data ?: return@mapNotNull null
-                // Filter out expired banners client-side (Firestore can't do AND on two range fields)
+                val startDate = (data["startDate"] as? Long) ?: 0L
                 val endDate = (data["endDate"] as? Long) ?: Long.MAX_VALUE
-                if (endDate < now) return@mapNotNull null
+                if (startDate > now || endDate < now) return@mapNotNull null
                 Banner.fromMap(data, doc.id)
             }
             .sortedBy { it.sortOrder }

--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
@@ -77,7 +77,10 @@ class RoomRepositoryImpl(
         val roomId = firestore.collection("rooms").document().id
         val timestamp = System.currentTimeMillis()
         val emptySeat = mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false)
-        val seats = (0..7).associate { it.toString() to emptySeat }
+        val ownerSeat = mapOf("userId" to ownerId, "state" to "OCCUPIED", "isMuted" to false)
+        val seats = (0..7).associate { i ->
+            i.toString() to if (i == 0) ownerSeat else emptySeat
+        }
         val roomData = mapOf(
             "id" to roomId,
             "name" to name,
@@ -94,7 +97,7 @@ class RoomRepositoryImpl(
             "requireApproval" to false,
             "firstJoinTimestamps" to emptyMap<String, Any>(),
             "allTimeHostIds" to emptyList<String>(),
-            "allTimeSeatUserIds" to emptyList<String>(),
+            "allTimeSeatUserIds" to listOf(ownerId),
         )
         firestore.document("rooms/$roomId").set(roomData).await()
         firestore.document("users/$ownerId").update("currentRoomId", roomId).await()

--- a/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/profile/ProfileScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -285,6 +286,8 @@ fun ProfileScreen(
                 onNavigateToWallet = onNavigateToWallet,
                 onTestPurchaseSuperShy = onTestPurchaseSuperShy,
                 onClaimTrial = { viewModel.claimSuperShyTrial() },
+                isRefreshing = uiState.isRefreshing,
+                onRefresh = { viewModel.refreshProfile() },
                 snackbarHostState = snackbarHostState,
                 modifier = Modifier.fillMaxSize()
             )
@@ -337,6 +340,8 @@ fun ProfileScreen(
                 onNavigateToWallet = onNavigateToWallet,
                 onTestPurchaseSuperShy = onTestPurchaseSuperShy,
                 onClaimTrial = { viewModel.claimSuperShyTrial() },
+                isRefreshing = uiState.isRefreshing,
+                onRefresh = { viewModel.refreshProfile() },
                 snackbarHostState = snackbarHostState,
                 modifier = Modifier
                     .fillMaxSize()
@@ -483,6 +488,8 @@ private fun ProfileContent(
     onNavigateToWallet: (() -> Unit)? = null,
     onTestPurchaseSuperShy: ((String) -> Unit)? = null,
     onClaimTrial: (() -> Unit)? = null,
+    isRefreshing: Boolean = false,
+    onRefresh: () -> Unit = {},
     snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier
 ) {
@@ -602,8 +609,13 @@ private fun ProfileContent(
     val giftingViewModel: GiftingViewModel? = if (isOwn) koinInject() else null
     val giftingState = giftingViewModel?.uiState?.collectAsStateWithLifecycle()
 
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
+        modifier = modifier.fillMaxSize()
+    ) {
     Column(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
     ) {
@@ -1239,6 +1251,7 @@ private fun ProfileContent(
         }
 
         Spacer(modifier = Modifier.height(16.dp))
+    }
     }
 
     // Super Shy bottom sheet

--- a/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -61,10 +61,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MicOff
 import androidx.compose.material3.Icon
 import com.shyden.shytalk.core.util.Constants
+import com.shyden.shytalk.ui.theme.DarkColorScheme
 import com.shyden.shytalk.core.model.RoomRole
 import com.shyden.shytalk.core.model.RoomState
 import com.shyden.shytalk.core.model.SeatState
 import com.shyden.shytalk.feature.room.components.ChatPanel
+import com.shyden.shytalk.feature.room.components.RoomStarfieldBackground
 import com.shyden.shytalk.feature.room.components.OwnerAwayBanner
 import com.shyden.shytalk.feature.room.components.ParticipantInfo
 import com.shyden.shytalk.feature.room.components.ParticipantListPanel
@@ -568,11 +570,11 @@ fun RoomScreen(
         uiState.allKnownUsers
     }
 
+    MaterialTheme(colorScheme = DarkColorScheme) {
     Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
+        modifier = Modifier.fillMaxSize()
     ) {
+        RoomStarfieldBackground(modifier = Modifier.fillMaxSize())
         Scaffold(
             containerColor = Color.Transparent,
             snackbarHost = {
@@ -1211,5 +1213,6 @@ fun RoomScreen(
             )
         }
         }
+    }
     }
 }

--- a/app/src/test/java/com/shyden/shytalk/core/room/ActiveRoomManagerTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/room/ActiveRoomManagerTest.kt
@@ -792,10 +792,11 @@ class ActiveRoomManagerTest {
 
         testScheduler.advanceTimeBy(Constants.PRESENCE_TIMEOUT_MS + 100)
 
-        // Should not try to remove self; seated users and unseated participants are sent to
-        // removeDisconnectedUser (Firestore transaction handles owner protection server-side)
+        // Should not try to remove self; owner absence triggers setOwnerAway instead of removal;
+        // unseated non-owner participants are removed normally
         coVerify(exactly = 0) { roomRepository.removeDisconnectedUser("room-1", currentUserId) }
-        coVerify { roomRepository.removeDisconnectedUser("room-1", "other-owner") }
+        coVerify { roomRepository.setOwnerAway("room-1") }
+        coVerify(exactly = 0) { roomRepository.removeDisconnectedUser("room-1", "other-owner") }
         coVerify { roomRepository.removeDisconnectedUser("room-1", "unseated-participant") }
     }
 

--- a/app/src/test/java/com/shyden/shytalk/feature/messaging/GroupSetupViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/messaging/GroupSetupViewModelTest.kt
@@ -16,6 +16,8 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.job
@@ -47,6 +49,8 @@ class GroupSetupViewModelTest {
 
     @Before
     fun setup() {
+        mockkStatic("com.shyden.shytalk.core.util.ImageCompressor_androidKt")
+        coEvery { com.shyden.shytalk.core.util.compressImage(any(), any(), any()) } answers { firstArg() }
         every { authRepository.currentUserId } returns "me"
         coEvery { pmRepository.getOwnedGroupCount("me") } returns Resource.Success(0)
     }
@@ -55,6 +59,7 @@ class GroupSetupViewModelTest {
     fun tearDown() = runBlocking {
         activeViewModels.forEach { it.viewModelScope.coroutineContext.job.cancelAndJoin() }
         activeViewModels.clear()
+        unmockkStatic("com.shyden.shytalk.core.util.ImageCompressor_androidKt")
     }
 
     private fun createViewModel(selectedIds: String = "u1,u2"): GroupSetupViewModel {
@@ -253,6 +258,7 @@ class GroupSetupViewModelTest {
         vm.setGroupName("Test Group")
         vm.setGroupPhoto(byteArrayOf(1, 2, 3))
         vm.createGroup()
+        kotlinx.coroutines.delay(50) // Allow Dispatchers.Default (compressImage) to complete
         advanceUntilIdle()
 
         assertEquals("new-conv", vm.uiState.value.createdConversationId)
@@ -474,6 +480,7 @@ class GroupSetupViewModelTest {
         vm.setGroupName("Photo Group")
         vm.setGroupPhoto(byteArrayOf(1, 2, 3))
         vm.createGroup()
+
         advanceUntilIdle()
 
         assertEquals("Failed to upload group photo", vm.uiState.value.error)

--- a/app/src/test/java/com/shyden/shytalk/feature/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/profile/ProfileViewModelTest.kt
@@ -16,6 +16,8 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.job
@@ -54,6 +56,8 @@ class ProfileViewModelTest {
 
     @Before
     fun setup() {
+        mockkStatic("com.shyden.shytalk.core.util.ImageCompressor_androidKt")
+        coEvery { com.shyden.shytalk.core.util.compressImage(any(), any(), any()) } answers { firstArg() }
         every { authRepository.currentUserId } returns currentUserId
         every { authRepository.currentUserEmail } returns "test@example.com"
         every { userRepository.userUpdates } returns MutableSharedFlow()
@@ -63,6 +67,7 @@ class ProfileViewModelTest {
     fun tearDown() = runBlocking {
         activeViewModels.forEach { it.viewModelScope.coroutineContext.job.cancelAndJoin() }
         activeViewModels.clear()
+        unmockkStatic("com.shyden.shytalk.core.util.ImageCompressor_androidKt")
     }
 
     private fun createViewModel(): ProfileViewModel {
@@ -387,6 +392,7 @@ class ProfileViewModelTest {
         advanceUntilIdle()
 
         vm.uploadProfilePhoto(byteArrayOf(1, 2, 3))
+
         advanceUntilIdle()
 
         assertEquals("https://photo.url", vm.uiState.value.user?.profilePhotoUrl)
@@ -399,6 +405,7 @@ class ProfileViewModelTest {
 
         val vm = createViewModel()
         vm.uploadProfilePhoto(byteArrayOf(1))
+
         advanceUntilIdle()
 
         assertEquals("upload failed", vm.uiState.value.error)
@@ -412,6 +419,7 @@ class ProfileViewModelTest {
 
         val vm = createViewModel()
         vm.uploadProfilePhoto(byteArrayOf(1))
+
         advanceUntilIdle()
 
         assertNotNull(vm.uiState.value.error)
@@ -431,6 +439,7 @@ class ProfileViewModelTest {
         advanceUntilIdle()
 
         vm.uploadProfilePhoto(byteArrayOf(1, 2))
+
         advanceUntilIdle()
 
         coVerify { storageRepository.deleteImageByUrl(oldUrl) }
@@ -448,6 +457,7 @@ class ProfileViewModelTest {
         advanceUntilIdle()
 
         vm.uploadProfilePhoto(byteArrayOf(1, 2))
+
         advanceUntilIdle()
 
         coVerify(exactly = 0) { storageRepository.deleteImageByUrl(any()) }
@@ -465,6 +475,7 @@ class ProfileViewModelTest {
         advanceUntilIdle()
 
         vm.uploadProfilePhoto(byteArrayOf(1))
+
         advanceUntilIdle()
 
         coVerify(exactly = 0) { storageRepository.deleteImageByUrl(any()) }
@@ -483,6 +494,7 @@ class ProfileViewModelTest {
         advanceUntilIdle()
 
         vm.uploadProfilePhoto(byteArrayOf(1))
+
         advanceUntilIdle()
 
         coVerify(exactly = 0) { storageRepository.deleteImageByUrl(any()) }
@@ -502,6 +514,7 @@ class ProfileViewModelTest {
         advanceUntilIdle()
 
         vm.uploadCoverPhoto(byteArrayOf(1, 2))
+
         advanceUntilIdle()
 
         assertEquals("https://cover.url", vm.uiState.value.user?.coverPhotoUrl)
@@ -521,6 +534,7 @@ class ProfileViewModelTest {
         advanceUntilIdle()
 
         vm.uploadCoverPhoto(byteArrayOf(1, 2))
+
         advanceUntilIdle()
 
         coVerify { storageRepository.deleteImageByUrl(oldUrl) }
@@ -532,6 +546,7 @@ class ProfileViewModelTest {
 
         val vm = createViewModel()
         vm.uploadCoverPhoto(byteArrayOf(1))
+
         advanceUntilIdle()
 
         assertEquals("cover upload failed", vm.uiState.value.error)
@@ -1369,6 +1384,7 @@ class ProfileViewModelTest {
 
         val vm = createViewModel()
         vm.uploadProfilePhoto(byteArrayOf(1, 2, 3))
+
         advanceUntilIdle()
 
         coVerify(exactly = 0) { storageRepository.uploadImage(any(), any(), any()) }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -23,6 +23,14 @@
         { "fieldPath": "showInStore", "order": "ASCENDING" },
         { "fieldPath": "order", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "gifts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "showOnWheel", "order": "ASCENDING" },
+        { "fieldPath": "order", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+/cyber_bullying /cyber-bullying 301

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1621,6 +1621,13 @@
         /* --- Reports Panel --- */
         #reports-panel { display: none; }
         #reports-panel.visible { display: block; }
+        #banners-panel { display: none; }
+        #banners-panel.visible { display: block; }
+        #funfacts-panel { display: none; }
+        #funfacts-panel.visible { display: block; }
+        #backups-panel { display: none; }
+        #backups-panel.visible { display: block; }
+        @keyframes spin { to { transform: rotate(360deg); } }
 
         .stats-bar {
           display: flex;
@@ -2255,6 +2262,7 @@
             <button class="tab-btn" id="tab-monitor">Spin Monitor</button>
             <button class="tab-btn" id="tab-banners">Banners</button>
             <button class="tab-btn" id="tab-funfacts">Fun Facts</button>
+            <button class="tab-btn" id="tab-backups">Backups</button>
         </div>
         <button id="signout-btn">Sign Out</button>
     </div>
@@ -2272,7 +2280,10 @@
                 <h3>Identity</h3>
                 <div class="field-group">
                     <label>UID <span class="readonly-badge">READ ONLY</span></label>
-                    <div class="uid-display" id="field-uid"></div>
+                    <div style="display:flex;align-items:center;gap:10px;">
+                        <div class="uid-display" id="field-uid" style="flex:1;"></div>
+                        <button type="button" id="reset-device-binding-btn" style="padding:4px 12px;background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:12px;white-space:nowrap;" title="Remove device bindings for this user">Reset Device Binding</button>
+                    </div>
                 </div>
                 <div class="field-group">
                     <label>Display Name</label>
@@ -2713,8 +2724,6 @@
             <div class="gifts-toolbar">
                 <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
                     <button class="gift-add-btn" id="gift-add-btn">+ Add Gift</button>
-                    <button class="gift-add-btn" id="gift-seed-btn"
-                            style="background:var(--warning);">Seed Defaults</button>
                     <button id="gift-apply-btn">Apply Changes <span class="badge">0</span></button>
                     <button id="gift-discard-btn">Discard</button>
                 </div>
@@ -2942,6 +2951,18 @@
                     <button id="clear-supershy-btn">Remove All Super Shy</button>
                     <div class="maintenance-result" id="clear-supershy-result"></div>
                 </div>
+                <div class="maintenance-card">
+                    <h3>Destroyed Users</h3>
+                    <p>Remove user docs corrupted by the batch update bug (missing createdAt). These users can then re-register fresh.</p>
+                    <button id="clean-destroyed-btn">Clean Destroyed Users</button>
+                    <div class="maintenance-result" id="clean-destroyed-result"></div>
+                </div>
+                <div class="maintenance-card">
+                    <h3>Device Bindings</h3>
+                    <p>Delete all device-to-user bindings. Allows any user to sign in from any device.</p>
+                    <button id="clear-device-bindings-btn">Clear All Device Bindings</button>
+                    <div class="maintenance-result" id="clear-device-bindings-result"></div>
+                </div>
                 <div class="maintenance-card nuclear">
                     <h3>&#9762; RESET ALL</h3>
                     <p>Runs every maintenance action above in sequence. This will wipe system messages,
@@ -3150,7 +3171,6 @@
                 </div>
             </div>
         </div>
-    </div>
 
         <!-- Fun Facts Panel -->
         <div id="funfacts-panel">
@@ -3160,6 +3180,18 @@
                 <button id="funfact-add-btn" style="padding:8px 18px;background:var(--accent);color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:14px;font-weight:600;">+ Add Fun Fact</button>
             </div>
             <div id="funfacts-list" style="display:flex;flex-direction:column;gap:10px;"></div>
+        </div>
+
+        <!-- Backups Panel -->
+        <div id="backups-panel">
+            <h2 style="margin-bottom:16px;">User Profile Backups</h2>
+            <p style="color:var(--text2);margin-bottom:12px;">Daily automated backups to R2. Last 7 days retained.</p>
+            <div style="display:flex;gap:10px;margin-bottom:20px;">
+                <button id="backup-trigger-btn" style="padding:8px 18px;background:var(--accent);color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:14px;font-weight:600;">Backup Now</button>
+                <button id="backup-refresh-btn" style="padding:8px 18px;background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:14px;">Refresh</button>
+                <button id="backup-recover-photos-btn" style="padding:8px 18px;background:#10b981;color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:14px;font-weight:600;">Recover Photos from R2</button>
+            </div>
+            <div id="backups-list" style="display:flex;flex-direction:column;gap:10px;"></div>
         </div>
 
         <!-- Fun Fact Add/Edit Dialog -->
@@ -3201,6 +3233,7 @@
                 </div>
             </div>
         </div>
+    </div>
 </div>
 
 <!-- Toast -->
@@ -3340,6 +3373,11 @@
         const savedTab = localStorage.getItem("admin_tab");
         if (savedTab && ["users", "appeals", "reports", "gifts", "economy", "maintenance", "monitor", "banners", "funfacts"].includes(savedTab)) {
           switchTab(savedTab);
+        }
+        const savedUserSearch = localStorage.getItem("admin_user_search");
+        if (savedUserSearch) {
+          searchUid.value = savedUserSearch;
+          if (!savedTab || savedTab === "users") doSearchFinal();
         }
         const savedReportFilter = localStorage.getItem("admin_report_filter");
         if (savedReportFilter && ["pending", "resolved", "archived"].includes(savedReportFilter)) {
@@ -3877,6 +3915,8 @@
     const monitorPanel = $("#monitor-panel");
     const bannersPanel = $("#banners-panel");
     const funfactsPanel = $("#funfacts-panel");
+    const backupsPanel = $("#backups-panel");
+    const tabBackups = $("#tab-backups");
     let currentTab = "users";
 
     function switchTab(tab) {
@@ -3891,6 +3931,7 @@
       tabMonitor.classList.toggle("active", tab === "monitor");
       tabBanners.classList.toggle("active", tab === "banners");
       tabFunfacts.classList.toggle("active", tab === "funfacts");
+      tabBackups.classList.toggle("active", tab === "backups");
       $(".search-bar").style.display = tab === "users" ? "" : "none";
       userForm.style.display = tab === "users" ? "" : "none";
       appealsPanel.classList.toggle("visible", tab === "appeals");
@@ -3901,12 +3942,22 @@
       monitorPanel.classList.toggle("visible", tab === "monitor");
       bannersPanel.classList.toggle("visible", tab === "banners");
       funfactsPanel.classList.toggle("visible", tab === "funfacts");
+      backupsPanel.classList.toggle("visible", tab === "backups");
 
+      if (tab === "backups") loadBackups();
       if (tab === "appeals") loadAppeals("pending");
       if (tab === "reports") { loadReports(); loadReportStats(); }
       if (tab === "gifts") loadGifts();
       if (tab === "economy") loadEconomyConfig();
-      if (tab === "monitor") $("#monitor-uid-input")?.focus();
+      if (tab === "monitor") {
+        const savedMonitorUid = localStorage.getItem("admin_monitor_uid");
+        if (savedMonitorUid && !monitorUid) {
+          monitorUidInput.value = savedMonitorUid;
+          startMonitoring(savedMonitorUid);
+        } else {
+          $("#monitor-uid-input")?.focus();
+        }
+      }
       if (tab === "banners") loadBanners();
       if (tab === "funfacts") loadFunFacts();
     }
@@ -3920,6 +3971,7 @@
     tabMonitor.addEventListener("click", () => switchTab("monitor"));
     tabBanners.addEventListener("click", () => switchTab("banners"));
     tabFunfacts.addEventListener("click", () => switchTab("funfacts"));
+    tabBackups.addEventListener("click", () => switchTab("backups"));
 
     // --- Suspension section ---
     const suspensionSection = $("#suspension-section");
@@ -4029,6 +4081,21 @@
       unsuspendBtn.disabled = false;
     });
 
+    document.getElementById("reset-device-binding-btn").addEventListener("click", async () => {
+      if (!currentUid) { showToast("No user loaded", "error"); return; }
+      if (!confirm("Remove all device bindings for this user? They will be able to sign in from any device.")) return;
+      const btn = document.getElementById("reset-device-binding-btn");
+      btn.disabled = true; btn.textContent = "Resetting...";
+      try {
+        const result = await apiCall("POST", `/api/cleanup/device-binding/${currentUid}`);
+        showToast("Removed " + (result.deleted || 0) + " device binding(s)", "success");
+      } catch (err) {
+        showToast("Failed: " + err.message, "error");
+      } finally {
+        btn.disabled = false; btn.textContent = "Reset Device Binding";
+      }
+    });
+
     // Hook into populateForm to also populate suspension section
     const _originalPopulateForm = populateForm;
     async function populateFormWithSuspension(data) {
@@ -4077,13 +4144,14 @@
     async function loadAppeals(status) {
       appealsList.innerHTML = '<div style="color:var(--text2);font-size:13px;">Loading...</div>';
       try {
-        const result = await apiCall("GET", `/api/appeals?status=${status}`);
-        if (result.appeals.length === 0) {
+        const raw = await apiCall("GET", `/api/appeals?status=${status}`);
+        const appeals = Array.isArray(raw) ? raw : (raw.appeals || []);
+        if (appeals.length === 0) {
           appealsList.innerHTML = '<div style="color:var(--text2);font-size:13px;font-style:italic;">No appeals found</div>';
           return;
         }
         appealsList.innerHTML = "";
-        for (const appeal of result.appeals) {
+        for (const appeal of appeals) {
           const card = document.createElement("div");
           card.className = "appeal-card";
           const date = appeal.submittedAt ? new Date(appeal.submittedAt).toLocaleString() : "";
@@ -4275,7 +4343,7 @@
       reportHistoryList.innerHTML = '<div style="color:var(--text2);font-size:12px;">Loading...</div>';
       try {
         const result = await apiCall("GET", `/api/reports?status=resolved&userId=${uid}`);
-        const allReports = result.users.flatMap((u) => u.reports);
+        const allReports = Array.isArray(result) ? result : (result.users ? result.users.flatMap((u) => u.reports) : []);
         if (allReports.length === 0) {
           reportHistoryList.innerHTML = '<div style="color:var(--text2);font-size:12px;font-style:italic;">No report history</div>';
           return;
@@ -4363,8 +4431,10 @@
       try {
         const data = await apiCall("GET", `/api/search/uniqueId/${q}`);
         await populateFormFull(data);
+        localStorage.setItem("admin_user_search", q);
       } catch (err) {
         showToast(err.message, "error");
+        localStorage.removeItem("admin_user_search");
       }
       searchBtn.disabled = false;
       searchBtn.textContent = "Search";
@@ -5362,8 +5432,8 @@
     async function populateGiftSelect() {
       const select = $("#backpack-gift-select");
       try {
-        const data = await apiCall("GET", "/api/gifts");
-        _giftCatalog = data.gifts || [];
+        const raw = await apiCall("GET", "/api/gifts");
+        _giftCatalog = Array.isArray(raw) ? raw : (raw.gifts || []);
         select.innerHTML = '<option value="">Add gift...</option>' +
           _giftCatalog.map(g => `<option value="${g.id}">${escapeHtml(g.name)}</option>`).join("");
       } catch (err) {
@@ -5441,8 +5511,8 @@
 
     async function loadGifts() {
       try {
-        const data = await apiCall("GET", "/api/gifts");
-        giftsCache = data.gifts || [];
+        const raw = await apiCall("GET", "/api/gifts");
+        giftsCache = Array.isArray(raw) ? raw : (raw.gifts || []);
         clearPendingState();
         renderGiftsTable();
       } catch (err) {
@@ -5761,25 +5831,6 @@
       submitBtn.disabled = false;
       cancelBtn.disabled = false;
       submitBtn.textContent = "Confirm";
-    });
-
-    // --- Seed defaults (immediate, reloads table) ---
-    $("#gift-seed-btn").addEventListener("click", async () => {
-      if (!confirm("Seed the default 27-gift catalog? Existing gifts with the same names will be merged.")) return;
-      const btn = $("#gift-seed-btn");
-      btn.disabled = true;
-      btn.textContent = "Seeding...";
-
-      try {
-        await apiCall("POST", "/api/gifts/seed");
-        showToast("Default gifts seeded", "success");
-        loadGifts(); // loadGifts clears pending state
-      } catch (err) {
-        showToast("Seed failed: " + err.message, "error");
-      }
-
-      btn.disabled = false;
-      btn.textContent = "Seed Defaults";
     });
 
     // --- Economy Config (global config/economy document) ---
@@ -6241,6 +6292,66 @@
       btn.textContent = "Delete All Appeals";
     });
 
+    // Clean Destroyed Users
+    $("#clean-destroyed-btn").addEventListener("click", async () => {
+      const btn = $("#clean-destroyed-btn");
+      const result = $("#clean-destroyed-result");
+      if (!confirm("Delete all corrupted user docs (missing createdAt)? These users can then re-register.")) return;
+
+      btn.disabled = true;
+      btn.textContent = "Scanning...";
+      result.style.display = "none";
+
+      try {
+        const token = await auth.currentUser.getIdToken();
+        const resp = await fetch(`${API_BASE}/api/cleanup/destroyed-users`, {
+          method: "POST",
+          headers: { "Authorization": `Bearer ${token}`, "Content-Type": "application/json" },
+        });
+        const data = await resp.json();
+        if (!resp.ok) throw new Error(data.error || "Request failed");
+        result.className = "maintenance-result success";
+        result.textContent = `Deleted ${data.destroyed} destroyed users, ${data.intact} intact users preserved`;
+        result.style.display = "block";
+      } catch (err) {
+        result.className = "maintenance-result error";
+        result.textContent = err.message;
+        result.style.display = "block";
+      }
+      btn.disabled = false;
+      btn.textContent = "Clean Destroyed Users";
+    });
+
+    // Clear All Device Bindings
+    $("#clear-device-bindings-btn").addEventListener("click", async () => {
+      const btn = $("#clear-device-bindings-btn");
+      const result = $("#clear-device-bindings-result");
+      if (!confirm("Delete ALL device bindings? Every user will need to re-bind on next sign-in.")) return;
+
+      btn.disabled = true;
+      btn.textContent = "Clearing...";
+      result.style.display = "none";
+
+      try {
+        const token = await auth.currentUser.getIdToken();
+        const resp = await fetch(`${API_BASE}/api/cleanup/all-device-bindings`, {
+          method: "POST",
+          headers: { "Authorization": `Bearer ${token}`, "Content-Type": "application/json" },
+        });
+        const data = await resp.json();
+        if (!resp.ok) throw new Error(data.error || "Request failed");
+        result.className = "maintenance-result success";
+        result.textContent = `Deleted ${data.deleted} device binding(s)`;
+        result.style.display = "block";
+      } catch (err) {
+        result.className = "maintenance-result error";
+        result.textContent = err.message;
+        result.style.display = "block";
+      }
+      btn.disabled = false;
+      btn.textContent = "Clear All Device Bindings";
+    });
+
     // =====================================================
     // --- Reset All (nuclear) ---
     // =====================================================
@@ -6502,6 +6613,19 @@
           setMaintenanceButtonsDisabled(true);
 
           const token = await auth.currentUser.getIdToken();
+
+          // Auto-backup before wipe — safety net
+          stepLabel.textContent = "Creating safety backup...";
+          try {
+            await fetch(`${API_BASE}/api/admin/backups/trigger`, {
+              method: "POST",
+              headers: { "Authorization": `Bearer ${token}` },
+            });
+            console.log("Pre-wipe backup created");
+          } catch (backupErr) {
+            console.error("Pre-wipe backup failed:", backupErr);
+          }
+
           const actions = [
             { id: "np-system-msgs", endpoint: "all-system-conversations", label: "System messages" },
             { id: "np-reports", endpoint: "all-reports", label: "Reports" },
@@ -6918,6 +7042,7 @@
       if (monitorUserUnsub) { monitorUserUnsub(); monitorUserUnsub = null; }
       if (monitorTxUnsub) { monitorTxUnsub(); monitorTxUnsub = null; }
       monitorUid = null;
+      localStorage.removeItem("admin_monitor_uid");
 
       // Update status
       monitorDot.classList.remove("live");
@@ -6933,6 +7058,7 @@
     // Wire up monitor buttons
     monitorStartBtn.addEventListener("click", () => {
       const uid = monitorUidInput.value.trim();
+      if (uid) localStorage.setItem("admin_monitor_uid", uid);
       startMonitoring(uid);
     });
 
@@ -6969,7 +7095,7 @@
       // Now fetch actual gift IDs to map name -> id
       try {
         const giftsData = await apiCall("GET", "/api/gifts");
-        const giftList = giftsData.gifts || [];
+        const giftList = Array.isArray(giftsData) ? giftsData : (giftsData.gifts || []);
         // Rebuild options with proper IDs
         while (guaranteeGiftSelect.options.length > 1) {
           guaranteeGiftSelect.remove(1);
@@ -7079,11 +7205,37 @@
     let bannersData = [];
     let editingBannerId = null;
 
+    function showListLoader(listEl, label) {
+      listEl.textContent = "";
+      const wrapper = document.createElement("div");
+      wrapper.style.cssText = "text-align:center;padding:32px;color:var(--text2);";
+      const spinner = document.createElement("div");
+      spinner.style.cssText = "display:inline-block;width:24px;height:24px;border:3px solid var(--border);border-top-color:var(--accent);border-radius:50%;animation:spin 0.8s linear infinite;";
+      wrapper.appendChild(spinner);
+      const text = document.createElement("div");
+      text.style.marginTop = "8px";
+      text.textContent = label;
+      wrapper.appendChild(text);
+      listEl.appendChild(wrapper);
+    }
+
     async function loadBanners() {
+      showListLoader(document.getElementById("banners-list"), "Loading banners...");
       try {
-        bannersData = await apiCall("GET", "/api/admin/banners");
+        const raw = await apiCall("GET", "/api/admin/banners");
+        bannersData = raw.map(b => ({
+          ...b,
+          image_url: b.imageUrl ?? b.image_url,
+          action_type: b.actionType ?? b.action_type ?? "NONE",
+          action_value: b.actionValue ?? b.action_value,
+          sort_order: b.sortOrder ?? b.sort_order ?? 0,
+          is_active: b.isActive ?? b.is_active ?? true,
+          start_date: b.startDate ?? b.start_date,
+          end_date: b.endDate ?? b.end_date,
+        }));
         renderBannersList();
       } catch (err) {
+        document.getElementById("banners-list").textContent = "";
         showToast("Failed to load banners: " + err.message, "error");
       }
     }
@@ -7343,7 +7495,7 @@
           const formData = new FormData();
           formData.append("file", bannerFileInput.files[0]);
           const uploadResult = await apiCall("POST", "/api/admin/banners/upload", formData);
-          imageUrl = uploadResult.image_url;
+          imageUrl = uploadResult.imageUrl || uploadResult.image_url;
         }
 
         if (!imageUrl) {
@@ -7392,8 +7544,14 @@
     let editingFunFactId = null;
 
     async function loadFunFacts() {
+      showListLoader(document.getElementById("funfacts-list"), "Loading fun facts...");
       try {
-        funFactsData = await apiCall("GET", "/api/admin/fun-facts");
+        const raw = await apiCall("GET", "/api/admin/fun-facts");
+        funFactsData = raw.map(f => ({
+          ...f,
+          source_language: f.sourceLanguage ?? f.source_language,
+          is_active: f.isActive ?? f.is_active ?? true,
+        }));
         renderFunFactsList();
       } catch (err) {
         showToast("Failed to load fun facts: " + err.message, "error");
@@ -7552,6 +7710,149 @@
       } finally {
         saveBtnEl.disabled = false;
         saveBtnEl.textContent = "Save";
+      }
+    });
+
+    // --- Backups ---
+    async function loadBackups() {
+      const list = document.getElementById("backups-list");
+      list.textContent = 'Loading...';
+      list.style.color = 'var(--text2)';
+      try {
+        const token = await currentUser.getIdToken();
+        const res = await fetch(`${API_BASE}/api/admin/backups`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        if (!res.ok) throw new Error(await res.text());
+        const { backups } = await res.json();
+        list.textContent = '';
+        list.style.color = '';
+        if (backups.length === 0) {
+          list.textContent = 'No backups yet. Click "Backup Now" to create one.';
+          list.style.color = 'var(--text2)';
+          return;
+        }
+        for (const b of backups) {
+          const row = document.createElement('div');
+          row.style.cssText = 'display:flex;align-items:center;gap:12px;padding:12px 16px;background:var(--card);border:1px solid var(--border);border-radius:8px;';
+
+          const info = document.createElement('div');
+          info.style.flex = '1';
+          const dateEl = document.createElement('div');
+          dateEl.style.cssText = 'font-weight:600;font-size:15px;';
+          dateEl.textContent = b.date;
+          const meta = document.createElement('div');
+          meta.style.cssText = 'font-size:13px;color:var(--text2);';
+          meta.textContent = `${b.userCount ?? '?'} users \u00b7 ${(b.size / 1024).toFixed(1)} KB`;
+          info.appendChild(dateEl);
+          info.appendChild(meta);
+
+          const dlBtn = document.createElement('button');
+          dlBtn.textContent = 'Download';
+          dlBtn.style.cssText = 'padding:6px 14px;background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:13px;';
+          dlBtn.addEventListener('click', () => downloadBackup(b.date));
+
+          const restoreMissingBtn = document.createElement('button');
+          restoreMissingBtn.textContent = 'Restore Missing';
+          restoreMissingBtn.title = 'Only fill in fields that are currently null/missing';
+          restoreMissingBtn.style.cssText = 'padding:6px 14px;background:#f59e0b;color:#000;border:none;border-radius:6px;cursor:pointer;font-size:13px;font-weight:600;';
+          restoreMissingBtn.addEventListener('click', () => restoreBackup(b.date, 'missing'));
+
+          const fullRestoreBtn = document.createElement('button');
+          fullRestoreBtn.textContent = 'Full Restore';
+          fullRestoreBtn.title = 'Overwrite all fields from backup';
+          fullRestoreBtn.style.cssText = 'padding:6px 14px;background:var(--danger);color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:13px;font-weight:600;';
+          fullRestoreBtn.addEventListener('click', () => restoreBackup(b.date, 'full'));
+
+          row.appendChild(info);
+          row.appendChild(dlBtn);
+          row.appendChild(restoreMissingBtn);
+          row.appendChild(fullRestoreBtn);
+          list.appendChild(row);
+        }
+      } catch (err) {
+        list.textContent = 'Error: ' + err.message;
+        list.style.color = 'var(--danger)';
+      }
+    }
+
+    async function downloadBackup(date) {
+      try {
+        const token = await currentUser.getIdToken();
+        const res = await fetch(`${API_BASE}/api/admin/backups/${date}`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        if (!res.ok) throw new Error(await res.text());
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url; a.download = `shytalk-users-${date}.json`; a.click();
+        URL.revokeObjectURL(url);
+        showToast("Download started", "success");
+      } catch (err) {
+        showToast("Download failed: " + err.message, "error");
+      }
+    }
+
+    async function restoreBackup(date, mode) {
+      const label = mode === 'full' ? 'FULL RESTORE (overwrites all fields)' : 'Restore missing fields only';
+      if (!confirm(label + ' from backup ' + date + '?\n\nThis will update user profiles in Firestore.')) return;
+      if (mode === 'full' && !confirm('Are you SURE? Full restore will overwrite current data with backup data.')) return;
+      try {
+        showToast("Restoring...", "info");
+        const token = await currentUser.getIdToken();
+        const res = await fetch(`${API_BASE}/api/admin/backups/restore/${date}`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ mode })
+        });
+        if (!res.ok) throw new Error(await res.text());
+        const result = await res.json();
+        showToast('Restored ' + result.restoredCount + '/' + result.totalInBackup + ' users (' + mode + ')', "success");
+      } catch (err) {
+        showToast("Restore failed: " + err.message, "error");
+      }
+    }
+
+    document.getElementById("backup-trigger-btn").addEventListener("click", async () => {
+      const btn = document.getElementById("backup-trigger-btn");
+      btn.disabled = true; btn.textContent = "Backing up...";
+      try {
+        const token = await currentUser.getIdToken();
+        const res = await fetch(`${API_BASE}/api/admin/backups/trigger`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        if (!res.ok) throw new Error(await res.text());
+        const result = await res.json();
+        showToast('Backup complete: ' + result.message, "success");
+        await loadBackups();
+      } catch (err) {
+        showToast("Backup failed: " + err.message, "error");
+      } finally {
+        btn.disabled = false; btn.textContent = "Backup Now";
+      }
+    });
+
+    document.getElementById("backup-refresh-btn").addEventListener("click", () => loadBackups());
+
+    document.getElementById("backup-recover-photos-btn").addEventListener("click", async () => {
+      if (!confirm("Scan R2 storage and restore missing profile/cover photo URLs?")) return;
+      const btn = document.getElementById("backup-recover-photos-btn");
+      btn.disabled = true; btn.textContent = "Scanning R2...";
+      try {
+        const token = await currentUser.getIdToken();
+        const res = await fetch(`${API_BASE}/api/admin/backups/recover-photos`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        if (!res.ok) throw new Error(await res.text());
+        const result = await res.json();
+        showToast(result.message, "success");
+      } catch (err) {
+        showToast("Photo recovery failed: " + err.message, "error");
+      } finally {
+        btn.disabled = false; btn.textContent = "Recover Photos from R2";
       }
     });
 </script>

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/ChatRoom.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/ChatRoom.kt
@@ -36,6 +36,11 @@ data class ChatRoom(
     fun findUserSeat(userId: String): Map.Entry<String, Seat>? =
         seats.entries.find { it.value.isOccupiedBy(userId) }
 
+    /** True if any non-owner user is currently seated (OCCUPIED). */
+    fun hasSeatedNonOwners(): Boolean = seats.any { (_, seat) ->
+        seat.userId != null && seat.userId != ownerId && seat.state == SeatState.OCCUPIED
+    }
+
     fun toMap(): Map<String, Any?> = mapOf(
         "roomId" to roomId,
         "name" to name,

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -66,39 +68,13 @@ fun RoomListContent(
         }
     }
 
-    PullToRefreshBox(
-        isRefreshing = uiState.isRefreshing,
-        onRefresh = { viewModel.refreshRooms() },
-        modifier = modifier.fillMaxSize()
-    ) {
+    Box(modifier = modifier.fillMaxSize()) {
         if (uiState.isLoading) {
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
                 CircularProgressIndicator()
-            }
-        } else if (uiState.rooms.isEmpty() && uiState.banners.isEmpty()) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .testTag("roomList_emptyState"),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        text = "No active rooms",
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Text(
-                        text = "Tap + to create one",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
             }
         } else {
             Column(modifier = Modifier.fillMaxSize()) {
@@ -124,43 +100,50 @@ fun RoomListContent(
                         modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
                     )
                 }
-                if (uiState.rooms.isEmpty()) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .testTag("roomList_emptyState"),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally
+                PullToRefreshBox(
+                    isRefreshing = uiState.isRefreshing,
+                    onRefresh = { viewModel.refreshRooms() },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    if (uiState.rooms.isEmpty()) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .verticalScroll(rememberScrollState())
+                                .testTag("roomList_emptyState"),
+                            contentAlignment = Alignment.Center
                         ) {
-                            Text(
-                                text = "No active rooms",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                            Text(
-                                text = "Tap + to create one",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Text(
+                                    text = "No active rooms",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Text(
+                                    text = "Tap + to create one",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
                         }
-                    }
-                } else {
-                    LazyColumn(
-                        state = listState,
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        items(uiState.rooms, key = { it.roomId }) { room ->
-                            RoomListItem(
-                                room = room,
-                                seatUsers = uiState.seatUsers,
-                                onClick = {
-                                    onPrewarmRoom(room)
-                                    onNavigateToRoom(room.roomId)
-                                },
-                                modifier = Modifier.testTag("roomList_roomCard_${room.roomId}")
-                            )
+                    } else {
+                        LazyColumn(
+                            state = listState,
+                            modifier = Modifier.fillMaxSize()
+                        ) {
+                            items(uiState.rooms, key = { it.roomId }) { room ->
+                                RoomListItem(
+                                    room = room,
+                                    seatUsers = uiState.seatUsers,
+                                    onClick = {
+                                        onPrewarmRoom(room)
+                                        onNavigateToRoom(room.roomId)
+                                    },
+                                    modifier = Modifier.testTag("roomList_roomCard_${room.roomId}")
+                                )
+                            }
                         }
                     }
                 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ConversationListScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ConversationListScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.Close
@@ -24,6 +26,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -31,6 +34,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -45,7 +49,7 @@ import androidx.compose.ui.unit.dp
 import org.koin.compose.viewmodel.koinViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun ConversationListScreen(
     onNavigateToChat: (String) -> Unit,
@@ -97,109 +101,116 @@ fun ConversationListScreen(
         } else {
             val conversations = viewModel.getFilteredConversations()
 
-            if (conversations.isEmpty()) {
-                // Empty state
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .testTag("conversationList_emptyState"),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+            PullToRefreshBox(
+                isRefreshing = uiState.isRefreshing,
+                onRefresh = { viewModel.refreshConversations() },
+                modifier = Modifier.weight(1f)
+            ) {
+                if (conversations.isEmpty()) {
+                    // Empty state
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(rememberScrollState())
+                            .testTag("conversationList_emptyState"),
+                        contentAlignment = Alignment.Center
                     ) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.Chat,
-                            contentDescription = null,
-                            modifier = Modifier.size(64.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
-                        )
-                        Text(
-                            text = if (uiState.searchQuery.isNotBlank()) "No matches found" else "No messages yet",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        if (uiState.searchQuery.isBlank()) {
-                            Text(
-                                text = "Start a conversation from someone's\nprofile or user card in a room",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
-                                textAlign = TextAlign.Center
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Icon(
+                                Icons.AutoMirrored.Filled.Chat,
+                                contentDescription = null,
+                                modifier = Modifier.size(64.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
                             )
+                            Text(
+                                text = if (uiState.searchQuery.isNotBlank()) "No matches found" else "No messages yet",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            if (uiState.searchQuery.isBlank()) {
+                                Text(
+                                    text = "Start a conversation from someone's\nprofile or user card in a room",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                                    textAlign = TextAlign.Center
+                                )
+                            }
                         }
                     }
-                }
-            } else {
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(
-                        items = conversations,
-                        key = { it.conversation.conversationId }
-                    ) { conversationWithUser ->
-                        val cId = conversationWithUser.conversation.conversationId
-                        Box {
-                            val navigateAction = {
-                                viewModel.markConversationRead(cId)
-                                if (conversationWithUser.isGroup) {
-                                    onNavigateToGroupChat(cId)
-                                } else {
-                                    val otherUserId = conversationWithUser.conversation.otherUserId(viewModel.currentUserId)
-                                    if (otherUserId != null) onNavigateToChat(otherUserId)
+                } else {
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(
+                            items = conversations,
+                            key = { it.conversation.conversationId }
+                        ) { conversationWithUser ->
+                            val cId = conversationWithUser.conversation.conversationId
+                            Box {
+                                val navigateAction = {
+                                    viewModel.markConversationRead(cId)
+                                    if (conversationWithUser.isGroup) {
+                                        onNavigateToGroupChat(cId)
+                                    } else {
+                                        val otherUserId = conversationWithUser.conversation.otherUserId(viewModel.currentUserId)
+                                        if (otherUserId != null) onNavigateToChat(otherUserId)
+                                    }
                                 }
-                            }
 
-                            ConversationListItem(
-                                otherUser = conversationWithUser.otherUser,
-                                lastMessageText = conversationWithUser.conversation.lastMessage?.text,
-                                lastMessageType = conversationWithUser.conversation.lastMessage?.type,
-                                lastMessageAt = conversationWithUser.conversation.lastMessageAt,
-                                unreadCount = conversationWithUser.settings?.unreadCount ?: 0,
-                                isMuted = conversationWithUser.settings?.isMuted == true,
-                                isPinned = conversationWithUser.settings?.isPinned == true,
-                                onClick = { navigateAction() },
-                                isGroup = conversationWithUser.isGroup,
-                                groupName = conversationWithUser.groupName,
-                                groupPhotoUrl = conversationWithUser.groupPhotoUrl,
-                                currentUserRole = if (conversationWithUser.isGroup) {
-                                    conversationWithUser.conversation.roleOf(viewModel.currentUserId)
-                                } else {
-                                    com.shyden.shytalk.core.model.GroupRole.MEMBER
-                                },
-                                aliases = uiState.aliases,
-                                modifier = Modifier.combinedClickable(
+                                ConversationListItem(
+                                    otherUser = conversationWithUser.otherUser,
+                                    lastMessageText = conversationWithUser.conversation.lastMessage?.text,
+                                    lastMessageType = conversationWithUser.conversation.lastMessage?.type,
+                                    lastMessageAt = conversationWithUser.conversation.lastMessageAt,
+                                    unreadCount = conversationWithUser.settings?.unreadCount ?: 0,
+                                    isMuted = conversationWithUser.settings?.isMuted == true,
+                                    isPinned = conversationWithUser.settings?.isPinned == true,
                                     onClick = { navigateAction() },
-                                    onLongClick = {
-                                        contextMenuConversationId = cId
-                                    }
-                                )
-                            )
-
-                            // Context menu
-                            DropdownMenu(
-                                expanded = contextMenuConversationId == cId,
-                                onDismissRequest = { contextMenuConversationId = null },
-                                offset = DpOffset(x = 200.dp, y = 0.dp)
-                            ) {
-                                val isPinned = conversationWithUser.settings?.isPinned == true
-                                DropdownMenuItem(
-                                    text = { Text(if (isPinned) "Unpin" else "Pin") },
-                                    onClick = {
-                                        contextMenuConversationId = null
-                                        viewModel.pinConversation(cId)
-                                    }
-                                )
-                                if (!conversationWithUser.isGroup) {
-                                    DropdownMenuItem(
-                                        text = { Text("Delete Conversation") },
-                                        onClick = {
-                                            contextMenuConversationId = null
-                                            showDeleteConfirm = cId
+                                    isGroup = conversationWithUser.isGroup,
+                                    groupName = conversationWithUser.groupName,
+                                    groupPhotoUrl = conversationWithUser.groupPhotoUrl,
+                                    currentUserRole = if (conversationWithUser.isGroup) {
+                                        conversationWithUser.conversation.roleOf(viewModel.currentUserId)
+                                    } else {
+                                        com.shyden.shytalk.core.model.GroupRole.MEMBER
+                                    },
+                                    aliases = uiState.aliases,
+                                    modifier = Modifier.combinedClickable(
+                                        onClick = { navigateAction() },
+                                        onLongClick = {
+                                            contextMenuConversationId = cId
                                         }
                                     )
+                                )
+
+                                // Context menu
+                                DropdownMenu(
+                                    expanded = contextMenuConversationId == cId,
+                                    onDismissRequest = { contextMenuConversationId = null },
+                                    offset = DpOffset(x = 200.dp, y = 0.dp)
+                                ) {
+                                    val isPinned = conversationWithUser.settings?.isPinned == true
+                                    DropdownMenuItem(
+                                        text = { Text(if (isPinned) "Unpin" else "Pin") },
+                                        onClick = {
+                                            contextMenuConversationId = null
+                                            viewModel.pinConversation(cId)
+                                        }
+                                    )
+                                    if (!conversationWithUser.isGroup) {
+                                        DropdownMenuItem(
+                                            text = { Text("Delete Conversation") },
+                                            onClick = {
+                                                contextMenuConversationId = null
+                                                showDeleteConfirm = cId
+                                            }
+                                        )
+                                    }
                                 }
                             }
+                            HorizontalDivider(modifier = Modifier.padding(start = 80.dp))
                         }
-                        HorizontalDivider(modifier = Modifier.padding(start = 80.dp))
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ConversationListViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ConversationListViewModel.kt
@@ -31,6 +31,7 @@ data class ConversationWithUser(
 data class ConversationListUiState(
     val conversations: List<ConversationWithUser> = emptyList(),
     val isLoading: Boolean = true,
+    val isRefreshing: Boolean = false,
     val error: String? = null,
     val totalUnreadCount: Long = 0,
     val searchQuery: String = "",
@@ -263,6 +264,17 @@ class ConversationListViewModel(
         // Persist to backend so re-fetches don't revert the local state
         viewModelScope.launch {
             pmRepository.resetUnreadCount(conversationId, currentUserId)
+        }
+    }
+
+    fun refreshConversations() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isRefreshing = true) }
+            userCache.clear()
+            settingsCache.clear()
+            observeConversations()
+            kotlinx.coroutines.delay(500)
+            _uiState.update { it.copy(isRefreshing = false) }
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/GroupSetupViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/GroupSetupViewModel.kt
@@ -8,6 +8,7 @@ import com.shyden.shytalk.core.model.SystemMessageConfig
 import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.util.Constants
 import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.core.util.compressImage
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.PrivateMessageRepository
 import com.shyden.shytalk.data.repository.StorageRepository
@@ -160,8 +161,9 @@ class GroupSetupViewModel(
             var photoUrl: String? = null
             val photoBytes = state.groupPhotoBytes
             if (photoBytes != null) {
+                val compressed = compressImage(photoBytes)
                 when (val uploadResult = storageRepository.uploadImage(
-                    currentUserId, "group_photos", photoBytes
+                    currentUserId, "group_photos", compressed
                 )) {
                     is Resource.Success -> photoUrl = uploadResult.data
                     is Resource.Error -> {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
@@ -6,6 +6,7 @@ import com.shyden.shytalk.core.model.RoomState
 import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.util.Constants
 import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.core.util.compressImage
 import com.shyden.shytalk.core.util.currentTimeMillis
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.EconomyRepository
@@ -46,7 +47,8 @@ data class ProfileUiState(
     val isSubmittingReport: Boolean = false,
     val reportSubmitted: Boolean = false,
     val reportError: String? = null,
-    val isPurchasingSuperShy: Boolean = false
+    val isPurchasingSuperShy: Boolean = false,
+    val isRefreshing: Boolean = false
 )
 
 class ProfileViewModel(
@@ -215,6 +217,16 @@ class ProfileViewModel(
         }
     }
 
+    fun refreshProfile() {
+        val userId = _uiState.value.user?.uid ?: authRepository.currentUserId ?: return
+        val targetId = if (_uiState.value.isOwnProfile) null else userId
+        viewModelScope.launch {
+            _uiState.update { it.copy(isRefreshing = true) }
+            loadProfile(targetId)
+            _uiState.update { it.copy(isRefreshing = false) }
+        }
+    }
+
     fun saveProfile(displayName: String, dateOfBirth: Long) {
         val userId = authRepository.currentUserId ?: return
         viewModelScope.launch {
@@ -326,7 +338,8 @@ class ProfileViewModel(
         val userId = authRepository.currentUserId ?: return
         viewModelScope.launch {
             _uiState.update { it.copy(isUploadingPhoto = true) }
-            when (val result = storageRepository.uploadImage(userId, folder, imageData)) {
+            val compressed = compressImage(imageData)
+            when (val result = storageRepository.uploadImage(userId, folder, compressed)) {
                 is Resource.Success -> {
                     val url = result.data
                     when (val saveResult = userRepository.updateProfile(userId, mapOf(profileField to url))) {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -599,6 +599,7 @@ class RoomViewModel(
         loadSeatUsers(room)
         loadParticipantUsers(room)
         observeRemoteUserChanges(collectRoomUserIds(room, _uiState.value.currentUserId))
+        closeOwnerAwayIfSeatsEmpty(room)
         handleOwnerAwayCountdown(room)
         refilterPendingRequests()
         handleGiftEvent(room)
@@ -850,6 +851,18 @@ class RoomViewModel(
                     )
                 }
             }
+        }
+    }
+
+    /** Close OWNER_AWAY room immediately once all non-owner seats are empty. */
+    private fun closeOwnerAwayIfSeatsEmpty(room: ChatRoom) {
+        if (room.state != RoomState.OWNER_AWAY) return
+        if (room.hasSeatedNonOwners()) return
+
+        logD(TAG, "closeOwnerAwayIfSeatsEmpty: no seated non-owners → closeRoom")
+        ownerAwayCountdownJob?.cancel()
+        viewModelScope.launch {
+            roomRepository.closeRoom(roomId)
         }
     }
 
@@ -1256,6 +1269,20 @@ class RoomViewModel(
                     // owner stays in participants during OWNER_AWAY for reconnection
                     if (room.ownerId != userId) {
                         roomRepository.leaveRoom(roomId, userId)
+
+                        // If no non-owner seats remain in an OWNER_AWAY room, close it —
+                        // don't count unseated visitors, only seated users matter.
+                        if (room.state == RoomState.OWNER_AWAY) {
+                            val othersStillSeated = room.seats.any { (_, seat) ->
+                                seat.userId != null && seat.userId != userId
+                                    && seat.userId != room.ownerId
+                                    && seat.state == SeatState.OCCUPIED
+                            }
+                            if (!othersStillSeated) {
+                                logD(TAG, "leaveRoom: no seated non-owners left in OWNER_AWAY room → closeRoom")
+                                roomRepository.closeRoom(roomId)
+                            }
+                        }
                     }
                 } finally {
                     roomLifecycleManager.markLeaveCompleted(roomId)

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/RoomStarfieldBackground.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/RoomStarfieldBackground.kt
@@ -1,0 +1,110 @@
+package com.shyden.shytalk.feature.room.components
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import kotlin.math.sin
+import kotlin.random.Random
+
+private data class Star(
+    val x: Float,
+    val y: Float,
+    val baseRadius: Float,
+    val phaseOffset: Float,
+    val twinkleSpeed: Float,
+    val brightness: Float
+)
+
+@Composable
+fun RoomStarfieldBackground(modifier: Modifier = Modifier) {
+    val stars = remember {
+        val rng = Random(42)
+        List(100) {
+            Star(
+                x = rng.nextFloat(),
+                y = rng.nextFloat(),
+                baseRadius = rng.nextFloat() * 1.5f + 0.5f,
+                phaseOffset = rng.nextFloat() * 6.2832f,
+                twinkleSpeed = rng.nextFloat() * 1.5f + 0.5f,
+                brightness = rng.nextFloat() * 0.6f + 0.4f
+            )
+        }
+    }
+
+    val transition = rememberInfiniteTransition(label = "starfieldTwinkle")
+    val phase by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 6.2832f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 8000),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "twinklePhase"
+    )
+
+    val gradientColors = remember {
+        listOf(Color(0xFF0A0E21), Color(0xFF1A1A2E))
+    }
+
+    Canvas(modifier = modifier) {
+        val dp = density // pixels per dp — scale radii so stars are visible on high-DPI
+
+        // Dark gradient background
+        drawRect(brush = Brush.verticalGradient(gradientColors))
+
+        // Faint nebula circles for depth
+        drawCircle(
+            color = Color(0xFF4A148C),
+            radius = size.minDimension * 0.35f,
+            center = Offset(size.width * 0.25f, size.height * 0.3f),
+            alpha = 0.06f
+        )
+        drawCircle(
+            color = Color(0xFF0D47A1),
+            radius = size.minDimension * 0.28f,
+            center = Offset(size.width * 0.75f, size.height * 0.65f),
+            alpha = 0.06f
+        )
+        drawCircle(
+            color = Color(0xFF1A237E),
+            radius = size.minDimension * 0.22f,
+            center = Offset(size.width * 0.55f, size.height * 0.15f),
+            alpha = 0.05f
+        )
+
+        // Stars
+        for (star in stars) {
+            val twinkleAlpha = ((sin(phase * star.twinkleSpeed + star.phaseOffset) + 1f) / 2f)
+            val alpha = twinkleAlpha * star.brightness
+            val center = Offset(star.x * size.width, star.y * size.height)
+            val radius = star.baseRadius * dp
+
+            drawCircle(
+                color = Color.White,
+                radius = radius,
+                center = center,
+                alpha = alpha
+            )
+
+            // Bright stars get a glow halo
+            if (star.brightness > 0.8f) {
+                drawCircle(
+                    color = Color.White,
+                    radius = radius * 3f,
+                    center = center,
+                    alpha = alpha * 0.12f
+                )
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/splash/FunFactSplashScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/splash/FunFactSplashScreen.kt
@@ -1,7 +1,5 @@
 package com.shyden.shytalk.feature.splash
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -62,16 +60,12 @@ fun FunFactSplashScreen(
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            AnimatedVisibility(
-                visible = warmUpComplete,
-                enter = fadeIn()
+            Button(
+                onClick = onContinue,
+                enabled = warmUpComplete,
+                modifier = Modifier.fillMaxWidth()
             ) {
-                Button(
-                    onClick = onContinue,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text("Continue")
-                }
+                Text(if (warmUpComplete) "Continue" else "Getting ready...")
             }
         }
     }

--- a/worker-api/src/index.js
+++ b/worker-api/src/index.js
@@ -23,6 +23,7 @@ const { registerAdminUserRoutes } = require('./routes/admin-users');
 const { registerAdminEconomyRoutes } = require('./routes/admin-economy');
 const { registerAdminGiftRoutes } = require('./routes/admin-gifts');
 const { registerAdminCleanupRoutes } = require('./routes/admin-cleanup');
+const { registerAdminBackupRoutes } = require('./routes/admin-backup');
 const {
   isCircuitOpen,
   getDoc, setDoc, updateDoc, deleteDoc,
@@ -47,6 +48,7 @@ registerAdminUserRoutes(router);
 registerAdminEconomyRoutes(router);
 registerAdminGiftRoutes(router);
 registerAdminCleanupRoutes(router);
+registerAdminBackupRoutes(router);
 
 // ── Health check (no auth) ──
 router.get('/api/health', async (request, env) => {
@@ -190,6 +192,10 @@ export default {
         await closeStaleOwnerAwayRooms(env);
         break;
 
+      case '0 2 * * *': // Backup user profiles to R2 (daily 02:00)
+        await backupUserProfiles(env);
+        break;
+
       default:
         console.log(`Unknown cron: ${cron}`);
     }
@@ -328,6 +334,38 @@ async function cleanExpiredBackpackItems(env) {
   }
 
   console.log(`Cleaned ${totalCleaned} expired backpack items`);
+}
+
+async function backupUserProfiles(env) {
+  const users = await queryCollection(env, 'users', { limit: 5000 });
+  if (users.length === 0) {
+    console.log('Backup: no users to back up');
+    return;
+  }
+
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const key = `backups/users/${today}.json`;
+  const json = JSON.stringify(users, null, 2);
+
+  await env.R2_BUCKET.put(key, json, {
+    httpMetadata: { contentType: 'application/json' },
+    customMetadata: { userCount: String(users.length), createdAt: new Date().toISOString() },
+  });
+  console.log(`Backup: saved ${users.length} users to ${key} (${json.length} bytes)`);
+
+  // Prune backups older than 7 days
+  const listed = await env.R2_BUCKET.list({ prefix: 'backups/users/' });
+  const sevenDaysAgo = Date.now() - (7 * 24 * 60 * 60 * 1000);
+
+  for (const obj of listed.objects) {
+    // Parse date from key: backups/users/YYYY-MM-DD.json
+    const dateStr = obj.key.replace('backups/users/', '').replace('.json', '');
+    const backupDate = new Date(dateStr + 'T00:00:00Z');
+    if (!isNaN(backupDate.getTime()) && backupDate.getTime() < sevenDaysAgo) {
+      await env.R2_BUCKET.delete(obj.key);
+      console.log(`Backup: pruned old backup ${obj.key}`);
+    }
+  }
 }
 
 async function cleanupOrphanedStorage(env) {

--- a/worker-api/src/routes/admin-backup.js
+++ b/worker-api/src/routes/admin-backup.js
@@ -1,0 +1,172 @@
+/**
+ * Admin backup routes — R2-based user profile backups.
+ *
+ * GET  /api/admin/backups              → List available backups
+ * POST /api/admin/backups/trigger      → Trigger immediate backup
+ * GET  /api/admin/backups/:date        → Download a backup by date (YYYY-MM-DD)
+ * POST /api/admin/backups/restore/:date → Restore all users from a backup
+ * POST /api/admin/backups/recover-photos → Scan R2 and restore missing photo URLs
+ */
+
+const { json, jsonError } = require('../utils');
+const { requireAdmin } = require('../middleware/auth');
+const { queryCollection, updateDoc, getDoc } = require('../utils/firestore');
+
+function registerAdminBackupRoutes(router) {
+  // ── List available backups ──
+  router.get('/api/admin/backups', async (request, env) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    const listed = await env.R2_BUCKET.list({ prefix: 'backups/users/' });
+    const backups = listed.objects.map(obj => ({
+      key: obj.key,
+      date: obj.key.replace('backups/users/', '').replace('.json', ''),
+      size: obj.size,
+      uploaded: obj.uploaded?.toISOString() ?? null,
+      userCount: obj.customMetadata?.userCount ?? null,
+    }));
+
+    // Sort newest first
+    backups.sort((a, b) => b.date.localeCompare(a.date));
+    return json({ backups });
+  });
+
+  // ── Trigger immediate backup ──
+  router.post('/api/admin/backups/trigger', async (request, env) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    const users = await queryCollection(env, 'users', { limit: 5000 });
+    if (users.length === 0) return json({ message: 'No users found', userCount: 0 });
+
+    const today = new Date().toISOString().slice(0, 10);
+    const key = `backups/users/${today}.json`;
+    const payload = JSON.stringify(users, null, 2);
+
+    await env.R2_BUCKET.put(key, payload, {
+      httpMetadata: { contentType: 'application/json' },
+      customMetadata: { userCount: String(users.length), createdAt: new Date().toISOString() },
+    });
+
+    return json({ message: `Backed up ${users.length} users`, key, bytes: payload.length });
+  });
+
+  // ── Download a specific backup ──
+  router.get('/api/admin/backups/:date', async (request, env, params) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    const key = `backups/users/${params.date}.json`;
+    const obj = await env.R2_BUCKET.get(key);
+    if (!obj) return jsonError(`No backup found for ${params.date}`, 404);
+
+    return new Response(obj.body, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+    });
+  });
+
+  // ── Restore users from a backup ──
+  router.post('/api/admin/backups/restore/:date', async (request, env, params) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    const body = await request.json().catch(() => ({}));
+    const mode = body.mode || 'missing'; // 'missing' = only fill missing fields, 'full' = overwrite
+
+    const key = `backups/users/${params.date}.json`;
+    const obj = await env.R2_BUCKET.get(key);
+    if (!obj) return jsonError(`No backup found for ${params.date}`, 404);
+
+    const backupUsers = JSON.parse(await obj.text());
+    let restoredCount = 0;
+
+    for (const backupUser of backupUsers) {
+      const uid = backupUser.id;
+      if (!uid) continue;
+
+      if (mode === 'full') {
+        // Full restore — overwrite all fields from backup
+        const { id, ...data } = backupUser;
+        await updateDoc(env, `users/${uid}`, data);
+        restoredCount++;
+      } else {
+        // Missing-only restore — only fill in fields that are currently null/missing
+        const current = await getDoc(env, `users/${uid}`);
+        if (!current) continue;
+
+        const { id: _id, ...backupData } = backupUser;
+        const fieldsToRestore = {};
+        for (const [field, value] of Object.entries(backupData)) {
+          if (value != null && (current[field] === null || current[field] === undefined)) {
+            fieldsToRestore[field] = value;
+          }
+        }
+
+        if (Object.keys(fieldsToRestore).length > 0) {
+          await updateDoc(env, `users/${uid}`, fieldsToRestore);
+          restoredCount++;
+        }
+      }
+    }
+
+    return json({
+      message: `Restored ${restoredCount}/${backupUsers.length} users (mode: ${mode})`,
+      mode,
+      date: params.date,
+      restoredCount,
+      totalInBackup: backupUsers.length,
+    });
+  });
+  // ── Recover profile/cover photos from R2 ──
+  router.post('/api/admin/backups/recover-photos', async (request, env) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    const CDN_URL = env.CDN_URL || 'https://images.shytalk.shyden.co.uk';
+    let recovered = 0;
+
+    // Scan R2 for profile photos and cover photos
+    for (const folder of ['profile_photos/', 'cover_photos/']) {
+      const field = folder === 'profile_photos/' ? 'profilePhotoUrl' : 'coverPhotoUrl';
+      const userPhotos = {}; // uid → latest key
+
+      let cursor;
+      do {
+        const listed = await env.R2_BUCKET.list({ prefix: folder, cursor, limit: 1000 });
+        for (const obj of listed.objects) {
+          // Keys are like: profile_photos/{uid}/{filename}
+          const parts = obj.key.split('/');
+          if (parts.length >= 3) {
+            const uid = parts[1];
+            // Keep the most recently uploaded photo per user
+            if (!userPhotos[uid] || obj.uploaded > userPhotos[uid].uploaded) {
+              userPhotos[uid] = { key: obj.key, uploaded: obj.uploaded };
+            }
+          }
+        }
+        cursor = listed.truncated ? listed.cursor : undefined;
+      } while (cursor);
+
+      // For each user with an R2 photo, check if their Firestore doc is missing the URL
+      for (const [uid, photo] of Object.entries(userPhotos)) {
+        const user = await getDoc(env, `users/${uid}`);
+        if (!user) continue;
+
+        const currentUrl = user[field];
+        if (!currentUrl) {
+          const photoUrl = `${CDN_URL}/${photo.key}`;
+          await updateDoc(env, `users/${uid}`, { [field]: photoUrl });
+          recovered++;
+        }
+      }
+    }
+
+    return json({ message: `Recovered ${recovered} photo URLs from R2`, recovered });
+  });
+}
+
+module.exports = { registerAdminBackupRoutes };

--- a/worker-api/src/routes/admin-cleanup.js
+++ b/worker-api/src/routes/admin-cleanup.js
@@ -493,6 +493,78 @@ function registerAdminCleanupRoutes(router) {
 
     return json({ success: true, summary, totalDeleted });
   });
+
+  // ── Clean up destroyed user profiles ──
+  // Identifies user docs that were corrupted by the batchUpdateOp bug
+  // (missing createdAt = never properly created) and deletes them.
+  router.post('/api/cleanup/destroyed-users', async (request, env) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    const users = await queryCollection(env, 'users', { limit: 5000 });
+
+    // A user is "destroyed" if they're missing createdAt (always set on real creation)
+    const destroyed = users.filter(u => !u.createdAt);
+    const intact = users.length - destroyed.length;
+
+    if (destroyed.length === 0) {
+      return json({ success: true, destroyed: 0, intact, message: 'No destroyed users found' });
+    }
+
+    const writes = destroyed.map(u => batchDeleteOp(env, `users/${u.id}`));
+    for (let i = 0; i < writes.length; i += 500) {
+      await batchWrite(env, writes.slice(i, i + 500));
+    }
+
+    return json({
+      success: true,
+      destroyed: destroyed.length,
+      intact,
+      deletedUids: destroyed.map(u => u.id),
+    });
+  });
+
+  // ── Delete all device bindings ──
+  // Allows destroyed users to re-register on the same device.
+  router.post('/api/cleanup/all-device-bindings', async (request, env) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    const bindings = await queryCollection(env, 'deviceBindings', { limit: 5000 });
+
+    if (bindings.length === 0) {
+      return json({ success: true, deleted: 0, message: 'No device bindings found' });
+    }
+
+    const writes = bindings.map(b => batchDeleteOp(env, `deviceBindings/${b.id}`));
+    for (let i = 0; i < writes.length; i += 500) {
+      await batchWrite(env, writes.slice(i, i + 500));
+    }
+
+    return json({ success: true, deleted: bindings.length });
+  });
+
+  // ── Delete device binding for a specific user ──
+  router.post('/api/cleanup/device-binding/:uid', async (request, env, params) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    const uid = params.uid;
+    // Find bindings where userId matches
+    const bindings = await queryCollection(env, 'deviceBindings', {
+      where: fieldFilter('userId', 'EQUAL', uid),
+      limit: 50,
+    });
+
+    if (bindings.length === 0) {
+      return json({ success: true, deleted: 0, message: 'No device bindings for this user' });
+    }
+
+    const writes = bindings.map(b => batchDeleteOp(env, `deviceBindings/${b.id}`));
+    await batchWrite(env, writes);
+
+    return json({ success: true, deleted: bindings.length });
+  });
 }
 
 /**

--- a/worker-api/src/routes/admin-users.js
+++ b/worker-api/src/routes/admin-users.js
@@ -249,9 +249,14 @@ function registerAdminUserRoutes(router) {
     const map = {};
     for (let i = 0; i < uids.length; i++) {
       const doc = docs[i];
-      if (doc) map[uids[i]] = doc.uniqueId ?? doc.unique_id ?? null;
+      if (doc) {
+        map[uids[i]] = {
+          uniqueId: doc.uniqueId ?? doc.unique_id ?? null,
+          displayName: doc.displayName ?? doc.display_name ?? null,
+        };
+      }
     }
-    return json(map);
+    return json({ mapping: map });
   });
 
   // ── Unique ID → UID resolver ──

--- a/worker-api/src/routes/economy.js
+++ b/worker-api/src/routes/economy.js
@@ -372,60 +372,85 @@ function registerEconomyRoutes(router) {
     const newBalance = shyCoins - cost;
     const timestamp = now();
 
-    // Update user
-    await updateDoc(env, `users/${uid}`, {
-      shyCoins: newBalance,
-      pityCounter: pity,
-      luckScore: luck,
-      guaranteedNextPullGiftId: null,
-    });
-
-    // Add gifts to backpack
+    // ── Aggregate duplicate gifts so each backpack doc is written once ──
+    const giftCounts = {};
     for (const gift of results) {
-      const bpDoc = await getDoc(env, `users/${uid}/backpack/${gift.id}`);
+      giftCounts[gift.id] = (giftCounts[gift.id] || 0) + 1;
+    }
+    const uniqueGiftIds = Object.keys(giftCounts);
+
+    // Fetch existing backpack docs in parallel
+    const existingDocs = await Promise.all(
+      uniqueGiftIds.map(gid => getDoc(env, `users/${uid}/backpack/${gid}`))
+    );
+
+    // Build batch writes for backpack + user update in one atomic operation
+    const writes = [];
+    for (let i = 0; i < uniqueGiftIds.length; i++) {
+      const gid = uniqueGiftIds[i];
+      const gift = results.find(g => g.id === gid);
+      const bpDoc = existingDocs[i];
       const currentQty = bpDoc?.quantity || 0;
       const expiresAt = gift.expiresAfterDays
         ? timestamp + gift.expiresAfterDays * 86400000
         : bpDoc?.expiresAt || null;
-      await setDoc(env, `users/${uid}/backpack/${gift.id}`, {
-        giftId: gift.id,
-        quantity: currentQty + 1,
+      writes.push(batchUpdateOp(env, `users/${uid}/backpack/${gid}`, {
+        giftId: gid,
+        quantity: currentQty + giftCounts[gid],
         lastAcquired: timestamp,
         expiresAt,
-        // Denormalized gift metadata for display
         giftName: gift.name,
         coinValue: gift.coinValue,
         iconUrl: gift.iconUrl || '',
-      });
+      }));
     }
 
-    // Transaction record
-    const gachaTxId = generateId();
-    await writeTransaction(env, uid, gachaTxId, {
-      type: 'GACHA_PULL',
-      amount: -cost,
-      currency: 'COINS',
-      balanceAfter: newBalance,
-      pullCount,
-      details: results.map(g => g.name).join(', '),
-      guaranteed: !!guaranteedFirstPull,
-    });
+    // Include coin deduction in the same batch
+    writes.push(batchUpdateOp(env, `users/${uid}`, {
+      shyCoins: newBalance,
+      pityCounter: pity,
+      luckScore: luck,
+      guaranteedNextPullGiftId: null,
+    }));
 
-    // Broadcast qualifying wins
-    const winThreshold = config.broadcastWinThreshold;
-    for (const gift of results) {
-      if (gift.coinValue >= winThreshold) {
-        await addBroadcast(env, {
-          type: 'GACHA_WIN',
-          senderName: userField(user, 'displayName', 'display_name') || '',
-          senderPhotoUrl: userField(user, 'profilePhotoUrl', 'profile_photo_url'),
-          recipientName: '',
-          giftName: gift.name,
-          giftIconUrl: gift.iconUrl || '',
-          giftCoinValue: gift.coinValue,
-        });
-        break; // one broadcast per pull session
+    // Execute atomically — all or nothing
+    await batchWrite(env, writes);
+
+    // Transaction record (best-effort — coins already deducted)
+    try {
+      const gachaTxId = generateId();
+      await writeTransaction(env, uid, gachaTxId, {
+        type: 'GACHA_PULL',
+        amount: -cost,
+        currency: 'COINS',
+        balanceAfter: newBalance,
+        pullCount,
+        details: results.map(g => g.name).join(', '),
+        guaranteed: !!guaranteedFirstPull,
+      });
+    } catch (err) {
+      console.error(`[GACHA] Failed to write transaction for ${uid}: ${err.message}`);
+    }
+
+    // Broadcast qualifying wins (best-effort)
+    try {
+      const winThreshold = config.broadcastWinThreshold;
+      for (const gift of results) {
+        if (gift.coinValue >= winThreshold) {
+          await addBroadcast(env, {
+            type: 'GACHA_WIN',
+            senderName: userField(user, 'displayName', 'display_name') || '',
+            senderPhotoUrl: userField(user, 'profilePhotoUrl', 'profile_photo_url'),
+            recipientName: '',
+            giftName: gift.name,
+            giftIconUrl: gift.iconUrl || '',
+            giftCoinValue: gift.coinValue,
+          });
+          break; // one broadcast per pull session
+        }
       }
+    } catch (err) {
+      console.error(`[GACHA] Failed to broadcast win for ${uid}: ${err.message}`);
     }
 
     return json({

--- a/worker-api/src/routes/users.js
+++ b/worker-api/src/routes/users.js
@@ -112,6 +112,9 @@ function registerUserRoutes(router) {
   });
 
   // ── Generate unique numeric ID ──
+  // IDs are always 8-digit numbers starting at 10000000.
+  const MIN_UNIQUE_ID = 10000000;
+
   router.post('/api/users/:uid/unique-id', async (request, env, params) => {
     if (request.auth.uid !== params.uid) {
       return jsonError('Cannot generate ID for another user', 403);
@@ -120,14 +123,20 @@ function registerUserRoutes(router) {
     // Return existing ID if already assigned
     const user = await getDoc(env, `users/${params.uid}`);
     const existingId = user?.uniqueId ?? user?.unique_id ?? null;
-    if (existingId) {
+    if (existingId && existingId >= MIN_UNIQUE_ID) {
       return json({ uniqueId: existingId });
     }
 
     // Atomic increment of the global counter
-    const newId = await incrementField(env, 'counters/uniqueId', 'value', 1);
+    let newId = await incrementField(env, 'counters/uniqueId', 'value', 1);
     if (newId === null) {
       return jsonError('Failed to generate unique ID', 500);
+    }
+
+    // Guard: if counter was corrupted/reset, fix it to start at MIN_UNIQUE_ID
+    if (newId < MIN_UNIQUE_ID) {
+      await setDoc(env, 'counters/uniqueId', { value: MIN_UNIQUE_ID });
+      newId = MIN_UNIQUE_ID;
     }
 
     await updateDoc(env, `users/${params.uid}`, { uniqueId: newId });

--- a/worker-api/src/utils/firestore.js
+++ b/worker-api/src/utils/firestore.js
@@ -372,6 +372,9 @@ function batchUpdateOp(env, path, data) {
       name: `projects/${projectId}/databases/(default)/documents/${path}`,
       fields: toFirestoreFields(data),
     },
+    updateMask: {
+      fieldPaths: Object.keys(data),
+    },
   };
 }
 

--- a/worker-api/wrangler.toml
+++ b/worker-api/wrangler.toml
@@ -36,6 +36,7 @@ crons = [
   "0 0 * * *",    # checkSubscriptionStatus + cleanExpiredBackpackItems — daily 00:00 UTC
   # updateGiftRankings cron REMOVED — rankings now updated incrementally in economy.js
   "*/5 * * * *",  # closeStaleOwnerAwayRooms — every 5 minutes
+  "0 2 * * *",    # backupUserProfiles — daily 02:00 UTC to R2
 ]
 
 # ── Environment ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Fix critical batchUpdateOp bug**: added `updateMask` to prevent admin cleanup from replacing entire user documents (caused profile data loss)
- **Add daily R2 backup system**: cron at 02:00 UTC backs up all user profiles to R2 with 7-day retention, plus admin panel for manual backup/restore
- **Add pre-wipe safety net**: RESET EVERYTHING now auto-creates a backup before executing
- **Fix uniqueId counter**: added floor guard (>= 10000000) so IDs always stay 8-digit
- **Add destroyed user cleanup**: admin endpoint to identify and delete corrupted user docs
- **Add device binding management**: bulk clear and per-user reset to unblock returning users
- **Fix room lifecycle**: OWNER_AWAY rooms now close when last seated user leaves (not visitors)
- **Add starfield background**: animated Canvas-based twinkling stars behind room content

## Test plan
- [ ] Open admin panel → verify Backups tab appears with Backup Now, Recover Photos buttons
- [ ] Trigger manual backup → verify it appears in list with user count
- [ ] Open Maintenance tab → verify Destroyed Users and Device Bindings cards appear
- [ ] Search a user → verify Reset Device Binding button next to UID
- [ ] Create a room, owner leaves → verify OWNER_AWAY countdown respects seated users only
- [ ] Run `./gradlew test` to verify unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)