### PR TITLE
Fix gacha pity, admin economy, and maintenance tools (v0.51)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 50
-        versionName = "0.50"
+        versionCode = 51
+        versionName = "0.51"
 
         testInstrumentationRunner = "com.shyden.shytalk.ShyTalkTestRunner"
 

--- a/app/src/main/java/com/shyden/shytalk/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shyden/shytalk/navigation/NavGraph.kt
@@ -754,16 +754,36 @@ fun NavGraph(
         composable(Screen.Wallet.route) {
             val walletViewModel: WalletViewModel = org.koin.compose.viewmodel.koinViewModel()
             val billingService: BillingService = koinInject()
+            val walletContext = LocalContext.current
+            val walletScope = rememberCoroutineScope()
 
             WalletScreen(
                 viewModel = walletViewModel,
                 onNavigateBack = { navController.safePopBackStack() },
                 onNavigateToTransactions = { navController.navigate(Screen.Transactions.route) },
                 onPurchasePackage = { pkg ->
-                    // TODO: Launch billing flow for coin package
+                    walletScope.launch {
+                        val products = billingService.queryProducts(listOf(pkg.productId))
+                        val details = products.firstOrNull()
+                        if (details != null) {
+                            val activity = walletContext as android.app.Activity
+                            billingService.launchPurchaseFlow(activity, details)
+                        }
+                    }
                 },
                 onPurchaseSubscription = { productId ->
-                    // TODO: Launch billing flow for subscription
+                    walletScope.launch {
+                        val products = billingService.queryProducts(
+                            listOf(productId),
+                            com.android.billingclient.api.BillingClient.ProductType.SUBS
+                        )
+                        val details = products.firstOrNull()
+                        if (details != null) {
+                            val activity = walletContext as android.app.Activity
+                            val offerToken = details.subscriptionOfferDetails?.firstOrNull()?.offerToken
+                            billingService.launchPurchaseFlow(activity, details, offerToken)
+                        }
+                    }
                 }
             )
         }

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,8 +1,10 @@
-v0.50 — Social & Safety
+v0.51 — Economy & Admin Fixes
 
-- Follow/unfollow now works reliably from profile pages
-- Profile visitors (stalkers) are now tracked properly
-- Daily user backups to protect against data loss
-- Admin panel shows accurate counts for all maintenance actions
-- Unique IDs always start at 8 digits (10000000+)
-- Storage audit and cleanup display fixed
+- Fixed gacha pity system not guaranteeing high-value gifts at max pity
+- Gacha spin results load instantly (removed unnecessary delay)
+- Fixed coin/bean balance adjustments from admin panel
+- Fixed guaranteed gift prize setting showing undefined
+- Admin panel: email, user type, and all attributes display correctly
+- New maintenance tools: clear PMs, group chats, rooms, broadcasts, audit logs
+- RESET ALL now requires successful backup before proceeding
+- Economy tab save errors resolved

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -137,8 +137,8 @@
           margin: 0 auto;
         }
 
-        /* Narrow panels (form-heavy) get a comfortable reading width */
-        #user-form, .search-bar { max-width: 800px; }
+        /* Search bar gets a comfortable reading width */
+        .search-bar { max-width: 800px; }
 
         /* --- Search --- */
         .search-bar {
@@ -2963,10 +2963,46 @@
                     <button id="clear-device-bindings-btn">Clear All Device Bindings</button>
                     <div class="maintenance-result" id="clear-device-bindings-result"></div>
                 </div>
+                <div class="maintenance-card">
+                    <h3>Backfill User Types</h3>
+                    <p>Set userType to "MEMBER" for all users that are missing it. Safe to run multiple times.</p>
+                    <button id="backfill-user-type-btn">Backfill User Types</button>
+                    <div class="maintenance-result" id="backfill-user-type-result"></div>
+                </div>
+                <div class="maintenance-card">
+                    <h3>Private Messages</h3>
+                    <p>Delete all 1-on-1 private message conversations and their associated images from storage.</p>
+                    <button id="clear-pms-btn">Delete All Private Messages</button>
+                    <div class="maintenance-result" id="clear-pms-result"></div>
+                </div>
+                <div class="maintenance-card">
+                    <h3>Group Chats</h3>
+                    <p>Delete all group chat conversations, their messages, and associated media (group photos, images).</p>
+                    <button id="clear-groups-btn">Delete All Group Chats</button>
+                    <div class="maintenance-result" id="clear-groups-result"></div>
+                </div>
+                <div class="maintenance-card">
+                    <h3>Closed Rooms</h3>
+                    <p>Delete all closed rooms and their messages/seat requests. Active and owner-away rooms are preserved. Also runs automatically daily (rooms closed &gt; 7 days).</p>
+                    <button id="clear-rooms-btn">Delete All Closed Rooms</button>
+                    <div class="maintenance-result" id="clear-rooms-result"></div>
+                </div>
+                <div class="maintenance-card">
+                    <h3>Broadcasts</h3>
+                    <p>Delete all gift send and gacha win broadcast records.</p>
+                    <button id="clear-broadcasts-btn">Delete All Broadcasts</button>
+                    <div class="maintenance-result" id="clear-broadcasts-result"></div>
+                </div>
+                <div class="maintenance-card">
+                    <h3>Audit Logs</h3>
+                    <p>Delete all admin audit log entries.</p>
+                    <button id="clear-audit-logs-btn">Delete All Audit Logs</button>
+                    <div class="maintenance-result" id="clear-audit-logs-result"></div>
+                </div>
                 <div class="maintenance-card nuclear">
                     <h3>&#9762; RESET ALL</h3>
                     <p>Runs every maintenance action above in sequence. This will wipe system messages,
-                        reports, warnings, orphaned storage, backpacks, gift walls, coins, beans, spin history, Super Shy, and appeals.</p>
+                        reports, warnings, orphaned storage, backpacks, gift walls, coins, beans, spin history, Super Shy, appeals, private messages, group chats, closed rooms, broadcasts, and audit logs.</p>
                     <div class="nuclear-actions">
                         <span>System Messages</span>
                         <span>Reports</span>
@@ -2979,6 +3015,11 @@
                         <span>Beans</span>
                         <span>Spin History</span>
                         <span>Super Shy</span>
+                        <span>Private Messages</span>
+                        <span>Group Chats</span>
+                        <span>Closed Rooms</span>
+                        <span>Broadcasts</span>
+                        <span>Audit Logs</span>
                     </div>
                     <button id="reset-all-btn">RESET EVERYTHING</button>
                     <div class="maintenance-result" id="reset-all-result"></div>
@@ -2991,9 +3032,9 @@
             <div class="nuclear-dialog">
                 <div class="step-indicator" id="nuclear-step-label">Step 1 of 3</div>
                 <h2 id="nuclear-title">Are you sure?</h2>
-                <p id="nuclear-desc">This will run ALL 11 maintenance actions and permanently delete
+                <p id="nuclear-desc">This will run ALL 16 maintenance actions and permanently delete
                     system messages, reports, warnings, orphaned files, backpacks, gift walls, coins,
-                    beans, spin history, Super Shy, and appeals for every user. This cannot be undone.</p>
+                    beans, spin history, Super Shy, appeals, private messages, group chats, closed rooms, broadcasts, and audit logs. This cannot be undone.</p>
                 <div id="nuclear-input-wrap" style="display:none;">
                     <input type="text" id="nuclear-confirm-input" placeholder="Type here..." autocomplete="off">
                 </div>
@@ -3024,6 +3065,11 @@
                     <div class="step" id="np-beans">&#9679; Empty beans</div>
                     <div class="step" id="np-spin-history">&#9679; Clear spin history</div>
                     <div class="step" id="np-supershy">&#9679; Remove Super Shy</div>
+                    <div class="step" id="np-pms">&#9679; Delete private messages</div>
+                    <div class="step" id="np-groups">&#9679; Delete group chats</div>
+                    <div class="step" id="np-rooms">&#9679; Delete closed rooms</div>
+                    <div class="step" id="np-broadcasts">&#9679; Delete broadcasts</div>
+                    <div class="step" id="np-audit-logs">&#9679; Delete audit logs</div>
                 </div>
             </div>
         </div>
@@ -4315,9 +4361,9 @@
 
     function populateGcsSection(data) {
       gcsSection.style.display = "block";
-      const floor = data.goodCharacterScore ?? 100;
-      const lastDeduction = data.goodCharacterLastDeductionAt || null;
-      const display = computeDisplayScore(floor, lastDeduction);
+      const floor = data.gcsScore ?? data.goodCharacterScore ?? 100;
+      const lastDeduction = data.gcsLastDeductionAt ?? data.goodCharacterLastDeductionAt ?? null;
+      const display = data.gcsDisplayScore ?? computeDisplayScore(floor, lastDeduction);
       gcsBadgeUser.className = `gcs-badge ${gcsClass(display)}`;
       gcsBadgeUser.textContent = `${gcsEmoji(display)} ${display}`;
       gcsFloor.textContent = floor;
@@ -4496,7 +4542,7 @@
         $("#stat-pending").textContent = stats.pendingCount;
         $("#stat-resolved-today").textContent = stats.resolvedToday;
         $("#stat-avg-response").textContent = stats.avgResponseHours != null ? `${stats.avgResponseHours}h` : "-";
-        $("#stat-reviewers").textContent = stats.activeReviewers;
+        $("#stat-reviewers").textContent = Array.isArray(stats.activeReviewers) ? stats.activeReviewers.length : (stats.activeReviewers || 0);
 
         // Update tab badge
         updateReportBadge(stats.pendingCount);
@@ -4613,7 +4659,7 @@
         card.dataset.uid = user.uid;
         reportCards.push(card);
 
-        const gcsScore = user.gcs?.displayScore ?? 100;
+        const gcsScore = user.gcsDisplayScore ?? 100;
 
         // Header
         let headerHtml = `<div class="report-card-header">`;
@@ -6353,6 +6399,176 @@
       btn.textContent = "Clear All Device Bindings";
     });
 
+    $("#backfill-user-type-btn").addEventListener("click", async () => {
+      const btn = $("#backfill-user-type-btn");
+      const result = $("#backfill-user-type-result");
+
+      btn.disabled = true;
+      btn.textContent = "Backfilling...";
+      result.style.display = "none";
+
+      try {
+        const token = await auth.currentUser.getIdToken();
+        const resp = await fetch(`${API_BASE}/api/cleanup/backfill-user-type`, {
+          method: "POST",
+          headers: { "Authorization": `Bearer ${token}`, "Content-Type": "application/json" },
+        });
+        const data = await resp.json();
+        if (!resp.ok) throw new Error(data.error || "Request failed");
+        result.className = "maintenance-result success";
+        result.textContent = data.updated > 0
+          ? `Set userType to MEMBER for ${data.updated} user(s)`
+          : data.message;
+        result.style.display = "block";
+      } catch (err) {
+        result.className = "maintenance-result error";
+        result.textContent = err.message;
+        result.style.display = "block";
+      }
+      btn.disabled = false;
+      btn.textContent = "Backfill User Types";
+    });
+
+    // ── Delete all private messages ──
+    $("#clear-pms-btn").addEventListener("click", async () => {
+      const btn = $("#clear-pms-btn");
+      const result = $("#clear-pms-result");
+      if (!confirm("Delete ALL private message conversations and their images? This cannot be undone.")) return;
+      btn.disabled = true;
+      btn.textContent = "Deleting...";
+      result.style.display = "none";
+      try {
+        const token = await auth.currentUser.getIdToken();
+        const resp = await fetch(`${API_BASE}/api/cleanup/all-private-messages`, {
+          method: "POST",
+          headers: { "Authorization": `Bearer ${token}`, "Content-Type": "application/json" },
+        });
+        const data = await resp.json();
+        if (!resp.ok) throw new Error(data.error || "Request failed");
+        result.className = "maintenance-result success";
+        result.textContent = `Deleted ${data.deleted} conversation(s), ${data.mediaDeleted} media file(s)`;
+        result.style.display = "block";
+      } catch (err) {
+        result.className = "maintenance-result error";
+        result.textContent = err.message;
+        result.style.display = "block";
+      }
+      btn.disabled = false;
+      btn.textContent = "Delete All Private Messages";
+    });
+
+    // ── Delete all group chats ──
+    $("#clear-groups-btn").addEventListener("click", async () => {
+      const btn = $("#clear-groups-btn");
+      const result = $("#clear-groups-result");
+      if (!confirm("Delete ALL group chats, their messages, and associated media? This cannot be undone.")) return;
+      btn.disabled = true;
+      btn.textContent = "Deleting...";
+      result.style.display = "none";
+      try {
+        const token = await auth.currentUser.getIdToken();
+        const resp = await fetch(`${API_BASE}/api/cleanup/all-group-chats`, {
+          method: "POST",
+          headers: { "Authorization": `Bearer ${token}`, "Content-Type": "application/json" },
+        });
+        const data = await resp.json();
+        if (!resp.ok) throw new Error(data.error || "Request failed");
+        result.className = "maintenance-result success";
+        result.textContent = `Deleted ${data.deleted} group chat(s), ${data.mediaDeleted} media file(s)`;
+        result.style.display = "block";
+      } catch (err) {
+        result.className = "maintenance-result error";
+        result.textContent = err.message;
+        result.style.display = "block";
+      }
+      btn.disabled = false;
+      btn.textContent = "Delete All Group Chats";
+    });
+
+    // ── Delete all closed rooms ──
+    $("#clear-rooms-btn").addEventListener("click", async () => {
+      const btn = $("#clear-rooms-btn");
+      const result = $("#clear-rooms-result");
+      if (!confirm("Delete ALL closed rooms and their messages? Active rooms will not be affected.")) return;
+      btn.disabled = true;
+      btn.textContent = "Deleting...";
+      result.style.display = "none";
+      try {
+        const token = await auth.currentUser.getIdToken();
+        const resp = await fetch(`${API_BASE}/api/cleanup/all-rooms`, {
+          method: "POST",
+          headers: { "Authorization": `Bearer ${token}`, "Content-Type": "application/json" },
+        });
+        const data = await resp.json();
+        if (!resp.ok) throw new Error(data.error || "Request failed");
+        result.className = "maintenance-result success";
+        result.textContent = `Deleted ${data.deleted} closed room(s)`;
+        result.style.display = "block";
+      } catch (err) {
+        result.className = "maintenance-result error";
+        result.textContent = err.message;
+        result.style.display = "block";
+      }
+      btn.disabled = false;
+      btn.textContent = "Delete All Closed Rooms";
+    });
+
+    // ── Delete all broadcasts ──
+    $("#clear-broadcasts-btn").addEventListener("click", async () => {
+      const btn = $("#clear-broadcasts-btn");
+      const result = $("#clear-broadcasts-result");
+      if (!confirm("Delete ALL broadcast records?")) return;
+      btn.disabled = true;
+      btn.textContent = "Deleting...";
+      result.style.display = "none";
+      try {
+        const token = await auth.currentUser.getIdToken();
+        const resp = await fetch(`${API_BASE}/api/cleanup/all-broadcasts`, {
+          method: "POST",
+          headers: { "Authorization": `Bearer ${token}`, "Content-Type": "application/json" },
+        });
+        const data = await resp.json();
+        if (!resp.ok) throw new Error(data.error || "Request failed");
+        result.className = "maintenance-result success";
+        result.textContent = `Deleted ${data.deleted} broadcast(s)`;
+        result.style.display = "block";
+      } catch (err) {
+        result.className = "maintenance-result error";
+        result.textContent = err.message;
+        result.style.display = "block";
+      }
+      btn.disabled = false;
+      btn.textContent = "Delete All Broadcasts";
+    });
+
+    // ── Delete all audit logs ──
+    $("#clear-audit-logs-btn").addEventListener("click", async () => {
+      const btn = $("#clear-audit-logs-btn");
+      const result = $("#clear-audit-logs-result");
+      if (!confirm("Delete ALL admin audit log entries?")) return;
+      btn.disabled = true;
+      btn.textContent = "Deleting...";
+      result.style.display = "none";
+      try {
+        const token = await auth.currentUser.getIdToken();
+        const resp = await fetch(`${API_BASE}/api/cleanup/all-audit-logs`, {
+          method: "POST",
+          headers: { "Authorization": `Bearer ${token}`, "Content-Type": "application/json" },
+        });
+        const data = await resp.json();
+        if (!resp.ok) throw new Error(data.error || "Request failed");
+        result.className = "maintenance-result success";
+        result.textContent = `Deleted ${data.deleted} audit log(s)`;
+        result.style.display = "block";
+      } catch (err) {
+        result.className = "maintenance-result error";
+        result.textContent = err.message;
+        result.style.display = "block";
+      }
+      btn.disabled = false;
+      btn.textContent = "Delete All Audit Logs";
+    });
+
     // =====================================================
     // --- Reset All (nuclear) ---
     // =====================================================
@@ -6520,7 +6736,7 @@
         step = 1;
         stepLabel.textContent = "Step 1 of 3";
         title.textContent = "Are you absolutely sure?";
-        desc.textContent = "This will run ALL 9 maintenance actions and permanently delete system messages, reports, warnings, orphaned files, backpacks, gift walls, coins, beans, and spin history for every user. This cannot be undone.";
+        desc.textContent = "This will run ALL 16 maintenance actions and permanently delete system messages, reports, warnings, orphaned files, backpacks, gift walls, coins, beans, spin history, Super Shy, appeals, private messages, group chats, closed rooms, broadcasts, and audit logs for every user. This cannot be undone.";
         inputWrap.style.display = "none";
         confirmInput.value = "";
         btnRow.style.display = "flex";
@@ -6573,7 +6789,7 @@
           step = 2;
           stepLabel.textContent = "Step 2 of 3";
           title.textContent = "This is your last warning";
-          desc.textContent = "Every user will lose their coins, beans, backpack items, gift wall, spin history, and warnings. All reports, system messages, and appeals will be deleted. Orphaned files will be purged.";
+          desc.textContent = "Every user will lose their coins, beans, backpack items, gift wall, spin history, and warnings. All reports, system messages, appeals, private messages, group chats, closed rooms, broadcasts, and audit logs will be deleted. Orphaned files will be purged.";
           proceedBtn.textContent = "Continue to final step";
           return;
         }
@@ -6615,16 +6831,25 @@
 
           const token = await auth.currentUser.getIdToken();
 
-          // Auto-backup before wipe — safety net
+          // Auto-backup before wipe — required safety net
           stepLabel.textContent = "Creating safety backup...";
           try {
-            await fetch(`${API_BASE}/api/admin/backups/trigger`, {
+            const backupResp = await fetch(`${API_BASE}/api/admin/backups/trigger`, {
               method: "POST",
               headers: { "Authorization": `Bearer ${token}` },
             });
+            if (!backupResp.ok) throw new Error("Backup request failed");
             console.log("Pre-wipe backup created");
           } catch (backupErr) {
             console.error("Pre-wipe backup failed:", backupErr);
+            result.className = "maintenance-result error";
+            result.textContent = "Backup failed — reset aborted for safety. Fix backup first.";
+            result.style.display = "block";
+            mainBtn.disabled = false;
+            mainBtn.textContent = "RESET EVERYTHING";
+            setMaintenanceButtonsDisabled(false);
+            overlay.style.display = "none";
+            return;
           }
 
           const actions = [
@@ -6639,6 +6864,11 @@
             { id: "np-beans", endpoint: "all-beans", label: "Beans" },
             { id: "np-spin-history", endpoint: "all-spin-history", label: "Spin history" },
             { id: "np-supershy", endpoint: "all-supershy", label: "Super Shy" },
+            { id: "np-pms", endpoint: "all-private-messages", label: "Private messages" },
+            { id: "np-groups", endpoint: "all-group-chats", label: "Group chats" },
+            { id: "np-rooms", endpoint: "all-rooms", label: "Closed rooms" },
+            { id: "np-broadcasts", endpoint: "all-broadcasts", label: "Broadcasts" },
+            { id: "np-audit-logs", endpoint: "all-audit-logs", label: "Audit logs" },
           ];
 
           let failed = 0;
@@ -6683,7 +6913,7 @@
           title.textContent = failed ? "Some actions failed" : "All done";
           desc.textContent = failed
             ? `${actions.length - failed} of ${actions.length} actions succeeded. Check the results below.`
-            : "All 11 maintenance actions completed successfully.";
+            : "All 16 maintenance actions completed successfully.";
           btnRow.style.display = "flex";
           proceedBtn.style.display = "none";
           cancelBtn.textContent = "Close";

--- a/scripts/backup-r2.sh
+++ b/scripts/backup-r2.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Backup R2 bucket to local folder
+# Run manually or via Task Scheduler: bash scripts/backup-r2.sh
+#
+# Syncs all files from the shytalk-media R2 bucket to backups/r2/
+# Only downloads new or changed files (incremental).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BACKUP_DIR="$SCRIPT_DIR/../backups/r2"
+RCLONE="${RCLONE:-rclone}"
+
+mkdir -p "$BACKUP_DIR"
+
+echo "$(date): Starting R2 backup to $BACKUP_DIR"
+"$RCLONE" sync shytalk-r2:shytalk-media "$BACKUP_DIR" \
+  --progress \
+  --log-level INFO \
+  --transfers 4
+STATUS=$?
+
+if [ $STATUS -eq 0 ]; then
+  echo "$(date): Backup complete — $(find "$BACKUP_DIR" -type f | wc -l) files"
+else
+  echo "$(date): Backup FAILED with exit code $STATUS"
+fi

--- a/scripts/compress-r2-images.mjs
+++ b/scripts/compress-r2-images.mjs
@@ -1,0 +1,189 @@
+/**
+ * Compress all images in the R2 bucket (via local backup) and re-upload.
+ *
+ * - JPEG/PNG → WebP (quality 80, max 1920px wide)
+ * - Updates Firestore URLs from .jpg/.png to .webp where applicable
+ * - Skips files already in WebP format
+ *
+ * Run:
+ *   node scripts/compress-r2-images.mjs
+ */
+
+import { existsSync, readdirSync, statSync, readFileSync } from "fs";
+import { resolve, dirname, join, extname, basename } from "path";
+import { fileURLToPath } from "url";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const sharp = require("sharp");
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = resolve(__dirname, "../.env");
+if (existsSync(envPath)) {
+  const { config } = await import("dotenv");
+  config({ path: envPath });
+}
+
+const {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+} = await import("@aws-sdk/client-s3");
+const { initializeApp, getApps } = await import("firebase-admin/app");
+const { getFirestore } = await import("firebase-admin/firestore");
+
+if (!getApps().length) initializeApp();
+const db = getFirestore();
+
+const CF_ACCOUNT_ID = process.env.CF_ACCOUNT_ID;
+const R2_ACCESS_KEY = process.env.R2_ACCESS_KEY;
+const R2_SECRET_KEY = process.env.R2_SECRET_KEY;
+const BUCKET_NAME = process.env.R2_BUCKET_NAME ?? "shytalk-media";
+const R2_PUBLIC_BASE = "https://images.shytalk.shyden.co.uk";
+
+const s3 = new S3Client({
+  region: "auto",
+  endpoint: `https://${CF_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: R2_ACCESS_KEY, secretAccessKey: R2_SECRET_KEY },
+});
+
+const BACKUP_DIR = resolve(__dirname, "../backups/r2");
+const IMAGE_EXTS = new Set([".jpg", ".jpeg", ".png", ".webp"]);
+const MAX_WIDTH = 1920;
+const WEBP_QUALITY = 80;
+
+function walkDir(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      results.push(...walkDir(full));
+    } else if (IMAGE_EXTS.has(extname(full).toLowerCase())) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+async function compressAndUpload(localPath) {
+  const relPath = localPath.replace(BACKUP_DIR + "\\", "").replace(BACKUP_DIR + "/", "");
+  const r2Key = relPath.replace(/\\/g, "/");
+  const ext = extname(r2Key).toLowerCase();
+  const originalSize = statSync(localPath).size;
+
+  // Read and compress
+  const buffer = readFileSync(localPath);
+  let compressed;
+  let newKey = r2Key;
+
+  if (ext === ".webp") {
+    // Already WebP — just resize if needed
+    compressed = await sharp(buffer)
+      .resize({ width: MAX_WIDTH, withoutEnlargement: true })
+      .webp({ quality: WEBP_QUALITY })
+      .toBuffer();
+  } else {
+    // Convert to WebP
+    compressed = await sharp(buffer)
+      .resize({ width: MAX_WIDTH, withoutEnlargement: true })
+      .webp({ quality: WEBP_QUALITY })
+      .toBuffer();
+    newKey = r2Key.replace(/\.(jpg|jpeg|png)$/i, ".webp");
+  }
+
+  const savings = ((1 - compressed.length / originalSize) * 100).toFixed(1);
+  console.log(
+    `  ${r2Key}: ${(originalSize / 1024).toFixed(0)}KB → ${(compressed.length / 1024).toFixed(0)}KB (${savings}% smaller)${newKey !== r2Key ? ` → ${newKey}` : ""}`
+  );
+
+  // Upload compressed version
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: BUCKET_NAME,
+      Key: newKey,
+      Body: compressed,
+      ContentType: "image/webp",
+      CacheControl: "public, max-age=31536000, immutable",
+    })
+  );
+
+  // Delete old key if we changed extension
+  if (newKey !== r2Key) {
+    await s3.send(new DeleteObjectCommand({ Bucket: BUCKET_NAME, Key: r2Key }));
+  }
+
+  return { oldUrl: `${R2_PUBLIC_BASE}/${r2Key}`, newUrl: `${R2_PUBLIC_BASE}/${newKey}`, changed: newKey !== r2Key };
+}
+
+async function updateFirestoreUrls(urlMap) {
+  if (urlMap.size === 0) return;
+  console.log(`\nUpdating ${urlMap.size} Firestore URL(s)...`);
+
+  // Users
+  const users = await db.collection("users").get();
+  for (const doc of users.docs) {
+    const d = doc.data();
+    const updates = {};
+    if (d.profilePhotoUrl && urlMap.has(d.profilePhotoUrl)) updates.profilePhotoUrl = urlMap.get(d.profilePhotoUrl);
+    if (d.coverPhotoUrl && urlMap.has(d.coverPhotoUrl)) updates.coverPhotoUrl = urlMap.get(d.coverPhotoUrl);
+    if (Object.keys(updates).length) {
+      await doc.ref.update(updates);
+      console.log(`  Updated user ${doc.id}`);
+    }
+  }
+
+  // Banners
+  const banners = await db.collection("banners").get();
+  for (const doc of banners.docs) {
+    const d = doc.data();
+    if (d.imageUrl && urlMap.has(d.imageUrl)) {
+      await doc.ref.update({ imageUrl: urlMap.get(d.imageUrl) });
+      console.log(`  Updated banner ${doc.id}`);
+    }
+  }
+
+  // Conversations (group photos)
+  const convs = await db.collection("conversations").get();
+  for (const doc of convs.docs) {
+    const d = doc.data();
+    if (d.groupPhotoUrl && urlMap.has(d.groupPhotoUrl)) {
+      await doc.ref.update({ groupPhotoUrl: urlMap.get(d.groupPhotoUrl) });
+      console.log(`  Updated conversation ${doc.id}`);
+    }
+  }
+}
+
+async function main() {
+  if (!existsSync(BACKUP_DIR)) {
+    console.error("No backup dir found. Run backup-r2.sh first.");
+    process.exit(1);
+  }
+
+  const files = walkDir(BACKUP_DIR);
+  console.log(`Found ${files.length} images to compress\n`);
+
+  const urlMap = new Map();
+  let totalSaved = 0;
+
+  for (const file of files) {
+    try {
+      const originalSize = statSync(file).size;
+      const result = await compressAndUpload(file);
+      const newSize = statSync(file).size; // approximate
+      if (result.changed) {
+        urlMap.set(result.oldUrl, result.newUrl);
+      }
+      totalSaved += originalSize;
+    } catch (e) {
+      console.error(`  ERROR: ${file}: ${e.message}`);
+    }
+  }
+
+  await updateFirestoreUrls(urlMap);
+  console.log(`\nDone! Compressed and re-uploaded ${files.length} images.`);
+}
+
+main().catch((e) => {
+  console.error("Fatal:", e);
+  process.exit(1);
+});

--- a/scripts/delete-firebase-storage.mjs
+++ b/scripts/delete-firebase-storage.mjs
@@ -1,0 +1,57 @@
+/**
+ * One-time cleanup: delete all files from Firebase Storage after R2 migration.
+ * Run ONLY after confirming R2 migration was successful.
+ *
+ * Run:
+ *   node scripts/delete-firebase-storage.mjs
+ */
+
+import { existsSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = resolve(__dirname, "../.env");
+if (existsSync(envPath)) {
+  const { config } = await import("dotenv");
+  config({ path: envPath });
+}
+
+const { initializeApp, getApps } = await import("firebase-admin/app");
+const { getStorage } = await import("firebase-admin/storage");
+
+const FIREBASE_STORAGE_BUCKET =
+  process.env.FIREBASE_STORAGE_BUCKET ?? "shytalk-7ba69.appspot.com";
+
+if (!getApps().length) {
+  initializeApp({ storageBucket: FIREBASE_STORAGE_BUCKET });
+}
+const bucket = getStorage().bucket();
+
+const FOLDERS = [
+  "pm_images",
+  "stickers",
+  "report_evidence",
+  "profile_photos",
+  "cover_photos",
+  "group_photos",
+];
+
+let total = 0;
+
+for (const folder of FOLDERS) {
+  const [files] = await bucket.getFiles({ prefix: `${folder}/` });
+  console.log(`📂 ${folder}/: ${files.length} files`);
+  for (const file of files) {
+    try {
+      await file.delete();
+      console.log(`  🗑️  Deleted: ${file.name}`);
+      total++;
+    } catch (e) {
+      console.error(`  ❌ Failed to delete ${file.name}: ${e.message}`);
+    }
+  }
+}
+
+console.log(`\nDone — deleted ${total} files from Firebase Storage.`);
+console.log("You can now downgrade back to Spark plan.");

--- a/scripts/seed-banners.mjs
+++ b/scripts/seed-banners.mjs
@@ -1,0 +1,64 @@
+/**
+ * One-time seed script: populate Firestore `banners` collection
+ *
+ * Run:
+ *   node scripts/seed-banners.mjs
+ */
+
+import { existsSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = resolve(__dirname, "../.env");
+if (existsSync(envPath)) {
+  const { config } = await import("dotenv");
+  config({ path: envPath });
+}
+
+const { initializeApp, getApps } = await import("firebase-admin/app");
+const { getFirestore } = await import("firebase-admin/firestore");
+
+if (!getApps().length) initializeApp();
+const db = getFirestore();
+
+const BANNERS = [
+  {
+    title: "Safe & Supportive Community",
+    imageUrl: "https://images.shytalk.shyden.co.uk/banners/safe-community.png",
+    actionType: "NONE",
+    actionValue: null,
+    sortOrder: 1,
+    isActive: true,
+    startDate: Date.now(),
+    endDate: null, // no expiry
+  },
+];
+
+async function seed() {
+  const collection = db.collection("banners");
+  const existing = await collection.get();
+  const existingTitles = new Set(existing.docs.map((d) => d.data().title));
+
+  let added = 0;
+  let skipped = 0;
+
+  for (const banner of BANNERS) {
+    if (existingTitles.has(banner.title)) {
+      console.log(`  SKIP (exists): ${banner.title}`);
+      skipped++;
+      continue;
+    }
+
+    await collection.add(banner);
+    console.log(`  ADD: ${banner.title}`);
+    added++;
+  }
+
+  console.log(`\nDone! Added ${added}, skipped ${skipped}.`);
+}
+
+seed().catch((err) => {
+  console.error("Seed failed:", err);
+  process.exit(1);
+});

--- a/scripts/seed-fun-facts.mjs
+++ b/scripts/seed-fun-facts.mjs
@@ -1,0 +1,187 @@
+/**
+ * One-time seed script: populate Firestore `funFacts` collection
+ *
+ * Setup:
+ *   npm install firebase-admin dotenv  (if not already installed)
+ *   Ensure .env has GOOGLE_APPLICATION_CREDENTIALS pointing to the service account JSON
+ *
+ * Run:
+ *   node scripts/seed-fun-facts.mjs
+ */
+
+import { existsSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+// Load .env from project root
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = resolve(__dirname, "../.env");
+if (existsSync(envPath)) {
+  const { config } = await import("dotenv");
+  config({ path: envPath });
+}
+
+const { initializeApp, getApps } = await import("firebase-admin/app");
+const { getFirestore, FieldValue } = await import("firebase-admin/firestore");
+
+if (!getApps().length) {
+  initializeApp();
+}
+const db = getFirestore();
+
+const FACTS = [
+  {
+    text: "There are over 7,000 languages spoken in the world today",
+    category: "languages",
+    emoji: "🌍",
+    sourceLanguage: "en",
+  },
+  {
+    text: "Mandarin Chinese has the most native speakers of any language",
+    category: "languages",
+    emoji: "🇨🇳",
+    sourceLanguage: "en",
+  },
+  {
+    text: "The word 'emoji' comes from the Japanese words for picture (e) and character (moji)",
+    category: "communication",
+    emoji: "😊",
+    sourceLanguage: "ja",
+  },
+  {
+    text: "Finnish has no grammatical gender — no 'he' or 'she', just 'hän'",
+    category: "languages",
+    emoji: "🇫🇮",
+    sourceLanguage: "fi",
+  },
+  {
+    text: "The shortest complete sentence in English is 'Go.'",
+    category: "languages",
+    emoji: "✍️",
+    sourceLanguage: "en",
+  },
+  {
+    text: "In Thailand, the traditional greeting involves pressing palms together in a 'wai'",
+    category: "culture",
+    emoji: "🙏",
+    sourceLanguage: "th",
+  },
+  {
+    text: "South Africa has 11 official languages — the most of any country",
+    category: "languages",
+    emoji: "🇿🇦",
+    sourceLanguage: "en",
+  },
+  {
+    text: "The Hawaiian alphabet has only 13 letters: 5 vowels and 8 consonants",
+    category: "languages",
+    emoji: "🌺",
+    sourceLanguage: "haw",
+  },
+  {
+    text: "A 'polyglot' is someone who speaks six or more languages fluently",
+    category: "communication",
+    emoji: "🗣️",
+    sourceLanguage: "en",
+  },
+  {
+    text: "In Japan, silence during conversation is valued as a sign of respect",
+    category: "culture",
+    emoji: "🇯🇵",
+    sourceLanguage: "ja",
+  },
+  {
+    text: "The most translated book in the world is 'The Little Prince'",
+    category: "trivia",
+    emoji: "📖",
+    sourceLanguage: "fr",
+  },
+  {
+    text: "Korean was designed as a scientific writing system by King Sejong in 1443",
+    category: "languages",
+    emoji: "🇰🇷",
+    sourceLanguage: "ko",
+  },
+  {
+    text: "Whistled languages exist in places like Turkey and the Canary Islands",
+    category: "communication",
+    emoji: "🎵",
+    sourceLanguage: "en",
+  },
+  {
+    text: "The word 'coffee' comes from the Arabic 'qahwa'",
+    category: "trivia",
+    emoji: "☕",
+    sourceLanguage: "ar",
+  },
+  {
+    text: "Basque, spoken in Spain and France, is not related to any other known language",
+    category: "languages",
+    emoji: "🏔️",
+    sourceLanguage: "eu",
+  },
+  {
+    text: "In many cultures, a head nod doesn't always mean 'yes' — in Bulgaria it means 'no'",
+    category: "culture",
+    emoji: "🤔",
+    sourceLanguage: "bg",
+  },
+  {
+    text: "Pirahã, an Amazonian language, has no words for specific numbers",
+    category: "languages",
+    emoji: "🌿",
+    sourceLanguage: "myp",
+  },
+  {
+    text: "The most common letter in English is 'E', appearing in 11% of all words",
+    category: "trivia",
+    emoji: "🔤",
+    sourceLanguage: "en",
+  },
+  {
+    text: "Sign languages are fully developed languages with their own grammar",
+    category: "communication",
+    emoji: "🤟",
+    sourceLanguage: "en",
+  },
+  {
+    text: "Icelandic has changed so little that modern speakers can read 800-year-old texts",
+    category: "languages",
+    emoji: "🇮🇸",
+    sourceLanguage: "is",
+  },
+];
+
+async function seed() {
+  const collection = db.collection("funFacts");
+  const existing = await collection.get();
+  const existingTexts = new Set(existing.docs.map((d) => d.data().text));
+
+  let added = 0;
+  let skipped = 0;
+
+  for (const fact of FACTS) {
+    if (existingTexts.has(fact.text)) {
+      console.log(`  SKIP (exists): ${fact.text.slice(0, 50)}...`);
+      skipped++;
+      continue;
+    }
+
+    const now = FieldValue.serverTimestamp();
+    await collection.add({
+      ...fact,
+      isActive: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    console.log(`  ADD: ${fact.emoji} ${fact.text.slice(0, 50)}...`);
+    added++;
+  }
+
+  console.log(`\nDone! Added ${added}, skipped ${skipped} (already existed).`);
+}
+
+seed().catch((err) => {
+  console.error("Seed failed:", err);
+  process.exit(1);
+});

--- a/scripts/seed-gifts.mjs
+++ b/scripts/seed-gifts.mjs
@@ -1,0 +1,103 @@
+/**
+ * One-time seed script: populate Firestore `gifts` collection
+ *
+ * Seeds 27 gifts used by the gacha wheel and gift store.
+ * Idempotent — skips gifts that already exist (matched by document ID).
+ *
+ * Setup:
+ *   npm install firebase-admin dotenv  (if not already installed)
+ *   Ensure .env has GOOGLE_APPLICATION_CREDENTIALS pointing to the service account JSON
+ *
+ * Run:
+ *   node scripts/seed-gifts.mjs
+ */
+
+import { existsSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+// Load .env from project root
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = resolve(__dirname, "../.env");
+if (existsSync(envPath)) {
+  const { config } = await import("dotenv");
+  config({ path: envPath });
+}
+
+const { initializeApp, getApps } = await import("firebase-admin/app");
+const { getFirestore } = await import("firebase-admin/firestore");
+
+if (!getApps().length) {
+  initializeApp();
+}
+const db = getFirestore();
+
+// Same catalog as worker-api/src/routes/admin-gifts.js seed endpoint
+const SEED_GIFTS = [
+  { id: "rose",           name: "Rose",           coinValue: 1,      order: 1  },
+  { id: "lollipop",       name: "Lollipop",       coinValue: 5,      order: 2  },
+  { id: "ice_cream",      name: "Ice Cream",      coinValue: 10,     order: 3  },
+  { id: "coffee",         name: "Coffee",         coinValue: 25,     order: 4  },
+  { id: "teddy_bear",     name: "Teddy Bear",     coinValue: 50,     order: 5  },
+  { id: "chocolate_box",  name: "Chocolate Box",  coinValue: 100,    order: 6  },
+  { id: "bouquet",        name: "Bouquet",         coinValue: 200,    order: 7  },
+  { id: "perfume",        name: "Perfume",         coinValue: 500,    order: 8  },
+  { id: "fireworks",      name: "Fireworks",       coinValue: 1000,   order: 9  },
+  { id: "diamond_ring",   name: "Diamond Ring",    coinValue: 2000,   order: 10 },
+  { id: "crown",          name: "Crown",           coinValue: 5000,   order: 11 },
+  { id: "castle",         name: "Castle",          coinValue: 10000,  order: 12 },
+  { id: "yacht",          name: "Yacht",           coinValue: 20000,  order: 13 },
+  { id: "rocket",         name: "Rocket",          coinValue: 50000,  order: 14 },
+  { id: "planet",         name: "Planet",          coinValue: 100000, order: 15 },
+  { id: "universe",       name: "Universe",        coinValue: 200000, order: 16 },
+  { id: "star",           name: "Star",            coinValue: 10,     order: 17 },
+  { id: "heart",          name: "Heart",           coinValue: 25,     order: 18 },
+  { id: "balloon",        name: "Balloon",         coinValue: 5,      order: 19 },
+  { id: "cake",           name: "Cake",            coinValue: 50,     order: 20 },
+  { id: "pizza",          name: "Pizza",           coinValue: 15,     order: 21 },
+  { id: "sushi",          name: "Sushi",           coinValue: 30,     order: 22 },
+  { id: "rainbow",        name: "Rainbow",         coinValue: 500,    order: 23 },
+  { id: "sunflower",      name: "Sunflower",       coinValue: 100,    order: 24 },
+  { id: "music_box",      name: "Music Box",       coinValue: 250,    order: 25 },
+  { id: "magic_lamp",     name: "Magic Lamp",      coinValue: 1500,   order: 26 },
+  { id: "treasure_chest", name: "Treasure Chest",  coinValue: 3000,   order: 27 },
+];
+
+async function seed() {
+  const collection = db.collection("gifts");
+  const existing = await collection.get();
+  const existingIds = new Set(existing.docs.map((d) => d.id));
+
+  let added = 0;
+  let skipped = 0;
+
+  for (const gift of SEED_GIFTS) {
+    if (existingIds.has(gift.id)) {
+      console.log(`  SKIP (exists): ${gift.name}`);
+      skipped++;
+      continue;
+    }
+
+    await collection.doc(gift.id).set({
+      id:           gift.id,
+      name:         gift.name,
+      coinValue:    gift.coinValue,
+      order:        gift.order,
+      animationUrl: "",
+      soundUrl:     "",
+      iconUrl:      "",
+      showInStore:  true,
+      showOnWheel:  true,
+      weight:       1.0,
+    });
+    console.log(`  ADD: ${gift.name} (${gift.coinValue} coins)`);
+    added++;
+  }
+
+  console.log(`\nDone! Added ${added}, skipped ${skipped} (already existed).`);
+}
+
+seed().catch((err) => {
+  console.error("Seed failed:", err);
+  process.exit(1);
+});

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
@@ -154,7 +154,7 @@ data class User(
                 ?.filterIsInstance<String>()?.toSet() ?: emptySet(),
             followerIds = (map["followerIds"] as? List<*>)
                 ?.filterIsInstance<String>()?.toSet() ?: emptySet(),
-            dateOfBirth = map["dateOfBirth"]?.let { timestampToMillis(it) },
+            dateOfBirth = (map["dateOfBirth"] ?: map["date_of_birth"])?.let { timestampToMillis(it) },
             hideFollowing = map["hideFollowing"].asBool(),
             hideOnlineStatus = map["hideOnlineStatus"].asBool(),
             hideAge = map["hideAge"].asBool(),

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/GachaViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/GachaViewModel.kt
@@ -212,8 +212,7 @@ class GachaViewModel(
                 }
                 is Resource.Loading -> {}
             }
-            // Delay to allow cloud function to write transaction doc
-            loadSpinHistory(delayMs = 2000)
+            loadSpinHistory()
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinOverlay.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/gacha/LuckySpinOverlay.kt
@@ -645,7 +645,7 @@ fun LuckySpinOverlay(
 
                         Button(
                             onClick = {
-                                if (spinning) return@Button
+                                if (spinning || showSummary) return@Button
                                 if (!canAfford) {
                                     showCoinShop = true
                                 } else if (!gachaState.isPulling) {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -278,6 +278,12 @@ class RoomViewModel(
                                 currentUserName = if (uid == state.currentUserId) updatedUser.displayName else state.currentUserName
                             )
                         }
+                        // Re-resolve room limits if the owner's SuperShy status changed
+                        val room = _uiState.value.room
+                        if (room != null && uid == room.ownerId && cached.isSuperShy != updatedUser.isSuperShy) {
+                            resolveRoomDuration()
+                            resolveSeatLimit()
+                        }
                     }
                 }
         }

--- a/worker-api/package-lock.json
+++ b/worker-api/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "jest": "^29.7.0",
-        "wrangler": "^4.0.0"
+        "wrangler": "^4.71.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -455,12 +455,14 @@
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.14.0",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
+      "integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
-        "workerd": "^1.20260218.0"
+        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -469,9 +471,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260305.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260305.0.tgz",
-      "integrity": "sha512-chhKOpymo0Eh9J3nymrauMqKGboCc4uz/j0gA1G4gioMnKsN2ZDKJ+qjRZDnCoVGy8u2C4pxlmyIfsXCAfIzhQ==",
+      "version": "1.20260301.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260301.1.tgz",
+      "integrity": "sha512-+kJvwociLrvy1JV9BAvoSVsMEIYD982CpFmo/yMEvBwxDIjltYsLTE8DLi0mCkGsQ8Ygidv2fD9wavzXeiY7OQ==",
       "cpu": [
         "x64"
       ],
@@ -486,9 +488,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260305.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260305.0.tgz",
-      "integrity": "sha512-K9aG2OQk5bBfOP+fyGPqLcqZ9OR3ra6uwnxJ8f2mveq2A2LsCI7ZeGxQiAj75Ti80ytH/gJffZIx4Np2JtU3aQ==",
+      "version": "1.20260301.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260301.1.tgz",
+      "integrity": "sha512-PPIetY3e67YBr9O4UhILK8nbm5TqUDl14qx4rwFNrRSBOvlzuczzbd4BqgpAtbGVFxKp1PWpjAnBvGU/OI/tLQ==",
       "cpu": [
         "arm64"
       ],
@@ -503,9 +505,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260305.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260305.0.tgz",
-      "integrity": "sha512-tt7XUoIw/cYFeGbkPkcZ6XX1aZm26Aju/4ih+DXxOosbBeGshFSrNJDBfAKKOvkjsAZymJ+WWVDBU+hmNaGfwA==",
+      "version": "1.20260301.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260301.1.tgz",
+      "integrity": "sha512-Gu5vaVTZuYl3cHa+u5CDzSVDBvSkfNyuAHi6Mdfut7TTUdcb3V5CIcR/mXRSyMXzEy9YxEWIfdKMxOMBjupvYQ==",
       "cpu": [
         "x64"
       ],
@@ -520,9 +522,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260305.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260305.0.tgz",
-      "integrity": "sha512-72QTkY5EzylmvCZ8ZTrnJ9DctmQsfSof1OKyOWqu/pv/B2yACfuPMikq8RpPxvVu7hhS0ztGP6ZvXz72Htq4Zg==",
+      "version": "1.20260301.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260301.1.tgz",
+      "integrity": "sha512-igL1pkyCXW6GiGpjdOAvqMi87UW0LMc/+yIQe/CSzuZJm5GzXoAMrwVTkCFnikk6JVGELrM5x0tGYlxa0sk5Iw==",
       "cpu": [
         "arm64"
       ],
@@ -537,7 +539,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260305.0",
+      "version": "1.20260301.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260301.1.tgz",
+      "integrity": "sha512-Q0wMJ4kcujXILwQKQFc1jaYamVsNvjuECzvRrTI8OxGFMx2yq9aOsswViE4X1gaS2YQQ5u0JGwuGi5WdT1Lt7A==",
       "cpu": [
         "x64"
       ],
@@ -553,6 +557,8 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -564,6 +570,8 @@
     },
     "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1023,7 +1031,9 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1492,6 +1502,8 @@
     },
     "node_modules/@img/sharp-win32-x64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
@@ -1844,6 +1856,8 @@
     },
     "node_modules/@poppinss/colors": {
       "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1852,6 +1866,8 @@
     },
     "node_modules/@poppinss/colors/node_modules/kleur": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1860,6 +1876,8 @@
     },
     "node_modules/@poppinss/dumper": {
       "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1870,6 +1888,8 @@
     },
     "node_modules/@poppinss/dumper/node_modules/supports-color": {
       "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1881,6 +1901,8 @@
     },
     "node_modules/@poppinss/exception": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1891,6 +1913,8 @@
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1918,6 +1942,8 @@
     },
     "node_modules/@speed-highlight/core": {
       "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
+      "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -2428,6 +2454,8 @@
     },
     "node_modules/cookie": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2510,6 +2538,8 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2563,6 +2593,8 @@
     },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3718,14 +3750,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260305.0",
+      "version": "4.20260301.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260301.1.tgz",
+      "integrity": "sha512-fqkHx0QMKswRH9uqQQQOU/RoaS3Wjckxy3CUX3YGJr0ZIMu7ObvI+NovdYi6RIsSPthNtq+3TPmRNxjeRiasog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
         "undici": "7.18.2",
-        "workerd": "1.20260305.0",
+        "workerd": "1.20260301.1",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10"
       },
@@ -3908,6 +3942,8 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4076,6 +4112,8 @@
     },
     "node_modules/sharp": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -4119,6 +4157,8 @@
     },
     "node_modules/sharp/node_modules/semver": {
       "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4314,6 +4354,8 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
       "optional": true
@@ -4339,6 +4381,8 @@
     },
     "node_modules/undici": {
       "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
+      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4352,6 +4396,8 @@
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4424,10 +4470,13 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260305.0",
+      "version": "1.20260301.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260301.1.tgz",
+      "integrity": "sha512-oterQ1IFd3h7PjCfT4znSFOkJCvNQ6YMOyZ40YsnO3nrSpgB4TbJVYWFOnyJAw71/RQuupfVqZZWKvsy8GO3fw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -4435,26 +4484,28 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260305.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20260305.0",
-        "@cloudflare/workerd-linux-64": "1.20260305.0",
-        "@cloudflare/workerd-linux-arm64": "1.20260305.0",
-        "@cloudflare/workerd-windows-64": "1.20260305.0"
+        "@cloudflare/workerd-darwin-64": "1.20260301.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260301.1",
+        "@cloudflare/workerd-linux-64": "1.20260301.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260301.1",
+        "@cloudflare/workerd-windows-64": "1.20260301.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.69.0",
+      "version": "4.71.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.71.0.tgz",
+      "integrity": "sha512-j6pSGAncOLNQDRzqtp0EqzYj52CldDP7uz/C9cxVrIgqa5p+cc0b4pIwnapZZAGv9E1Loa3tmPD0aXonH7KTkw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.2",
-        "@cloudflare/unenv-preset": "2.14.0",
+        "@cloudflare/unenv-preset": "2.15.0",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260305.0",
+        "miniflare": "4.20260301.1",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260305.0"
+        "workerd": "1.20260301.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -4467,7 +4518,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260305.0"
+        "@cloudflare/workers-types": "^4.20260226.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -4510,6 +4561,8 @@
     },
     "node_modules/ws": {
       "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4579,6 +4632,8 @@
     },
     "node_modules/youch": {
       "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4591,6 +4646,8 @@
     },
     "node_modules/youch-core": {
       "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/worker-api/package.json
+++ b/worker-api/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
-    "wrangler": "^4.0.0"
+    "wrangler": "^4.71.0"
   }
 }

--- a/worker-api/src/index.js
+++ b/worker-api/src/index.js
@@ -192,8 +192,9 @@ export default {
         await closeStaleOwnerAwayRooms(env);
         break;
 
-      case '0 2 * * *': // Backup user profiles to R2 (daily 02:00)
+      case '0 2 * * *': // Backup user profiles to R2 + cleanup old rooms (daily 02:00)
         await backupUserProfiles(env);
+        await cleanupClosedRooms(env);
         break;
 
       default:
@@ -366,6 +367,38 @@ async function backupUserProfiles(env) {
       console.log(`Backup: pruned old backup ${obj.key}`);
     }
   }
+}
+
+async function cleanupClosedRooms(env) {
+  const sevenDaysAgo = Date.now() - (7 * 24 * 60 * 60 * 1000);
+
+  const closedRooms = await queryCollection(env, 'rooms', {
+    where: fieldFilter('state', 'EQUAL', 'CLOSED'),
+    limit: 500,
+  });
+
+  // Only delete rooms closed more than 7 days ago
+  const old = closedRooms.filter(r => r.closedAt && r.closedAt < sevenDaysAgo);
+  if (old.length === 0) return;
+
+  for (const room of old) {
+    const [messages, seatRequests] = await Promise.all([
+      queryCollection(env, `rooms/${room.id}/messages`, {}),
+      queryCollection(env, `rooms/${room.id}/seatRequests`, {}),
+    ]);
+
+    const writes = [
+      ...messages.map(m => batchDeleteOp(env, `rooms/${room.id}/messages/${m.id}`)),
+      ...seatRequests.map(s => batchDeleteOp(env, `rooms/${room.id}/seatRequests/${s.id}`)),
+      batchDeleteOp(env, `rooms/${room.id}`),
+    ];
+
+    for (let i = 0; i < writes.length; i += 500) {
+      await batchWrite(env, writes.slice(i, i + 500));
+    }
+  }
+
+  console.log(`Cleaned up ${old.length} closed rooms (older than 7 days)`);
 }
 
 async function cleanupOrphanedStorage(env) {

--- a/worker-api/src/routes/admin-cleanup.js
+++ b/worker-api/src/routes/admin-cleanup.js
@@ -14,6 +14,12 @@
  * POST /api/cleanup/all-spin-history           → Delete gacha transactions + reset pity
  * POST /api/cleanup/all-supershy               → Clear Super Shy status
  * POST /api/cleanup/all-appeals                → Delete all suspension appeals
+ * POST /api/cleanup/backfill-user-type          → Set userType=MEMBER for users missing it
+ * POST /api/cleanup/all-private-messages       → Delete all 1-on-1 PMs + R2 media
+ * POST /api/cleanup/all-group-chats            → Delete all group chats + R2 media
+ * POST /api/cleanup/all-rooms                  → Delete all closed rooms + subcollections
+ * POST /api/cleanup/all-broadcasts             → Delete all broadcast records
+ * POST /api/cleanup/all-audit-logs             → Delete all admin audit logs
  * GET  /api/storage/audit                      → R2 folder audit
  * POST /api/cleanup/orphaned-storage           → Smart R2 cleanup
  */
@@ -192,21 +198,25 @@ function registerAdminCleanupRoutes(router) {
     const adminCheck = requireAdmin(request);
     if (adminCheck) return adminCheck;
 
-    const [giftWall, giftWallSenders] = await Promise.all([
-      queryCollection(env, 'giftWall', {}),
-      queryCollection(env, 'giftWallSenders', {}),
-    ]);
+    // Gift wall data is stored as subcollections: users/{uid}/giftWall/{giftId}
+    const users = await queryCollection(env, 'users', {
+      orderBy: [orderBy('uid', 'ASCENDING')],
+    });
 
-    const writes = [
-      ...giftWall.map(d => batchDeleteOp(env, `giftWall/${d.id}`)),
-      ...giftWallSenders.map(d => batchDeleteOp(env, `giftWallSenders/${d.id}`)),
-    ];
+    let deleted = 0;
+    for (const user of users) {
+      const uid = user.uid ?? user.id;
+      const gifts = await queryCollection(env, `users/${uid}/giftWall`, {});
+      if (gifts.length === 0) continue;
 
-    for (let i = 0; i < writes.length; i += 500) {
-      await batchWrite(env, writes.slice(i, i + 500));
+      const writes = gifts.map(gift => batchDeleteOp(env, `users/${uid}/giftWall/${gift.id}`));
+      for (let i = 0; i < writes.length; i += 500) {
+        await batchWrite(env, writes.slice(i, i + 500));
+      }
+      deleted += gifts.length;
     }
 
-    return json({ success: true, deleted: giftWall.length + giftWallSenders.length });
+    return json({ success: true, deleted });
   });
 
   // ── Reset all coins ──
@@ -572,6 +582,159 @@ function registerAdminCleanupRoutes(router) {
 
     return json({ success: true, deleted: bindings.length });
   });
+
+  // ── Backfill userType for users missing it ──
+  router.post('/api/cleanup/backfill-user-type', async (request, env) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    const users = await queryCollection(env, 'users', { limit: 5000 });
+    const missing = users.filter(u => !u.userType && !u.user_type);
+
+    if (missing.length === 0) {
+      return json({ success: true, updated: 0, message: 'All users already have a userType' });
+    }
+
+    const writes = missing.map(u =>
+      batchUpdateOp(env, `users/${u.uid ?? u.id}`, { userType: 'MEMBER' })
+    );
+    for (let i = 0; i < writes.length; i += 500) {
+      await batchWrite(env, writes.slice(i, i + 500));
+    }
+
+    return json({ success: true, updated: missing.length });
+  });
+
+  // ── Delete all private messages (1-on-1 conversations) + R2 media ──
+  router.post('/api/cleanup/all-private-messages', async (request, env) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    // Get all non-group conversations
+    const allConvs = await queryCollection(env, 'conversations', { limit: 5000 });
+    const pms = allConvs.filter(c => !c.isGroup);
+
+    if (pms.length === 0) {
+      return json({ success: true, deleted: 0, mediaDeleted: 0, message: 'No private messages found' });
+    }
+
+    // Collect image URLs from messages before deleting
+    let mediaDeleted = 0;
+    const CDN_PREFIX = 'https://images.shytalk.shyden.co.uk/';
+
+    for (const conv of pms) {
+      const messages = await queryCollection(env, `conversations/${conv.id}/messages`, {});
+      for (const msg of messages) {
+        const urls = msg.imageUrls || [];
+        for (const url of urls) {
+          if (url && url.startsWith(CDN_PREFIX)) {
+            try { await env.R2_BUCKET.delete(url.slice(CDN_PREFIX.length)); mediaDeleted++; } catch (_) {}
+          }
+        }
+      }
+      await deleteConversation(env, conv.id);
+    }
+
+    return json({ success: true, deleted: pms.length, mediaDeleted });
+  });
+
+  // ── Delete all group chats + R2 media ──
+  router.post('/api/cleanup/all-group-chats', async (request, env) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    const allConvs = await queryCollection(env, 'conversations', {
+      where: fieldFilter('isGroup', 'EQUAL', true),
+      limit: 5000,
+    });
+
+    if (allConvs.length === 0) {
+      return json({ success: true, deleted: 0, mediaDeleted: 0, message: 'No group chats found' });
+    }
+
+    const CDN_PREFIX = 'https://images.shytalk.shyden.co.uk/';
+    let mediaDeleted = 0;
+
+    for (const conv of allConvs) {
+      // Delete group photo from R2
+      const photoUrl = conv.groupPhotoUrl || conv.group_photo_url;
+      if (photoUrl && photoUrl.startsWith(CDN_PREFIX)) {
+        try { await env.R2_BUCKET.delete(photoUrl.slice(CDN_PREFIX.length)); mediaDeleted++; } catch (_) {}
+      }
+      // Delete message images
+      const messages = await queryCollection(env, `conversations/${conv.id}/messages`, {});
+      for (const msg of messages) {
+        const urls = msg.imageUrls || [];
+        for (const url of urls) {
+          if (url && url.startsWith(CDN_PREFIX)) {
+            try { await env.R2_BUCKET.delete(url.slice(CDN_PREFIX.length)); mediaDeleted++; } catch (_) {}
+          }
+        }
+      }
+      await deleteConversation(env, conv.id);
+    }
+
+    return json({ success: true, deleted: allConvs.length, mediaDeleted });
+  });
+
+  // ── Delete all closed rooms + subcollections ──
+  router.post('/api/cleanup/all-rooms', async (request, env) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    const closedRooms = await queryCollection(env, 'rooms', {
+      where: fieldFilter('state', 'EQUAL', 'CLOSED'),
+      limit: 5000,
+    });
+
+    if (closedRooms.length === 0) {
+      return json({ success: true, deleted: 0, message: 'No closed rooms found' });
+    }
+
+    for (const room of closedRooms) {
+      await deleteRoom(env, room.id);
+    }
+
+    return json({ success: true, deleted: closedRooms.length });
+  });
+
+  // ── Delete all broadcasts ──
+  router.post('/api/cleanup/all-broadcasts', async (request, env) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    const broadcasts = await queryCollection(env, 'broadcasts', { limit: 5000 });
+
+    if (broadcasts.length === 0) {
+      return json({ success: true, deleted: 0, message: 'No broadcasts found' });
+    }
+
+    const writes = broadcasts.map(b => batchDeleteOp(env, `broadcasts/${b.id}`));
+    for (let i = 0; i < writes.length; i += 500) {
+      await batchWrite(env, writes.slice(i, i + 500));
+    }
+
+    return json({ success: true, deleted: broadcasts.length });
+  });
+
+  // ── Delete all admin audit logs ──
+  router.post('/api/cleanup/all-audit-logs', async (request, env) => {
+    const adminCheck = requireAdmin(request);
+    if (adminCheck) return adminCheck;
+
+    const logs = await queryCollection(env, 'adminAuditLog', { limit: 5000 });
+
+    if (logs.length === 0) {
+      return json({ success: true, deleted: 0, message: 'No audit logs found' });
+    }
+
+    const writes = logs.map(l => batchDeleteOp(env, `adminAuditLog/${l.id}`));
+    for (let i = 0; i < writes.length; i += 500) {
+      await batchWrite(env, writes.slice(i, i + 500));
+    }
+
+    return json({ success: true, deleted: logs.length });
+  });
 }
 
 /**
@@ -595,6 +758,26 @@ async function deleteConversation(env, convId) {
     ...userSettings.map(s => batchDeleteOp(env, `conversations/${convId}/userSettings/${s.id}`)),
     ...mutes.map(m => batchDeleteOp(env, `conversations/${convId}/mutes/${m.id}`)),
     batchDeleteOp(env, `conversations/${convId}`),
+  ];
+
+  for (let i = 0; i < writes.length; i += 500) {
+    await batchWrite(env, writes.slice(i, i + 500));
+  }
+}
+
+/**
+ * Delete a room and all its associated subcollection data from Firestore.
+ */
+async function deleteRoom(env, roomId) {
+  const [messages, seatRequests] = await Promise.all([
+    queryCollection(env, `rooms/${roomId}/messages`, {}),
+    queryCollection(env, `rooms/${roomId}/seatRequests`, {}),
+  ]);
+
+  const writes = [
+    ...messages.map(m => batchDeleteOp(env, `rooms/${roomId}/messages/${m.id}`)),
+    ...seatRequests.map(s => batchDeleteOp(env, `rooms/${roomId}/seatRequests/${s.id}`)),
+    batchDeleteOp(env, `rooms/${roomId}`),
   ];
 
   for (let i = 0; i < writes.length; i += 500) {

--- a/worker-api/src/routes/admin-economy.js
+++ b/worker-api/src/routes/admin-economy.js
@@ -58,10 +58,14 @@ function registerAdminEconomyRoutes(router) {
     const body = await parseBody(request);
     if (!body) return jsonError('Invalid JSON body', 400);
 
-    const { amount, currency, reason } = body;
+    const { reason } = body;
+    const currency = (body.currency || '').toLowerCase();
+    // Support both signed amount and operation+amount
+    let amount = body.amount;
     if (typeof amount !== 'number' || amount === 0) {
       return jsonError('amount must be a non-zero number', 400);
     }
+    if (body.operation === 'deduct' && amount > 0) amount = -amount;
     if (!['coins', 'beans'].includes(currency)) {
       return jsonError('currency must be "coins" or "beans"', 400);
     }
@@ -263,7 +267,11 @@ function registerAdminEconomyRoutes(router) {
       }),
     ]);
 
-    return json({ success: true });
+    return json({
+      success: true,
+      giftName: gift.name ?? gift.giftName ?? body.giftId,
+      coinValue: gift.coinValue ?? gift.coin_value ?? 0,
+    });
   });
 
   // ── Gacha guarantee: revoke ──

--- a/worker-api/src/routes/admin-users.js
+++ b/worker-api/src/routes/admin-users.js
@@ -19,6 +19,7 @@ const { json, jsonError, generateId, now, parseBody } = require('../utils');
 const { requireAdmin } = require('../middleware/auth');
 const { sendSystemPm } = require('../utils/system-pm');
 const { computeDisplayScore } = require('../utils/gcs');
+const { getAccessToken } = require('../utils/fcm');
 const {
   getDoc,
   setDoc,
@@ -30,6 +31,40 @@ const {
   fieldFilter,
   orderBy,
 } = require('../utils/firestore');
+
+/**
+ * Look up a Firebase Auth user's email by UID.
+ * Uses the Identity Toolkit REST API with service account credentials.
+ */
+async function getFirebaseAuthEmail(env, uid) {
+  try {
+    const accessToken = await getAccessToken(env);
+    const projectId = env.FIREBASE_PROJECT_ID;
+    const resp = await fetch(
+      `https://identitytoolkit.googleapis.com/v1/projects/${projectId}/accounts:lookup`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ localId: [uid] }),
+      }
+    );
+    if (!resp.ok) {
+      const text = await resp.text();
+      console.error(`Firebase Auth lookup failed (${resp.status}): ${text}`);
+      return null;
+    }
+    const data = await resp.json();
+    const authUser = data.users?.[0];
+    // Return email or phone number as fallback
+    return authUser?.email ?? null;
+  } catch (err) {
+    console.error('Firebase Auth email lookup error:', err.message);
+    return null;
+  }
+}
 
 function registerAdminUserRoutes(router) {
 
@@ -45,10 +80,38 @@ function registerAdminUserRoutes(router) {
     const user = await getDoc(env, `users/${params.uid}`);
     if (!user) return jsonError('User not found', 404);
 
+    // Normalize snake_case → camelCase for admin panel compatibility
+    user.displayName      = user.displayName      ?? user.display_name      ?? null;
+    user.profilePhotoUrl  = user.profilePhotoUrl  ?? user.profile_photo_url ?? null;
+    user.coverPhotoUrl    = user.coverPhotoUrl    ?? user.cover_photo_url   ?? null;
+    user.dateOfBirth      = user.dateOfBirth      ?? user.date_of_birth     ?? null;
+    user.uniqueId         = user.uniqueId         ?? user.unique_id         ?? null;
+    user.isSuperShy       = user.isSuperShy       ?? user.is_super_shy      ?? false;
+    user.superShyExpiry   = user.superShyExpiry   ?? user.super_shy_expiry  ?? null;
+    user.superShyTier     = user.superShyTier     ?? user.super_shy_tier    ?? null;
+    user.loginStreak      = user.loginStreak      ?? user.login_streak      ?? 0;
+    user.shyCoins         = user.shyCoins         ?? user.shy_coins         ?? 0;
+    user.shyBeans         = user.shyBeans         ?? user.shy_beans         ?? 0;
+    user.warningCount     = user.warningCount     ?? user.warning_count     ?? 0;
+    user.luckScore        = user.luckScore        ?? user.luck_score        ?? 0;
+    user.pityCounter      = user.pityCounter      ?? user.pity_counter      ?? 0;
+    user.gcsScore         = user.gcsScore         ?? user.gcs_score         ?? 100;
+    user.gcsLastDeductionAt = user.gcsLastDeductionAt ?? user.gcs_last_deduction_at ?? null;
+    user.hasActiveWarning = user.hasActiveWarning ?? user.has_active_warning ?? false;
+    user.warningReason    = user.warningReason    ?? user.warning_reason    ?? null;
+    user.userType         = user.userType         ?? user.user_type         ?? 'MEMBER';
+
+    // Fetch email from Firebase Auth if not in Firestore doc
+    if (!user.email) {
+      user.email = await getFirebaseAuthEmail(env, params.uid);
+      // Backfill to Firestore for future lookups
+      if (user.email) {
+        updateDoc(env, `users/${params.uid}`, { email: user.email }).catch(() => {});
+      }
+    }
+
     // Enrich with GCS display score
-    const gcsScore = user.gcsScore ?? user.gcs_score ?? 100;
-    const gcsLastDeductionAt = user.gcsLastDeductionAt ?? user.gcs_last_deduction_at ?? null;
-    user.gcsDisplayScore = computeDisplayScore(gcsScore, gcsLastDeductionAt);
+    user.gcsDisplayScore = computeDisplayScore(user.gcsScore, user.gcsLastDeductionAt);
 
     return json(user);
   });
@@ -98,7 +161,7 @@ function registerAdminUserRoutes(router) {
       createdAt:    now(),
     });
 
-    return json({ success: true });
+    return json({ success: true, updatedFields: Object.keys(updates) });
   });
 
   // ══════════════════════════════════════════════════════════════

--- a/worker-api/src/routes/economy.js
+++ b/worker-api/src/routes/economy.js
@@ -300,12 +300,21 @@ function registerEconomyRoutes(router) {
       const weights = [...baseWeights];
 
       // Pity system
+      let hardPityTriggered = false;
       if (pity >= config.pityHardLimit) {
+        hardPityTriggered = true;
+        // Zero out low-value gifts so only high-value remain
         for (let j = 0; j < winnableGifts.length; j++) {
           if (winnableGifts[j].coinValue < highValueThreshold) weights[j] = 0;
         }
         if (weights.every(w => w === 0)) {
-          for (let j = 0; j < weights.length; j++) weights[j] = baseWeights[j];
+          // No gifts meet the threshold — guarantee the most expensive gift
+          let bestIdx = 0;
+          for (let j = 1; j < winnableGifts.length; j++) {
+            if (winnableGifts[j].coinValue > winnableGifts[bestIdx].coinValue) bestIdx = j;
+          }
+          // Set only the most expensive gift's weight
+          for (let j = 0; j < weights.length; j++) weights[j] = j === bestIdx ? 1 : 0;
         }
       } else if (pity >= config.pitySoftStart) {
         const progress = (pity - config.pitySoftStart) / (config.pityHardLimit - config.pitySoftStart);
@@ -353,7 +362,7 @@ function registerEconomyRoutes(router) {
 
       // Roll
       const total = weights.reduce((s, w) => s + w, 0);
-      if (total <= 0) { results.push(winnableGifts[0]); pity++; continue; }
+      if (total <= 0) { results.push(winnableGifts[0]); pity = hardPityTriggered ? 0 : pity + 1; continue; }
 
       const roll = Math.random() * total;
       let cumulative = 0, selectedIndex = 0;
@@ -364,7 +373,8 @@ function registerEconomyRoutes(router) {
 
       const gift = winnableGifts[selectedIndex];
       results.push(gift);
-      pity = gift.coinValue >= highValueThreshold ? 0 : pity + 1;
+      // Reset pity on hard pity trigger OR when a high-value gift is won naturally
+      pity = (hardPityTriggered || gift.coinValue >= highValueThreshold) ? 0 : pity + 1;
     }
 
     if (pullCount === 100) luck = Math.min(100, luck + 2);

--- a/worker-api/src/routes/reports.js
+++ b/worker-api/src/routes/reports.js
@@ -222,18 +222,26 @@ function registerReportRoutes(router) {
         const key = r.reportedUserId;
         if (!grouped[key]) {
           grouped[key] = {
+            uid:            key,
             reportedUserId: key,
-            reportedUser:   r.reportedUser,
+            displayName:    r.reportedUser?.displayName ?? r.reportedUser?.display_name ?? null,
+            profilePhotoUrl: r.reportedUser?.profilePhotoUrl ?? r.reportedUser?.profile_photo_url ?? null,
+            uniqueId:       r.reportedUser?.uniqueId ?? r.reportedUser?.unique_id ?? null,
+            warningCount:   r.reportedUser?.warningCount ?? r.reportedUser?.warning_count ?? 0,
+            isSuspended:    r.reportedUser?.isSuspended ?? r.reportedUser?.is_suspended ?? false,
+            gcsDisplayScore: r.reportedUser?.gcsDisplayScore ?? 100,
             lock:           r.lock,
             reports:        [],
+            reportCount:    0,
           };
         }
         grouped[key].reports.push(r);
+        grouped[key].reportCount = grouped[key].reports.length;
       }
-      return json(Object.values(grouped));
+      return json({ users: Object.values(grouped) });
     }
 
-    return json(enriched);
+    return json({ users: enriched });
   });
 
   // ── Resolve report (admin — full logic) ──

--- a/worker-api/src/routes/users.js
+++ b/worker-api/src/routes/users.js
@@ -94,17 +94,25 @@ function registerUserRoutes(router) {
     const existing = await getDoc(env, `users/${uid}`);
 
     if (existing) {
-      // Update lastSeen only
-      await updateDoc(env, `users/${uid}`, { lastSeen: now() });
+      // Update lastSeen + backfill missing fields
+      const updates = { lastSeen: now() };
+      const incomingEmail = body.email || null;
+      if (incomingEmail && !existing.email) updates.email = incomingEmail;
+      if (!existing.userType) updates.userType = 'MEMBER';
+      await updateDoc(env, `users/${uid}`, updates);
       return json({ success: true, created: false });
     }
 
     // Create new user doc with camelCase fields
     const photoUrl = body.profilePhotoUrl || body.profile_photo_url || null;
+    const dob = body.dateOfBirth || body.date_of_birth || null;
     await setDoc(env, `users/${uid}`, {
       uid,
       displayName:     body.displayName || body.display_name || null,
+      email:           body.email || null,
       profilePhotoUrl: photoUrl,
+      dateOfBirth:     dob,
+      userType:        'MEMBER',
       blockedUserIds:  [],
       followingIds:    [],
       followerIds:     [],
@@ -207,10 +215,15 @@ function registerUserRoutes(router) {
     if (request.auth.uid !== params.uid) return jsonError('Forbidden', 403);
     if (params.uid === targetUid) return jsonError('Cannot follow yourself', 400);
 
-    await Promise.all([
-      arrayUnionField(env, `users/${params.uid}`, 'followingIds', [targetUid]),
-      arrayUnionField(env, `users/${targetUid}`, 'followerIds', [params.uid]),
-    ]);
+    try {
+      await Promise.all([
+        arrayUnionField(env, `users/${params.uid}`, 'followingIds', [targetUid]),
+        arrayUnionField(env, `users/${targetUid}`, 'followerIds', [params.uid]),
+      ]);
+    } catch (err) {
+      console.error('Follow failed:', err);
+      return jsonError('Failed to follow user', 500);
+    }
 
     return json({ success: true });
   });
@@ -222,10 +235,15 @@ function registerUserRoutes(router) {
     if (!targetUid) return jsonError('targetUserId required', 400);
     if (request.auth.uid !== params.uid) return jsonError('Forbidden', 403);
 
-    await Promise.all([
-      arrayRemoveField(env, `users/${params.uid}`, 'followingIds', [targetUid]),
-      arrayRemoveField(env, `users/${targetUid}`, 'followerIds', [params.uid]),
-    ]);
+    try {
+      await Promise.all([
+        arrayRemoveField(env, `users/${params.uid}`, 'followingIds', [targetUid]),
+        arrayRemoveField(env, `users/${targetUid}`, 'followerIds', [params.uid]),
+      ]);
+    } catch (err) {
+      console.error('Unfollow failed:', err);
+      return jsonError('Failed to unfollow user', 500);
+    }
 
     return json({ success: true });
   });
@@ -237,10 +255,15 @@ function registerUserRoutes(router) {
     if (!followerUid) return jsonError('followerUserId required', 400);
     if (request.auth.uid !== params.uid) return jsonError('Forbidden', 403);
 
-    await Promise.all([
-      arrayRemoveField(env, `users/${params.uid}`, 'followerIds', [followerUid]),
-      arrayRemoveField(env, `users/${followerUid}`, 'followingIds', [params.uid]),
-    ]);
+    try {
+      await Promise.all([
+        arrayRemoveField(env, `users/${params.uid}`, 'followerIds', [followerUid]),
+        arrayRemoveField(env, `users/${followerUid}`, 'followingIds', [params.uid]),
+      ]);
+    } catch (err) {
+      console.error('Remove follower failed:', err);
+      return jsonError('Failed to remove follower', 500);
+    }
 
     return json({ success: true });
   });

--- a/worker-api/src/utils/fcm.js
+++ b/worker-api/src/utils/fcm.js
@@ -69,7 +69,7 @@ async function getAccessToken(env) {
   const header = { alg: 'RS256', typ: 'JWT' };
   const payload = {
     iss: email,
-    scope: 'https://www.googleapis.com/auth/firebase.messaging https://www.googleapis.com/auth/firebase.database https://www.googleapis.com/auth/datastore',
+    scope: 'https://www.googleapis.com/auth/firebase.messaging https://www.googleapis.com/auth/firebase.database https://www.googleapis.com/auth/datastore https://www.googleapis.com/auth/identitytoolkit',
     aud: 'https://oauth2.googleapis.com/token',
     iat: now,
     exp: now + 3600,

--- a/worker-api/src/utils/firestore.js
+++ b/worker-api/src/utils/firestore.js
@@ -611,7 +611,9 @@ async function arrayUnionField(env, path, field, elements) {
 
   if (!response.ok) {
     const text = await response.text();
-    console.error(`Firestore ARRAY_UNION ${path}.${field}: ${response.status} ${text}`);
+    const msg = `Firestore ARRAY_UNION ${path}.${field}: ${response.status} ${text}`;
+    console.error(msg);
+    throw new Error(msg);
   }
 }
 
@@ -650,7 +652,9 @@ async function arrayRemoveField(env, path, field, elements) {
 
   if (!response.ok) {
     const text = await response.text();
-    console.error(`Firestore ARRAY_REMOVE ${path}.${field}: ${response.status} ${text}`);
+    const msg = `Firestore ARRAY_REMOVE ${path}.${field}: ${response.status} ${text}`;
+    console.error(msg);
+    throw new Error(msg);
   }
 }
 

--- a/worker-api/wrangler.toml
+++ b/worker-api/wrangler.toml
@@ -36,7 +36,7 @@ crons = [
   "0 0 * * *",    # checkSubscriptionStatus + cleanExpiredBackpackItems — daily 00:00 UTC
   # updateGiftRankings cron REMOVED — rankings now updated incrementally in economy.js
   "*/5 * * * *",  # closeStaleOwnerAwayRooms — every 5 minutes
-  "0 2 * * *",    # backupUserProfiles — daily 02:00 UTC to R2
+  "0 2 * * *",    # backupUserProfiles + cleanupClosedRooms — daily 02:00 UTC
 ]
 
 # ── Environment ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Gacha pity system**: Fixed hard pity (120 pulls) not guaranteeing high-value gifts and never resetting. Now selects most expensive gift available and always resets pity counter.
- **Admin panel economy fixes**: Currency case sensitivity, guaranteed gift response, economy tab save error (`.join` on undefined)
- **Admin user display**: Email fetched from Firebase Auth when missing, userType defaults to MEMBER, all snake_case fields normalized
- **New maintenance tools**: Delete all PMs, group chats, closed rooms, broadcasts, audit logs (with R2 media cleanup)
- **Safety**: RESET ALL now requires successful backup before proceeding; closed room auto-cleanup on daily cron (7-day retention)
- **Gacha performance**: Removed unnecessary 2s delay on spin history load
- **Scripts**: Added seed scripts for gifts, banners, fun facts; R2 backup/compression utilities

## Test plan
- [x] All unit tests pass (`./gradlew test`)
- [ ] Verify gacha hard pity awards high-value gift at 120 pulls
- [ ] Verify admin panel economy tab saves without error
- [ ] Verify email shows on admin panel user lookup
- [ ] Test each new maintenance button (PMs, groups, rooms, broadcasts, audit logs)
- [ ] Verify RESET ALL aborts if backup fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)