### PR TITLE
Trim release notes to fit 500 char limit

### DIFF
--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,12 +1,11 @@
-v0.52 — API Migration & Presence Reliability
+v0.52 — API Migration & Presence Fixes
 
-- Migrated API to Express.js on Oracle Cloud (faster, no quota limits)
-- Presence timeout increased 15s→30s to reduce false disconnects
-- Auto-reconnect presence after network blips (RTDB .info/connected)
+- Migrated API to Express.js on Oracle Cloud (no quota limits)
+- Presence timeout 15s→30s, auto-reconnect on network blips
 - Re-check presence before evicting users from rooms
-- Economy config fallback defaults when Firestore doc missing
-- Fixed stalkerCount parsing crash (Int/Double cast)
+- Economy config fallback when Firestore doc missing
+- Fixed stalkerCount parsing crash
 - CLOSED rooms filtered from home screen
-- Seat request panel: approved requests vanish immediately (no flicker)
+- Approved seat requests vanish immediately
 - Follow/unfollow now atomic (batch transforms)
-- Admin: clear all transactions, auth debug endpoint
+- Admin: clear all transactions endpoint


### PR DESCRIPTION
## Summary
- Trim v0.52 release notes from 632 to 493 characters (Play Store max is 500)

## Test plan
- [x] `wc -c` confirms 493 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)