### PR TITLE
Fix PM2 config for 1GB Oracle VM

### DIFF
--- a/express-api/ecosystem.config.js
+++ b/express-api/ecosystem.config.js
@@ -2,13 +2,13 @@ module.exports = {
   apps: [{
     name: 'shytalk-api',
     script: 'src/index.js',
-    instances: 2,
-    exec_mode: 'cluster',
+    instances: 1,
+    exec_mode: 'fork',
     env: {
       NODE_ENV: 'production',
       PORT: 3000,
     },
-    max_memory_restart: '500M',
+    max_memory_restart: '400M',
     error_file: './logs/error.log',
     out_file: './logs/output.log',
     merge_logs: true,


### PR DESCRIPTION
## Summary
- Change from cluster/2 instances to fork/1 instance (1GB RAM VM)
- Lower max_memory_restart from 500M to 400M

🤖 Generated with [Claude Code](https://claude.com/claude-code)