### PR TITLE
Release v0.54: Security & Stability

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "com.shyden.shytalk"
         minSdk = 28
         targetSdk = 36
-        versionCode = 53
-        versionName = "0.53"
+        versionCode = 54
+        versionName = "0.54"
 
         testInstrumentationRunner = "com.shyden.shytalk.ShyTalkTestRunner"
 

--- a/app/src/main/play/release-notes/en-US/internal.txt
+++ b/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,4 +1,4 @@
-v0.53 — Security & Stability
+v0.54 — Security & Stability
 
 - Improved security across the app
 - Added privacy policy and terms of service


### PR DESCRIPTION
## Summary
- Bump version to 0.54 (versionCode 54) — versionCode 53 was already used by v0.52.1

## Test plan
- [x] All 1821 unit tests pass (verified in PR #96)
- [ ] Publish to Play Store internal track

🤖 Generated with [Claude Code](https://claude.com/claude-code)