### PR TITLE
Fix deprecated androidLibrary {} → android {} in shared module

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
     // JVM target exists solely to run commonTest on Windows/Linux/CI
     jvm()
 
-    androidLibrary {
+    android {
         namespace = "com.shyden.shytalk.shared"
         compileSdk = 36
         minSdk = 28


### PR DESCRIPTION
## Summary
Replace deprecated `androidLibrary {}` block with `android {}` in `shared/build.gradle.kts` per Kotlin Multiplatform plugin migration guide.

## Test plan
- [x] `./gradlew :shared:compileAndroidMain` — BUILD SUCCESSFUL, no deprecation warning
- [x] `./gradlew test` — BUILD SUCCESSFUL, all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)