### PR TITLE
Update E2E workflow actions to latest versions (fix Node.js 20 warning)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -282,7 +282,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Run E2E tests on emulator
-        uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # v2
+        uses: reactivecircus/android-emulator-runner@9125fe764b516df676e33c5e6df011c6f375ef88 # v2.36.0
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.api-level >= 30 && 'google_apis' || 'default' }}
@@ -422,7 +422,7 @@ jobs:
           ref: ${{ needs.resolve-inputs.outputs.ref }}
 
       - name: Download iOS test bundle
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ios-test-bundle
           path: build/ios-derived-data/


### PR DESCRIPTION
## Summary
- Update `reactivecircus/android-emulator-runner` to v2.36.0 (was using older SHA)
- Update `actions/download-artifact` from v4 to v8 (aligning with release.yml)

Resolves the "running on Node.js 20 and may not work as expected" warning.

Note: The emulator runner v2.36.0 is still on Node 20 internally — no Node 24 version exists yet. This is the latest available version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)