### PR TITLE
Fix E2E workflow: remove Node 24 force flag (breaks emulator runner)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,8 +27,9 @@ permissions:
   checks: write
   issues: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+# Note: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 is NOT set here because
+# reactivecircus/android-emulator-runner only supports Node 20.
+# Re-enable once the emulator runner releases a Node 24 version.
 
 concurrency:
   group: e2e-tests-${{ github.event.inputs.platform || 'comment' }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
Remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` from the E2E workflow. The `reactivecircus/android-emulator-runner` only supports Node 20 — forcing Node 24 caused all 8 emulator test jobs to fail.

Will re-enable once the emulator runner releases a Node 24 compatible version.

## Test plan
- Trigger E2E workflow after merge to validate emulator jobs run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)