### PR TITLE
Fix E2E workflow: add Android SDK paths for shell emulator

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -281,10 +281,19 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: Set up Android SDK paths
+        run: |
+          echo "$ANDROID_HOME/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
+          echo "$ANDROID_HOME/platform-tools" >> "$GITHUB_PATH"
+          echo "$ANDROID_HOME/emulator" >> "$GITHUB_PATH"
+
       - name: Install emulator system image
         run: |
           TARGET=${{ matrix.api-level >= 30 && 'google_apis' || 'default' }}
-          yes | sdkmanager "system-images;android-${{ matrix.api-level }};${TARGET};x86_64" "emulator" "platform-tools" || true
+          yes | sdkmanager --install \
+            "system-images;android-${{ matrix.api-level }};${TARGET};x86_64" \
+            "emulator" \
+            "platform-tools" || true
 
       - name: Create and start emulator
         run: |
@@ -295,7 +304,7 @@ jobs:
             -d "${{ matrix.profile }}" \
             --force
 
-          $ANDROID_HOME/emulator/emulator -avd test_device \
+          emulator -avd test_device \
             -no-snapshot-save -no-window -gpu swiftshader_indirect \
             -noaudio -no-boot-anim \
             -memory ${{ matrix.ram-size }} &


### PR DESCRIPTION
Adds ANDROID_HOME SDK paths to GITHUB_PATH so sdkmanager/avdmanager/emulator/adb are available.