### PR TITLE
Fix E2E workflow: use unique concurrency group to prevent cancellation

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,8 +31,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:
-  group: e2e-tests-${{ github.event.inputs.platform || 'comment' }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: e2e-tests-${{ github.run_id }}
+  cancel-in-progress: false
 
 jobs:
   # ── Parse PR comment trigger ──────────────────────────────────


### PR DESCRIPTION
E2E runs were being cancelled by concurrent workflows. Use run_id for a unique group.