### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Parse /run-e2e comment
         id: parse
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const comment = context.payload.comment.body.trim();

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -411,7 +411,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Run E2E tests on ${{ matrix.device }}
-        uses: reactivecircus/android-emulator-runner@9125fe764b516df676e33c5e6df011c6f375ef88 # v2
+        uses: reactivecircus/android-emulator-runner@0a638108440efd5c7f980e6ba145dbcdd8f32009 # v2.37.0
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}


### PR DESCRIPTION
## Summary
- `actions/github-script` v7 → **v8** (e2e-tests.yml)
- `reactivecircus/android-emulator-runner` v2.36 → **v2.37.0** (release.yml)

All other actions already on latest:
- `actions/checkout` v6.0.2, `actions/setup-java` v5.2.0, `gradle/actions/setup-gradle` v5.0.2
- `actions/upload-artifact` v7.0.0, `actions/download-artifact` v8.0.1, `actions/setup-node` v6.3.0
- `EnricoMi/publish-unit-test-result-action` v2.23.0, `peaceiris/actions-gh-pages` v4.0.0
- `r0adkll/upload-google-play` v1.1.3, `wzieba/Firebase-Distribution-Github-Action` v1.7.1

## Test plan
- [ ] CI workflows pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)