### PR TITLE
Add missing Firestore rule for purchaseReceipts

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -310,5 +310,10 @@ service cloud.firestore {
     match /emailMetrics/{docId} {
       allow read, write: if false;
     }
+
+    // ── Purchase receipts — server-only (IAP dedup) ─────────────
+    match /purchaseReceipts/{receiptId} {
+      allow read, write: if false;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add deny-all rule for `purchaseReceipts/{receiptId}` collection
- Used by Express API for IAP receipt deduplication but had no security rule
- Clients could previously read/write purchase receipts directly via Firestore SDK

## Test plan
- [x] Workflow-only change — no app build needed
- [ ] Deploy rules: `npx firebase deploy --only firestore:rules --project shytalk-dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)