### PR TITLE
Allow Cloudflare Pages preview wildcards in CORS

### DIFF
--- a/express-api/src/middleware/cors.js
+++ b/express-api/src/middleware/cors.js
@@ -9,6 +9,10 @@ module.exports = cors({
     // Allow requests with no origin (mobile apps, curl, server-to-server)
     if (!origin) return callback(null, true);
     if (allowedOrigins.includes(origin)) return callback(null, true);
+    // Allow Cloudflare Pages preview deployments
+    if (origin.endsWith('.shytalk-site-dev.pages.dev') || origin.endsWith('.shytalk-site.pages.dev')) {
+      return callback(null, true);
+    }
     callback(new Error('Not allowed by CORS'));
   },
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],


### PR DESCRIPTION
## Summary
Add `*.shytalk-site-dev.pages.dev` and `*.shytalk-site.pages.dev` wildcards to CORS allowlist so Cloudflare Pages preview deployments work without manual CORS updates per deploy.

## Test plan
- [x] Already deployed and tested on dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)