### PR TITLE
Fix admin auth-status getDoc path

### DIFF
--- a/express-api/src/routes/admin-users.js
+++ b/express-api/src/routes/admin-users.js
@@ -1022,7 +1022,7 @@ router.get('/user/:uniqueId/auth-status', async (req, res) => {
     if (requireAdmin(req, res)) return;
     const { uniqueId } = req.params;
 
-    const userDoc = await getDoc('users', uniqueId);
+    const userDoc = await getDoc(`users/${uniqueId}`);
     if (!userDoc) return res.status(404).json({ error: 'User not found' });
 
     // Get biometric keys for this user


### PR DESCRIPTION
## Summary
Fix `getDoc('users', uniqueId)` → `getDoc('users/' + uniqueId)` in the admin auth-status endpoint. `getDoc()` takes a single document path string, not separate collection and ID arguments.

## Test plan
- [x] 891 Express tests passing
- [x] Tested live on admin panel — Security tab now shows PIN status, biometric keys, and OTP metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)