### PR TITLE
Fix E2E workflow — first successful CI run

### DIFF
--- a/.github/scripts/run-e2e.sh
+++ b/.github/scripts/run-e2e.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Find pre-built APKs (artifact preserves Gradle output directory structure)
+echo "Looking for APKs in $GITHUB_WORKSPACE/apks/..."
+find "$GITHUB_WORKSPACE/apks/" -name "*.apk" -type f
+
+APP_APK=$(find "$GITHUB_WORKSPACE/apks/" -name "*.apk" -type f ! -name "*androidTest*" | head -1)
+TEST_APK=$(find "$GITHUB_WORKSPACE/apks/" -name "*androidTest*.apk" -type f | head -1)
+
+if [ -z "$APP_APK" ] || [ -z "$TEST_APK" ]; then
+  echo "::error::APKs not found"
+  find "$GITHUB_WORKSPACE/apks/" -type f
+  exit 1
+fi
+
+echo "Installing app APK: $APP_APK"
+adb install -t "$APP_APK"
+
+echo "Installing test APK: $TEST_APK"
+adb install -t "$TEST_APK"
+
+# Verify installation
+adb shell pm list packages | grep shytalk || echo "::warning::ShyTalk package not found"
+
+# Run Cucumber instrumentation tests
+echo "Running E2E tests..."
+adb shell am instrument -w \
+  com.shyden.shytalk.dev.test/com.shyden.shytalk.ShyTalkTestRunner \
+  2>&1 | tee "$GITHUB_WORKSPACE/test-output.log"
+
+echo "Tests complete."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -244,35 +244,7 @@ jobs:
           force-avd-creation: true
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
-          script: |
-            # Find pre-built APKs (artifact preserves directory structure)
-            echo "Looking for APKs..."
-            find $GITHUB_WORKSPACE/apks/ -name "*.apk" -type f
-            APP_APK=$(find $GITHUB_WORKSPACE/apks/ -name "*.apk" -type f ! -name "*androidTest*" | head -1)
-            TEST_APK=$(find $GITHUB_WORKSPACE/apks/ -name "*androidTest*.apk" -type f | head -1)
-
-            if [ -z "$APP_APK" ] || [ -z "$TEST_APK" ]; then
-              echo "::error::APKs not found. Contents of apks/:"
-              find $GITHUB_WORKSPACE/apks/ -type f
-              exit 1
-            fi
-
-            echo "Installing app APK: $APP_APK"
-            adb install -t "$APP_APK"
-
-            echo "Installing test APK: $TEST_APK"
-            adb install -t "$TEST_APK"
-
-            # List installed packages to verify
-            adb shell pm list packages | grep shytalk || echo "::warning::Package not found after install"
-
-            # Run Cucumber instrumentation tests via am instrument
-            echo "Running E2E tests..."
-            adb shell am instrument -w \
-              com.shyden.shytalk.dev.test/com.shyden.shytalk.ShyTalkTestRunner \
-              2>&1 | tee test-output.log
-
-            echo "Test output saved to test-output.log"
+          script: bash $GITHUB_WORKSPACE/.github/scripts/run-e2e.sh
 
       - name: Pull Allure results from device
         if: always()


### PR DESCRIPTION
## Summary
The E2E test workflow (`e2e-tests.yml`) has completed its **first successful run** after fixing multiple issues:

### Changes
- **Switched from shell-based emulator to `reactivecircus/android-emulator-runner`** — shell emulator boot hung indefinitely on CI runners
- **Fixed build-once/test-many pattern** — test job now downloads pre-built APKs from build job instead of rebuilding (~20 min saved per matrix job)
- **Extracted test script to `.github/scripts/run-e2e.sh`** — the emulator runner action executes each script line as a separate `sh -c` command, breaking multi-line constructs
- **Simplified matrix to single device (API 34 Pixel 6)** for validation — can expand to full 8-device matrix in follow-up
- **Added `contents: write` permission** for Allure GitHub Pages deployment

### Successful run
- Run: https://github.com/ShydenMcM/ShyTalk/actions/runs/23155542033
- Build Android: success
- Android E2E (API 34, phone): success (APK install + `am instrument` + Allure pull)
- Allure Report: generated and deployed

### Follow-up needed
- [ ] Enable GitHub Pages in repo settings (source: `gh-pages` branch)
- [ ] Expand Android matrix back to 8 devices (API 28/30/33/35 × phone/tablet)
- [ ] Test `/run-e2e` comment trigger on a real PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)