### PR TITLE
Fix Playwright flaky admin tests — revert to 1 worker

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -261,7 +261,7 @@ jobs:
     needs: [resolve-inputs]
     if: always() && needs.resolve-inputs.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment: dev
     strategy:
       fail-fast: false

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   testIgnore: ['**/auth.setup.ts'],
   timeout: 60_000,
   retries: 1,
-  workers: 3, // Limited parallelism — Firebase Auth rate-limits concurrent logins
+  workers: 1, // Serial — Firebase Auth rate-limits concurrent logins causing flaky admin tests
   reporter: reporters,
   use: {
     baseURL: process.env.WEB_BASE_URL || 'https://dev.shytalk.shyden.co.uk',


### PR DESCRIPTION
## Summary
Revert Playwright workers from 3 to 1. Concurrent Firebase Auth logins cause rate-limiting that leaves the dashboard hidden after login, causing 30s timeouts on admin tests.

With 1 worker per browser and 5 browsers running as parallel CI jobs, wall time is ~11 min total.

## Test plan
- [ ] Verify E2E workflow completes with fewer defects in Allure report

🤖 Generated with [Claude Code](https://claude.com/claude-code)