### PR TITLE
Fix admin login + trigger dev web deploy

### DIFF
--- a/tests/web/helpers/admin-auth.ts
+++ b/tests/web/helpers/admin-auth.ts
@@ -22,13 +22,8 @@ export async function adminLogin(page: Page): Promise<void> {
   const signInBtn = page.getByRole('button', { name: 'Sign In' });
   await expect(signInBtn).toBeVisible({ timeout: 10_000 });
 
-  // Use evaluate to set values without logging credentials in CI console
-  const emailInput = page.getByRole('textbox', { name: 'Email' });
-  const passwordInput = page.getByRole('textbox', { name: 'Password' });
-  await emailInput.click();
-  await emailInput.evaluate((el, val) => { (el as HTMLInputElement).value = val; el.dispatchEvent(new Event('input', { bubbles: true })); }, ADMIN_EMAIL);
-  await passwordInput.click();
-  await passwordInput.evaluate((el, val) => { (el as HTMLInputElement).value = val; el.dispatchEvent(new Event('input', { bubbles: true })); }, ADMIN_PASSWORD);
+  await page.getByRole('textbox', { name: 'Email' }).fill(ADMIN_EMAIL);
+  await page.getByRole('textbox', { name: 'Password' }).fill(ADMIN_PASSWORD);
   await signInBtn.click();
 
   await expect(dashboard).toBeVisible({ timeout: 30_000 });


### PR DESCRIPTION
## Summary
- Revert admin login from evaluate() back to fill() — evaluate() broke Firebase Auth input listeners
- Triggers CI web deploy to get security subtab + loadReportHistory fix deployed to dev.shytalk.shyden.co.uk

🤖 Generated with [Claude Code](https://claude.com/claude-code)