### PR TITLE
Fix: deploy web to dev before running Playwright tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,8 +260,11 @@ jobs:
 
   web-tests:
     name: Web Tests (Playwright)
-    needs: [detect-changes]
-    if: needs.detect-changes.outputs.web_changed == 'true'
+    needs: [detect-changes, deploy-web-dev]
+    if: |
+      always() &&
+      needs.detect-changes.outputs.web_changed == 'true' &&
+      needs.deploy-web-dev.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -360,11 +363,10 @@ jobs:
 
   deploy-web-dev:
     name: Deploy Web to Dev
-    needs: [detect-changes, web-tests]
+    needs: [detect-changes]
     if: |
       always() &&
-      needs.detect-changes.outputs.web_changed == 'true' &&
-      needs.web-tests.result == 'success'
+      needs.detect-changes.outputs.web_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary
Pipeline was running Playwright tests against the OLD deployment, then deploying. Now the order is correct:

1. Detect changes
2. Deploy web to dev
3. Run Playwright tests against the fresh deployment

This fixes the circular dependency where Playwright tests failed because the deployed admin panel didn't have the security subtab, but the deploy required Playwright to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)