### PR TITLE
Allow Playwright CI to continue on test failure

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -305,7 +305,13 @@ jobs:
           ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
           ALLURE_ENABLED: 'true'
           ALLURE_PROJECT: ${{ matrix.project }}
+        id: playwright
+        continue-on-error: true
         run: npx playwright test --project=${{ matrix.project }} --reporter=list,allure-playwright,html
+
+      - name: Report test outcome
+        if: steps.playwright.outcome == 'failure'
+        run: echo "::warning::${{ matrix.project }} had test failures — see Allure report"
 
       - name: Write environment.properties
         if: always()


### PR DESCRIPTION
Test failures tracked in Allure, not as CI blockers