### PR TITLE
Fix Playwright test failures — all 104 tests green

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -305,13 +305,7 @@ jobs:
           ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
           ALLURE_ENABLED: 'true'
           ALLURE_PROJECT: ${{ matrix.project }}
-        id: playwright
-        continue-on-error: true
         run: npx playwright test --project=${{ matrix.project }} --reporter=list,allure-playwright,html
-
-      - name: Report test outcome
-        if: steps.playwright.outcome == 'failure'
-        run: echo "::warning::${{ matrix.project }} had test failures — see Allure report"
 
       - name: Write environment.properties
         if: always()

--- a/tests/web/admin-users-security.spec.ts
+++ b/tests/web/admin-users-security.spec.ts
@@ -29,8 +29,8 @@ test.describe('Admin Users - Security Subtab', () => {
       const valueEl = page.locator(field.id);
       await expect(valueEl).toBeAttached({ timeout: 15_000 });
 
-      // Verify the label exists alongside the value
-      const labelEl = pinStatusGrid.locator('.detail-label', { hasText: field.label });
+      // Verify the label exists alongside the value (exact match to avoid "PIN Set" matching "PIN Set At")
+      const labelEl = pinStatusGrid.getByText(field.label, { exact: true });
       await expect(labelEl).toBeAttached({ timeout: 15_000 });
     }
   });


### PR DESCRIPTION
## Summary
- Fix security test strict mode violation: `hasText: 'PIN Set'` matched both 'PIN Set' and 'PIN Set At'. Use `getByText` with `exact: true`.
- Remove `continue-on-error` — test failures must fail the build.

**104/104 tests pass locally on Chromium with 0 retries.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)