### PR TITLE
Fix Allure environment table showing only last test suite

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -608,6 +608,26 @@ jobs:
           path: allure-results-all/
           merge-multiple: true
 
+      - name: Merge environment.properties from all test suites
+        run: |
+          # Each artifact writes its own environment.properties in a subdirectory.
+          # Allure only reads one file at the results root — merge them all into one
+          # with section headers so every suite's environment is visible.
+          MERGED="allure-results-all/environment.properties"
+          > "$MERGED"
+          find allure-results-all -name environment.properties -not -path "$MERGED" | sort | while read -r f; do
+            SUITE=$(echo "$f" | sed 's|allure-results-all/||;s|/environment.properties||;s|/|.|g')
+            while IFS= read -r line; do
+              trimmed=$(echo "$line" | sed 's/^[[:space:]]*//')
+              [ -z "$trimmed" ] && continue
+              KEY=$(echo "$trimmed" | cut -d= -f1)
+              VALUE=$(echo "$trimmed" | cut -d= -f2-)
+              echo "${SUITE}.${KEY}=${VALUE}" >> "$MERGED"
+            done < "$f"
+          done
+          echo "Merged environment.properties:"
+          cat "$MERGED"
+
       - name: Sanitize results (strip secrets for public report)
         run: bash .github/scripts/sanitize-allure.sh allure-results-all/
 


### PR DESCRIPTION
## Summary
- Each Playwright/Android matrix job writes its own `environment.properties`, but Allure only reads one file at the results root — last artifact to merge wins, overwriting the rest
- Now merges all `environment.properties` files into a single combined file with suite-prefixed keys (e.g., `chromium.browser=Chromium`, `firefox.browser=Firefox`, `android.api_level=34`)

## Test plan
- [x] Trigger E2E workflow and check the Allure report environment table shows all suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)