### PR TITLE
Fix test uniqueId range — avoid manual tester collision

### DIFF
--- a/express-api/src/routes/test-helpers.js
+++ b/express-api/src/routes/test-helpers.js
@@ -44,7 +44,7 @@ router.post('/test/setup', async (req, res) => {
       const counterRef = db.doc('counters/uniqueId');
       const uniqueId = await db.runTransaction(async (t) => {
         const counterDoc = await t.get(counterRef);
-        const current = counterDoc.exists ? counterDoc.data().value : 10000000;
+        const current = counterDoc.exists ? counterDoc.data().value : 100000000;
         const next = current + 1;
         t.set(counterRef, { value: next }, { merge: true });
         return next;

--- a/express-api/tests/routes/test-helpers.test.js
+++ b/express-api/tests/routes/test-helpers.test.js
@@ -27,7 +27,7 @@ const mockWhere = jest.fn(() => ({ get: mockQueryGet }));
 const mockCollection = jest.fn(() => ({ where: mockWhere }));
 
 // Transaction mock: calls the callback with a transaction object that has get/set
-let transactionUniqueIdCounter = 10000000;
+let transactionUniqueIdCounter = 100000000;
 const mockTransactionGet = jest.fn();
 const mockTransactionSet = jest.fn();
 const mockRunTransaction = jest.fn(async (callback) => {
@@ -74,7 +74,7 @@ function createApp() {
 beforeEach(() => {
   jest.clearAllMocks();
   mockIdCounter = 0;
-  transactionUniqueIdCounter = 10000000;
+  transactionUniqueIdCounter = 100000000;
   process.env.TEST_API_KEY = VALID_API_KEY;
 
   // Restore default mock implementations after clearAllMocks


### PR DESCRIPTION
## Summary
- Changed test-helpers.js counter cold-start fallback from 10000000 to 100000000
- Range 10M–99M reserved for manual testers — test-seeded users now start at 100M+

## Test plan
- [ ] `cd express-api && npm test` — 1139 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)