### PR TITLE
Fix: align appeal UI labels with API — Rejected → Denied

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -3421,7 +3421,7 @@
             <div class="filter-bar">
                 <button class="tab-btn active" data-appeal-filter="pending">Pending</button>
                 <button class="tab-btn" data-appeal-filter="approved">Approved</button>
-                <button class="tab-btn" data-appeal-filter="rejected">Rejected</button>
+                <button class="tab-btn" data-appeal-filter="denied">Denied</button>
             </div>
             <div id="appeals-list"></div>
         </div>
@@ -3665,7 +3665,7 @@
                 </div>
                 <div class="maintenance-card">
                     <h3>Appeals</h3>
-                    <p>Delete all suspension appeals (pending, approved, rejected).</p>
+                    <p>Delete all suspension appeals (pending, approved, denied).</p>
                     <button id="clear-appeals-btn">Delete All Appeals</button>
                     <div class="maintenance-result" id="clear-appeals-result"></div>
                 </div>
@@ -5590,7 +5590,7 @@
             <div class="appeal-actions">
               <input type="text" placeholder="Admin note (optional)" data-note-for="${appeal.id}">
               <button class="btn-approve" data-resolve="${appeal.id}" data-status="approved">Approve</button>
-              <button class="btn-reject" data-resolve="${appeal.id}" data-status="rejected">Reject</button>
+              <button class="btn-reject" data-resolve="${appeal.id}" data-status="denied">Deny</button>
             </div>` : `
             <div style="font-size:12px;color:var(--text2);">
               ${appeal.adminNote ? `Note: ${escapeHtml(appeal.adminNote)}` : ""}


### PR DESCRIPTION
## Summary
- API enforces `"approved"` and `"denied"` status values for appeals
- Admin panel used "Rejected" as filter label and `"rejected"` as action status
- Changed all 3 occurrences to "Denied"/"denied" for consistency

## Test plan
- [ ] Workflow-only change (web deploy) — verify appeals tab filter works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)