### PR TITLE
Fix: SuspensionScreen appeal status — rejected → denied

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/feature/suspension/SuspensionScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/suspension/SuspensionScreen.kt
@@ -236,8 +236,8 @@ fun SuspensionScreen(
                     color = MaterialTheme.colorScheme.primary
                 )
             }
-            // Rejected
-            appealStatus == "rejected" -> {
+            // Denied
+            appealStatus == "denied" -> {
                 Text(
                     text = stringResource(Res.string.appeal_unsuccessful),
                     style = MaterialTheme.typography.bodyMedium,


### PR DESCRIPTION
## Summary
- The API stores appeal status as `"denied"` but SuspensionScreen.kt was checking for `"rejected"`
- Users whose appeal was denied never saw the "appeal unsuccessful" message
- Found during Playwright test spec review of the appeals flow

## Test plan
- [ ] Build: `./gradlew assembleDevDebug`
- [ ] Verify suspended user with denied appeal sees the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)