### PR TITLE
Fix: rename btn-reject to btn-deny for appeal consistency

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -643,7 +643,7 @@
           color: #fff;
         }
         .appeal-card .btn-approve { background: var(--success); }
-        .appeal-card .btn-reject { background: var(--danger); }
+        .appeal-card .btn-deny { background: var(--danger); }
 
         .appeal-card .appeal-profile {
           display: flex;
@@ -5590,7 +5590,7 @@
             <div class="appeal-actions">
               <input type="text" placeholder="Admin note (optional)" data-note-for="${appeal.id}">
               <button class="btn-approve" data-resolve="${appeal.id}" data-status="approved">Approve</button>
-              <button class="btn-reject" data-resolve="${appeal.id}" data-status="denied">Deny</button>
+              <button class="btn-deny" data-resolve="${appeal.id}" data-status="denied">Deny</button>
             </div>` : `
             <div style="font-size:12px;color:var(--text2);">
               ${appeal.adminNote ? `Note: ${escapeHtml(appeal.adminNote)}` : ""}


### PR DESCRIPTION
## Summary
- Renamed CSS class `btn-reject` → `btn-deny` in admin panel appeals section
- All appeal terminology now consistently uses "deny/denied": API status, UI filter label, button text, CSS class, and audit log action

## Test plan
- [ ] Workflow-only change (web deploy) — verify Deny button still styled red

🤖 Generated with [Claude Code](https://claude.com/claude-code)