### PR TITLE
chore: force GitHub to re-index deploy workflow triggers

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,4 +1,5 @@
 name: Deploy To Dev
+# Deploy to dev environment and distribute to testers
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,4 +1,5 @@
 name: Deploy To Prod
+# Deploy a specific release tag to production
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
GitHub's workflow index cache doesn't recognize `workflow_dispatch` on `deploy-prod.yml` because it first saw the file on a feature branch before it existed on main. Adding a comment to each deploy workflow forces GitHub to re-index and recognize the dispatch trigger.

## Test plan
- [ ] After merge, Deploy To Prod appears in Actions tab with "Run workflow" button