### PR TITLE
fix: correct prod smoke test task name

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -209,7 +209,7 @@ jobs:
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           LIVEKIT_URL: ${{ secrets.LIVEKIT_URL }}
-        run: ./gradlew testProdReleaseUnitTest
+        run: ./gradlew testProdDebugUnitTest
 
       - name: Upload to Play Store internal testing track
         uses: r0adkll/upload-google-play@935ef9c68bb393a8e6116b1575626a7f5be3a7fb # v1


### PR DESCRIPTION
## Summary
The task `testProdReleaseUnitTest` doesn't exist — unit tests run against the debug build type. Changed to `testProdDebugUnitTest`.

## Test plan
- [ ] deploy-prod Android job passes smoke tests