### PR TITLE
fix: Play Store version and release notes match GitHub release

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -219,6 +219,8 @@ jobs:
           releaseFiles: app/build/outputs/bundle/prodRelease/*.aab
           track: internal
           status: draft
+          releaseName: ${{ needs.validate-release.outputs.version }}
+          whatsNewDirectory: app/src/main/play/release-notes
 
   deploy-ios-prod:
     name: Deploy iOS to App Store


### PR DESCRIPTION
## Summary
- Set `releaseName` to the semver version from the release tag (e.g. `0.55.1`) so Play Store shows the same version as the GitHub release
- Pass `whatsNewDirectory` so the release notes from `app/src/main/play/release-notes/en-US/internal.txt` appear in Play Store

Previously Play Store auto-generated the release name from `versionCode` (e.g. `56`), making versions inconsistent with GitHub releases.

## Test plan
- [ ] Next deploy-prod shows correct version name in Play Store
- [ ] Release notes appear in Play Store internal track