### PR TITLE
fix: iOS CryptoKeyPair — use CPointerVar<CFError> for Security API

### DIFF
--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/util/CryptoKeyPair.ios.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/util/CryptoKeyPair.ios.kt
@@ -56,7 +56,7 @@ actual class CryptoKeyPair {
             )
 
         memScoped {
-            val error = alloc<kotlinx.cinterop.ObjCObjectVar<platform.CoreFoundation.CFErrorRef?>>()
+            val error = alloc<kotlinx.cinterop.CPointerVar<platform.CoreFoundation.CFError>>()
             val key = SecKeyCreateRandomKey(attributes as CFDictionaryRef, error.ptr)
             return key != null
         }
@@ -67,7 +67,7 @@ actual class CryptoKeyPair {
         val privateKey = getPrivateKeyRef(alias) ?: return null
 
         memScoped {
-            val error = alloc<kotlinx.cinterop.ObjCObjectVar<platform.CoreFoundation.CFErrorRef?>>()
+            val error = alloc<kotlinx.cinterop.CPointerVar<platform.CoreFoundation.CFError>>()
             // Get public key from private key
             val publicKey = platform.Security.SecKeyCopyPublicKey(privateKey) ?: return null
             val data = SecKeyCopyExternalRepresentation(publicKey, error.ptr) as? NSData ?: return null
@@ -81,7 +81,7 @@ actual class CryptoKeyPair {
         val nsData = data.toNSData()
 
         memScoped {
-            val error = alloc<kotlinx.cinterop.ObjCObjectVar<platform.CoreFoundation.CFErrorRef?>>()
+            val error = alloc<kotlinx.cinterop.CPointerVar<platform.CoreFoundation.CFError>>()
             val signature =
                 SecKeyCreateSignature(
                     privateKey,


### PR DESCRIPTION
## Summary
The previous fix (#179) used `ObjCObjectVar<CFErrorRef?>` which still didn't match the expected type. Security framework functions expect `CValuesRef<CPointerVarOf<CPointer<__CFError>>>` which maps to `CPointerVar<CFError>`.

## Test plan
- [ ] iOS KMP framework compiles successfully in CI