### PR TITLE
fix: iOS CryptoKeyPair — use __CFError cinterop type

### DIFF
--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/util/CryptoKeyPair.ios.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/util/CryptoKeyPair.ios.kt
@@ -56,7 +56,7 @@ actual class CryptoKeyPair {
             )
 
         memScoped {
-            val error = alloc<kotlinx.cinterop.CPointerVar<platform.CoreFoundation.CFError>>()
+            val error = alloc<kotlinx.cinterop.CPointerVar<platform.CoreFoundation.__CFError>>()
             val key = SecKeyCreateRandomKey(attributes as CFDictionaryRef, error.ptr)
             return key != null
         }
@@ -67,7 +67,7 @@ actual class CryptoKeyPair {
         val privateKey = getPrivateKeyRef(alias) ?: return null
 
         memScoped {
-            val error = alloc<kotlinx.cinterop.CPointerVar<platform.CoreFoundation.CFError>>()
+            val error = alloc<kotlinx.cinterop.CPointerVar<platform.CoreFoundation.__CFError>>()
             // Get public key from private key
             val publicKey = platform.Security.SecKeyCopyPublicKey(privateKey) ?: return null
             val data = SecKeyCopyExternalRepresentation(publicKey, error.ptr) as? NSData ?: return null
@@ -81,7 +81,7 @@ actual class CryptoKeyPair {
         val nsData = data.toNSData()
 
         memScoped {
-            val error = alloc<kotlinx.cinterop.CPointerVar<platform.CoreFoundation.CFError>>()
+            val error = alloc<kotlinx.cinterop.CPointerVar<platform.CoreFoundation.__CFError>>()
             val signature =
                 SecKeyCreateSignature(
                     privateKey,


### PR DESCRIPTION
## Summary
Previous fixes used `CFErrorRef?` then `CFError`, but Kotlin/Native cinterop maps the Core Foundation error type as `__CFError`. Using `CPointerVar<__CFError>` matches the exact expected type signature.

## Test plan
- [ ] iOS KMP framework compiles in CI