### PR TITLE
fix: iOS compilation errors — BiometricAuth opt-in, CryptoKeyPair types

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,11 +176,14 @@ jobs:
           truncated=$(head -c 500 "$PLAY_FILE")
           echo "$truncated" > "$PLAY_FILE"
 
+          # Copy to default.txt (r0adkll/upload-google-play looks for default.txt as fallback)
+          cp "$PLAY_FILE" "app/src/main/play/release-notes/en-US/default.txt"
+
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add app/build.gradle.kts app/src/main/play/release-notes/en-US/internal.txt
+          git add app/build.gradle.kts app/src/main/play/release-notes/en-US/internal.txt app/src/main/play/release-notes/en-US/default.txt
           git commit -m "chore: release v${{ steps.version.outputs.version }}"
           git push
 

--- a/app/src/main/play/release-notes/en-US/default.txt
+++ b/app/src/main/play/release-notes/en-US/default.txt
@@ -1,0 +1,8 @@
+v0.55.4
+
+iOS CryptoKeyPair — pass null for unused error params (#189)
+- iOS CryptoKeyPair null error + smoke test curl/shell fixes
+- - Pass null for unused Security framework error params (avoids cinterop
+-   type resolution issues with __CFError)
+- remove -f from curl (was failing on 401 status
+-   codes before checking the status)

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/util/BiometricAuth.ios.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/util/BiometricAuth.ios.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package com.shyden.shytalk.core.util
 
 import kotlinx.coroutines.suspendCancellableCoroutine

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/util/CryptoKeyPair.ios.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/util/CryptoKeyPair.ios.kt
@@ -8,8 +8,6 @@ import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
 import platform.CoreFoundation.CFDictionaryRef
 import platform.Foundation.NSData
-import platform.Foundation.NSString
-import platform.Foundation.NSUTF8StringEncoding
 import platform.Foundation.base64EncodedStringWithOptions
 import platform.Foundation.create
 import platform.Security.SecItemCopyMatching
@@ -43,7 +41,7 @@ actual class CryptoKeyPair {
         if (getPrivateKeyRef(alias) != null) return true
 
         // Generate new keypair
-        val tagData = (alias as NSString).dataUsingEncoding(NSUTF8StringEncoding) ?: return false
+        val tagData = alias.encodeToByteArray().toNSData() ?: return false
         val attributes =
             mapOf<Any?, Any?>(
                 kSecAttrKeyType to kSecAttrKeyTypeECSECPrimeRandom,
@@ -84,7 +82,7 @@ actual class CryptoKeyPair {
     }
 
     actual fun delete(alias: String) {
-        val tagData = (alias as NSString).dataUsingEncoding(NSUTF8StringEncoding) ?: return
+        val tagData = alias.encodeToByteArray().toNSData() ?: return
         val query =
             mapOf<Any?, Any?>(
                 kSecClass to kSecClassKey,
@@ -95,7 +93,7 @@ actual class CryptoKeyPair {
     }
 
     private fun getPrivateKeyRef(alias: String): platform.Security.SecKeyRef? {
-        val tagData = (alias as NSString).dataUsingEncoding(NSUTF8StringEncoding) ?: return null
+        val tagData = alias.encodeToByteArray().toNSData() ?: return null
         val query =
             mapOf<Any?, Any?>(
                 kSecClass to kSecClassKey,
@@ -105,9 +103,10 @@ actual class CryptoKeyPair {
                 kSecMatchLimit to kSecMatchLimitOne,
             )
         memScoped {
-            val result = alloc<kotlinx.cinterop.ObjCObjectVar<Any?>>()
+            val result = alloc<platform.CoreFoundation.CFTypeRefVar>()
             val status = SecItemCopyMatching(query as CFDictionaryRef, result.ptr)
             if (status != errSecSuccess) return null
+            @Suppress("UNCHECKED_CAST")
             return result.value as? platform.Security.SecKeyRef
         }
     }


### PR DESCRIPTION
## Summary
Fix three pre-existing iOS compilation errors that prevented `compileKotlinIosArm64`:

1. **BiometricAuth.ios.kt**: Missing `@ExperimentalForeignApi` file-level opt-in
2. **CryptoKeyPair.ios.kt**: `dataUsingEncoding` unresolved — Kotlin String can't be cast to NSString directly. Replaced with `encodeToByteArray().toNSData()`
3. **CryptoKeyPair.ios.kt**: `SecItemCopyMatching` result param type — `ObjCObjectVar<Any?>` no longer matches. Use `CFTypeRefVar` instead

## Test plan
- [ ] PR checks pass (Build & Test, SonarCloud)
- [ ] After merge, deploy-prod iOS job compiles successfully

Note: The `url.parse()` deprecation warning is from the `r0adkll/upload-google-play` action (v1.1.3, latest). Already using `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`. Nothing to fix on our side.