### PR TITLE
fix: CRITICAL — MainActivity crash on launch (ClassCastException)

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/MainActivity.kt
+++ b/app/src/main/java/com/shyden/shytalk/MainActivity.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.net.Uri
 import android.os.Bundle
-import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Arrangement
@@ -67,7 +67,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.shyden.shytalk.data.repository.AppLockRepository
 
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
 
     private val authRepository: AuthRepository by inject()
     private val userRepository: UserRepository by inject()
@@ -93,7 +93,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        biometricAuth.setActivity(this as androidx.fragment.app.FragmentActivity)
+        biometricAuth.setActivity(this)
         enableEdgeToEdge()
 
         // Track app background/foreground for lock timeout


### PR DESCRIPTION
## Summary
**Production is broken.** The app crashes immediately on launch for ALL users.

`MainActivity` extends `ComponentActivity` but `biometricAuth.setActivity()` casts it to `FragmentActivity`, causing `ClassCastException` at line 96 of `onCreate`.

Fix: change `ComponentActivity` to `AppCompatActivity` (which extends `FragmentActivity`). Remove the unsafe cast.

## Test plan
- [ ] Build compiles locally (verified)
- [ ] PR checks pass
- [ ] After merge, deploy to prod IMMEDIATELY
- [ ] Android smoke test passes (app no longer crashes on launch)