### PR TITLE
fix(android): local flavor supports physical devices via -PlocalHost

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,8 @@ Social chat app with voice rooms. Kotlin Multiplatform (Android + iOS), Firebase
 ## Local Development (Zero Cloud)
 - **Start:** `bash local/start.sh` (starts Firebase Emulators + LiveKit Docker)
 - **API:** `cd express-api && npm run local`
-- **Android:** `./gradlew installLocalDebug`
+- **Android on emulator:** `./gradlew installLocalDebug` (uses `10.0.2.2` as host alias)
+- **Android on physical device:** `./gradlew installLocalDebug -PlocalHost=localhost` AND run `adb reverse tcp:3000 tcp:3000 && adb reverse tcp:7880 tcp:7880 && adb reverse tcp:9000 tcp:9000` (tunnels device localhost to laptop)
 - **Firebase UI:** http://localhost:4000
 - **Stop:** `bash local/stop.sh` or Ctrl+C in the start.sh terminal
 - **Prerequisites:** Java 21+, Docker, Firebase CLI (`npm i -g firebase-tools`)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,10 +67,17 @@ android {
         create("local") {
             dimension = "env"
             applicationIdSuffix = ".local"
-            buildConfigField("String", "API_BASE_URL", "\"http://10.0.2.2:3000\"")
-            buildConfigField("String", "WORKER_URL", "\"http://10.0.2.2:3000\"")
-            buildConfigField("String", "LIVEKIT_SERVER_URL", "\"ws://10.0.2.2:7880\"")
-            buildConfigField("String", "RTDB_URL", "\"http://10.0.2.2:9000\"")
+            // Host alias — defaults to 10.0.2.2 (Android emulator's loopback to host machine).
+            // For physical devices: build with `-PlocalHost=localhost` and run
+            //   adb reverse tcp:3000 tcp:3000   (Express API)
+            //   adb reverse tcp:7880 tcp:7880   (LiveKit)
+            //   adb reverse tcp:9000 tcp:9000   (Firebase RTDB emulator)
+            // This tunnels the device's localhost to the laptop's localhost.
+            val localHostAlias = (project.findProperty("localHost") as String?) ?: "10.0.2.2"
+            buildConfigField("String", "API_BASE_URL", "\"http://$localHostAlias:3000\"")
+            buildConfigField("String", "WORKER_URL", "\"http://$localHostAlias:3000\"")
+            buildConfigField("String", "LIVEKIT_SERVER_URL", "\"ws://$localHostAlias:7880\"")
+            buildConfigField("String", "RTDB_URL", "\"http://$localHostAlias:9000\"")
             buildConfigField("String", "EMAIL_LINK_DOMAIN", "\"localhost\"")
             buildConfigField("String", "WEB_CLIENT_ID", "\"placeholder-local\"")
             buildConfigField("Boolean", "BYPASS_DEVICE_CHECKS", "true")


### PR DESCRIPTION
## Summary
The `local` Android build flavor hardcoded all URLs to `10.0.2.2` (Android emulator's host alias), so physical devices showed "Technical Difficulties" on launch because API requests failed. This was found during PR #284 manual QA on a physical device.

## Fix
Make the host alias configurable via a gradle property with `10.0.2.2` as the default — **zero regression for existing emulator workflows**.

| Use case | Command |
|---|---|
| Emulator (default, no change) | `./gradlew installLocalDebug` → `10.0.2.2` |
| Physical device | `./gradlew installLocalDebug -PlocalHost=localhost` + `adb reverse tcp:3000 tcp:3000` (and 7880, 9000) |

Implementation: `val localHostAlias = (project.findProperty("localHost") as String?) ?: "10.0.2.2"` then all 4 URL build config fields use `$localHostAlias`.

## Docs
Updated `CLAUDE.md` under "Local Development (Zero Cloud)" to document the physical device path + the three `adb reverse` commands needed.

## Test plan
- [x] Default build: `./gradlew :app:assembleLocalDebug` → BuildConfig `API_BASE_URL = "http://10.0.2.2:3000"` ✓
- [x] Override build: `./gradlew :app:assembleLocalDebug -PlocalHost=localhost` → BuildConfig `API_BASE_URL = "http://localhost:3000"` ✓
- [x] ktlint passes
- [ ] CI: Build & Test
- [ ] CI: SonarCloud
- [ ] CI: Android E2E (validates default path still works on emulator)

Closes follow-up task #20 from PR #284 manual QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)