### PR TITLE
refactor(admin): extract core ES modules from inline script (PR A)

### DIFF
--- a/.project/plans/2026-03-29-feature-roadmap.md
+++ b/.project/plans/2026-03-29-feature-roadmap.md
@@ -13,7 +13,6 @@ These enable everything else. SonarCloud blocks all future PRs. Allure gives vis
 | 36 | **Fix all SonarCloud issues on main** — 500+ issues, must be clean before quality gate blocks PRs | Medium | DONE (PR #223, 2026-03-30) — 400+ fixed, quality gate passing |
 | 37 | **Allure report directory structure** — per-suite, per-environment, landing page. See `2026-03-29-allure-directory-spec.md` | Medium | DONE (PR #241, 2026-03-31) |
 | 35 | **Legal docs: Shyden Ltd branding** — update all public docs and legal pages | Small | DONE (PR #280, 2026-04-09) |
-| 32 | **OnPush CLI** — local doc generation (`onpush init/generate/clean`). CI is paid; run locally only | Small | |
 | 40 | **CI workflow deduplication** — extract duplicated steps into reusable workflows (Firebase rules deploy, google-services decode, iOS signing, Allure report). 6+ workflows have duplicated logic | Small | DONE (PR #282, 2026-04-09) |
 | 41 | **Admin panel restructure** — break 12,000+ line index.html into modular components/pages. Support future growth (more tabs, more features). Consider SPA framework or web components. Blocked by #47 (now in Phase 6) | Large | |
 
@@ -106,7 +105,9 @@ Public-facing website improvements and creator/admin tools.
 | 46 | **Web page i18n completion** — full translations for all web pages including admin panel, legal pages. Language selector on every page | Medium | |
 | 42 | **Admin role-based access control** — internal admin roles (super-admin, moderator, viewer) controlling which tools each admin can use. Store roles in Firestore, enforce server-side | Medium | |
 | 43 | **MC Host dedicated panel** — separate login + dashboard for MC Hosts to manage games, participants, prizes. Isolated from main admin panel | Medium | |
+| 49 | **MC Host Team Leader panel** — oversight panel for Team Leaders who manage multiple MC Hosts. View team performance, assign games/events, review MC Host activity, handle escalations | Medium | |
 | 44 | **MC Singer dedicated panel** — separate login + dashboard for MC Singers to manage singing sessions, rooms, competitions | Medium | |
+| 50 | **MC Singer Team Leader panel** — oversight panel for Team Leaders who manage multiple MC Singers. View team performance, assign singing sessions, review MC Singer activity, handle escalations | Medium | |
 | 45 | **Teacher dedicated panel** — separate login + dashboard for Teachers to manage teaching rooms, students, schedules | Medium | |
 
 ---
@@ -158,3 +159,13 @@ In-app support and niche room types.
 | B20 | **Clans system** — user-created groups with leaders, members, ranks, shared chat, clan-level leaderboards, inter-clan competitions (PK battles, gift wars). Clan badges on profiles. Ties into nobility system for clan perks | |
 | B22 | **App startup redesign** — redesign app launch flow to prevent login screen flash when auto-login will happen (race condition), improve perceived startup time, better loading states | |
 | B21 | **Automated content moderation** — AI-powered detection of prohibited content across all UGC channels: pornography/nudity detection on video streams and uploaded images (profile photos, cover photos, chat images), profanity/hate speech detection on voice chat (speech-to-text + filter), and text toxicity detection on chat messages, usernames, room names, suggestions. Auto-flag for admin review or auto-action (warn/mute/suspend) based on severity. Dashboard for false-positive review and threshold tuning | |
+
+---
+
+## Nice to Have (deferred — end-of-roadmap polish)
+
+Items that are useful but not blocking. Do these only after all numbered phases are complete.
+
+| ID | Item | Effort | Notes |
+|----|------|--------|-------|
+| 32 | **OnPush CLI** — local doc generation (`onpush init/generate/clean`). CI is paid; run locally only | Small | Moved from Phase 0 (2026-04-11) — productivity tool, not user-visible. Defer until core roadmap is done. |

--- a/.project/plans/2026-04-11-admin-panel-restructure-design.md
+++ b/.project/plans/2026-04-11-admin-panel-restructure-design.md
@@ -1,0 +1,584 @@
+# Admin Panel Restructure — Design
+
+**Date:** 2026-04-11
+**Roadmap item:** #41 Phase 0 — Admin panel restructure
+**Goal:** Break the 14,520-line `public/admin/index.html` into modular ES modules to support future growth (more tabs, shared infrastructure for 5+ upcoming panels) without a build step.
+**Unblocks:** MC Host panel (#43), MC Host Team Leader (#49), MC Singer panel (#44), MC Singer Team Leader (#50), Teacher panel (#45), Web personal profile (#48) — all planned for Phase 6.
+
+## Current state
+
+- `public/admin/index.html`: **14,520 lines**
+- ~3,000 lines of HTML markup + CSS
+- One giant inline `<script type="module">` from lines 5058-14510 (~9,500 lines of JS, **214 top-level functions**)
+- 21 tabs (Users, Reports, Appeals, Gifts, Economy, Maintenance, Spin Monitor, Banners, Fun Facts, Backups, Logs, Devices, Starting Screens, Suggestions, Audit Log, …)
+- Tab buttons use IDs `tab-users`, `tab-reports`, etc. (nav buttons in the top bar)
+- Tab content panels use IDs `appeals-panel`, `reports-panel`, etc. — **with one asymmetry**: Users tab uses `user-form` (no `users-panel` wrapper; it's the default main content)
+- Already uses ES modules internally (the big inline `<script type="module">`)
+- Modular Firebase SDK v11.6.0 (`import {initializeApp, getAuth, onAuthStateChanged}`)
+- 28 Playwright spec files with extensive `data-testid` / data-attribute selectors
+- Deployed as static files to Cloudflare Pages — **zero build step**, $0 hosting constraint
+
+## Constraints
+
+1. **Zero build step** — Cloudflare Pages deploys `public/` verbatim. No bundler, no transpiler, no preprocessor.
+2. **$0 hosting** — no paid tools, no CDN-only solutions that introduce subscription costs.
+3. **Playwright tests must pass unchanged** — any rewrite of the 28 admin spec files would double the cost. DOM shapes, class names, IDs, and data-attributes are preserved.
+4. **Reusable for future panels** — MC Host, MC Host Team Leader, MC Singer, MC Singer Team Leader, Teacher, and Personal Profile panels are all coming (Phase 6). Shared infrastructure should be designed for reuse from day one, not retrofitted later.
+5. **Incremental migration** — one big PR is too risky. Split into phases that can each be reviewed, deployed, manually QA'd, and reverted independently.
+
+## Approach
+
+**Pure ES modules, no framework, no build step.** ES modules are natively supported by every modern browser and work over HTTP/2 with caching. The admin panel already uses a `<script type="module">` inline block, so nothing new to learn.
+
+**Alternatives considered and rejected:**
+- **Web Components (native Custom Elements)** — Shadow DOM breaks Playwright's normal selectors unless pierced with `::part()` or Light DOM escape hatches. Significant test rewrite risk.
+- **Lightweight framework (Vue/Svelte/Alpine)** — Requires a build step (breaks zero-build constraint). CDN versions are slower and clunky. Playwright tests would need rewrites for reactive DOM.
+- **Multi-page app (one HTML file per tab)** — Full page reloads between tabs break the SPA feel; tests would need to handle navigation; more HTML duplication.
+- **Extract JS only, leave HTML monolithic** — Minimal but doesn't unblock future panels. Still a single unmanageable HTML file.
+
+## Directory layout
+
+Shared modules live at `public/js/core/` alongside the existing shared utilities (`logger.js`, `language-selector.js`). Admin-specific code lives in `public/admin/js/`.
+
+```
+public/
+├── js/
+│   ├── logger.js                (existing — shared)
+│   ├── language-selector.js     (existing — shared)
+│   └── core/                    ← NEW
+│       ├── state.js             (createStore factory — app-agnostic)
+│       ├── auth.js              (SDK-agnostic auth-state handler factory)
+│       ├── api.js               (apiCall wrapper, AbortController per tab)
+│       ├── ui.js                (showToast, showConfirm, showScreen, escapeHtml)
+│       └── tabs.js              (tab switcher — generic, uses panel ID map)
+├── admin/
+│   ├── index.html               (thin HTML shell — markup + one script tag)
+│   ├── js/
+│   │   ├── main.js              (admin entry point — imports core, wires auth, registers tabs)
+│   │   └── tabs/
+│   │       ├── users.js         (~1000 lines)
+│   │       ├── reports.js       (~800 lines)
+│   │       ├── appeals.js       (~400 lines)
+│   │       ├── gifts.js         (~600 lines)
+│   │       ├── economy.js       (~400 lines)
+│   │       ├── maintenance.js   (~600 lines)
+│   │       ├── spin-monitor.js  (~300 lines)
+│   │       ├── banners.js       (~500 lines)
+│   │       ├── fun-facts.js     (~400 lines)
+│   │       ├── backups.js       (~300 lines)
+│   │       ├── logs.js          (~600 lines)
+│   │       ├── devices.js       (~400 lines)
+│   │       ├── starting-screens.js (~400 lines)
+│   │       ├── suggestions.js   (~900 lines)
+│   │       └── audit-log.js     (~200 lines)
+│   ├── assets/                  (unchanged)
+│   ├── config.js                (unchanged — env URLs)
+│   └── translations.js          (unchanged — already external)
+```
+
+**Total result:** ~7,500 lines of JS spread across ~20 files, replacing the current 9,500-line inline block. No file exceeds ~1,000 lines. Each file has a single responsibility.
+
+## Module contracts
+
+### `public/js/core/state.js` — app-agnostic state store factory
+
+```js
+export function createStore(initial) {
+  const _state = { ...initial };
+  const _listeners = new EventTarget();
+  return {
+    get: (key) => _state[key],
+    set: (key, value) => {
+      const old = _state[key];
+      _state[key] = value;
+      if (old !== value) {
+        _listeners.dispatchEvent(new CustomEvent(`${key}:change`, { detail: { old, value } }));
+      }
+    },
+    on: (key, handler) => _listeners.addEventListener(`${key}:change`, handler),
+    off: (key, handler) => _listeners.removeEventListener(`${key}:change`, handler),
+  };
+}
+```
+
+The admin panel's `main.js` creates its own store with admin-specific keys. Future panels create their own stores with panel-specific keys.
+
+### `public/js/core/auth.js` — SDK-agnostic auth state handler
+
+```js
+// Zero Firebase imports — pure logic. Caller plugs this into their own onAuthStateChanged.
+export function createAuthStateHandler({ requireClaim, onAccessDenied, onReady }) {
+  return async (user) => {
+    if (!user) { onReady(null); return; }
+    const tokenResult = await user.getIdTokenResult();
+    if (requireClaim && tokenResult.claims[requireClaim] !== true) {
+      onAccessDenied({ reason: 'missing_claim', claim: requireClaim });
+      return;
+    }
+    onReady(user, tokenResult);
+  };
+}
+```
+
+Works with both modular Firebase SDK (admin panel) and compat Firebase SDK (portal) because it's a pure callback factory. Required: admin panel sets `requireClaim: 'admin'` and `onAccessDenied` shows the inline error (preserving PR #284 behavior — no `signOut()` call).
+
+### `public/js/core/api.js` — fetch wrapper with per-tab AbortController
+
+```js
+let _apiBase = '';
+let _getToken = () => Promise.resolve(null);
+let _abortController = new AbortController();
+
+export function configure({ apiBase, getToken }) {
+  _apiBase = apiBase;
+  _getToken = getToken;
+}
+
+/** Called by core/tabs.js on every tab switch to cancel stale in-flight requests. */
+export function resetAbortController() {
+  _abortController.abort();
+  _abortController = new AbortController();
+}
+
+/**
+ * @param opts.signal        caller-supplied AbortSignal (overrides tab-level abort)
+ * @param opts.skipTabAbort  true = survive tab switches (for saves, user search, etc.)
+ */
+export async function apiCall(method, path, body, { signal, skipTabAbort } = {}) {
+  const token = await _getToken();
+  const opts = {
+    method,
+    headers: { 'Authorization': `Bearer ${token}` },
+    signal: signal || (skipTabAbort ? undefined : _abortController.signal),
+  };
+  if (body instanceof FormData) {
+    opts.body = body;
+  } else if (body) {
+    opts.headers['Content-Type'] = 'application/json';
+    opts.body = JSON.stringify(body);
+  }
+  const res = await fetch(`${_apiBase}${path}`, opts);
+  const contentType = res.headers.get('content-type') || '';
+  if (!contentType.includes('application/json')) {
+    throw new Error(`HTTP ${res.status}: server returned non-JSON response`);
+  }
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+  return data;
+}
+```
+
+Preserves all semantics of the current inline `apiCall`: Bearer auth, FormData uploads, tab-scoped abort, content-type validation.
+
+### `public/js/core/ui.js` — DOM-preserving UI helpers
+
+```js
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  }[c]));
+}
+
+let _toastTimer = null;
+export function showToast(msg, type = 'success') {
+  const toast = document.getElementById('toast');
+  if (!toast) return;
+  clearTimeout(_toastTimer);
+  toast.textContent = msg;
+  toast.className = `toast ${type} visible`;
+  _toastTimer = setTimeout(
+    () => toast.classList.remove('visible'),
+    type === 'error' ? 7000 : 4000
+  );
+}
+
+const _screens = new Map();
+export function registerScreen(name, element) { _screens.set(name, element); }
+export function showScreen(name) {
+  for (const el of _screens.values()) el.classList.remove('active');
+  _screens.get(name)?.classList.add('active');
+}
+
+export function showConfirm(title, message) {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'confirm-overlay';
+    overlay.innerHTML = `
+      <div class="confirm-dialog">
+        <h3>${escapeHtml(title)}</h3>
+        <p>${escapeHtml(message)}</p>
+        <div class="confirm-buttons">
+          <button class="confirm-cancel">Cancel</button>
+          <button class="confirm-ok">Confirm</button>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+    overlay.querySelector('.confirm-cancel').addEventListener('click', () => { overlay.remove(); resolve(false); });
+    overlay.querySelector('.confirm-ok').addEventListener('click', () => { overlay.remove(); resolve(true); });
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) { overlay.remove(); resolve(false); } });
+  });
+}
+
+export { escapeHtml };
+```
+
+**Critical:** class names (`.toast`, `.confirm-overlay`, `.confirm-dialog`, `.confirm-ok`, `.confirm-cancel`) and element IDs (`#toast`) are **identical to current code**. Playwright tests use `page.locator('.confirm-ok')` — these must keep working.
+
+### `public/js/core/tabs.js` — generic tab switcher
+
+```js
+import { resetAbortController } from './api.js';
+
+const _modules = new Map();  // tabId -> { init, activate, deactivate, initialized }
+let _panelMap = null;
+let _activeTab = null;
+
+export function configure({ panelMap }) {
+  _panelMap = panelMap;
+}
+
+export function register(tabId, module) {
+  _modules.set(tabId, { ...module, initialized: false });
+}
+
+export async function show(tabId) {
+  if (!_panelMap) throw new Error('tabs.configure() must be called first');
+  const mod = _modules.get(tabId);
+  if (!mod) throw new Error(`No tab module registered for: ${tabId}`);
+
+  resetAbortController();   // cancel previous tab's in-flight requests
+
+  // deactivate previous tab
+  if (_activeTab && _activeTab !== tabId) {
+    const prevMod = _modules.get(_activeTab);
+    await prevMod?.deactivate?.();
+  }
+
+  // init on first activation
+  if (!mod.initialized) {
+    const root = document.getElementById(_panelMap[tabId]);
+    await mod.init?.({ root });
+    mod.initialized = true;
+  }
+
+  // update panel visibility (preserves the asymmetric class/display pattern
+  // from current code — .visible for most panels, style.display for audit-log
+  // and user-form, preserving test compatibility)
+  setPanelVisibility(tabId);
+
+  // update tab button active state
+  document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+  const btn = document.getElementById(`tab-${tabId}`);
+  if (btn) {
+    btn.classList.add('active');
+    // Force synchronous layout flush — WebKit batches classList mutations,
+    // which can cause automated tests to read stale class values.
+    void btn.offsetHeight;
+  }
+
+  // activate current tab
+  const root = document.getElementById(_panelMap[tabId]);
+  await mod.activate?.({ root });
+
+  sessionStorage.setItem('admin_tab', tabId);
+  _activeTab = tabId;
+}
+
+function setPanelVisibility(tabId) {
+  // Exact logic from current switchTab() (lines 6055-6070) — preserves the
+  // asymmetric DOM: Users uses inline style (no panel wrapper), Audit Log
+  // uses style.display="block", everything else uses a .visible class toggle.
+  const isUsers = tabId === 'users';
+  const searchBar = document.querySelector('.search-bar');
+  const userForm = document.getElementById('user-form');
+  if (searchBar) searchBar.style.display = isUsers ? '' : 'none';
+  if (userForm) userForm.style.display = isUsers ? '' : 'none';
+
+  // .visible class toggle for most panels
+  const visibleClassPanels = [
+    'appeals', 'reports', 'gifts', 'economy', 'maintenance', 'monitor',
+    'banners', 'funfacts', 'backups', 'logs', 'devices',
+    'starting-screens', 'suggestions',
+  ];
+  for (const id of visibleClassPanels) {
+    const panel = document.getElementById(`${id}-panel`);
+    if (panel) panel.classList.toggle('visible', tabId === id);
+  }
+
+  // Audit log uses style.display (not .visible class) for historical reasons
+  const auditLogPanel = document.getElementById('audit-log-panel');
+  if (auditLogPanel) {
+    auditLogPanel.style.display = tabId === 'audit-log' ? 'block' : 'none';
+  }
+}
+
+export function getActiveTab() { return _activeTab; }
+```
+
+### Tab module shape
+
+Each tab module exports up to three functions:
+
+```js
+// public/admin/js/tabs/users.js
+import { store } from '../main.js';
+import { apiCall } from '/js/core/api.js';
+import { showToast, showConfirm } from '/js/core/ui.js';
+import { show as showTab } from '/js/core/tabs.js';
+
+// Local state (not shared across tabs)
+let tabAbortController = new AbortController();
+let currentFormData = null;
+
+/** Run once on first activation — wire DOM listeners, nothing async. */
+export function init({ root }) {
+  root.querySelector('#search-btn')?.addEventListener('click', handleSearch);
+  // etc.
+}
+
+/** Run every time the tab becomes active — data loads go here. */
+export function activate({ root }) {
+  // e.g., loadUserByLastSearched();
+}
+
+/** Run when the tab is switched away from — optional. */
+export function deactivate() {
+  // e.g., stopPollingIfAny();
+}
+
+// ... rest of tab logic
+```
+
+Tabs are imported eagerly in `main.js` (static imports) but `init()` runs lazily on first activation. This gives fast startup (parse all modules upfront) without paying the cost of initializing tabs the user never visits.
+
+### `public/admin/js/main.js` — admin entry point
+
+```js
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.6.0/firebase-app.js';
+import { getAuth, onAuthStateChanged, connectAuthEmulator } from 'https://www.gstatic.com/firebasejs/11.6.0/firebase-auth.js';
+
+import { createStore } from '/js/core/state.js';
+import { createAuthStateHandler } from '/js/core/auth.js';
+import * as api from '/js/core/api.js';
+import { showToast, showScreen, registerScreen } from '/js/core/ui.js';
+import * as tabs from '/js/core/tabs.js';
+
+// Admin-specific tabs
+import * as usersTab from './tabs/users.js';
+import * as reportsTab from './tabs/reports.js';
+// ... all 15 tab modules imported
+
+// Admin-specific state store
+export const store = createStore({
+  currentUser: null,
+  currentUid: null,
+  currentFirebaseUid: null,
+  currentTab: 'users',
+});
+
+// Register screens for the showScreen helper
+registerScreen('loading', document.getElementById('loading-screen'));
+registerScreen('login', document.getElementById('login-screen'));
+registerScreen('dashboard', document.getElementById('dashboard-screen'));
+
+// Firebase Auth
+const app = initializeApp(window.SHYTALK_CONFIG.FIREBASE_CONFIG);
+const auth = getAuth(app);
+if (window.SHYTALK_CONFIG.USE_EMULATORS) {
+  connectAuthEmulator(auth, 'http://localhost:9099', { disableWarnings: true });
+}
+
+// Configure core/api with auth provider
+api.configure({
+  apiBase: window.SHYTALK_CONFIG.API_BASE,
+  getToken: () => store.get('currentUser')?.getIdToken() ?? Promise.resolve(null),
+});
+
+// Configure core/tabs with the panel ID map
+tabs.configure({
+  panelMap: {
+    users:             'user-form',           // asymmetric
+    appeals:           'appeals-panel',
+    reports:           'reports-panel',
+    gifts:             'gifts-panel',
+    economy:           'economy-panel',
+    maintenance:       'maintenance-panel',
+    monitor:           'monitor-panel',
+    banners:           'banners-panel',
+    funfacts:          'funfacts-panel',
+    backups:           'backups-panel',
+    logs:              'logs-panel',
+    devices:           'devices-panel',
+    'starting-screens':'starting-screens-panel',
+    suggestions:       'suggestions-panel',
+    'audit-log':       'audit-log-panel',
+  },
+});
+
+// Register each tab module
+tabs.register('users', usersTab);
+tabs.register('reports', reportsTab);
+// ... etc
+
+// Wire tab button clicks
+for (const tabId of Object.keys(tabs.getPanelMap())) {
+  document.getElementById(`tab-${tabId}`)?.addEventListener('click', () => tabs.show(tabId));
+}
+
+// Wire Firebase Auth
+onAuthStateChanged(auth, createAuthStateHandler({
+  requireClaim: 'admin',
+  onAccessDenied: () => {
+    const loginError = document.getElementById('login-error');
+    loginError.textContent = 'Access denied — admin privileges required. If you have a portal account, go to /portal/ instead.';
+    loginError.style.display = 'block';
+    showScreen('login');
+  },
+  onReady: (user) => {
+    if (user) {
+      store.set('currentUser', user);
+      showScreen('dashboard');
+      // Restore last-viewed tab from sessionStorage
+      const saved = sessionStorage.getItem('admin_tab') || 'users';
+      tabs.show(saved);
+    } else {
+      showScreen('login');
+    }
+  },
+}));
+```
+
+## Cross-tab navigation
+
+Each tab module that needs to navigate to another tab imports `{ show as showTab }` from `/js/core/tabs.js` and calls it:
+
+```js
+// tabs/reports.js — clicking a username navigates to Users tab
+userNameLink.addEventListener('click', (e) => {
+  e.preventDefault();
+  store.set('currentUid', clickedUid);
+  showTab('users');
+});
+```
+
+Only 5 cross-tab call sites in the current code. None create circular dependencies because tabs only depend on `core/tabs.js`, not on other tab modules.
+
+## Phased delivery
+
+### PR A — Core infrastructure (no tab extraction)
+
+**Scope:** ~1,500 lines moved. Zero tab logic touched.
+
+1. Create `public/js/core/{state,auth,api,ui,tabs}.js` with the contracts above.
+2. Create `public/admin/js/main.js` that wires Firebase Auth, creates the store, configures `api`/`tabs`, imports each core module.
+3. Modify `public/admin/index.html`:
+   - Replace the inline `<script type="module">` opening with `<script type="module" src="js/main.js">`
+   - Keep the inline block, but **shortened** — remove the functions that were extracted (`showToast`, `showConfirm`, `showScreen`, `apiCall`, `switchTab`, auth setup).
+   - Add a transitional **backwards-compat shim** at the top of the inline block:
+     ```js
+     // Transitional shim — until PR B extracts tab logic, the inline script
+     // still expects these as globals. PR C removes this shim.
+     import { showToast, showConfirm, showScreen } from '/js/core/ui.js';
+     import { apiCall } from '/js/core/api.js';
+     import { show as switchTab } from '/js/core/tabs.js';
+     import { store } from './js/main.js';
+     // Re-export as module-local bindings (not window.*) — ES module scope only
+     ```
+4. All Playwright tests still pass unchanged.
+5. Manual QA: all tabs still work, all confirm dialogs still work, tab switching still cancels requests, admin access-denied fix (PR #284) still works.
+
+**Commit structure within PR A** (3 commits):
+- Commit A1: create core modules + main.js, no HTML changes (standalone files)
+- Commit A2: add `<script src="js/main.js">` to index.html, add shim at top of inline block
+- Commit A3: remove the now-duplicated helper functions from the inline block
+
+**Why this order:** A1 is a pure addition (zero regression risk). A2 wires main.js but the inline block still has its own copies. A3 is the actual removal. Each commit is revertable.
+
+### PR B — Tab extraction
+
+**Scope:** ~7,000 lines moved. One tab per commit, grouped by risk.
+
+**Commit group 1 — Easy tabs (read-only or simple CRUD):**
+- audit-log.js
+- backups.js
+- fun-facts.js
+- banners.js
+
+**Commit group 2 — Medium tabs:**
+- appeals.js
+- devices.js
+- starting-screens.js
+- spin-monitor.js
+
+**Commit group 3 — Complex tabs:**
+- gifts.js
+- economy.js
+- maintenance.js
+- logs.js
+- suggestions.js
+- reports.js
+- users.js (largest, most interconnected)
+
+**Extraction procedure per tab** (documented in the impl plan, not the design):
+1. Identify the tab's functions in the inline block (grep by tab-specific DOM IDs, comments).
+2. Move them to `tabs/{tab}.js` as a module with `init/activate/deactivate` exports.
+3. Replace any references to extracted helpers (`apiCall`, `showToast`) with ES module imports.
+4. Move `loadXxx()` calls from `switchTab`'s activation side-effects into the tab module's `activate()`.
+5. Import the module in `main.js` and register it with `tabs.register()`.
+6. Delete the now-extracted functions from the inline block.
+7. Run Playwright tests for that tab's spec file.
+8. Manual smoke check: open the tab, verify basic functionality.
+9. Commit.
+
+### PR C — Cleanup
+
+1. Remove the now-empty inline `<script type="module">` block from `index.html`.
+2. Remove any lingering backwards-compat shims from PR A.
+3. Add JSDoc to core module exports.
+4. Create `public/js/core/README.md` describing the core modules for future panel work (MC Host/Singer/Team Leaders/Teacher/Personal Profile).
+5. Update `CLAUDE.md` with the new module layout under "Architecture".
+6. Verify no `window.*` globals leak from the admin panel (console check).
+
+## Testing strategy
+
+**Unchanged (must pass):**
+- 28 Playwright spec files × 5 browsers × Android E2E (CI)
+- Full manual QA cycle before each PR merges (per auto-mode rule)
+
+**New (optional, non-blocking):**
+- Jest unit tests for pure core functions (`createStore`, `createAuthStateHandler`, `escapeHtml`). Placed in `public/js/core/__tests__/` or merged into `express-api/tests/unit/` (easier — jest config already exists). Not blocking for this PR — can ship as a follow-up.
+
+## Rollback strategy
+
+Each PR is independently revertable via `git revert <merge-commit>`.
+
+- **PR A revert:** restores inline `showToast`/`apiCall`/etc. in the same file. No tab logic was touched. Fully reversible in one commit.
+- **PR B revert:** restores the big inline block. Tab modules are deleted. Larger diff but reversible. Individual commits within PR B can also be reverted in isolation.
+- **PR C revert:** restores the window shims and the (still empty) inline script tag. Trivial.
+
+## Non-goals
+
+- No framework adoption (Vue/Svelte/React) — explicitly out of scope.
+- No TypeScript — out of scope for this PR (could be a follow-up).
+- No test rewrites — existing Playwright tests must pass unchanged.
+- No refactoring beyond extraction — `users.js` stays ~1,000 lines. Splitting it further (e.g., `users/profile.js`, `users/moderation.js`) is a follow-up, not this PR.
+- No bundling / minification — Cloudflare Pages serves as-is over HTTP/2.
+- No lazy loading via dynamic `import()` — eager static imports give simpler startup and are fine for <20 modules. Dynamic imports can be added later if the bundle grows.
+
+## Success criteria
+
+- `public/admin/index.html` is < 5,000 lines (down from 14,520) — most of that is HTML markup + CSS, no inline JS.
+- `public/js/core/` exists with 5 app-agnostic modules, all importable from future panels.
+- `public/admin/js/tabs/` exists with 15 per-tab modules.
+- Every existing Playwright admin spec passes unchanged on all 5 browsers.
+- Full manual QA pass on each PR before merge.
+- Dev and prod deploys successful after each merge.
+- No regressions reported within 24h of prod deploy.
+
+## Follow-up tasks (out of scope for this design)
+
+1. Unit tests for `public/js/core/` modules (`createStore`, `createAuthStateHandler`, `escapeHtml`).
+2. Split `users.js` further into subtab modules (`profile`, `moderation`, `security`, `economy`, `identity`) if it grows beyond ~1,500 lines.
+3. Migrate `public/portal/portal.js` to use `public/js/core/` modules (currently uses compat Firebase SDK with its own wrappers).
+4. MC Host panel at `public/mc-host/` using the shared `public/js/core/` modules (roadmap #43).

--- a/.project/plans/2026-04-11-admin-panel-restructure-design.md
+++ b/.project/plans/2026-04-11-admin-panel-restructure-design.md
@@ -10,7 +10,7 @@
 - `public/admin/index.html`: **14,520 lines**
 - ~3,000 lines of HTML markup + CSS
 - One giant inline `<script type="module">` from lines 5058-14510 (~9,500 lines of JS, **214 top-level functions**)
-- 21 tabs (Users, Reports, Appeals, Gifts, Economy, Maintenance, Spin Monitor, Banners, Fun Facts, Backups, Logs, Devices, Starting Screens, Suggestions, Audit Log, …)
+- 15 tabs: Users, Appeals, Reports, Gifts, Economy, Maintenance, Spin Monitor, Banners, Fun Facts, Backups, Logs, Devices, Starting Screens, Suggestions, Audit Log
 - Tab buttons use IDs `tab-users`, `tab-reports`, etc. (nav buttons in the top bar)
 - Tab content panels use IDs `appeals-panel`, `reports-panel`, etc. — **with one asymmetry**: Users tab uses `user-form` (no `users-panel` wrapper; it's the default main content)
 - Already uses ES modules internally (the big inline `<script type="module">`)
@@ -395,34 +395,39 @@ api.configure({
   getToken: () => store.get('currentUser')?.getIdToken() ?? Promise.resolve(null),
 });
 
-// Configure core/tabs with the panel ID map
-tabs.configure({
-  panelMap: {
-    users:             'user-form',           // asymmetric
-    appeals:           'appeals-panel',
-    reports:           'reports-panel',
-    gifts:             'gifts-panel',
-    economy:           'economy-panel',
-    maintenance:       'maintenance-panel',
-    monitor:           'monitor-panel',
-    banners:           'banners-panel',
-    funfacts:          'funfacts-panel',
-    backups:           'backups-panel',
-    logs:              'logs-panel',
-    devices:           'devices-panel',
-    'starting-screens':'starting-screens-panel',
-    suggestions:       'suggestions-panel',
-    'audit-log':       'audit-log-panel',
-  },
-});
+// Configure core/tabs with the panel ID map (defined as a constant so
+// we can reuse it below to wire tab button click handlers)
+const PANEL_MAP = {
+  users:              'user-form',           // asymmetric — no panel wrapper
+  appeals:            'appeals-panel',
+  reports:            'reports-panel',
+  gifts:              'gifts-panel',
+  economy:            'economy-panel',
+  maintenance:        'maintenance-panel',
+  monitor:            'monitor-panel',
+  banners:            'banners-panel',
+  funfacts:           'funfacts-panel',
+  backups:            'backups-panel',
+  logs:               'logs-panel',
+  devices:            'devices-panel',
+  'starting-screens': 'starting-screens-panel',
+  suggestions:        'suggestions-panel',
+  'audit-log':        'audit-log-panel',
+};
+tabs.configure({ panelMap: PANEL_MAP });
 
-// Register each tab module
-tabs.register('users', usersTab);
-tabs.register('reports', reportsTab);
-// ... etc
+// Register each tab module (mapping tab ID to the imported module)
+const TAB_MODULES = {
+  users: usersTab,
+  reports: reportsTab,
+  // ... etc (15 entries)
+};
+for (const [tabId, mod] of Object.entries(TAB_MODULES)) {
+  tabs.register(tabId, mod);
+}
 
 // Wire tab button clicks
-for (const tabId of Object.keys(tabs.getPanelMap())) {
+for (const tabId of Object.keys(PANEL_MAP)) {
   document.getElementById(`tab-${tabId}`)?.addEventListener('click', () => tabs.show(tabId));
 }
 
@@ -473,25 +478,32 @@ Only 5 cross-tab call sites in the current code. None create circular dependenci
 1. Create `public/js/core/{state,auth,api,ui,tabs}.js` with the contracts above.
 2. Create `public/admin/js/main.js` that wires Firebase Auth, creates the store, configures `api`/`tabs`, imports each core module.
 3. Modify `public/admin/index.html`:
-   - Replace the inline `<script type="module">` opening with `<script type="module" src="js/main.js">`
-   - Keep the inline block, but **shortened** — remove the functions that were extracted (`showToast`, `showConfirm`, `showScreen`, `apiCall`, `switchTab`, auth setup).
-   - Add a transitional **backwards-compat shim** at the top of the inline block:
+   - Add a new `<script type="module" src="js/main.js"></script>` before the existing inline block. This triggers all the core-module setup (Firebase Auth, store, tab switcher wiring) without touching any tab logic.
+   - Keep the existing inline `<script type="module">` block, but add `import` statements at the top to bring in the extracted helpers as module-local bindings:
      ```js
-     // Transitional shim — until PR B extracts tab logic, the inline script
-     // still expects these as globals. PR C removes this shim.
+     <script type="module">
+     // Import the helpers that used to be defined inline. These are module-
+     // local bindings (not window.* globals) and completely replace the
+     // original function definitions. PR B will move the rest of the tab
+     // logic out of this block into tabs/*.js files. PR C removes this
+     // block entirely.
      import { showToast, showConfirm, showScreen } from '/js/core/ui.js';
      import { apiCall } from '/js/core/api.js';
      import { show as switchTab } from '/js/core/tabs.js';
      import { store } from './js/main.js';
-     // Re-export as module-local bindings (not window.*) — ES module scope only
+
+     // ... rest of the original inline code, minus the duplicated function
+     // definitions that were just imported above.
+     </script>
      ```
-4. All Playwright tests still pass unchanged.
+   - Delete the original `function showToast(...)`, `function showConfirm(...)`, `function showScreen(...)`, `async function apiCall(...)`, `function switchTab(...)`, and the Firebase Auth init block — they're all replaced by the imports above.
+4. All Playwright tests still pass unchanged (class names and DOM shapes preserved).
 5. Manual QA: all tabs still work, all confirm dialogs still work, tab switching still cancels requests, admin access-denied fix (PR #284) still works.
 
 **Commit structure within PR A** (3 commits):
-- Commit A1: create core modules + main.js, no HTML changes (standalone files)
-- Commit A2: add `<script src="js/main.js">` to index.html, add shim at top of inline block
-- Commit A3: remove the now-duplicated helper functions from the inline block
+- **A1**: create `public/js/core/*.js` modules + `public/admin/js/main.js`. No changes to `index.html`. Pure addition — zero regression risk. Deployed files exist but aren't imported yet.
+- **A2**: add `<script type="module" src="js/main.js"></script>` to `index.html`. Now `main.js` runs alongside the inline block, but the inline block still has its own copies of `showToast`/`apiCall`/etc. Both versions exist but the inline ones win (they're defined after main.js runs). Tests still pass because inline versions are unchanged.
+- **A3**: replace the inline `function showToast(...)` etc. definitions with `import` statements at the top of the inline block. Each commit in isolation is revertable.
 
 **Why this order:** A1 is a pure addition (zero regression risk). A2 wires main.js but the inline block still has its own copies. A3 is the actual removal. Each commit is revertable.
 

--- a/.project/plans/2026-04-12-admin-panel-restructure-pr-a-plan.md
+++ b/.project/plans/2026-04-12-admin-panel-restructure-pr-a-plan.md
@@ -1,0 +1,705 @@
+# Admin Panel Restructure — PR A Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract shared core modules (`state`, `auth`, `api`, `ui`, `tabs`) from the 9,500-line inline `<script>` in `public/admin/index.html` into reusable ES module files, and wire them via `public/admin/js/main.js`. Zero behavior change, zero Playwright regressions.
+
+**Architecture:** Pure ES modules at `public/js/core/` (shared, reusable by future panels) + `public/admin/js/main.js` (admin-specific entry point). Inline `<script type="module">` block is shortened by ~1,500 lines. Remaining inline code imports the extracted helpers via standard ES module `import` statements.
+
+**Tech Stack:** Vanilla JS (ES modules), Firebase Auth (modular SDK v11.6.0), Jest (unit tests for pure functions)
+
+**Spec:** `.project/plans/2026-04-11-admin-panel-restructure-design.md`
+
+---
+
+## File Structure
+
+### New Files
+```
+public/js/core/state.js              ← createStore factory (EventTarget-based)
+public/js/core/auth.js               ← createAuthStateHandler (SDK-agnostic)
+public/js/core/api.js                ← apiCall + resetAbortController
+public/js/core/ui.js                 ← showToast, showConfirm, showScreen, escapeHtml
+public/js/core/tabs.js               ← register, configure, show, setPanelVisibility
+public/admin/js/main.js              ← admin entry point (Firebase init, store, tab wiring)
+express-api/tests/client-core/state.test.js     ← unit tests for createStore
+express-api/tests/client-core/auth.test.js      ← unit tests for createAuthStateHandler
+express-api/tests/client-core/ui.test.js        ← unit tests for escapeHtml
+```
+
+### Modified Files
+```
+public/admin/index.html              ← add <script src="js/main.js">, replace inline helpers with imports
+```
+
+---
+
+## Commit A1 — Create core modules + main.js (no HTML changes)
+
+### Task 1: core/state.js — TDD
+
+**Files:**
+- Create: `public/js/core/state.js`
+- Test: `express-api/tests/client-core/state.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `express-api/tests/client-core/state.test.js`:
+```js
+const { createStore } = require('../../../public/js/core/state');
+
+describe('createStore', () => {
+  test('get returns undefined for unset key', () => {
+    const store = createStore({});
+    expect(store.get('missing')).toBeUndefined();
+  });
+
+  test('get returns initial value', () => {
+    const store = createStore({ name: 'Alice' });
+    expect(store.get('name')).toBe('Alice');
+  });
+
+  test('set updates value and get reflects it', () => {
+    const store = createStore({ count: 0 });
+    store.set('count', 5);
+    expect(store.get('count')).toBe(5);
+  });
+
+  test('set fires change event with old and new value', () => {
+    const store = createStore({ x: 1 });
+    const handler = jest.fn();
+    store.on('x:change', handler);
+    store.set('x', 2);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].detail).toEqual({ old: 1, value: 2 });
+  });
+
+  test('set does NOT fire event when value unchanged', () => {
+    const store = createStore({ x: 1 });
+    const handler = jest.fn();
+    store.on('x:change', handler);
+    store.set('x', 1);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('off removes listener', () => {
+    const store = createStore({ x: 1 });
+    const handler = jest.fn();
+    store.on('x:change', handler);
+    store.off('x:change', handler);
+    store.set('x', 2);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('multiple stores are independent', () => {
+    const a = createStore({ val: 'a' });
+    const b = createStore({ val: 'b' });
+    a.set('val', 'changed');
+    expect(a.get('val')).toBe('changed');
+    expect(b.get('val')).toBe('b');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+Run: `cd express-api && npx jest tests/client-core/state.test.js --verbose`
+Expected: FAIL — `Cannot find module '../../../public/js/core/state'`
+
+- [ ] **Step 3: Implement state.js**
+
+Create `public/js/core/state.js`:
+```js
+/**
+ * App-agnostic reactive state store factory.
+ *
+ * Each app (admin panel, MC Host panel, etc.) creates its own store
+ * with app-specific keys. Changes fire events via EventTarget so
+ * modules can subscribe to cross-cutting state updates.
+ *
+ * @param {Object} initial - Initial state keys and values
+ * @returns {{ get, set, on, off }}
+ */
+function createStore(initial) {
+  const _state = { ...initial };
+  const _listeners = new EventTarget();
+  return {
+    get: (key) => _state[key],
+    set: (key, value) => {
+      const old = _state[key];
+      _state[key] = value;
+      if (old !== value) {
+        _listeners.dispatchEvent(
+          new CustomEvent(`${key}:change`, { detail: { old, value } }),
+        );
+      }
+    },
+    on: (key, handler) => _listeners.addEventListener(key, handler),
+    off: (key, handler) => _listeners.removeEventListener(key, handler),
+  };
+}
+
+// Dual export: ES module default + CJS for Jest
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { createStore };
+}
+export { createStore };
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+Run: `cd express-api && npx jest tests/client-core/state.test.js --verbose`
+Expected: ALL PASS (7 tests)
+
+### Task 2: core/auth.js — TDD
+
+**Files:**
+- Create: `public/js/core/auth.js`
+- Test: `express-api/tests/client-core/auth.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `express-api/tests/client-core/auth.test.js`:
+```js
+const { createAuthStateHandler } = require('../../../public/js/core/auth');
+
+describe('createAuthStateHandler', () => {
+  test('calls onReady(null) when user is null', async () => {
+    const onReady = jest.fn();
+    const handler = createAuthStateHandler({ onReady });
+    await handler(null);
+    expect(onReady).toHaveBeenCalledWith(null);
+  });
+
+  test('calls onReady(user, tokenResult) when no claim required', async () => {
+    const onReady = jest.fn();
+    const user = { getIdTokenResult: () => Promise.resolve({ claims: {} }) };
+    const handler = createAuthStateHandler({ onReady });
+    await handler(user);
+    expect(onReady).toHaveBeenCalledWith(user, { claims: {} });
+  });
+
+  test('calls onReady when required claim is present', async () => {
+    const onReady = jest.fn();
+    const user = { getIdTokenResult: () => Promise.resolve({ claims: { admin: true } }) };
+    const handler = createAuthStateHandler({ requireClaim: 'admin', onReady });
+    await handler(user);
+    expect(onReady).toHaveBeenCalledWith(user, { claims: { admin: true } });
+  });
+
+  test('calls onAccessDenied when required claim is missing', async () => {
+    const onAccessDenied = jest.fn();
+    const onReady = jest.fn();
+    const user = { getIdTokenResult: () => Promise.resolve({ claims: {} }) };
+    const handler = createAuthStateHandler({
+      requireClaim: 'admin',
+      onAccessDenied,
+      onReady,
+    });
+    await handler(user);
+    expect(onAccessDenied).toHaveBeenCalledWith({ reason: 'missing_claim', claim: 'admin' });
+    expect(onReady).not.toHaveBeenCalled();
+  });
+
+  test('calls onAccessDenied when claim is false', async () => {
+    const onAccessDenied = jest.fn();
+    const onReady = jest.fn();
+    const user = { getIdTokenResult: () => Promise.resolve({ claims: { admin: false } }) };
+    const handler = createAuthStateHandler({
+      requireClaim: 'admin',
+      onAccessDenied,
+      onReady,
+    });
+    await handler(user);
+    expect(onAccessDenied).toHaveBeenCalled();
+    expect(onReady).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+Run: `cd express-api && npx jest tests/client-core/auth.test.js --verbose`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement auth.js**
+
+Create `public/js/core/auth.js`:
+```js
+/**
+ * SDK-agnostic Firebase Auth state handler factory.
+ *
+ * Returns a callback suitable for both:
+ *   - Modular SDK: onAuthStateChanged(auth, handler)
+ *   - Compat SDK:  auth.onAuthStateChanged(handler)
+ *
+ * Zero Firebase imports — the caller owns the SDK.
+ *
+ * @param {Object} opts
+ * @param {string} [opts.requireClaim] - Custom claim key that must be true
+ * @param {Function} [opts.onAccessDenied] - Called with { reason, claim } when claim missing
+ * @param {Function} opts.onReady - Called with (user, tokenResult) or (null) on sign-out
+ * @returns {Function} Auth state handler callback
+ */
+function createAuthStateHandler({ requireClaim, onAccessDenied, onReady }) {
+  return async (user) => {
+    if (!user) {
+      onReady(null);
+      return;
+    }
+    const tokenResult = await user.getIdTokenResult();
+    if (requireClaim && tokenResult.claims[requireClaim] !== true) {
+      if (onAccessDenied) {
+        onAccessDenied({ reason: 'missing_claim', claim: requireClaim });
+      }
+      return;
+    }
+    onReady(user, tokenResult);
+  };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { createAuthStateHandler };
+}
+export { createAuthStateHandler };
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+Run: `cd express-api && npx jest tests/client-core/auth.test.js --verbose`
+Expected: ALL PASS (5 tests)
+
+### Task 3: core/ui.js — TDD (escapeHtml) + implementation (DOM helpers)
+
+**Files:**
+- Create: `public/js/core/ui.js`
+- Test: `express-api/tests/client-core/ui.test.js`
+
+- [ ] **Step 1: Write failing tests for escapeHtml**
+
+Create `express-api/tests/client-core/ui.test.js`:
+```js
+const { escapeHtml } = require('../../../public/js/core/ui');
+
+describe('escapeHtml', () => {
+  test('escapes ampersand', () => {
+    expect(escapeHtml('a&b')).toBe('a&amp;b');
+  });
+
+  test('escapes angle brackets', () => {
+    expect(escapeHtml('<script>')).toBe('&lt;script&gt;');
+  });
+
+  test('escapes quotes', () => {
+    expect(escapeHtml('"hello" & \'world\'')).toBe('&quot;hello&quot; &amp; &#39;world&#39;');
+  });
+
+  test('handles empty string', () => {
+    expect(escapeHtml('')).toBe('');
+  });
+
+  test('converts non-string to string first', () => {
+    expect(escapeHtml(42)).toBe('42');
+    expect(escapeHtml(null)).toBe('null');
+  });
+
+  test('preserves safe characters', () => {
+    expect(escapeHtml('hello world 123')).toBe('hello world 123');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+Run: `cd express-api && npx jest tests/client-core/ui.test.js --verbose`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement ui.js**
+
+Create `public/js/core/ui.js` — full file with escapeHtml (testable), showToast, showConfirm, showScreen, registerScreen (DOM-dependent, tested via Playwright):
+
+```js
+/**
+ * Generic UI helpers for admin-style panels.
+ *
+ * DOM shapes (class names, element IDs) are identical to the original
+ * inline admin panel code so Playwright selectors keep working.
+ *
+ * showToast, showConfirm, showScreen operate on the DOM directly.
+ * escapeHtml is a pure function, unit-tested independently.
+ */
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c],
+  );
+}
+
+// --- Toast ---
+let _toastTimer = null;
+
+function showToast(msg, type = 'success') {
+  const toast = document.getElementById('toast');
+  if (!toast) return;
+  clearTimeout(_toastTimer);
+  toast.textContent = msg;
+  toast.className = `toast ${type} visible`;
+  _toastTimer = setTimeout(
+    () => toast.classList.remove('visible'),
+    type === 'error' ? 7000 : 4000,
+  );
+}
+
+// --- Screen switcher ---
+const _screens = new Map();
+
+function registerScreen(name, element) {
+  _screens.set(name, element);
+}
+
+function showScreen(name) {
+  for (const el of _screens.values()) el.classList.remove('active');
+  _screens.get(name)?.classList.add('active');
+}
+
+// --- Confirm dialog ---
+function showConfirm(title, message) {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'confirm-overlay';
+    overlay.innerHTML = `
+      <div class="confirm-dialog">
+        <h3>${escapeHtml(title)}</h3>
+        <p>${escapeHtml(message)}</p>
+        <div class="confirm-buttons">
+          <button class="confirm-cancel">Cancel</button>
+          <button class="confirm-ok">Confirm</button>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+    overlay.querySelector('.confirm-cancel').addEventListener('click', () => {
+      overlay.remove();
+      resolve(false);
+    });
+    overlay.querySelector('.confirm-ok').addEventListener('click', () => {
+      overlay.remove();
+      resolve(true);
+    });
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) {
+        overlay.remove();
+        resolve(false);
+      }
+    });
+  });
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { escapeHtml, showToast, showConfirm, showScreen, registerScreen };
+}
+export { escapeHtml, showToast, showConfirm, showScreen, registerScreen };
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+Run: `cd express-api && npx jest tests/client-core/ui.test.js --verbose`
+Expected: ALL PASS (6 tests)
+
+### Task 4: core/api.js — implementation
+
+**Files:**
+- Create: `public/js/core/api.js`
+
+- [ ] **Step 1: Create api.js**
+
+Create `public/js/core/api.js` — copy the exact `apiCall` logic from `public/admin/index.html:5313-5338` plus the `resetAbortController` function from the design spec. Include the dual CJS/ESM export pattern.
+
+Key code: see `.project/plans/2026-04-11-admin-panel-restructure-design.md` § `core/api.js` for the full implementation. Copy it verbatim. The function signatures are:
+
+```js
+export function configure({ apiBase, getToken })
+export function resetAbortController()
+export async function apiCall(method, path, body, { signal, skipTabAbort } = {})
+```
+
+- [ ] **Step 2: Verify it parses**
+
+Run: `node -e "require('./public/js/core/api.js'); console.log('OK')"`
+Expected: `OK`
+
+### Task 5: core/tabs.js — implementation
+
+**Files:**
+- Create: `public/js/core/tabs.js`
+
+- [ ] **Step 1: Create tabs.js**
+
+Create `public/js/core/tabs.js` — full implementation from the design spec including `configure`, `register`, `show`, `getActiveTab`, `setPanelVisibility`. Import `resetAbortController` from `./api.js`.
+
+Key code: see design spec § `core/tabs.js` for the full implementation including the `setPanelVisibility` function that handles the asymmetric Users/AuditLog/other-panels DOM toggling.
+
+- [ ] **Step 2: Verify it parses**
+
+Run: `node -e "require('./public/js/core/tabs.js'); console.log('OK')"`
+Expected: `OK`
+
+### Task 6: admin/js/main.js — implementation
+
+**Files:**
+- Create: `public/admin/js/main.js`
+
+- [ ] **Step 1: Create main.js**
+
+Create `public/admin/js/main.js` — the admin entry point from the design spec. Imports all core modules, creates the admin store, configures Firebase Auth (modular SDK v11.6.0 via CDN), configures api and tabs with the panel map, and wires `onAuthStateChanged` with `createAuthStateHandler({ requireClaim: 'admin' })`.
+
+Key code: see design spec § `public/admin/js/main.js` for the full implementation.
+
+**Important:** This file will NOT import tab modules yet (PR B handles that). For now it only wires core infrastructure.
+
+- [ ] **Step 2: Verify it parses (won't fully run without browser, but syntax check)**
+
+Run: `node --check public/admin/js/main.js` (will fail on ESM import syntax from CDN — expected for browser-only code)
+
+### Task 7: Run existing tests — verify zero regressions
+
+- [ ] **Step 1: Run full Express test suite**
+
+Run: `cd express-api && npx jest --silent`
+Expected: 4097+ tests pass (including the 3 new client-core test files)
+
+- [ ] **Step 2: Commit A1**
+
+```bash
+git add public/js/core/ public/admin/js/main.js express-api/tests/client-core/
+git commit -m "feat(admin): add core ES modules + admin entry point (A1, no HTML changes)
+
+Create the shared module infrastructure for the admin panel restructure:
+
+- public/js/core/state.js: createStore factory with EventTarget-based reactivity
+- public/js/core/auth.js: SDK-agnostic createAuthStateHandler for claim checking
+- public/js/core/api.js: apiCall wrapper with per-tab AbortController
+- public/js/core/ui.js: showToast, showConfirm, showScreen, escapeHtml
+- public/js/core/tabs.js: generic tab switcher with panel ID map
+- public/admin/js/main.js: admin entry point (Firebase Auth, store, tab config)
+
+These files exist but are NOT yet wired into index.html — that happens
+in commits A2 and A3. Zero regression risk: no existing code is changed.
+
+Unit tests added for pure functions: createStore (7), createAuthStateHandler (5),
+escapeHtml (6). Total: 18 new tests."
+```
+
+---
+
+## Commit A2 — Wire main.js into index.html (coexistence)
+
+### Task 8: Add `<script>` tag for main.js
+
+**Files:**
+- Modify: `public/admin/index.html:5057`
+
+- [ ] **Step 1: Add the new script tag BEFORE the existing inline block**
+
+Find line 5057 (`<script src="config.js"></script>`) and add main.js after it:
+
+```html
+<script src="config.js"></script>
+<script type="module" src="js/main.js"></script>
+<script type="module">
+```
+
+Both main.js AND the inline block now run. The inline block still has its own `showToast`, `apiCall`, etc. definitions which shadow the imports. No behavior change.
+
+- [ ] **Step 2: Run Playwright admin tests locally (chromium only)**
+
+Run: `API_BASE_URL=http://localhost:3000 WEB_BASE_URL=http://localhost:8888 ADMIN_EMAIL=claude-test@shytalk.dev ADMIN_PASSWORD=localdev123 TEST_API_KEY=local-test-key npx playwright test tests/web/admin-panel.spec.ts tests/web/admin-login.spec.ts --project=chromium --reporter=list`
+
+Expected: ALL PASS — inline block still has its own copies, main.js runs silently alongside
+
+- [ ] **Step 3: Commit A2**
+
+```bash
+git add public/admin/index.html
+git commit -m "feat(admin): wire main.js into index.html (A2, coexistence)
+
+Add <script type=\"module\" src=\"js/main.js\"> before the existing inline
+block. Both versions of the helpers now coexist — the inline definitions
+shadow the module imports, so behavior is unchanged. This commit proves
+main.js loads without errors alongside the existing code."
+```
+
+---
+
+## Commit A3 — Replace inline helpers with imports
+
+### Task 9: Replace inline function definitions with imports
+
+**Files:**
+- Modify: `public/admin/index.html:5058-6110` (approximately)
+
+- [ ] **Step 1: Add imports at the top of the inline `<script type="module">` block**
+
+Replace the following inline definitions with imports. At the very top of the inline block (after the opening `<script type="module">` tag), add:
+
+```js
+// ── Imports from extracted core modules ──────────────────────────
+// These replace the inline function definitions that were here before.
+// PR B will move the remaining tab-specific code into tabs/*.js files.
+import { createStore } from '/js/core/state.js';
+import { createAuthStateHandler } from '/js/core/auth.js';
+import { apiCall, configure as configureApi, resetAbortController } from '/js/core/api.js';
+import { showToast, showConfirm, showScreen, registerScreen, escapeHtml } from '/js/core/ui.js';
+import { configure as configureTabs, register as registerTab, show as showTab, getActiveTab } from '/js/core/tabs.js';
+```
+
+- [ ] **Step 2: Delete the following inline function definitions**
+
+Remove these functions/blocks from the inline script (they're now imported):
+
+1. `function escapeHtml(s)` — find and delete (any location)
+2. `function showScreen(name)` — lines ~5195-5198
+3. `function showToast(msg, type)` — lines ~5202-5207 plus `let toastTimer`
+4. `function showConfirm(title, message)` — lines ~8179-8198
+5. `async function apiCall(method, path, body, opts)` — lines ~5313-5338 plus `let tabAbortController`
+6. Firebase Auth init block (lines ~5060-5090: `initializeApp`, `getAuth`, `connectAuthEmulator`, the `const app/auth` declarations) — now in main.js
+7. `onAuthStateChanged(auth, async (user) => { ... })` at lines ~5210-5230 — now in main.js
+8. `function switchTab(tab)` — lines ~6031-6105
+
+**Do NOT delete:**
+- The `const $ = ...` / `const $$ = ...` shorthand selectors
+- Any tab-specific functions (loadReports, loadGifts, etc.)
+- Any DOM element references (`const giftsPanel = ...`)
+- Any event listener registrations
+
+- [ ] **Step 3: Make remaining inline code use the imported names**
+
+The remaining inline code already uses `showToast(...)`, `apiCall(...)`, `showConfirm(...)`, `switchTab(...)` by name. Since these are now imported at the top of the same `<script type="module">` block, they resolve correctly. No renaming needed.
+
+Where the inline code calls `switchTab("users")`, it will now call the imported `showTab("users")` from core/tabs.js. So: **rename all `switchTab(` calls to `showTab(` in the remaining inline code** (there are ~22 call sites).
+
+- [ ] **Step 4: Run Playwright admin tests locally (chromium only — full admin suite)**
+
+Run: `bash local/test-playwright.sh tests/web/admin-*.spec.ts --project=chromium`
+
+Expected: ALL PASS — same DOM, same class names, same behavior. Only the function definitions moved files.
+
+- [ ] **Step 5: Run full Express test suite**
+
+Run: `cd express-api && npx jest --silent`
+Expected: 4097+ tests pass
+
+- [ ] **Step 6: Commit A3**
+
+```bash
+git add public/admin/index.html
+git commit -m "refactor(admin): replace inline helpers with core module imports (A3)
+
+Remove ~1,500 lines of inline function definitions (showToast, showConfirm,
+showScreen, apiCall, switchTab, escapeHtml, Firebase Auth init) and replace
+them with ES module imports from public/js/core/*.js.
+
+The remaining inline code (~8,000 lines of tab-specific logic) now uses
+the imported helpers. PR B will extract those tabs into separate files.
+
+All Playwright admin tests pass unchanged — DOM shapes, class names, IDs,
+and data-attributes are identical."
+```
+
+---
+
+## Ship PR A
+
+### Task 10: Push + open PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/admin-panel-restructure-pr-a
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create --title "refactor(admin): extract core ES modules from inline script (PR A)" \
+  --body "## Summary
+PR A of 3 for the admin panel restructure (#41).
+
+Extracts ~1,500 lines of shared helper functions from the 9,500-line inline
+\`<script type=\"module\">\` in \`public/admin/index.html\` into reusable ES
+modules at \`public/js/core/\`.
+
+## New modules
+- \`public/js/core/state.js\` — createStore factory
+- \`public/js/core/auth.js\` — SDK-agnostic auth handler
+- \`public/js/core/api.js\` — apiCall with per-tab AbortController
+- \`public/js/core/ui.js\` — showToast, showConfirm, showScreen, escapeHtml
+- \`public/js/core/tabs.js\` — generic tab switcher
+- \`public/admin/js/main.js\` — admin entry point
+
+## Test plan
+- [x] 18 new unit tests (createStore, createAuthStateHandler, escapeHtml)
+- [ ] Full Playwright admin suite (all 5 browsers)
+- [ ] SonarCloud quality gate
+- [ ] Manual QA on dev
+
+## Design
+See \`.project/plans/2026-04-11-admin-panel-restructure-design.md\`"
+```
+
+### Task 11: Monitor CI
+
+- [ ] **Step 1: Wait for CI to complete**
+
+Watch for: Lint, Build & Test, SonarCloud, Playwright (5 browsers), Android E2E, PR Gate
+
+- [ ] **Step 2: Fix any failures, push fixes, re-monitor**
+
+### Task 12: Deploy to dev + smoke test
+
+- [ ] **Step 1: Deploy to dev from branch**
+
+```bash
+gh workflow run deploy-dev.yml --ref=feat/admin-panel-restructure-pr-a -f web=true -f backend=false -f playwright=true
+```
+
+- [ ] **Step 2: Smoke test dev**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" https://dev.shytalk.shyden.co.uk/admin/
+curl -s https://dev.shytalk.shyden.co.uk/admin/js/main.js | head -5
+```
+
+### Task 13: Merge + deploy to prod
+
+- [ ] **Step 1: Manual QA pass (2 clean runs)**
+- [ ] **Step 2: Merge**
+
+```bash
+gh pr merge <PR_NUMBER> --merge
+```
+
+- [ ] **Step 3: Monitor Release workflow**
+- [ ] **Step 4: Deploy to prod**
+
+```bash
+gh workflow run deploy-prod.yml -f release-tag=<TAG> -f web=true -f backend=false
+```
+
+- [ ] **Step 5: Verify prod**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" https://shytalk.shyden.co.uk/admin/
+curl -s https://shytalk.shyden.co.uk/admin/js/main.js | head -5
+```
+
+---
+
+## Execution Order
+
+Tasks 1-7 (core modules + tests + commit A1) are the foundation.
+Task 8 (wire main.js + commit A2) requires A1.
+Task 9 (replace inline helpers + commit A3) requires A2.
+Tasks 10-13 (ship) require A3.
+
+Recommended: sequential execution, Tasks 1 → 13.

--- a/express-api/jest.config.js
+++ b/express-api/jest.config.js
@@ -7,4 +7,13 @@ module.exports = {
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov'],
   collectCoverageFrom: ['src/**/*.js', '!src/__tests__/**'],
+  // Strip `export` keyword from public/js/core/*.js so ESM browser modules
+  // can be require()'d in Jest's CJS test environment. Only affects files
+  // outside express-api — does NOT transform any express source files.
+  // NOTE: adding `transform` overrides Jest's default babel-jest for ALL
+  // .js files, so we re-add babel-jest as the fallback for non-matching paths.
+  transform: {
+    'public[\\\\/]js[\\\\/]core[\\\\/].*\\.js$': '<rootDir>/tests/client-core/esm-transform.js',
+    '\\.js$': 'babel-jest',
+  },
 };

--- a/express-api/tests/client-core/auth.test.js
+++ b/express-api/tests/client-core/auth.test.js
@@ -1,0 +1,46 @@
+const { createAuthStateHandler } = require('../../../public/js/core/auth');
+
+describe('createAuthStateHandler', () => {
+  test('calls onReady(null) when user is null', async () => {
+    const onReady = jest.fn();
+    const handler = createAuthStateHandler({ onReady });
+    await handler(null);
+    expect(onReady).toHaveBeenCalledWith(null);
+  });
+
+  test('calls onReady(user, tokenResult) when no claim required', async () => {
+    const onReady = jest.fn();
+    const user = { getIdTokenResult: () => Promise.resolve({ claims: {} }) };
+    const handler = createAuthStateHandler({ onReady });
+    await handler(user);
+    expect(onReady).toHaveBeenCalledWith(user, { claims: {} });
+  });
+
+  test('calls onReady when required claim is present', async () => {
+    const onReady = jest.fn();
+    const user = { getIdTokenResult: () => Promise.resolve({ claims: { admin: true } }) };
+    const handler = createAuthStateHandler({ requireClaim: 'admin', onReady });
+    await handler(user);
+    expect(onReady).toHaveBeenCalledWith(user, { claims: { admin: true } });
+  });
+
+  test('calls onAccessDenied when required claim is missing', async () => {
+    const onAccessDenied = jest.fn();
+    const onReady = jest.fn();
+    const user = { getIdTokenResult: () => Promise.resolve({ claims: {} }) };
+    const handler = createAuthStateHandler({ requireClaim: 'admin', onAccessDenied, onReady });
+    await handler(user);
+    expect(onAccessDenied).toHaveBeenCalledWith({ reason: 'missing_claim', claim: 'admin' });
+    expect(onReady).not.toHaveBeenCalled();
+  });
+
+  test('calls onAccessDenied when claim is false', async () => {
+    const onAccessDenied = jest.fn();
+    const onReady = jest.fn();
+    const user = { getIdTokenResult: () => Promise.resolve({ claims: { admin: false } }) };
+    const handler = createAuthStateHandler({ requireClaim: 'admin', onAccessDenied, onReady });
+    await handler(user);
+    expect(onAccessDenied).toHaveBeenCalled();
+    expect(onReady).not.toHaveBeenCalled();
+  });
+});

--- a/express-api/tests/client-core/esm-transform.js
+++ b/express-api/tests/client-core/esm-transform.js
@@ -1,0 +1,36 @@
+/**
+ * Minimal Jest transform: ESM → CJS for public/js/core/*.js files.
+ *
+ * Converts `export function foo()` / `export const bar` / `export { x, y }`
+ * into plain declarations + `module.exports = { foo, bar, x, y }` at the end.
+ *
+ * Only applied to files matching the transform pattern in jest.config.js.
+ */
+module.exports = {
+  process(src) {
+    const names = [];
+
+    // export function foo(...) / export class Foo / export const x = ...
+    let code = src.replace(
+      /^export\s+(function|const|let|var|class)\s+(\w+)/gm,
+      (_match, keyword, name) => {
+        names.push(name);
+        return `${keyword} ${name}`;
+      },
+    );
+
+    // export { a, b, c }
+    code = code.replace(/^export\s*\{([^}]+)\}/gm, (_match, list) => {
+      for (const name of list.split(',').map((n) => n.trim())) {
+        if (name && !names.includes(name)) names.push(name);
+      }
+      return '';
+    });
+
+    if (names.length > 0) {
+      code += `\nmodule.exports = { ${names.join(', ')} };\n`;
+    }
+
+    return { code };
+  },
+};

--- a/express-api/tests/client-core/state.test.js
+++ b/express-api/tests/client-core/state.test.js
@@ -1,0 +1,53 @@
+const { createStore } = require('../../../public/js/core/state');
+
+describe('createStore', () => {
+  test('get returns undefined for unset key', () => {
+    const store = createStore({});
+    expect(store.get('missing')).toBeUndefined();
+  });
+
+  test('get returns initial value', () => {
+    const store = createStore({ name: 'Alice' });
+    expect(store.get('name')).toBe('Alice');
+  });
+
+  test('set updates value and get reflects it', () => {
+    const store = createStore({ count: 0 });
+    store.set('count', 5);
+    expect(store.get('count')).toBe(5);
+  });
+
+  test('set fires change event with old and new value', () => {
+    const store = createStore({ x: 1 });
+    const handler = jest.fn();
+    store.on('x:change', handler);
+    store.set('x', 2);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].detail).toEqual({ old: 1, value: 2 });
+  });
+
+  test('set does NOT fire event when value unchanged', () => {
+    const store = createStore({ x: 1 });
+    const handler = jest.fn();
+    store.on('x:change', handler);
+    store.set('x', 1);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('off removes listener', () => {
+    const store = createStore({ x: 1 });
+    const handler = jest.fn();
+    store.on('x:change', handler);
+    store.off('x:change', handler);
+    store.set('x', 2);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('multiple stores are independent', () => {
+    const a = createStore({ val: 'a' });
+    const b = createStore({ val: 'b' });
+    a.set('val', 'changed');
+    expect(a.get('val')).toBe('changed');
+    expect(b.get('val')).toBe('b');
+  });
+});

--- a/express-api/tests/client-core/ui.test.js
+++ b/express-api/tests/client-core/ui.test.js
@@ -1,0 +1,23 @@
+const { escapeHtml } = require('../../../public/js/core/ui');
+
+describe('escapeHtml', () => {
+  test('escapes ampersand', () => {
+    expect(escapeHtml('a&b')).toBe('a&amp;b');
+  });
+  test('escapes angle brackets', () => {
+    expect(escapeHtml('<script>')).toBe('&lt;script&gt;');
+  });
+  test('escapes quotes', () => {
+    expect(escapeHtml('"hello" & \'world\'')).toBe('&quot;hello&quot; &amp; &#39;world&#39;');
+  });
+  test('handles empty string', () => {
+    expect(escapeHtml('')).toBe('');
+  });
+  test('converts non-string to string first', () => {
+    expect(escapeHtml(42)).toBe('42');
+    expect(escapeHtml(null)).toBe('null');
+  });
+  test('preserves safe characters', () => {
+    expect(escapeHtml('hello world 123')).toBe('hello world 123');
+  });
+});

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -5055,6 +5055,7 @@
 <div class="toast" id="toast"></div>
 
 <script src="config.js"></script>
+<script type="module" src="js/main.js"></script>
 <script type="module">
     // --- Firebase SDK (CDN) ---
     import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.0/firebase-app.js";

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -5057,32 +5057,30 @@
 <script src="config.js"></script>
 <script type="module" src="js/main.js"></script>
 <script type="module">
+    // ── Core module imports (PR A extraction) ────────────────────
+    // These replace the inline function definitions that were here.
+    // PR B will move the remaining tab-specific code to tabs/*.js.
+    import { showToast, showConfirm } from '/js/core/ui.js';
+
     // --- Firebase SDK (CDN) ---
-    import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.0/firebase-app.js";
-    import { getAuth, signInWithEmailAndPassword, onAuthStateChanged, signOut, connectAuthEmulator }
+    // Firebase App + Auth are now initialized by main.js (loaded before this block).
+    // Import auth from main.js and use getApp() to get the already-initialized app.
+    import { getApp } from "https://www.gstatic.com/firebasejs/11.6.0/firebase-app.js";
+    import { onAuthStateChanged, connectAuthEmulator }
       from "https://www.gstatic.com/firebasejs/11.6.0/firebase-auth.js";
     import { getFirestore as getClientFirestore, connectFirestoreEmulator, collection, query, where, onSnapshot, getDocs, orderBy, limit, doc, Timestamp }
       from "https://www.gstatic.com/firebasejs/11.6.0/firebase-firestore.js";
+    import { auth, signInWithEmailAndPassword, signOut } from './js/main.js';
 
-    // --- Config (loaded from config.js, or fetched from API) ---
+    // --- Config ---
     const API_BASE = window.SHYTALK_CONFIG.API_BASE;
-    let FIREBASE_CONFIG = window.SHYTALK_CONFIG.FIREBASE_CONFIG;
-    if (!FIREBASE_CONFIG) {
-      try {
-        const cfgRes = await fetch(API_BASE + '/api/firebase-config');
-        FIREBASE_CONFIG = await cfgRes.json();
-      } catch (e) {
-        console.error('Failed to load Firebase config from API:', e);
-      }
-    }
 
-    const app = initializeApp(FIREBASE_CONFIG);
-    const auth = getAuth(app);
+    // Use the app already initialized by main.js (avoids duplicate initializeApp error)
+    const app = getApp();
     const clientDb = getClientFirestore(app);
 
-    // Connect to Firebase emulators when running locally or in CI
+    // Connect Firestore to emulators (Auth emulator is handled by main.js)
     if (window.SHYTALK_CONFIG.USE_EMULATORS) {
-      connectAuthEmulator(auth, "http://localhost:9099", { disableWarnings: true });
       connectFirestoreEmulator(clientDb, "localhost", 8080);
     }
 
@@ -5198,14 +5196,7 @@
       screens[name].classList.add("active");
     }
 
-    // --- Toast ---
-    let toastTimer;
-    function showToast(msg, type = "success") {
-      clearTimeout(toastTimer);
-      toast.textContent = msg;
-      toast.className = `toast ${type} visible`;
-      toastTimer = setTimeout(() => toast.classList.remove("visible"), type === "error" ? 7000 : 4000);
-    }
+    // showToast: imported from /js/core/ui.js (see import at top of this block)
 
     // --- Auth ---
     onAuthStateChanged(auth, async (user) => {
@@ -8177,26 +8168,7 @@
     }
 
     // Confirmation dialog
-    function showConfirm(title, message) {
-      return new Promise((resolve) => {
-        const overlay = document.createElement("div");
-        overlay.className = "confirm-overlay";
-        overlay.innerHTML = `
-          <div class="confirm-dialog">
-            <h3>${escapeHtml(title)}</h3>
-            <p>${escapeHtml(message)}</p>
-            <div class="confirm-buttons">
-              <button class="confirm-cancel">Cancel</button>
-              <button class="confirm-ok">Confirm</button>
-            </div>
-          </div>
-        `;
-        document.body.appendChild(overlay);
-        overlay.querySelector(".confirm-cancel").addEventListener("click", () => { overlay.remove(); resolve(false); });
-        overlay.querySelector(".confirm-ok").addEventListener("click", () => { overlay.remove(); resolve(true); });
-        overlay.addEventListener("click", (e) => { if (e.target === overlay) { overlay.remove(); resolve(false); } });
-      });
-    }
+    // showConfirm: imported from /js/core/ui.js (see import at top of this block)
 
     async function resolveReport(reportedUserId, resolveAll) {
       const form = reportsList.querySelector(`[data-form-uid="${reportedUserId}"]`);

--- a/public/admin/js/main.js
+++ b/public/admin/js/main.js
@@ -1,0 +1,112 @@
+/**
+ * Admin panel entry point.
+ *
+ * Wires Firebase Auth, creates the admin state store, configures
+ * core modules (api, tabs, ui), and handles the auth state flow
+ * (admin claim check, access-denied inline error, dashboard show).
+ *
+ * Tab modules are NOT imported here yet — PR B handles that.
+ * The inline <script> block in index.html still owns all tab logic.
+ */
+
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.6.0/firebase-app.js';
+import { getAuth, onAuthStateChanged, signInWithEmailAndPassword, signOut, connectAuthEmulator }
+  from 'https://www.gstatic.com/firebasejs/11.6.0/firebase-auth.js';
+
+import { createStore } from '/js/core/state.js';
+import { createAuthStateHandler } from '/js/core/auth.js';
+import * as api from '/js/core/api.js';
+import { showScreen, registerScreen } from '/js/core/ui.js';
+import * as tabs from '/js/core/tabs.js';
+
+// ── Config ──────────────────────────────────────────────────────
+const CONFIG = window.SHYTALK_CONFIG || {};
+const FIREBASE_CONFIG = CONFIG.FIREBASE_CONFIG || {};
+const API_BASE = CONFIG.API_BASE || '';
+
+// ── Admin state store ───────────────────────────────────────────
+export const store = createStore({
+  currentUser: null,
+  currentUid: null,
+  currentFirebaseUid: null,
+  currentTab: 'users',
+});
+
+// ── Firebase Auth ───────────────────────────────────────────────
+const app = initializeApp(FIREBASE_CONFIG);
+const auth = getAuth(app);
+
+if (CONFIG.USE_EMULATORS) {
+  connectAuthEmulator(auth, 'http://localhost:9099', { disableWarnings: true });
+}
+
+// Re-export auth utilities for the inline script block to use during
+// the transitional period (PR A). PR B will remove these re-exports.
+export { auth, signInWithEmailAndPassword, signOut };
+
+// ── Configure core modules ──────────────────────────────────────
+api.configure({
+  apiBase: API_BASE,
+  getToken: () => {
+    const user = store.get('currentUser');
+    return user ? user.getIdToken() : Promise.resolve(null);
+  },
+});
+
+const PANEL_MAP = {
+  users:              'user-form',
+  appeals:            'appeals-panel',
+  reports:            'reports-panel',
+  gifts:              'gifts-panel',
+  economy:            'economy-panel',
+  maintenance:        'maintenance-panel',
+  monitor:            'monitor-panel',
+  banners:            'banners-panel',
+  funfacts:           'funfacts-panel',
+  backups:            'backups-panel',
+  logs:               'logs-panel',
+  devices:            'devices-panel',
+  'starting-screens': 'starting-screens-panel',
+  suggestions:        'suggestions-panel',
+  'audit-log':        'audit-log-panel',
+};
+
+tabs.configure({ panelMap: PANEL_MAP });
+
+// ── Screens ─────────────────────────────────────────────────────
+// These are registered once the DOM is ready (this script runs as
+// type="module" which is deferred, so DOM is available).
+registerScreen('loading', document.getElementById('loading-screen'));
+registerScreen('login', document.getElementById('login-screen'));
+registerScreen('dashboard', document.getElementById('dashboard-screen'));
+
+// ── Auth state handler ──────────────────────────────────────────
+// NOTE: During PR A transition, the inline script block still has its
+// own onAuthStateChanged handler that does the actual dashboard setup.
+// This handler in main.js is NOT wired yet — it will be wired in PR B
+// when the inline auth block is removed. For now, main.js just sets up
+// the infrastructure; the inline block remains authoritative for auth flow.
+
+// Export for future use in PR B:
+export const authHandler = createAuthStateHandler({
+  requireClaim: 'admin',
+  onAccessDenied: () => {
+    const loginError = document.getElementById('login-error');
+    if (loginError) {
+      loginError.textContent = 'Access denied \u2014 admin privileges required. If you have a portal account, go to /portal/ instead.';
+      loginError.style.display = 'block';
+    }
+    showScreen('login');
+  },
+  onReady: (user) => {
+    if (user) {
+      store.set('currentUser', user);
+      showScreen('dashboard');
+      const saved = sessionStorage.getItem('admin_tab') || 'users';
+      tabs.show(saved);
+    } else {
+      store.set('currentUser', null);
+      showScreen('login');
+    }
+  },
+});

--- a/public/js/core/api.js
+++ b/public/js/core/api.js
@@ -1,0 +1,41 @@
+/**
+ * Fetch wrapper with per-tab AbortController.
+ * Configure once at app startup with configure(), then call apiCall() anywhere.
+ */
+
+let _apiBase = '';
+let _getToken = () => Promise.resolve(null);
+let _abortController = new AbortController();
+
+export function configure({ apiBase, getToken }) {
+  _apiBase = apiBase;
+  _getToken = getToken;
+}
+
+export function resetAbortController() {
+  _abortController.abort();
+  _abortController = new AbortController();
+}
+
+export async function apiCall(method, path, body, { signal, skipTabAbort } = {}) {
+  const token = await _getToken();
+  const opts = {
+    method,
+    headers: { 'Authorization': `Bearer ${token}` },
+    signal: signal || (skipTabAbort ? undefined : _abortController.signal),
+  };
+  if (body instanceof FormData) {
+    opts.body = body;
+  } else if (body) {
+    opts.headers['Content-Type'] = 'application/json';
+    opts.body = JSON.stringify(body);
+  }
+  const res = await fetch(`${_apiBase}${path}`, opts);
+  const contentType = res.headers.get('content-type') || '';
+  if (!contentType.includes('application/json')) {
+    throw new Error(`HTTP ${res.status}: server returned non-JSON response`);
+  }
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+  return data;
+}

--- a/public/js/core/auth.js
+++ b/public/js/core/auth.js
@@ -1,0 +1,20 @@
+/**
+ * SDK-agnostic Firebase Auth state handler factory.
+ * Returns a callback for onAuthStateChanged. Zero Firebase imports.
+ */
+export function createAuthStateHandler({ requireClaim, onAccessDenied, onReady }) {
+  return async (user) => {
+    if (!user) {
+      onReady(null);
+      return;
+    }
+    const tokenResult = await user.getIdTokenResult();
+    if (requireClaim && tokenResult.claims[requireClaim] !== true) {
+      if (onAccessDenied) {
+        onAccessDenied({ reason: 'missing_claim', claim: requireClaim });
+      }
+      return;
+    }
+    onReady(user, tokenResult);
+  };
+}

--- a/public/js/core/state.js
+++ b/public/js/core/state.js
@@ -1,0 +1,37 @@
+/**
+ * Reactive state store factory.
+ *
+ * Each app (admin panel, MC Host panel, etc.) creates its own store
+ * instance with app-specific keys. Changes fire events via EventTarget
+ * so modules can subscribe to cross-cutting state updates.
+ *
+ * @param {Object} initial - Initial state keys and values
+ * @returns {{ get, set, on, off }}
+ */
+export function createStore(initial) {
+  const _state = { ...initial };
+  const _listeners = new EventTarget();
+
+  return {
+    get(key) {
+      return _state[key];
+    },
+
+    set(key, value) {
+      const old = _state[key];
+      if (old === value) return;
+      _state[key] = value;
+      _listeners.dispatchEvent(
+        new CustomEvent(`${key}:change`, { detail: { old, value } }),
+      );
+    },
+
+    on(event, handler) {
+      _listeners.addEventListener(event, handler);
+    },
+
+    off(event, handler) {
+      _listeners.removeEventListener(event, handler);
+    },
+  };
+}

--- a/public/js/core/tabs.js
+++ b/public/js/core/tabs.js
@@ -1,0 +1,121 @@
+/**
+ * Generic tab switcher for admin/MC Host/Singer panels.
+ * Each tab module must expose: init({root}), activate({root}), deactivate().
+ */
+
+import { resetAbortController } from './api.js';
+
+let _panelMap = {};
+const _modules = new Map();
+const _initialised = new Set();
+let _activeTab = null;
+
+/**
+ * Configure the tab switcher with a panel map.
+ * @param {{ panelMap: Object }} options
+ */
+export function configure({ panelMap }) {
+  _panelMap = panelMap || {};
+}
+
+/**
+ * Register a tab module.
+ * @param {string} tabId
+ * @param {{ init, activate, deactivate }} module
+ */
+export function register(tabId, module) {
+  _modules.set(tabId, module);
+}
+
+/**
+ * Get the currently active tab ID.
+ * @returns {string|null}
+ */
+export function getActiveTab() {
+  return _activeTab;
+}
+
+/**
+ * Handle asymmetric DOM visibility for different tab panels.
+ * @param {string} tabId
+ */
+function setPanelVisibility(tabId) {
+  // Hide all known panels first
+  const usersForm = document.getElementById('user-form');
+  const searchBar = document.getElementById('search-bar');
+  const auditPanel = document.getElementById('audit-log-panel');
+
+  if (usersForm) usersForm.style.display = 'none';
+  if (searchBar) searchBar.style.display = 'none';
+  if (auditPanel) auditPanel.style.display = 'none';
+
+  // Hide all generic panels via .visible class
+  for (const id of Object.values(_panelMap)) {
+    const el = document.getElementById(id);
+    if (el) el.classList.remove('visible');
+  }
+
+  // Show the active panel
+  if (tabId === 'users') {
+    if (usersForm) usersForm.style.display = '';
+    if (searchBar) searchBar.style.display = '';
+  } else if (tabId === 'audit') {
+    if (auditPanel) auditPanel.style.display = 'block';
+  } else {
+    const panelId = _panelMap[tabId] || `${tabId}-panel`;
+    const el = document.getElementById(panelId);
+    if (el) el.classList.add('visible');
+  }
+}
+
+/**
+ * Switch to the given tab.
+ * @param {string} tabId
+ */
+export async function show(tabId) {
+  resetAbortController();
+
+  const prevTab = _activeTab;
+  const prevModule = prevTab ? _modules.get(prevTab) : null;
+  if (prevModule && typeof prevModule.deactivate === 'function') {
+    prevModule.deactivate();
+  }
+
+  _activeTab = tabId;
+
+  const mod = _modules.get(tabId);
+  if (mod) {
+    const root = document.getElementById(_panelMap[tabId] || `${tabId}-panel`);
+    if (!_initialised.has(tabId) && typeof mod.init === 'function') {
+      await mod.init({ root });
+      _initialised.add(tabId);
+    }
+
+    setPanelVisibility(tabId);
+
+    // Update .tab-btn active states with WebKit layout flush
+    document.querySelectorAll('.tab-btn').forEach((btn) => {
+      btn.classList.remove('active');
+      if (btn.dataset.tab === tabId) {
+        btn.classList.add('active');
+        void btn.offsetHeight; // WebKit layout flush
+      }
+    });
+
+    if (typeof mod.activate === 'function') {
+      mod.activate({ root });
+    }
+  } else {
+    setPanelVisibility(tabId);
+
+    document.querySelectorAll('.tab-btn').forEach((btn) => {
+      btn.classList.remove('active');
+      if (btn.dataset.tab === tabId) {
+        btn.classList.add('active');
+        void btn.offsetHeight;
+      }
+    });
+  }
+
+  sessionStorage.setItem('activeTab', tabId);
+}

--- a/public/js/core/ui.js
+++ b/public/js/core/ui.js
@@ -1,0 +1,107 @@
+/**
+ * UI helpers: escapeHtml (unit-tested) + DOM helpers (Playwright-tested).
+ */
+
+/**
+ * Escape a value for safe HTML output.
+ * Converts non-strings to string first.
+ */
+export function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Show a toast notification.
+ * @param {string} msg
+ * @param {'success'|'error'|'info'} type
+ */
+export function showToast(msg, type = 'success') {
+  const toast = document.getElementById('toast');
+  if (!toast) return;
+  toast.textContent = msg;
+  toast.className = `toast ${type} visible`;
+  const delay = type === 'error' ? 7000 : 4000;
+  setTimeout(() => {
+    toast.className = `toast ${type}`;
+  }, delay);
+}
+
+/**
+ * Show a confirmation dialog.
+ * @param {string} title
+ * @param {string} message
+ * @returns {Promise<boolean>}
+ */
+export function showConfirm(title, message) {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'confirm-overlay';
+
+    const dialog = document.createElement('div');
+    dialog.className = 'confirm-dialog';
+
+    const h3 = document.createElement('h3');
+    h3.textContent = title;
+
+    const p = document.createElement('p');
+    p.textContent = message;
+
+    const buttons = document.createElement('div');
+    buttons.className = 'confirm-buttons';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'confirm-cancel';
+    cancelBtn.textContent = 'Cancel';
+
+    const okBtn = document.createElement('button');
+    okBtn.className = 'confirm-ok';
+    okBtn.textContent = 'OK';
+
+    buttons.appendChild(cancelBtn);
+    buttons.appendChild(okBtn);
+
+    dialog.appendChild(h3);
+    dialog.appendChild(p);
+    dialog.appendChild(buttons);
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    const cleanup = (result) => {
+      overlay.remove();
+      resolve(result);
+    };
+
+    okBtn.addEventListener('click', () => cleanup(true));
+    cancelBtn.addEventListener('click', () => cleanup(false));
+  });
+}
+
+const _screens = new Map();
+
+/**
+ * Register a screen element by name.
+ * @param {string} name
+ * @param {Element} element
+ */
+export function registerScreen(name, element) {
+  _screens.set(name, element);
+}
+
+/**
+ * Show a registered screen, hiding all others.
+ * @param {string} name
+ */
+export function showScreen(name) {
+  for (const [, el] of _screens) {
+    el.classList.remove('active');
+  }
+  const target = _screens.get(name);
+  if (target) {
+    target.classList.add('active');
+  }
+}

--- a/public/roadmap-data.json
+++ b/public/roadmap-data.json
@@ -3150,6 +3150,12 @@
           }
         },
         {
+          "name": "MC Host Team Leader panel",
+          "description": "oversight panel for Team Leaders who manage multiple MC Hosts. View team performance, assign games/events, review MC Host activity, handle escalations",
+          "status": "planned",
+          "i18n": {}
+        },
+        {
           "name": "MC Singer dedicated panel",
           "description": "separate login + dashboard for MC Singers to manage singing sessions, rooms, competitions",
           "status": "planned",
@@ -3231,6 +3237,12 @@
               "d": "MC歌手专用的表演管理面板"
             }
           }
+        },
+        {
+          "name": "MC Singer Team Leader panel",
+          "description": "oversight panel for Team Leaders who manage multiple MC Singers. View team performance, assign singing sessions, review MC Singer activity, handle escalations",
+          "status": "planned",
+          "i18n": {}
         },
         {
           "name": "Teacher dedicated panel",


### PR DESCRIPTION
## Summary
PR A of 3 for the admin panel restructure (#41). Extracts shared helper functions from the 9,500-line inline `<script type="module">` into reusable ES modules.

## New modules at `public/js/core/` (shared across future panels)
- `state.js` — createStore factory with EventTarget-based reactivity
- `auth.js` — SDK-agnostic createAuthStateHandler for claim checking
- `api.js` — apiCall wrapper with per-tab AbortController
- `ui.js` — showToast, showConfirm, showScreen, escapeHtml
- `tabs.js` — generic tab switcher with panel ID map

## Admin entry point at `public/admin/js/main.js`
- Firebase Auth init (modular SDK v11.6.0) — moved from inline block
- Admin state store, API + tabs configuration
- Re-exports auth utilities for the inline block during transition

## What was extracted from index.html (commit A3)
- `showToast` and `showConfirm` → imported from `/js/core/ui.js`
- Firebase `initializeApp` + `getAuth` + Auth emulator → moved to `main.js`
- Inline block now uses `getApp()` and imports `auth` from `main.js`
- Net: -28 lines from the 14,520-line file

## What stays inline (PR B scope)
- `showScreen`, `apiCall`, `switchTab`, `escapeHtml` (coupled with local state)
- All 15 tab-specific function blocks
- `onAuthStateChanged` handler (auth flow stays inline for now)

## Tests
- 18 new unit tests (createStore: 7, createAuthStateHandler: 5, escapeHtml: 6)
- Custom ESM→CJS transform for Jest (zero deps, scoped to `public/js/core/`)
- 4115/4115 Express tests pass (including 18 new)

## Test plan
- [x] 18 new unit tests passing
- [x] SonarCloud quality gate passing
- [x] Local admin-panel Playwright tests pass (9/10, 1 flaky title check = pre-existing)
- [ ] CI: Playwright all 5 browsers
- [ ] CI: Android E2E
- [ ] CI: PR Gate

## Design
`.project/plans/2026-04-11-admin-panel-restructure-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)