### PR TITLE
feat(ios): wire Koin init + update MainViewController (Steps 1.6-1.7)

### DIFF
--- a/.project/plans/2026-03-29-feature-roadmap.md
+++ b/.project/plans/2026-03-29-feature-roadmap.md
@@ -25,7 +25,7 @@ roadmap — user-facing web features previously listed here have moved to Phase 
 | 52  | **Khmer (km) as 20th locale** — full app translation to Khmer script (771/781 strings)                                                                                                           | Medium | DONE (PR #302, 2026-04-16)                                    |
 | 53  | **Admin core module tests** — 34 Jest unit tests + 9 Playwright integration tests for PR A core modules                                                                                          | Small  | DONE (PR #290, 2026-04-13)                                    |
 | B5 | **iOS build fix** — cinterop errors block all iOS work. Now on Mac, this is unblocked                                                                                                          | Medium | DONE (PRs #312-316, 2026-04-22) — iOS compiles, cinterop fixed |
-| B6 | **iOS parity** — testers receiving builds with zero enforcement screens. Must match Android feature-for-feature                                                                                 | Large  | IN PROGRESS — Phase 1 Steps 1.1-1.5 done (PRs #312-317), Steps 1.6-1.7 next |
+| B6 | **iOS parity** — testers receiving builds with zero enforcement screens. Must match Android feature-for-feature                                                                                 | Large  | IN PROGRESS — Phase 1 complete (PRs #312-318), Phase 2 (Firebase) next |
 | B16 | **Cross-device E2E testing** — admin actions (suspension, moderation, ban cascade) performed in admin panel and verified in app on real device. Proves full pipeline end-to-end                  | Large  |                                                               |
 
 ---

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,8 +1,13 @@
 import SwiftUI
+import shared
 
 @main
 struct iOSApp: App {
     @StateObject private var coordinator = StartingScreenCoordinator()
+
+    init() {
+        KoinHelperKt.doInitKoin()
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/scripts/generate-roadmap-json.js
+++ b/scripts/generate-roadmap-json.js
@@ -211,7 +211,10 @@ if (fs.existsSync(OUTPUT_PATH)) {
   const existingWithoutDate = { ...existing, lastUpdated: '' };
   const newWithoutDate = { ...output, lastUpdated: '' };
   if (JSON.stringify(existingWithoutDate) === JSON.stringify(newWithoutDate)) {
-    console.log('Roadmap unchanged — skipping write');
+    console.log(
+      'Roadmap markdown changed but public JSON is identical — internal details ' +
+      '(PR numbers, step counts) don\'t affect the public output. Skipping write.',
+    );
     if (require.main === module) process.exit(0);
   }
 }

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/MainViewController.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/MainViewController.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -26,7 +27,7 @@ private fun IosApp() {
             modifier = Modifier.fillMaxSize(),
         ) {
             Column(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier.fillMaxSize().padding(32.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
             ) {
@@ -37,9 +38,15 @@ private fun IosApp() {
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    text = "iOS",
+                    text = "iOS — Koin initialized",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                Text(
+                    text = "Phase 2 will add Firebase and repository bindings.\nPhase 3 will wire the full NavGraph.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                 )
             }
         }


### PR DESCRIPTION
## Summary
- **Step 1.6**: Updated `MainViewController.kt` to show Koin-initialized status with phase progression notes instead of bare placeholder
- **Step 1.7**: `iOSApp.swift` now calls `KoinHelperKt.doInitKoin()` in `init()`, loading `viewModelModule + iosPlatformModule` before Compose UI starts

This completes Phase 1 (Core Wiring) of the iOS feature parity plan. The iOS app now has:
- Shared navigation structure (PRs #312-316)
- Shared ViewModel module via Koin (PR #317)
- Koin initialized from Swift with double-init guard
- Empty platform module ready for Phase 2 (Firebase) bindings

## Test plan
- [x] iOS compilation passes (`compileKotlinIosArm64`)
- [x] Android compilation passes (`compileDevDebugKotlin`)
- [x] All Kotlin unit tests pass
- [x] ktlint clean
- [ ] CI passes
- [ ] iOS Simulator: app launches, shows "Koin initialized" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)