### PR TITLE
feat(ios): real Auth + Identity + AppLock repositories (PR B+C)

### DIFF
--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/IosPlatformModule.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/IosPlatformModule.kt
@@ -1,8 +1,6 @@
 package com.shyden.shytalk.core.di
 
 import com.shyden.shytalk.core.di.stubs.IosAppConfigServiceStub
-import com.shyden.shytalk.core.di.stubs.IosAppLockRepositoryStub
-import com.shyden.shytalk.core.di.stubs.IosAuthRepositoryStub
 import com.shyden.shytalk.core.di.stubs.IosBannerImagePreloaderStub
 import com.shyden.shytalk.core.di.stubs.IosBannerRepositoryStub
 import com.shyden.shytalk.core.di.stubs.IosBiometricRepositoryStub
@@ -32,6 +30,7 @@ import com.shyden.shytalk.core.di.stubs.IosWebContentPreloaderStub
 import com.shyden.shytalk.core.room.RoomLifecycleManager
 import com.shyden.shytalk.core.util.BiometricAuth
 import com.shyden.shytalk.core.util.CryptoKeyPair
+import com.shyden.shytalk.core.util.SecureStorage
 import com.shyden.shytalk.data.local.StickerStorage
 import com.shyden.shytalk.data.remote.AppConfigService
 import com.shyden.shytalk.data.remote.ConversationWebSocketService
@@ -40,6 +39,7 @@ import com.shyden.shytalk.data.remote.PresenceService
 import com.shyden.shytalk.data.remote.TokenService
 import com.shyden.shytalk.data.remote.VoiceService
 import com.shyden.shytalk.data.repository.AppLockRepository
+import com.shyden.shytalk.data.repository.AppLockRepositoryImpl
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.BannerRepository
 import com.shyden.shytalk.data.repository.BiometricRepository
@@ -48,6 +48,7 @@ import com.shyden.shytalk.data.repository.EconomyRepository
 import com.shyden.shytalk.data.repository.FunFactRepository
 import com.shyden.shytalk.data.repository.GiftRepository
 import com.shyden.shytalk.data.repository.IdentityRepository
+import com.shyden.shytalk.data.repository.IosAuthRepositoryImpl
 import com.shyden.shytalk.data.repository.MessageRepository
 import com.shyden.shytalk.data.repository.NotificationRepository
 import com.shyden.shytalk.data.repository.OtpRepository
@@ -97,7 +98,7 @@ val iosPlatformModule =
         single { CryptoKeyPair() }
 
         // Repositories
-        single<AuthRepository> { IosAuthRepositoryStub() }
+        single<AuthRepository> { IosAuthRepositoryImpl(get()) }
         single<UserRepository> { IosUserRepositoryStub() }
         single<RoomRepository> { IosRoomRepositoryStub() }
         single<MessageRepository> { IosMessageRepositoryStub() }
@@ -117,7 +118,8 @@ val iosPlatformModule =
         single<OtpRepository> { IosOtpRepositoryStub() }
         single<PinRepository> { IosPinRepositoryStub() }
         single<BiometricRepository> { IosBiometricRepositoryStub() }
-        single<AppLockRepository> { IosAppLockRepositoryStub() }
+        single { SecureStorage() }
+        single<AppLockRepository> { AppLockRepositoryImpl(get<SecureStorage>()) }
 
         // Services
         single<TokenService> { IosTokenServiceStub() }

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/IosPlatformModule.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/IosPlatformModule.kt
@@ -9,7 +9,6 @@ import com.shyden.shytalk.core.di.stubs.IosDeviceRepositoryStub
 import com.shyden.shytalk.core.di.stubs.IosEconomyRepositoryStub
 import com.shyden.shytalk.core.di.stubs.IosFunFactRepositoryStub
 import com.shyden.shytalk.core.di.stubs.IosGiftRepositoryStub
-import com.shyden.shytalk.core.di.stubs.IosIdentityRepositoryStub
 import com.shyden.shytalk.core.di.stubs.IosMessageRepositoryStub
 import com.shyden.shytalk.core.di.stubs.IosNotificationRepositoryStub
 import com.shyden.shytalk.core.di.stubs.IosOtpRepositoryStub
@@ -49,6 +48,7 @@ import com.shyden.shytalk.data.repository.FunFactRepository
 import com.shyden.shytalk.data.repository.GiftRepository
 import com.shyden.shytalk.data.repository.IdentityRepository
 import com.shyden.shytalk.data.repository.IosAuthRepositoryImpl
+import com.shyden.shytalk.data.repository.IosIdentityRepositoryImpl
 import com.shyden.shytalk.data.repository.MessageRepository
 import com.shyden.shytalk.data.repository.NotificationRepository
 import com.shyden.shytalk.data.repository.OtpRepository
@@ -105,7 +105,7 @@ val iosPlatformModule =
         single<SeatRequestRepository> { IosSeatRequestRepositoryStub() }
         single<StorageRepository> { IosStorageRepositoryStub() }
         single<DeviceRepository> { IosDeviceRepositoryStub() }
-        single<IdentityRepository> { IosIdentityRepositoryStub() }
+        single<IdentityRepository> { IosIdentityRepositoryImpl(get(), get()) }
         single<PrivateMessageRepository> { IosPrivateMessageRepositoryStub() }
         single<ReportRepository> { IosReportRepositoryStub() }
         single<TypingRepository> { IosTypingRepositoryStub() }

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosApiClient.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosApiClient.kt
@@ -84,6 +84,11 @@ class IosApiClient(
         }
     }
 
+    fun clearTokenCache() {
+        cachedToken = null
+        tokenTimestamp = 0
+    }
+
     suspend fun get(path: String): JsonObject = request("GET", path)
 
     suspend fun post(
@@ -102,6 +107,11 @@ class IosApiClient(
     ): JsonObject = request("PUT", path, body)
 
     suspend fun delete(path: String): JsonObject = request("DELETE", path)
+
+    suspend fun delete(
+        path: String,
+        body: JsonObject?,
+    ): JsonObject = request("DELETE", path, body)
 
     suspend fun getPublic(path: String): JsonObject {
         val response =

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosAuthRepositoryImpl.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosAuthRepositoryImpl.kt
@@ -1,0 +1,110 @@
+package com.shyden.shytalk.data.repository
+
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.core.util.firebaseCall
+import dev.gitlive.firebase.auth.FirebaseAuth
+import dev.gitlive.firebase.auth.GoogleAuthProvider
+import dev.gitlive.firebase.auth.OAuthProvider
+
+class IosAuthRepositoryImpl(
+    private val auth: FirebaseAuth,
+    private val emailLinkDomain: String = "shytalk.shyden.co.uk",
+) : AuthRepository {
+    override var resolvedUniqueId: String? = null
+
+    override val currentUserId: String?
+        get() = resolvedUniqueId ?: auth.currentUser?.uid
+
+    override val currentFirebaseUid: String?
+        get() = auth.currentUser?.uid
+
+    override val isAuthenticated: Boolean
+        get() = auth.currentUser != null
+
+    override val currentUserEmail: String?
+        get() = auth.currentUser?.email
+
+    override fun getProviderInfo(): Pair<String, String>? {
+        val user = auth.currentUser ?: return null
+        for (profile in user.providerData) {
+            when (profile.providerId) {
+                "google.com" -> {
+                    val email = profile.email ?: continue
+                    return "google" to email
+                }
+
+                "apple.com" -> {
+                    return "apple" to profile.uid
+                }
+
+                "password" -> {
+                    val email = profile.email ?: continue
+                    return "email" to email
+                }
+            }
+        }
+        return null
+    }
+
+    override suspend fun signInWithGoogleIdToken(idToken: String): Resource<String> =
+        firebaseCall("Google sign in failed") {
+            val credential = GoogleAuthProvider.credential(idToken, null)
+            val result = auth.signInWithCredential(credential)
+            result.user?.uid ?: throw Exception("Sign in failed: no user returned")
+        }
+
+    override suspend fun signInWithAppleIdToken(
+        idToken: String,
+        rawNonce: String,
+    ): Resource<String> =
+        firebaseCall("Apple sign-in failed") {
+            val credential =
+                OAuthProvider.credential(
+                    providerId = "apple.com",
+                    idToken = idToken,
+                    accessToken = null,
+                    rawNonce = rawNonce,
+                )
+            val result = auth.signInWithCredential(credential)
+            result.user?.uid ?: throw Exception("Apple sign-in failed: no user returned")
+        }
+
+    override suspend fun signInWithAppleViaProvider(activity: Any): Resource<String> =
+        // iOS uses ASAuthorizationController, not activity-based flow.
+        // Apple sign-in on iOS goes through signInWithAppleIdToken after native auth.
+        Resource.Error("Use signInWithAppleIdToken on iOS")
+
+    override suspend fun sendSignInLink(email: String): Resource<Unit> =
+        firebaseCall("Failed to send sign-in link") {
+            val settings =
+                dev.gitlive.firebase.auth.ActionCodeSettings(
+                    url = "https://$emailLinkDomain/auth/email-link",
+                    canHandleCodeInApp = true,
+                    iOSBundleId = "com.shyden.shytalk",
+                )
+            auth.sendSignInLinkToEmail(email, settings)
+        }
+
+    override suspend fun signInWithEmailLink(
+        email: String,
+        link: String,
+    ): Resource<String> =
+        firebaseCall("Email sign-in failed") {
+            val result = auth.signInWithEmailLink(email, link)
+            result.user?.uid ?: throw Exception("Sign in failed: no user returned")
+        }
+
+    override suspend fun signInWithCustomToken(token: String): Resource<String> =
+        firebaseCall("Custom token sign-in failed") {
+            val result = auth.signInWithCustomToken(token)
+            result.user?.uid ?: throw Exception("Sign in failed: no user returned")
+        }
+
+    override fun signOut() {
+        resolvedUniqueId = null
+        // GitLive signOut is a suspend function, but our interface declares it as non-suspend.
+        // Firebase iOS SDK's signOut is synchronous underneath, so this is safe.
+        @Suppress("BlockingMethodInNonBlockingContext")
+        kotlinx.coroutines.runBlocking { auth.signOut() }
+    }
+}

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosIdentityRepositoryImpl.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosIdentityRepositoryImpl.kt
@@ -1,0 +1,111 @@
+package com.shyden.shytalk.data.repository
+
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.core.util.logE
+import com.shyden.shytalk.data.remote.IosApiClient
+import dev.gitlive.firebase.auth.FirebaseAuth
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+
+class IosIdentityRepositoryImpl(
+    private val apiClient: IosApiClient,
+    private val auth: FirebaseAuth,
+) : IdentityRepository {
+    override suspend fun resolveIdentity(
+        provider: String,
+        identifier: String,
+    ): Resource<SignInResult> =
+        try {
+            val body = buildBody("provider" to provider, "identifier" to identifier)
+            val response = apiClient.post("/api/users/sign-in", body)
+
+            val found = response["found"]?.jsonPrimitive?.boolean ?: false
+            if (found) {
+                val uniqueId = response["uniqueId"]!!.jsonPrimitive.long
+                Resource.Success(SignInResult.Found(uniqueId))
+            } else {
+                val deactivated = response["deactivated"]?.jsonPrimitive?.boolean ?: false
+                if (deactivated) {
+                    Resource.Success(SignInResult.Deactivated)
+                } else {
+                    Resource.Success(SignInResult.NotFound)
+                }
+            }
+        } catch (e: Exception) {
+            logE("IdentityRepository", "resolveIdentity failed: ${e.message}", e)
+            Resource.Error(e.message ?: "Failed to resolve identity", e)
+        }
+
+    override suspend fun createUser(
+        provider: String,
+        identifier: String,
+        displayName: String?,
+        email: String?,
+        profilePhotoUrl: String?,
+        dateOfBirth: Long?,
+        language: String,
+    ): Resource<CreateUserResult> =
+        try {
+            val fields =
+                mutableListOf<Pair<String, JsonPrimitive>>(
+                    "provider" to JsonPrimitive(provider),
+                    "identifier" to JsonPrimitive(identifier),
+                    "language" to JsonPrimitive(language),
+                )
+            displayName?.let { fields.add("displayName" to JsonPrimitive(it)) }
+            email?.let { fields.add("email" to JsonPrimitive(it)) }
+            profilePhotoUrl?.let { fields.add("profilePhotoUrl" to JsonPrimitive(it)) }
+            dateOfBirth?.let { fields.add("dateOfBirth" to JsonPrimitive(it)) }
+
+            val body = JsonObject(fields.toMap())
+            val response = apiClient.post("/api/users", body)
+            val uniqueId = response["uniqueId"]!!.jsonPrimitive.long
+            Resource.Success(CreateUserResult(uniqueId))
+        } catch (e: Exception) {
+            logE("IdentityRepository", "createUser failed: ${e.message}", e)
+            Resource.Error(e.message ?: "Failed to create user", e)
+        }
+
+    override suspend fun linkProvider(
+        uniqueId: Long,
+        provider: String,
+        identifier: String,
+    ): Resource<Unit> =
+        try {
+            val body = buildBody("provider" to provider, "identifier" to identifier)
+            apiClient.post("/api/users/$uniqueId/link-provider", body)
+            Resource.Success(Unit)
+        } catch (e: Exception) {
+            logE("IdentityRepository", "linkProvider failed: ${e.message}", e)
+            Resource.Error(e.message ?: "Failed to link provider", e)
+        }
+
+    override suspend fun unlinkProvider(
+        uniqueId: Long,
+        provider: String,
+        identifier: String,
+    ): Resource<Unit> =
+        try {
+            val body = buildBody("provider" to provider, "identifier" to identifier)
+            apiClient.delete("/api/users/$uniqueId/link-provider", body)
+            Resource.Success(Unit)
+        } catch (e: Exception) {
+            logE("IdentityRepository", "unlinkProvider failed: ${e.message}", e)
+            Resource.Error(e.message ?: "Failed to unlink provider", e)
+        }
+
+    override suspend fun forceRefreshToken(): Resource<Unit> =
+        try {
+            apiClient.clearTokenCache()
+            auth.currentUser?.getIdToken(true)
+            Resource.Success(Unit)
+        } catch (e: Exception) {
+            logE("IdentityRepository", "forceRefreshToken failed: ${e.message}", e)
+            Resource.Error(e.message ?: "Failed to refresh token", e)
+        }
+
+    private fun buildBody(vararg pairs: Pair<String, String>): JsonObject = JsonObject(pairs.associate { (k, v) -> k to JsonPrimitive(v) })
+}


### PR DESCRIPTION
## Summary
First batch of iOS repository implementations — replaces 3 stubs with real code.

### AuthRepository (PR B)
- **IosAuthRepositoryImpl**: GitLive Firebase Auth KMP — Google, Apple (idToken), email link, custom token sign-in
- Provider detection mirrors Android (`google.com`, `apple.com`, `password`)

### IdentityRepository (PR C)
- **IosIdentityRepositoryImpl**: Express API calls via IosApiClient — identity resolution, user creation, provider link/unlink, token refresh
- Uses `kotlinx.serialization.json` (not `org.json`) per KMP plan

### AppLockRepository
- Activated commonMain `AppLockRepositoryImpl` backed by iOS Keychain `SecureStorage`

### IosApiClient enhancements
- Added `clearTokenCache()` for token refresh flows
- Added `delete(path, body)` overload for unlinkProvider

### Stubs removed: 3
| Repository | Before | After |
|---|---|---|
| AuthRepository | `IosAuthRepositoryStub` | `IosAuthRepositoryImpl` (GitLive Firebase Auth) |
| IdentityRepository | `IosIdentityRepositoryStub` | `IosIdentityRepositoryImpl` (Express API) |
| AppLockRepository | `IosAppLockRepositoryStub` | `AppLockRepositoryImpl` (Keychain) |

## Test plan
- [x] `./gradlew :shared:compileKotlinIosArm64` — zero warnings, zero errors
- [x] `./gradlew :shared:jvmTest` — all pass
- [x] `ktlint --relative` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)