### PR TITLE
fix: trigger roadmap subscription notifications on status changes

### DIFF
--- a/express-api/jest.config.js
+++ b/express-api/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   testEnvironment: 'node',
+  maxWorkers: '50%',
   restoreMocks: true,
   clearMocks: true,
   resetMocks: false,

--- a/express-api/src/routes/suggestions.js
+++ b/express-api/src/routes/suggestions.js
@@ -46,6 +46,7 @@ const { sanitise, sanitiseTitle } = require('../utils/text-sanitiser');
 const { similarity } = require('../utils/similarity');
 const { sendSystemPm } = require('../utils/system-pm');
 const { sendFcmToTokens } = require('../utils/fcm');
+const { notifyRoadmapSubscribers } = require('../utils/roadmap-notify');
 const {
   VALID_TAGS,
   VALID_LANGUAGES,
@@ -1216,12 +1217,20 @@ router.put('/admin/suggestions/:id/status', async (req, res) => {
       { previousStatus: currentStatus, newStatus, reason: reason || null },
     );
 
-    // Notify subscribers
+    // Notify per-suggestion subscribers (FCM + system PM)
     await notifySubscribers(data, newStatus, {
       suggestionId: id,
       previousStatus: currentStatus,
       reason: reason || null,
     });
+
+    // Notify roadmap subscribers when roadmap changes (fire-and-forget)
+    if (newStatus === 'planned' || newStatus === 'completed') {
+      const action = newStatus === 'planned' ? 'added to the roadmap' : 'marked as complete';
+      notifyRoadmapSubscribers(`"${data.title}" has been ${action}.`).catch((err) => {
+        log.error('admin-suggestions', 'Roadmap notification failed', { error: err.message });
+      });
+    }
 
     log.info('admin-suggestions', 'Suggestion status changed', {
       id,
@@ -1276,6 +1285,14 @@ router.put('/admin/suggestions/:id/link', async (req, res) => {
 
     await createAuditEntry(req.auth.uniqueId, 'suggestion_link', 'suggestion', id, {
       roadmapFeatureId,
+    });
+
+    // Notify roadmap subscribers (fire-and-forget)
+    const sugData = sugDoc.data();
+    notifyRoadmapSubscribers(
+      `"${sugData.title || 'A suggestion'}" has been added to the roadmap.`,
+    ).catch((err) => {
+      log.error('admin-suggestions', 'Roadmap notification failed', { error: err.message });
     });
 
     log.info('admin-suggestions', 'Suggestion linked to roadmap feature', {

--- a/express-api/src/utils/roadmap-notify.js
+++ b/express-api/src/utils/roadmap-notify.js
@@ -1,0 +1,80 @@
+/**
+ * Roadmap update notification trigger.
+ *
+ * Queries all subscribers who opted into roadmapUpdate notifications,
+ * then creates notification queue entries for dispatch via the
+ * notification-dispatch cron job.
+ */
+
+const { db } = require('./firebase');
+const log = require('./log');
+const { now } = require('./helpers');
+
+const BATCH_LIMIT = 400;
+
+/**
+ * Notify all roadmapUpdate subscribers about a roadmap change.
+ *
+ * @param {string} message - Description of what changed (shown to users)
+ */
+async function notifyRoadmapSubscribers(message) {
+  try {
+    const snap = await db.collection('subscriptions').get();
+
+    if (snap.empty) return;
+
+    let batch = db.batch();
+    let batchCount = 0;
+    let total = 0;
+
+    for (const doc of snap.docs) {
+      const sub = doc.data();
+      const prefs = sub.channelPreferences?.roadmapUpdate;
+
+      // Skip if no roadmapUpdate preference or all channels disabled
+      if (!prefs) continue;
+      const hasAnyChannel = prefs.email || prefs.push || prefs.inApp || prefs.systemMessage;
+      if (!hasAnyChannel) continue;
+
+      const notifRef = db.collection('notificationQueue').doc();
+      batch.set(notifRef, {
+        type: 'roadmapUpdate',
+        uid: sub.uid || doc.id,
+        title: 'Roadmap Update',
+        body: message,
+        channels: {
+          email: !!prefs.email,
+          push: !!prefs.push,
+          inApp: !!prefs.inApp,
+          systemMessage: !!prefs.systemMessage,
+        },
+        email: sub.email || null,
+        pushToken: sub.pushToken || null,
+        status: 'queued',
+        createdAt: now(),
+      });
+      batchCount++;
+      total++;
+
+      if (batchCount === BATCH_LIMIT) {
+        await batch.commit();
+        batch = db.batch();
+        batchCount = 0;
+      }
+    }
+
+    if (batchCount > 0) {
+      await batch.commit();
+    }
+
+    if (total > 0) {
+      log.info('roadmap-notify', `Queued ${total} roadmap update notifications`);
+    }
+  } catch (err) {
+    log.error('roadmap-notify', 'Failed to notify roadmap subscribers', {
+      error: err.message,
+    });
+  }
+}
+
+module.exports = { notifyRoadmapSubscribers };

--- a/express-api/tests/middleware/rateLimit.test.js
+++ b/express-api/tests/middleware/rateLimit.test.js
@@ -86,9 +86,9 @@ describe('generalLimiter', () => {
   test('returns 429 when limit is exceeded', async () => {
     const app = createGeneralApp();
 
-    // Send 200 requests (the limit)
-    for (let i = 0; i < 200; i++) {
-      await request(app).get('/test');
+    // Send 200 requests in batches to avoid socket exhaustion
+    for (let batch = 0; batch < 10; batch++) {
+      await Promise.all(Array.from({ length: 20 }, () => request(app).get('/test')));
     }
 
     // The 201st request should be rate limited
@@ -107,8 +107,9 @@ describe('writeLimiter', () => {
   test('returns 429 when write limit (30) is exceeded', async () => {
     const app = createWriteApp();
 
-    for (let i = 0; i < 30; i++) {
-      await request(app).post('/message');
+    // Send 30 requests in batches to avoid socket exhaustion
+    for (let batch = 0; batch < 3; batch++) {
+      await Promise.all(Array.from({ length: 10 }, () => request(app).post('/message')));
     }
 
     const res = await request(app).post('/message').expect(429);
@@ -134,9 +135,7 @@ describe('sensitiveLimiter', () => {
   test('returns 429 when sensitive limit (5) is exceeded', async () => {
     const app = createSensitiveApp();
 
-    for (let i = 0; i < 5; i++) {
-      await request(app).post('/report');
-    }
+    await Promise.all(Array.from({ length: 5 }, () => request(app).post('/report')));
 
     const res = await request(app).post('/report').expect(429);
     expect(res.body.error).toBe('Rate limit exceeded for this operation');
@@ -145,9 +144,7 @@ describe('sensitiveLimiter', () => {
   test('logs a warning when sensitive rate limit is hit', async () => {
     const app = createSensitiveApp();
 
-    for (let i = 0; i < 5; i++) {
-      await request(app).post('/report');
-    }
+    await Promise.all(Array.from({ length: 5 }, () => request(app).post('/report')));
 
     await request(app).post('/report').expect(429);
 
@@ -181,10 +178,12 @@ describe('admin exemption', () => {
     app.use(generalLimiter);
     app.get('/test', (req, res) => res.json({ success: true }));
 
-    // Send 210 requests — exceeds the 200 limit
-    for (let i = 0; i < 210; i++) {
-      const res = await request(app).get('/test');
-      expect(res.status).toBe(200);
+    // Send 210 requests in batches — exceeds the 200 limit, all should pass for admin
+    for (let batch = 0; batch < 7; batch++) {
+      const results = await Promise.all(
+        Array.from({ length: 30 }, () => request(app).get('/test')),
+      );
+      results.forEach((res) => expect(res.status).toBe(200));
     }
   });
 
@@ -199,11 +198,11 @@ describe('admin exemption', () => {
     app.use(sensitiveLimiter);
     app.post('/report', (req, res) => res.json({ success: true }));
 
-    // Send 10 requests — double the 5-request limit
-    for (let i = 0; i < 10; i++) {
-      const res = await request(app).post('/report');
-      expect(res.status).toBe(200);
-    }
+    // Send 10 requests in parallel — double the 5-request limit, all should pass for admin
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => request(app).post('/report')),
+    );
+    results.forEach((res) => expect(res.status).toBe(200));
   });
 
   test('non-admin users are still rate-limited on sensitiveLimiter', async () => {
@@ -217,9 +216,7 @@ describe('admin exemption', () => {
     app.use(sensitiveLimiter);
     app.post('/report', (req, res) => res.json({ success: true }));
 
-    for (let i = 0; i < 5; i++) {
-      await request(app).post('/report');
-    }
+    await Promise.all(Array.from({ length: 5 }, () => request(app).post('/report')));
 
     // 6th request should be rate limited
     const res = await request(app).post('/report').expect(429);
@@ -236,9 +233,7 @@ describe('admin exemption', () => {
     app.use(sensitiveLimiter);
     app.post('/report', (req, res) => res.json({ success: true }));
 
-    for (let i = 0; i < 5; i++) {
-      await request(app).post('/report');
-    }
+    await Promise.all(Array.from({ length: 5 }, () => request(app).post('/report')));
 
     const res = await request(app).post('/report').expect(429);
     expect(res.body.error).toBe('Rate limit exceeded for this operation');
@@ -259,9 +254,7 @@ describe('keyGenerator', () => {
     app.post('/report', (req, res) => res.json({ success: true }));
 
     // Exhaust the limit for user-123
-    for (let i = 0; i < 5; i++) {
-      await request(app).post('/report');
-    }
+    await Promise.all(Array.from({ length: 5 }, () => request(app).post('/report')));
 
     // user-123 should be rate limited
     await request(app).post('/report').expect(429);
@@ -289,9 +282,7 @@ describe('keyGenerator', () => {
     app.post('/report', (req, res) => res.json({ success: true }));
 
     // Exhaust limit — all requests from same IP
-    for (let i = 0; i < 5; i++) {
-      await request(app).post('/report');
-    }
+    await Promise.all(Array.from({ length: 5 }, () => request(app).post('/report')));
 
     // Should be rate limited by IP
     const res = await request(app).post('/report').expect(429);

--- a/express-api/tests/routes/admin-suggestions-extended.test.js
+++ b/express-api/tests/routes/admin-suggestions-extended.test.js
@@ -124,6 +124,10 @@ jest.mock('../../src/utils/fcm', () => ({
   sendFcmToTokens: jest.fn().mockResolvedValue([]),
 }));
 
+jest.mock('../../src/utils/roadmap-notify', () => ({
+  notifyRoadmapSubscribers: jest.fn().mockResolvedValue(),
+}));
+
 // ─── App setup ──────────────────────────────────────────────────
 
 const suggestionsRouter = require('../../src/routes/suggestions');

--- a/express-api/tests/routes/admin-suggestions-new-routes.test.js
+++ b/express-api/tests/routes/admin-suggestions-new-routes.test.js
@@ -113,6 +113,10 @@ jest.mock('../../src/utils/fcm', () => ({
   sendFcmToTokens: jest.fn().mockResolvedValue([]),
 }));
 
+jest.mock('../../src/utils/roadmap-notify', () => ({
+  notifyRoadmapSubscribers: jest.fn().mockResolvedValue(),
+}));
+
 // ─── App setup ──────────────────────────────────────────────────
 
 const suggestionsRouter = require('../../src/routes/suggestions');

--- a/express-api/tests/routes/roadmap-notifications.test.js
+++ b/express-api/tests/routes/roadmap-notifications.test.js
@@ -1,0 +1,225 @@
+/**
+ * Tests for roadmap update notifications.
+ *
+ * When the public roadmap JSON changes (new features done, phases updated),
+ * subscribers who opted into roadmapUpdate notifications must be notified
+ * via their configured channels (email, push, inApp, systemMessage).
+ */
+
+// Firebase mock — imported values used by the mocked module below
+
+// ── Mocks ──────────────────────────────────────────────────────
+jest.mock('../../src/utils/firebase', () => {
+  const store = {};
+  const mockDoc = (path) => ({
+    get: jest.fn(async () => ({
+      exists: !!store[path],
+      data: () => store[path] || null,
+      id: path.split('/').pop(),
+    })),
+    set: jest.fn(async (data) => {
+      store[path] = data;
+    }),
+    update: jest.fn(async (data) => {
+      store[path] = { ...store[path], ...data };
+    }),
+  });
+
+  const mockCollection = (name) => ({
+    where: jest.fn().mockReturnThis(),
+    get: jest.fn(async () => ({
+      empty: !Object.keys(store).some((k) => k.startsWith(name + '/')),
+      docs: Object.entries(store)
+        .filter(([k]) => k.startsWith(name + '/'))
+        .map(([k, v]) => ({
+          id: k.split('/').pop(),
+          data: () => v,
+          ref: {
+            update: jest.fn(async (d) => {
+              store[k] = { ...store[k], ...d };
+            }),
+          },
+        })),
+    })),
+    doc: jest.fn((id) => {
+      const path = id
+        ? `${name}/${id}`
+        : `${name}/${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const d = mockDoc(path);
+      d._path = path;
+      return d;
+    }),
+  });
+
+  return {
+    db: {
+      collection: jest.fn((name) => mockCollection(name)),
+      doc: jest.fn((path) => mockDoc(path)),
+      batch: jest.fn(() => {
+        const pending = [];
+        return {
+          set: jest.fn((ref, data) => {
+            pending.push({ path: ref._path, data });
+          }),
+          commit: jest.fn(async () => {
+            for (const { path, data } of pending) {
+              store[path] = data;
+            }
+          }),
+        };
+      }),
+    },
+    _store: store,
+    _reset: () => {
+      Object.keys(store).forEach((k) => delete store[k]);
+    },
+  };
+});
+
+jest.mock('../../src/utils/log', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('../../src/utils/helpers', () => ({
+  now: jest.fn(() => 1709913600000),
+}));
+
+const { _store, _reset } = require('../../src/utils/firebase');
+
+beforeEach(() => {
+  _reset();
+  jest.clearAllMocks();
+});
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('notifyRoadmapSubscribers', () => {
+  let notifyRoadmapSubscribers;
+
+  beforeAll(() => {
+    // The function we're testing — it should be exported from a module
+    // that we'll create as part of the implementation
+    notifyRoadmapSubscribers = require('../../src/utils/roadmap-notify').notifyRoadmapSubscribers;
+  });
+
+  it('creates notification queue entries for subscribers with roadmapUpdate.inApp enabled', async () => {
+    // Arrange: subscriber with inApp enabled
+    _store['subscriptions/user1'] = {
+      uid: 'user1',
+      channelPreferences: {
+        roadmapUpdate: { email: false, push: false, inApp: true, systemMessage: false },
+      },
+    };
+
+    // Act
+    await notifyRoadmapSubscribers('New feature shipped: voice rooms!');
+
+    // Assert: a notification queue entry was created
+    const queueEntries = Object.entries(_store).filter(([k]) => k.startsWith('notificationQueue/'));
+    expect(queueEntries.length).toBeGreaterThanOrEqual(1);
+
+    const [, entry] = queueEntries[0];
+    expect(entry.type).toBe('roadmapUpdate');
+    expect(entry.uid).toBe('user1');
+    expect(entry.status).toBe('queued');
+    expect(entry.title).toContain('Roadmap');
+    expect(entry.body).toContain('voice rooms');
+  });
+
+  it('creates notification with email channel when subscriber has roadmapUpdate.email enabled', async () => {
+    _store['subscriptions/user2'] = {
+      uid: 'user2',
+      email: 'user2@test.com',
+      channelPreferences: {
+        roadmapUpdate: { email: true, push: false, inApp: true, systemMessage: false },
+      },
+    };
+
+    await notifyRoadmapSubscribers('Phase 3 complete');
+
+    const queueEntries = Object.entries(_store).filter(([k]) => k.startsWith('notificationQueue/'));
+    expect(queueEntries.length).toBeGreaterThanOrEqual(1);
+
+    const [, entry] = queueEntries[0];
+    expect(entry.channels.email).toBe(true);
+    expect(entry.email).toBe('user2@test.com');
+  });
+
+  it('does NOT create notifications for subscribers with roadmapUpdate disabled', async () => {
+    _store['subscriptions/user3'] = {
+      uid: 'user3',
+      channelPreferences: {
+        roadmapUpdate: { email: false, push: false, inApp: false, systemMessage: false },
+      },
+    };
+
+    await notifyRoadmapSubscribers('Minor update');
+
+    const queueEntries = Object.entries(_store).filter(([k]) => k.startsWith('notificationQueue/'));
+    expect(queueEntries.length).toBe(0);
+  });
+
+  it('does NOT create notifications for subscribers without roadmapUpdate preference', async () => {
+    _store['subscriptions/user4'] = {
+      uid: 'user4',
+      channelPreferences: {
+        suggestionAccepted: { email: true, push: false, inApp: true, systemMessage: false },
+      },
+    };
+
+    await notifyRoadmapSubscribers('Another update');
+
+    const queueEntries = Object.entries(_store).filter(([k]) => k.startsWith('notificationQueue/'));
+    expect(queueEntries.length).toBe(0);
+  });
+
+  it('handles multiple subscribers correctly', async () => {
+    _store['subscriptions/userA'] = {
+      uid: 'userA',
+      channelPreferences: {
+        roadmapUpdate: { email: false, push: false, inApp: true, systemMessage: false },
+      },
+    };
+    _store['subscriptions/userB'] = {
+      uid: 'userB',
+      email: 'b@test.com',
+      channelPreferences: {
+        roadmapUpdate: { email: true, push: true, inApp: true, systemMessage: true },
+      },
+    };
+    _store['subscriptions/userC'] = {
+      uid: 'userC',
+      channelPreferences: {
+        roadmapUpdate: { email: false, push: false, inApp: false, systemMessage: false },
+      },
+    };
+
+    await notifyRoadmapSubscribers('Big release');
+
+    const queueEntries = Object.entries(_store).filter(([k]) => k.startsWith('notificationQueue/'));
+    // userA (inApp) + userB (all channels) = 2 entries. userC opted out = 0.
+    expect(queueEntries.length).toBe(2);
+  });
+
+  it('does not crash when there are no subscribers', async () => {
+    // No subscriptions in store
+    await expect(notifyRoadmapSubscribers('No one listening')).resolves.not.toThrow();
+  });
+
+  it('includes the update message in the notification body', async () => {
+    _store['subscriptions/user5'] = {
+      uid: 'user5',
+      channelPreferences: {
+        roadmapUpdate: { email: false, push: false, inApp: true, systemMessage: false },
+      },
+    };
+
+    const message = 'Voice rooms are now live! Join a room and start chatting.';
+    await notifyRoadmapSubscribers(message);
+
+    const queueEntries = Object.entries(_store).filter(([k]) => k.startsWith('notificationQueue/'));
+    expect(queueEntries[0][1].body).toBe(message);
+  });
+});

--- a/express-api/tests/routes/suggestions-comments.test.js
+++ b/express-api/tests/routes/suggestions-comments.test.js
@@ -97,6 +97,10 @@ jest.mock('../../src/utils/log', () => ({
   error: jest.fn(),
 }));
 
+jest.mock('../../src/utils/roadmap-notify', () => ({
+  notifyRoadmapSubscribers: jest.fn().mockResolvedValue(),
+}));
+
 // ─── App setup ──────────────────────────────────────────────────
 
 let suggestionsRouter;

--- a/express-api/tests/routes/suggestions-contracts.test.js
+++ b/express-api/tests/routes/suggestions-contracts.test.js
@@ -150,6 +150,10 @@ jest.mock('../../src/utils/fcm', () => ({
   sendFcmToTokens: jest.fn().mockResolvedValue([]),
 }));
 
+jest.mock('../../src/utils/roadmap-notify', () => ({
+  notifyRoadmapSubscribers: jest.fn().mockResolvedValue(),
+}));
+
 // ─── App setup ──────────────────────────────────────────────────
 
 const suggestionsRouter = require('../../src/routes/suggestions');

--- a/express-api/tests/routes/suggestions-duplicates.test.js
+++ b/express-api/tests/routes/suggestions-duplicates.test.js
@@ -128,6 +128,10 @@ jest.mock('../../src/utils/fcm', () => ({
   sendFcmToTokens: jest.fn().mockResolvedValue([]),
 }));
 
+jest.mock('../../src/utils/roadmap-notify', () => ({
+  notifyRoadmapSubscribers: jest.fn().mockResolvedValue(),
+}));
+
 // ─── App setup ──────────────────────────────────────────────────
 
 let suggestionsRouter;

--- a/express-api/tests/routes/suggestions-integration.test.js
+++ b/express-api/tests/routes/suggestions-integration.test.js
@@ -147,6 +147,10 @@ jest.mock('../../src/utils/email', () => ({
   sendEmail: jest.fn().mockResolvedValue(),
 }));
 
+jest.mock('../../src/utils/roadmap-notify', () => ({
+  notifyRoadmapSubscribers: jest.fn().mockResolvedValue(),
+}));
+
 // --- App setup ---------------------------------------------------------------
 
 const suggestionsRouter = require('../../src/routes/suggestions');

--- a/express-api/tests/routes/suggestions-lifecycle.test.js
+++ b/express-api/tests/routes/suggestions-lifecycle.test.js
@@ -116,6 +116,11 @@ jest.mock('../../src/utils/fcm', () => ({
   sendFcmToTokens: jest.fn().mockResolvedValue([]),
 }));
 
+const mockNotifyRoadmapSubscribers = jest.fn().mockResolvedValue();
+jest.mock('../../src/utils/roadmap-notify', () => ({
+  notifyRoadmapSubscribers: (...args) => mockNotifyRoadmapSubscribers(...args),
+}));
+
 // ─── App setup ──────────────────────────────────────────────────
 
 const suggestionsRouter = require('../../src/routes/suggestions');
@@ -1389,5 +1394,141 @@ describe('11.106 — Concurrent Admin Operations Extended', () => {
       // Stale data is possible — the point is the request doesn't error
       expect(res2.body).toHaveProperty('status');
     }
+  });
+});
+
+// ─── Roadmap subscription notification trigger ──────────────────
+
+describe('Roadmap subscription notification trigger', () => {
+  test('accepted → planned triggers notifyRoadmapSubscribers', async () => {
+    setupDocMocks({
+      'suggestions/sug-1': makeSuggestionSnap('sug-1', {
+        status: 'accepted',
+        title: 'Dark mode support',
+      }),
+      'roadmapFeatures/feat-1': makeRoadmapFeatureSnap('feat-1'),
+    });
+    const app = createAdminApp();
+    await request(app)
+      .put('/api/admin/suggestions/sug-1/status')
+      .send({ status: 'planned', linkedRoadmapFeature: 'feat-1' })
+      .expect(200);
+
+    expect(mockNotifyRoadmapSubscribers).toHaveBeenCalledTimes(1);
+    expect(mockNotifyRoadmapSubscribers).toHaveBeenCalledWith(
+      expect.stringContaining('Dark mode support'),
+    );
+    expect(mockNotifyRoadmapSubscribers).toHaveBeenCalledWith(
+      expect.stringContaining('added to the roadmap'),
+    );
+  });
+
+  test('planned → completed triggers notifyRoadmapSubscribers', async () => {
+    setupDocMocks({
+      'suggestions/sug-1': makeSuggestionSnap('sug-1', {
+        status: 'planned',
+        title: 'Voice rooms',
+        linkedRoadmapFeature: 'feat-1',
+      }),
+    });
+    const app = createAdminApp();
+    await request(app)
+      .put('/api/admin/suggestions/sug-1/status')
+      .send({ status: 'completed' })
+      .expect(200);
+
+    expect(mockNotifyRoadmapSubscribers).toHaveBeenCalledTimes(1);
+    expect(mockNotifyRoadmapSubscribers).toHaveBeenCalledWith(
+      expect.stringContaining('Voice rooms'),
+    );
+    expect(mockNotifyRoadmapSubscribers).toHaveBeenCalledWith(
+      expect.stringContaining('marked as complete'),
+    );
+  });
+
+  test('pending → accepted does NOT trigger notifyRoadmapSubscribers', async () => {
+    setupDocMocks({
+      'suggestions/sug-1': makeSuggestionSnap('sug-1', { status: 'pending' }),
+    });
+    const app = createAdminApp();
+    await request(app)
+      .put('/api/admin/suggestions/sug-1/status')
+      .send({ status: 'accepted' })
+      .expect(200);
+
+    expect(mockNotifyRoadmapSubscribers).not.toHaveBeenCalled();
+  });
+
+  test('pending → rejected does NOT trigger notifyRoadmapSubscribers', async () => {
+    setupDocMocks({
+      'suggestions/sug-1': makeSuggestionSnap('sug-1', { status: 'pending' }),
+    });
+    const app = createAdminApp();
+    await request(app)
+      .put('/api/admin/suggestions/sug-1/status')
+      .send({ status: 'rejected', reason: 'Duplicate' })
+      .expect(200);
+
+    expect(mockNotifyRoadmapSubscribers).not.toHaveBeenCalled();
+  });
+
+  test('completed → planned triggers notifyRoadmapSubscribers (re-planned)', async () => {
+    setupDocMocks({
+      'suggestions/sug-1': makeSuggestionSnap('sug-1', {
+        status: 'completed',
+        title: 'Gift system',
+        linkedRoadmapFeature: 'feat-1',
+        completedAt: 1709913600000,
+      }),
+    });
+    const app = createAdminApp();
+    await request(app)
+      .put('/api/admin/suggestions/sug-1/status')
+      .send({ status: 'planned', reason: 'Needs rework' })
+      .expect(200);
+
+    expect(mockNotifyRoadmapSubscribers).toHaveBeenCalledTimes(1);
+    expect(mockNotifyRoadmapSubscribers).toHaveBeenCalledWith(
+      expect.stringContaining('Gift system'),
+    );
+  });
+
+  test('planned → accepted does NOT trigger notifyRoadmapSubscribers', async () => {
+    setupDocMocks({
+      'suggestions/sug-1': makeSuggestionSnap('sug-1', {
+        status: 'planned',
+        linkedRoadmapFeature: 'feat-1',
+      }),
+    });
+    const app = createAdminApp();
+    await request(app)
+      .put('/api/admin/suggestions/sug-1/status')
+      .send({ status: 'accepted' })
+      .expect(200);
+
+    expect(mockNotifyRoadmapSubscribers).not.toHaveBeenCalled();
+  });
+
+  test('PUT /admin/suggestions/:id/link triggers notifyRoadmapSubscribers', async () => {
+    setupDocMocks({
+      'suggestions/sug-1': makeSuggestionSnap('sug-1', {
+        status: 'accepted',
+        title: 'Custom themes',
+      }),
+      'roadmapFeatures/feat-1': makeRoadmapFeatureSnap('feat-1'),
+    });
+    const app = createAdminApp();
+    await request(app)
+      .put('/api/admin/suggestions/sug-1/link')
+      .send({ roadmapFeatureId: 'feat-1' })
+      .expect(200);
+
+    expect(mockNotifyRoadmapSubscribers).toHaveBeenCalledTimes(1);
+    expect(mockNotifyRoadmapSubscribers).toHaveBeenCalledWith(
+      expect.stringContaining('Custom themes'),
+    );
+    expect(mockNotifyRoadmapSubscribers).toHaveBeenCalledWith(
+      expect.stringContaining('added to the roadmap'),
+    );
   });
 });

--- a/express-api/tests/routes/suggestions-voting.test.js
+++ b/express-api/tests/routes/suggestions-voting.test.js
@@ -114,6 +114,10 @@ jest.mock('../../src/utils/fcm', () => ({
   sendFcmToTokens: jest.fn().mockResolvedValue([]),
 }));
 
+jest.mock('../../src/utils/roadmap-notify', () => ({
+  notifyRoadmapSubscribers: jest.fn().mockResolvedValue(),
+}));
+
 // ─── App setup ──────────────────────────────────────────────────
 
 const suggestionsRouter = require('../../src/routes/suggestions');

--- a/express-api/tests/routes/suggestions.test.js
+++ b/express-api/tests/routes/suggestions.test.js
@@ -134,6 +134,10 @@ jest.mock('../../src/utils/fcm', () => ({
   sendFcmToTokens: jest.fn().mockResolvedValue([]),
 }));
 
+jest.mock('../../src/utils/roadmap-notify', () => ({
+  notifyRoadmapSubscribers: jest.fn().mockResolvedValue(),
+}));
+
 // ─── App setup ──────────────────────────────────────────────────
 
 const suggestionsRouter = require('../../src/routes/suggestions');


### PR DESCRIPTION
## Summary
- roadmapUpdate notification channel was defined in the subscription system but never triggered when suggestions moved to planned/completed status
- Adds `notifyRoadmapSubscribers` utility that queries subscriptions and creates notificationQueue entries for dispatch via the notification-dispatch cron
- Wires trigger into both status change endpoint and link endpoint (fire-and-forget to avoid blocking admin response)
- Respects Firestore 500-doc batch limit via chunked writes
- Fixes rateLimit test timeouts by batching sequential request loops (200/30/5 sequential requests → parallel batches)
- Adds `maxWorkers: '50%'` to jest.config to reduce parallel socket contention

## Test plan
- [x] 7 unit tests for notifyRoadmapSubscribers utility (inApp, email, disabled, no prefs, multiple subscribers, no subscribers, message content)
- [x] 7 integration tests for status change trigger (planned, completed, accepted→no trigger, rejected→no trigger, re-planned, planned→accepted→no trigger, link endpoint)
- [x] Full Express test suite passes (4224 tests)
- [x] ESLint + Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)