### PR TITLE
feat(ios): PlatformTts expect/actual for cross-platform TTS (PR I)

### DIFF
--- a/shared/src/androidMain/kotlin/com/shyden/shytalk/core/audio/PlatformTts.android.kt
+++ b/shared/src/androidMain/kotlin/com/shyden/shytalk/core/audio/PlatformTts.android.kt
@@ -1,0 +1,45 @@
+package com.shyden.shytalk.core.audio
+
+import android.content.Context
+import android.speech.tts.TextToSpeech
+import com.shyden.shytalk.core.util.logW
+import java.util.Locale
+
+actual object PlatformTts {
+    private var engine: TextToSpeech? = null
+
+    actual val isInitialized: Boolean
+        get() = engine != null
+
+    fun initialize(context: Context) {
+        if (engine != null) return
+        engine =
+            TextToSpeech(context) { status ->
+                if (status == TextToSpeech.SUCCESS) {
+                    engine?.language = Locale.US
+                    engine?.setPitch(0.75f)
+                    engine?.setSpeechRate(0.85f)
+                } else {
+                    logW("PlatformTts", "TTS initialization failed with status $status")
+                    engine = null
+                }
+            }
+    }
+
+    actual fun speak(
+        text: String,
+        utteranceId: String,
+    ) {
+        engine?.speak(text, TextToSpeech.QUEUE_FLUSH, null, utteranceId)
+    }
+
+    actual fun stop() {
+        engine?.stop()
+    }
+
+    actual fun release() {
+        engine?.stop()
+        engine?.shutdown()
+        engine = null
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/audio/PlatformTts.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/audio/PlatformTts.kt
@@ -1,0 +1,14 @@
+package com.shyden.shytalk.core.audio
+
+expect object PlatformTts {
+    val isInitialized: Boolean
+
+    fun speak(
+        text: String,
+        utteranceId: String = "",
+    )
+
+    fun stop()
+
+    fun release()
+}

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/audio/PlatformTts.ios.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/audio/PlatformTts.ios.kt
@@ -1,0 +1,41 @@
+package com.shyden.shytalk.core.audio
+
+import platform.AVFAudio.AVSpeechSynthesisVoice
+import platform.AVFAudio.AVSpeechSynthesizer
+import platform.AVFAudio.AVSpeechUtterance
+
+actual object PlatformTts {
+    private var synthesizer: AVSpeechSynthesizer? = null
+
+    actual val isInitialized: Boolean
+        get() = synthesizer != null
+
+    fun initialize() {
+        if (synthesizer != null) return
+        synthesizer = AVSpeechSynthesizer()
+    }
+
+    actual fun speak(
+        text: String,
+        utteranceId: String,
+    ) {
+        if (synthesizer == null) initialize()
+        val utterance = AVSpeechUtterance(string = text)
+        utterance.voice = AVSpeechSynthesisVoice.voiceWithLanguage("en-US")
+        utterance.pitchMultiplier = 0.75f
+        utterance.rate = 0.4f // iOS rate scale differs from Android; 0.4 ≈ Android's 0.85
+        synthesizer?.speakUtterance(utterance)
+    }
+
+    actual fun stop() {
+        if (synthesizer?.isSpeaking() == true) {
+            // Deallocate and recreate to immediately stop all speech
+            // (AVSpeechBoundary constants not directly available in K/N cinterop)
+            synthesizer = AVSpeechSynthesizer()
+        }
+    }
+
+    actual fun release() {
+        synthesizer = null
+    }
+}

--- a/shared/src/jvmMain/kotlin/com/shyden/shytalk/core/audio/PlatformTts.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/shyden/shytalk/core/audio/PlatformTts.jvm.kt
@@ -1,0 +1,20 @@
+package com.shyden.shytalk.core.audio
+
+actual object PlatformTts {
+    actual val isInitialized: Boolean = false
+
+    actual fun speak(
+        text: String,
+        utteranceId: String,
+    ) {
+        // No-op on JVM (test-only target)
+    }
+
+    actual fun stop() {
+        // No-op on JVM (test-only target)
+    }
+
+    actual fun release() {
+        // No-op on JVM (test-only target)
+    }
+}

--- a/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/audio/PlatformTtsTest.kt
+++ b/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/audio/PlatformTtsTest.kt
@@ -1,0 +1,38 @@
+package com.shyden.shytalk.core.audio
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class PlatformTtsTest {
+    @Test
+    fun `speak does not throw on jvm`() {
+        PlatformTts.speak("test message", "test-id")
+    }
+
+    @Test
+    fun `stop does not throw on jvm`() {
+        PlatformTts.stop()
+    }
+
+    @Test
+    fun `release does not throw on jvm`() {
+        PlatformTts.release()
+    }
+
+    @Test
+    fun `isInitialized returns false on jvm`() {
+        assertFalse(PlatformTts.isInitialized)
+    }
+
+    @Test
+    fun `speak then stop does not throw`() {
+        PlatformTts.speak("Room self destruct sequence activated.", "self_destruct")
+        PlatformTts.stop()
+    }
+
+    @Test
+    fun `release then speak does not throw`() {
+        PlatformTts.release()
+        PlatformTts.speak("Should be no-op after release", "post-release")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `PlatformTts` expect/actual object for cross-platform text-to-speech
- Android: wraps `android.speech.tts.TextToSpeech` (US locale, 0.75 pitch, 0.85 rate)
- iOS: wraps `AVSpeechSynthesizer` (en-US voice, matching pitch/rate)
- JVM: no-op stub for test target
- Part of iOS feature parity plan — prerequisite for moving RoomScreen to shared

## Test plan
- [x] 6 JVM contract tests (speak, stop, release, isInitialized, combined operations)
- [x] iOS compilation verified (`compileKotlinIosArm64`)
- [x] Android build verified (`assembleDevDebug`)
- [x] Full Kotlin test suite passes (`testDevDebugUnitTest`, `jvmTest`, `detekt`)
- [x] ktlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)