### PR TITLE
feat(ios): KeepScreenOn + RequestMicPermission expect/actual (PR J)

### DIFF
--- a/shared/src/androidMain/kotlin/com/shyden/shytalk/core/effects/PlatformEffects.android.kt
+++ b/shared/src/androidMain/kotlin/com/shyden/shytalk/core/effects/PlatformEffects.android.kt
@@ -1,0 +1,47 @@
+package com.shyden.shytalk.core.effects
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.view.WindowManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+
+@Composable
+actual fun KeepScreenOn() {
+    val activity = LocalContext.current as? android.app.Activity
+    DisposableEffect(Unit) {
+        activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        onDispose {
+            activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+}
+
+@Composable
+actual fun RequestMicPermission(onResult: (Boolean) -> Unit) {
+    val context = LocalContext.current
+    val launcher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+        ) { granted ->
+            onResult(granted)
+        }
+
+    LaunchedEffect(Unit) {
+        val already =
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.RECORD_AUDIO,
+            ) == PackageManager.PERMISSION_GRANTED
+        if (already) {
+            onResult(true)
+        } else {
+            launcher.launch(Manifest.permission.RECORD_AUDIO)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/effects/PlatformEffects.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/effects/PlatformEffects.kt
@@ -1,0 +1,9 @@
+package com.shyden.shytalk.core.effects
+
+import androidx.compose.runtime.Composable
+
+@Composable
+expect fun KeepScreenOn()
+
+@Composable
+expect fun RequestMicPermission(onResult: (Boolean) -> Unit)

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/effects/PlatformEffects.ios.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/effects/PlatformEffects.ios.kt
@@ -1,0 +1,54 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.shyden.shytalk.core.effects
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionCategoryOptionDefaultToSpeaker
+import platform.AVFAudio.AVAudioSessionCategoryPlayAndRecord
+import platform.AVFAudio.setActive
+import platform.UIKit.UIApplication
+
+@Composable
+actual fun KeepScreenOn() {
+    DisposableEffect(Unit) {
+        UIApplication.sharedApplication.idleTimerDisabled = true
+        onDispose {
+            UIApplication.sharedApplication.idleTimerDisabled = false
+        }
+    }
+}
+
+@Composable
+actual fun RequestMicPermission(onResult: (Boolean) -> Unit) {
+    LaunchedEffect(Unit) {
+        val session = AVAudioSession.sharedInstance()
+        session.requestRecordPermission { granted ->
+            onResult(granted)
+        }
+    }
+
+    // Also configure the audio session for voice room use
+    DisposableEffect(Unit) {
+        val session = AVAudioSession.sharedInstance()
+        try {
+            session.setCategory(
+                AVAudioSessionCategoryPlayAndRecord,
+                withOptions = AVAudioSessionCategoryOptionDefaultToSpeaker,
+                error = null,
+            )
+            session.setActive(true, error = null)
+        } catch (_: Exception) {
+            // Audio session setup failure is non-fatal
+        }
+        onDispose {
+            try {
+                session.setActive(false, error = null)
+            } catch (_: Exception) {
+                // Best effort cleanup
+            }
+        }
+    }
+}

--- a/shared/src/jvmMain/kotlin/com/shyden/shytalk/core/effects/PlatformEffects.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/shyden/shytalk/core/effects/PlatformEffects.jvm.kt
@@ -1,0 +1,13 @@
+package com.shyden.shytalk.core.effects
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun KeepScreenOn() {
+    // No-op on JVM (test-only target)
+}
+
+@Composable
+actual fun RequestMicPermission(onResult: (Boolean) -> Unit) {
+    // No-op on JVM (test-only target)
+}

--- a/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/effects/PlatformEffectsTest.kt
+++ b/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/effects/PlatformEffectsTest.kt
@@ -1,0 +1,26 @@
+package com.shyden.shytalk.core.effects
+
+import kotlin.test.Test
+
+class PlatformEffectsTest {
+    @Test
+    fun `KeepScreenOn composable exists and is callable`() {
+        // Verify the function signature exists — actual rendering is platform-specific.
+        // The composable is a no-op on JVM; this test verifies the expect/actual compiles.
+        val fn: @androidx.compose.runtime.Composable () -> Unit = { KeepScreenOn() }
+
+        // Composables can't be invoked outside a composition, so just verify the reference exists.
+        @Suppress("UNUSED_VARIABLE")
+        val ref = fn
+    }
+
+    @Test
+    fun `RequestMicPermission composable exists and is callable`() {
+        val fn: @androidx.compose.runtime.Composable (onResult: (Boolean) -> Unit) -> Unit = { onResult ->
+            RequestMicPermission(onResult = onResult)
+        }
+
+        @Suppress("UNUSED_VARIABLE")
+        val ref = fn
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `KeepScreenOn` and `RequestMicPermission` cross-platform composable effects
- Android: `FLAG_KEEP_SCREEN_ON` + `ActivityResultContracts.RequestPermission()`
- iOS: `UIApplication.idleTimerDisabled` + `AVAudioSession.requestRecordPermission`
- iOS also configures audio session for PlayAndRecord with speaker output
- JVM: no-op stubs for test target
- Part of iOS feature parity plan — prerequisite for moving RoomScreen to shared

## Test plan
- [x] 2 JVM contract tests (composable references compile)
- [x] iOS compilation verified (`compileKotlinIosArm64`)
- [x] Full Kotlin test suite passes (`testDevDebugUnitTest`, `jvmTest`, `detekt`)
- [x] ktlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)