### PR TITLE
feat(ios): real PHPicker image picking (PR G)

### DIFF
--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/navigation/IosPlatformNavCallbacks.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/navigation/IosPlatformNavCallbacks.kt
@@ -1,6 +1,7 @@
 package com.shyden.shytalk.navigation
 
 import com.shyden.shytalk.core.util.logW
+import com.shyden.shytalk.util.IosImagePicker
 import platform.Foundation.NSCharacterSet
 import platform.Foundation.NSString
 import platform.Foundation.NSURL
@@ -13,7 +14,7 @@ import platform.Foundation.stringByRemovingPercentEncoding
  *
  * v1: Most callbacks are no-ops (FCM, permissions, billing, sync service).
  * URL encoding uses Foundation's percent-encoding APIs.
- * Media picking stubs will be replaced with PHPicker in a future PR.
+ * Media picking uses PHPickerViewController for image selection.
  */
 class IosPlatformNavCallbacks : PlatformNavCallbacks {
     // ── Push notifications (no-op v1 — APNs integration in future PR) ──
@@ -44,24 +45,23 @@ class IosPlatformNavCallbacks : PlatformNavCallbacks {
 
     override fun canDrawOverlays(): Boolean = false // Not applicable on iOS
 
-    // ── Media picking (stubs v1) ──
+    // ── Media picking (PHPickerViewController) ──
 
     override fun pickImages(
         maxCount: Int,
         onResult: (List<ByteArray>) -> Unit,
     ) {
-        logW("IosPlatformNavCallbacks", "pickImages($maxCount) — PHPickerViewController not yet integrated")
-        onResult(emptyList())
+        IosImagePicker.pickImages(maxCount = maxCount, onResult = onResult)
     }
 
     override fun pickStickerImage(onResult: (ByteArray?) -> Unit) {
-        logW("IosPlatformNavCallbacks", "pickStickerImage — PHPickerViewController not yet integrated")
-        onResult(null)
+        IosImagePicker.pickSingleImage(onResult = onResult)
     }
 
     override fun pickAndCropPhoto(onResult: (ByteArray?) -> Unit) {
-        logW("IosPlatformNavCallbacks", "pickAndCropPhoto — PHPickerViewController not yet integrated")
-        onResult(null)
+        // iOS has no built-in crop UI in PHPicker — deliver the raw image.
+        // A crop overlay can be added later if needed.
+        IosImagePicker.pickSingleImage(onResult = onResult)
     }
 
     // ── Billing (no-op v1 — StoreKit integration in future PR) ──

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/util/IosImagePicker.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/util/IosImagePicker.kt
@@ -1,0 +1,129 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
+
+package com.shyden.shytalk.util
+
+import com.shyden.shytalk.core.util.logE
+import com.shyden.shytalk.core.util.logW
+import kotlinx.cinterop.refTo
+import platform.Foundation.NSData
+import platform.PhotosUI.PHPickerConfiguration
+import platform.PhotosUI.PHPickerFilter
+import platform.PhotosUI.PHPickerResult
+import platform.PhotosUI.PHPickerViewController
+import platform.PhotosUI.PHPickerViewControllerDelegateProtocol
+import platform.UIKit.UIApplication
+import platform.UIKit.UIImage
+import platform.UIKit.UIImageJPEGRepresentation
+import platform.UniformTypeIdentifiers.UTTypeImage
+import platform.darwin.NSObject
+import platform.posix.memcpy
+
+/**
+ * iOS image picker using PHPickerViewController.
+ *
+ * Presents the system photo picker and delivers selected images as ByteArray.
+ * Automatically compresses images to JPEG at 0.8 quality.
+ */
+object IosImagePicker {
+    private const val JPEG_QUALITY = 0.8
+
+    fun pickImages(
+        maxCount: Int,
+        onResult: (List<ByteArray>) -> Unit,
+    ) {
+        val config = PHPickerConfiguration()
+        config.selectionLimit = maxCount.toLong()
+        config.filter = PHPickerFilter.imagesFilter
+
+        val picker = PHPickerViewController(configuration = config)
+        val delegate = PickerDelegate(maxCount, onResult)
+        picker.delegate = delegate
+
+        presentPicker(picker)
+    }
+
+    fun pickSingleImage(onResult: (ByteArray?) -> Unit) {
+        pickImages(maxCount = 1) { results ->
+            onResult(results.firstOrNull())
+        }
+    }
+
+    private fun presentPicker(picker: PHPickerViewController) {
+        val rootVc = getRootViewController()
+        if (rootVc == null) {
+            logW("IosImagePicker", "No root view controller available to present picker")
+            return
+        }
+        rootVc.presentViewController(picker, animated = true, completion = null)
+    }
+
+    private fun getRootViewController(): platform.UIKit.UIViewController? {
+        val scenes = UIApplication.sharedApplication.connectedScenes
+        for (scene in scenes) {
+            val windowScene = scene as? platform.UIKit.UIWindowScene ?: continue
+            val window = windowScene.keyWindow ?: continue
+            return window.rootViewController
+        }
+        return null
+    }
+
+    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+    private class PickerDelegate(
+        private val maxCount: Int,
+        private val onResult: (List<ByteArray>) -> Unit,
+    ) : NSObject(),
+        PHPickerViewControllerDelegateProtocol {
+        // Strong reference to self to prevent GC before callback
+        private var selfRef: PickerDelegate? = this
+
+        override fun picker(
+            picker: PHPickerViewController,
+            didFinishPicking: List<*>,
+        ) {
+            picker.dismissViewControllerAnimated(true, completion = null)
+
+            val results = didFinishPicking.filterIsInstance<PHPickerResult>()
+            if (results.isEmpty()) {
+                onResult(emptyList())
+                selfRef = null
+                return
+            }
+
+            val images = mutableListOf<ByteArray>()
+            var remaining = results.size
+
+            for (result in results) {
+                result.itemProvider.loadDataRepresentationForTypeIdentifier(
+                    UTTypeImage.identifier,
+                ) { data, error ->
+                    if (error != null) {
+                        logE("IosImagePicker", "Failed to load image: ${error.localizedDescription}")
+                    } else if (data != null) {
+                        // Convert to UIImage for JPEG compression
+                        val image = UIImage(data = data)
+                        val jpegData = UIImageJPEGRepresentation(image, JPEG_QUALITY)
+                        if (jpegData != null) {
+                            val bytes = nsDataToByteArray(jpegData)
+                            images.add(bytes)
+                        }
+                    }
+
+                    remaining--
+                    if (remaining == 0) {
+                        onResult(images.take(maxCount))
+                        selfRef = null
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+internal fun nsDataToByteArray(data: NSData): ByteArray {
+    val length = data.length.toInt()
+    if (length == 0) return ByteArray(0)
+    val bytes = ByteArray(length)
+    memcpy(bytes.refTo(0), data.bytes, data.length)
+    return bytes
+}


### PR DESCRIPTION
## Summary
- Replaces iOS image picking stubs with real PHPickerViewController implementation
- `IosImagePicker` object presents system photo picker and converts to JPEG ByteArray
- Multi-image selection (`pickImages`) and single image selection (`pickStickerImage`, `pickAndCropPhoto`)
- Uses `loadDataRepresentationForTypeIdentifier` for K/N cinterop compatibility
- Strong delegate reference pattern to prevent GC before callback completes
- Part of iOS feature parity plan — enables real image selection in Profile and Room screens

## Test plan
- [x] iOS compilation verified (`compileKotlinIosArm64`)
- [x] Full Kotlin test suite passes (`testDevDebugUnitTest`, `jvmTest`, `detekt`)
- [x] ktlint clean
- [ ] Manual testing on iOS Simulator (photo picker presents, image returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)