### PR TITLE
fix(web): subscribe button uses shared login modal + fix sign-in order

### DIFF
--- a/public/js/suggestions-board.js
+++ b/public/js/suggestions-board.js
@@ -420,28 +420,6 @@
 
     document.body.insertAdjacentHTML("beforeend", html);
 
-    // Wire up Google/Apple sign-in buttons
-    var modalOverlay = document.getElementById("sg-login-modal-overlay");
-    var googleSignIn = modalOverlay.querySelector(".auth-google-btn");
-    var appleSignIn = modalOverlay.querySelector(".auth-apple-btn");
-    function closeModal() { modalOverlay.remove(); }
-    if (googleSignIn) {
-      googleSignIn.addEventListener("click", function () {
-        if (window.shytalkAuth && window.shytalkAuth.signInWithGoogle) {
-          window.shytalkAuth.signInWithGoogle();
-        }
-        closeModal();
-      });
-    }
-    if (appleSignIn) {
-      appleSignIn.addEventListener("click", function () {
-        if (window.shytalkAuth && window.shytalkAuth.signInWithApple) {
-          window.shytalkAuth.signInWithApple();
-        }
-        closeModal();
-      });
-    }
-
     var overlay = document.getElementById("sg-login-modal-overlay");
     var closeBtn = overlay.querySelector(".sg-modal-close");
     var modalContent = overlay.querySelector(".sg-modal");
@@ -450,6 +428,26 @@
       overlay.remove();
       document.removeEventListener("click", outsideClickHandler, true);
       document.removeEventListener("keydown", keyHandler);
+    }
+
+    // Wire up Google/Apple sign-in buttons
+    var googleSignIn = overlay.querySelector(".auth-google-btn");
+    var appleSignIn = overlay.querySelector(".auth-apple-btn");
+    if (googleSignIn) {
+      googleSignIn.addEventListener("click", function () {
+        if (window.shytalkAuth && window.shytalkAuth.signInWithGoogle) {
+          window.shytalkAuth.signInWithGoogle();
+        }
+        close();
+      });
+    }
+    if (appleSignIn) {
+      appleSignIn.addEventListener("click", function () {
+        if (window.shytalkAuth && window.shytalkAuth.signInWithApple) {
+          window.shytalkAuth.signInWithApple();
+        }
+        close();
+      });
     }
 
     function outsideClickHandler(e) {

--- a/public/js/suggestions-board.js
+++ b/public/js/suggestions-board.js
@@ -427,14 +427,18 @@
     function closeModal() { modalOverlay.remove(); }
     if (googleSignIn) {
       googleSignIn.addEventListener("click", function () {
+        if (window.shytalkAuth && window.shytalkAuth.signInWithGoogle) {
+          window.shytalkAuth.signInWithGoogle();
+        }
         closeModal();
-        if (window.shytalkAuth && window.shytalkAuth.signInWithGoogle) window.shytalkAuth.signInWithGoogle();
       });
     }
     if (appleSignIn) {
       appleSignIn.addEventListener("click", function () {
+        if (window.shytalkAuth && window.shytalkAuth.signInWithApple) {
+          window.shytalkAuth.signInWithApple();
+        }
         closeModal();
-        if (window.shytalkAuth && window.shytalkAuth.signInWithApple) window.shytalkAuth.signInWithApple();
       });
     }
 
@@ -474,22 +478,7 @@
     var existing = document.getElementById("sg-subscribe-overlay");
     if (existing) existing.remove();
 
-    var isAuthed = getUser() && hasValidAccount();
-    var bodyHtml = isAuthed
-      ? '<div class="sg-loading">Loading preferences...</div>'
-      : '<div class="login-prompt" data-testid="login-prompt">' +
-          '<p style="text-align:center;margin-bottom:16px;">' + sgT("signInTo") + " manage subscriptions.</p>" +
-          '<div class="auth-buttons" style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap;">' +
-            '<button class="auth-google-btn" data-testid="auth-google-btn" aria-label="Sign in with Google" style="display:inline-flex;align-items:center;gap:10px;padding:10px 24px;background:#fff;color:#3c4043;border:1px solid #dadce0;border-radius:4px;font-size:14px;font-weight:500;cursor:pointer;min-height:44px;">' +
-              '<svg width="20" height="20" viewBox="0 0 48 48"><path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/><path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/><path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/><path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/></svg>' +
-              "<span>" + sgT("signInGoogle") + "</span>" +
-            "</button>" +
-            '<button class="auth-apple-btn" data-testid="auth-apple-btn" aria-label="Sign in with Apple" style="display:inline-flex;align-items:center;gap:10px;padding:10px 24px;background:#000;color:#fff;border:none;border-radius:4px;font-size:14px;font-weight:500;cursor:pointer;min-height:44px;">' +
-              '<svg width="20" height="20" viewBox="0 0 24 24"><path fill="#fff" d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.53-3.23 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>' +
-              "<span>" + sgT("signInApple") + "</span>" +
-            "</button>" +
-          "</div>" +
-        "</div>";
+    var bodyHtml = '<div class="sg-loading">Loading preferences...</div>';
 
     var html =
       '<div class="sg-modal-overlay subscribe-modal" id="sg-subscribe-overlay" data-testid="subscribe-modal">' +
@@ -536,24 +525,8 @@
       if (e.target === overlay) close();
     });
 
-    // If not authed, wire up the Google/Apple sign-in buttons in the login-prompt body
-    if (!isAuthed) {
-      var googleBtn = overlay.querySelector(".auth-google-btn");
-      var appleBtn = overlay.querySelector(".auth-apple-btn");
-      if (googleBtn) {
-        googleBtn.addEventListener("click", function () {
-          close();
-          if (window.shytalkAuth && window.shytalkAuth.signInWithGoogle) window.shytalkAuth.signInWithGoogle();
-        });
-      }
-      if (appleBtn) {
-        appleBtn.addEventListener("click", function () {
-          close();
-          if (window.shytalkAuth && window.shytalkAuth.signInWithApple) window.shytalkAuth.signInWithApple();
-        });
-      }
-      return; // Skip preferences loading
-    }
+    // openSubscribeModal is only called when user is already authenticated
+    // (unauthenticated users are directed to showLoginPromptModal instead)
 
     if (gdprCheckbox) {
       gdprCheckbox.addEventListener("change", function () {
@@ -1499,7 +1472,12 @@
     btn.replaceWith(btn.cloneNode(true));
     btn = document.getElementById("subscribe-btn");
     btn.addEventListener("click", function () {
-      openSubscribeModal(null);
+      var isAuthed = getUser() && hasValidAccount();
+      if (!isAuthed) {
+        showLoginPromptModal("manage subscriptions");
+      } else {
+        openSubscribeModal(null);
+      }
     });
   }
 

--- a/tests/web/roadmap-auth.spec.ts
+++ b/tests/web/roadmap-auth.spec.ts
@@ -153,6 +153,141 @@ test.describe('Roadmap Auth — Login Prompt', () => {
   });
 });
 
+test.describe('Roadmap Auth — Subscribe uses shared login modal', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/roadmap.html');
+  });
+
+  test('subscribe button (unauthenticated) opens the shared login modal, NOT its own modal', async ({
+    page,
+  }) => {
+    const subscribeBtn = page.locator('[data-testid="subscribe-btn"], .subscribe-btn');
+    await subscribeBtn.waitFor({ timeout: 10_000 });
+    await subscribeBtn.click();
+
+    // Should open the shared login modal (login-modal-overlay), NOT the subscribe modal
+    const loginModal = page.locator('[data-testid="login-modal-overlay"]');
+    await expect(loginModal).toBeVisible({ timeout: 5_000 });
+
+    // The subscribe-specific modal should NOT appear when unauthenticated
+    const subscribeModal = page.locator('[data-testid="subscribe-modal"]');
+    expect(await subscribeModal.count()).toBe(0);
+  });
+
+  test('subscribe login modal matches bell login modal (same testid, same structure)', async ({
+    page,
+  }) => {
+    // Open via subscribe button
+    const subscribeBtn = page.locator('[data-testid="subscribe-btn"], .subscribe-btn');
+    await subscribeBtn.waitFor({ timeout: 10_000 });
+    await subscribeBtn.click();
+
+    const modal = page.locator('[data-testid="login-modal-overlay"]');
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    // Should have Google + Apple sign-in buttons
+    await expect(modal.locator('[data-testid="auth-google-btn"]')).toBeVisible();
+    await expect(modal.locator('[data-testid="auth-apple-btn"]')).toBeVisible();
+
+    // Should have close button
+    await expect(modal.locator('[data-testid="login-modal-close"]')).toBeVisible();
+  });
+
+  test('Google sign-in button calls signInWithGoogle (not just closing the modal)', async ({
+    page,
+  }) => {
+    // Intercept the signInWithGoogle call
+    await page.evaluate(() => {
+      (window as any).__signInCalled = null;
+      if ((window as any).shytalkAuth) {
+        (window as any).shytalkAuth.signInWithGoogle = () => {
+          (window as any).__signInCalled = 'google';
+        };
+      }
+      // Also set up for late binding
+      const origDesc = Object.getOwnPropertyDescriptor(window, 'shytalkAuth');
+      if (!origDesc || !origDesc.set) {
+        let _auth = (window as any).shytalkAuth;
+        Object.defineProperty(window, 'shytalkAuth', {
+          get: () => _auth,
+          set: (v) => {
+            _auth = v;
+            if (_auth) {
+              _auth.signInWithGoogle = () => {
+                (window as any).__signInCalled = 'google';
+              };
+            }
+          },
+          configurable: true,
+        });
+      }
+    });
+
+    // Trigger the login modal
+    const suggestBtn = page.locator('[data-testid="suggest-btn"]');
+    await suggestBtn.waitFor({ timeout: 10_000 });
+    await suggestBtn.click();
+    const modal = page.locator('[data-testid="login-modal-overlay"]');
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    // Click Google sign-in
+    await modal.locator('[data-testid="auth-google-btn"]').click();
+
+    // Verify signInWithGoogle was called
+    const called = await page.evaluate(() => (window as any).__signInCalled);
+    expect(called).toBe('google');
+  });
+
+  test('Apple sign-in button calls signInWithApple (not just closing the modal)', async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      (window as any).__signInCalled = null;
+      if ((window as any).shytalkAuth) {
+        (window as any).shytalkAuth.signInWithApple = () => {
+          (window as any).__signInCalled = 'apple';
+        };
+      }
+      const origDesc = Object.getOwnPropertyDescriptor(window, 'shytalkAuth');
+      if (!origDesc || !origDesc.set) {
+        let _auth = (window as any).shytalkAuth;
+        Object.defineProperty(window, 'shytalkAuth', {
+          get: () => _auth,
+          set: (v) => {
+            _auth = v;
+            if (_auth) {
+              _auth.signInWithApple = () => {
+                (window as any).__signInCalled = 'apple';
+              };
+            }
+          },
+          configurable: true,
+        });
+      }
+    });
+
+    const suggestBtn = page.locator('[data-testid="suggest-btn"]');
+    await suggestBtn.waitFor({ timeout: 10_000 });
+    await suggestBtn.click();
+    const modal = page.locator('[data-testid="login-modal-overlay"]');
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    await modal.locator('[data-testid="auth-apple-btn"]').click();
+
+    const called = await page.evaluate(() => (window as any).__signInCalled);
+    expect(called).toBe('apple');
+  });
+
+  test('bell button (unauthenticated) opens the shared login modal', async ({ page }) => {
+    const bell = page.locator('[data-testid="feature-bell"], .feature-bell').first();
+    await bell.waitFor({ timeout: 10_000 });
+    await bell.click();
+
+    const loginModal = page.locator('[data-testid="login-modal-overlay"]');
+    await expect(loginModal).toBeVisible({ timeout: 5_000 });
+  });
+});
+
 test.describe('Roadmap Auth — No Account Found', () => {
   test('shows download prompt when Google login has no ShyTalk account', async ({ page }) => {
     // Simulate: user authenticated with Google but API returns 404

--- a/tests/web/suggestions-subscribe.spec.ts
+++ b/tests/web/suggestions-subscribe.spec.ts
@@ -19,28 +19,31 @@ test.describe('Subscribe Modal', () => {
 
   // ── 11.12 — Subscribe Modal ──
 
-  test('opens from header Subscribe button', async ({ page }) => {
+  test('unauthenticated: subscribe button opens shared login modal', async ({ page }) => {
     const subscribeBtn = page.locator('[data-testid="subscribe-btn"], .subscribe-btn');
     await subscribeBtn.waitFor({ timeout: 10_000 });
     await subscribeBtn.click();
-    const modal = page.locator('[data-testid="subscribe-modal"], .subscribe-modal');
-    await expect(modal).toBeVisible({ timeout: 5_000 });
+    // When not logged in, should show the shared login modal (not the subscribe modal)
+    const loginModal = page.locator('[data-testid="login-modal-overlay"]');
+    await expect(loginModal).toBeVisible({ timeout: 5_000 });
   });
 
-  test('opens from per-feature bell icon (feature pre-selected)', async ({ page }) => {
+  test('unauthenticated: bell icon opens shared login modal', async ({ page }) => {
     const bell = page.locator('[data-testid="feature-bell"], .feature-bell').first();
     await bell.waitFor({ timeout: 10_000 });
     await bell.click();
-    // If login prompt appears, that's tested elsewhere — here we test the modal flow
+    const loginModal = page.locator('[data-testid="login-modal-overlay"]');
+    await expect(loginModal).toBeVisible({ timeout: 5_000 });
   });
 
-  test('shows login prompt when not logged in', async ({ page }) => {
+  test('unauthenticated: login modal has Google and Apple sign-in buttons', async ({ page }) => {
     const subscribeBtn = page.locator('[data-testid="subscribe-btn"], .subscribe-btn');
-    if (await subscribeBtn.count() > 0) {
-      await subscribeBtn.click();
-      const loginPrompt = page.locator('[data-testid="login-prompt"], .login-prompt');
-      await expect(loginPrompt).toBeVisible({ timeout: 5_000 });
-    }
+    await subscribeBtn.waitFor({ timeout: 10_000 });
+    await subscribeBtn.click();
+    const loginModal = page.locator('[data-testid="login-modal-overlay"]');
+    await expect(loginModal).toBeVisible({ timeout: 5_000 });
+    await expect(loginModal.locator('[data-testid="auth-google-btn"]')).toBeVisible();
+    await expect(loginModal.locator('[data-testid="auth-apple-btn"]')).toBeVisible();
   });
 
   test('all event types listed with 4 channel toggles each', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Subscribe button (when unauthenticated) now opens the **shared login modal** (`showLoginPromptModal`) instead of building its own duplicate inline auth buttons
- Google/Apple sign-in buttons now call `signInWithGoogle`/`signInWithApple` **before** closing the modal, preserving the user-gesture context needed for `signInWithPopup`
- Removed duplicate auth UI from `openSubscribeModal` — it's now only callable when already authenticated

## Root cause
The subscribe button built its own inline Google/Apple auth buttons that were visually different from the shared login modal used by bell icons and other auth-gated actions. The sign-in also silently failed because `closeModal()` was called before `signInWithPopup()`, which in some browsers loses the user-gesture context needed to open the popup.

## Test plan
- [x] 5 new Playwright tests verifying subscribe uses the shared login modal
- [x] 3 existing subscribe tests updated to match new behaviour
- [x] 295 roadmap auth tests pass across 5 browsers (chromium, firefox, webkit, mobile-chrome, mobile-safari)
- [x] 36 subscribe tests pass
- [x] Express API tests pass (4224 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)