### PR TITLE
fix(web): bell auth check + Google account picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ public/admin/config.js
 public/admin/config.dev.js
 public/portal/config.js
 public/js/roadmap-config.js
+.scannerwork/
 /node_modules/
 e2e_results/
 test_output.txt

--- a/public/js/roadmap-app.js
+++ b/public/js/roadmap-app.js
@@ -739,8 +739,13 @@
     for (var i = 0; i < bells.length; i++) {
       bells[i].addEventListener("click", function (e) {
         e.stopPropagation();
-        // Show login modal (from suggestions-board.js) instead of toast
-        if (window.shytalkShowLoginModal) {
+        var auth = window.shytalkAuth;
+        if (auth && auth.currentUser && auth.profile) {
+          // Authenticated — open subscribe modal
+          if (window.shytalkOpenSubscribeModal) {
+            window.shytalkOpenSubscribeModal();
+          }
+        } else if (window.shytalkShowLoginModal) {
           window.shytalkShowLoginModal("subscribe to feature updates");
         } else {
           showLoginToast();

--- a/public/js/roadmap-auth.js
+++ b/public/js/roadmap-auth.js
@@ -180,6 +180,7 @@
   function signInWithGoogle() {
     if (!auth) return;
     var provider = new firebase.auth.GoogleAuthProvider();
+    provider.setCustomParameters({ prompt: 'select_account' });
     auth.signInWithPopup(provider).catch(function (err) {
       if (err.code !== 'auth/popup-closed-by-user') {
         console.error('Google sign-in failed:', err);

--- a/public/js/suggestions-board.js
+++ b/public/js/suggestions-board.js
@@ -1481,8 +1481,9 @@
     setupHeaderSubscribe();
     fetchSuggestions();
 
-    // Expose login modal globally so roadmap-app.js bell handlers can use it
+    // Expose modals globally so roadmap-app.js bell handlers can use them
     window.shytalkShowLoginModal = showLoginPromptModal;
+    window.shytalkOpenSubscribeModal = openSubscribeModal;
 
     // Re-render when auth state changes (show/hide suggest button)
     document.addEventListener("shytalk-auth-changed", function () {

--- a/tests/web/roadmap-auth.spec.ts
+++ b/tests/web/roadmap-auth.spec.ts
@@ -1200,3 +1200,89 @@ test.describe('Roadmap Auth — Mobile Responsiveness', () => {
     }
   });
 });
+
+test.describe('Roadmap Auth — Bell icon auth behaviour', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/roadmap.html');
+  });
+
+  test('bell icon when NOT authenticated opens login modal', async ({ page }) => {
+    const bell = page.locator('[data-testid="feature-bell"]').first();
+    await bell.waitFor({ timeout: 10_000 });
+    await bell.click();
+    const loginModal = page.locator('[data-testid="login-modal-overlay"]');
+    await expect(loginModal).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('bell icon when authenticated does NOT open login modal', async ({ page }) => {
+    // Simulate authenticated state
+    await page.evaluate(() => {
+      (window as any).shytalkAuth = {
+        ...(window as any).shytalkAuth,
+        currentUser: {
+          uid: 'test-123',
+          displayName: 'TestUser',
+          getIdToken: () => Promise.resolve('fake'),
+        },
+        profile: { uniqueId: 1001, displayName: 'TestUser' },
+      };
+    });
+
+    const bell = page.locator('[data-testid="feature-bell"]').first();
+    await bell.waitFor({ timeout: 10_000 });
+    await bell.click();
+
+    // Login modal should NOT appear for authenticated users
+    const loginModal = page.locator('[data-testid="login-modal-overlay"]');
+    await page.waitForTimeout(1000);
+    expect(await loginModal.count()).toBe(0);
+  });
+
+  test('bell icon when authenticated opens subscribe modal', async ({ page }) => {
+    // Simulate authenticated state with profile
+    await page.evaluate(() => {
+      (window as any).shytalkAuth = {
+        ...(window as any).shytalkAuth,
+        currentUser: {
+          uid: 'test-123',
+          displayName: 'TestUser',
+          getIdToken: () => Promise.resolve('fake'),
+        },
+        profile: { uniqueId: 1001, displayName: 'TestUser' },
+      };
+    });
+
+    // Mock the subscribe API to avoid real network call
+    await page.route('**/api/roadmap/subscribe/preferences*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ preferences: {}, watchList: [] }),
+      }),
+    );
+
+    const bell = page.locator('[data-testid="feature-bell"]').first();
+    await bell.waitFor({ timeout: 10_000 });
+    await bell.click();
+
+    // Subscribe modal should appear (not login modal)
+    const subscribeModal = page.locator('[data-testid="subscribe-modal"]');
+    await expect(subscribeModal).toBeVisible({ timeout: 5_000 });
+  });
+});
+
+test.describe('Roadmap Auth — Google account picker', () => {
+  test('signInWithGoogle source contains select_account prompt', async ({ page }) => {
+    await page.goto('/roadmap.html');
+
+    // Verify the signInWithGoogle function source includes setCustomParameters with select_account
+    // This is a static analysis test — Firebase SDK may not be initialized in test mode
+    const source = await page.evaluate(async () => {
+      const res = await fetch('/js/roadmap-auth.js');
+      return res.text();
+    });
+    expect(source).toContain("prompt");
+    expect(source).toContain("select_account");
+    expect(source).toMatch(/setCustomParameters.*select_account|select_account.*setCustomParameters/s);
+  });
+});


### PR DESCRIPTION
## Summary
- **Bell icons**: now check auth state — authenticated users get subscribe modal, not login prompt
- **Google sign-in**: added `prompt: 'select_account'` so users can choose which Google account to use on re-sign-in
- **SonarCloud**: `.scannerwork` added to `.gitignore`

## Test plan
- [x] 66 roadmap-auth tests pass (4 new bell/picker tests)
- [ ] Verify on PROD: bell icons work correctly when signed in
- [ ] Verify on PROD: Google re-sign-in shows account picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)