### PR TITLE
feat(web): shared header component across all pages

### DIFF
--- a/public/community-guidelines.html
+++ b/public/community-guidelines.html
@@ -231,6 +231,7 @@
     </footer>
   </div>
 <script>window.LEGAL_PAGE_TYPE = 'guidelines';</script>
+<script src="/js/shared-header.js"></script>
 <script src="/js/language-selector.js"></script>
 <script src="/js/legal-translations.js"></script>
 <script>

--- a/public/cyber-bullying.html
+++ b/public/cyber-bullying.html
@@ -278,6 +278,7 @@
 <script>window.LEGAL_PAGE_TYPE = 'cyber';</script>
 <script src="/js/legal-translations.js"></script>
 <script src="/js/logger.js"></script>
+<script src="/js/shared-header.js"></script>
 <script src="/js/language-selector.js" defer></script>
 <script>
   ShyTalkLogger.init({

--- a/public/index.html
+++ b/public/index.html
@@ -160,6 +160,7 @@
   }
 </style>
 <script src="/js/logger.js"></script>
+<script src="/js/shared-header.js"></script>
 <script src="/js/language-selector.js" defer></script>
 </head>
 <body>

--- a/public/js/shared-header.js
+++ b/public/js/shared-header.js
@@ -1,0 +1,279 @@
+/**
+ * ShyTalk Shared Header
+ *
+ * Consistent header across all web pages.
+ * - Logo (left) linking to home
+ * - Auth state (right): user info dropdown when signed in, Sign In button when not
+ * - Listens for shytalk-auth-changed events to update state
+ *
+ * Usage: <script src="/js/shared-header.js"></script>
+ * The header injects itself at the top of <body> automatically.
+ */
+(function () {
+  'use strict';
+
+  var isRendered = false;
+
+  function getAuth() {
+    var auth = window.shytalkAuth;
+    if (!auth) return null;
+    if (!auth.currentUser || !auth.profile) return null;
+    return auth;
+  }
+
+  function getDisplayName() {
+    var auth = getAuth();
+    if (!auth) return null;
+    return (auth.profile && auth.profile.displayName) || auth.currentUser.displayName || null;
+  }
+
+  function getAvatarUrl() {
+    var auth = getAuth();
+    if (!auth) return null;
+    return (auth.profile && auth.profile.profilePhotoUrl) || auth.currentUser.photoURL || null;
+  }
+
+  function render() {
+    var existing = document.querySelector('[data-testid="shared-header"]');
+    if (existing) existing.remove();
+
+    var auth = getAuth();
+    var isAuthenticated = !!auth;
+    var displayName = getDisplayName();
+    var avatarUrl = getAvatarUrl();
+
+    var rightHtml;
+    if (isAuthenticated) {
+      var avatarHtml = avatarUrl
+        ? '<img src="' + avatarUrl + '" alt="" class="sh-avatar" />'
+        : '<span class="sh-avatar sh-avatar--fallback">' + (displayName ? displayName.charAt(0).toUpperCase() : '?') + '</span>';
+
+      rightHtml =
+        '<div class="sh-user" data-testid="header-user-info">' +
+          avatarHtml +
+          '<span class="sh-user-name">' + escapeHtml(displayName || 'User') + '</span>' +
+          '<svg class="sh-chevron" width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M7 10l5 5 5-5z"/></svg>' +
+        '</div>' +
+        '<div class="sh-dropdown" data-testid="header-dropdown">' +
+          '<button class="sh-dropdown-item" data-testid="header-signout-btn">Sign Out</button>' +
+        '</div>';
+    } else {
+      rightHtml =
+        '<button class="sh-signin-btn" data-testid="header-signin-btn">Sign In</button>';
+    }
+
+    var html =
+      '<header class="sh-header" role="banner" data-testid="shared-header">' +
+        '<div class="sh-header-inner">' +
+          '<a href="/" class="sh-logo" data-testid="header-logo">ShyTalk</a>' +
+          '<div class="sh-right">' + rightHtml + '</div>' +
+        '</div>' +
+      '</header>';
+
+    document.body.insertAdjacentHTML('afterbegin', html);
+    isRendered = true;
+
+    // Wire up event handlers
+    var header = document.querySelector('[data-testid="shared-header"]');
+
+    if (isAuthenticated) {
+      var userInfo = header.querySelector('[data-testid="header-user-info"]');
+      var dropdown = header.querySelector('[data-testid="header-dropdown"]');
+      var signOutBtn = header.querySelector('[data-testid="header-signout-btn"]');
+
+      userInfo.addEventListener('click', function (e) {
+        e.stopPropagation();
+        dropdown.classList.toggle('sh-dropdown--open');
+      });
+
+      signOutBtn.addEventListener('click', function () {
+        dropdown.classList.remove('sh-dropdown--open');
+        if (window.shytalkAuth && window.shytalkAuth.signOut) {
+          window.shytalkAuth.signOut();
+        } else if (typeof firebase !== 'undefined' && firebase.auth) {
+          firebase.auth().signOut();
+        }
+      });
+
+      // Close dropdown on outside click
+      document.addEventListener('click', function () {
+        dropdown.classList.remove('sh-dropdown--open');
+      });
+    } else {
+      var signInBtn = header.querySelector('[data-testid="header-signin-btn"]');
+      if (signInBtn) {
+        signInBtn.addEventListener('click', function () {
+          if (window.shytalkShowLoginModal) {
+            window.shytalkShowLoginModal('access your account');
+          }
+        });
+      }
+    }
+  }
+
+  function escapeHtml(str) {
+    if (!str) return '';
+    var div = document.createElement('div');
+    div.appendChild(document.createTextNode(str));
+    return div.innerHTML;
+  }
+
+  function injectStyles() {
+    if (document.getElementById('sh-header-styles')) return;
+    var style = document.createElement('style');
+    style.id = 'sh-header-styles';
+    style.textContent =
+      '.sh-header {' +
+        'background: var(--surface, #1a1d27);' +
+        'border-bottom: 1px solid var(--border, #2a2e3a);' +
+        'padding: 0 24px;' +
+        'position: relative;' +
+        'z-index: 100;' +
+      '}' +
+      '.sh-header-inner {' +
+        'max-width: 960px;' +
+        'margin: 0 auto;' +
+        'display: flex;' +
+        'align-items: center;' +
+        'justify-content: space-between;' +
+        'min-height: 56px;' +
+      '}' +
+      '.sh-logo {' +
+        'font-size: 1.4rem;' +
+        'font-weight: 800;' +
+        'letter-spacing: 0.04em;' +
+        'background: linear-gradient(135deg, var(--primary, #7c5cfc) 0%, var(--primary-glow, #9b82ff) 100%);' +
+        '-webkit-background-clip: text;' +
+        '-webkit-text-fill-color: transparent;' +
+        'background-clip: text;' +
+        'text-decoration: none;' +
+        'min-height: 44px;' +
+        'min-width: 44px;' +
+        'display: inline-flex;' +
+        'align-items: center;' +
+      '}' +
+      '.sh-logo:focus-visible {' +
+        'outline: 2px solid var(--primary, #7c5cfc);' +
+        'outline-offset: 4px;' +
+        'border-radius: 4px;' +
+      '}' +
+      '.sh-right {' +
+        'display: flex;' +
+        'align-items: center;' +
+        'gap: 12px;' +
+        'position: relative;' +
+      '}' +
+      '.sh-signin-btn {' +
+        'padding: 8px 20px;' +
+        'background: var(--primary, #7c5cfc);' +
+        'color: #fff;' +
+        'border: none;' +
+        'border-radius: 999px;' +
+        'font-family: inherit;' +
+        'font-size: 0.85rem;' +
+        'font-weight: 600;' +
+        'cursor: pointer;' +
+        'min-height: 40px;' +
+        'transition: background 0.2s, transform 0.2s;' +
+      '}' +
+      '.sh-signin-btn:hover {' +
+        'background: var(--primary-glow, #9b82ff);' +
+        'transform: translateY(-1px);' +
+      '}' +
+      '.sh-signin-btn:focus-visible {' +
+        'outline: 2px solid var(--primary-glow, #9b82ff);' +
+        'outline-offset: 3px;' +
+      '}' +
+      '.sh-user {' +
+        'display: flex;' +
+        'align-items: center;' +
+        'gap: 8px;' +
+        'cursor: pointer;' +
+        'padding: 6px 12px;' +
+        'border-radius: 999px;' +
+        'transition: background 0.2s;' +
+      '}' +
+      '.sh-user:hover {' +
+        'background: rgba(255,255,255,0.06);' +
+      '}' +
+      '.sh-avatar {' +
+        'width: 32px;' +
+        'height: 32px;' +
+        'border-radius: 50%;' +
+        'object-fit: cover;' +
+      '}' +
+      '.sh-avatar--fallback {' +
+        'display: flex;' +
+        'align-items: center;' +
+        'justify-content: center;' +
+        'background: var(--primary, #7c5cfc);' +
+        'color: #fff;' +
+        'font-weight: 700;' +
+        'font-size: 0.85rem;' +
+      '}' +
+      '.sh-user-name {' +
+        'font-size: 0.85rem;' +
+        'font-weight: 500;' +
+        'color: var(--text, #e0e0e0);' +
+      '}' +
+      '.sh-chevron {' +
+        'color: var(--text-secondary, #8b8fa3);' +
+        'transition: transform 0.2s;' +
+      '}' +
+      '.sh-dropdown {' +
+        'display: none;' +
+        'position: absolute;' +
+        'top: 100%;' +
+        'right: 0;' +
+        'margin-top: 4px;' +
+        'background: var(--surface, #1a1d27);' +
+        'border: 1px solid var(--border, #2a2e3a);' +
+        'border-radius: 8px;' +
+        'box-shadow: 0 8px 32px rgba(0,0,0,0.4);' +
+        'min-width: 160px;' +
+        'z-index: 200;' +
+        'overflow: hidden;' +
+      '}' +
+      '.sh-dropdown--open {' +
+        'display: block;' +
+      '}' +
+      '.sh-dropdown-item {' +
+        'display: block;' +
+        'width: 100%;' +
+        'padding: 12px 16px;' +
+        'background: none;' +
+        'border: none;' +
+        'color: var(--text, #e0e0e0);' +
+        'font-family: inherit;' +
+        'font-size: 0.85rem;' +
+        'text-align: left;' +
+        'cursor: pointer;' +
+      '}' +
+      '.sh-dropdown-item:hover {' +
+        'background: rgba(255,255,255,0.06);' +
+      '}' +
+      '@media (max-width: 640px) {' +
+        '.sh-header { padding: 0 16px; }' +
+        '.sh-user-name { display: none; }' +
+      '}';
+    document.head.appendChild(style);
+  }
+
+  // Initialize
+  function init() {
+    injectStyles();
+    render();
+  }
+
+  // Re-render on auth state change
+  document.addEventListener('shytalk-auth-changed', function () {
+    if (isRendered) render();
+  });
+
+  // Initialize when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -237,6 +237,7 @@
     </footer>
   </div>
 <script>window.LEGAL_PAGE_TYPE = 'privacy';</script>
+<script src="/js/shared-header.js"></script>
 <script src="/js/language-selector.js"></script>
 <script src="/js/legal-translations.js"></script>
 <script>

--- a/public/roadmap.html
+++ b/public/roadmap.html
@@ -1672,25 +1672,8 @@
       >Skip to content</a
     >
 
-    <!-- ── Header ── -->
-    <header class="header" role="banner">
-      <a href="/" class="header-logo" aria-label="ShyTalk home">ShyTalk</a>
-      <button
-        class="subscribe-btn"
-        id="subscribe-btn"
-        aria-label="Subscribe to updates"
-        data-testid="subscribe-btn"
-        data-log="subscribe-btn"
-        data-i18n="subscribe"
-      >
-        <svg viewBox="0 0 24 24" aria-hidden="true">
-          <path
-            d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.63-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.64 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"
-          />
-        </svg>
-        Subscribe
-      </button>
-    </header>
+    <!-- Shared header injected by /js/shared-header.js -->
+    <script src="/js/shared-header.js"></script>
 
     <!-- ── Stats section ── -->
     <section class="stats-section" aria-label="Progress overview">
@@ -1747,6 +1730,22 @@
           data-i18n="navSuggestions"
           >Suggestions</a
         >
+        <button
+          class="subscribe-btn"
+          id="subscribe-btn"
+          aria-label="Subscribe to updates"
+          data-testid="subscribe-btn"
+          data-log="subscribe-btn"
+          data-i18n="subscribe"
+          style="margin-left: auto;"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.63-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.64 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"
+            />
+          </svg>
+          Subscribe
+        </button>
       </div>
     </nav>
 

--- a/public/terms.html
+++ b/public/terms.html
@@ -227,6 +227,7 @@
     </footer>
   </div>
 <script>window.LEGAL_PAGE_TYPE = 'terms';</script>
+<script src="/js/shared-header.js"></script>
 <script src="/js/language-selector.js"></script>
 <script src="/js/legal-translations.js"></script>
 <script>

--- a/tests/web/shared-header.spec.ts
+++ b/tests/web/shared-header.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Shared header component tests.
+ *
+ * The shared header appears on ALL web pages with:
+ * - Logo (left) linking to home
+ * - User auth state (right): avatar + name when signed in, "Sign In" when not
+ * - Language selector globe button
+ * - Consistent look across roadmap, landing, legal, portal, admin pages
+ */
+
+const PAGES = [
+  { name: 'roadmap', path: '/roadmap.html' },
+  { name: 'landing', path: '/' },
+  { name: 'privacy', path: '/privacy.html' },
+  { name: 'terms', path: '/terms.html' },
+  { name: 'community-guidelines', path: '/community-guidelines.html' },
+];
+
+test.describe('Shared Header — Presence on all pages', () => {
+  for (const page of PAGES) {
+    test(`${page.name} page has the shared header`, async ({ page: p }) => {
+      await p.goto(page.path);
+      const header = p.locator('[data-testid="shared-header"]');
+      await expect(header).toBeVisible({ timeout: 10_000 });
+    });
+
+    test(`${page.name} page header has logo linking to home`, async ({ page: p }) => {
+      await p.goto(page.path);
+      const logo = p.locator('[data-testid="header-logo"]');
+      await expect(logo).toBeVisible({ timeout: 10_000 });
+      const href = await logo.getAttribute('href');
+      expect(href).toBe('/');
+    });
+  }
+});
+
+test.describe('Shared Header — Unauthenticated state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/roadmap.html');
+  });
+
+  test('shows Sign In button when not authenticated', async ({ page }) => {
+    const signInBtn = page.locator('[data-testid="header-signin-btn"]');
+    await expect(signInBtn).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('Sign In button opens login modal', async ({ page }) => {
+    const signInBtn = page.locator('[data-testid="header-signin-btn"]');
+    await signInBtn.waitFor({ timeout: 10_000 });
+    await signInBtn.click();
+    const loginModal = page.locator('[data-testid="login-modal-overlay"]');
+    await expect(loginModal).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('no user avatar or name shown when not authenticated', async ({ page }) => {
+    await page.waitForTimeout(3_000);
+    const userInfo = page.locator('[data-testid="header-user-info"]');
+    expect(await userInfo.count()).toBe(0);
+  });
+});
+
+test.describe('Shared Header — Authenticated state', () => {
+  test('shows user display name when authenticated', async ({ page }) => {
+    await page.goto('/roadmap.html');
+    // Simulate authenticated state
+    await page.evaluate(() => {
+      (window as any).shytalkAuth = {
+        ...(window as any).shytalkAuth,
+        currentUser: {
+          uid: 'test-123',
+          displayName: 'TestUser',
+          getIdToken: () => Promise.resolve('fake'),
+        },
+        profile: { uniqueId: 1001, displayName: 'TestUser', profilePhotoUrl: null },
+      };
+      document.dispatchEvent(
+        new CustomEvent('shytalk-auth-changed', {
+          detail: {
+            user: { uid: 'test-123', displayName: 'TestUser' },
+            profile: { uniqueId: 1001, displayName: 'TestUser' },
+          },
+        }),
+      );
+    });
+
+    const userInfo = page.locator('[data-testid="header-user-info"]');
+    await expect(userInfo).toBeVisible({ timeout: 5_000 });
+    await expect(userInfo).toContainText('TestUser');
+  });
+
+  test('shows sign out option when authenticated', async ({ page }) => {
+    await page.goto('/roadmap.html');
+    await page.evaluate(() => {
+      (window as any).shytalkAuth = {
+        ...(window as any).shytalkAuth,
+        currentUser: {
+          uid: 'test-123',
+          displayName: 'TestUser',
+          getIdToken: () => Promise.resolve('fake'),
+        },
+        profile: { uniqueId: 1001, displayName: 'TestUser' },
+      };
+      document.dispatchEvent(
+        new CustomEvent('shytalk-auth-changed', {
+          detail: { user: { uid: 'test-123' }, profile: { uniqueId: 1001, displayName: 'TestUser' } },
+        }),
+      );
+    });
+
+    // Click user info area to open dropdown
+    const userInfo = page.locator('[data-testid="header-user-info"]');
+    await userInfo.waitFor({ timeout: 5_000 });
+    await userInfo.click();
+
+    const signOutBtn = page.locator('[data-testid="header-signout-btn"]');
+    await expect(signOutBtn).toBeVisible({ timeout: 3_000 });
+  });
+
+  test('Sign In button hidden when authenticated', async ({ page }) => {
+    await page.goto('/roadmap.html');
+    await page.evaluate(() => {
+      (window as any).shytalkAuth = {
+        ...(window as any).shytalkAuth,
+        currentUser: {
+          uid: 'test-123',
+          displayName: 'TestUser',
+          getIdToken: () => Promise.resolve('fake'),
+        },
+        profile: { uniqueId: 1001, displayName: 'TestUser' },
+      };
+      document.dispatchEvent(
+        new CustomEvent('shytalk-auth-changed', {
+          detail: { user: { uid: 'test-123' }, profile: { uniqueId: 1001, displayName: 'TestUser' } },
+        }),
+      );
+    });
+
+    await page.waitForTimeout(1000);
+    const signInBtn = page.locator('[data-testid="header-signin-btn"]');
+    expect(await signInBtn.count()).toBe(0);
+  });
+});
+
+test.describe('Shared Header — Responsive', () => {
+  test('header fits on 320px mobile screen', async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.goto('/roadmap.html');
+    const header = page.locator('[data-testid="shared-header"]');
+    await expect(header).toBeVisible({ timeout: 10_000 });
+    const box = await header.boundingBox();
+    if (box) {
+      expect(box.width).toBeLessThanOrEqual(320);
+    }
+  });
+
+  test('logo and sign-in button visible on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.goto('/roadmap.html');
+    await expect(page.locator('[data-testid="header-logo"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[data-testid="header-signin-btn"]')).toBeVisible({ timeout: 10_000 });
+  });
+});
+
+test.describe('Shared Header — Accessibility', () => {
+  test('header has role="banner"', async ({ page }) => {
+    await page.goto('/roadmap.html');
+    const header = page.locator('[data-testid="shared-header"]');
+    await expect(header).toBeVisible({ timeout: 10_000 });
+    const role = await header.getAttribute('role');
+    expect(role).toBe('banner');
+  });
+
+  test('logo has descriptive text', async ({ page }) => {
+    await page.goto('/roadmap.html');
+    const logo = page.locator('[data-testid="header-logo"]');
+    await expect(logo).toBeVisible({ timeout: 10_000 });
+    const text = await logo.textContent();
+    expect(text?.toLowerCase()).toContain('shytalk');
+  });
+});


### PR DESCRIPTION
## Summary
- New `shared-header.js` component: consistent header on every public page
- Logo (left) + auth state (right): avatar/name dropdown when signed in, Sign In button when not
- Sign out via dropdown, real-time auth state via `shytalk-auth-changed` events
- Responsive: user name hidden on mobile, 44px touch targets
- Self-contained CSS with theme variables
- Added to: roadmap, landing, privacy, terms, community-guidelines, cyber-bullying
- Roadmap: subscribe button moved from old header to sticky section nav

## Test plan
- [x] 20 new shared-header tests pass (presence, auth states, responsive, a11y)
- [x] 66 roadmap-auth tests pass (no regression)
- [x] 137 suggestions-board tests pass (no regression)
- [x] 32 subscribe tests pass (no regression)
- [ ] Visual check on PROD after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)