### PR TITLE
feat: real iOS VoiceService with LiveKit Swift SDK bridge

### DIFF
--- a/iosApp/Podfile
+++ b/iosApp/Podfile
@@ -11,6 +11,9 @@ target 'iosApp' do
 
   # Google Sign-In
   pod 'GoogleSignIn'
+
+  # LiveKit — voice rooms
+  pod 'LiveKitClient'
 end
 
 post_install do |installer|

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1373,12 +1373,19 @@ PODS:
   - gRPC-Core/Privacy (1.69.0)
   - GTMSessionFetcher/Core (5.2.0)
   - leveldb-library (1.22.6)
+  - LiveKitClient (2.0.18):
+    - LiveKitWebRTC (= 125.6422.11)
+    - Logging
+    - SwiftProtobuf
+  - LiveKitWebRTC (125.6422.11)
+  - Logging (1.4.0)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
   - RecaptchaInterop (101.0.0)
+  - SwiftProtobuf (1.37.0)
 
 DEPENDENCIES:
   - FirebaseAuth
@@ -1386,6 +1393,7 @@ DEPENDENCIES:
   - FirebaseDatabase
   - FirebaseFirestore
   - GoogleSignIn
+  - LiveKitClient
 
 SPEC REPOS:
   trunk:
@@ -1411,8 +1419,12 @@ SPEC REPOS:
     - gRPC-Core
     - GTMSessionFetcher
     - leveldb-library
+    - LiveKitClient
+    - LiveKitWebRTC
+    - Logging
     - nanopb
     - RecaptchaInterop
+    - SwiftProtobuf
 
 SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
@@ -1437,9 +1449,13 @@ SPEC CHECKSUMS:
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
   GTMSessionFetcher: 904bdd2a82c635bcd6f44edf94cc8775c5d1d6e6
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
+  LiveKitClient: 051bd7a7562c12df4dc0fca5ff70a414a2c11eaf
+  LiveKitWebRTC: fd39d4e51ea51db3367f98c8c82cbf33e50b88c2
+  Logging: beeb016c9c80cf77042d62e83495816847ef108b
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
+  SwiftProtobuf: 3fafd1b2fb97e6d95ad9c8adb2215da9afec7c83
 
-PODFILE CHECKSUM: 7526472920623949454e995bfa33ed8084d61f79
+PODFILE CHECKSUM: 77e2c9b96426d6c4cd352e31f0bd88e8e2eabcd8
 
 COCOAPODS: 1.16.2

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 				058557C0273AAA2400C9D062 /* Frameworks */,
 				058557E2273AAA2400C9D062 /* Resources */,
 				F83B98CEA6024D5B04E5A22D /* [CP] Copy Pods Resources */,
+				E4DBDBF3A971F380423C179B /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -316,6 +317,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E4DBDBF3A971F380423C179B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F83B98CEA6024D5B04E5A22D /* [CP] Copy Pods Resources */ = {

--- a/iosApp/iosApp/LiveKitBridge.swift
+++ b/iosApp/iosApp/LiveKitBridge.swift
@@ -1,0 +1,93 @@
+import Foundation
+import LiveKit
+import shared
+
+/// Swift implementation of the Kotlin LiveKitBridge interface.
+/// Wraps the LiveKit Swift SDK Room API and forwards events to the Kotlin delegate.
+class LiveKitBridgeImpl: shared.LiveKitBridge {
+    private var room: Room?
+    private var kotlinDelegate: shared.LiveKitBridgeDelegate?
+    private var eventTask: Task<Void, Never>?
+
+    func setDelegate(delegate: shared.LiveKitBridgeDelegate) {
+        self.kotlinDelegate = delegate
+    }
+
+    func connect(url: String, token: String) {
+        let room = Room()
+        self.room = room
+
+        // Listen for room events
+        eventTask?.cancel()
+        eventTask = Task { [weak self] in
+            for await event in room.events {
+                await MainActor.run {
+                    self?.handleEvent(event)
+                }
+            }
+        }
+
+        // Connect to LiveKit server
+        Task {
+            do {
+                try await room.connect(url: url, token: token)
+            } catch {
+                await MainActor.run {
+                    self.kotlinDelegate?.onConnectionFailed(error: error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    func disconnect() {
+        Task {
+            await room?.disconnect()
+            eventTask?.cancel()
+            eventTask = nil
+            room = nil
+        }
+    }
+
+    func setMicrophoneEnabled(enabled: Bool) {
+        guard let room = room else { return }
+        Task {
+            try? await room.localParticipant.setMicrophone(enabled: enabled)
+        }
+    }
+
+    func isMicrophoneEnabled() -> Bool {
+        return room?.localParticipant.isMicrophoneEnabled() ?? false
+    }
+
+    func isConnected() -> Bool {
+        return room?.connectionState == .connected
+    }
+
+    private func handleEvent(_ event: RoomEvent) {
+        switch event {
+        case .connected:
+            kotlinDelegate?.onConnected()
+
+        case .disconnected:
+            kotlinDelegate?.onDisconnected()
+
+        case .reconnecting:
+            kotlinDelegate?.onReconnecting()
+
+        case .reconnected:
+            kotlinDelegate?.onReconnected()
+
+        case .activeSpeakersChanged(let speakers):
+            let identities = speakers.compactMap { $0.identity?.stringValue }
+            kotlinDelegate?.onActiveSpeakersChanged(speakerIdentities: identities)
+
+        case .participantDisconnected(let participant):
+            if let identity = participant.identity?.stringValue {
+                kotlinDelegate?.onParticipantDisconnected(identity: identity)
+            }
+
+        default:
+            break
+        }
+    }
+}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -18,6 +18,12 @@ struct iOSApp: App {
         KoinHelperKt.doInitKoin(useEmulators: false)
         #endif
         setupGoogleSignIn()
+        setupLiveKit()
+    }
+
+    private func setupLiveKit() {
+        let bridge = LiveKitBridgeImpl()
+        IosLiveKitBridgeKt.registerLiveKitBridge(bridge: bridge)
     }
 
     var body: some Scene {

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/IosPlatformModule.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/IosPlatformModule.kt
@@ -1,6 +1,5 @@
 package com.shyden.shytalk.core.di
 
-import com.shyden.shytalk.core.di.stubs.IosVoiceServiceStub
 import com.shyden.shytalk.core.room.IosRoomLifecycleManager
 import com.shyden.shytalk.core.room.RoomLifecycleManager
 import com.shyden.shytalk.core.util.BiometricAuth
@@ -12,6 +11,7 @@ import com.shyden.shytalk.data.remote.ConversationWebSocketService
 import com.shyden.shytalk.data.remote.IosApiClient
 import com.shyden.shytalk.data.remote.IosAppConfigServiceImpl
 import com.shyden.shytalk.data.remote.IosConversationWebSocketServiceImpl
+import com.shyden.shytalk.data.remote.IosLiveKitVoiceService
 import com.shyden.shytalk.data.remote.IosPresenceServiceImpl
 import com.shyden.shytalk.data.remote.IosTokenServiceImpl
 import com.shyden.shytalk.data.remote.IosTypingRepositoryImpl
@@ -121,7 +121,7 @@ val iosPlatformModule =
 
         // Services
         single<TokenService> { IosTokenServiceImpl(get()) }
-        single<VoiceService> { IosVoiceServiceStub() }
+        single<VoiceService> { IosLiveKitVoiceService(get()) }
         single<PresenceService> { IosPresenceServiceImpl(get()) }
         single<ConversationWebSocketService> { IosConversationWebSocketServiceImpl(get()) }
         single<AppConfigService> { IosAppConfigServiceImpl(get()) }

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosLiveKitBridge.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosLiveKitBridge.kt
@@ -1,0 +1,65 @@
+package com.shyden.shytalk.data.remote
+
+/**
+ * Bridge interface for LiveKit on iOS.
+ *
+ * The Swift app registers an implementation at startup that wraps the
+ * LiveKit Swift SDK Room API. Kotlin cannot call Swift directly — this
+ * interface provides the Objective-C-compatible bridge.
+ */
+interface LiveKitBridgeHandler {
+    fun connect(
+        url: String,
+        token: String,
+    )
+
+    fun disconnect()
+
+    fun setMicrophoneEnabled(enabled: Boolean)
+
+    fun isMicrophoneEnabled(): Boolean
+
+    fun isConnected(): Boolean
+}
+
+/**
+ * Delegate interface that LiveKit events are forwarded through.
+ * The Kotlin VoiceService sets itself as the delegate to receive events.
+ */
+interface LiveKitBridgeDelegate {
+    fun onConnected()
+
+    fun onDisconnected()
+
+    fun onReconnecting()
+
+    fun onReconnected()
+
+    fun onActiveSpeakersChanged(speakerIdentities: List<String>)
+
+    fun onParticipantDisconnected(identity: String)
+
+    fun onConnectionFailed(error: String)
+}
+
+/**
+ * Combines the bridge handler with a way to set the delegate.
+ */
+interface LiveKitBridge : LiveKitBridgeHandler {
+    fun setDelegate(delegate: LiveKitBridgeDelegate)
+}
+
+@kotlin.concurrent.Volatile
+private var liveKitBridge: LiveKitBridge? = null
+
+/**
+ * Called from Swift during app init to register the LiveKit bridge.
+ */
+fun registerLiveKitBridge(bridge: LiveKitBridge) {
+    liveKitBridge = bridge
+}
+
+/**
+ * Access the registered LiveKit bridge from Kotlin.
+ */
+fun getLiveKitBridge(): LiveKitBridge? = liveKitBridge

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosLiveKitVoiceService.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosLiveKitVoiceService.kt
@@ -1,0 +1,209 @@
+package com.shyden.shytalk.data.remote
+
+import com.shyden.shytalk.core.util.logE
+import com.shyden.shytalk.core.util.logI
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Real iOS VoiceService implementation using LiveKit via the Swift bridge.
+ *
+ * Mirrors the Android LiveKitVoiceService behaviour:
+ * - Token prewarming for fast room entry
+ * - Mutex-locked join/leave for thread safety
+ * - Speaking user tracking via delegate events
+ * - Connection state management
+ */
+class IosLiveKitVoiceService(
+    private val tokenService: TokenService,
+) : VoiceService,
+    LiveKitBridgeDelegate {
+    companion object {
+        private const val TAG = "IosVoiceService"
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val joinMutex = Mutex()
+
+    private val _speakingUsers = MutableStateFlow<Set<String>>(emptySet())
+    override val speakingUsers: StateFlow<Set<String>> = _speakingUsers.asStateFlow()
+
+    private val _isJoined = MutableStateFlow(false)
+    override val isJoined: StateFlow<Boolean> = _isJoined.asStateFlow()
+
+    private val _connectionState = MutableStateFlow(VoiceConnectionState.DISCONNECTED)
+    override val connectionState: StateFlow<VoiceConnectionState> = _connectionState.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    override val error: StateFlow<String?> = _error.asStateFlow()
+
+    // Token caching
+    private var cachedToken: String? = null
+    private var cachedServerUrl: String? = null
+    private var currentRoomName: String? = null
+    private var currentUserId: String? = null
+
+    // Prewarming
+    private var prewarmedToken: String? = null
+    private var prewarmedUrl: String? = null
+    private var prewarmedRoomName: String? = null
+    private var prewarmJob: Job? = null
+
+    private val bridge: LiveKitBridge?
+        get() = getLiveKitBridge()
+
+    init {
+        // Register ourselves as the delegate for LiveKit events
+        bridge?.setDelegate(this)
+    }
+
+    override suspend fun joinRoom(
+        roomName: String,
+        userId: String,
+    ) {
+        joinMutex.withLock {
+            // Disconnect from any existing room
+            if (_isJoined.value) {
+                bridge?.disconnect()
+                _isJoined.value = false
+                _speakingUsers.value = emptySet()
+            }
+
+            currentRoomName = roomName
+            currentUserId = userId
+
+            // Use prewarmed token if available and matching
+            val token: String
+            val serverUrl: String
+            if (prewarmedToken != null && prewarmedRoomName == roomName) {
+                token = prewarmedToken!!
+                serverUrl = prewarmedUrl ?: ""
+                prewarmedToken = null
+                prewarmedUrl = null
+                prewarmedRoomName = null
+                logI(TAG, "Using prewarmed token for room $roomName")
+            } else {
+                logI(TAG, "Fetching fresh token for room $roomName")
+                try {
+                    val response = tokenService.fetchToken(roomName)
+                    token = response.token
+                    serverUrl = response.url ?: ""
+                } catch (e: Exception) {
+                    logE(TAG, "Token fetch failed: ${e.message}")
+                    _error.value = "Failed to connect to voice: ${e.message}"
+                    return
+                }
+            }
+
+            cachedToken = token
+            cachedServerUrl = serverUrl
+
+            val currentBridge = bridge
+            if (currentBridge == null) {
+                logE(TAG, "LiveKit bridge not registered — cannot connect")
+                _error.value = "Voice service not available on this device"
+                return
+            }
+
+            // Re-register delegate (bridge may have been re-created)
+            currentBridge.setDelegate(this)
+            currentBridge.connect(url = serverUrl, token = token)
+        }
+    }
+
+    override fun leaveChannel() {
+        scope.launch {
+            joinMutex.withLock {
+                bridge?.disconnect()
+                _isJoined.value = false
+                _connectionState.value = VoiceConnectionState.DISCONNECTED
+                _speakingUsers.value = emptySet()
+                cachedToken = null
+                cachedServerUrl = null
+                currentRoomName = null
+                currentUserId = null
+                logI(TAG, "Left voice channel")
+            }
+        }
+    }
+
+    override fun setMicrophoneEnabled(enabled: Boolean) {
+        bridge?.setMicrophoneEnabled(enabled)
+    }
+
+    override fun setAudioMode(voiceMode: Boolean) {
+        // iOS audio session management is handled by LiveKit SDK internally
+        // No separate audio mode switch needed (unlike Android AudioManager)
+    }
+
+    override fun clearError() {
+        _error.value = null
+    }
+
+    override fun prewarmToken(
+        roomName: String,
+        userId: String,
+    ) {
+        prewarmJob?.cancel()
+        prewarmJob =
+            scope.launch {
+                try {
+                    val response = tokenService.fetchToken(roomName)
+                    prewarmedToken = response.token
+                    prewarmedUrl = response.url
+                    prewarmedRoomName = roomName
+                    logI(TAG, "Prewarmed token for room $roomName")
+                } catch (e: Exception) {
+                    logE(TAG, "Token prewarm failed: ${e.message}")
+                }
+            }
+    }
+
+    // ── LiveKitBridgeDelegate events ──
+
+    override fun onConnected() {
+        _isJoined.value = true
+        _connectionState.value = VoiceConnectionState.CONNECTED
+        logI(TAG, "Connected to room $currentRoomName")
+    }
+
+    override fun onDisconnected() {
+        _isJoined.value = false
+        _connectionState.value = VoiceConnectionState.DISCONNECTED
+        _speakingUsers.value = emptySet()
+        logI(TAG, "Disconnected from room")
+    }
+
+    override fun onReconnecting() {
+        _connectionState.value = VoiceConnectionState.RECONNECTING
+        logI(TAG, "Reconnecting...")
+    }
+
+    override fun onReconnected() {
+        _connectionState.value = VoiceConnectionState.CONNECTED
+        logI(TAG, "Reconnected")
+    }
+
+    override fun onActiveSpeakersChanged(speakerIdentities: List<String>) {
+        _speakingUsers.update { speakerIdentities.toSet() }
+    }
+
+    override fun onParticipantDisconnected(identity: String) {
+        _speakingUsers.update { it - identity }
+    }
+
+    override fun onConnectionFailed(error: String) {
+        _error.value = "Voice connection failed: $error"
+        _connectionState.value = VoiceConnectionState.DISCONNECTED
+        logE(TAG, "Connection failed: $error")
+    }
+}


### PR DESCRIPTION
## Summary
- Real `IosLiveKitVoiceService` replaces `IosVoiceServiceStub`
- Uses Swift bridge pattern (same as Google/Apple Sign-In): Kotlin interface → Swift implementation via ObjC interop
- `LiveKitBridgeImpl` (Swift) wraps LiveKit Room API and forwards events to Kotlin delegate
- Token prewarming, mutex-locked join/leave, speaking user tracking, connection state management
- `LiveKitClient` 2.0.18 pod added to Podfile
- DI binding updated in `IosPlatformModule.kt`

## Test plan
- [x] Kotlin iOS compilation passes (`compileKotlinIosArm64`)
- [x] `pod install` successful
- [x] ktlint clean
- [ ] Xcode build verification (requires Xcode open)
- [ ] iOS Simulator test with local LiveKit server

🤖 Generated with [Claude Code](https://claude.com/claude-code)