### PR TITLE
fix(ios): disable code-signing on pod targets

### DIFF
--- a/iosApp/Podfile
+++ b/iosApp/Podfile
@@ -20,6 +20,13 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.0'
+      # Pod targets are static libraries embedded in the parent app — they
+      # don't ship as separate signed bundles. Disabling code-signing for
+      # pods prevents xcodebuild's global manual-signing CLI flags
+      # (CODE_SIGN_STYLE=Manual, PROVISIONING_PROFILE_SPECIFIER, etc.) from
+      # leaking onto every pod target and triggering the "X does not support
+      # provisioning profiles" error during release archives.
+      config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
     end
   end
 end


### PR DESCRIPTION
## Summary
- Today's Deploy To Dev + Deploy To Prod failed iOS jobs with 30+ "X does not support provisioning profiles" errors across pod targets (FirebaseAuth, gRPC-C++, GoogleSignIn, etc.)
- Root cause: workflow's `xcodebuild ... CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE_SPECIFIER=...` CLI flags apply to ALL targets in the workspace, including pod static libraries that don't ship as signed bundles
- Fix: add `CODE_SIGNING_ALLOWED=NO` to every pod target in the Podfile post_install hook so xcodebuild skips signing on them entirely
- Same workflow + Podfile worked on 2026-04-24; the GitHub macOS runner's Xcode/CocoaPods toolchain appears to have become stricter about provisioning-profile validation between then and 2026-04-28

## Test plan
- [ ] CI green on this PR (Lint, Test Backend, Build & Test, Playwright, etc.)
- [ ] Once merged, re-trigger Deploy To Dev — verify `Distribute iOS to TestFlight` job succeeds
- [ ] Once Dev verified, re-trigger Deploy To Prod for v0.93.10 — verify `Deploy iOS to App Store` job succeeds
- [ ] Confirm DEV + PROD `/api/health` still 200 throughout (already deployed; iOS rebuild only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)