### PR TITLE
fix(ci): bump iOS deploy timeout 45 -> 90 min

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -190,7 +190,12 @@ jobs:
     name: Distribute iOS to TestFlight
     if: inputs.ios-testers
     runs-on: macos-15
-    timeout-minutes: 45
+    # Bumped from 45 -> 90 on 2026-04-28: K/Native linkReleaseFrameworkIosArm64
+    # has been taking 24-29 min on the macos-15 runner pool (was ~10 min in
+    # mid-April). Plus xcodebuild archive ~15-20 min + pod install ~3 min +
+    # TestFlight upload ~2 min = comfortable 50-min worst case. 90 min gives
+    # headroom for runner-pool slowdowns without impacting normal-case time.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -221,7 +221,10 @@ jobs:
     needs: [validate-release]
     if: inputs.ios
     runs-on: macos-latest
-    timeout-minutes: 45
+    # Bumped from 45 -> 90 on 2026-04-28: K/Native linkReleaseFrameworkIosArm64
+    # plus xcodebuild archive plus App Store upload total ~50 min worst case
+    # on slow days; 90 gives runner-pool-slowdown headroom.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary
- Today's iOS deploy attempts (DEV + PROD) hit the 45-min job timeout during `xcodebuild archive`
- KMP `linkReleaseFrameworkIosArm64` consumed 24-29 min on the macos-15 runner pool today (~10 min normally) — environmental slowdown
- Bumping iOS jobs `timeout-minutes` from 45 → 90 to absorb runner pool slowdowns; normal case unchanged

## Test plan
- [ ] Merge → re-trigger Deploy To Dev + Deploy To Prod
- [ ] iOS jobs complete within new 90-min budget
- [ ] TestFlight (DEV) + App Store Connect (PROD) receive new builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)