### PR TITLE
chore(ci): upgrade all runners to highest free-tier specs

### DIFF
--- a/.github/workflows/allure-report.yml
+++ b/.github/workflows/allure-report.yml
@@ -52,7 +52,7 @@ concurrency:
 jobs:
   generate-report:
     name: Generate Allure Report
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   analyze-javascript:
     name: Analyze JavaScript
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -40,7 +40,7 @@ jobs:
     # against. Re-enable by removing this guard once GitHub publishes a compatible
     # extractor. Track upstream at https://github.com/github/codeql-action.
     if: false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     timeout-minutes: 5
     steps:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -40,7 +40,7 @@ jobs:
   deploy-backend-dev:
     name: Deploy Backend to Dev
     if: inputs.backend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -82,7 +82,7 @@ jobs:
   deploy-web-dev:
     name: Deploy Web to Dev
     if: inputs.web
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -106,7 +106,7 @@ jobs:
   distribute-android:
     name: Distribute Android to Testers
     if: inputs.android-testers
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -189,7 +189,7 @@ jobs:
   distribute-ios:
     name: Distribute iOS to TestFlight
     if: inputs.ios-testers
-    runs-on: macos-15
+    runs-on: macos-15-xlarge
     # Bumped from 45 -> 90 on 2026-04-28: K/Native linkReleaseFrameworkIosArm64
     # has been taking 24-29 min on the macos-15 runner pool (was ~10 min in
     # mid-April). Plus xcodebuild archive ~15-20 min + pod install ~3 min +
@@ -287,7 +287,7 @@ jobs:
       inputs.playwright &&
       (needs.deploy-backend-dev.result == 'success' || needs.deploy-backend-dev.result == 'skipped') &&
       (needs.deploy-web-dev.result == 'success' || needs.deploy-web-dev.result == 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -39,7 +39,7 @@ env:
 jobs:
   validate-release:
     name: Validate Release Tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 5
     outputs:
       version: ${{ steps.validate.outputs.version }}
@@ -70,7 +70,7 @@ jobs:
     name: Build Android
     needs: [validate-release]
     if: inputs.android
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -116,7 +116,7 @@ jobs:
     name: Deploy Backend to Prod
     needs: [validate-release]
     if: inputs.backend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -166,7 +166,7 @@ jobs:
     name: Deploy Web to Prod
     needs: [validate-release]
     if: inputs.web
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -193,7 +193,7 @@ jobs:
     name: Deploy Android to Play Store
     needs: [validate-release, build-android]
     if: inputs.android
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 10
     steps:
       - name: Download release artifacts
@@ -220,7 +220,7 @@ jobs:
     name: Deploy iOS to App Store
     needs: [validate-release]
     if: inputs.ios
-    runs-on: macos-latest
+    runs-on: macos-latest-xlarge
     # Bumped from 45 -> 90 on 2026-04-28: K/Native linkReleaseFrameworkIosArm64
     # plus xcodebuild archive plus App Store upload total ~50 min worst case
     # on slow days; 90 gives runner-pool-slowdown headroom.
@@ -305,7 +305,7 @@ jobs:
       needs.validate-release.result == 'success' &&
       (needs.deploy-backend-prod.result == 'success' ||
        needs.deploy-web-prod.result == 'success')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 5
     steps:
       - name: Verify API health
@@ -364,7 +364,7 @@ jobs:
     if: |
       always() &&
       needs.deploy-android-prod.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     steps:
       - name: Download debug APK
@@ -407,7 +407,7 @@ jobs:
     if: |
       always() &&
       needs.deploy-ios-prod.result == 'success'
-    runs-on: macos-latest
+    runs-on: macos-latest-xlarge
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -484,7 +484,7 @@ jobs:
        needs.smoke-test-backend-web.result == 'failure' ||
        needs.smoke-test-android.result == 'failure' ||
        needs.smoke-test-ios.result == 'failure')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -54,7 +54,7 @@ jobs:
   # ── Resolve inputs into device matrix ────────────────────────
   resolve-inputs:
     name: Resolve Inputs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 2
     outputs:
       run_android: ${{ steps.resolve.outputs.run_android }}
@@ -103,7 +103,7 @@ jobs:
     name: "Android E2E (API ${{ matrix.api-level }}, ${{ matrix.form-factor }})"
     needs: [resolve-inputs]
     if: always() && needs.resolve-inputs.result == 'success' && needs.resolve-inputs.outputs.run_android == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -220,7 +220,7 @@ jobs:
     name: Android E2E Summary
     needs: [resolve-inputs, test-android]
     if: always() && needs.resolve-inputs.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 5
     steps:
       - name: Check results

--- a/.github/workflows/force-cancel.yml
+++ b/.github/workflows/force-cancel.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   force-cancel:
     name: Force Cancel All Runs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 2
     steps:
       - name: Force-cancel all non-completed workflow runs

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -46,7 +46,7 @@ jobs:
   # ── Resolve inputs into device matrix ────────────────────────
   resolve-inputs:
     name: Resolve Inputs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 2
     outputs:
       run_ios: ${{ steps.resolve.outputs.run_ios }}
@@ -93,7 +93,7 @@ jobs:
     name: Build iOS
     needs: [resolve-inputs]
     if: always() && needs.resolve-inputs.result == 'success' && needs.resolve-inputs.outputs.run_ios == 'true'
-    runs-on: macos-14
+    runs-on: macos-14-xlarge
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -151,7 +151,7 @@ jobs:
     name: "iOS E2E (iOS ${{ matrix.ios-version }}, ${{ matrix.form-factor }})"
     needs: [resolve-inputs, build-ios]
     if: always() && needs.build-ios.result == 'success' && needs.resolve-inputs.outputs.run_ios == 'true' && needs.build-ios.outputs.has_tests == 'true'
-    runs-on: macos-14
+    runs-on: macos-14-xlarge
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -217,7 +217,7 @@ jobs:
     name: iOS Summary
     needs: [resolve-inputs, test-ios]
     if: always() && needs.resolve-inputs.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 5
     steps:
       - name: Check results

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -53,7 +53,7 @@ jobs:
   # ── Resolve inputs into browser matrix ──────────────────────
   resolve-inputs:
     name: Resolve Inputs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 2
     outputs:
       run_web: ${{ steps.resolve.outputs.run_web }}
@@ -99,7 +99,7 @@ jobs:
     name: Prepare Playwright
     needs: [resolve-inputs]
     if: always() && needs.resolve-inputs.result == 'success' && needs.resolve-inputs.outputs.run_web == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -133,7 +133,7 @@ jobs:
     name: "Playwright (${{ matrix.project }})"
     needs: [resolve-inputs, prepare-playwright]
     if: always() && needs.prepare-playwright.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -263,7 +263,7 @@ jobs:
     name: Playwright Summary
     needs: [resolve-inputs, test-playwright]
     if: always() && needs.resolve-inputs.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 5
     steps:
       - name: Check results

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   detect-changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 5
     outputs:
       app_changed: ${{ steps.changes.outputs.app_changed }}
@@ -79,7 +79,7 @@ jobs:
       needs.detect-changes.outputs.app_changed == 'true' &&
       (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
       (needs.test-backend.result == 'success' || needs.test-backend.result == 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -223,7 +223,7 @@ jobs:
     name: PR Gate
     needs: [detect-changes, lint, build-and-test, sonarcloud, test-backend, android-e2e, playwright-web, ios-e2e]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 2
     steps:
       - name: Evaluate results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   check-skip:
     name: Check Skip
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 2
     outputs:
       should_skip: ${{ steps.check.outputs.skip }}
@@ -40,7 +40,7 @@ jobs:
     name: Detect Changes
     needs: [check-skip]
     if: needs.check-skip.outputs.should_skip != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 5
     outputs:
       app_changed: ${{ steps.changes.outputs.app_changed }}
@@ -79,7 +79,7 @@ jobs:
     if: |
       needs.check-skip.outputs.should_skip != 'true' &&
       (github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.workflow_only != 'true')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 10
     steps:
       - name: Generate app token

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -33,7 +33,7 @@ env:
 jobs:
   sonarcloud:
     name: SonarCloud Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   test-backend:
     name: Test Backend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
Open-source repo → free upgrade to ubuntu-latest-16-cores + macos-*-xlarge. Today's macos-15 pool issues exposed the slowness; xlarge runners come from a different/less-congested pool. ~3-4x faster builds expected.