### PR TITLE
chore(ci): switch iOS jobs to self-hosted macOS runner

### DIFF
--- a/.github/actions/setup-ios-signing/action.yml
+++ b/.github/actions/setup-ios-signing/action.yml
@@ -26,14 +26,28 @@ runs:
     - name: Select Xcode ${{ inputs.xcode-version }}
       shell: bash
       run: |
+        # GitHub-hosted runners ship Xcode at /Applications/Xcode_<version>.app,
+        # self-hosted runners typically have /Applications/Xcode.app (no suffix).
+        # Try the versioned path first, fall back to the unversioned one if its
+        # CFBundleShortVersionString matches the requested major version.
         XCODE=$(ls -d /Applications/Xcode_${{ inputs.xcode-version }}*.app 2>/dev/null | head -1)
+        if [ -z "$XCODE" ] && [ -d /Applications/Xcode.app ]; then
+          ACTUAL=$(defaults read /Applications/Xcode.app/Contents/Info CFBundleShortVersionString 2>/dev/null || echo "")
+          if [[ "$ACTUAL" == "${{ inputs.xcode-version }}" || "$ACTUAL" == "${{ inputs.xcode-version }}".* ]]; then
+            XCODE=/Applications/Xcode.app
+          fi
+        fi
         if [ -z "$XCODE" ]; then
           echo "Available Xcode versions:"
-          ls /Applications/Xcode*.app
+          ls /Applications/Xcode*.app 2>/dev/null || echo "(none)"
           echo "::error::Xcode ${{ inputs.xcode-version }} not found on this runner"
           exit 1
         fi
-        sudo xcode-select -s "$XCODE/Contents/Developer"
+        # Use DEVELOPER_DIR env var instead of `sudo xcode-select -s`. The env
+        # var is honoured by xcodebuild / xcrun / clang; setting it via
+        # GITHUB_ENV means subsequent steps inherit it. Avoids needing
+        # passwordless sudo on self-hosted runners.
+        echo "DEVELOPER_DIR=$XCODE/Contents/Developer" >> "$GITHUB_ENV"
         echo "Selected: $XCODE"
 
     - name: Install Apple API key

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -189,7 +189,7 @@ jobs:
   distribute-ios:
     name: Distribute iOS to TestFlight
     if: inputs.ios-testers
-    runs-on: macos-15
+    runs-on: [self-hosted, macOS, ARM64, shytalk-mac]
     # Bumped from 45 -> 90 on 2026-04-28: K/Native linkReleaseFrameworkIosArm64
     # has been taking 24-29 min on the macos-15 runner pool (was ~10 min in
     # mid-April). Plus xcodebuild archive ~15-20 min + pod install ~3 min +

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -220,7 +220,7 @@ jobs:
     name: Deploy iOS to App Store
     needs: [validate-release]
     if: inputs.ios
-    runs-on: macos-latest
+    runs-on: [self-hosted, macOS, ARM64, shytalk-mac]
     # Bumped from 45 -> 90 on 2026-04-28: K/Native linkReleaseFrameworkIosArm64
     # plus xcodebuild archive plus App Store upload total ~50 min worst case
     # on slow days; 90 gives runner-pool-slowdown headroom.
@@ -407,7 +407,7 @@ jobs:
     if: |
       always() &&
       needs.deploy-ios-prod.result == 'success'
-    runs-on: macos-latest
+    runs-on: [self-hosted, macOS, ARM64, shytalk-mac]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
Today's GitHub macos-15 pool unreliable; self-hosted runner on dev Mac (A18 Pro, Xcode 26.4.1, 8 GB RAM, 271 GB free). Action handles unversioned Xcode.app + sudo-less DEVELOPER_DIR.