### PR TITLE
fix(ios): restore TestFlight uploads broken since 2026-03-12

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -340,9 +340,19 @@ jobs:
         # Self-hosted runner: scrub all signing material to prevent .p8/.p12
         # leaking between jobs. Don't fail the job on cleanup — log warnings
         # instead so the deploy outcome reflects deploy success/failure only.
+        # Mirrors what setup-ios-signing/action.yml writes — keep these in sync.
         run: |
           set -uo pipefail
           fail=0
+          # Extract the profile UUID before deleting the source profile, since
+          # we need it to remove the mirrored copy in ~/Library/MobileDevice/.
+          PROFILE_UUID=""
+          if [ -f "$RUNNER_TEMP/profile.mobileprovision" ]; then
+            PROFILE_UUID=$(/usr/bin/security cms -D -i "$RUNNER_TEMP/profile.mobileprovision" 2>/dev/null \
+              | grep -A1 '<key>UUID</key>' | grep '<string>' \
+              | sed 's/.*<string>\(.*\)<\/string>.*/\1/' || true)
+          fi
+          # Temp keychain
           if [ -f "$RUNNER_TEMP/app-signing.keychain-db" ]; then
             if ! security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db"; then
               echo "::warning::Failed to delete keychain at $RUNNER_TEMP/app-signing.keychain-db"
@@ -355,11 +365,19 @@ jobs:
             echo "::warning::Failed to restore login keychain search list"
             fail=1
           fi
+          # All signing material in $RUNNER_TEMP (cert .p12, profile, IPA, archive, log)
           rm -rf "$RUNNER_TEMP/export" \
                  "$RUNNER_TEMP/iosApp.xcarchive" \
                  "$RUNNER_TEMP/altool-upload.log" || true
+          rm -f "$RUNNER_TEMP/certificate.p12" \
+                "$RUNNER_TEMP/profile.mobileprovision" || true
+          # App Store Connect API key (.p8) lives outside $RUNNER_TEMP
           if [ -n "${APP_STORE_CONNECT_KEY_ID:-}" ]; then
             rm -f "$HOME/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" || true
+          fi
+          # Mirrored profile in ~/Library/MobileDevice/Provisioning Profiles/
+          if [ -n "$PROFILE_UUID" ]; then
+            rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision" || true
           fi
           if [ "$fail" -eq 0 ]; then
             echo "Signing material scrubbed."

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -208,7 +208,7 @@ jobs:
           set -euo pipefail
           dest=$(/usr/libexec/PlistBuddy -c "Print :destination" iosApp/ExportOptions.plist)
           if [ "$dest" != "export" ]; then
-            echo "::error::iosApp/ExportOptions.plist destination must be 'export' (got '$dest'). 'upload' would upload silently and the altool step would fail."
+            echo "::error::iosApp/ExportOptions.plist destination must be 'export' (got '$dest'). 'upload' uploads silently during exportArchive and writes no local IPA, breaking the next step."
             exit 1
           fi
 
@@ -306,27 +306,21 @@ jobs:
           shopt -s nullglob
           ipas=("$RUNNER_TEMP/export"/*.ipa)
           shopt -u nullglob
-          if [ "${#ipas[@]}" -ne 1 ]; then
-            echo "::error::Expected exactly one .ipa for upload, found ${#ipas[@]}"
-            exit 1
-          fi
+          # Post-export step already verified exactly one IPA exists. Re-glob is
+          # only needed to populate ipas[0] for altool's -f arg.
           # altool is famous for printing product-errors to stdout while exiting 0
-          # (auth-key revoked, asset validation rejection, etc). Capture output and
-          # grep it so we fail loudly when ASC reports an upload-time error.
+          # (auth-key revoked, asset validation rejection, etc). Capture output
+          # and grep it so we fail loudly when ASC reports an upload-time error.
+          # `set -o pipefail` (already on from `set -euo pipefail`) makes a
+          # non-zero altool exit propagate through the `tee` pipe, so we don't
+          # need PIPESTATUS gymnastics — set -e aborts before the grep runs.
           upload_log="$RUNNER_TEMP/altool-upload.log"
-          set +e
           xcrun altool --upload-app \
             -f "${ipas[0]}" \
             -t ios \
             --apiKey "$APP_STORE_CONNECT_KEY_ID" \
             --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID" \
             --output-format xml 2>&1 | tee "$upload_log"
-          rc=${PIPESTATUS[0]}
-          set -e
-          if [ "$rc" -ne 0 ]; then
-            echo "::error::altool exited $rc"
-            exit "$rc"
-          fi
           if grep -qE '<key>product-errors</key>|<key>tool-errors</key>' "$upload_log"; then
             echo "::error::altool reported errors despite exit 0 — see log above"
             exit 1

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -239,6 +239,7 @@ jobs:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
+          set -euo pipefail
           cd iosApp
           # Archive
           xcodebuild \
@@ -262,15 +263,37 @@ jobs:
             -authenticationKeyPath ~/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8 \
             -authenticationKeyID $APP_STORE_CONNECT_KEY_ID \
             -authenticationKeyIssuerID $APP_STORE_CONNECT_ISSUER_ID
+          # Verify a single IPA was produced (catches `destination: upload` regressions
+          # that uploaded silently and left no local artifact, breaking the next step)
+          shopt -s nullglob
+          ipas=("$RUNNER_TEMP/export"/*.ipa)
+          shopt -u nullglob
+          if [ "${#ipas[@]}" -eq 0 ]; then
+            echo "::error::xcodebuild -exportArchive completed but no .ipa was written to $RUNNER_TEMP/export/. Check ExportOptions.plist (destination must be 'export', not 'upload')."
+            ls -la "$RUNNER_TEMP/export/" 2>&1 || true
+            exit 1
+          fi
+          if [ "${#ipas[@]}" -gt 1 ]; then
+            echo "::error::Expected exactly one .ipa, found ${#ipas[@]}: ${ipas[*]}"
+            exit 1
+          fi
+          echo "Exported IPA: ${ipas[0]} ($(du -h "${ipas[0]}" | cut -f1))"
 
       - name: Upload to TestFlight
-
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
+          set -euo pipefail
+          shopt -s nullglob
+          ipas=("$RUNNER_TEMP/export"/*.ipa)
+          shopt -u nullglob
+          if [ "${#ipas[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one .ipa for upload, found ${#ipas[@]}"
+            exit 1
+          fi
           xcrun altool --upload-app \
-            -f $RUNNER_TEMP/export/*.ipa \
+            -f "${ipas[0]}" \
             -t ios \
             --apiKey "$APP_STORE_CONNECT_KEY_ID" \
             --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -199,6 +199,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # Fast pre-flight: assert the export plist hasn't been flipped back to
+      # `destination: upload` (which would upload silently and break TestFlight,
+      # as happened 2026-03-12 → 2026-04-29). Fails in <1s before we burn 20 min
+      # on archive + export.
+      - name: Assert ExportOptions.plist requires local export
+        run: |
+          set -euo pipefail
+          dest=$(/usr/libexec/PlistBuddy -c "Print :destination" iosApp/ExportOptions.plist)
+          if [ "$dest" != "export" ]; then
+            echo "::error::iosApp/ExportOptions.plist destination must be 'export' (got '$dest'). 'upload' would upload silently and the altool step would fail."
+            exit 1
+          fi
+
       - uses: ./.github/actions/setup-jdk-gradle
 
       - uses: ./.github/actions/setup-ios-signing
@@ -222,7 +235,9 @@ jobs:
 
       - name: Build KMP shared framework for iOS
         if: steps.kmp-cache.outputs.cache-hit != 'true'
-        run: ./gradlew :shared:linkReleaseFrameworkIosArm64
+        run: |
+          set -euo pipefail
+          ./gradlew :shared:linkReleaseFrameworkIosArm64
 
       - name: Cache Xcode derived data
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -232,7 +247,10 @@ jobs:
           restore-keys: xcode-derived-
 
       - name: Install CocoaPods
-        run: cd iosApp && pod install
+        run: |
+          set -euo pipefail
+          cd iosApp
+          pod install
 
       - name: Build, archive, and export iOS app
         env:
@@ -292,15 +310,61 @@ jobs:
             echo "::error::Expected exactly one .ipa for upload, found ${#ipas[@]}"
             exit 1
           fi
+          # altool is famous for printing product-errors to stdout while exiting 0
+          # (auth-key revoked, asset validation rejection, etc). Capture output and
+          # grep it so we fail loudly when ASC reports an upload-time error.
+          upload_log="$RUNNER_TEMP/altool-upload.log"
+          set +e
           xcrun altool --upload-app \
             -f "${ipas[0]}" \
             -t ios \
             --apiKey "$APP_STORE_CONNECT_KEY_ID" \
-            --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID"
+            --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID" \
+            --output-format xml 2>&1 | tee "$upload_log"
+          rc=${PIPESTATUS[0]}
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::altool exited $rc"
+            exit "$rc"
+          fi
+          if grep -qE '<key>product-errors</key>|<key>tool-errors</key>' "$upload_log"; then
+            echo "::error::altool reported errors despite exit 0 — see log above"
+            exit 1
+          fi
+          echo "altool upload accepted by App Store Connect"
 
-      - name: Clean up keychain
+      - name: Clean up signing material
         if: always()
-        run: security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+        # Self-hosted runner: scrub all signing material to prevent .p8/.p12
+        # leaking between jobs. Don't fail the job on cleanup — log warnings
+        # instead so the deploy outcome reflects deploy success/failure only.
+        run: |
+          set -uo pipefail
+          fail=0
+          if [ -f "$RUNNER_TEMP/app-signing.keychain-db" ]; then
+            if ! security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db"; then
+              echo "::warning::Failed to delete keychain at $RUNNER_TEMP/app-signing.keychain-db"
+              fail=1
+            fi
+          fi
+          # Restore the user keychain search list so we don't accumulate
+          # references to deleted keychains across runs on the persistent runner.
+          if ! security list-keychain -d user -s "$HOME/Library/Keychains/login.keychain-db"; then
+            echo "::warning::Failed to restore login keychain search list"
+            fail=1
+          fi
+          rm -rf "$RUNNER_TEMP/export" \
+                 "$RUNNER_TEMP/iosApp.xcarchive" \
+                 "$RUNNER_TEMP/altool-upload.log" || true
+          if [ -n "${APP_STORE_CONNECT_KEY_ID:-}" ]; then
+            rm -f "$HOME/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" || true
+          fi
+          if [ "$fail" -eq 0 ]; then
+            echo "Signing material scrubbed."
+          fi
+          exit 0
 
   sanity-check:
     name: Dev Sanity Check

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -230,6 +230,19 @@ jobs:
         with:
           ref: ${{ inputs.release-tag }}
 
+      # Fast pre-flight: assert the export plist hasn't been flipped back to
+      # `destination: upload` (which would upload silently and break TestFlight,
+      # as happened 2026-03-12 → 2026-04-29). Fails in <1s before we burn 20 min
+      # on archive + export.
+      - name: Assert ExportOptions.plist requires local export
+        run: |
+          set -euo pipefail
+          dest=$(/usr/libexec/PlistBuddy -c "Print :destination" iosApp/ExportOptions.plist)
+          if [ "$dest" != "export" ]; then
+            echo "::error::iosApp/ExportOptions.plist destination must be 'export' (got '$dest'). 'upload' would upload silently and the altool step would fail."
+            exit 1
+          fi
+
       - uses: ./.github/actions/setup-jdk-gradle
 
       - uses: ./.github/actions/setup-ios-signing
@@ -246,13 +259,19 @@ jobs:
           prod-base64: ${{ secrets.GOOGLE_SERVICES_PROD_BASE64 }}
 
       - name: Build KMP shared framework for iOS
-        run: ./gradlew :shared:linkReleaseFrameworkIosArm64
+        run: |
+          set -euo pipefail
+          ./gradlew :shared:linkReleaseFrameworkIosArm64
 
       - name: Install CocoaPods
-        run: cd iosApp && pod install
+        run: |
+          set -euo pipefail
+          cd iosApp
+          pod install
 
       - name: Build and archive iOS app
         run: |
+          set -euo pipefail
           cd iosApp
           xcodebuild \
             -workspace iosApp.xcworkspace \
@@ -310,15 +329,61 @@ jobs:
             echo "::error::Expected exactly one .ipa for upload, found ${#ipas[@]}"
             exit 1
           fi
+          # altool is famous for printing product-errors to stdout while exiting 0
+          # (auth-key revoked, asset validation rejection, etc). Capture output and
+          # grep it so we fail loudly when ASC reports an upload-time error.
+          upload_log="$RUNNER_TEMP/altool-upload.log"
+          set +e
           xcrun altool --upload-app \
             -f "${ipas[0]}" \
             -t ios \
             --apiKey "$APP_STORE_CONNECT_KEY_ID" \
-            --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID"
+            --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID" \
+            --output-format xml 2>&1 | tee "$upload_log"
+          rc=${PIPESTATUS[0]}
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::altool exited $rc"
+            exit "$rc"
+          fi
+          if grep -qE '<key>product-errors</key>|<key>tool-errors</key>' "$upload_log"; then
+            echo "::error::altool reported errors despite exit 0 — see log above"
+            exit 1
+          fi
+          echo "altool upload accepted by App Store Connect"
 
-      - name: Clean up keychain
+      - name: Clean up signing material
         if: always()
-        run: security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+        # Self-hosted runner: scrub all signing material to prevent .p8/.p12
+        # leaking between jobs. Don't fail the job on cleanup — log warnings
+        # instead so the deploy outcome reflects deploy success/failure only.
+        run: |
+          set -uo pipefail
+          fail=0
+          if [ -f "$RUNNER_TEMP/app-signing.keychain-db" ]; then
+            if ! security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db"; then
+              echo "::warning::Failed to delete keychain at $RUNNER_TEMP/app-signing.keychain-db"
+              fail=1
+            fi
+          fi
+          # Restore the user keychain search list so we don't accumulate
+          # references to deleted keychains across runs on the persistent runner.
+          if ! security list-keychain -d user -s "$HOME/Library/Keychains/login.keychain-db"; then
+            echo "::warning::Failed to restore login keychain search list"
+            fail=1
+          fi
+          rm -rf "$RUNNER_TEMP/export" \
+                 "$RUNNER_TEMP/iosApp.xcarchive" \
+                 "$RUNNER_TEMP/altool-upload.log" || true
+          if [ -n "${APP_STORE_CONNECT_KEY_ID:-}" ]; then
+            rm -f "$HOME/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" || true
+          fi
+          if [ "$fail" -eq 0 ]; then
+            echo "Signing material scrubbed."
+          fi
+          exit 0
 
   # ── Smoke tests (after deploys) ────────────────────────────
   smoke-test-backend-web:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -359,9 +359,19 @@ jobs:
         # Self-hosted runner: scrub all signing material to prevent .p8/.p12
         # leaking between jobs. Don't fail the job on cleanup — log warnings
         # instead so the deploy outcome reflects deploy success/failure only.
+        # Mirrors what setup-ios-signing/action.yml writes — keep these in sync.
         run: |
           set -uo pipefail
           fail=0
+          # Extract the profile UUID before deleting the source profile, since
+          # we need it to remove the mirrored copy in ~/Library/MobileDevice/.
+          PROFILE_UUID=""
+          if [ -f "$RUNNER_TEMP/profile.mobileprovision" ]; then
+            PROFILE_UUID=$(/usr/bin/security cms -D -i "$RUNNER_TEMP/profile.mobileprovision" 2>/dev/null \
+              | grep -A1 '<key>UUID</key>' | grep '<string>' \
+              | sed 's/.*<string>\(.*\)<\/string>.*/\1/' || true)
+          fi
+          # Temp keychain
           if [ -f "$RUNNER_TEMP/app-signing.keychain-db" ]; then
             if ! security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db"; then
               echo "::warning::Failed to delete keychain at $RUNNER_TEMP/app-signing.keychain-db"
@@ -374,11 +384,19 @@ jobs:
             echo "::warning::Failed to restore login keychain search list"
             fail=1
           fi
+          # All signing material in $RUNNER_TEMP (cert .p12, profile, IPA, archive, log)
           rm -rf "$RUNNER_TEMP/export" \
                  "$RUNNER_TEMP/iosApp.xcarchive" \
                  "$RUNNER_TEMP/altool-upload.log" || true
+          rm -f "$RUNNER_TEMP/certificate.p12" \
+                "$RUNNER_TEMP/profile.mobileprovision" || true
+          # App Store Connect API key (.p8) lives outside $RUNNER_TEMP
           if [ -n "${APP_STORE_CONNECT_KEY_ID:-}" ]; then
             rm -f "$HOME/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" || true
+          fi
+          # Mirrored profile in ~/Library/MobileDevice/Provisioning Profiles/
+          if [ -n "$PROFILE_UUID" ]; then
+            rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision" || true
           fi
           if [ "$fail" -eq 0 ]; then
             echo "Signing material scrubbed."

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -271,6 +271,7 @@ jobs:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
+          set -euo pipefail
           cd iosApp
           xcodebuild \
             -exportArchive \
@@ -280,14 +281,37 @@ jobs:
             -authenticationKeyPath ~/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8 \
             -authenticationKeyID $APP_STORE_CONNECT_KEY_ID \
             -authenticationKeyIssuerID $APP_STORE_CONNECT_ISSUER_ID
+          # Verify a single IPA was produced (catches `destination: upload` regressions
+          # that uploaded silently and left no local artifact, breaking the next step)
+          shopt -s nullglob
+          ipas=("$RUNNER_TEMP/export"/*.ipa)
+          shopt -u nullglob
+          if [ "${#ipas[@]}" -eq 0 ]; then
+            echo "::error::xcodebuild -exportArchive completed but no .ipa was written to $RUNNER_TEMP/export/. Check ExportOptions.plist (destination must be 'export', not 'upload')."
+            ls -la "$RUNNER_TEMP/export/" 2>&1 || true
+            exit 1
+          fi
+          if [ "${#ipas[@]}" -gt 1 ]; then
+            echo "::error::Expected exactly one .ipa, found ${#ipas[@]}: ${ipas[*]}"
+            exit 1
+          fi
+          echo "Exported IPA: ${ipas[0]} ($(du -h "${ipas[0]}" | cut -f1))"
 
       - name: Upload to App Store Connect
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
+          set -euo pipefail
+          shopt -s nullglob
+          ipas=("$RUNNER_TEMP/export"/*.ipa)
+          shopt -u nullglob
+          if [ "${#ipas[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one .ipa for upload, found ${#ipas[@]}"
+            exit 1
+          fi
           xcrun altool --upload-app \
-            -f $RUNNER_TEMP/export/*.ipa \
+            -f "${ipas[0]}" \
             -t ios \
             --apiKey "$APP_STORE_CONNECT_KEY_ID" \
             --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -239,7 +239,7 @@ jobs:
           set -euo pipefail
           dest=$(/usr/libexec/PlistBuddy -c "Print :destination" iosApp/ExportOptions.plist)
           if [ "$dest" != "export" ]; then
-            echo "::error::iosApp/ExportOptions.plist destination must be 'export' (got '$dest'). 'upload' would upload silently and the altool step would fail."
+            echo "::error::iosApp/ExportOptions.plist destination must be 'export' (got '$dest'). 'upload' uploads silently during exportArchive and writes no local IPA, breaking the next step."
             exit 1
           fi
 
@@ -325,27 +325,21 @@ jobs:
           shopt -s nullglob
           ipas=("$RUNNER_TEMP/export"/*.ipa)
           shopt -u nullglob
-          if [ "${#ipas[@]}" -ne 1 ]; then
-            echo "::error::Expected exactly one .ipa for upload, found ${#ipas[@]}"
-            exit 1
-          fi
+          # Post-export step already verified exactly one IPA exists. Re-glob is
+          # only needed to populate ipas[0] for altool's -f arg.
           # altool is famous for printing product-errors to stdout while exiting 0
-          # (auth-key revoked, asset validation rejection, etc). Capture output and
-          # grep it so we fail loudly when ASC reports an upload-time error.
+          # (auth-key revoked, asset validation rejection, etc). Capture output
+          # and grep it so we fail loudly when ASC reports an upload-time error.
+          # `set -o pipefail` (already on from `set -euo pipefail`) makes a
+          # non-zero altool exit propagate through the `tee` pipe, so we don't
+          # need PIPESTATUS gymnastics — set -e aborts before the grep runs.
           upload_log="$RUNNER_TEMP/altool-upload.log"
-          set +e
           xcrun altool --upload-app \
             -f "${ipas[0]}" \
             -t ios \
             --apiKey "$APP_STORE_CONNECT_KEY_ID" \
             --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID" \
             --output-format xml 2>&1 | tee "$upload_log"
-          rc=${PIPESTATUS[0]}
-          set -e
-          if [ "$rc" -ne 0 ]; then
-            echo "::error::altool exited $rc"
-            exit "$rc"
-          fi
           if grep -qE '<key>product-errors</key>|<key>tool-errors</key>' "$upload_log"; then
             echo "::error::altool reported errors despite exit 0 — see log above"
             exit 1

--- a/iosApp/ExportOptions.plist
+++ b/iosApp/ExportOptions.plist
@@ -7,11 +7,11 @@
 	<key>teamID</key>
 	<string>F3XX4PM3MF</string>
 	<key>uploadSymbols</key>
-	<true/>
+	<false/>
 	<key>uploadBitcode</key>
 	<false/>
 	<key>destination</key>
-	<string>upload</string>
+	<string>export</string>
 	<key>signingStyle</key>
 	<string>manual</string>
 	<key>provisioningProfiles</key>


### PR DESCRIPTION
## Summary
Comprehensive iOS deploy chain fix. Five commits, applied to both `deploy-dev.yml` and `deploy-prod.yml`. TestFlight has been starved for 7 weeks (no builds since 2026-03-12) — this restores it and hardens against the same class of regression recurring.

### Commits
| | |
|---|---|
| `9d625b3c` | **Restore upload.** `iosApp/ExportOptions.plist` had `destination: upload`, making `xcodebuild -exportArchive` attempt the App Store Connect upload during export. Upload silently failed while xcodebuild reported `** EXPORT SUCCEEDED **`, so the dedicated `altool` step crashed because no IPA reached the local export path. Switch to `destination: export` and `uploadSymbols: false`. |
| `c59a55ea` | **Fail loudly if export produces no IPA.** Verify exactly one `.ipa` after `xcodebuild -exportArchive`; resolve via bash glob array (no more literal `*.ipa` reaching altool); `set -euo pipefail`. |
| `1d214adc` | **Close the rest of the silent-failure chain.** Pre-flight PlistBuddy assertion (`destination = export` check, fails in <1s before 20-min archive). altool product-errors detection (capture stdout via `--output-format xml`, grep `<key>product-errors</key>` / `<key>tool-errors</key>` — historic "exit 0 with errors" mode now caught). Comprehensive signing-material cleanup. `set -euo pipefail` everywhere. |
| `5c1b2880` | **Scrub all signing material.** Review surfaced cleanup missed `.p12`, source profile, and mirrored `~/Library/MobileDevice/Provisioning Profiles/<UUID>.mobileprovision`. Now extracts UUID from source profile *before* deletion to remove the mirrored copy by exact name. All 5 paths from `setup-ios-signing/action.yml` covered with cross-reference comment. |
| `e267778d` | **Simplify and clarify.** Code-simplifier review: drop redundant pre-upload IPA count check (post-export step already verifies it); replace `set +e/PIPESTATUS/set -e` block with reliance on already-enabled `pipefail`. Comment-analyzer review: pre-flight error message updated to match post-PR failure path. Net 12 lines removed, no behaviour change. |

### Review loop
Reviews iterated until convergence:
- code-reviewer: approved
- silent-failure-hunter round 1: 3 HIGH findings → fixed in `1d214adc`
- pr-test-analyzer: 1 inline (PlistBuddy) + 2 deferred to follow-ups
- security-reviewer: 1 LOW (signing material cleanup) → fixed in `1d214adc`
- silent-failure-hunter round 2: 1 HIGH (missing .p12/profile paths) → fixed in `5c1b2880`
- silent-failure-hunter round 3: clean
- code-simplifier: 2 simplifications + 1 comment fix → fixed in `e267778d`
- comment-analyzer: 1 wording nit → fixed in `e267778d`
- silent-failure-hunter round 4: clean (verified bash 3.2 pipefail behaviour empirically on the actual macOS runner shell)

### Local verification
All guard scenarios exercised against bash 3.2 (the macOS runner shell):
- 0 / 1 / 2 IPAs in `$RUNNER_TEMP/export/` → correct exit codes and error messages
- PlistBuddy assertion passes for `destination: export`, fails for `destination: upload`
- altool pipeline: non-zero exit (pipefail propagates) ✓; exit 0 with `<key>product-errors</key>` (grep fires) ✓; exit 0 clean (success) ✓
- UUID extraction from `.mobileprovision` returns empty string on malformed input → cleanup `if [ -n "$PROFILE_UUID" ]` guard prevents `rm -f .../.mobileprovision` matching nothing

### Follow-ups (separate PRs to keep this one focused)
- `actionlint`/`shellcheck` job on PR CI (catches unquoted-glob class of bugs at PR time, not after a 20-min iOS deploy)
- Path-filtered export-only dry-run job (validates IPA materializes without burning a TestFlight build number)
- Extract iOS deploy steps to a composite action so dev/prod can't drift
- `setup-ios-signing` returning created paths via `$GITHUB_OUTPUT` for cleanup consumption (eliminates contract drift)
- LiveKitWebRTC dSYM ingestion from upstream releases (so `uploadSymbols: true` can return)
- Roadmap items #56 (paid-runner lint guard) and #57 (stuck-run reaper) from #373

### Test plan
- [ ] Merge → push triggers Release → bumps to v0.93.12
- [ ] Trigger Deploy To Dev → confirm `Distribute iOS to TestFlight` job is green
- [ ] Confirm new build appears in App Store Connect → TestFlight → ShyTalk dev app
- [ ] Trigger Deploy To Prod against `v0.93.12` (or `v0.93.11` — both work now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)