### PR TITLE
fix(ci): never silently fall back prod google-services to dev creds

### DIFF
--- a/.github/actions/decode-google-services/action.yml
+++ b/.github/actions/decode-google-services/action.yml
@@ -38,7 +38,13 @@ runs:
         if [ -n "$PROD_BASE64" ]; then
           echo "$PROD_BASE64" | base64 -d > app/src/prod/google-services.json
         else
-          cp app/src/dev/google-services.json app/src/prod/google-services.json
+          # NEVER fall back to dev creds for prod — that would point a prod build
+          # at the dev Firebase project (env isolation breach, see
+          # feedback-environment-isolation.md). Write a placeholder so prod-flavor
+          # builds in dev-only contexts (e.g. PR checks, ios-tests) succeed but
+          # cannot connect to anything real.
+          echo "$PLACEHOLDER" > app/src/prod/google-services.json
+          echo "::warning::Using placeholder prod google-services.json (PROD_BASE64 unavailable). A real prod-flavor build needs the secret."
         fi
 
         if [ "$INCLUDE_LOCAL" = "true" ]; then


### PR DESCRIPTION
## Summary
`.github/actions/decode-google-services/action.yml` previously fell back to `cp app/src/dev/google-services.json app/src/prod/google-services.json` when `PROD_BASE64` was unset. A prod-flavor build in any context that didn't pass the prod secret would silently ship pointed at the dev Firebase project — env-isolation breach of the kind \`feedback-environment-isolation.md\` forbids.

Mirror the dev fallback (write placeholder JSON + emit \`::warning::\`).

## Discovered during
Comprehensive workflow audit triggered after the iOS TestFlight upload regression (PR #372 review).

## Test plan
- [ ] Existing prod deploy continues to work (PROD_BASE64 secret is set, fallback path not triggered)
- [ ] PR-check builds that build the prod flavor without the secret get the placeholder + warning, and the resulting APK fails at Firebase init rather than connecting to dev
- [ ] Workflow YAML still parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)