### PR TITLE
fix(ci): harden iOS signing material against coresident-process leak

### DIFF
--- a/.github/actions/setup-ios-signing/action.yml
+++ b/.github/actions/setup-ios-signing/action.yml
@@ -103,9 +103,12 @@ runs:
         echo "$IOS_PROVISION_PROFILE_BASE64" | base64 -d > "$PROFILE_PATH"
         # PlistBuddy is exact and robust against grep/sed brittleness if
         # Apple changes whitespace or nests <string> tags in a future macOS.
-        PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print :UUID" /dev/stdin <<<"$(/usr/bin/security cms -D -i "$PROFILE_PATH")")
+        # `|| true` keeps set -e from aborting the assignment on PlistBuddy
+        # failure — the explicit empty-check below fires with a diagnostic
+        # ::error:: message instead of a raw bash-1 exit on the assignment line.
+        PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print :UUID" /dev/stdin <<<"$(/usr/bin/security cms -D -i "$PROFILE_PATH")" || true)
         if [ -z "$PROFILE_UUID" ]; then
-          echo "::error::Could not extract UUID from provisioning profile at $PROFILE_PATH"
+          echo "::error::Could not extract UUID from provisioning profile at $PROFILE_PATH (PlistBuddy failed or :UUID missing)"
           exit 1
         fi
         mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles

--- a/.github/actions/setup-ios-signing/action.yml
+++ b/.github/actions/setup-ios-signing/action.yml
@@ -59,9 +59,16 @@ runs:
       env:
         APP_STORE_CONNECT_KEY: ${{ inputs.app-store-connect-key }}
         APP_STORE_CONNECT_KEY_ID: ${{ inputs.app-store-connect-key-id }}
+      # umask 077 makes secret files mode 0600 (owner-read only) regardless
+      # of the runner's default umask. On a self-hosted Mac with multiple
+      # UIDs, the file-system permission is the actual security boundary —
+      # without this the .p8 lands as world-readable 0644.
       run: |
+        set -euo pipefail
+        umask 077
         mkdir -p ~/private_keys
-        echo "$APP_STORE_CONNECT_KEY" > ~/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8
+        chmod 700 ~/private_keys
+        printf '%s' "$APP_STORE_CONNECT_KEY" > ~/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8
 
     - name: Decode signing certificate and provisioning profile
       shell: bash
@@ -70,11 +77,18 @@ runs:
         IOS_CERTIFICATE_PASSWORD: ${{ inputs.certificate-password }}
         IOS_PROVISION_PROFILE_BASE64: ${{ inputs.provision-profile-base64 }}
       run: |
+        set -euo pipefail
+        umask 077
         CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
         KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
         echo "$IOS_CERTIFICATE_BASE64" | base64 -d > "$CERTIFICATE_PATH"
         security create-keychain -p "" "$KEYCHAIN_PATH"
-        security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+        # Auto-lock after 30 min instead of 6 h. On a self-hosted Mac if
+        # cleanup ever fails, a 6-hour unlocked keychain gives a coresident
+        # attacker a huge window to dump the cert + private key. 30 min
+        # comfortably exceeds the typical iOS deploy time (~20 min) while
+        # closing that window aggressively.
+        security set-keychain-settings -lut 1800 "$KEYCHAIN_PATH"
         security unlock-keychain -p "" "$KEYCHAIN_PATH"
         security import "$CERTIFICATE_PATH" -P "$IOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
         security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
@@ -87,6 +101,13 @@ runs:
         security list-keychain -d user -s "$KEYCHAIN_PATH" "$HOME/Library/Keychains/login.keychain-db"
         PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
         echo "$IOS_PROVISION_PROFILE_BASE64" | base64 -d > "$PROFILE_PATH"
-        PROFILE_UUID=$(/usr/bin/security cms -D -i "$PROFILE_PATH" 2>/dev/null | grep -A1 '<key>UUID</key>' | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+        # PlistBuddy is exact and robust against grep/sed brittleness if
+        # Apple changes whitespace or nests <string> tags in a future macOS.
+        PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print :UUID" /dev/stdin <<<"$(/usr/bin/security cms -D -i "$PROFILE_PATH")")
+        if [ -z "$PROFILE_UUID" ]; then
+          echo "::error::Could not extract UUID from provisioning profile at $PROFILE_PATH"
+          exit 1
+        fi
         mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
         cp "$PROFILE_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/${PROFILE_UUID}.mobileprovision
+        chmod 600 ~/Library/MobileDevice/Provisioning\ Profiles/${PROFILE_UUID}.mobileprovision


### PR DESCRIPTION
## Summary
Self-hosted Mac runner is persistent — secret files written with the default 0644 umask are world-readable to any other UID on the machine (homebrew daemons, Screen Sharing service, additional user accounts). On GitHub-hosted runners this doesn't matter (ephemeral VM); on self-hosted, file-system permission is the real security boundary.

Three changes to `.github/actions/setup-ios-signing/action.yml`:

1. **`umask 077` + explicit `chmod`** so .p8, .p12, profile, and mirrored `~/Library/MobileDevice/Provisioning Profiles/<UUID>.mobileprovision` are owner-readable only.
2. **Replace `grep|sed` UUID extraction with PlistBuddy.** Exact and robust against future macOS changes to `security cms` whitespace or nested `<string>` tags. Verified locally on bash 3.2 (the actual self-hosted runner shell): a malformed profile aborts the step with a clear error under `set -euo pipefail` instead of silently falling through with empty UUID.
3. **Drop keychain auto-lock from 21600s (6h) to 1800s (30 min).** On a crashed-cleanup run, the unlocked keychain DB sits on disk; shrinking the window from 6 hours to 30 min limits how long a coresident attacker can dump the cert + private key.

Also adds `set -euo pipefail` to both setup steps so unset env vars abort early.

## Discovered during
Comprehensive workflow audit triggered after the iOS TestFlight upload regression. PR #372 is the deploy-side cleanup fix; this is the setup-side hardening.

## Deferred to follow-up PR
- Move `~/private_keys/AuthKey_<KEY_ID>.p8` → `$RUNNER_TEMP/private_keys/` so the file lives in the runner's per-job temp area. Defers because it conflicts with PR #372's existing cleanup-step path. Once PR #372 lands, this becomes a small follow-up.
- Pre-cleanup step at start of iOS deploy job to scrub leftovers from prior crashed runs (force-killed runner can't run `if: always()` cleanup).

## Test plan
- [ ] Existing iOS deploy continues to work (signing material correct mode for codesign/altool — both run as runner UID, mode 0600 owner-read is sufficient)
- [ ] PlistBuddy UUID extraction parses production provisioning profile correctly (verify in Deploy To Dev iOS job log: `Exported IPA…` line + presence of `~/Library/MobileDevice/Provisioning Profiles/<UUID>.mobileprovision`)
- [ ] Workflow YAML still parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)