### PR TITLE
fix(ci): hard-fail on off-main prod tag + assert AAB before Play upload

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -54,12 +54,17 @@ jobs:
         env:
           TAG: ${{ inputs.release-tag }}
         run: |
+          set -euo pipefail
           if ! git tag -l "$TAG" | grep -q "$TAG"; then
             echo "::error::Tag $TAG does not exist"
             exit 1
           fi
-          if ! git merge-base --is-ancestor "$TAG" origin/main 2>/dev/null; then
-            echo "::warning::Tag $TAG may not be on the main branch"
+          # Hard fail (not warn) if the tag isn't on main. Prod hygiene: only
+          # deploy code that's been merged to main. Don't suppress stderr
+          # from git merge-base — a typo'd tag should produce a real error.
+          if ! git merge-base --is-ancestor "$TAG" origin/main; then
+            echo "::error::Tag $TAG is not an ancestor of origin/main. Refusing to deploy off-main code to prod."
+            exit 1
           fi
           VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -202,8 +207,18 @@ jobs:
           name: android-prod-release
           path: android-release
 
-      - name: List downloaded artifacts
-        run: find android-release -type f | head -20
+      - name: Verify AAB present
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          aabs=(android-release/build/outputs/bundle/prodRelease/*.aab)
+          shopt -u nullglob
+          if [ "${#aabs[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one .aab in android-release/build/outputs/bundle/prodRelease/, got ${#aabs[@]}"
+            find android-release -type f
+            exit 1
+          fi
+          echo "AAB present: ${aabs[0]} ($(du -h "${aabs[0]}" | cut -f1))"
 
       - name: Upload to Play Store internal testing track
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1


### PR DESCRIPTION
## Summary
Two prod hygiene fixes in `.github/workflows/deploy-prod.yml`:

1. **`validate-release` hard-fails on off-main tag** instead of yellow-warning. Prod hygiene: only deploy code that's been merged to main. Plus the previous `2>/dev/null` on `git merge-base` swallowed real errors (typo'd tag exited 128 silently).
2. **Replace soft-info "List downloaded artifacts" with a real AAB-presence assertion** before invoking `r0adkll/upload-google-play`. Without this, an empty bundle/ folder would silently expand the `releaseFiles: …/*.aab` glob to a literal string and either silently fail or upload nothing.

## Discovered during
Comprehensive workflow audit triggered after the iOS TestFlight upload regression.

## Test plan
- [ ] Deploy To Prod with a valid on-main tag → both checks pass quietly
- [ ] Deploy To Prod with a typo'd tag → fails at validate-release with clear error (instead of silent warning)
- [ ] Deploy To Prod with empty/missing AAB → fails at the new verify step (instead of silently uploading wrong/no file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)