### PR TITLE
fix(ci): trap-clean firebase-sa + whitelist endpoint status codes

### DIFF
--- a/.github/actions/deploy-firebase-rules/action.yml
+++ b/.github/actions/deploy-firebase-rules/action.yml
@@ -26,7 +26,13 @@ runs:
         DEPLOY_FIRESTORE: ${{ inputs.deploy-firestore }}
         DEPLOY_DATABASE: ${{ inputs.deploy-database }}
       run: |
+        set -euo pipefail
+        # Use trap so the service-account JSON is removed even if a deploy
+        # fails. Without this, set -e aborts before the trailing `rm` runs
+        # and the credential leaks across reusable-runner jobs.
+        umask 077
         echo "$SA_JSON" > /tmp/firebase-sa.json
+        trap 'rm -f /tmp/firebase-sa.json' EXIT
         export GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json
         if [ "$DEPLOY_FIRESTORE" = "true" ]; then
           firebase deploy --only firestore:rules --project "$PROJECT" --non-interactive
@@ -34,4 +40,3 @@ runs:
         if [ "$DEPLOY_DATABASE" = "true" ]; then
           firebase deploy --only database --project "$PROJECT" --non-interactive
         fi
-        rm /tmp/firebase-sa.json

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -330,7 +330,12 @@ jobs:
           check() {
             local endpoint=$1 expected=$2
             local status
-            status=$(curl -s -o /dev/null -w '%{http_code}' "https://api.shytalk.shyden.co.uk${endpoint}")
+            # `--max-time 10` caps DNS+connect+TLS+response. `|| echo "000"`
+            # converts curl's exit-on-network-failure (DNS, refused, timeout)
+            # into a sentinel status so the check fails-loud at the same
+            # whitelist comparison as a wrong HTTP code, rather than `set -e`
+            # aborting the whole verification before the FAIL line prints.
+            status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "https://api.shytalk.shyden.co.uk${endpoint}" || echo "000")
             if echo "$status" | grep -qE "^(${expected})$"; then
               echo "OK: ${endpoint} → ${status} (expected ${expected})"
             else

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -319,25 +319,32 @@ jobs:
       - name: Verify API endpoints respond
         if: needs.deploy-backend-prod.result == 'success'
         run: |
+          set -euo pipefail
           echo "=== API Endpoint Checks ==="
           ERRORS=0
-          for endpoint in "/api/health"; do
-            STATUS=$(curl -s -o /dev/null -w '%{http_code}' "https://api.shytalk.shyden.co.uk${endpoint}")
-            if [ "$STATUS" = "200" ]; then echo "OK: ${endpoint} → ${STATUS}"
-            else echo "FAIL: ${endpoint} → ${STATUS}"; ERRORS=$((ERRORS + 1)); fi
-          done
-          for endpoint in "/api/users/me" "/api/rooms" "/api/conversations"; do
-            STATUS=$(curl -s -o /dev/null -w '%{http_code}' "https://api.shytalk.shyden.co.uk${endpoint}")
-            if [ "$STATUS" = "401" ]; then echo "OK: ${endpoint} → ${STATUS} (auth required)"
-            elif [ "$STATUS" -ge 500 ]; then echo "FAIL: ${endpoint} → ${STATUS} (server error)"; ERRORS=$((ERRORS + 1))
-            else echo "OK: ${endpoint} → ${STATUS}"; fi
-          done
-          for endpoint in "/api/admin/alerts" "/api/admin/banners"; do
-            STATUS=$(curl -s -o /dev/null -w '%{http_code}' "https://api.shytalk.shyden.co.uk${endpoint}")
-            if [ "$STATUS" -ge 500 ]; then echo "FAIL: ${endpoint} → ${STATUS}"; ERRORS=$((ERRORS + 1))
-            else echo "OK: ${endpoint} → ${STATUS}"; fi
-          done
-          [ "$ERRORS" -eq 0 ] || { echo "::error::${ERRORS} endpoint(s) returned server errors"; exit 1; }
+          # Whitelist expected status per endpoint. Anything else fails the
+          # smoke test — including 404 (route removed), 400 (validation
+          # broke), 403 (auth misconfigured), 429 (rate-limit gone wild).
+          # The previous "anything not 5xx is OK" pattern silently passed
+          # all of those.
+          check() {
+            local endpoint=$1 expected=$2
+            local status
+            status=$(curl -s -o /dev/null -w '%{http_code}' "https://api.shytalk.shyden.co.uk${endpoint}")
+            if echo "$status" | grep -qE "^(${expected})$"; then
+              echo "OK: ${endpoint} → ${status} (expected ${expected})"
+            else
+              echo "FAIL: ${endpoint} → ${status} (expected ${expected})"
+              ERRORS=$((ERRORS + 1))
+            fi
+          }
+          check "/api/health"            "200"
+          check "/api/users/me"          "401"
+          check "/api/rooms"             "401"
+          check "/api/conversations"     "401"
+          check "/api/admin/alerts"      "401"
+          check "/api/admin/banners"     "401"
+          [ "$ERRORS" -eq 0 ] || { echo "::error::${ERRORS} endpoint(s) returned unexpected status"; exit 1; }
           echo "All API endpoints responding correctly"
 
       - name: Verify web landing page


### PR DESCRIPTION
## Summary
Two cleanups, both stop "looks like a check, isn't a check" patterns at the production deploy boundary.

### .github/actions/deploy-firebase-rules/action.yml
Trailing \`rm /tmp/firebase-sa.json\` only ran on success path — with \`set -e\` (default for \`shell: bash\`), a deploy failure aborts before the \`rm\`. Service-account JSON sits at \`/tmp/firebase-sa.json\` for whichever runner is reused next.

Replace with \`trap 'rm -f' EXIT\` so cleanup runs on any exit. Also add \`umask 077\` so the file mode is 0600 instead of 0644.

### .github/workflows/deploy-prod.yml — Verify API endpoints
Previous loop silently accepted any non-5xx, non-401 status as "OK" — including 404 (route removed), 400 (validation broke), 403 (auth misconfigured), 429 (rate limit). All would print "OK" while indicating real problems.

Replace with a \`check\` helper that whitelists expected status per endpoint.

## Discovered during
Comprehensive workflow audit triggered after the iOS TestFlight upload regression.

## Test plan
- [ ] firebase-rules cleanup: deliberately fail a deploy → verify /tmp/firebase-sa.json doesn't persist
- [ ] endpoint check: temporarily route 404 a tracked endpoint → smoke test fails with clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)