### PR TITLE
fix(ci): assert exactly one APK before Firebase distribution

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -166,15 +166,27 @@ jobs:
       - name: Locate APK
         id: find-apk
         run: |
-          APK_PATH=$(find dev-release-apk -name "*.apk" -type f | head -1)
-          if [ -z "$APK_PATH" ]; then
+          set -euo pipefail
+          # Glob with explicit count check rather than `find | head -1`. Two
+          # APKs can land in dev-release-apk/ if signing config changes
+          # produce both `app-dev-release.apk` and
+          # `app-dev-release-unsigned.apk`; alphabetical pick would silently
+          # upload the unsigned one to Firebase App Distribution.
+          shopt -s nullglob
+          apks=(dev-release-apk/*.apk)
+          shopt -u nullglob
+          if [ "${#apks[@]}" -eq 0 ]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "::error::No APK found"
-          else
-            echo "found=true" >> "$GITHUB_OUTPUT"
-            echo "apk_path=$APK_PATH" >> "$GITHUB_OUTPUT"
-            echo "Found APK: $APK_PATH"
+            echo "::error::No APK found in dev-release-apk/"
+            exit 1
           fi
+          if [ "${#apks[@]}" -gt 1 ]; then
+            echo "::error::Expected exactly one APK, found ${#apks[@]}: ${apks[*]}"
+            exit 1
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "apk_path=${apks[0]}" >> "$GITHUB_OUTPUT"
+          echo "Found APK: ${apks[0]}"
 
       - name: Upload to Firebase App Distribution
         if: steps.find-apk.outputs.found == 'true'


### PR DESCRIPTION
## Summary
\`find dev-release-apk -name "*.apk" | head -1\` silently picks the first APK alphabetically. If gradle ever produces both \`app-dev-release.apk\` and \`app-dev-release-unsigned.apk\` (signing config changes, build cache pollution from previous runs), alphabetical pick sends the *unsigned* one to Firebase App Distribution — testers download something that won't install.

Replace with explicit glob + count check (same pattern PR #372 landed for .ipa). Fails clearly on zero or more-than-one.

## Discovered during
Comprehensive workflow audit triggered after the iOS TestFlight upload regression.

## Test plan
- [ ] Standard Deploy To Dev → exactly one APK matched, distribution succeeds
- [ ] Inject a second APK in dev-release-apk → step fails clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)