### PR TITLE
fix(api): image policy violations must return 400, not silent store

### DIFF
--- a/express-api/src/routes/storage.js
+++ b/express-api/src/routes/storage.js
@@ -14,7 +14,7 @@ const multer = require('multer');
 const r2 = require('../utils/r2');
 const { getExtension } = require('../utils/helpers');
 const log = require('../utils/log');
-const { compressImage } = require('../utils/imageCompressor');
+const { compressImage, ImagePolicyError } = require('../utils/imageCompressor');
 
 const router = express.Router();
 const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 10 * 1024 * 1024 } });
@@ -74,7 +74,23 @@ router.post('/storage/upload', upload.single('file'), async (req, res) => {
       originalSize = compressed.originalSize;
       compressedSize = compressed.compressedSize;
     } catch (compressionErr) {
-      log.warn('storage', 'Compression failed, storing original', {
+      // Policy violations (oversized image, SVG, empty buffer) MUST be
+      // surfaced as a 4xx — silently uploading the original would defeat
+      // the dimension/MIME checks that exist for safety reasons.
+      if (compressionErr instanceof ImagePolicyError) {
+        log.warn('storage', 'Upload rejected: image policy violation', {
+          uniqueId,
+          contentType,
+          error: compressionErr.message,
+        });
+        return res.status(400).json({ error: compressionErr.message });
+      }
+      // Compression-engine failures (sharp internal error, codec issue,
+      // timeout) — store original, log warning, succeed. The caller asked
+      // to upload an image; compression is a best-effort optimisation.
+      log.warn('storage', 'Compression engine failed, storing original', {
+        uniqueId,
+        contentType,
         error: compressionErr.message,
       });
     }

--- a/express-api/src/utils/imageCompressor.js
+++ b/express-api/src/utils/imageCompressor.js
@@ -11,25 +11,39 @@ const MAX_DIMENSION = 4096;
 const MIN_DIMENSION = 100;
 const COMPRESSION_TIMEOUT_MS = 10000;
 
+/**
+ * Distinguishes policy rejections (oversized image, SVG XSS risk, empty
+ * buffer) from compression-engine failures (sharp threw, timeout). Callers
+ * MUST re-throw ImagePolicyError as a 4xx client error rather than
+ * silently storing the original buffer — that would defeat the dimension
+ * check and let an oversized image become a permanent R2 object.
+ */
+class ImagePolicyError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ImagePolicyError';
+  }
+}
+
 async function compressImage(buffer, mimeType) {
   if (!buffer || buffer.length === 0) {
-    throw new Error('Empty image buffer');
+    throw new ImagePolicyError('Empty image buffer');
   }
 
   if (mimeType === 'image/svg+xml') {
-    throw new Error('SVG format not supported — XSS risk');
+    throw new ImagePolicyError('SVG format not supported — XSS risk');
   }
 
   const originalSize = buffer.length;
 
   const metadata = await sharp(buffer).metadata();
   if (metadata.width > MAX_DIMENSION || metadata.height > MAX_DIMENSION) {
-    throw new Error(
+    throw new ImagePolicyError(
       `Image dimensions ${metadata.width}x${metadata.height} exceed maximum ${MAX_DIMENSION}x${MAX_DIMENSION}`,
     );
   }
   if (metadata.width < MIN_DIMENSION || metadata.height < MIN_DIMENSION) {
-    throw new Error(
+    throw new ImagePolicyError(
       `Image dimensions ${metadata.width}x${metadata.height} below minimum ${MIN_DIMENSION}x${MIN_DIMENSION}`,
     );
   }
@@ -69,19 +83,36 @@ async function compressImage(buffer, mimeType) {
   pipeline = pipeline.toColorspace('srgb');
 
   let timer;
+  let timedOut = false;
   const timeoutPromise = new Promise((_, reject) => {
-    timer = setTimeout(
-      () => reject(new Error('Image compression timed out')),
-      COMPRESSION_TIMEOUT_MS,
-    );
+    timer = setTimeout(() => {
+      timedOut = true;
+      reject(new Error('Image compression timed out'));
+    }, COMPRESSION_TIMEOUT_MS);
+  });
+
+  // Hold a reference to the in-flight sharp promise so we can attach a
+  // tail .catch() for the post-timeout case. Without this, when the
+  // timeout fires first, the sharp promise's eventual rejection becomes
+  // an unhandled rejection with no context back to this request.
+  const sharpPromise = pipeline.toBuffer();
+  sharpPromise.catch((tailErr) => {
+    if (timedOut) {
+      log.warn('imageCompressor', 'Sharp pipeline rejected after timeout (post-mortem)', {
+        error: tailErr.message,
+        format: outputMime,
+        originalSize,
+      });
+    }
   });
 
   let compressed;
   try {
-    compressed = await Promise.race([pipeline.toBuffer(), timeoutPromise]);
+    compressed = await Promise.race([sharpPromise, timeoutPromise]);
   } catch (err) {
     log.warn('imageCompressor', 'Compression failed, returning original', {
       error: err.message,
+      timedOut,
       format: outputMime,
       originalSize,
     });
@@ -105,4 +136,4 @@ async function compressImage(buffer, mimeType) {
   };
 }
 
-module.exports = { compressImage };
+module.exports = { compressImage, ImagePolicyError };

--- a/express-api/tests/routes/storage.test.js
+++ b/express-api/tests/routes/storage.test.js
@@ -8,14 +8,24 @@ jest.mock('../../src/utils/r2', () => ({
   deleteObject: jest.fn().mockResolvedValue(),
 }));
 
-jest.mock('../../src/utils/imageCompressor', () => ({
-  compressImage: jest.fn().mockResolvedValue({
-    buffer: Buffer.from('compressed'),
-    mimeType: 'image/jpeg',
-    originalSize: 100,
-    compressedSize: 50,
-  }),
-}));
+jest.mock('../../src/utils/imageCompressor', () => {
+  // Provide a real subclass so route's `instanceof ImagePolicyError` works
+  class ImagePolicyError extends Error {
+    constructor(message) {
+      super(message);
+      this.name = 'ImagePolicyError';
+    }
+  }
+  return {
+    compressImage: jest.fn().mockResolvedValue({
+      buffer: Buffer.from('compressed'),
+      mimeType: 'image/jpeg',
+      originalSize: 100,
+      compressedSize: 50,
+    }),
+    ImagePolicyError,
+  };
+});
 
 jest.mock('../../src/utils/helpers', () => ({
   getExtension: jest.fn((mime) => {
@@ -223,7 +233,7 @@ describe('POST /api/storage/upload', () => {
     expect(r2.putObject).toHaveBeenCalledWith(expect.any(String), compressedBuf, 'image/jpeg');
   });
 
-  test('compression failure falls back to storing original', async () => {
+  test('compression engine failure falls back to storing original', async () => {
     const { compressImage } = require('../../src/utils/imageCompressor');
     compressImage.mockRejectedValueOnce(new Error('sharp failed'));
     const app = createApp();
@@ -237,6 +247,47 @@ describe('POST /api/storage/upload', () => {
 
     expect(res.status).toBe(200);
     expect(r2.putObject).toHaveBeenCalled();
+  });
+
+  test('policy violation (oversized image) returns 400 — does NOT silently store original', async () => {
+    const { compressImage, ImagePolicyError } = require('../../src/utils/imageCompressor');
+    compressImage.mockRejectedValueOnce(
+      new ImagePolicyError('Image dimensions 9999x9999 exceed maximum 4096x4096'),
+    );
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/storage/upload')
+      .field('path', 'profiles')
+      .attach('file', Buffer.from('oversized-data'), {
+        filename: 'huge.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/exceed maximum/);
+    expect(r2.putObject).not.toHaveBeenCalled();
+  });
+
+  test('policy violation (SVG) returns 400 — does NOT silently store original', async () => {
+    // MIME-type allowlist already rejects SVG before compressImage is called,
+    // but verify the layered defence: even if a future change loosens the
+    // allowlist, ImagePolicyError thrown by compressImage still produces 400.
+    const { compressImage, ImagePolicyError } = require('../../src/utils/imageCompressor');
+    compressImage.mockRejectedValueOnce(
+      new ImagePolicyError('SVG format not supported — XSS risk'),
+    );
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/storage/upload')
+      .field('path', 'profiles')
+      .attach('file', Buffer.from('<svg></svg>'), {
+        filename: 'a.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/SVG format/);
+    expect(r2.putObject).not.toHaveBeenCalled();
   });
 
   test('HEIC upload key uses post-compression extension (.jpg not .heic)', async () => {


### PR DESCRIPTION
## Summary
\`storage.js\`'s catch lumped policy violations (oversized image, SVG XSS, empty buffer) together with sharp/timeout failures and silently uploaded the unmodified original to R2. A 9999×9999 image became a permanent R2 object the dimension check was supposed to reject. Same hole for SVG.

Introduce typed \`ImagePolicyError\` class:
- Policy violations in \`imageCompressor.js\` throw \`ImagePolicyError\`
- \`storage.js\` re-throws as 400 with the violation message
- Sharp internal errors and timeout remain "store original" (not the user's fault)

Plus: the abandoned sharp pipeline after \`Promise.race\` timeout was an unhandled rejection with no request context. Attach a tail \`.catch()\` for the post-mortem when timedOut=true.

## Discovered during
Comprehensive Express API silent-failure audit triggered after the iOS workflow audit.

## Test plan
- [x] Existing 70 storage tests pass (1 renamed)
- [x] 2 new tests: oversized → 400 + R2 not called; SVG → 400 + R2 not called
- [x] Total 72/72 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)