### PR TITLE
fix(api): log cron + data-export status-write failures

### DIFF
--- a/express-api/src/cron/notification-dispatch.js
+++ b/express-api/src/cron/notification-dispatch.js
@@ -70,8 +70,15 @@ async function dispatchNotifications() {
               await db.doc(`subscriptions/${notif.uid}`).update({
                 pushToken: null,
               });
-            } catch {
-              // Best effort cleanup
+            } catch (cleanupErr) {
+              // Don't fail the notification dispatch over a stale-token
+              // write failure, but log it: stale tokens that linger here
+              // mean future sends keep failing for that user (silent decay).
+              log.warn('notification-dispatch', 'Failed to clear invalid pushToken (best-effort)', {
+                uid: notif.uid,
+                notifId: doc.id,
+                error: cleanupErr.message,
+              });
             }
           }
         } catch (err) {
@@ -107,8 +114,19 @@ async function dispatchNotifications() {
       });
       try {
         await doc.ref.update({ status: 'failed', error: err.message });
-      } catch {
-        // Best effort
+      } catch (statusErr) {
+        // If we can't mark `failed`, the queue item stays `queued` and gets
+        // re-dispatched on every cron tick — potentially re-spamming the
+        // user AND burning Firestore quota. Log so this is visible in
+        // production, even though we can't auto-recover.
+        log.error(
+          'notification-dispatch',
+          'Failed to mark notification as failed (will re-attempt next tick)',
+          {
+            notifId: doc.id,
+            error: statusErr.message,
+          },
+        );
       }
       failed++;
     }

--- a/express-api/src/routes/data-export.js
+++ b/express-api/src/routes/data-export.js
@@ -127,10 +127,25 @@ router.post('/users/:uniqueId/data-export', async (req, res) => {
           uniqueId,
           error: err.message,
         });
+        // Don't swallow the status update failure silently — if this fails,
+        // the user's `dataExportStatus` stays at `building` forever, the
+        // polling endpoint reports "in progress", and the user sits waiting
+        // for an export that will never complete. This is a GDPR
+        // data-export endpoint — silent stuck-in-progress states are a
+        // compliance issue.
         await db
           .doc(`users/${uniqueId}`)
           .update({ dataExportStatus: 'failed' })
-          .catch(() => {});
+          .catch((statusErr) => {
+            log.error(
+              'data-export',
+              'Failed to mark dataExportStatus=failed — user may be stuck in building state',
+              {
+                uniqueId,
+                error: statusErr.message,
+              },
+            );
+          });
       }
     })();
 


### PR DESCRIPTION
## Summary
Three empty \`catch {}\` / \`.catch(() => {})\` blocks were swallowing real failures with consequences that decay invisibly over time:

1. **notification-dispatch.js:73** — invalid-token cleanup silently failed. Stale FCM tokens persist forever, future sends keep failing for that user.
2. **notification-dispatch.js:110** — \`doc.ref.update({status: 'failed'})\` silently failed. Queue item stays \`queued\`, gets re-dispatched on every cron tick (re-spam + Firestore quota burn).
3. **data-export.js:130** — \`dataExportStatus: 'failed'\` update silently swallowed. User's \`dataExportStatus\` stays at \`building\` forever, polling keeps reporting "in progress". **GDPR compliance issue.**

All three: replace empty catch with \`log.warn\`/\`log.error\` with diagnostic context. Cleanup remains best-effort.

## Discovered during
Comprehensive Express API silent-failure audit triggered after the iOS workflow audit.

## Test plan
- [x] 75/75 tests passing (3 affected test suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)