### PR TITLE
fix(api): PM partial-failure flags on admin-bans/economy/devices

### DIFF
--- a/express-api/src/routes/admin-bans.js
+++ b/express-api/src/routes/admin-bans.js
@@ -90,16 +90,22 @@ router.post('/admin/bans/device', async (req, res) => {
       createdAt: now(),
     });
 
-    // Send system PM if linked to a user (non-blocking)
+    // Send system PM if linked to a user (non-blocking). Track failure so
+    // the admin UI's PartialFailureToast.buildPartialFailureMessage() can
+    // surface it via the standard `pms: { failed, total }` shape.
+    let pmFailed = 0;
+    let pmTotal = 0;
     if (linkedUniqueId) {
+      pmTotal = 1;
       try {
         await sendSystemPm(linkedUniqueId, 'A restriction has been placed on your account.');
       } catch (e) {
         log.warn('system-pm', 'Failed to send', { uniqueId: linkedUniqueId, error: e.message });
+        pmFailed = 1;
       }
     }
 
-    res.json({ success: true });
+    res.json({ success: true, pms: { failed: pmFailed, total: pmTotal } });
   } catch (err) {
     log.error('admin-bans', 'Error banning device', { error: err.message });
     res.status(500).json({ error: 'Internal server error' });
@@ -158,16 +164,22 @@ router.post('/admin/bans/network', async (req, res) => {
       createdAt: now(),
     });
 
-    // Send system PM if linked to a user (non-blocking)
+    // Send system PM if linked to a user (non-blocking). Track failure so
+    // the admin UI's PartialFailureToast.buildPartialFailureMessage() can
+    // surface it via the standard `pms: { failed, total }` shape.
+    let pmFailed = 0;
+    let pmTotal = 0;
     if (linkedUniqueId) {
+      pmTotal = 1;
       try {
         await sendSystemPm(linkedUniqueId, 'A restriction has been placed on your account.');
       } catch (e) {
         log.warn('system-pm', 'Failed to send', { uniqueId: linkedUniqueId, error: e.message });
+        pmFailed = 1;
       }
     }
 
-    res.json({ success: true });
+    res.json({ success: true, pms: { failed: pmFailed, total: pmTotal } });
   } catch (err) {
     log.error('admin-bans', 'Error banning network', { error: err.message });
     res.status(500).json({ error: 'Internal server error' });
@@ -263,14 +275,20 @@ router.post('/admin/bans/unban-all/:uniqueId', async (req, res) => {
       createdAt: now(),
     });
 
-    // Send system PM about restriction lifted (non-blocking)
+    // Send system PM about restriction lifted. Track failure for admin UI.
+    let pmFailed = 0;
     try {
       await sendSystemPm(uniqueId, 'A restriction on your account has been lifted.');
     } catch (e) {
       log.warn('system-pm', 'Failed to send', { uniqueId, error: e.message });
+      pmFailed = 1;
     }
 
-    res.json({ success: true, removed: allDocs.length });
+    res.json({
+      success: true,
+      removed: allDocs.length,
+      pms: { failed: pmFailed, total: 1 },
+    });
   } catch (err) {
     log.error('admin-bans', 'Error unbanning all for user', {
       uniqueId: req.params.uniqueId,

--- a/express-api/src/routes/admin-devices.js
+++ b/express-api/src/routes/admin-devices.js
@@ -157,8 +157,12 @@ router.delete('/admin/devices/:deviceId', async (req, res) => {
       createdAt: now(),
     });
 
-    // Send system PM to the bound user (non-blocking)
+    // Send system PM to the bound user. Track failure for admin UI's
+    // PartialFailureToast — `pms: { failed, total }` is the standard shape.
+    let pmFailed = 0;
+    let pmTotal = 0;
     if (deviceData.uniqueId) {
+      pmTotal = 1;
       try {
         await sendSystemPm(
           deviceData.uniqueId,
@@ -166,10 +170,11 @@ router.delete('/admin/devices/:deviceId', async (req, res) => {
         );
       } catch (e) {
         log.warn('system-pm', 'Failed to send', { error: e.message });
+        pmFailed = 1;
       }
     }
 
-    res.json({ success: true });
+    res.json({ success: true, pms: { failed: pmFailed, total: pmTotal } });
   } catch (err) {
     log.error('admin-devices', 'Error unbinding device', {
       deviceId: req.params.deviceId,

--- a/express-api/src/routes/admin-economy.js
+++ b/express-api/src/routes/admin-economy.js
@@ -105,10 +105,12 @@ router.post('/users/:uniqueId/adjust-balance', async (req, res) => {
       }),
     ]);
 
-    // Send system PM about balance adjustment (non-blocking)
+    // Send system PM about balance adjustment. Track failure for admin UI's
+    // PartialFailureToast — `pms: { failed, total }` is the standard shape.
     const currencyName = currency === 'coins' ? 'Shy Coins' : 'Shy Beans';
     const absAmount = Math.abs(amount);
     const action = amount > 0 ? 'were added to' : 'were deducted from';
+    let pmFailed = 0;
     try {
       await sendSystemPm(
         req.params.uniqueId,
@@ -116,9 +118,15 @@ router.post('/users/:uniqueId/adjust-balance', async (req, res) => {
       );
     } catch (e) {
       log.warn('system-pm', 'Failed to send', { uid: req.params.uniqueId, error: e.message });
+      pmFailed = 1;
     }
 
-    res.json({ success: true, newBalance, currency });
+    res.json({
+      success: true,
+      newBalance,
+      currency,
+      pms: { failed: pmFailed, total: 1 },
+    });
   } catch (err) {
     log.error('admin-economy', 'Error adjusting balance', {
       uid: req.params.uniqueId,


### PR DESCRIPTION
## Summary
Extends the PM partial-failure pattern from PR #384 to the remaining admin routes. All five had \`try { await sendSystemPm(...) } catch (e) { log.warn(...) }\` returning success even when the user-facing PM was silently dropped:

- \`admin-bans.js\` POST /admin/bans/device
- \`admin-bans.js\` POST /admin/bans/network
- \`admin-bans.js\` POST /admin/bans/unban-all/:uniqueId
- \`admin-economy.js\` POST /users/:uniqueId/balance
- \`admin-devices.js\` POST /admin/devices/:deviceId/unbind

All now return \`pms: { failed, total }\` — same shape as PR #384 and reports.js — so the existing \`PartialFailureToast.buildPartialFailureMessage()\` helper picks them up without any client-side handler change.

## Test plan
- [x] 166/166 tests on affected suites passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)