### PR TITLE
fix(api): dedup rtdbEventsFailed counter in evict-suspended-user

### DIFF
--- a/express-api/src/utils/evict-suspended-user.js
+++ b/express-api/src/utils/evict-suspended-user.js
@@ -155,7 +155,12 @@ async function evictSuspendedUser(uid) {
   // emitting `room_closed` for a room that's still OPEN in Firestore would lie
   // to live clients listening on the RTDB channel.
   const failedSet = new Set(failedRoomIds);
-  let rtdbEventsFailed = 0;
+  // Track per-room failures via a Set so that owner-closure rooms (which
+  // make TWO RTDB calls — lastEvent + node remove) don't double-count
+  // toward rtdbEventsFailed when both calls fail. The admin-facing counter
+  // should mean "rooms whose RTDB sync failed", not "RTDB ops attempted
+  // and failed".
+  const rtdbFailedRooms = new Set();
   for (const evt of rtdbEvents) {
     if (failedSet.has(evt.roomId)) continue;
     try {
@@ -168,7 +173,7 @@ async function evictSuspendedUser(uid) {
         roomId: evt.roomId,
         error: err.message,
       });
-      rtdbEventsFailed += 1;
+      rtdbFailedRooms.add(evt.roomId);
     }
     // For owner closures, also tear down the RTDB room node entirely so any
     // lingering presence/typing/event children are cleaned up.
@@ -180,10 +185,11 @@ async function evictSuspendedUser(uid) {
           roomId: evt.roomId,
           error: err.message,
         });
-        rtdbEventsFailed += 1;
+        rtdbFailedRooms.add(evt.roomId);
       }
     }
   }
+  const rtdbEventsFailed = rtdbFailedRooms.size;
 
   return {
     roomsClosed,

--- a/express-api/tests/utils/evict-suspended-user.test.js
+++ b/express-api/tests/utils/evict-suspended-user.test.js
@@ -669,9 +669,11 @@ describe('evictSuspendedUser — RTDB failure tolerance', () => {
       expect(result.rtdbEventsFailed).toBe(0);
     });
 
-    it('counts both RTDB set + remove failures for owner closure', async () => {
+    it('counts owner-closure room with both RTDB ops failing as ONE failed room', async () => {
       // Owner branch fires: ref(.../events/lastEvent).set + ref(...).remove.
-      // Reject both → rtdbEventsFailed=2.
+      // Both reject → rtdbEventsFailed should be 1 (one room failed),
+      // not 2 (number of RTDB ops). The admin-facing counter means
+      // "rooms whose RTDB sync failed", not "RTDB ops attempted".
       mockQueryDocs.mockResolvedValueOnce([]).mockResolvedValueOnce([
         {
           id: 'ownedRoom',
@@ -686,7 +688,7 @@ describe('evictSuspendedUser — RTDB failure tolerance', () => {
       mockRtdbRemove.mockRejectedValueOnce(new Error('rtdb remove fail'));
 
       const result = await evictSuspendedUser('suspended-uid');
-      expect(result.rtdbEventsFailed).toBe(2);
+      expect(result.rtdbEventsFailed).toBe(1);
       expect(result.roomsClosed).toBe(1);
     });
   });


### PR DESCRIPTION
## Summary
Owner-closure rooms in the suspension cascade fire two RTDB calls:
1. \`set('rooms/<id>/events/lastEvent', { type: 'room_closed' })\`
2. \`remove('rooms/<id>')\`

Both incremented the same \`rtdbEventsFailed\` counter, so a room whose RTDB sync failed completely was reported as \`rtdbEventsFailed: 2\` — implying two rooms had problems. The counter's intended semantic is "rooms whose RTDB sync failed".

Track failures via Set keyed by \`roomId\`. Update test assertion: existing test asserted the old double-count as correct; corrected to assert the dedup'd count of 1 for one failed owner-closure room.

## Test plan
- [x] 24/24 evict-suspended-user tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)