### PR TITLE
fix(ci): paid-runner lint guard (closes Phase 0 #56)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,3 +82,6 @@ jobs:
           # in run: blocks where the alternative would be every reference
           # gaining a quote. Other shellcheck rules apply normally.
           actionlint -shellcheck='-e SC2086'
+
+      - name: No paid GitHub-hosted runner specs
+        run: bash scripts/check-no-paid-runners.sh

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -16,6 +16,15 @@ fi
 
 CHANGED=$(git diff --name-only origin/main...HEAD 2>/dev/null)
 
+# Always run paid-runner guard — protects against PR #370-style regressions
+# where a workflow file gets bumped to a paid runner spec that personal-
+# account public repos can't allocate, blocking CI indefinitely. Cost ~10ms.
+if ! bash scripts/check-no-paid-runners.sh; then
+  echo ""
+  echo "✗ Paid runner specs detected — push blocked"
+  exit 1
+fi
+
 # Run actionlint on workflow changes BEFORE the SonarCloud check (so workflow
 # regressions don't slip through when nothing else changes). This catches
 # unquoted globs, missing `set -euo pipefail`, and other silent-failure

--- a/scripts/check-no-paid-runners.sh
+++ b/scripts/check-no-paid-runners.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Reject any workflow that references a paid GitHub-hosted runner spec.
+#
+# Background: PR #370 attempted to upgrade all runners to `*-xlarge` /
+# `*-cores` thinking those tiers were free for public repos. They are
+# free for ORGANIZATION-owned public repos, not personal-account public
+# repos like this one. Result: dozens of CI runs sat in `queued` for
+# hours requesting nonexistent runner tiers, blocking the entire pipeline.
+# See feedback-larger-runners-paid.md for the lesson.
+#
+# This guard rejects any commit that re-introduces those specs, so the
+# same incident can't recur. Run from project root.
+
+set -euo pipefail
+
+# Patterns that are paid for personal-account public repos. Match in
+# `runs-on:` lines (line-anchored to avoid false positives in comments
+# that mention these specs as warnings).
+#   *-xlarge       → macos-*-xlarge, ubuntu-*-xlarge etc.
+#   *-cores        → ubuntu-latest-N-cores etc.
+#   large-*        → some Windows large-runner variants
+#   *-large        → catches both ubuntu-large-runner and macos-*-large
+PAID_RE='runs-on:\s*[\["{]?\s*(\b[a-z0-9.-]+-(xlarge|large|[0-9]+-cores)\b|\blarge-[a-z0-9.-]+\b)'
+
+# Search workflow YAML and composite action YAML.
+hits=$(
+  grep -rEn --include='*.yml' --include='*.yaml' "$PAID_RE" \
+    .github/workflows .github/actions 2>/dev/null \
+    | grep -v '^[^:]*:\s*[0-9]\+:\s*#' || true
+)
+
+if [ -n "$hits" ]; then
+  echo "::error::Paid runner specs detected. Personal-account public repos must use only free-tier runners."
+  echo "$hits"
+  echo ""
+  echo "Allowed: ubuntu-latest, macos-latest, macos-14, macos-15, windows-latest, self-hosted"
+  echo "Blocked: *-xlarge, *-cores, *-large, large-*"
+  echo ""
+  echo "Background: GitHub larger runners are free for ORGANIZATION-owned"
+  echo "public repos, not personal-account ones. PR #370 (reverted) tried"
+  echo "this and blocked CI for hours with queued runs. See"
+  echo "feedback-larger-runners-paid.md for the full incident."
+  exit 1
+fi
+
+echo "✓ No paid runner specs detected."


### PR DESCRIPTION
## Summary
Reject any workflow that references a paid GitHub-hosted runner spec (\`*-xlarge\`, \`*-cores\`, \`*-large\`, \`large-*\`). Personal-account public repos can only allocate the free tier; PR #370 (reverted) tried to upgrade to paid runners and blocked CI for hours with queued runs.

\`scripts/check-no-paid-runners.sh\` is wired into:
- \`.github/workflows/lint.yml\` as a CI step (always runs)
- \`.husky/pre-push\` so issues are caught locally before push

Verified: rejects \`runs-on: ubuntu-latest-16-cores\`, accepts current free-tier specs.

Closes Phase 0 roadmap item #56. Together with PR #387 (actionlint), the silent-failure + paid-runner bug families are now both caught at PR time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)