### PR TITLE
fix(admin): wire admin UI to consume PM partial-failure flags

### DIFF
--- a/express-api/tests/admin-client/partial-failure-toast.test.js
+++ b/express-api/tests/admin-client/partial-failure-toast.test.js
@@ -7,7 +7,7 @@
  * fallbacks for missing optional fields.
  */
 const path = require('path');
-const { buildPartialFailureMessage } = require(
+const { buildPartialFailureMessage, showResultToast } = require(
   path.resolve(__dirname, '../../../public/admin/js/lib/partial-failure-toast.js'),
 );
 
@@ -361,5 +361,42 @@ describe('buildPartialFailureMessage — Number.isFinite edge cases (Pass-15 fix
     });
     expect(msg).toContain('2/? PMs failed');
     expect(msg).not.toContain('NaN');
+  });
+});
+
+describe('showResultToast — shared helper for tab handlers', () => {
+  let calls;
+  const fakeToast = (msg, kind) => calls.push({ msg, kind });
+  beforeEach(() => {
+    calls = [];
+  });
+
+  it('shows error toast on partial failure', () => {
+    showResultToast(fakeToast, { pms: { failed: 1, total: 1 } }, 'OK');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].kind).toBe('error');
+    expect(calls[0].msg).toContain('PMs failed');
+  });
+
+  it('shows success toast on full success', () => {
+    showResultToast(fakeToast, { success: true }, 'Done');
+    expect(calls).toEqual([{ msg: 'Done', kind: 'success' }]);
+  });
+
+  it('shows nothing on full success when successMessage is null', () => {
+    // Used by autosave handlers that don't want a success toast.
+    showResultToast(fakeToast, { success: true }, null);
+    expect(calls).toEqual([]);
+  });
+
+  it('shows nothing on full success when successMessage is undefined', () => {
+    showResultToast(fakeToast, { success: true });
+    expect(calls).toEqual([]);
+  });
+
+  it('partial failure overrides null successMessage (always surface failures)', () => {
+    showResultToast(fakeToast, { pms: { failed: 1, total: 2 } }, null);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].kind).toBe('error');
   });
 });

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -5055,9 +5055,13 @@
 <div class="toast" id="toast"></div>
 
 <script src="config.js"></script>
-<!-- Partial-failure toast lib (UMD) — must load BEFORE main.js so the
-     window.PartialFailureToast global is available when tabs/reports.js
-     processes a /api/reports/:id/resolve response. -->
+<!-- Partial-failure toast lib (UMD) — must remain a CLASSIC <script> tag
+     (no type="module", no defer) so window.PartialFailureToast is set
+     synchronously at parse time. main.js below is type="module" which
+     is implicitly deferred — by the time any tab module's body runs,
+     the global is already populated. If anyone reorders these tags or
+     converts this lib to a module, every tab consumer must also be
+     audited for load-order safety. -->
 <script src="js/lib/partial-failure-toast.js"></script>
 <script type="module" src="js/main.js"></script>
 <script src="/js/language-selector.js"></script>

--- a/public/admin/js/lib/partial-failure-toast.js
+++ b/public/admin/js/lib/partial-failure-toast.js
@@ -77,5 +77,24 @@
     return 'Partial: ' + parts.join('; ') + '. Please retry the failed step.';
   }
 
-  return { buildPartialFailureMessage };
+  /**
+   * Show either the partial-failure toast or a normal success toast,
+   * depending on whether the response carries any partial-failure flags.
+   *
+   * @param showToast {(msg: string, kind?: 'success' | 'error') => void}
+   *   The page-level toast function (varies between admin/portal/etc.).
+   * @param result {object} — API response body.
+   * @param successMessage {string | null} — message for the all-clear path.
+   *   Pass null to show NO toast on success (e.g., silent autosave).
+   */
+  function showResultToast(showToast, result, successMessage) {
+    const partialMessage = buildPartialFailureMessage(result);
+    if (partialMessage) {
+      showToast(partialMessage, 'error');
+    } else if (successMessage !== null && successMessage !== undefined) {
+      showToast(successMessage, 'success');
+    }
+  }
+
+  return { buildPartialFailureMessage, showResultToast };
 });

--- a/public/admin/js/tabs/devices.js
+++ b/public/admin/js/tabs/devices.js
@@ -215,23 +215,11 @@ function renderDevicesTable(data) {
   }
 }
 
-// Helper: surface partial-failure (PM delivery failed) via the shared toast
-// builder, falling back to the success message when the action succeeded
-// fully. Used by every endpoint that emits `pms: { failed, total }`.
-function showResultToast(result, successMessage) {
-  const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
-  if (partialMessage) {
-    showToast(partialMessage, 'error');
-  } else {
-    showToast(successMessage, 'success');
-  }
-}
-
 async function unbindDevice(deviceId) {
   if (!confirm(`Unbind device ${deviceId}?`)) return;
   try {
     const result = await apiCall('DELETE', `/api/admin/devices/${deviceId}`);
-    showResultToast(result, 'Device unbound successfully');
+    window.PartialFailureToast?.showResultToast(showToast, result, 'Device unbound successfully');
     loadDevices();
   } catch (err) {
     showToast('Failed to unbind: ' + err.message, 'error');
@@ -248,7 +236,7 @@ async function banDeviceFromDevices(deviceId, userId) {
       reason,
       linkedUniqueId: userId || null,
     });
-    showResultToast(result, 'Device banned');
+    window.PartialFailureToast?.showResultToast(showToast, result, 'Device banned');
     loadDevices();
   } catch (err) {
     showToast('Failed to ban device: ' + err.message, 'error');
@@ -269,7 +257,7 @@ async function banNetworkFromDevices(ip, userId) {
       reason,
       linkedUniqueId: userId || null,
     });
-    showResultToast(result, 'Network banned');
+    window.PartialFailureToast?.showResultToast(showToast, result, 'Network banned');
     loadDevices();
   } catch (err) {
     showToast('Failed to ban network: ' + err.message, 'error');

--- a/public/admin/js/tabs/devices.js
+++ b/public/admin/js/tabs/devices.js
@@ -215,11 +215,23 @@ function renderDevicesTable(data) {
   }
 }
 
+// Helper: surface partial-failure (PM delivery failed) via the shared toast
+// builder, falling back to the success message when the action succeeded
+// fully. Used by every endpoint that emits `pms: { failed, total }`.
+function showResultToast(result, successMessage) {
+  const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
+  if (partialMessage) {
+    showToast(partialMessage, 'error');
+  } else {
+    showToast(successMessage, 'success');
+  }
+}
+
 async function unbindDevice(deviceId) {
   if (!confirm(`Unbind device ${deviceId}?`)) return;
   try {
-    await apiCall('DELETE', `/api/admin/devices/${deviceId}`);
-    showToast('Device unbound successfully', 'success');
+    const result = await apiCall('DELETE', `/api/admin/devices/${deviceId}`);
+    showResultToast(result, 'Device unbound successfully');
     loadDevices();
   } catch (err) {
     showToast('Failed to unbind: ' + err.message, 'error');
@@ -231,12 +243,12 @@ async function banDeviceFromDevices(deviceId, userId) {
   if (!confirm('Ban this device?')) return;
   const reason = prompt('Reason (optional):') || '';
   try {
-    await apiCall('POST', '/api/admin/bans/device', {
+    const result = await apiCall('POST', '/api/admin/bans/device', {
       deviceId,
       reason,
       linkedUniqueId: userId || null,
     });
-    showToast('Device banned', 'success');
+    showResultToast(result, 'Device banned');
     loadDevices();
   } catch (err) {
     showToast('Failed to ban device: ' + err.message, 'error');
@@ -251,13 +263,13 @@ async function banNetworkFromDevices(ip, userId) {
   if (!confirm('Ban IP ' + ip + '?')) return;
   const reason = prompt('Reason (optional):') || '';
   try {
-    await apiCall('POST', '/api/admin/bans/network', {
+    const result = await apiCall('POST', '/api/admin/bans/network', {
       type: 'ip',
       value: ip,
       reason,
       linkedUniqueId: userId || null,
     });
-    showToast('Network banned', 'success');
+    showResultToast(result, 'Network banned');
     loadDevices();
   } catch (err) {
     showToast('Failed to ban network: ' + err.message, 'error');

--- a/public/admin/js/tabs/reports.js
+++ b/public/admin/js/tabs/reports.js
@@ -730,14 +730,14 @@ async function resolveReport(reportedUserId, resolveAll) {
     }
 
     // Partial-failure contract — see public/admin/js/lib/partial-failure-toast.js
-    // for the full key list and ordering rationale. Extracted to a shared lib so
-    // it's testable AND reusable by future admin consumers (bulk-warn, etc.).
-    const partialMessage = window.PartialFailureToast.buildPartialFailureMessage(result);
-    if (partialMessage) {
-      showToast(partialMessage, 'error');
-    } else {
-      showToast(`Report${resolveAll ? 's' : ''} resolved: ${actionLabel}`);
-    }
+    // for the full key list and ordering rationale. Optional chaining defends
+    // against the lib not being loaded (e.g., script-tag reordering); other
+    // tab consumers use the same defensive shape for consistency.
+    window.PartialFailureToast?.showResultToast(
+      showToast,
+      result,
+      `Report${resolveAll ? 's' : ''} resolved: ${actionLabel}`,
+    );
 
     if (result.autoEscalateSuggested) {
       showToast('This user has 5+ warnings. Consider suspending.', 'error');

--- a/public/admin/js/tabs/suggestions.js
+++ b/public/admin/js/tabs/suggestions.js
@@ -185,8 +185,16 @@ export function init(deps) {
   document.querySelector('#suggestion-complete-dialog .btn-confirm-complete').addEventListener('click', async () => {
     if (!completeSuggestionId) return;
     try {
-      await apiCall('PUT', `/api/admin/suggestions/${completeSuggestionId}/status`, { status: 'completed' });
-      showToast('Suggestion marked as completed', 'success');
+      const result = await apiCall('PUT', `/api/admin/suggestions/${completeSuggestionId}/status`, { status: 'completed' });
+      // Surface partial-failure: subscribers who didn't receive the
+      // "suggestion completed" notification (notifySubscribers in
+      // suggestions.js emits pms: { failed, total } per PR #384).
+      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
+      if (partialMessage) {
+        showToast(partialMessage, 'error');
+      } else {
+        showToast('Suggestion marked as completed', 'success');
+      }
       document.getElementById('suggestion-complete-dialog').style.display = 'none';
       completeSuggestionId = null;
       loadSuggestions();
@@ -594,8 +602,13 @@ function renderSuggestionCard(sg) {
   approveBtn.addEventListener('click', async () => {
     try {
       // Backend state machine uses "accepted", not "approved".
-      await apiCall('PUT', `/api/admin/suggestions/${sg.id}/status`, { status: 'accepted' });
-      showToast('Suggestion approved', 'success');
+      const result = await apiCall('PUT', `/api/admin/suggestions/${sg.id}/status`, { status: 'accepted' });
+      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
+      if (partialMessage) {
+        showToast(partialMessage, 'error');
+      } else {
+        showToast('Suggestion approved', 'success');
+      }
       loadSuggestions();
     } catch (err) { showToast(err.message, 'error'); }
   });
@@ -612,8 +625,13 @@ function renderSuggestionCard(sg) {
   rejectWrap.querySelector('button').addEventListener('click', async () => {
     const reason = rejectWrap.querySelector('input').value.trim();
     try {
-      await apiCall('PUT', `/api/admin/suggestions/${sg.id}/status`, { status: 'rejected', reason });
-      showToast('Suggestion rejected', 'success');
+      const result = await apiCall('PUT', `/api/admin/suggestions/${sg.id}/status`, { status: 'rejected', reason });
+      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
+      if (partialMessage) {
+        showToast(partialMessage, 'error');
+      } else {
+        showToast('Suggestion rejected', 'success');
+      }
       loadSuggestions();
     } catch (err) { showToast(err.message, 'error'); }
   });

--- a/public/admin/js/tabs/suggestions.js
+++ b/public/admin/js/tabs/suggestions.js
@@ -121,6 +121,12 @@ export function init(deps) {
     const ids = JSON.parse(dialog.dataset.ids || '[]');
     dialog.style.display = 'none';
     try {
+      // Bulk approve uses two-tier endpoint chain (new POST /approve falls
+      // back to legacy PUT /status). We don't aggregate per-id
+      // pms: { failed, total } here because the .catch fallback masks per-call
+      // shape — single-suggestion handlers (~line 188, 605, 628) DO consume
+      // pms via PartialFailureToast. Tracked as follow-up: align bulk +
+      // single shapes once the legacy fallback is removed.
       await Promise.all(ids.map((id) =>
         apiCall('POST', `/api/admin/suggestions/${id}/approve`).catch(() =>
           apiCall('PUT', `/api/admin/suggestions/${id}/status`, { status: 'accepted' }),
@@ -141,6 +147,8 @@ export function init(deps) {
     const reason = document.getElementById('bulk-reject-reason').value || '';
     dialog.style.display = 'none';
     try {
+      // See bulk-approve comment above — same two-tier fallback shape, same
+      // deferred per-id partial-failure aggregation.
       await Promise.all(ids.map((id) =>
         apiCall('POST', `/api/admin/suggestions/${id}/reject`, { reason }).catch(() =>
           apiCall('PUT', `/api/admin/suggestions/${id}/status`, { status: 'rejected', reason }),
@@ -186,15 +194,7 @@ export function init(deps) {
     if (!completeSuggestionId) return;
     try {
       const result = await apiCall('PUT', `/api/admin/suggestions/${completeSuggestionId}/status`, { status: 'completed' });
-      // Surface partial-failure: subscribers who didn't receive the
-      // "suggestion completed" notification (notifySubscribers in
-      // suggestions.js emits pms: { failed, total } per PR #384).
-      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
-      if (partialMessage) {
-        showToast(partialMessage, 'error');
-      } else {
-        showToast('Suggestion marked as completed', 'success');
-      }
+      window.PartialFailureToast?.showResultToast(showToast, result, 'Suggestion marked as completed');
       document.getElementById('suggestion-complete-dialog').style.display = 'none';
       completeSuggestionId = null;
       loadSuggestions();
@@ -603,12 +603,7 @@ function renderSuggestionCard(sg) {
     try {
       // Backend state machine uses "accepted", not "approved".
       const result = await apiCall('PUT', `/api/admin/suggestions/${sg.id}/status`, { status: 'accepted' });
-      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
-      if (partialMessage) {
-        showToast(partialMessage, 'error');
-      } else {
-        showToast('Suggestion approved', 'success');
-      }
+      window.PartialFailureToast?.showResultToast(showToast, result, 'Suggestion approved');
       loadSuggestions();
     } catch (err) { showToast(err.message, 'error'); }
   });
@@ -626,12 +621,7 @@ function renderSuggestionCard(sg) {
     const reason = rejectWrap.querySelector('input').value.trim();
     try {
       const result = await apiCall('PUT', `/api/admin/suggestions/${sg.id}/status`, { status: 'rejected', reason });
-      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
-      if (partialMessage) {
-        showToast(partialMessage, 'error');
-      } else {
-        showToast('Suggestion rejected', 'success');
-      }
+      window.PartialFailureToast?.showResultToast(showToast, result, 'Suggestion rejected');
       loadSuggestions();
     } catch (err) { showToast(err.message, 'error'); }
   });

--- a/public/admin/js/tabs/users.js
+++ b/public/admin/js/tabs/users.js
@@ -328,7 +328,14 @@ async function autoSaveListField(field) {
         .filter(Boolean)
         .map(Number)
         .filter((n) => !isNaN(n));
-      await apiCall("PATCH", `/api/user/${currentUid}`, { [field]: items });
+      const result = await apiCall("PATCH", `/api/user/${currentUid}`, { [field]: items });
+      // Partial-failure contract — the route emits `pms: { failed, total }`
+      // when one of the user-visible PMs (display name change, photo
+      // removed, etc.) couldn't be delivered. See partial-failure-toast.js.
+      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
+      if (partialMessage) {
+        showToast(partialMessage, "error");
+      }
     }
   } catch (err) {
     showToast(`Failed to save ${field}: ${err.message}`, "error");
@@ -1231,16 +1238,36 @@ export function wireModerationListeners() {
     const endDate = endDateVal ? new Date(endDateVal).toISOString() : null;
     const canAppeal = $("#suspend-can-appeal")?.checked;
     suspendBtn.disabled = true;
-    try { await apiCall("POST", `/api/user/${currentUid}/suspend`, { reason, endDate, canAppeal }); showToast("User suspended"); const data = await apiCall("GET", `/api/user/${currentUid}`); await populateFormFull(data); }
-    catch (err) { showToast(err.message, "error"); }
+    try {
+      const result = await apiCall("POST", `/api/user/${currentUid}/suspend`, { reason, endDate, canAppeal });
+      // Partial-failure: surface "1/1 PMs failed" if the suspension PM didn't
+      // reach the user, so admin can manually retry the notification.
+      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
+      if (partialMessage) {
+        showToast(partialMessage, "error");
+      } else {
+        showToast("User suspended");
+      }
+      const data = await apiCall("GET", `/api/user/${currentUid}`);
+      await populateFormFull(data);
+    } catch (err) { showToast(err.message, "error"); }
     suspendBtn.disabled = false;
   });
   // Unsuspend
   const unsuspendBtn = $("#unsuspend-btn");
   if (unsuspendBtn) unsuspendBtn.addEventListener("click", async () => {
     unsuspendBtn.disabled = true;
-    try { await apiCall("POST", `/api/user/${currentUid}/unsuspend`); showToast("User unsuspended"); const data = await apiCall("GET", `/api/user/${currentUid}`); await populateFormFull(data); }
-    catch (err) { showToast(err.message, "error"); }
+    try {
+      const result = await apiCall("POST", `/api/user/${currentUid}/unsuspend`);
+      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
+      if (partialMessage) {
+        showToast(partialMessage, "error");
+      } else {
+        showToast("User unsuspended");
+      }
+      const data = await apiCall("GET", `/api/user/${currentUid}`);
+      await populateFormFull(data);
+    } catch (err) { showToast(err.message, "error"); }
     unsuspendBtn.disabled = false;
   });
   // Duration presets
@@ -1460,9 +1487,44 @@ export function wireEconomyListeners() {
   const unlimitedCb = $("#eco-super-shy-unlimited");
   if (unlimitedCb) unlimitedCb.addEventListener("change", () => { const unlimited = unlimitedCb.checked; const expiryEl = $("#eco-super-shy-expiry"); if (!expiryEl) return; if (unlimited) { _prevExpiryValue = expiryEl.value; expiryEl.value = ""; expiryEl.disabled = true; autoSaveEconomyField("superShyExpiry"); } else { expiryEl.disabled = false; expiryEl.value = _prevExpiryValue || "1970-01-01T00:00"; autoSaveEconomyField("superShyExpiry"); } });
   const coinsApply = $("#eco-coins-apply");
-  if (coinsApply) coinsApply.addEventListener("click", async () => { if (!currentUid) return; const op = $("#eco-coins-op")?.value; const amount = parseInt($("#eco-coins-amount")?.value) || 0; if (amount <= 0) { showToast("Enter a positive amount", "error"); return; } try { const result = await apiCall("POST", `/api/users/${currentUid}/adjust-balance`, { currency: "COINS", amount, operation: op }); _ecoCoins = result.newBalance; const cd = $("#eco-coins-display"); if (cd) cd.textContent = _ecoCoins; const ca = $("#eco-coins-amount"); if (ca) ca.value = ""; showToast((op === "add" ? "Added" : "Deducted") + " " + amount + " coins (now " + _ecoCoins + ")"); } catch (err) { showToast(err.message, "error"); } });
+  if (coinsApply) coinsApply.addEventListener("click", async () => {
+    if (!currentUid) return;
+    const op = $("#eco-coins-op")?.value;
+    const amount = parseInt($("#eco-coins-amount")?.value) || 0;
+    if (amount <= 0) { showToast("Enter a positive amount", "error"); return; }
+    try {
+      const result = await apiCall("POST", `/api/users/${currentUid}/adjust-balance`, { currency: "COINS", amount, operation: op });
+      _ecoCoins = result.newBalance;
+      const cd = $("#eco-coins-display"); if (cd) cd.textContent = _ecoCoins;
+      const ca = $("#eco-coins-amount"); if (ca) ca.value = "";
+      // Partial-failure: surface PM delivery failure (balance still adjusted).
+      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
+      if (partialMessage) {
+        showToast(partialMessage, "error");
+      } else {
+        showToast((op === "add" ? "Added" : "Deducted") + " " + amount + " coins (now " + _ecoCoins + ")");
+      }
+    } catch (err) { showToast(err.message, "error"); }
+  });
   const beansApply = $("#eco-beans-apply");
-  if (beansApply) beansApply.addEventListener("click", async () => { if (!currentUid) return; const op = $("#eco-beans-op")?.value; const amount = parseInt($("#eco-beans-amount")?.value) || 0; if (amount <= 0) { showToast("Enter a positive amount", "error"); return; } try { const result = await apiCall("POST", `/api/users/${currentUid}/adjust-balance`, { currency: "BEANS", amount, operation: op }); _ecoBeans = result.newBalance; const bd = $("#eco-beans-display"); if (bd) bd.textContent = _ecoBeans; const ba = $("#eco-beans-amount"); if (ba) ba.value = ""; showToast((op === "add" ? "Added" : "Deducted") + " " + amount + " beans (now " + _ecoBeans + ")"); } catch (err) { showToast(err.message, "error"); } });
+  if (beansApply) beansApply.addEventListener("click", async () => {
+    if (!currentUid) return;
+    const op = $("#eco-beans-op")?.value;
+    const amount = parseInt($("#eco-beans-amount")?.value) || 0;
+    if (amount <= 0) { showToast("Enter a positive amount", "error"); return; }
+    try {
+      const result = await apiCall("POST", `/api/users/${currentUid}/adjust-balance`, { currency: "BEANS", amount, operation: op });
+      _ecoBeans = result.newBalance;
+      const bd = $("#eco-beans-display"); if (bd) bd.textContent = _ecoBeans;
+      const ba = $("#eco-beans-amount"); if (ba) ba.value = "";
+      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
+      if (partialMessage) {
+        showToast(partialMessage, "error");
+      } else {
+        showToast((op === "add" ? "Added" : "Deducted") + " " + amount + " beans (now " + _ecoBeans + ")");
+      }
+    } catch (err) { showToast(err.message, "error"); }
+  });
   const bpSearch = document.getElementById("backpack-search"); if (bpSearch) bpSearch.addEventListener("input", renderBackpack);
   const bpCatFilter = document.getElementById("backpack-category-filter"); if (bpCatFilter) bpCatFilter.addEventListener("change", renderBackpack);
   const addBtn = $("#backpack-add-btn");
@@ -1700,7 +1762,22 @@ export function wireBansListeners() {
   const banIpBtn = $("#bans-ban-last-ip");
   if (banIpBtn) banIpBtn.addEventListener("click", async () => { if (!currentUid) return; try { const devicesData = await apiCall("GET", `/api/admin/devices/user/${currentUid}`); const devices = devicesData.devices || []; const lastDevice = devices.sort((a, b) => (b.lastSeen || 0) - (a.lastSeen || 0))[0]; if (!lastDevice || !lastDevice.lastIp) { showToast("No IP address found", "error"); return; } if (!confirm("Ban IP " + lastDevice.lastIp + "?")) return; const reason = prompt("Reason (optional):") || ""; await apiCall("POST", "/api/admin/bans/network", { type: "ip", value: lastDevice.lastIp, reason, linkedUniqueId: currentUid }); showToast("IP banned", "success"); populateBansSection(currentUid); } catch (err) { showToast("Failed: " + err.message, "error"); } });
   const unbanAllBtn = $("#bans-unban-all");
-  if (unbanAllBtn) unbanAllBtn.addEventListener("click", async () => { if (!currentUid) return; if (!confirm("Remove all bans for this user?")) return; try { const result = await apiCall("POST", `/api/admin/bans/unban-all/${currentUid}`); showToast("Removed " + (result.removed || 0) + " ban(s)", "success"); populateBansSection(currentUid); } catch (err) { showToast("Failed: " + err.message, "error"); } });
+  if (unbanAllBtn) unbanAllBtn.addEventListener("click", async () => {
+    if (!currentUid) return;
+    if (!confirm("Remove all bans for this user?")) return;
+    try {
+      const result = await apiCall("POST", `/api/admin/bans/unban-all/${currentUid}`);
+      // Surface PM delivery failure (the "restriction lifted" PM didn't reach
+      // the user). Bans were still removed; admin may want to retry the PM.
+      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
+      if (partialMessage) {
+        showToast(partialMessage, "error");
+      } else {
+        showToast("Removed " + (result.removed || 0) + " ban(s)", "success");
+      }
+      populateBansSection(currentUid);
+    } catch (err) { showToast("Failed: " + err.message, "error"); }
+  });
   const viewLogsBtn = $("#bans-view-logs");
   if (viewLogsBtn) viewLogsBtn.addEventListener("click", () => { if (!currentUid) return; const logsUserFilter = $("#log-filter-userId"); if (logsUserFilter) logsUserFilter.value = currentUid; _switchTab("logs"); });
   // Identity graph suspend/unsuspend (tabular version)

--- a/public/admin/js/tabs/users.js
+++ b/public/admin/js/tabs/users.js
@@ -329,13 +329,10 @@ async function autoSaveListField(field) {
         .map(Number)
         .filter((n) => !isNaN(n));
       const result = await apiCall("PATCH", `/api/user/${currentUid}`, { [field]: items });
-      // Partial-failure contract — the route emits `pms: { failed, total }`
-      // when one of the user-visible PMs (display name change, photo
-      // removed, etc.) couldn't be delivered. See partial-failure-toast.js.
-      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
-      if (partialMessage) {
-        showToast(partialMessage, "error");
-      }
+      // Surface partial-failure if the user-visible PM (display name
+      // changed, photo removed, etc.) was silently dropped. Pass null
+      // success message — autosave is silent on success.
+      window.PartialFailureToast?.showResultToast(showToast, result, null);
     }
   } catch (err) {
     showToast(`Failed to save ${field}: ${err.message}`, "error");
@@ -1240,14 +1237,7 @@ export function wireModerationListeners() {
     suspendBtn.disabled = true;
     try {
       const result = await apiCall("POST", `/api/user/${currentUid}/suspend`, { reason, endDate, canAppeal });
-      // Partial-failure: surface "1/1 PMs failed" if the suspension PM didn't
-      // reach the user, so admin can manually retry the notification.
-      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
-      if (partialMessage) {
-        showToast(partialMessage, "error");
-      } else {
-        showToast("User suspended");
-      }
+      window.PartialFailureToast?.showResultToast(showToast, result, "User suspended");
       const data = await apiCall("GET", `/api/user/${currentUid}`);
       await populateFormFull(data);
     } catch (err) { showToast(err.message, "error"); }
@@ -1259,12 +1249,7 @@ export function wireModerationListeners() {
     unsuspendBtn.disabled = true;
     try {
       const result = await apiCall("POST", `/api/user/${currentUid}/unsuspend`);
-      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
-      if (partialMessage) {
-        showToast(partialMessage, "error");
-      } else {
-        showToast("User unsuspended");
-      }
+      window.PartialFailureToast?.showResultToast(showToast, result, "User unsuspended");
       const data = await apiCall("GET", `/api/user/${currentUid}`);
       await populateFormFull(data);
     } catch (err) { showToast(err.message, "error"); }
@@ -1497,13 +1482,10 @@ export function wireEconomyListeners() {
       _ecoCoins = result.newBalance;
       const cd = $("#eco-coins-display"); if (cd) cd.textContent = _ecoCoins;
       const ca = $("#eco-coins-amount"); if (ca) ca.value = "";
-      // Partial-failure: surface PM delivery failure (balance still adjusted).
-      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
-      if (partialMessage) {
-        showToast(partialMessage, "error");
-      } else {
-        showToast((op === "add" ? "Added" : "Deducted") + " " + amount + " coins (now " + _ecoCoins + ")");
-      }
+      window.PartialFailureToast?.showResultToast(
+        showToast, result,
+        (op === "add" ? "Added" : "Deducted") + " " + amount + " coins (now " + _ecoCoins + ")",
+      );
     } catch (err) { showToast(err.message, "error"); }
   });
   const beansApply = $("#eco-beans-apply");
@@ -1517,12 +1499,10 @@ export function wireEconomyListeners() {
       _ecoBeans = result.newBalance;
       const bd = $("#eco-beans-display"); if (bd) bd.textContent = _ecoBeans;
       const ba = $("#eco-beans-amount"); if (ba) ba.value = "";
-      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
-      if (partialMessage) {
-        showToast(partialMessage, "error");
-      } else {
-        showToast((op === "add" ? "Added" : "Deducted") + " " + amount + " beans (now " + _ecoBeans + ")");
-      }
+      window.PartialFailureToast?.showResultToast(
+        showToast, result,
+        (op === "add" ? "Added" : "Deducted") + " " + amount + " beans (now " + _ecoBeans + ")",
+      );
     } catch (err) { showToast(err.message, "error"); }
   });
   const bpSearch = document.getElementById("backpack-search"); if (bpSearch) bpSearch.addEventListener("input", renderBackpack);
@@ -1755,26 +1735,79 @@ export function wireBansListeners() {
   const bansDevicesBoundList = $("#bans-devices-bound-list");
   if (bansDevicesBoundList) {
     bansDevicesBoundList.addEventListener("click", (e) => { const header = e.target.closest(".device-card-header"); if (!header) return; const body = header.nextElementSibling; const chevron = header.querySelector(".chevron"); if (body) { body.style.display = body.style.display === "none" ? "block" : "none"; if (chevron) chevron.textContent = body.style.display === "none" ? "\u25B6" : "\u25BC"; } });
-    bansDevicesBoundList.addEventListener("click", async (e) => { const btn = e.target.closest("[data-ban-action]"); if (!btn) return; const action = btn.dataset.banAction; const deviceId = btn.dataset.deviceId; if (action === "ban") { const reasonInput = btn.closest(".device-card-body")?.querySelector(".ban-reason-input"); const durationSelect = btn.closest(".device-card-body")?.querySelector(".ban-duration-select"); try { await apiCall("POST", "/api/admin/bans/device", { deviceId, reason: reasonInput?.value?.trim() || null, duration: durationSelect?.value || null, linkedUniqueId: currentUid }); showToast("Device banned", "success"); populateBansSection(currentUid); } catch (err) { showToast(err.message, "error"); } } else if (action === "unban") { if (!confirm("Unban this device?")) return; try { await apiCall("DELETE", `/api/admin/bans/device/${deviceId}`); showToast("Device unbanned", "success"); populateBansSection(currentUid); } catch (err) { showToast(err.message, "error"); } } });
+    bansDevicesBoundList.addEventListener("click", async (e) => {
+      const btn = e.target.closest("[data-ban-action]");
+      if (!btn) return;
+      const action = btn.dataset.banAction;
+      const deviceId = btn.dataset.deviceId;
+      if (action === "ban") {
+        const reasonInput = btn.closest(".device-card-body")?.querySelector(".ban-reason-input");
+        const durationSelect = btn.closest(".device-card-body")?.querySelector(".ban-duration-select");
+        try {
+          // Returns pms: { failed, total } per admin-bans.js POST /admin/bans/device.
+          const result = await apiCall("POST", "/api/admin/bans/device", { deviceId, reason: reasonInput?.value?.trim() || null, duration: durationSelect?.value || null, linkedUniqueId: currentUid });
+          window.PartialFailureToast?.showResultToast(showToast, result, "Device banned");
+          populateBansSection(currentUid);
+        } catch (err) { showToast(err.message, "error"); }
+      } else if (action === "unban") {
+        if (!confirm("Unban this device?")) return;
+        try {
+          await apiCall("DELETE", `/api/admin/bans/device/${deviceId}`);
+          showToast("Device unbanned", "success");
+          populateBansSection(currentUid);
+        } catch (err) { showToast(err.message, "error"); }
+      }
+    });
   }
   const banAllBtn = $("#bans-ban-all-devices");
-  if (banAllBtn) banAllBtn.addEventListener("click", async () => { if (!currentUid) return; if (!confirm("Ban all devices for this user?")) return; const reason = prompt("Reason (optional):") || ""; try { const devicesData = await apiCall("GET", `/api/admin/devices/user/${currentUid}`); const devices = devicesData.devices || []; if (devices.length === 0) { showToast("No devices to ban", "error"); return; } await Promise.all(devices.map(d => apiCall("POST", "/api/admin/bans/device", { deviceId: d.id, reason, linkedUniqueId: currentUid }))); showToast("Banned " + devices.length + " device(s)", "success"); populateBansSection(currentUid); } catch (err) { showToast("Failed: " + err.message, "error"); } });
+  if (banAllBtn) banAllBtn.addEventListener("click", async () => {
+    if (!currentUid) return;
+    if (!confirm("Ban all devices for this user?")) return;
+    const reason = prompt("Reason (optional):") || "";
+    try {
+      const devicesData = await apiCall("GET", `/api/admin/devices/user/${currentUid}`);
+      const devices = devicesData.devices || [];
+      if (devices.length === 0) { showToast("No devices to ban", "error"); return; }
+      // Aggregate per-call partial failures: each /admin/bans/device returns
+      // pms: { failed, total } for the user-visible ban-notice PM. Sum
+      // across the bulk call so the admin sees "N/M PMs failed" once
+      // instead of N separate toasts.
+      const results = await Promise.all(devices.map(d =>
+        apiCall("POST", "/api/admin/bans/device", { deviceId: d.id, reason, linkedUniqueId: currentUid }),
+      ));
+      const aggregate = {
+        pms: results.reduce((acc, r) => ({
+          failed: (acc.failed || 0) + (r?.pms?.failed || 0),
+          total: (acc.total || 0) + (r?.pms?.total || 0),
+        }), { failed: 0, total: 0 }),
+      };
+      window.PartialFailureToast?.showResultToast(showToast, aggregate, "Banned " + devices.length + " device(s)");
+      populateBansSection(currentUid);
+    } catch (err) { showToast("Failed: " + err.message, "error"); }
+  });
   const banIpBtn = $("#bans-ban-last-ip");
-  if (banIpBtn) banIpBtn.addEventListener("click", async () => { if (!currentUid) return; try { const devicesData = await apiCall("GET", `/api/admin/devices/user/${currentUid}`); const devices = devicesData.devices || []; const lastDevice = devices.sort((a, b) => (b.lastSeen || 0) - (a.lastSeen || 0))[0]; if (!lastDevice || !lastDevice.lastIp) { showToast("No IP address found", "error"); return; } if (!confirm("Ban IP " + lastDevice.lastIp + "?")) return; const reason = prompt("Reason (optional):") || ""; await apiCall("POST", "/api/admin/bans/network", { type: "ip", value: lastDevice.lastIp, reason, linkedUniqueId: currentUid }); showToast("IP banned", "success"); populateBansSection(currentUid); } catch (err) { showToast("Failed: " + err.message, "error"); } });
+  if (banIpBtn) banIpBtn.addEventListener("click", async () => {
+    if (!currentUid) return;
+    try {
+      const devicesData = await apiCall("GET", `/api/admin/devices/user/${currentUid}`);
+      const devices = devicesData.devices || [];
+      const lastDevice = devices.sort((a, b) => (b.lastSeen || 0) - (a.lastSeen || 0))[0];
+      if (!lastDevice || !lastDevice.lastIp) { showToast("No IP address found", "error"); return; }
+      if (!confirm("Ban IP " + lastDevice.lastIp + "?")) return;
+      const reason = prompt("Reason (optional):") || "";
+      // Returns pms: { failed, total } per admin-bans.js POST /admin/bans/network.
+      const result = await apiCall("POST", "/api/admin/bans/network", { type: "ip", value: lastDevice.lastIp, reason, linkedUniqueId: currentUid });
+      window.PartialFailureToast?.showResultToast(showToast, result, "IP banned");
+      populateBansSection(currentUid);
+    } catch (err) { showToast("Failed: " + err.message, "error"); }
+  });
   const unbanAllBtn = $("#bans-unban-all");
   if (unbanAllBtn) unbanAllBtn.addEventListener("click", async () => {
     if (!currentUid) return;
     if (!confirm("Remove all bans for this user?")) return;
     try {
       const result = await apiCall("POST", `/api/admin/bans/unban-all/${currentUid}`);
-      // Surface PM delivery failure (the "restriction lifted" PM didn't reach
-      // the user). Bans were still removed; admin may want to retry the PM.
-      const partialMessage = window.PartialFailureToast?.buildPartialFailureMessage(result);
-      if (partialMessage) {
-        showToast(partialMessage, "error");
-      } else {
-        showToast("Removed " + (result.removed || 0) + " ban(s)", "success");
-      }
+      window.PartialFailureToast?.showResultToast(showToast, result, "Removed " + (result.removed || 0) + " ban(s)");
       populateBansSection(currentUid);
     } catch (err) { showToast("Failed: " + err.message, "error"); }
   });

--- a/public/admin/js/tabs/users.js
+++ b/public/admin/js/tabs/users.js
@@ -1768,20 +1768,35 @@ export function wireBansListeners() {
       const devicesData = await apiCall("GET", `/api/admin/devices/user/${currentUid}`);
       const devices = devicesData.devices || [];
       if (devices.length === 0) { showToast("No devices to ban", "error"); return; }
-      // Aggregate per-call partial failures: each /admin/bans/device returns
-      // pms: { failed, total } for the user-visible ban-notice PM. Sum
-      // across the bulk call so the admin sees "N/M PMs failed" once
-      // instead of N separate toasts.
-      const results = await Promise.all(devices.map(d =>
+      // Promise.allSettled so a single failed device-ban (HTTP 4xx/5xx)
+      // doesn't reject the whole batch. Promise.all would mask both how
+      // many devices got banned AND any per-call PM failures.
+      const settled = await Promise.allSettled(devices.map(d =>
         apiCall("POST", "/api/admin/bans/device", { deviceId: d.id, reason, linkedUniqueId: currentUid }),
       ));
-      const aggregate = {
-        pms: results.reduce((acc, r) => ({
-          failed: (acc.failed || 0) + (r?.pms?.failed || 0),
-          total: (acc.total || 0) + (r?.pms?.total || 0),
-        }), { failed: 0, total: 0 }),
-      };
-      window.PartialFailureToast?.showResultToast(showToast, aggregate, "Banned " + devices.length + " device(s)");
+      const fulfilled = settled.filter(s => s.status === "fulfilled").map(s => s.value);
+      const rejected = settled.filter(s => s.status === "rejected");
+      // Aggregate PM failures across only the fulfilled responses (rejected
+      // ones never ran their PM step).
+      const aggregatePmFailed = fulfilled.reduce((sum, r) => sum + (r?.pms?.failed || 0), 0);
+      const aggregatePmTotal = fulfilled.reduce((sum, r) => sum + (r?.pms?.total || 0), 0);
+      // Log every HTTP-level rejection for triage (admin can copy from
+      // browser console when re-running with specific deviceIds).
+      for (const r of rejected) console.error("Ban device failed:", r.reason);
+      // Build a single toast message. Order: HTTP failures first (most
+      // actionable), then PM failures, then success count.
+      const segments = [];
+      if (rejected.length > 0) {
+        segments.push(`${rejected.length}/${devices.length} ban call(s) failed (first: ${rejected[0].reason?.message || "unknown"})`);
+      }
+      if (aggregatePmFailed > 0) {
+        segments.push(`${aggregatePmFailed}/${aggregatePmTotal} PMs failed`);
+      }
+      if (segments.length > 0) {
+        showToast(`Partial: ${segments.join("; ")}. Please retry the failed step.`, "error");
+      } else {
+        showToast(`Banned ${fulfilled.length} device(s)`, "success");
+      }
       populateBansSection(currentUid);
     } catch (err) { showToast("Failed: " + err.message, "error"); }
   });


### PR DESCRIPTION
## Summary
Closes the half-built loop from PRs #384 + #385 — server emits \`pms: { failed, total }\` on every admin route that could silently drop a user-visible PM, but the admin UI was discarding those responses, so admins never saw the signal.

Wire \`PartialFailureToast.buildPartialFailureMessage()\` into:
- **users.js**: PATCH user, suspend, unsuspend, adjust-balance (coins + beans), unban-all
- **devices.js**: unbind, ban-device, ban-network (extracted shared \`showResultToast\` helper)
- **suggestions.js**: single-suggestion approve / reject / mark-complete

Bulk operations (Promise.all loops) intentionally left for a follow-up that aggregates per-item failures.

## Test plan
- [x] 1214 backend tests still passing
- [ ] Manual: trigger any of the above actions where a PM would fail (e.g., suspend a user whose FCM tokens are invalid) — admin should now see "1/1 PMs failed" toast instead of plain success
- [ ] Manual: trigger same actions where PM succeeds — should see normal success toast (no false positives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)