### PR TITLE
fix(api+admin): warn + backpack PMs surface partial-failure flags

### DIFF
--- a/express-api/src/routes/admin-economy.js
+++ b/express-api/src/routes/admin-economy.js
@@ -168,22 +168,29 @@ router.post('/users/:uniqueId/backpack', async (req, res) => {
       createdAt: timestamp,
     });
 
-    // Notify user about backpack change (unless silent)
+    // Notify user about backpack change (unless silent). Track failure
+    // so admin UI sees `pms: { failed, total }` for partial-failure toast.
+    let pmFailed = 0;
+    let pmTotal = 0;
     if (!body.silent) {
+      pmTotal = 1;
       const name = body.giftName || body.giftId;
       const msg =
         body.quantity === 0
           ? `🎒 "${name}" has been removed from your backpack by the moderation team.`
           : `🎒 Your backpack has been updated: "${name}" quantity set to ${body.quantity}.`;
-      sendSystemPm(req.params.uniqueId, msg).catch((err) =>
+      try {
+        await sendSystemPm(req.params.uniqueId, msg);
+      } catch (err) {
         log.error('admin-economy', 'Failed to send backpack PM', {
           uid: req.params.uniqueId,
           error: err.message,
-        }),
-      );
+        });
+        pmFailed = 1;
+      }
     }
 
-    res.json({ success: true });
+    res.json({ success: true, pms: { failed: pmFailed, total: pmTotal } });
   } catch (err) {
     log.error('admin-economy', 'Error setting backpack item', {
       uid: req.params.uniqueId,

--- a/express-api/src/routes/admin-users.js
+++ b/express-api/src/routes/admin-users.js
@@ -506,18 +506,24 @@ router.post('/user/:uniqueId/warn', async (req, res) => {
       adminUniqueId: req.auth.uniqueId,
     });
 
-    // Send system PM to warned user (fire-and-forget)
-    sendSystemPm(
-      req.params.uniqueId,
-      `\u26a0\ufe0f You have received a warning from the moderation team.\n\nReason: ${body.reason}\n\nRepeated violations may result in suspension.`,
-    ).catch((err) =>
+    // Send system PM to warned user. Track failure so the admin UI knows
+    // whether the user was actually informed (`pms: { failed, total }`
+    // shape matches partial-failure-toast.js).
+    let pmFailed = 0;
+    try {
+      await sendSystemPm(
+        req.params.uniqueId,
+        `\u26a0\ufe0f You have received a warning from the moderation team.\n\nReason: ${body.reason}\n\nRepeated violations may result in suspension.`,
+      );
+    } catch (err) {
       log.error('admin-users', 'Failed to send warning PM', {
         targetUniqueId: req.params.uniqueId,
         error: err.message,
-      }),
-    );
+      });
+      pmFailed = 1;
+    }
 
-    res.json({ success: true, ...result });
+    res.json({ success: true, ...result, pms: { failed: pmFailed, total: 1 } });
   } catch (err) {
     if (err.message === 'User not found') return res.status(404).json({ error: err.message });
     log.error('admin-users', 'Warn user failed', {

--- a/public/admin/js/tabs/users.js
+++ b/public/admin/js/tabs/users.js
@@ -1276,7 +1276,16 @@ export function wireModerationListeners() {
     const adminNote = $("#direct-warn-note")?.value?.trim() || undefined;
     if (!confirm("Issue a warning for \"" + reason + "\" (severity " + severity + ", -" + severity * 5 + " GCS)?")) return;
     directWarnBtn.disabled = true; directWarnBtn.textContent = "Issuing...";
-    try { const result = await apiCall("POST", `/api/user/${currentUid}/warn`, { reason, severity, adminNote }); showToast("Warning issued successfully"); if (result.autoEscalateSuggested) showToast("This user has 5+ warnings. Consider suspending.", "error"); const data = await apiCall("GET", `/api/user/${currentUid}`); populateGcsSection(data); loadWarningHistory(currentUid, false); loadReportHistory(currentUid); if ($("#direct-warn-reason")) $("#direct-warn-reason").value = ""; if ($("#direct-warn-note")) $("#direct-warn-note").value = ""; }
+    try {
+      const result = await apiCall("POST", `/api/user/${currentUid}/warn`, { reason, severity, adminNote });
+      // Surface partial-failure: the warning PM may have failed silently.
+      window.PartialFailureToast?.showResultToast(showToast, result, "Warning issued successfully");
+      if (result.autoEscalateSuggested) showToast("This user has 5+ warnings. Consider suspending.", "error");
+      const data = await apiCall("GET", `/api/user/${currentUid}`);
+      populateGcsSection(data); loadWarningHistory(currentUid, false); loadReportHistory(currentUid);
+      if ($("#direct-warn-reason")) $("#direct-warn-reason").value = "";
+      if ($("#direct-warn-note")) $("#direct-warn-note").value = "";
+    }
     catch (err) { showToast(err.message, "error"); }
     finally { directWarnBtn.disabled = false; directWarnBtn.textContent = "Issue Warning"; }
   });
@@ -1408,7 +1417,8 @@ export function renderBackpack() {
 export async function autoSaveBackpackItem(giftId, newQty, originalQty) {
   try {
     const gift = _giftCatalog.find(function(g) { return g.id === giftId; });
-    await apiCall("POST", "/api/users/" + currentUid + "/backpack", { giftId: giftId, quantity: newQty, giftName: gift ? gift.name : giftId });
+    const result = await apiCall("POST", "/api/users/" + currentUid + "/backpack", { giftId: giftId, quantity: newQty, giftName: gift ? gift.name : giftId });
+    window.PartialFailureToast?.showResultToast(showToast, result, null);
     const item = _backpackItems.find(function(i) { return i.giftId === giftId; });
     if (item) { if (newQty <= 0) { _backpackItems = _backpackItems.filter(function(i) { return i.giftId !== giftId; }); } else { item.quantity = newQty; } }
     delete _backpackEdits[giftId]; renderBackpack();
@@ -1466,7 +1476,21 @@ export function wireEconomyListeners() {
   const bpSearch = document.getElementById("backpack-search"); if (bpSearch) bpSearch.addEventListener("input", renderBackpack);
   const bpCatFilter = document.getElementById("backpack-category-filter"); if (bpCatFilter) bpCatFilter.addEventListener("change", renderBackpack);
   const addBtn = $("#backpack-add-btn");
-  if (addBtn) addBtn.addEventListener("click", async () => { const giftId = $("#backpack-gift-select")?.value; const qty = parseInt($("#backpack-qty")?.value) || 0; if (!giftId || !currentUid || qty <= 0) { showToast("Select a gift and enter a quantity", "error"); return; } try { const existing = _backpackItems.find(i => i.giftId === giftId); const newQty = (existing ? existing.quantity : 0) + qty; const giftInfo = _giftCatalog.find(g => g.id === giftId); await apiCall("POST", `/api/users/${currentUid}/backpack`, { giftId, quantity: newQty, giftName: giftInfo ? giftInfo.name : giftId }); showToast("Added " + qty + " (total now " + newQty + ")"); loadBackpack(currentUid); const bpQty = $("#backpack-qty"); if (bpQty) bpQty.value = "1"; const bpSel = $("#backpack-gift-select"); if (bpSel) bpSel.value = ""; } catch (err) { showToast(err.message, "error"); } });
+  if (addBtn) addBtn.addEventListener("click", async () => {
+    const giftId = $("#backpack-gift-select")?.value;
+    const qty = parseInt($("#backpack-qty")?.value) || 0;
+    if (!giftId || !currentUid || qty <= 0) { showToast("Select a gift and enter a quantity", "error"); return; }
+    try {
+      const existing = _backpackItems.find(i => i.giftId === giftId);
+      const newQty = (existing ? existing.quantity : 0) + qty;
+      const giftInfo = _giftCatalog.find(g => g.id === giftId);
+      const result = await apiCall("POST", `/api/users/${currentUid}/backpack`, { giftId, quantity: newQty, giftName: giftInfo ? giftInfo.name : giftId });
+      window.PartialFailureToast?.showResultToast(showToast, result, "Added " + qty + " (total now " + newQty + ")");
+      loadBackpack(currentUid);
+      const bpQty = $("#backpack-qty"); if (bpQty) bpQty.value = "1";
+      const bpSel = $("#backpack-gift-select"); if (bpSel) bpSel.value = "";
+    } catch (err) { showToast(err.message, "error"); }
+  });
   const clearBtn = $("#backpack-clear-btn");
   if (clearBtn) clearBtn.addEventListener("click", () => { if (_backpackItems.length === 0) { showToast("Backpack is already empty", "error"); return; } showClearAllConfirmation(); });
   const txLoadBtn = $("#tx-load-btn");


### PR DESCRIPTION
## Summary
Closes the two pre-existing fire-and-forget PM routes that PR #384/#385's cohort missed:

- **POST /user/:uid/warn** — warning PM was \`sendSystemPm(...).catch(log.error)\`, route returned plain success. Admin saw green toast while user was silently uninformed about being warned.
- **POST /users/:uid/backpack** — backpack-change PM same shape. User silently uninformed about gifts being added/removed.

Both now \`await sendSystemPm\` inside try/catch and return \`pms: { failed, total }\` matching partial-failure-toast.js contract. Admin UI handlers in \`public/admin/js/tabs/users.js\` wired with \`PartialFailureToast.showResultToast\`.

The backpack autosave path uses \`null\` success message (silent on success) to preserve the existing UX. Manual "Add" button gets normal success toast.

## Test plan
- [x] 235 backend tests for admin-users + admin-economy still passing
- [ ] Manual: warn user with broken FCM tokens → admin sees "1/1 PMs failed" instead of "Warning issued successfully"
- [ ] Manual: warn user normally → admin sees "Warning issued successfully" (no false positive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)