### PR TITLE
refactor(ci): use cleanup-ios-signing composite action (closes Phase 0 #61)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -353,54 +353,9 @@ jobs:
 
       - name: Clean up signing material
         if: always()
-        env:
-          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-        # Self-hosted runner: scrub all signing material to prevent .p8/.p12
-        # leaking between jobs. Don't fail the job on cleanup — log warnings
-        # instead so the deploy outcome reflects deploy success/failure only.
-        # Mirrors what setup-ios-signing/action.yml writes — keep these in sync.
-        run: |
-          set -uo pipefail
-          fail=0
-          # Extract the profile UUID before deleting the source profile, since
-          # we need it to remove the mirrored copy in ~/Library/MobileDevice/.
-          PROFILE_UUID=""
-          if [ -f "$RUNNER_TEMP/profile.mobileprovision" ]; then
-            PROFILE_UUID=$(/usr/bin/security cms -D -i "$RUNNER_TEMP/profile.mobileprovision" 2>/dev/null \
-              | grep -A1 '<key>UUID</key>' | grep '<string>' \
-              | sed 's/.*<string>\(.*\)<\/string>.*/\1/' || true)
-          fi
-          # Temp keychain
-          if [ -f "$RUNNER_TEMP/app-signing.keychain-db" ]; then
-            if ! security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db"; then
-              echo "::warning::Failed to delete keychain at $RUNNER_TEMP/app-signing.keychain-db"
-              fail=1
-            fi
-          fi
-          # Restore the user keychain search list so we don't accumulate
-          # references to deleted keychains across runs on the persistent runner.
-          if ! security list-keychain -d user -s "$HOME/Library/Keychains/login.keychain-db"; then
-            echo "::warning::Failed to restore login keychain search list"
-            fail=1
-          fi
-          # All signing material in $RUNNER_TEMP (cert .p12, profile, IPA, archive, log)
-          rm -rf "$RUNNER_TEMP/export" \
-                 "$RUNNER_TEMP/iosApp.xcarchive" \
-                 "$RUNNER_TEMP/altool-upload.log" || true
-          rm -f "$RUNNER_TEMP/certificate.p12" \
-                "$RUNNER_TEMP/profile.mobileprovision" || true
-          # App Store Connect API key (.p8) lives outside $RUNNER_TEMP
-          if [ -n "${APP_STORE_CONNECT_KEY_ID:-}" ]; then
-            rm -f "$HOME/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" || true
-          fi
-          # Mirrored profile in ~/Library/MobileDevice/Provisioning Profiles/
-          if [ -n "$PROFILE_UUID" ]; then
-            rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision" || true
-          fi
-          if [ "$fail" -eq 0 ]; then
-            echo "Signing material scrubbed."
-          fi
-          exit 0
+        uses: ./.github/actions/cleanup-ios-signing
+        with:
+          app-store-connect-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
 
   sanity-check:
     name: Dev Sanity Check

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -370,54 +370,9 @@ jobs:
 
       - name: Clean up signing material
         if: always()
-        env:
-          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-        # Self-hosted runner: scrub all signing material to prevent .p8/.p12
-        # leaking between jobs. Don't fail the job on cleanup — log warnings
-        # instead so the deploy outcome reflects deploy success/failure only.
-        # Mirrors what setup-ios-signing/action.yml writes — keep these in sync.
-        run: |
-          set -uo pipefail
-          fail=0
-          # Extract the profile UUID before deleting the source profile, since
-          # we need it to remove the mirrored copy in ~/Library/MobileDevice/.
-          PROFILE_UUID=""
-          if [ -f "$RUNNER_TEMP/profile.mobileprovision" ]; then
-            PROFILE_UUID=$(/usr/bin/security cms -D -i "$RUNNER_TEMP/profile.mobileprovision" 2>/dev/null \
-              | grep -A1 '<key>UUID</key>' | grep '<string>' \
-              | sed 's/.*<string>\(.*\)<\/string>.*/\1/' || true)
-          fi
-          # Temp keychain
-          if [ -f "$RUNNER_TEMP/app-signing.keychain-db" ]; then
-            if ! security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db"; then
-              echo "::warning::Failed to delete keychain at $RUNNER_TEMP/app-signing.keychain-db"
-              fail=1
-            fi
-          fi
-          # Restore the user keychain search list so we don't accumulate
-          # references to deleted keychains across runs on the persistent runner.
-          if ! security list-keychain -d user -s "$HOME/Library/Keychains/login.keychain-db"; then
-            echo "::warning::Failed to restore login keychain search list"
-            fail=1
-          fi
-          # All signing material in $RUNNER_TEMP (cert .p12, profile, IPA, archive, log)
-          rm -rf "$RUNNER_TEMP/export" \
-                 "$RUNNER_TEMP/iosApp.xcarchive" \
-                 "$RUNNER_TEMP/altool-upload.log" || true
-          rm -f "$RUNNER_TEMP/certificate.p12" \
-                "$RUNNER_TEMP/profile.mobileprovision" || true
-          # App Store Connect API key (.p8) lives outside $RUNNER_TEMP
-          if [ -n "${APP_STORE_CONNECT_KEY_ID:-}" ]; then
-            rm -f "$HOME/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" || true
-          fi
-          # Mirrored profile in ~/Library/MobileDevice/Provisioning Profiles/
-          if [ -n "$PROFILE_UUID" ]; then
-            rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision" || true
-          fi
-          if [ "$fail" -eq 0 ]; then
-            echo "Signing material scrubbed."
-          fi
-          exit 0
+        uses: ./.github/actions/cleanup-ios-signing
+        with:
+          app-store-connect-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
 
   # ── Smoke tests (after deploys) ────────────────────────────
   # Smoke tests are split per-surface so the GitHub UI status reflects what


### PR DESCRIPTION
## Summary
PR #388 added the \`cleanup-ios-signing\` composite action; this rewires deploy-dev.yml + deploy-prod.yml to use it. Eliminates 90 lines of duplicated inline bash that had drifted out of sync once (audit Round 2 caught cleanup missing 3 paths).

Going forward: when \`setup-ios-signing\` adds a new path, update the composite action ONCE.

No behaviour change — composite action mirrors inline logic exactly.

## Test plan
- [x] YAML parses, actionlint clean
- [ ] Next iOS deploy invokes composite action — log output should match the previous "Signing material scrubbed." line

🤖 Generated with [Claude Code](https://claude.com/claude-code)