### PR TITLE
fix(ci): move .p8 to $RUNNER_TEMP/private_keys/ (closes Phase 0 #63)

### DIFF
--- a/.github/actions/cleanup-ios-signing/action.yml
+++ b/.github/actions/cleanup-ios-signing/action.yml
@@ -57,10 +57,15 @@ runs:
         rm -f "$RUNNER_TEMP/certificate.p12" \
               "$RUNNER_TEMP/profile.mobileprovision" || true
 
-        # App Store Connect API key (.p8) lives outside $RUNNER_TEMP
+        # App Store Connect API key (.p8). Post-PR Phase-0 #63 writes to
+        # $RUNNER_TEMP/private_keys/; legacy path under $HOME is cleaned
+        # too so any leftovers from pre-#63 runs get scrubbed.
         if [ -n "${APP_STORE_CONNECT_KEY_ID:-}" ]; then
+          rm -f "$RUNNER_TEMP/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" || true
           rm -f "$HOME/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" || true
         fi
+        # Remove the now-empty $RUNNER_TEMP/private_keys/ directory if present.
+        rmdir "$RUNNER_TEMP/private_keys" 2>/dev/null || true
 
         # Mirrored profile in ~/Library/MobileDevice/Provisioning Profiles/
         if [ -n "$PROFILE_UUID" ]; then

--- a/.github/actions/setup-ios-signing/action.yml
+++ b/.github/actions/setup-ios-signing/action.yml
@@ -63,12 +63,20 @@ runs:
       # of the runner's default umask. On a self-hosted Mac with multiple
       # UIDs, the file-system permission is the actual security boundary —
       # without this the .p8 lands as world-readable 0644.
+      #
+      # Write to $RUNNER_TEMP/private_keys/ instead of $HOME/private_keys/
+      # so the .p8 lives in the runner's per-job temp area. On a self-hosted
+      # Mac this means a force-killed job can't leave the credential
+      # persisting under $HOME indefinitely. The cleanup composite action
+      # cleans both paths so legacy leftovers from before this change still
+      # get scrubbed.
       run: |
         set -euo pipefail
         umask 077
-        mkdir -p ~/private_keys
-        chmod 700 ~/private_keys
-        printf '%s' "$APP_STORE_CONNECT_KEY" > ~/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8
+        KEY_DIR="$RUNNER_TEMP/private_keys"
+        mkdir -p "$KEY_DIR"
+        chmod 700 "$KEY_DIR"
+        printf '%s' "$APP_STORE_CONNECT_KEY" > "$KEY_DIR/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8"
 
     - name: Decode signing certificate and provisioning profile
       shell: bash

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -302,7 +302,7 @@ jobs:
             -archivePath $RUNNER_TEMP/iosApp.xcarchive \
             -exportOptionsPlist ExportOptions.plist \
             -exportPath $RUNNER_TEMP/export \
-            -authenticationKeyPath ~/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8 \
+            -authenticationKeyPath $RUNNER_TEMP/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8 \
             -authenticationKeyID $APP_STORE_CONNECT_KEY_ID \
             -authenticationKeyIssuerID $APP_STORE_CONNECT_ISSUER_ID
           # Verify a single IPA was produced (catches `destination: upload` regressions

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -320,7 +320,7 @@ jobs:
             -archivePath $RUNNER_TEMP/iosApp.xcarchive \
             -exportOptionsPlist ExportOptions.plist \
             -exportPath $RUNNER_TEMP/export \
-            -authenticationKeyPath ~/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8 \
+            -authenticationKeyPath $RUNNER_TEMP/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8 \
             -authenticationKeyID $APP_STORE_CONNECT_KEY_ID \
             -authenticationKeyIssuerID $APP_STORE_CONNECT_ISSUER_ID
           # Verify a single IPA was produced (catches `destination: upload` regressions

--- a/scripts/ensure-testflight-auto-distribution.js
+++ b/scripts/ensure-testflight-auto-distribution.js
@@ -14,8 +14,10 @@
  *   APP_STORE_CONNECT_KEY_ID — the API key ID (10-char string)
  *   APP_STORE_CONNECT_ISSUER_ID — the issuer ID (UUID)
  *   APP_STORE_CONNECT_KEY_PATH — path to the .p8 file (defaults to
- *     ~/private_keys/AuthKey_<KEY_ID>.p8 — same path setup-ios-signing
- *     writes to)
+ *     $RUNNER_TEMP/private_keys/AuthKey_<KEY_ID>.p8 — same path
+ *     setup-ios-signing writes to as of Phase-0 #63; falls back to the
+ *     legacy ~/private_keys/ path so this script also works during the
+ *     deploy-workflow rollout window)
  *
  * Optional env:
  *   BUNDLE_ID — defaults to com.shyden.shytalk
@@ -26,9 +28,16 @@ const fs = require('node:fs');
 
 const KEY_ID = process.env.APP_STORE_CONNECT_KEY_ID;
 const ISSUER_ID = process.env.APP_STORE_CONNECT_ISSUER_ID;
+// Resolve .p8 path: explicit env > $RUNNER_TEMP (current setup-ios-signing)
+// > legacy $HOME (pre Phase-0 #63). Pick whichever exists.
+const explicitPath = process.env.APP_STORE_CONNECT_KEY_PATH;
+const runnerTempPath = process.env.RUNNER_TEMP
+  ? `${process.env.RUNNER_TEMP}/private_keys/AuthKey_${KEY_ID}.p8`
+  : null;
+const homePath = `${process.env.HOME}/private_keys/AuthKey_${KEY_ID}.p8`;
 const KEY_PATH =
-  process.env.APP_STORE_CONNECT_KEY_PATH ||
-  `${process.env.HOME}/private_keys/AuthKey_${KEY_ID}.p8`;
+  explicitPath ||
+  (runnerTempPath && fs.existsSync(runnerTempPath) ? runnerTempPath : homePath);
 const BUNDLE_ID = process.env.BUNDLE_ID || 'com.shyden.shytalk';
 
 if (!KEY_ID || !ISSUER_ID) {


### PR DESCRIPTION
## Summary
Move the App Store Connect API key (.p8) from \$HOME/private_keys/ to \$RUNNER_TEMP/private_keys/. On the self-hosted Mac, force-killed jobs (where \`if: always()\` doesn't run) left the credential under \$HOME indefinitely. Moving to \$RUNNER_TEMP scopes lifetime to per-job.

The cleanup composite action now scrubs BOTH paths so legacy leftovers from pre-#63 runs get cleaned up on the next deploy.

Touches: setup-ios-signing, cleanup-ios-signing, deploy-dev.yml, deploy-prod.yml, ensure-testflight-auto-distribution.js (script's path resolver tries \$RUNNER_TEMP first, falls back to \$HOME for legacy compat).

Closes Phase 0 roadmap item #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)