### PR TITLE
feat(ios): real device ID via UIDevice.identifierForVendor

### DIFF
--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/IosPlatformModule.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/IosPlatformModule.kt
@@ -92,7 +92,18 @@ val iosPlatformModule =
         }
 
         // Named qualifiers required by AuthViewModel
-        single(named("deviceId")) { "ios-device-placeholder" }
+        // Stable per-device identifier: `UIDevice.identifierForVendor` returns
+        // the same UUID for every app from the same vendor on the same device,
+        // and persists across app launches. It IS reset when the user uninstalls
+        // every app from this vendor, which matches Android's `ANDROID_ID`
+        // behaviour after a factory reset / settings reset. Falls back to a
+        // generated UUID if iOS returns null (rare — happens before the device
+        // is unlocked for the first time after boot).
+        single(named("deviceId")) {
+            platform.UIKit.UIDevice.currentDevice.identifierForVendor
+                ?.UUIDString
+                ?: platform.Foundation.NSUUID().UUIDString
+        }
         single(named("bypassDeviceChecks")) { true }
 
         // Platform utilities (actual classes already exist in iosMain)


### PR DESCRIPTION
[skip-android-e2e]

## Summary

Replaces the `"ios-device-placeholder"` stub with a real per-device stable identifier via `UIDevice.identifierForVendor`. Closes the device-binding gap on iOS — the Express API endpoints that gate behaviour on `X-Device-Id` (ban check, device binding, identity graph) now receive a real value instead of every iOS user sharing the same placeholder.

## Changes

- `IosPlatformModule.kt`: Koin `single(named("deviceId"))` now returns `UIDevice.currentDevice.identifierForVendor?.UUIDString` with `NSUUID().UUIDString` fallback.

## Behaviour notes

`identifierForVendor` is the Apple-recommended key for this purpose:
- Same UUID across every app from this vendor (Shyden Ltd) on this device
- Persists across app launches and OS updates
- Resets only when every app from this vendor is uninstalled (matches Android `ANDROID_ID`'s factory-reset semantics)
- Returns null only during the rare first-boot-before-unlock window — fallback covers it

## Test plan

- [x] `:shared:compileKotlinIosArm64` (BUILD SUCCESSFUL)
- [ ] CI all green

## Marker

`[skip-android-e2e]` — only `shared/src/iosMain/**` touched; iOS-only platform interop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)