### PR TITLE
feat(ios): port GachaSoundPlayer using AVAudioEngine + commonMain generators

### DIFF
--- a/shared/src/androidMain/kotlin/com/shyden/shytalk/core/audio/GachaSoundPlayer.android.kt
+++ b/shared/src/androidMain/kotlin/com/shyden/shytalk/core/audio/GachaSoundPlayer.android.kt
@@ -3,24 +3,6 @@ package com.shyden.shytalk.core.audio
 import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.AudioTrack
-import kotlin.math.PI
-import kotlin.math.cos
-import kotlin.math.exp
-import kotlin.math.sin
-
-private const val SAMPLE_RATE = 44100
-
-/** Coin-value thresholds for sound tiers (replacing bracket tiers). */
-private enum class SoundTier { COMMON, UNCOMMON, RARE, EPIC, LEGENDARY }
-
-private fun soundTierForCoinValue(coinValue: Int): SoundTier =
-    when {
-        coinValue < 50 -> SoundTier.COMMON
-        coinValue < 200 -> SoundTier.UNCOMMON
-        coinValue < 2000 -> SoundTier.RARE
-        coinValue < 10000 -> SoundTier.EPIC
-        else -> SoundTier.LEGENDARY
-    }
 
 actual object GachaSoundPlayer {
     private var spinStartTrack: AudioTrack? = null
@@ -28,7 +10,7 @@ actual object GachaSoundPlayer {
     private var coinPurchaseTrack: AudioTrack? = null
     private var highTierFanfareTrack: AudioTrack? = null
     private val tickTracks = arrayOfNulls<AudioTrack>(8)
-    private val winTracks = mutableMapOf<SoundTier, AudioTrack>()
+    private val winTracks = mutableMapOf<GachaSoundTier, AudioTrack>()
 
     @Volatile private var initialized = false
     private val lock = Any()
@@ -44,7 +26,7 @@ actual object GachaSoundPlayer {
             for (band in 0 until 8) {
                 tickTracks[band] = buildTrack(generateTick(band))
             }
-            SoundTier.entries.forEach { tier ->
+            GachaSoundTier.entries.forEach { tier ->
                 winTracks[tier] = buildTrack(generateWinReveal(tier))
             }
         }
@@ -83,10 +65,8 @@ actual object GachaSoundPlayer {
     }
 
     actual fun playWinReveal(coinValue: Int) {
-        replay(winTracks[soundTierForCoinValue(coinValue)])
+        replay(winTracks[gachaSoundTierForCoinValue(coinValue)])
     }
-
-    // -- Playback helper --
 
     private fun replay(track: AudioTrack?) {
         track ?: return
@@ -98,8 +78,6 @@ actual object GachaSoundPlayer {
             android.util.Log.w("GachaSoundPlayer", "Audio track replay failed", e)
         }
     }
-
-    // -- Track builder --
 
     private fun buildTrack(samples: ShortArray): AudioTrack {
         val bufferSize = samples.size * 2
@@ -116,7 +94,7 @@ actual object GachaSoundPlayer {
                     AudioFormat
                         .Builder()
                         .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-                        .setSampleRate(SAMPLE_RATE)
+                        .setSampleRate(GACHA_SAMPLE_RATE)
                         .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
                         .build(),
                 ).setBufferSizeInBytes(bufferSize)
@@ -124,361 +102,5 @@ actual object GachaSoundPlayer {
                 .build()
         track.write(samples, 0, samples.size)
         return track
-    }
-
-    // -- Sound generators --
-
-    /** Ascending chirp 220->1760Hz, 420ms, cos² attack/decay */
-    private fun generateSpinStart(): ShortArray {
-        val durationMs = 420
-        val numSamples = SAMPLE_RATE * durationMs / 1000
-        val samples = ShortArray(numSamples)
-        val amplitude = 0.28f
-        val attackMs = 40
-        val decayMs = 80
-        val attackSamples = SAMPLE_RATE * attackMs / 1000
-        val decaySamples = SAMPLE_RATE * decayMs / 1000
-
-        var phase = 0.0
-        for (i in 0 until numSamples) {
-            val t = i.toFloat() / numSamples
-            val freq = 220.0 + (1760.0 - 220.0) * t
-            phase += 2.0 * PI * freq / SAMPLE_RATE
-            val envelope =
-                if (i < attackSamples) {
-                    val at = i.toFloat() / attackSamples
-                    (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
-                } else if (i > numSamples - decaySamples) {
-                    val dt = (i - (numSamples - decaySamples)).toFloat() / decaySamples
-                    (cos(dt * PI / 2) * cos(dt * PI / 2)).toFloat()
-                } else {
-                    1f
-                }
-            samples[i] =
-                (
-                    sin(
-                        phase,
-                    ) * amplitude * envelope * Short.MAX_VALUE
-                ).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
-        }
-        return samples
-    }
-
-    /** Short tick, pitch mapped to 8 bands (180->740Hz), 28ms */
-    private fun generateTick(band: Int): ShortArray {
-        val durationMs = 28
-        val numSamples = SAMPLE_RATE * durationMs / 1000
-        val samples = ShortArray(numSamples)
-        val freq = 180.0 + (740.0 - 180.0) * (band / 7.0)
-        val amplitude = 0.20f
-        val attackSamples = SAMPLE_RATE * 4 / 1000
-        val decaySamples = SAMPLE_RATE * 4 / 1000
-
-        var phase = 0.0
-        for (i in 0 until numSamples) {
-            phase += 2.0 * PI * freq / SAMPLE_RATE
-            var envelope = 1f
-            if (i < attackSamples) {
-                val at = i.toFloat() / attackSamples
-                envelope = (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
-            } else if (i > numSamples - decaySamples) {
-                val dt = (i - (numSamples - decaySamples)).toFloat() / decaySamples
-                envelope = (sin((1 - dt) * PI / 2) * sin((1 - dt) * PI / 2)).toFloat()
-            }
-            samples[i] =
-                (
-                    sin(
-                        phase,
-                    ) * amplitude * envelope * Short.MAX_VALUE
-                ).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
-        }
-        return samples
-    }
-
-    /** Sharp click at 660Hz, 22ms, exponential decay */
-    private fun generateBlinkClick(): ShortArray {
-        val durationMs = 22
-        val numSamples = SAMPLE_RATE * durationMs / 1000
-        val samples = ShortArray(numSamples)
-        val amplitude = 0.30f
-
-        var phase = 0.0
-        for (i in 0 until numSamples) {
-            phase += 2.0 * PI * 660.0 / SAMPLE_RATE
-            val envelope = exp(-5.0 * i.toDouble() / numSamples).toFloat()
-            samples[i] =
-                (
-                    sin(
-                        phase,
-                    ) * amplitude * envelope * Short.MAX_VALUE
-                ).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
-        }
-        return samples
-    }
-
-    /** Win reveal sound — complexity scales with coin value tier */
-    private fun generateWinReveal(tier: SoundTier): ShortArray =
-        when (tier) {
-            SoundTier.COMMON -> generateWinCommon()
-            SoundTier.UNCOMMON -> generateWinUncommon()
-            SoundTier.RARE -> generateWinRare()
-            SoundTier.EPIC -> generateWinEpic()
-            SoundTier.LEGENDARY -> generateWinLegendary()
-        }
-
-    /** COMMON (<50 coins): single C5 tone, 280ms */
-    private fun generateWinCommon(): ShortArray {
-        val durationMs = 280
-        val numSamples = SAMPLE_RATE * durationMs / 1000
-        val samples = ShortArray(numSamples)
-        val amplitude = 0.25f
-        val attackSamples = SAMPLE_RATE * 20 / 1000
-
-        var phase = 0.0
-        for (i in 0 until numSamples) {
-            phase += 2.0 * PI * 523.0 / SAMPLE_RATE
-            val envelope =
-                if (i < attackSamples) {
-                    val at = i.toFloat() / attackSamples
-                    (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
-                } else {
-                    val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
-                    (1f - dt * dt)
-                }
-            samples[i] =
-                (
-                    sin(
-                        phase,
-                    ) * amplitude * envelope * Short.MAX_VALUE
-                ).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
-        }
-        return samples
-    }
-
-    /** UNCOMMON (50-199 coins): C5+E5 chord, 420ms */
-    private fun generateWinUncommon(): ShortArray {
-        val durationMs = 420
-        val numSamples = SAMPLE_RATE * durationMs / 1000
-        val samples = ShortArray(numSamples)
-        val amplitude = 0.25f
-        val attackSamples = SAMPLE_RATE * 25 / 1000
-
-        var phase1 = 0.0
-        var phase2 = 0.0
-        for (i in 0 until numSamples) {
-            phase1 += 2.0 * PI * 523.0 / SAMPLE_RATE
-            phase2 += 2.0 * PI * 659.0 / SAMPLE_RATE
-            val envelope =
-                if (i < attackSamples) {
-                    val at = i.toFloat() / attackSamples
-                    (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
-                } else {
-                    val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
-                    (1f - dt)
-                }
-            val value = (sin(phase1) + sin(phase2)) * 0.5 * amplitude * envelope
-            samples[i] = (value * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
-        }
-        return samples
-    }
-
-    /** RARE (200-1999 coins): C5+E5+G5 triad + shimmer, 600ms */
-    private fun generateWinRare(): ShortArray {
-        val durationMs = 600
-        val numSamples = SAMPLE_RATE * durationMs / 1000
-        val samples = ShortArray(numSamples)
-        val amplitude = 0.28f
-        val attackSamples = SAMPLE_RATE * 25 / 1000
-
-        var phase1 = 0.0
-        var phase2 = 0.0
-        var phase3 = 0.0
-        var shimmerPhase = 0.0
-        for (i in 0 until numSamples) {
-            phase1 += 2.0 * PI * 523.0 / SAMPLE_RATE
-            phase2 += 2.0 * PI * 659.0 / SAMPLE_RATE
-            phase3 += 2.0 * PI * 784.0 / SAMPLE_RATE
-            shimmerPhase += 2.0 * PI * 8.0 / SAMPLE_RATE
-            val envelope =
-                if (i < attackSamples) {
-                    val at = i.toFloat() / attackSamples
-                    (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
-                } else {
-                    val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
-                    (1f - dt * 0.7f)
-                }
-            val shimmer = 1.0 + 0.15 * sin(shimmerPhase)
-            val value = (sin(phase1) + sin(phase2) + sin(phase3)) / 3.0 * amplitude * envelope * shimmer
-            samples[i] = (value * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
-        }
-        return samples
-    }
-
-    /** EPIC (2000-9999 coins): A4+C#5+E5 + sub-bass 80Hz, 800ms */
-    private fun generateWinEpic(): ShortArray {
-        val durationMs = 800
-        val numSamples = SAMPLE_RATE * durationMs / 1000
-        val samples = ShortArray(numSamples)
-        val amplitude = 0.30f
-        val attackSamples = SAMPLE_RATE * 30 / 1000
-
-        var phase1 = 0.0
-        var phase2 = 0.0
-        var phase3 = 0.0
-        var subPhase = 0.0
-        for (i in 0 until numSamples) {
-            phase1 += 2.0 * PI * 440.0 / SAMPLE_RATE
-            phase2 += 2.0 * PI * 554.0 / SAMPLE_RATE
-            phase3 += 2.0 * PI * 659.0 / SAMPLE_RATE
-            subPhase += 2.0 * PI * 80.0 / SAMPLE_RATE
-            val envelope =
-                if (i < attackSamples) {
-                    val at = i.toFloat() / attackSamples
-                    (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
-                } else {
-                    val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
-                    (1f - dt * 0.5f)
-                }
-            val chord = (sin(phase1) + sin(phase2) + sin(phase3)) / 3.0
-            val sub = sin(subPhase) * 0.3
-            val value = (chord + sub) * amplitude * envelope / 1.3
-            samples[i] = (value * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
-        }
-        return samples
-    }
-
-    /** LEGENDARY (10000+ coins): 5-note chord + chirp overlay, 1200ms */
-    private fun generateWinLegendary(): ShortArray {
-        val durationMs = 1200
-        val numSamples = SAMPLE_RATE * durationMs / 1000
-        val samples = ShortArray(numSamples)
-        val amplitude = 0.30f
-        val attackSamples = SAMPLE_RATE * 40 / 1000
-
-        var p1 = 0.0
-        var p2 = 0.0
-        var p3 = 0.0
-        var p4 = 0.0
-        var p5 = 0.0
-        var chirpPhase = 0.0
-        for (i in 0 until numSamples) {
-            p1 += 2.0 * PI * 220.0 / SAMPLE_RATE
-            p2 += 2.0 * PI * 440.0 / SAMPLE_RATE
-            p3 += 2.0 * PI * 550.0 / SAMPLE_RATE
-            p4 += 2.0 * PI * 660.0 / SAMPLE_RATE
-            p5 += 2.0 * PI * 880.0 / SAMPLE_RATE
-            val t = i.toFloat() / numSamples
-            val chirpFreq = 880.0 + 1760.0 * t
-            chirpPhase += 2.0 * PI * chirpFreq / SAMPLE_RATE
-            val envelope =
-                if (i < attackSamples) {
-                    val at = i.toFloat() / attackSamples
-                    (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
-                } else {
-                    val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
-                    (1f - dt * 0.4f)
-                }
-            val chord = (sin(p1) + sin(p2) + sin(p3) + sin(p4) + sin(p5)) / 5.0
-            val chirp = sin(chirpPhase) * 0.15 * (1.0 - t)
-            val value = (chord + chirp) * amplitude * envelope / 1.15
-            samples[i] = (value * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
-        }
-        return samples
-    }
-
-    /** High-tier fanfare: dramatic ascending arpeggio C-E-G-C with layered harmonics, 1800ms */
-    private fun generateHighTierFanfare(): ShortArray {
-        val durationMs = 1800
-        val numSamples = SAMPLE_RATE * durationMs / 1000
-        val samples = ShortArray(numSamples)
-        val amplitude = 0.32f
-
-        val notes = doubleArrayOf(261.6, 329.6, 392.0, 523.3)
-        val noteOnsets = intArrayOf(0, (numSamples * 0.18).toInt(), (numSamples * 0.36).toInt(), (numSamples * 0.52).toInt())
-        val noteDuration = (numSamples * 0.55)
-
-        var subPhase = 0.0
-        var shimmerPhase = 0.0
-
-        val phases = DoubleArray(notes.size)
-        val octavePhases = DoubleArray(notes.size)
-
-        for (i in 0 until numSamples) {
-            val t = i.toFloat() / numSamples
-            var value = 0.0
-
-            subPhase += 2.0 * PI * 60.0 / SAMPLE_RATE
-            val subEnv = if (i < SAMPLE_RATE * 400 / 1000) exp(-4.0 * i.toDouble() / (SAMPLE_RATE * 400 / 1000)) else 0.0
-            value += sin(subPhase) * 0.25 * subEnv
-
-            for (n in notes.indices) {
-                val onset = noteOnsets[n]
-                if (i < onset) continue
-                val noteT = (i - onset).toDouble()
-                if (noteT > noteDuration) continue
-
-                phases[n] += 2.0 * PI * notes[n] / SAMPLE_RATE
-                octavePhases[n] += 2.0 * PI * notes[n] * 2.0 / SAMPLE_RATE
-
-                val attackSamp = SAMPLE_RATE * 20 / 1000
-                val noteEnv =
-                    if (noteT < attackSamp) {
-                        val at = noteT / attackSamp
-                        sin(at * PI / 2) * sin(at * PI / 2)
-                    } else {
-                        val dt = (noteT - attackSamp) / (noteDuration - attackSamp)
-                        1.0 - dt * 0.6
-                    }
-
-                value += (sin(phases[n]) * 0.7 + sin(octavePhases[n]) * 0.3) * noteEnv / notes.size
-            }
-
-            shimmerPhase += 2.0 * PI * 6.0 / SAMPLE_RATE
-            val shimmer = 1.0 + 0.12 * sin(shimmerPhase) * t
-
-            val globalEnv =
-                if (i < SAMPLE_RATE * 30 / 1000) {
-                    val at = i.toFloat() / (SAMPLE_RATE * 30 / 1000)
-                    sin(at * PI / 2) * sin(at * PI / 2)
-                } else if (t > 0.85) {
-                    val dt = (t - 0.85) / 0.15
-                    (1.0 - dt * dt)
-                } else {
-                    1.0
-                }
-
-            val sample = value * amplitude * shimmer * globalEnv
-            samples[i] =
-                (sample * Short.MAX_VALUE)
-                    .toInt()
-                    .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
-                    .toShort()
-        }
-        return samples
-    }
-
-    /** Two sequential dings: 880Hz then 1108Hz, 330ms total */
-    private fun generateCoinPurchase(): ShortArray {
-        val durationMs = 330
-        val numSamples = SAMPLE_RATE * durationMs / 1000
-        val samples = ShortArray(numSamples)
-        val amplitude = 0.28f
-        val halfSamples = numSamples / 2
-
-        var phase = 0.0
-        for (i in 0 until numSamples) {
-            val freq = if (i < halfSamples) 880.0 else 1108.0
-            if (i == halfSamples) phase = 0.0
-            phase += 2.0 * PI * freq / SAMPLE_RATE
-            val localT = if (i < halfSamples) i.toFloat() / halfSamples else (i - halfSamples).toFloat() / (numSamples - halfSamples)
-            val envelope = exp(-3.0 * localT).toFloat()
-            samples[i] =
-                (
-                    sin(
-                        phase,
-                    ) * amplitude * envelope * Short.MAX_VALUE
-                ).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
-        }
-        return samples
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/audio/GachaSoundSamples.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/audio/GachaSoundSamples.kt
@@ -1,0 +1,370 @@
+package com.shyden.shytalk.core.audio
+
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.exp
+import kotlin.math.sin
+
+/**
+ * Procedural audio synthesis for the gacha screen. Pure-math sample
+ * generators kept platform-independent; each platform `actual` for
+ * GachaSoundPlayer wraps the resulting `ShortArray` in its native
+ * audio playback engine (AudioTrack on Android, AVAudioEngine on iOS).
+ *
+ * All generators output mono 16-bit PCM at 44100 Hz with sample values
+ * clamped to the signed-short range. The same sample data plays
+ * identically on both platforms, so audio behaviour stays in sync as
+ * we add features.
+ */
+const val GACHA_SAMPLE_RATE = 44100
+
+/**
+ * Coin-value thresholds for win-reveal sound tiers. Match the Android
+ * Wallet contract — common pings for low coins, layered chords +
+ * shimmers + sub-bass for legendary.
+ */
+enum class GachaSoundTier { COMMON, UNCOMMON, RARE, EPIC, LEGENDARY }
+
+fun gachaSoundTierForCoinValue(coinValue: Int): GachaSoundTier =
+    when {
+        coinValue < 50 -> GachaSoundTier.COMMON
+        coinValue < 200 -> GachaSoundTier.UNCOMMON
+        coinValue < 2000 -> GachaSoundTier.RARE
+        coinValue < 10000 -> GachaSoundTier.EPIC
+        else -> GachaSoundTier.LEGENDARY
+    }
+
+/** Ascending chirp 220→1760 Hz, 420 ms, cos² attack/decay. */
+fun generateSpinStart(): ShortArray {
+    val durationMs = 420
+    val numSamples = GACHA_SAMPLE_RATE * durationMs / 1000
+    val samples = ShortArray(numSamples)
+    val amplitude = 0.28f
+    val attackSamples = GACHA_SAMPLE_RATE * 40 / 1000
+    val decaySamples = GACHA_SAMPLE_RATE * 80 / 1000
+
+    var phase = 0.0
+    for (i in 0 until numSamples) {
+        val t = i.toFloat() / numSamples
+        val freq = 220.0 + (1760.0 - 220.0) * t
+        phase += 2.0 * PI * freq / GACHA_SAMPLE_RATE
+        val envelope =
+            if (i < attackSamples) {
+                val at = i.toFloat() / attackSamples
+                (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+            } else if (i > numSamples - decaySamples) {
+                val dt = (i - (numSamples - decaySamples)).toFloat() / decaySamples
+                (cos(dt * PI / 2) * cos(dt * PI / 2)).toFloat()
+            } else {
+                1f
+            }
+        samples[i] = (sin(phase) * amplitude * envelope).toShortSample()
+    }
+    return samples
+}
+
+/** Short tick, pitch mapped to 8 bands (180→740 Hz), 28 ms. */
+fun generateTick(band: Int): ShortArray {
+    val durationMs = 28
+    val numSamples = GACHA_SAMPLE_RATE * durationMs / 1000
+    val samples = ShortArray(numSamples)
+    val freq = 180.0 + (740.0 - 180.0) * (band / 7.0)
+    val amplitude = 0.20f
+    val attackSamples = GACHA_SAMPLE_RATE * 4 / 1000
+    val decaySamples = GACHA_SAMPLE_RATE * 4 / 1000
+
+    var phase = 0.0
+    for (i in 0 until numSamples) {
+        phase += 2.0 * PI * freq / GACHA_SAMPLE_RATE
+        var envelope = 1f
+        if (i < attackSamples) {
+            val at = i.toFloat() / attackSamples
+            envelope = (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+        } else if (i > numSamples - decaySamples) {
+            val dt = (i - (numSamples - decaySamples)).toFloat() / decaySamples
+            envelope = (sin((1 - dt) * PI / 2) * sin((1 - dt) * PI / 2)).toFloat()
+        }
+        samples[i] = (sin(phase) * amplitude * envelope).toShortSample()
+    }
+    return samples
+}
+
+/** Sharp click at 660 Hz, 22 ms, exponential decay. */
+fun generateBlinkClick(): ShortArray {
+    val durationMs = 22
+    val numSamples = GACHA_SAMPLE_RATE * durationMs / 1000
+    val samples = ShortArray(numSamples)
+    val amplitude = 0.30f
+
+    var phase = 0.0
+    for (i in 0 until numSamples) {
+        phase += 2.0 * PI * 660.0 / GACHA_SAMPLE_RATE
+        val envelope = exp(-5.0 * i.toDouble() / numSamples).toFloat()
+        samples[i] = (sin(phase) * amplitude * envelope).toShortSample()
+    }
+    return samples
+}
+
+fun generateWinReveal(tier: GachaSoundTier): ShortArray =
+    when (tier) {
+        GachaSoundTier.COMMON -> generateWinCommon()
+        GachaSoundTier.UNCOMMON -> generateWinUncommon()
+        GachaSoundTier.RARE -> generateWinRare()
+        GachaSoundTier.EPIC -> generateWinEpic()
+        GachaSoundTier.LEGENDARY -> generateWinLegendary()
+    }
+
+/** COMMON (<50 coins): single C5 tone, 280 ms. */
+private fun generateWinCommon(): ShortArray {
+    val durationMs = 280
+    val numSamples = GACHA_SAMPLE_RATE * durationMs / 1000
+    val samples = ShortArray(numSamples)
+    val amplitude = 0.25f
+    val attackSamples = GACHA_SAMPLE_RATE * 20 / 1000
+
+    var phase = 0.0
+    for (i in 0 until numSamples) {
+        phase += 2.0 * PI * 523.0 / GACHA_SAMPLE_RATE
+        val envelope =
+            if (i < attackSamples) {
+                val at = i.toFloat() / attackSamples
+                (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+            } else {
+                val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
+                (1f - dt * dt)
+            }
+        samples[i] = (sin(phase) * amplitude * envelope).toShortSample()
+    }
+    return samples
+}
+
+/** UNCOMMON (50-199 coins): C5+E5 chord, 420 ms. */
+private fun generateWinUncommon(): ShortArray {
+    val durationMs = 420
+    val numSamples = GACHA_SAMPLE_RATE * durationMs / 1000
+    val samples = ShortArray(numSamples)
+    val amplitude = 0.25f
+    val attackSamples = GACHA_SAMPLE_RATE * 25 / 1000
+
+    var phase1 = 0.0
+    var phase2 = 0.0
+    for (i in 0 until numSamples) {
+        phase1 += 2.0 * PI * 523.0 / GACHA_SAMPLE_RATE
+        phase2 += 2.0 * PI * 659.0 / GACHA_SAMPLE_RATE
+        val envelope =
+            if (i < attackSamples) {
+                val at = i.toFloat() / attackSamples
+                (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+            } else {
+                val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
+                (1f - dt)
+            }
+        val value = (sin(phase1) + sin(phase2)) * 0.5 * amplitude * envelope
+        samples[i] = value.toShortSample()
+    }
+    return samples
+}
+
+/** RARE (200-1999 coins): C5+E5+G5 triad + shimmer, 600 ms. */
+private fun generateWinRare(): ShortArray {
+    val durationMs = 600
+    val numSamples = GACHA_SAMPLE_RATE * durationMs / 1000
+    val samples = ShortArray(numSamples)
+    val amplitude = 0.28f
+    val attackSamples = GACHA_SAMPLE_RATE * 25 / 1000
+
+    var phase1 = 0.0
+    var phase2 = 0.0
+    var phase3 = 0.0
+    var shimmerPhase = 0.0
+    for (i in 0 until numSamples) {
+        phase1 += 2.0 * PI * 523.0 / GACHA_SAMPLE_RATE
+        phase2 += 2.0 * PI * 659.0 / GACHA_SAMPLE_RATE
+        phase3 += 2.0 * PI * 784.0 / GACHA_SAMPLE_RATE
+        shimmerPhase += 2.0 * PI * 8.0 / GACHA_SAMPLE_RATE
+        val envelope =
+            if (i < attackSamples) {
+                val at = i.toFloat() / attackSamples
+                (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+            } else {
+                val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
+                (1f - dt * 0.7f)
+            }
+        val shimmer = 1.0 + 0.15 * sin(shimmerPhase)
+        val value = (sin(phase1) + sin(phase2) + sin(phase3)) / 3.0 * amplitude * envelope * shimmer
+        samples[i] = value.toShortSample()
+    }
+    return samples
+}
+
+/** EPIC (2000-9999 coins): A4+C#5+E5 + sub-bass 80 Hz, 800 ms. */
+private fun generateWinEpic(): ShortArray {
+    val durationMs = 800
+    val numSamples = GACHA_SAMPLE_RATE * durationMs / 1000
+    val samples = ShortArray(numSamples)
+    val amplitude = 0.30f
+    val attackSamples = GACHA_SAMPLE_RATE * 30 / 1000
+
+    var phase1 = 0.0
+    var phase2 = 0.0
+    var phase3 = 0.0
+    var subPhase = 0.0
+    for (i in 0 until numSamples) {
+        phase1 += 2.0 * PI * 440.0 / GACHA_SAMPLE_RATE
+        phase2 += 2.0 * PI * 554.0 / GACHA_SAMPLE_RATE
+        phase3 += 2.0 * PI * 659.0 / GACHA_SAMPLE_RATE
+        subPhase += 2.0 * PI * 80.0 / GACHA_SAMPLE_RATE
+        val envelope =
+            if (i < attackSamples) {
+                val at = i.toFloat() / attackSamples
+                (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+            } else {
+                val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
+                (1f - dt * 0.5f)
+            }
+        val chord = (sin(phase1) + sin(phase2) + sin(phase3)) / 3.0
+        val sub = sin(subPhase) * 0.3
+        val value = (chord + sub) * amplitude * envelope / 1.3
+        samples[i] = value.toShortSample()
+    }
+    return samples
+}
+
+/** LEGENDARY (10000+ coins): 5-note chord + chirp overlay, 1200 ms. */
+private fun generateWinLegendary(): ShortArray {
+    val durationMs = 1200
+    val numSamples = GACHA_SAMPLE_RATE * durationMs / 1000
+    val samples = ShortArray(numSamples)
+    val amplitude = 0.30f
+    val attackSamples = GACHA_SAMPLE_RATE * 40 / 1000
+
+    var p1 = 0.0
+    var p2 = 0.0
+    var p3 = 0.0
+    var p4 = 0.0
+    var p5 = 0.0
+    var chirpPhase = 0.0
+    for (i in 0 until numSamples) {
+        p1 += 2.0 * PI * 220.0 / GACHA_SAMPLE_RATE
+        p2 += 2.0 * PI * 440.0 / GACHA_SAMPLE_RATE
+        p3 += 2.0 * PI * 550.0 / GACHA_SAMPLE_RATE
+        p4 += 2.0 * PI * 660.0 / GACHA_SAMPLE_RATE
+        p5 += 2.0 * PI * 880.0 / GACHA_SAMPLE_RATE
+        val t = i.toFloat() / numSamples
+        val chirpFreq = 880.0 + 1760.0 * t
+        chirpPhase += 2.0 * PI * chirpFreq / GACHA_SAMPLE_RATE
+        val envelope =
+            if (i < attackSamples) {
+                val at = i.toFloat() / attackSamples
+                (sin(at * PI / 2) * sin(at * PI / 2)).toFloat()
+            } else {
+                val dt = (i - attackSamples).toFloat() / (numSamples - attackSamples)
+                (1f - dt * 0.4f)
+            }
+        val chord = (sin(p1) + sin(p2) + sin(p3) + sin(p4) + sin(p5)) / 5.0
+        val chirp = sin(chirpPhase) * 0.15 * (1.0 - t)
+        val value = (chord + chirp) * amplitude * envelope / 1.15
+        samples[i] = value.toShortSample()
+    }
+    return samples
+}
+
+/** High-tier fanfare: dramatic ascending arpeggio C-E-G-C with layered harmonics, 1800 ms. */
+fun generateHighTierFanfare(): ShortArray {
+    val durationMs = 1800
+    val numSamples = GACHA_SAMPLE_RATE * durationMs / 1000
+    val samples = ShortArray(numSamples)
+    val amplitude = 0.32f
+
+    val notes = doubleArrayOf(261.6, 329.6, 392.0, 523.3)
+    val noteOnsets = intArrayOf(0, (numSamples * 0.18).toInt(), (numSamples * 0.36).toInt(), (numSamples * 0.52).toInt())
+    val noteDuration = (numSamples * 0.55)
+
+    var subPhase = 0.0
+    var shimmerPhase = 0.0
+
+    val phases = DoubleArray(notes.size)
+    val octavePhases = DoubleArray(notes.size)
+
+    for (i in 0 until numSamples) {
+        val t = i.toFloat() / numSamples
+        var value = 0.0
+
+        subPhase += 2.0 * PI * 60.0 / GACHA_SAMPLE_RATE
+        val subEnv =
+            if (i < GACHA_SAMPLE_RATE * 400 / 1000) {
+                exp(-4.0 * i.toDouble() / (GACHA_SAMPLE_RATE * 400 / 1000))
+            } else {
+                0.0
+            }
+        value += sin(subPhase) * 0.25 * subEnv
+
+        for (n in notes.indices) {
+            val onset = noteOnsets[n]
+            if (i < onset) continue
+            val noteT = (i - onset).toDouble()
+            if (noteT > noteDuration) continue
+
+            phases[n] += 2.0 * PI * notes[n] / GACHA_SAMPLE_RATE
+            octavePhases[n] += 2.0 * PI * notes[n] * 2.0 / GACHA_SAMPLE_RATE
+
+            val attackSamp = GACHA_SAMPLE_RATE * 20 / 1000
+            val noteEnv =
+                if (noteT < attackSamp) {
+                    val at = noteT / attackSamp
+                    sin(at * PI / 2) * sin(at * PI / 2)
+                } else {
+                    val dt = (noteT - attackSamp) / (noteDuration - attackSamp)
+                    1.0 - dt * 0.6
+                }
+
+            value += (sin(phases[n]) * 0.7 + sin(octavePhases[n]) * 0.3) * noteEnv / notes.size
+        }
+
+        shimmerPhase += 2.0 * PI * 6.0 / GACHA_SAMPLE_RATE
+        val shimmer = 1.0 + 0.12 * sin(shimmerPhase) * t
+
+        val globalEnv =
+            if (i < GACHA_SAMPLE_RATE * 30 / 1000) {
+                val at = i.toFloat() / (GACHA_SAMPLE_RATE * 30 / 1000)
+                sin(at * PI / 2) * sin(at * PI / 2)
+            } else if (t > 0.85) {
+                val dt = (t - 0.85) / 0.15
+                (1.0 - dt * dt)
+            } else {
+                1.0
+            }
+
+        val sample = value * amplitude * shimmer * globalEnv
+        samples[i] = sample.toShortSample()
+    }
+    return samples
+}
+
+/** Two sequential dings: 880 Hz then 1108 Hz, 330 ms total. */
+fun generateCoinPurchase(): ShortArray {
+    val durationMs = 330
+    val numSamples = GACHA_SAMPLE_RATE * durationMs / 1000
+    val samples = ShortArray(numSamples)
+    val amplitude = 0.28f
+    val halfSamples = numSamples / 2
+
+    var phase = 0.0
+    for (i in 0 until numSamples) {
+        val freq = if (i < halfSamples) 880.0 else 1108.0
+        if (i == halfSamples) phase = 0.0
+        phase += 2.0 * PI * freq / GACHA_SAMPLE_RATE
+        val localT =
+            if (i < halfSamples) {
+                i.toFloat() / halfSamples
+            } else {
+                (i - halfSamples).toFloat() / (numSamples - halfSamples)
+            }
+        val envelope = exp(-3.0 * localT).toFloat()
+        samples[i] = (sin(phase) * amplitude * envelope).toShortSample()
+    }
+    return samples
+}
+
+private fun Double.toShortSample(): Short =
+    (this * Short.MAX_VALUE).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/audio/GachaSoundSamplesTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/audio/GachaSoundSamplesTest.kt
@@ -1,0 +1,205 @@
+package com.shyden.shytalk.core.audio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for procedural gacha sound generators in commonMain.
+ * The same generator code drives both the Android AudioTrack
+ * and iOS AVAudioEngine playback paths, so we cover sample
+ * counts, value ranges, and the coin-tier mapping here.
+ */
+class GachaSoundSamplesTest {
+    @Test
+    fun `tier mapping at boundaries`() {
+        assertEquals(GachaSoundTier.COMMON, gachaSoundTierForCoinValue(0))
+        assertEquals(GachaSoundTier.COMMON, gachaSoundTierForCoinValue(49))
+        assertEquals(GachaSoundTier.UNCOMMON, gachaSoundTierForCoinValue(50))
+        assertEquals(GachaSoundTier.UNCOMMON, gachaSoundTierForCoinValue(199))
+        assertEquals(GachaSoundTier.RARE, gachaSoundTierForCoinValue(200))
+        assertEquals(GachaSoundTier.RARE, gachaSoundTierForCoinValue(1999))
+        assertEquals(GachaSoundTier.EPIC, gachaSoundTierForCoinValue(2000))
+        assertEquals(GachaSoundTier.EPIC, gachaSoundTierForCoinValue(9999))
+        assertEquals(GachaSoundTier.LEGENDARY, gachaSoundTierForCoinValue(10000))
+        assertEquals(GachaSoundTier.LEGENDARY, gachaSoundTierForCoinValue(1_000_000))
+    }
+
+    @Test
+    fun `spinStart sample count matches 420ms at 44_1kHz`() {
+        assertEquals(GACHA_SAMPLE_RATE * 420 / 1000, generateSpinStart().size)
+    }
+
+    @Test
+    fun `tick sample count matches 28ms`() {
+        assertEquals(GACHA_SAMPLE_RATE * 28 / 1000, generateTick(0).size)
+        assertEquals(GACHA_SAMPLE_RATE * 28 / 1000, generateTick(7).size)
+    }
+
+    @Test
+    fun `blinkClick sample count matches 22ms`() {
+        assertEquals(GACHA_SAMPLE_RATE * 22 / 1000, generateBlinkClick().size)
+    }
+
+    @Test
+    fun `coinPurchase sample count matches 330ms`() {
+        assertEquals(GACHA_SAMPLE_RATE * 330 / 1000, generateCoinPurchase().size)
+    }
+
+    @Test
+    fun `highTierFanfare sample count matches 1800ms`() {
+        assertEquals(GACHA_SAMPLE_RATE * 1800 / 1000, generateHighTierFanfare().size)
+    }
+
+    @Test
+    fun `winReveal sample counts grow with tier`() {
+        val common = generateWinReveal(GachaSoundTier.COMMON).size
+        val uncommon = generateWinReveal(GachaSoundTier.UNCOMMON).size
+        val rare = generateWinReveal(GachaSoundTier.RARE).size
+        val epic = generateWinReveal(GachaSoundTier.EPIC).size
+        val legendary = generateWinReveal(GachaSoundTier.LEGENDARY).size
+
+        assertEquals(GACHA_SAMPLE_RATE * 280 / 1000, common)
+        assertEquals(GACHA_SAMPLE_RATE * 420 / 1000, uncommon)
+        assertEquals(GACHA_SAMPLE_RATE * 600 / 1000, rare)
+        assertEquals(GACHA_SAMPLE_RATE * 800 / 1000, epic)
+        assertEquals(GACHA_SAMPLE_RATE * 1200 / 1000, legendary)
+
+        assertTrue(common < uncommon)
+        assertTrue(uncommon < rare)
+        assertTrue(rare < epic)
+        assertTrue(epic < legendary)
+    }
+
+    @Test
+    fun `tick generators produce different bands`() {
+        // Different bands should produce different sample data —
+        // proves the band parameter actually changes frequency.
+        val band0 = generateTick(0)
+        val band7 = generateTick(7)
+        assertEquals(band0.size, band7.size)
+        // Find at least one differing sample
+        var diff = false
+        for (i in band0.indices) {
+            if (band0[i] != band7[i]) {
+                diff = true
+                break
+            }
+        }
+        assertTrue(diff, "bands 0 and 7 should produce distinct samples")
+    }
+
+    @Test
+    fun `samples stay within Short range`() {
+        val sounds =
+            listOf(
+                generateSpinStart(),
+                generateBlinkClick(),
+                generateCoinPurchase(),
+                generateHighTierFanfare(),
+                generateWinReveal(GachaSoundTier.LEGENDARY),
+                generateTick(3),
+            )
+        sounds.forEach { samples ->
+            samples.forEach { s ->
+                assertTrue(s >= Short.MIN_VALUE)
+                assertTrue(s <= Short.MAX_VALUE)
+            }
+        }
+    }
+
+    @Test
+    fun `samples are not all silent`() {
+        val sounds =
+            listOf(
+                "spinStart" to generateSpinStart(),
+                "blinkClick" to generateBlinkClick(),
+                "coinPurchase" to generateCoinPurchase(),
+                "highTierFanfare" to generateHighTierFanfare(),
+                "tick" to generateTick(4),
+                "winLegendary" to generateWinReveal(GachaSoundTier.LEGENDARY),
+            )
+        sounds.forEach { (name, samples) ->
+            val nonZero = samples.count { it.toInt() != 0 }
+            assertTrue(
+                nonZero > samples.size / 4,
+                "$name has ${samples.size - nonZero} silent samples out of ${samples.size}",
+            )
+        }
+    }
+
+    @Test
+    fun `total PCM buffer size remains under 600KB`() {
+        val bytesPerSample = 2 // int16 PCM
+        val totalSamples =
+            generateSpinStart().size +
+                generateBlinkClick().size +
+                generateCoinPurchase().size +
+                generateHighTierFanfare().size +
+                (0 until 8).sumOf { generateTick(it).size } +
+                GachaSoundTier.entries.sumOf { generateWinReveal(it).size }
+
+        val totalBytes = totalSamples * bytesPerSample
+        assertTrue(
+            totalBytes < 600_000,
+            "Total PCM buffer size $totalBytes bytes exceeds 600KB budget",
+        )
+    }
+
+    @Test
+    fun `spinStart starts and ends close to silence`() {
+        val samples = generateSpinStart()
+        // First sample should be near silence (cos² attack starts at 0)
+        assertEquals(0, samples.first().toInt())
+        // Last sample should be near silence (cos² decay ends at 0)
+        assertTrue(kotlin.math.abs(samples.last().toInt()) < 1000)
+    }
+
+    @Test
+    fun `coinPurchase has two distinct dings via frequency switch`() {
+        val samples = generateCoinPurchase()
+        // The frequency change happens at halfSamples — exact peak amplitude
+        // shouldn't be at the boundary. We just verify both halves contain
+        // non-zero data so each ding actually plays.
+        val half = samples.size / 2
+        val firstHalfNonZero = (0 until half).count { samples[it].toInt() != 0 }
+        val secondHalfNonZero = (half until samples.size).count { samples[it].toInt() != 0 }
+        assertTrue(firstHalfNonZero > half / 2, "first ding mostly silent")
+        assertTrue(secondHalfNonZero > half / 2, "second ding mostly silent")
+    }
+
+    @Test
+    fun `tier ordering matches enum declaration`() {
+        // entries order is the declaration order — playback maps coin
+        // value to tier and we depend on this for sound selection
+        assertEquals(
+            listOf(
+                GachaSoundTier.COMMON,
+                GachaSoundTier.UNCOMMON,
+                GachaSoundTier.RARE,
+                GachaSoundTier.EPIC,
+                GachaSoundTier.LEGENDARY,
+            ),
+            GachaSoundTier.entries,
+        )
+    }
+
+    @Test
+    fun `different tiers produce different win reveal data`() {
+        val common = generateWinReveal(GachaSoundTier.COMMON)
+        val legendary = generateWinReveal(GachaSoundTier.LEGENDARY)
+        // Different lengths obviously, but the early samples should also
+        // differ because legendary uses a different chord stack.
+        val sharedLen = minOf(common.size, legendary.size)
+        var differs = false
+        for (i in 0 until sharedLen) {
+            if (common[i] != legendary[i]) {
+                differs = true
+                break
+            }
+        }
+        assertTrue(differs, "common and legendary win reveals should differ")
+        assertNotEquals(common.size, legendary.size, "tier sample counts should differ")
+    }
+}

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/audio/GachaSoundPlayer.ios.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/audio/GachaSoundPlayer.ios.kt
@@ -1,31 +1,216 @@
+@file:OptIn(
+    kotlinx.cinterop.ExperimentalForeignApi::class,
+    kotlinx.cinterop.BetaInteropApi::class,
+    kotlin.experimental.ExperimentalNativeApi::class,
+)
+
 package com.shyden.shytalk.core.audio
 
-import com.shyden.shytalk.core.util.logW
+import com.shyden.shytalk.core.util.logE
+import kotlinx.cinterop.ObjCObjectVar
+import kotlinx.cinterop.UShortVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.pointed
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.set
+import kotlinx.cinterop.value
+import platform.AVFAudio.AVAudioEngine
+import platform.AVFAudio.AVAudioFormat
+import platform.AVFAudio.AVAudioPCMBuffer
+import platform.AVFAudio.AVAudioPCMFormatInt16
+import platform.AVFAudio.AVAudioPlayerNode
+import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionCategoryAmbient
+import platform.AVFAudio.setActive
+import platform.Foundation.NSError
 
-/**
- * iOS gacha sound player. Currently uses no-op stubs since
- * procedural audio generation requires AVAudioEngine setup
- * that is non-trivial. Sound effects will be added when
- * bundled audio assets are available.
- */
+private const val TAG = "GachaSoundPlayer.ios"
+
 actual object GachaSoundPlayer {
-    private const val TAG = "GachaSoundPlayer.ios"
+    private var engine: AVAudioEngine? = null
+    private var spinStart: PreloadedSound? = null
+    private var blinkClick: PreloadedSound? = null
+    private var coinPurchase: PreloadedSound? = null
+    private var highTierFanfare: PreloadedSound? = null
+    private val ticks = arrayOfNulls<PreloadedSound>(8)
+    private val winReveals = mutableMapOf<GachaSoundTier, PreloadedSound>()
 
+    @kotlin.concurrent.Volatile
+    private var initialized = false
+
+    /**
+     * Init/release run on the main thread (Compose `LaunchedEffect` /
+     * `DisposableEffect` callbacks). Compose serialises recomposition,
+     * so a second init() cannot interleave with the first on the same
+     * screen, and we don't expose this object outside Compose-owned
+     * lifecycle. The volatile flag is the visibility barrier for
+     * `replay()` callers, which can come from arbitrary coroutine
+     * contexts during the gacha animation.
+     */
     actual fun init() {
-        logW(TAG, "init — iOS audio not yet implemented")
+        if (initialized) return
+        try {
+            memScoped {
+                val sessionErr = alloc<ObjCObjectVar<NSError?>>()
+                val session = AVAudioSession.sharedInstance()
+                // Ambient category lets the app play sound without
+                // interrupting other audio (music, calls). Maps to
+                // Android USAGE_GAME / CONTENT_TYPE_SONIFICATION.
+                if (!session.setCategory(AVAudioSessionCategoryAmbient, sessionErr.ptr)) {
+                    logE(TAG, "setCategory failed: ${sessionErr.value}")
+                    return
+                }
+                if (!session.setActive(true, sessionErr.ptr)) {
+                    logE(TAG, "setActive failed: ${sessionErr.value}")
+                    return
+                }
+            }
+
+            val format =
+                AVAudioFormat(
+                    commonFormat = AVAudioPCMFormatInt16,
+                    sampleRate = GACHA_SAMPLE_RATE.toDouble(),
+                    channels = 1u,
+                    interleaved = false,
+                )
+
+            val newEngine = AVAudioEngine()
+
+            spinStart = preload(newEngine, format, generateSpinStart())
+            blinkClick = preload(newEngine, format, generateBlinkClick())
+            coinPurchase = preload(newEngine, format, generateCoinPurchase())
+            highTierFanfare = preload(newEngine, format, generateHighTierFanfare())
+            for (band in 0 until 8) {
+                ticks[band] = preload(newEngine, format, generateTick(band))
+            }
+            GachaSoundTier.entries.forEach { tier ->
+                winReveals[tier] = preload(newEngine, format, generateWinReveal(tier))
+            }
+
+            memScoped {
+                val engineErr = alloc<ObjCObjectVar<NSError?>>()
+                if (!newEngine.startAndReturnError(engineErr.ptr)) {
+                    logE(TAG, "AVAudioEngine.start failed: ${engineErr.value}")
+                    clearPreloadedState()
+                    return
+                }
+            }
+
+            engine = newEngine
+            // Volatile write LAST — replay() callers must never observe
+            // a half-built audio graph through a relaxed read.
+            initialized = true
+        } catch (e: Throwable) {
+            logE(TAG, "Audio engine init threw", e)
+            clearPreloadedState()
+            engine = null
+            initialized = false
+        }
     }
 
-    actual fun release() {}
+    actual fun release() {
+        if (!initialized) return
+        // Volatile write FIRST so any concurrent replay() coroutine
+        // observes the gate flip and bails before touching a detached
+        // player node — scheduleBuffer on a stopped engine raises
+        // NSInternalInconsistencyException.
+        initialized = false
+        try {
+            engine?.stop()
+            allSounds().forEach { it.player.stop() }
+        } catch (e: Throwable) {
+            logE(TAG, "Audio engine release threw", e)
+        }
+        clearPreloadedState()
+        engine = null
+    }
 
-    actual fun playSpinStart() {}
+    actual fun playSpinStart() = replay(spinStart)
 
-    actual fun playTick(progress: Float) {}
+    actual fun playBlinkClick() = replay(blinkClick)
 
-    actual fun playBlinkClick() {}
+    actual fun playCoinPurchase() = replay(coinPurchase)
 
-    actual fun playWinReveal(coinValue: Int) {}
+    actual fun playHighTierFanfare() = replay(highTierFanfare)
 
-    actual fun playHighTierFanfare() {}
+    actual fun playTick(progress: Float) {
+        val band = (progress.coerceIn(0f, 1f) * 7).toInt().coerceIn(0, 7)
+        replay(ticks[band])
+    }
 
-    actual fun playCoinPurchase() {}
+    actual fun playWinReveal(coinValue: Int) {
+        replay(winReveals[gachaSoundTierForCoinValue(coinValue)])
+    }
+
+    private fun replay(sound: PreloadedSound?) {
+        sound ?: return
+        // Volatile gate prevents play after release() has detached the
+        // player from the engine — scheduleBuffer on a stopped engine
+        // raises NSInternalInconsistencyException on iOS.
+        if (!initialized) return
+        try {
+            // stop() drops any in-flight buffer so rapid replays restart
+            // from the beginning instead of queuing — matches Android
+            // pause()+reloadStaticData()+play() semantics.
+            sound.player.stop()
+            sound.player.scheduleBuffer(sound.buffer, completionHandler = null)
+            sound.player.play()
+        } catch (e: Throwable) {
+            logE(TAG, "Audio replay failed", e)
+        }
+    }
+
+    private fun preload(
+        engine: AVAudioEngine,
+        format: AVAudioFormat,
+        samples: ShortArray,
+    ): PreloadedSound {
+        val buffer =
+            AVAudioPCMBuffer(
+                pCMFormat = format,
+                frameCapacity = samples.size.convert(),
+            )
+        buffer.frameLength = samples.size.convert()
+
+        // AVAudioPCMBuffer.int16ChannelData is a pointer-to-pointer; channel 0
+        // holds the mono data. Reinterpret to UShortVar to bypass Kotlin/Native
+        // signedness mismatch warnings — the wire bits are identical.
+        val channels = buffer.int16ChannelData
+        if (channels != null) {
+            val channel0 = channels.pointed.value
+            if (channel0 != null) {
+                val raw = channel0.reinterpret<UShortVar>()
+                for (i in samples.indices) {
+                    raw[i] = samples[i].toUShort()
+                }
+            }
+        }
+
+        val player = AVAudioPlayerNode()
+        engine.attachNode(player)
+        engine.connect(player, to = engine.mainMixerNode, format = format)
+        return PreloadedSound(player, buffer)
+    }
+
+    private fun allSounds(): List<PreloadedSound> =
+        listOfNotNull(spinStart, blinkClick, coinPurchase, highTierFanfare) +
+            ticks.filterNotNull() +
+            winReveals.values
+
+    private fun clearPreloadedState() {
+        spinStart = null
+        blinkClick = null
+        coinPurchase = null
+        highTierFanfare = null
+        ticks.indices.forEach { ticks[it] = null }
+        winReveals.clear()
+    }
+
+    private data class PreloadedSound(
+        val player: AVAudioPlayerNode,
+        val buffer: AVAudioPCMBuffer,
+    )
 }


### PR DESCRIPTION
## Summary
- Refactor: extracts the 11 procedural sample generators (spinStart, 8 ticks, blink click, coin purchase, fanfare, 5 win-reveal tiers) from `shared/src/androidMain/.../GachaSoundPlayer.android.kt` into new `shared/src/commonMain/.../GachaSoundSamples.kt`. Pure math (`kotlin.math.sin/cos/exp` + `ShortArray`) — no Android deps, no JVM-only APIs. Same byte-identical samples drive both platforms so audio behaviour stays in sync.
- Promotes `SoundTier` enum (was private androidMain) to public `GachaSoundTier` in commonMain so iOS can reuse the win-reveal selector.
- Refactors Android impl from 484 → 110 lines — same `AudioTrack` wrapping, same `pause()+reloadStaticData()+play()` semantics, same `synchronized(lock) + @Volatile` init/release guards. Behaviour preserved.
- **Implements iOS `GachaSoundPlayer` from scratch** using `AVAudioEngine` + per-sound `AVAudioPlayerNode` + `AVAudioPCMBuffer`. `AVAudioSessionCategoryAmbient` matches Android `USAGE_GAME` (no music interruption). Replaces the previous no-op stubs that just logged "iOS audio not yet implemented".

## Silent-failure hardening (review-driven)
- **iOS NSError pointers captured**: `setCategory`, `setActive`, and `startAndReturnError` all now use `memScoped { val err = alloc<ObjCObjectVar<NSError?>>(); ... err.ptr }` and surface failures via `logE(TAG, "<op> failed: ${err.value}")`. Was passing `null` — every audio-init error was silently dropped.
- **TOCTOU race fix**: `initialized = true` is now set ONLY after `engine.startAndReturnError()` returns true. Was being set BEFORE the work, which could let a concurrent `replay()` observe a half-built audio graph.
- **Volatile ordering**: `init()` writes `initialized = true` LAST; `release()` writes `initialized = false` FIRST. Documents the exact memory-visibility contract that protects coroutine-side `replay()` callers from racing with main-thread lifecycle.
- **`replay()` gates on `initialized`**: prevents `scheduleBuffer` on a stopped engine which raises `NSInternalInconsistencyException` on iOS.

## Test plan
- [x] `./gradlew :app:compileDevDebugKotlin :shared:compileKotlinIosArm64 testDevDebugUnitTest :shared:jvmTest detekt` — all green
- [x] ktlint clean on all changed files
- [x] 12 new commonTest cases in `GachaSoundSamplesTest.kt` cover tier mapping, sample-count contracts, sample-range bounds, non-silence, total memory budget (<600KB), boundary attack/decay envelope, and tier distinctness — all pass
- [x] Pre-existing 14-case `GachaSoundPlayerTest.kt` (Android) still passes — sample-count constants preserved
- [x] code-reviewer agent: clean (no high-confidence issues, package paths preserved, no new JVM-only APIs in commonMain)
- [x] silent-failure-hunter agent (run twice): all CRITICAL findings fixed in this PR
- [x] SonarCloud quality gate: passed in pre-push
- [ ] CI: Android, iOS, Express, Playwright, SonarCloud
- [ ] Manual QA after CI: gacha screen on Android device + iOS Simulator (verify each sound plays once, ticks fire on spin, win-reveal fanfare plays for high-tier prizes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)