### PR TITLE
feat(ios): real image upload via Ktor multipart

### DIFF
--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosApiClient.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosApiClient.kt
@@ -10,6 +10,8 @@ import io.ktor.client.call.body
 import io.ktor.client.engine.darwin.Darwin
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.delete
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.patch
@@ -19,6 +21,8 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -140,6 +144,59 @@ class IosApiClient(
                 header("X-Device-Id", deviceId)
             }
         return parseResponse(response)
+    }
+
+    /**
+     * Multipart upload — used for image uploads to the storage worker.
+     * Mirrors Android `StorageRepositoryImpl.uploadImage` (OkHttp multipart),
+     * with the same auth + 401 retry semantics as the JSON endpoints.
+     */
+    suspend fun postMultipart(
+        path: String,
+        fileBytes: ByteArray,
+        fileName: String,
+        fileContentType: String,
+        formFields: Map<String, String> = emptyMap(),
+    ): JsonObject {
+        val token = getIdToken() ?: throw ApiException(401, "Not authenticated")
+        val response = executeMultipart(path, fileBytes, fileName, fileContentType, formFields, token)
+        if (response.status.value == 401) {
+            logI(TAG, "401 on multipart $path — refreshing token and retrying")
+            val freshToken = getIdToken(forceRefresh = true) ?: throw ApiException(401, "Token refresh failed")
+            return parseResponse(
+                executeMultipart(path, fileBytes, fileName, fileContentType, formFields, freshToken),
+            )
+        }
+        return parseResponse(response)
+    }
+
+    private suspend fun executeMultipart(
+        path: String,
+        fileBytes: ByteArray,
+        fileName: String,
+        fileContentType: String,
+        formFields: Map<String, String>,
+        token: String,
+    ): HttpResponse {
+        val multipart =
+            MultiPartFormDataContent(
+                formData {
+                    formFields.forEach { (name, value) -> append(name, value) }
+                    append(
+                        "file",
+                        fileBytes,
+                        Headers.build {
+                            append(HttpHeaders.ContentType, fileContentType)
+                            append(HttpHeaders.ContentDisposition, "filename=\"$fileName\"")
+                        },
+                    )
+                },
+            )
+        return client.post("$baseUrl$path") {
+            header("Authorization", "Bearer $token")
+            header("X-Device-Id", deviceId)
+            setBody(multipart)
+        }
     }
 
     suspend fun postPublic(

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosSmallRepositories.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosSmallRepositories.kt
@@ -5,11 +5,13 @@ import com.shyden.shytalk.core.model.FunFact
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.core.util.currentTimeMillis
 import com.shyden.shytalk.core.util.firebaseCall
+import com.shyden.shytalk.core.util.logE
 import com.shyden.shytalk.core.util.logW
 import com.shyden.shytalk.data.firestore.dataMap
 import com.shyden.shytalk.data.remote.ApiException
 import com.shyden.shytalk.data.remote.IosApiClient
 import dev.gitlive.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.boolean
@@ -460,14 +462,39 @@ class IosStorageRepositoryImpl(
         path: String,
         imageData: ByteArray,
         contentType: String,
-    ): Resource<String> = Resource.Error("Image upload not yet implemented on iOS")
+    ): Resource<String> =
+        try {
+            val json =
+                api.postMultipart(
+                    path = "/api/storage/upload",
+                    fileBytes = imageData,
+                    fileName = "upload",
+                    fileContentType = contentType,
+                    formFields = mapOf("path" to path),
+                )
+            val url = json["url"]?.jsonPrimitive?.content
+            if (url.isNullOrEmpty()) {
+                logE("StorageRepository", "Upload response missing url field; raw=$json")
+                Resource.Error("Upload response missing URL")
+            } else {
+                Resource.Success(url)
+            }
+        } catch (e: CancellationException) {
+            // Don't swallow structured-concurrency cancellation.
+            throw e
+        } catch (e: Exception) {
+            logE("StorageRepository", "Image upload failed", e)
+            Resource.Error(e.message ?: "Failed to upload image", e)
+        }
 
     override suspend fun deleteImageByUrl(url: String) {
         try {
             val key = url.removePrefix("https://images.shytalk.shyden.co.uk/")
             api.delete("/api/storage/delete?key=$key")
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            logW("StorageRepository", "Best-effort image delete failed: ${e.message}")
+            logW("StorageRepository", "Best-effort image delete failed", e)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replaces `IosStorageRepositoryImpl.uploadImage` stub (was returning `Resource.Error("Image upload not yet implemented on iOS")`) with a working Ktor multipart upload that mirrors the Android OkHttp implementation.
- Adds reusable `postMultipart(path, fileBytes, fileName, fileContentType, formFields)` helper to `IosApiClient` using `MultiPartFormDataContent + formData {}`. Same auth + 401-retry semantics as the existing JSON endpoints.

## Silent-failure hardening (review-driven)
- `logE` with throwable on upload failure (was `logW` with just `e.message` — Sentry would have downgraded the alert and lost stack trace).
- `logE` before returning `Resource.Error` when the response is missing the `url` field, including the raw JSON for triage. Schema drift would otherwise be invisible.
- Re-throw `CancellationException` so structured-concurrency cancellation propagates instead of being converted to `Resource.Error`. Same fix applied to `deleteImageByUrl` (which previously also swallowed cancellation).

## Test plan
- [x] `./gradlew :app:compileDevDebugKotlin :shared:compileKotlinIosArm64 testDevDebugUnitTest :shared:jvmTest detekt` — green
- [x] ktlint clean
- [x] silent-failure-hunter agent (run twice) — all 3 high-confidence findings fixed in this PR
- [x] SonarCloud quality gate — passed in pre-push
- [ ] CI: Android, iOS, Express, Sonar
- [ ] Manual QA: upload profile picture / message image on iOS Simulator, verify R2 URL returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)