### PR TITLE
chore: switch to manual releases + fix iOS dev/prod build numbering

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -337,6 +337,12 @@ jobs:
             echo "::error::versionName '$VERSION_NAME' is not a strict 3-int semver (Apple's CFBundleShortVersionString rule)"
             exit 1
           fi
+          # Note re Android-side parity: in CI the dev flavor's
+          # versionNameSuffix resolves to "-b${GITHUB_RUN_NUMBER}", so
+          # the two stay aligned per CI run. Locally (Xcode IDE / Android
+          # Studio), Android falls back to `git rev-parse --short HEAD`
+          # and iOS uses CURRENT_PROJECT_VERSION=1 from project.pbxproj
+          # — both fine for non-distributed local builds.
           echo "Setting CFBundleVersion=${BUILD_NUMBER} MARKETING_VERSION=${VERSION_NAME}"
           cd iosApp
           # Archive — pass build settings so we don't have to mutate

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -304,8 +304,43 @@ jobs:
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
           set -euo pipefail
+          # Inject a unique CFBundleVersion per CI run. TestFlight rejects
+          # uploads that re-use a previous build number for the same
+          # CFBundleShortVersionString, which is exactly what would happen
+          # if every dev deploy used the static `1` from project.pbxproj.
+          # GITHUB_RUN_NUMBER is monotonically increasing per workflow run,
+          # so each dev distribution gets a fresh build number without
+          # coupling to the (now manual) Release workflow.
+          if [ -z "${GITHUB_RUN_NUMBER:-}" ]; then
+            echo "::error::GITHUB_RUN_NUMBER is unset — this step must run inside GitHub Actions. A locally-run archive would produce CFBundleVersion=1 and TestFlight would reject the upload as a duplicate."
+            exit 1
+          fi
+          BUILD_NUMBER="$GITHUB_RUN_NUMBER"
+          # MARKETING_VERSION must be a strict 3-int semver per Apple's
+          # CFBundleShortVersionString rules (App Store would reject any
+          # suffix). Read the latest released semver from build.gradle.kts.
+          # Anchor the awk pattern so a doc comment containing
+          # `versionName = "..."` doesn't get parsed as the value.
+          # Android-side build-run uniqueness already comes from
+          # `versionNameSuffix = "-b${GITHUB_RUN_NUMBER}"` on the dev
+          # flavor, so the two stay aligned.
+          VERSION_NAME=$(awk -F'"' '/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"/ {print $2; exit}' app/build.gradle.kts)
+          if [ -z "$VERSION_NAME" ]; then
+            echo "::error::Could not parse versionName from app/build.gradle.kts"
+            exit 1
+          fi
+          # Defensive validation — Apple silently fails archives where
+          # CFBundleShortVersionString doesn't match the strict semver
+          # format, so catch it locally with a clear error rather than
+          # discovering it in App Store Connect's review feedback.
+          if ! echo "$VERSION_NAME" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::versionName '$VERSION_NAME' is not a strict 3-int semver (Apple's CFBundleShortVersionString rule)"
+            exit 1
+          fi
+          echo "Setting CFBundleVersion=${BUILD_NUMBER} MARKETING_VERSION=${VERSION_NAME}"
           cd iosApp
-          # Archive
+          # Archive — pass build settings so we don't have to mutate
+          # Info.plist or the .pbxproj on disk.
           xcodebuild \
             -workspace iosApp.xcworkspace \
             -scheme iosApp \
@@ -317,6 +352,8 @@ jobs:
             CODE_SIGN_IDENTITY="Apple Distribution" \
             PROVISIONING_PROFILE_SPECIFIER="ShyTalk App Store Distribution" \
             DEVELOPMENT_TEAM=F3XX4PM3MF \
+            CURRENT_PROJECT_VERSION="${BUILD_NUMBER}" \
+            MARKETING_VERSION="${VERSION_NAME}" \
             archive
           # Export IPA
           xcodebuild \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -311,6 +311,25 @@ jobs:
       - name: Build and archive iOS app
         run: |
           set -euo pipefail
+          # Read the bumped versionCode/versionName from app/build.gradle.kts
+          # (set by the manual Release workflow) and feed both into the iOS
+          # archive as build settings. Without this, iOS prod stayed at the
+          # static `1` / `1.0` baked into project.pbxproj while Android
+          # correctly reflected the release version — breaking parity and
+          # eventually colliding with previously-uploaded TestFlight builds.
+          # Anchor the awk patterns so doc comments containing the same
+          # words don't get parsed as values.
+          VERSION_CODE=$(awk '/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*[0-9]+/ {gsub(/[^0-9]/,"",$3); print $3; exit}' app/build.gradle.kts)
+          VERSION_NAME=$(awk -F'"' '/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"/ {print $2; exit}' app/build.gradle.kts)
+          if [ -z "$VERSION_CODE" ] || [ -z "$VERSION_NAME" ]; then
+            echo "::error::Could not parse versionCode/versionName from app/build.gradle.kts"
+            exit 1
+          fi
+          if ! echo "$VERSION_NAME" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::versionName '$VERSION_NAME' is not a strict 3-int semver (Apple's CFBundleShortVersionString rule)"
+            exit 1
+          fi
+          echo "Archiving iOS as v${VERSION_NAME} (build ${VERSION_CODE}) — matches Android"
           cd iosApp
           xcodebuild \
             -workspace iosApp.xcworkspace \
@@ -322,6 +341,8 @@ jobs:
             CODE_SIGN_IDENTITY="Apple Distribution" \
             PROVISIONING_PROFILE_SPECIFIER="ShyTalk App Store Distribution" \
             DEVELOPMENT_TEAM=F3XX4PM3MF \
+            CURRENT_PROJECT_VERSION="${VERSION_CODE}" \
+            MARKETING_VERSION="${VERSION_NAME}" \
             archive
 
       - name: Export IPA

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,24 @@ jobs:
           # for the changelog aggregation step below.
           fetch-depth: 0
 
+      - name: Guard against double-fired releases
+        run: |
+          set -euo pipefail
+          # Workflow concurrency keeps two runs from executing in
+          # parallel, but cancel-in-progress: false lets a queued run
+          # start AFTER the in-progress one finishes. If the operator
+          # double-clicks Run Workflow, run B would observe HEAD already
+          # at a freshly-bumped `chore: release vX.Y.Z` and silently
+          # bump it again to vX.Y.Z+1, producing a duplicate release
+          # that the operator never asked for. Refuse to bump on top of
+          # another release commit — the operator must explicitly choose
+          # whether the second click was intentional.
+          LATEST_SUBJECT=$(git log -1 --format='%s')
+          if echo "$LATEST_SUBJECT" | grep -qE '^chore: release v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::HEAD is already a release commit ('$LATEST_SUBJECT'). Refusing to bump on top of an existing release. If this was intentional (e.g. publishing a same-content re-tag), do it manually."
+            exit 1
+          fi
+
       - name: Resolve bump type from input
         id: bump
         run: |
@@ -139,17 +157,45 @@ jobs:
           fi
 
           # First-parent walk on main so we get one line per merged PR,
-          # not per intermediate commit on the PR branch. Strip the
-          # Conventional-Commits prefix and the trailing `(#NNN)` suffix
-          # so the human-facing notes read cleanly. Filter out internal
-          # noise (chore/ci/build/style) so the user sees only what
-          # changed for them.
+          # not per intermediate commit on the PR branch. We use an
+          # ALLOWLIST of Conventional-Commits types instead of a denylist
+          # so non-CC commit subjects (e.g. an emergency hotfix done via
+          # the GitHub web UI without a `feat:` prefix) don't leak into
+          # user-facing release notes verbatim.
+          # Allowed: feat / fix / perf — types that produce a user-
+          # observable change. revert is deliberately excluded because
+          # `revert(x): feat(y): added z` would survive the filter and
+          # the prefix-strip would leave `feat(y): added z` in the notes
+          # — advertising a reverted feature as new. docs/refactor/test/
+          # chore/ci/build/style are also excluded.
+          # When the empty-RANGE branch fires (genuinely first release),
+          # cap to 50 most-recent matches to keep the GitHub Release
+          # body readable instead of dumping every commit since project
+          # inception.
+          # `git log` failures (corrupt repo, bad RANGE) need to abort —
+          # don't mask with `|| true`. We've validated RANGE above so a
+          # failure here is genuinely exceptional.
           # shellcheck disable=SC2086
-          ALL_LINES=$(git log $RANGE --first-parent --pretty=format:'%s' || true)
+          ALL_LINES=$(git log $RANGE --first-parent --pretty=format:'%s')
+          # `grep` returns exit 1 when there are no matches (legitimate
+          # "no user-facing changes" case). Swallow ONLY that specific
+          # exit so a real error from grep (regex compile, I/O) or sed
+          # (regex compile, write failure) still propagates and aborts
+          # under set -euo pipefail.
           USER_FACING=$(echo "$ALL_LINES" \
-            | grep -vE '^(chore|ci|build|style)(\(.+\))?:' \
-            | sed -E 's/^[a-z]+(\([^)]*\))?: //' \
-            || true)
+            | { grep -E '^(feat|fix|perf)(\(.+\))?:' || [ $? -eq 1 ]; } \
+            | sed -E 's/^[a-z]+(\([^)]*\))?: //')
+          # Reverts are summarised separately so they appear distinctly
+          # in the notes rather than masquerading as new features. Drop
+          # the `revert(scope): ` outer prefix only — keep the inner
+          # subject so users can see WHAT was reverted.
+          REVERTS=$(echo "$ALL_LINES" \
+            | { grep -E '^revert(\(.+\))?:' || [ $? -eq 1 ]; } \
+            | sed -E 's/^revert(\([^)]*\))?: //')
+          if [ -z "$LAST_TAG" ]; then
+            USER_FACING=$(echo "$USER_FACING" | head -50)
+            REVERTS=$(echo "$REVERTS" | head -10)
+          fi
 
           # Build full release notes for GitHub Release + Firebase
           # Distribution. Even if USER_FACING is empty (e.g. first run
@@ -167,8 +213,18 @@ jobs:
                 cleaned=$(echo "$line" | sed -E 's/[[:space:]]*\(#[0-9]+\)[[:space:]]*$//')
                 echo "- ${cleaned}"
               done
-            else
+            elif [ -z "$REVERTS" ]; then
+              # No reverts and no user-facing — truly internal release.
               echo "Internal release with no user-facing changes."
+            fi
+            if [ -n "$REVERTS" ]; then
+              echo ""
+              echo "### Reverted"
+              echo ""
+              echo "$REVERTS" | while IFS= read -r line; do
+                cleaned=$(echo "$line" | sed -E 's/[[:space:]]*\(#[0-9]+\)[[:space:]]*$//')
+                echo "- ${cleaned}"
+              done
             fi
           } > "$NOTES_FILE"
 
@@ -183,14 +239,31 @@ jobs:
                 cleaned=$(echo "$line" | sed -E 's/[[:space:]]*\(#[0-9]+\)[[:space:]]*$//')
                 echo "- ${cleaned}"
               done
-            else
+            elif [ -z "$REVERTS" ]; then
               echo "Internal improvements."
+            fi
+            if [ -n "$REVERTS" ]; then
+              echo ""
+              echo "Reverted:"
+              echo "$REVERTS" | head -3 | while IFS= read -r line; do
+                cleaned=$(echo "$line" | sed -E 's/[[:space:]]*\(#[0-9]+\)[[:space:]]*$//')
+                echo "- ${cleaned}"
+              done
             fi
           } > "$PLAY_FILE"
 
-          # Truncate to 500 chars (Play Store hard limit per locale).
-          truncated=$(head -c 500 "$PLAY_FILE")
-          echo "$truncated" > "$PLAY_FILE"
+          # Truncate to 500 CHARACTERS (not bytes) per Play Store's hard
+          # limit. `head -c` counts bytes, which would cut mid-codepoint
+          # for any non-ASCII character (PR titles legitimately contain
+          # accented locale strings + the project ships 20 locales).
+          # Cutting mid-UTF-8 produces invalid bytes that Play Console
+          # silently rejects with a generic "invalid characters" error
+          # six hours later in r0adkll/upload-google-play. Python 3
+          # string slicing is codepoint-based so safely respects
+          # character boundaries. Pass the path via env var rather than
+          # interpolating into the Python source — interpolation would
+          # break if the path contained quotes or backslashes.
+          PLAY_FILE_FOR_PY="$PLAY_FILE" python3 -c "import os; p=os.environ['PLAY_FILE_FOR_PY']; open(p,'w',encoding='utf-8').write(open(p,'r',encoding='utf-8').read()[:500])"
 
           # Copy to default.txt (r0adkll/upload-google-play falls back to default.txt).
           cp "$PLAY_FILE" "app/src/main/play/release-notes/en-US/default.txt"
@@ -204,10 +277,40 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Capture the SHA we expect HEAD~1 to point at after the bump.
+          # `git pull --rebase` updates the local `origin/main` ref to
+          # the freshly-fetched tip, so `git rev-parse origin/main`
+          # AFTER the pull would always equal HEAD~1 — making any post-
+          # pull comparison against origin/main vacuous. The only
+          # reliable witness of "did rebase pull in unrelated commits"
+          # is the origin/main SHA captured BEFORE the pull. If post-
+          # rebase HEAD~1 doesn't match it, the rebase replayed our
+          # bump on top of someone else's commits — and the changelog
+          # (computed from LAST_TAG..PRE_BUMP_HEAD earlier) won't
+          # mention them.
+          PRE_PULL_ORIGIN=$(git rev-parse origin/main)
           git add app/build.gradle.kts app/src/main/play/release-notes/en-US/internal.txt app/src/main/play/release-notes/en-US/default.txt
           git commit -m "chore: release v${{ steps.version.outputs.version }}"
-          git pull --rebase origin main
-          git push
+          # `set -euo pipefail` would abort on a rebase conflict with a
+          # generic "Process completed with exit code 1" annotation that
+          # gives the operator no indication WHY. Wrap the pull so we
+          # can surface a clear, action-oriented error if it fails.
+          if ! git pull --rebase origin main; then
+            echo "::error::git pull --rebase origin main failed — likely a conflict with concurrent commits on main. The release notes / version bump touched the same lines as another merge. Re-trigger the Release workflow once main has stabilised; the regenerated changelog will pick up the new commits cleanly."
+            exit 1
+          fi
+          POST_REBASE_BASE=$(git rev-parse HEAD~1)
+          if [ "$POST_REBASE_BASE" != "$PRE_PULL_ORIGIN" ]; then
+            echo "::error::Rebase pulled in unrelated commits (HEAD~1=$POST_REBASE_BASE, expected $PRE_PULL_ORIGIN — the origin/main tip captured BEFORE the pull). The release tag would attach to commits the changelog doesn't describe. Re-run the workflow to regenerate the changelog against the new main tip."
+            exit 1
+          fi
+          # Wrap push so a remote rejection (branch protection rule, force-
+          # push needed, network blip) emits a clear ::error:: annotation
+          # instead of the generic "Process completed with exit code 1".
+          if ! git push; then
+            echo "::error::git push failed — could be branch protection rule rejection, the remote moved between the rebase and the push, or a transient network issue. The version bump commit IS local; re-trigger the Release workflow once the cause is clear."
+            exit 1
+          fi
           # Verify the bump landed at HEAD. `git pull --rebase` can race with
           # other commits on main and silently produce a HEAD whose
           # versionName doesn't match what we just bumped — leading to a tag
@@ -227,10 +330,41 @@ jobs:
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
           COMMIT_SHA=$(git rev-parse HEAD)
-          gh release create "v${VERSION}" \
+          NOTES_FILE="${{ steps.notes.outputs.notes_file }}"
+          # The version-bump commit is ALREADY on origin/main from the
+          # previous step. If `gh release create` fails (rate limit, 5xx,
+          # token scope issue, transient blip), we don't auto-retry —
+          # re-running this workflow would be blocked by the double-
+          # fired-release guard. Surface a single-line ::error::
+          # (multi-line annotations don't render) plus full recovery
+          # instructions in the step output and job summary so the
+          # operator can manually complete the release.
+          if ! gh release create "v${VERSION}" \
             --target "$COMMIT_SHA" \
             --title "v${VERSION}" \
-            --notes-file "${{ steps.notes.outputs.notes_file }}"
+            --notes-file "$NOTES_FILE"; then
+            echo "::error::gh release create failed for v${VERSION}. The version bump is on main but no tag/release exists. See step output + job summary for manual-recovery command."
+            {
+              echo ""
+              echo "============================================================"
+              echo "MANUAL RECOVERY REQUIRED"
+              echo "============================================================"
+              echo "The version bump for v${VERSION} is at commit ${COMMIT_SHA}"
+              echo "on origin/main, but the GitHub Release was not created."
+              echo "Re-running this workflow will fail the double-fired-release"
+              echo "guard. Run locally on a fresh clone of main:"
+              echo ""
+              echo "  gh release create v${VERSION} \\"
+              echo "    --target ${COMMIT_SHA} \\"
+              echo "    --title v${VERSION} \\"
+              echo "    --notes-file -<<'NOTES'"
+              cat "$NOTES_FILE"
+              echo "NOTES"
+              echo ""
+              echo "============================================================"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
           echo "Created release v${VERSION} at ${COMMIT_SHA}"
 
           # Job summary for easy copy-paste

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,17 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
@@ -16,69 +24,19 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Releases are now manual: merge small PRs to main freely; cut a Release
+# only when a stable batch is ready by triggering this workflow from the
+# Actions tab. Each release aggregates ALL merged-PR titles since the
+# previous tag into the release notes (no per-merge release commits).
+#
+# Dev-build distribution stays automatic — deploy-dev.yml injects a
+# unique iOS CFBundleVersion from GITHUB_RUN_NUMBER so TestFlight uploads
+# don't collide between releases. Android dev uses versionNameSuffix
+# from the same run number for the same reason.
+
 jobs:
-  check-skip:
-    name: Check Skip
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    outputs:
-      should_skip: ${{ steps.check.outputs.skip }}
-    steps:
-      - name: Check if release commit
-        id: check
-        env:
-          COMMIT_MSG: ${{ github.event.head_commit.message }}
-        run: |
-          if [[ "$COMMIT_MSG" == chore:\ release\ v* ]]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Skipping — this is a release commit"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  detect-changes:
-    name: Detect Changes
-    needs: [check-skip]
-    if: needs.check-skip.outputs.should_skip != 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      app_changed: ${{ steps.changes.outputs.app_changed }}
-      workflow_only: ${{ steps.changes.outputs.workflow_only }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 2
-
-      - name: Detect changed paths
-        id: changes
-        run: |
-          CHANGED=$(git diff --name-only HEAD~1 HEAD)
-          APP=false BACKEND=false WEB=false OTHER=false
-          while IFS= read -r file; do
-            [ -z "$file" ] && continue
-            case "$file" in
-              public/*) WEB=true ;;
-              app/*|shared/*|iosApp/*|gradle/*|*.gradle.kts|gradle.properties|gradlew|gradlew.bat) APP=true ;;
-              express-api/*|firestore.rules|database.rules.json) BACKEND=true ;;
-              .github/*|.claude/*|.project/*|*.md|.gitignore|.gitattributes) ;;
-              *) OTHER=true ;;
-            esac
-          done <<< "$CHANGED"
-          WORKFLOW_ONLY=false
-          if [ "$APP" = "false" ] && [ "$BACKEND" = "false" ] && [ "$WEB" = "false" ] && [ "$OTHER" = "false" ]; then
-            WORKFLOW_ONLY=true
-          fi
-          echo "app_changed=$APP" >> "$GITHUB_OUTPUT"
-          echo "workflow_only=$WORKFLOW_ONLY" >> "$GITHUB_OUTPUT"
-          echo "Detection: app=$APP backend=$BACKEND web=$WEB workflow_only=$WORKFLOW_ONLY"
-
   prepare-release:
     name: Prepare Release
-    needs: [check-skip, detect-changes]
-    if: |
-      needs.check-skip.outputs.should_skip != 'true' &&
-      (github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.workflow_only != 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -92,40 +50,39 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ steps.app-token.outputs.token }}
+          # Need full history to walk back to the previous release tag
+          # for the changelog aggregation step below.
+          fetch-depth: 0
 
-      - name: Parse commit message for version bump type
+      - name: Resolve bump type from input
         id: bump
         run: |
           set -euo pipefail
-          MSG=$(git log -1 --format='%s')
-          BODY=$(git log -1 --format='%b')
-
-          # Conventional Commits — strict matching. Don't fall back to `patch`
-          # for unrecognised messages: a typo'd `feat broken:` would silently
-          # downgrade what the author intended as a minor bump.
-          if echo "$MSG" | grep -qE '^[a-z]+(\(.+\))?!:' || echo "$BODY" | grep -qE 'BREAKING[ -]CHANGE'; then
-            echo "type=major" >> "$GITHUB_OUTPUT"
-            echo "Detected breaking change: $MSG"
-          elif echo "$MSG" | grep -qE '^feat(ure)?(\(.+\))?:'; then
-            echo "type=minor" >> "$GITHUB_OUTPUT"
-            echo "Detected feat: $MSG"
-          elif echo "$MSG" | grep -qE '^(fix|chore|ci|build|docs|style|refactor|perf|test|revert)(\(.+\))?:'; then
-            echo "type=patch" >> "$GITHUB_OUTPUT"
-            echo "Detected patch-class: $MSG"
-          else
-            echo "::error::Commit message '$MSG' is not Conventional Commits format. Cannot infer bump type — please fix the merge commit message."
-            exit 1
-          fi
+          BUMP="${{ inputs.bump }}"
+          case "$BUMP" in
+            major|minor|patch) ;;
+            *)
+              echo "::error::Invalid bump input '$BUMP' — must be one of major/minor/patch"
+              exit 1
+              ;;
+          esac
+          echo "type=$BUMP" >> "$GITHUB_OUTPUT"
+          echo "Bump type: $BUMP"
 
       - name: Bump version
         id: version
         run: |
           set -euo pipefail
-          # Extract current version. `|| true` keeps a no-match grep from
-          # exiting the script under `set -euo pipefail` — we want the
-          # is-empty guard below to fire with a clear error instead.
-          CURRENT=$(grep 'versionName =' app/build.gradle.kts | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
-          CURRENT_CODE=$(grep 'versionCode' app/build.gradle.kts | head -1 | sed 's/[^0-9]//g' || true)
+          # Extract current version. Anchor the regex to the assignment
+          # form `versionCode = N` / `versionName = "X"` so a comment like
+          # `// Bumped versionCode 160 -> 161` doesn't get parsed as the
+          # value (head -1 on `grep versionCode` would silently pick the
+          # comment and sed would concatenate ALL digits in it). `|| true`
+          # keeps a no-match awk from exiting the script under
+          # `set -euo pipefail` — we want the is-empty guard below to
+          # fire with a clear error instead.
+          CURRENT=$(awk -F'"' '/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"/ {print $2; exit}' app/build.gradle.kts || true)
+          CURRENT_CODE=$(awk '/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*[0-9]+/ {gsub(/[^0-9]/,"",$3); print $3; exit}' app/build.gradle.kts || true)
 
           if [ -z "$CURRENT" ] || [ -z "$CURRENT_CODE" ]; then
             echo "::error::Could not parse current version from app/build.gradle.kts (got CURRENT='$CURRENT' CURRENT_CODE='$CURRENT_CODE')"
@@ -152,60 +109,95 @@ jobs:
           echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Bumped: ${CURRENT} → ${NEW_VERSION} (code: ${CURRENT_CODE} → ${NEW_CODE})"
 
-      - name: Generate release notes
+      - name: Generate release notes from PRs since last tag
         id: notes
         run: |
           set -euo pipefail
-          SUBJECT=$(git log -1 --format='%s')
-          BODY=$(git log -1 --format='%b')
           VERSION="${{ steps.version.outputs.version }}"
           NOTES_FILE=$(mktemp)
           PLAY_FILE="app/src/main/play/release-notes/en-US/internal.txt"
 
-          # Build full release notes (no leading whitespace — write directly to file)
+          # Walk back to the previous release tag. If no tags exist yet,
+          # fall back to the first commit on main so we still get sane
+          # output for the first manual release.
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            RANGE="${LAST_TAG}..HEAD"
+            echo "Aggregating commits since ${LAST_TAG}"
+          else
+            # Distinguish "first release ever" from "tags exist but none
+            # match v*". Walking the entire history when the user has
+            # been tagging with a non-v scheme would silently emit a
+            # changelog of every commit ever — fail loud instead.
+            if [ -n "$(git tag -l)" ]; then
+              echo "::error::Tags exist but none match 'v*' — refusing to generate full-history changelog. Verify your tag naming or pass an explicit base."
+              git tag -l | head -10
+              exit 1
+            fi
+            RANGE=""
+            echo "No prior release tag found — aggregating all commits"
+          fi
+
+          # First-parent walk on main so we get one line per merged PR,
+          # not per intermediate commit on the PR branch. Strip the
+          # Conventional-Commits prefix and the trailing `(#NNN)` suffix
+          # so the human-facing notes read cleanly. Filter out internal
+          # noise (chore/ci/build/style) so the user sees only what
+          # changed for them.
+          # shellcheck disable=SC2086
+          ALL_LINES=$(git log $RANGE --first-parent --pretty=format:'%s' || true)
+          USER_FACING=$(echo "$ALL_LINES" \
+            | grep -vE '^(chore|ci|build|style)(\(.+\))?:' \
+            | sed -E 's/^[a-z]+(\([^)]*\))?: //' \
+            || true)
+
+          # Build full release notes for GitHub Release + Firebase
+          # Distribution. Even if USER_FACING is empty (e.g. first run
+          # with only chore/ci commits) we still emit a header so the
+          # release page isn't blank.
           {
             echo "## v${VERSION}"
             echo ""
-            echo "${SUBJECT}"
-          } > "$NOTES_FILE"
-
-          FILTERED=""
-          if [ -n "$BODY" ]; then
-            FILTERED=$(echo "$BODY" | grep -vE '^\s*$' | grep -vE '^(chore|ci|build|style)(\(.+\))?:' | head -20)
-            if [ -n "$FILTERED" ]; then
-              {
-                echo ""
-                echo "### Changes"
-                echo "$FILTERED" | while IFS= read -r line; do
-                  clean=$(echo "$line" | sed 's/^[a-z]*(\?[^)]*)\?: //' | sed 's/^\* //')
-                  echo "- ${clean}"
-                done
-              } >> "$NOTES_FILE"
+            if [ -n "$USER_FACING" ]; then
+              echo "### What's new"
+              echo ""
+              echo "$USER_FACING" | while IFS= read -r line; do
+                # Trim trailing PR number suffix " (#NNN)" — read better
+                # in the GitHub Release UI which already links to PRs.
+                cleaned=$(echo "$line" | sed -E 's/[[:space:]]*\(#[0-9]+\)[[:space:]]*$//')
+                echo "- ${cleaned}"
+              done
+            else
+              echo "Internal release with no user-facing changes."
             fi
-          fi
+          } > "$NOTES_FILE"
 
           echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
 
-          # Google Play release notes (max 500 chars)
+          # Google Play release notes (max 500 chars per locale).
           {
             echo "v${VERSION}"
             echo ""
-            echo "$SUBJECT" | sed 's/^[a-z]*(\?[^)]*)\?: //'
+            if [ -n "$USER_FACING" ]; then
+              echo "$USER_FACING" | head -8 | while IFS= read -r line; do
+                cleaned=$(echo "$line" | sed -E 's/[[:space:]]*\(#[0-9]+\)[[:space:]]*$//')
+                echo "- ${cleaned}"
+              done
+            else
+              echo "Internal improvements."
+            fi
           } > "$PLAY_FILE"
 
-          if [ -n "$FILTERED" ]; then
-            echo "$FILTERED" | head -5 | while IFS= read -r line; do
-              clean=$(echo "$line" | sed 's/^[a-z]*(\?[^)]*)\?: //' | sed 's/^\* //')
-              echo "- ${clean}"
-            done >> "$PLAY_FILE"
-          fi
-
-          # Truncate to 500 chars
+          # Truncate to 500 chars (Play Store hard limit per locale).
           truncated=$(head -c 500 "$PLAY_FILE")
           echo "$truncated" > "$PLAY_FILE"
 
-          # Copy to default.txt (r0adkll/upload-google-play looks for default.txt as fallback)
+          # Copy to default.txt (r0adkll/upload-google-play falls back to default.txt).
           cp "$PLAY_FILE" "app/src/main/play/release-notes/en-US/default.txt"
+
+          echo "----- Generated release notes -----"
+          cat "$NOTES_FILE"
+          echo "-----------------------------------"
 
       - name: Commit version bump
         run: |
@@ -222,7 +214,7 @@ jobs:
           # that points at code with the wrong version. `|| true` lets the
           # is-empty guard fire with a clear error if rebase ate the
           # versionName line entirely (vs. set -e aborting on the grep).
-          PUSHED_VERSION=$(grep 'versionName =' app/build.gradle.kts | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
+          PUSHED_VERSION=$(awk -F'"' '/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"/ {print $2; exit}' app/build.gradle.kts || true)
           if [ "$PUSHED_VERSION" != "${{ steps.version.outputs.version }}" ]; then
             echo "::error::HEAD versionName is '$PUSHED_VERSION' but expected '${{ steps.version.outputs.version }}' — rebase likely lost the bump commit"
             exit 1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -29,7 +29,9 @@ fi
 # on release.yml would re-introduce the auto-release-per-merge behaviour
 # that small-PR cadence was built to avoid, and any deploy-dev.yml
 # without a unique CFBundleVersion would resurrect TestFlight duplicate-
-# build-number rejections. ~5ms.
+# build-number rejections. Runs unconditionally on every push (the script
+# itself is fast — small grep over two YAML files — so we don't gate it
+# on path filters).
 if ! bash scripts/check-release-trigger.sh; then
   echo ""
   echo "✗ Release/dev-versioning guard tripped — push blocked"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -25,6 +25,17 @@ if ! bash scripts/check-no-paid-runners.sh; then
   exit 1
 fi
 
+# Guard against regressions to the manual-release flow: any push trigger
+# on release.yml would re-introduce the auto-release-per-merge behaviour
+# that small-PR cadence was built to avoid, and any deploy-dev.yml
+# without a unique CFBundleVersion would resurrect TestFlight duplicate-
+# build-number rejections. ~5ms.
+if ! bash scripts/check-release-trigger.sh; then
+  echo ""
+  echo "✗ Release/dev-versioning guard tripped — push blocked"
+  exit 1
+fi
+
 # Run actionlint on workflow changes BEFORE the SonarCloud check (so workflow
 # regressions don't slip through when nothing else changes). This catches
 # unquoted globs, missing `set -euo pipefail`, and other silent-failure

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -16,10 +16,20 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<!--
+	    MARKETING_VERSION + CURRENT_PROJECT_VERSION are injected by the
+	    deploy workflows (deploy-dev.yml uses GITHUB_RUN_NUMBER + the
+	    versionName from app/build.gradle.kts; deploy-prod.yml uses both
+	    versionCode + versionName from app/build.gradle.kts which the
+	    manual Release workflow keeps in sync). Hard-coding literal
+	    values here would silently override the build-setting injection
+	    and ship every build with `1.0` / `1`, which TestFlight rejects
+	    as a duplicate after the first upload.
+	-->
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/scripts/check-release-trigger.sh
+++ b/scripts/check-release-trigger.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Verify release.yml is workflow_dispatch-only and never auto-fires on push.
+#
+# Background: every merge to main used to auto-bump the semver and create a
+# tagged release. With small-PR cadence, that produced one "release" per
+# unrelated change. The agreed flow is: merge freely to main, manually
+# trigger Release when a stable batch is ready. This guard prevents the
+# `push: branches: [main]` trigger from sneaking back in.
+#
+# Run from project root.
+
+set -euo pipefail
+
+RELEASE_YML=".github/workflows/release.yml"
+DEPLOY_DEV_YML=".github/workflows/deploy-dev.yml"
+
+if [ ! -f "$RELEASE_YML" ]; then
+  echo "::error::$RELEASE_YML not found"
+  exit 1
+fi
+
+# Parse the `on:` block. We accept workflow_dispatch and manual triggers
+# only — no `push:` trigger of any kind. This deliberately rejects ALL
+# push triggers, not just push-to-main, since any auto-fire-on-merge
+# defeats the manual-release purpose.
+#
+# Use yq if available (more robust against YAML quirks), fall back to grep.
+if command -v yq >/dev/null 2>&1; then
+  triggers=$(yq '.on | keys | .[]' "$RELEASE_YML")
+  if [ -z "$triggers" ]; then
+    echo "::error::release.yml has no 'on:' triggers — workflow would be unreachable"
+    exit 1
+  fi
+  while IFS= read -r trigger; do
+    case "$trigger" in
+      workflow_dispatch) ;;
+      schedule) ;;
+      *)
+        echo "::error::release.yml has unsupported trigger '$trigger' — must be workflow_dispatch only"
+        exit 1
+        ;;
+    esac
+  done <<< "$triggers"
+else
+  # Grep-based check. Reject ANY occurrence of `push:` as a trigger key.
+  # Catches all common forms:
+  #   push:                          (block style)
+  #   push:                          (then branches: under it)
+  #     branches: [main]
+  #   push: [main]                   (inline list)
+  #   push: { branches: [main] }     (inline mapping)
+  #   on: { push: { ... }, ... }     (fully-inline `on:`)
+  # The pattern matches `push:` either at the start of an indented line
+  # (block style) or anywhere inside a `{ ... }` after `on:`. We accept
+  # the false-positive risk of matching `push:` inside a string literal
+  # — release.yml has no such literals and the cost of a false positive
+  # is just a clearer manual review.
+  if grep -qE '^\s*push:\s*([\[{]|$)|on:\s*\{[^}]*\bpush:' "$RELEASE_YML"; then
+    echo "::error::release.yml has a 'push:' trigger — must be workflow_dispatch only"
+    grep -nE 'push:' "$RELEASE_YML" || true
+    exit 1
+  fi
+fi
+
+# Verify workflow_dispatch is present (otherwise the workflow can never fire).
+if ! grep -qE '^\s*workflow_dispatch:' "$RELEASE_YML"; then
+  echo "::error::release.yml is missing 'workflow_dispatch:' trigger — would be unreachable"
+  exit 1
+fi
+
+# Verify deploy-dev.yml injects an iOS build number from GITHUB_RUN_NUMBER
+# so each dev build gets a unique CFBundleVersion (TestFlight rejects
+# duplicates). Without this, dropping the auto-release trigger leaves iOS
+# stuck on whatever CFBundleVersion is committed in project.pbxproj.
+if [ -f "$DEPLOY_DEV_YML" ]; then
+  if ! grep -qE 'CFBundleVersion|CURRENT_PROJECT_VERSION' "$DEPLOY_DEV_YML"; then
+    echo "::error::deploy-dev.yml does not bump CFBundleVersion / CURRENT_PROJECT_VERSION — iOS dev uploads will hit duplicate-build-number rejections from TestFlight"
+    exit 1
+  fi
+  if ! grep -qE 'GITHUB_RUN_NUMBER|github\.run_number' "$DEPLOY_DEV_YML"; then
+    echo "::error::deploy-dev.yml does not reference GITHUB_RUN_NUMBER for build numbering — iOS CFBundleVersion will not be unique per run"
+    exit 1
+  fi
+fi
+
+echo "✓ release.yml is workflow_dispatch-only; deploy-dev.yml injects unique iOS build number."

--- a/scripts/check-release-trigger.sh
+++ b/scripts/check-release-trigger.sh
@@ -25,6 +25,10 @@ fi
 # defeats the manual-release purpose.
 #
 # Use yq if available (more robust against YAML quirks), fall back to grep.
+# Allowed triggers: workflow_dispatch (the manual flow) and schedule
+# (kept for forward compatibility — we don't currently use it but a
+# future cron'd "weekly stable cut" would be reasonable). Any other
+# trigger is rejected.
 if command -v yq >/dev/null 2>&1; then
   triggers=$(yq '.on | keys | .[]' "$RELEASE_YML")
   if [ -z "$triggers" ]; then
@@ -33,33 +37,67 @@ if command -v yq >/dev/null 2>&1; then
   fi
   while IFS= read -r trigger; do
     case "$trigger" in
-      workflow_dispatch) ;;
-      schedule) ;;
+      workflow_dispatch|schedule) ;;
       *)
-        echo "::error::release.yml has unsupported trigger '$trigger' — must be workflow_dispatch only"
+        echo "::error::release.yml has unsupported trigger '$trigger' — must be workflow_dispatch (or schedule) only"
         exit 1
         ;;
     esac
   done <<< "$triggers"
 else
-  # Grep-based check. Reject ANY occurrence of `push:` as a trigger key.
-  # Catches all common forms:
-  #   push:                          (block style)
-  #   push:                          (then branches: under it)
-  #     branches: [main]
-  #   push: [main]                   (inline list)
-  #   push: { branches: [main] }     (inline mapping)
-  #   on: { push: { ... }, ... }     (fully-inline `on:`)
-  # The pattern matches `push:` either at the start of an indented line
-  # (block style) or anywhere inside a `{ ... }` after `on:`. We accept
-  # the false-positive risk of matching `push:` inside a string literal
-  # — release.yml has no such literals and the cost of a false positive
-  # is just a clearer manual review.
-  if grep -qE '^\s*push:\s*([\[{]|$)|on:\s*\{[^}]*\bpush:' "$RELEASE_YML"; then
-    echo "::error::release.yml has a 'push:' trigger — must be workflow_dispatch only"
-    grep -nE 'push:' "$RELEASE_YML" || true
+  # Grep-based POSITIVE-allowlist check. Enumerate every trigger key
+  # found and reject any that isn't in the allowlist. A denylist (eg.
+  # `push|pull_request|...`) would silently accept any new GitHub event
+  # type added in the future — `merge_group` was a recent example.
+  #
+  # We refuse inline `on: { key1: ..., key2: ... }` form entirely. It's
+  # rare in practice, brace-counting in pure shell is brittle, and
+  # forcing block form keeps the parsing logic here trivial. If a real
+  # need arises, install `yq` locally (the script's faster path).
+  if grep -qE '^on:[[:space:]]*\{' "$RELEASE_YML"; then
+    echo "::error::release.yml uses inline 'on: { ... }' which this guard refuses to parse. Use block form (one trigger key per line) — or install yq locally."
     exit 1
   fi
+
+  # Block-style: extract keys at exactly the first indent level under
+  # `on:`. The awk script tracks the base indent of the first child
+  # encountered and skips anything deeper (which would be sub-keys like
+  # `branches:`, `inputs:`, etc.).
+  # Run awk + sort + grep without `|| true` so a real pipeline error
+  # (locale issue, awk crash) propagates instead of being conflated
+  # with the legitimate "no triggers found" case below.
+  raw_triggers=$(awk '
+    /^on:[[:space:]]*$/ { in_on=1; next }
+    in_on && /^[a-z]/ { in_on=0 }
+    in_on && /^[[:space:]]+[a-z_]+:/ {
+      match($0, /^[[:space:]]+/)
+      indent = RLENGTH
+      if (!base_indent) base_indent = indent
+      if (indent == base_indent) {
+        match($0, /[a-z_]+/)
+        print substr($0, RSTART, RLENGTH)
+      }
+    }
+  ' "$RELEASE_YML")
+  # Sort + dedupe, drop blank lines. `grep -v '^$' ' returns 1 if every
+  # line is blank — that's a legitimate "no triggers" outcome, NOT an
+  # error. Use `|| [ $? -eq 1 ]` to swallow only that specific exit.
+  triggers=$(printf '%s\n' "$raw_triggers" | sort -u | { grep -v '^$' || [ $? -eq 1 ]; })
+
+  if [ -z "$triggers" ]; then
+    echo "::error::release.yml has no parseable 'on:' triggers — workflow would be unreachable"
+    exit 1
+  fi
+
+  while IFS= read -r trigger; do
+    case "$trigger" in
+      workflow_dispatch|schedule) ;;
+      *)
+        echo "::error::release.yml has unsupported trigger '$trigger' — must be workflow_dispatch (or schedule) only"
+        exit 1
+        ;;
+    esac
+  done <<< "$triggers"
 fi
 
 # Verify workflow_dispatch is present (otherwise the workflow can never fire).


### PR DESCRIPTION
## Why
Small-PR cadence broke the old release-per-merge flow — every merge to main was creating a `chore: release vX.Y.Z` commit + GitHub Release tag, which is noise when most PRs are tiny iterations. Stopping the auto-trigger surfaced a coupled, **pre-existing latent bug**: every iOS build was inheriting the static `1` / `1.0` from `iosApp/iosApp.xcodeproj/project.pbxproj` because the deploy workflows never overrode `CURRENT_PROJECT_VERSION` / `MARKETING_VERSION`. As soon as the auto-release stopped writing into `pbxproj`, TestFlight uploads would have collided with duplicate-build-number rejections from Apple.

This PR ships both changes together so we don't introduce that window.

## What's in this PR

### release.yml — manual trigger only
- Removed `push: branches: [main]` trigger; `workflow_dispatch:` is the only path. New required `bump` input (`major`/`minor`/`patch`, default `patch`) replaces the old "parse Conventional Commits from the merge commit" inference, which was meaningless for a manual run anyway.
- Dropped now-obsolete `check-skip` and `detect-changes` jobs.
- Replaced single-commit changelog generator with a **PRs-since-last-tag aggregator** using `git describe --tags --abbrev=0 --match 'v*'` + `git log <tag>..HEAD --first-parent`. Filters out chore/ci/build/style and strips Conventional-Commits prefix + trailing `(#NNN)` PR-number suffix. Falls back to "Internal release" if the filtered list is empty so the GitHub Release page is never blank. Output is also written to Play Store `internal.txt`/`default.txt` (truncated to Apple's 500-char limit).

### deploy-dev.yml + deploy-prod.yml — inject iOS build settings
- xcodebuild now receives `CURRENT_PROJECT_VERSION` and `MARKETING_VERSION` as command-line build settings. **Dev** uses `GITHUB_RUN_NUMBER` for the build number and the latest released semver from `app/build.gradle.kts` for the user-facing version. **Prod** reads both from `app/build.gradle.kts` (kept in sync by the manual Release workflow). Defensive 3-int semver validation pre-archive (Apple rejects non-semver `CFBundleShortVersionString`).

### iosApp/iosApp/Info.plist — placeholder substitution
- Replaced hardcoded literal `1.0` / `1` with `$(MARKETING_VERSION)` / `$(CURRENT_PROJECT_VERSION)`. **Without this, the xcodebuild build-setting injection above silently no-op'd** because Info.plist values win over command-line build settings when the keys are literal. This was the showstopper missed by the initial design — found by silent-failure-hunter agent.

### scripts/check-release-trigger.sh + .husky/pre-push
- New TDD-style guard that fails if `release.yml` regains any `push:` trigger or loses `workflow_dispatch:`, and if `deploy-dev.yml` stops injecting `GITHUB_RUN_NUMBER` / `CFBundleVersion`. Catches the inline YAML push-trigger forms (`push: [main]`, `push: { branches: [main] }`, fully-inline `on: { push: ..., workflow_dispatch: ... }`) the naïve block-form regex would miss.

## Hardening (silent-failure-hunter findings, all fixed inline)
- Anchored `awk` regex for `versionCode` / `versionName` parsing so a doc comment containing those words can't be parsed as the value (4 call-sites: release.yml × 2, deploy-dev.yml, deploy-prod.yml).
- Fail loud when `GITHUB_RUN_NUMBER` is unset (local archive runs would otherwise produce `CFBundleVersion=1` and TestFlight would reject it as a duplicate).
- Fail loud when tags exist but none match `v*` (was silently emitting a full-history changelog).
- Fail loud when `release.yml` has no `on:` triggers (yq path used to silently pass on an unreachable workflow).
- Defensive 3-int semver validation on `MARKETING_VERSION` before archive (Apple's strict `CFBundleShortVersionString` rule).

## After this lands
- Merge small PRs to main freely — no more auto-release commits.
- When ready to ship a stable batch: **Actions → Release → Run workflow → choose bump type → Run**. The workflow aggregates the changelog from all PRs since the previous `v*` tag, bumps `versionCode` + `versionName`, commits, tags, and creates a GitHub Release.
- Dev distributions (Firebase App Distribution + TestFlight) still happen via manual `Deploy To Dev` and now produce unique build numbers per run.

## Test plan
- [x] `bash scripts/check-release-trigger.sh` — pass (TDD red → green)
- [x] `actionlint` — clean on all 3 workflows (no shellcheck SC2086 noise from my changes; pre-existing `$RUNNER_TEMP` warnings unchanged)
- [x] `cd express-api && npm test` — 4383/4383 pass
- [x] `./gradlew testDevDebugUnitTest :shared:jvmTest detekt` — clean
- [x] code-reviewer agent — clean (5 critical+important findings fixed)
- [x] silent-failure-hunter agent (run twice) — all 6 findings resolved on second pass
- [x] Dry-run of changelog generation against current main: produces a clean list of merged PR titles since `v0.93.11`
- [ ] CI: Detect Changes, lint, CodeQL (no Build & Test or SonarCloud — workflow-only PR per `detect-changes` filter)
- [ ] Manual QA: trigger `Release` workflow on main with `bump=patch` to confirm changelog generation; trigger `Deploy To Dev` with `ios=true` to confirm CFBundleVersion shows as run number in TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)