### PR TITLE
fix(ci): deploy-dev fetch-depth ternary uses string literals

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -62,7 +62,13 @@ jobs:
           # checkout fails with `fatal: reference is not a tree`. Pull
           # full history when the operator overrides ref so any SHA is
           # reachable; keep depth 1 for default-ref runs to save time.
-          fetch-depth: ${{ inputs.ref != '' && 0 || 1 }}
+          # IMPORTANT: use string literals '0'/'1' here. GitHub Actions
+          # expression `cond && 0 || 1` evaluates to `1` even when cond
+          # is true because numeric 0 is falsy (JS-style coercion), so
+          # the `|| 1` short-circuit fires. Strings "0"/"1" are both
+          # truthy, so `cond && '0' || '1'` correctly returns '0' when
+          # cond is true. `actions/checkout` parses the input as int.
+          fetch-depth: ${{ inputs.ref != '' && '0' || '1' }}
 
       - name: Resolve deployed SHA
         id: deployed-sha
@@ -155,7 +161,13 @@ jobs:
           # checkout fails with `fatal: reference is not a tree`. Pull
           # full history when the operator overrides ref so any SHA is
           # reachable; keep depth 1 for default-ref runs to save time.
-          fetch-depth: ${{ inputs.ref != '' && 0 || 1 }}
+          # IMPORTANT: use string literals '0'/'1' here. GitHub Actions
+          # expression `cond && 0 || 1` evaluates to `1` even when cond
+          # is true because numeric 0 is falsy (JS-style coercion), so
+          # the `|| 1` short-circuit fires. Strings "0"/"1" are both
+          # truthy, so `cond && '0' || '1'` correctly returns '0' when
+          # cond is true. `actions/checkout` parses the input as int.
+          fetch-depth: ${{ inputs.ref != '' && '0' || '1' }}
 
       - uses: ./.github/actions/setup-node
 
@@ -193,7 +205,13 @@ jobs:
           # checkout fails with `fatal: reference is not a tree`. Pull
           # full history when the operator overrides ref so any SHA is
           # reachable; keep depth 1 for default-ref runs to save time.
-          fetch-depth: ${{ inputs.ref != '' && 0 || 1 }}
+          # IMPORTANT: use string literals '0'/'1' here. GitHub Actions
+          # expression `cond && 0 || 1` evaluates to `1` even when cond
+          # is true because numeric 0 is falsy (JS-style coercion), so
+          # the `|| 1` short-circuit fires. Strings "0"/"1" are both
+          # truthy, so `cond && '0' || '1'` correctly returns '0' when
+          # cond is true. `actions/checkout` parses the input as int.
+          fetch-depth: ${{ inputs.ref != '' && '0' || '1' }}
 
       - name: Resolve deployed SHA
         id: deployed-sha
@@ -319,7 +337,13 @@ jobs:
           # checkout fails with `fatal: reference is not a tree`. Pull
           # full history when the operator overrides ref so any SHA is
           # reachable; keep depth 1 for default-ref runs to save time.
-          fetch-depth: ${{ inputs.ref != '' && 0 || 1 }}
+          # IMPORTANT: use string literals '0'/'1' here. GitHub Actions
+          # expression `cond && 0 || 1` evaluates to `1` even when cond
+          # is true because numeric 0 is falsy (JS-style coercion), so
+          # the `|| 1` short-circuit fires. Strings "0"/"1" are both
+          # truthy, so `cond && '0' || '1'` correctly returns '0' when
+          # cond is true. `actions/checkout` parses the input as int.
+          fetch-depth: ${{ inputs.ref != '' && '0' || '1' }}
 
       # Pre-cleanup: scrub any signing material left behind by a PRIOR
       # crashed run. `if: always()` cleanup at job end doesn't run if the
@@ -547,7 +571,13 @@ jobs:
           # checkout fails with `fatal: reference is not a tree`. Pull
           # full history when the operator overrides ref so any SHA is
           # reachable; keep depth 1 for default-ref runs to save time.
-          fetch-depth: ${{ inputs.ref != '' && 0 || 1 }}
+          # IMPORTANT: use string literals '0'/'1' here. GitHub Actions
+          # expression `cond && 0 || 1` evaluates to `1` even when cond
+          # is true because numeric 0 is falsy (JS-style coercion), so
+          # the `|| 1` short-circuit fires. Strings "0"/"1" are both
+          # truthy, so `cond && '0' || '1'` correctly returns '0' when
+          # cond is true. `actions/checkout` parses the input as int.
+          fetch-depth: ${{ inputs.ref != '' && '0' || '1' }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
## Why
PR #413 introduced `fetch-depth: ${{ inputs.ref != '' && 0 || 1 }}` to pull full history when an override ref is supplied. **Discovered during Test 1 of the deploy-dev validation that this expression evaluates to `1` even when the condition is true** — numeric `0` is falsy in GitHub Actions expressions (JavaScript-style coercion), so the `|| 1` short-circuit always fires.

Verified in run 25200140680: log shows `fetch-depth: 1` despite `inputs.ref=0e3604a542` being set, and the fetch command falls through to a branch/tag glob match against the SHA (`+refs/heads/0e3604a542*:...`), failing because no branch is named that. All four deploy jobs failed at checkout.

## Fix
Switch to string literals `'0'` / `'1'`. Both strings are truthy, so `cond && '0' || '1'` correctly returns `'0'` when cond is true. `actions/checkout` parses the input as int regardless. Same change applied to all 5 checkouts.

Inline comment documents the trap so a future contributor doesn't "simplify" back to numerics.

## Test plan
- [x] `actionlint` clean
- [x] `bash scripts/check-release-trigger.sh` — pre-existing guards still pass
- [ ] CI workflow checks
- [ ] Manual QA: re-run Test 1 with full 40-char SHA — verify checkout shows `fetch-depth: 0` and fetch succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)