### PR TITLE
fix(android): Apple Sign-In credential uses setIdTokenWithRawNonce

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/AuthRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.core.util.firebaseCall
+import com.shyden.shytalk.core.util.logE
 import kotlinx.coroutines.tasks.await
 
 class AuthRepositoryImpl(
@@ -60,18 +61,30 @@ class AuthRepositoryImpl(
         rawNonce: String,
     ): Resource<String> {
         return try {
+            // Apple Sign-In on Firebase requires setIdTokenWithRawNonce,
+            // which stores BOTH idToken + rawNonce on the credential and
+            // leaves accessToken unset. Apple does NOT issue an
+            // access_token, so the prior .setAccessToken(rawNonce) call
+            // stuffed the nonce into the wrong field — Firebase backend
+            // would reject the credential as malformed, surfacing the
+            // generic "AccessToken must not be null" error.
             val credential =
                 com.google.firebase.auth.OAuthProvider
                     .newCredentialBuilder("apple.com")
-                    .setIdToken(idToken)
-                    .setAccessToken(rawNonce)
+                    .setIdTokenWithRawNonce(idToken, rawNonce)
                     .build()
             val authResult = auth.signInWithCredential(credential).await()
             val uid = authResult.user?.uid ?: return Resource.Error("Apple sign-in failed")
             Resource.Success(uid)
         } catch (e: com.google.firebase.auth.FirebaseAuthUserCollisionException) {
+            logE("AuthRepository", "Apple sign-in: user collision", e)
             Resource.Error("An account already exists with this email using a different sign-in method")
         } catch (e: Exception) {
+            // Log the underlying exception so a future credential
+            // malformation (the bug class fixed here) doesn't go
+            // undiagnosed under the generic "Apple sign-in failed"
+            // Resource.Error.
+            logE("AuthRepository", "Apple sign-in failed", e)
             Resource.Error("Apple sign-in failed")
         }
     }

--- a/app/src/test/java/com/shyden/shytalk/data/repository/AuthRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/AuthRepositoryImplTest.kt
@@ -11,6 +11,7 @@ import com.shyden.shytalk.core.util.Resource
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
@@ -117,6 +118,42 @@ class AuthRepositoryImplTest {
             val result = repo.signInWithAppleIdToken("token", "nonce")
 
             assertTrue(result is Resource.Error)
+        }
+
+    @Test
+    fun `signInWithAppleIdToken builds credential via setIdTokenWithRawNonce, never via setAccessToken(rawNonce)`() =
+        runTest {
+            // Regression test for the "AccessToken must not be null" bug. The
+            // pre-fix code called .setAccessToken(rawNonce) — semantically wrong
+            // because Apple does not issue an access_token, so Firebase backend
+            // would reject the credential as if accessToken were null. The
+            // correct API for Apple is .setIdTokenWithRawNonce(idToken, rawNonce)
+            // which sets BOTH idToken + rawNonce (and leaves accessToken unset).
+            //
+            // We can't verify the resulting credential's internal accessToken
+            // field directly because OAuthCredential's getters require a real
+            // Firebase Android runtime. Instead, capture the credential and
+            // assert it's a real OAuthCredential whose getAccessToken() does
+            // NOT equal the rawNonce. The pre-fix code would fail this because
+            // the rawNonce gets stored in the accessToken slot.
+            val credentialSlot = slot<AuthCredential>()
+            every { auth.signInWithCredential(capture(credentialSlot)) } returns
+                Tasks.forException(RuntimeException("short-circuit"))
+
+            repo.signInWithAppleIdToken("idtoken-X", "rawnonce-Y")
+
+            val captured = credentialSlot.captured
+            assertTrue(
+                "Expected OAuthCredential, got ${captured::class.simpleName}",
+                captured is com.google.firebase.auth.OAuthCredential,
+            )
+            val oauth = captured as com.google.firebase.auth.OAuthCredential
+            assertEquals("idtoken-X", oauth.idToken)
+            // Pre-fix bug: accessToken contained "rawnonce-Y". Post-fix: null.
+            assertFalse(
+                "rawNonce must NOT be stored as accessToken — that's the bug. accessToken=${oauth.accessToken}",
+                oauth.accessToken == "rawnonce-Y",
+            )
         }
 
     @Test


### PR DESCRIPTION
## Bug
Apple Sign-In on Android failed with `AccessToken must not be null`. Pre-fix code:

```kotlin
.newCredentialBuilder("apple.com").setIdToken(idToken).setAccessToken(rawNonce).build()
```

The rawNonce was being stored in the `accessToken` slot — Apple does not issue an access_token, so Firebase backend rejected the credential as malformed. The validator surfaces this as the generic `AccessToken must not be null` (the nonce-shaped string fails accessToken-shape validation server-side).

## Fix
Switch to the documented Firebase Apple Sign-In API: `setIdTokenWithRawNonce(idToken, rawNonce)`. Stores BOTH idToken + rawNonce, leaves accessToken unset — exactly what Apple OIDC expects.

## TDD
Regression test in `AuthRepositoryImplTest`: captures the `OAuthCredential` passed to `auth.signInWithCredential` and asserts:
- `idToken == "idtoken-X"` (correctly preserved)
- `accessToken != "rawnonce-Y"` (the bug — must be unset)

Test was written failing on the buggy code (rawNonce stored as accessToken), then went green after the fix.

## Pre-existing hardening
Both Apple-sign-in catch blocks discarded the exception entirely. Any future credential malformation would have surfaced as the same opaque "Apple sign-in failed" with zero diagnostic trail — the very anti-pattern that let this bug slip through. Both catches now `logE` with the underlying exception.

## Test plan
- [x] `./gradlew :app:testDevDebugUnitTest --tests AuthRepositoryImplTest` — 8 tests pass (including new regression test)
- [x] `./gradlew testDevDebugUnitTest :shared:jvmTest detekt` — full unit suite green
- [x] `cd express-api && npm test` — 4383/4383 pass
- [x] `./gradlew :shared:compileKotlinIosArm64` — iOS compile clean
- [x] ktlint clean
- [x] silent-failure-hunter agent: original finding (catch swallowing exceptions) fixed inline
- [ ] CI: full Build & Test + Android E2E
- [ ] Manual QA after merge: deploy to dev, real Apple Sign-In on physical Android device

🤖 Generated with [Claude Code](https://claude.com/claude-code)