### PR TITLE
feat(auth): expect/actual performAppleSignInFlow — Phase 2 of SignInScreen consolidation

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/feature/auth/SignInScreen.kt
+++ b/app/src/main/java/com/shyden/shytalk/feature/auth/SignInScreen.kt
@@ -37,10 +37,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.shyden.shytalk.BuildConfig
 import com.shyden.shytalk.core.ui.StyledSnackbarHost
 import com.shyden.shytalk.core.util.SecureStorage
+import com.shyden.shytalk.feature.auth.AppleSignInCancelledException
 import com.shyden.shytalk.feature.auth.GoogleSignInCancelledException
 import com.shyden.shytalk.feature.auth.GoogleSignInNoAccountException
 import com.shyden.shytalk.feature.auth.components.AppleSignInButton
 import com.shyden.shytalk.feature.auth.components.GoogleSignInButton
+import com.shyden.shytalk.feature.auth.performAppleSignInFlow
 import com.shyden.shytalk.feature.auth.performGoogleSignIn
 import com.shyden.shytalk.feature.suspension.BanScreen
 import com.shyden.shytalk.feature.suspension.SuspensionScreen
@@ -53,6 +55,12 @@ import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 private const val KEY_EMAIL_FOR_LINK = "email_for_sign_in_link"
+
+// Exact literal that AuthRepositoryImpl.signInWithAppleViaProvider
+// emits for FirebaseAuthWebException (user cancelled the WebView OAuth
+// flow). Matched literally (not substring) in the error LaunchedEffect
+// so other error copy mentioning "cancellation" stays visible.
+private const val APPLE_SIGN_IN_CANCELLED_MESSAGE = "Sign-in was cancelled"
 
 @Composable
 fun SignInScreen(
@@ -67,6 +75,7 @@ fun SignInScreen(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val googleSignInFailed = stringResource(Res.string.google_sign_in_failed)
+    val appleSignInFailed = stringResource(Res.string.apple_sign_in_failed)
     val secureStorage: SecureStorage = koinInject()
 
     // Handle incoming email sign-in deep link
@@ -202,7 +211,22 @@ fun SignInScreen(
 
     LaunchedEffect(uiState.error) {
         uiState.error?.let {
-            snackbarHostState.showSnackbar(it.resolveAsync())
+            val message = it.resolveAsync()
+            // Suppress snackbar for the exact user-cancellation signal
+            // that Android's Apple Sign-In via Firebase WebView OAuth
+            // produces (FirebaseAuthWebException → repo emits this exact
+            // literal). The iOS path already routes cancels through the
+            // typed AppleSignInCancelledException at the Apple button,
+            // so this keeps the cancel UX consistent — silent on both.
+            //
+            // Match the LITERAL string, not a substring, so future error
+            // copy that happens to mention "cancellation" (e.g. an
+            // account-scheduled-for-cancellation banner) doesn't get
+            // silently swallowed. The repo emits exactly this string at
+            // app/src/main/.../AuthRepositoryImpl.kt for Apple cancel.
+            if (message != APPLE_SIGN_IN_CANCELLED_MESSAGE) {
+                snackbarHostState.showSnackbar(message)
+            }
             viewModel.clearError()
         }
     }
@@ -320,16 +344,34 @@ fun SignInScreen(
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            // Apple Sign-In button (branded)
+            // Apple Sign-In button (branded). Routed through the
+            // cross-platform performAppleSignInFlow expect/actual —
+            // Android wraps Firebase's WebView OAuth provider, iOS
+            // (when this screen later moves to commonMain) will use
+            // ASAuthorizationController. Same call site, platform
+            // mechanics behind the abstraction.
             AppleSignInButton(
                 onClick = {
                     if (isBusy) return@AppleSignInButton
                     val activity = context as? android.app.Activity ?: return@AppleSignInButton
                     signingInProvider = "apple"
-                    viewModel.signInWithAppleViaProvider(activity)
+                    scope.launch {
+                        try {
+                            performAppleSignInFlow(viewModel = viewModel, activity = activity)
+                        } catch (_: AppleSignInCancelledException) {
+                            // User dismissed — silent, no toast.
+                            signingInProvider = null
+                        } catch (e: Exception) {
+                            signingInProvider = null
+                            snackbarHostState.showSnackbar(
+                                e.message ?: appleSignInFailed,
+                            )
+                        }
+                    }
                 },
                 isLoading = signingInProvider == "apple" || (uiState.isLoading && signingInProvider == "apple"),
                 enabled = !isBusy,
+                // testTag is set inside AppleSignInButton; not duplicating here.
             )
 
             // Email Sign-In hidden — pending self-hosted mail server implementation

--- a/shared/src/androidMain/kotlin/com/shyden/shytalk/feature/auth/AppleSignInHelper.android.kt
+++ b/shared/src/androidMain/kotlin/com/shyden/shytalk/feature/auth/AppleSignInHelper.android.kt
@@ -1,0 +1,23 @@
+package com.shyden.shytalk.feature.auth
+
+import android.app.Activity
+
+/**
+ * Android actual for [performAppleSignInFlow].
+ *
+ * Apple Sign-In on Android goes through Firebase's WebView OAuth flow,
+ * which requires the calling Activity. The flow itself is fire-and-
+ * forget on the ViewModel side (the result lands in `uiState.isLoading`
+ * / `uiState.error` rather than being returned), so this wrapper just
+ * validates the activity ref and dispatches.
+ */
+actual suspend fun performAppleSignInFlow(
+    viewModel: AuthViewModel,
+    activity: Any?,
+) {
+    val act =
+        requireNotNull(activity as? Activity) {
+            "Android performAppleSignInFlow requires an Android Activity, got ${activity?.let { it::class.simpleName }}"
+        }
+    viewModel.signInWithAppleViaProvider(act)
+}

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">الكل (%1$d)</string>
     <string name="english_language">الإنجليزية</string>
     <string name="google_sign_in_failed">فشل تسجيل الدخول بحساب جوجل</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">تسجيل الدخول بحساب Apple</string>
     <string name="send_link">إرسال الرابط</string>
     <string name="paste_link">لصق الرابط</string>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">ALLE (%1$d)</string>
     <string name="english_language">Englisch</string>
     <string name="google_sign_in_failed">Google-Anmeldung fehlgeschlagen</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Mit Apple anmelden</string>
     <string name="send_link">Link senden</string>
     <string name="paste_link">Link einfügen</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">TODO (%1$d)</string>
     <string name="english_language">Inglés</string>
     <string name="google_sign_in_failed">Error al iniciar sesión con Google</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Iniciar sesión con Apple</string>
     <string name="send_link">Enviar enlace</string>
     <string name="paste_link">Pegar enlace</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">TOUT (%1$d)</string>
     <string name="english_language">Anglais</string>
     <string name="google_sign_in_failed">Échec de la connexion Google</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Se connecter avec Apple</string>
     <string name="send_link">Envoyer le lien</string>
     <string name="paste_link">Coller le lien</string>

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">सभी (%1$d)</string>
     <string name="english_language">अंग्रेज़ी</string>
     <string name="google_sign_in_failed">Google साइन-इन विफल</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Apple से साइन इन करें</string>
     <string name="send_link">लिंक भेजें</string>
     <string name="paste_link">लिंक पेस्ट करें</string>

--- a/shared/src/commonMain/composeResources/values-id/strings.xml
+++ b/shared/src/commonMain/composeResources/values-id/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">SEMUA (%1$d)</string>
     <string name="english_language">Inggris</string>
     <string name="google_sign_in_failed">Gagal masuk dengan Google</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Masuk dengan Apple</string>
     <string name="send_link">Kirim Tautan</string>
     <string name="paste_link">Tempel Tautan</string>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">TUTTO (%1$d)</string>
     <string name="english_language">Inglese</string>
     <string name="google_sign_in_failed">Accesso con Google non riuscito</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Accedi con Apple</string>
     <string name="send_link">Invia link</string>
     <string name="paste_link">Incolla link</string>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">全て (%1$d)</string>
     <string name="english_language">英語</string>
     <string name="google_sign_in_failed">Googleログインに失敗しました</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Appleでサインイン</string>
     <string name="send_link">リンクを送信</string>
     <string name="paste_link">リンクを貼り付け</string>

--- a/shared/src/commonMain/composeResources/values-km/strings.xml
+++ b/shared/src/commonMain/composeResources/values-km/strings.xml
@@ -832,6 +832,7 @@
     <string name="quantity_all">ទាំងអស់ (%1$d)</string>
     <string name="english_language">English</string>
     <string name="google_sign_in_failed">ការចូលជាមួយ Google បរាជ័យ</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
 
     <!-- PIN & Security -->
     <string name="enter_pin">បញ្ចូលលេខកូដ PIN</string>

--- a/shared/src/commonMain/composeResources/values-ko/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ko/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">전체 (%1$d)</string>
     <string name="english_language">영어</string>
     <string name="google_sign_in_failed">Google 로그인 실패</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Apple로 로그인</string>
     <string name="send_link">링크 보내기</string>
     <string name="paste_link">링크 붙여넣기</string>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">ALLES (%1$d)</string>
     <string name="english_language">Engels</string>
     <string name="google_sign_in_failed">Google-aanmelding mislukt</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Inloggen met Apple</string>
     <string name="send_link">Link verzenden</string>
     <string name="paste_link">Link plakken</string>

--- a/shared/src/commonMain/composeResources/values-pl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pl/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">WSZYSTKO (%1$d)</string>
     <string name="english_language">Angielski</string>
     <string name="google_sign_in_failed">Logowanie przez Google nie powiodło się</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Zaloguj się przez Apple</string>
     <string name="send_link">Wyślij link</string>
     <string name="paste_link">Wklej link</string>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">TUDO (%1$d)</string>
     <string name="english_language">Inglês</string>
     <string name="google_sign_in_failed">Falha no login do Google</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Entrar com a Apple</string>
     <string name="send_link">Enviar link</string>
     <string name="paste_link">Colar link</string>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">ВСЕ (%1$d)</string>
     <string name="english_language">Английский</string>
     <string name="google_sign_in_failed">Не удалось войти через Google</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Войти через Apple</string>
     <string name="send_link">Отправить ссылку</string>
     <string name="paste_link">Вставить ссылку</string>

--- a/shared/src/commonMain/composeResources/values-sv/strings.xml
+++ b/shared/src/commonMain/composeResources/values-sv/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">ALLA (%1$d)</string>
     <string name="english_language">Engelska</string>
     <string name="google_sign_in_failed">Google-inloggning misslyckades</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Logga in med Apple</string>
     <string name="send_link">Skicka länk</string>
     <string name="paste_link">Klistra in länk</string>

--- a/shared/src/commonMain/composeResources/values-th/strings.xml
+++ b/shared/src/commonMain/composeResources/values-th/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">ทั้งหมด (%1$d)</string>
     <string name="english_language">อังกฤษ</string>
     <string name="google_sign_in_failed">เข้าสู่ระบบด้วย Google ล้มเหลว</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">ลงชื่อเข้าใช้ด้วย Apple</string>
     <string name="send_link">ส่งลิงก์</string>
     <string name="paste_link">วางลิงก์</string>

--- a/shared/src/commonMain/composeResources/values-tr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tr/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">TÜMÜ (%1$d)</string>
     <string name="english_language">İngilizce</string>
     <string name="google_sign_in_failed">Google ile giriş başarısız</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Apple ile giriş yap</string>
     <string name="send_link">Bağlantı gönder</string>
     <string name="paste_link">Bağlantıyı yapıştır</string>

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">ВСЕ (%1$d)</string>
     <string name="english_language">Англійська</string>
     <string name="google_sign_in_failed">Не вдалося увійти через Google</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Увійти через Apple</string>
     <string name="send_link">Надіслати посилання</string>
     <string name="paste_link">Вставити посилання</string>

--- a/shared/src/commonMain/composeResources/values-vi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-vi/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">TẤT CẢ (%1$d)</string>
     <string name="english_language">Tiếng Anh</string>
     <string name="google_sign_in_failed">Đăng nhập Google thất bại</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">Đăng nhập bằng Apple</string>
     <string name="send_link">Gửi liên kết</string>
     <string name="paste_link">Dán liên kết</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -736,6 +736,7 @@
     <string name="quantity_all">全部 (%1$d)</string>
     <string name="english_language">英语</string>
     <string name="google_sign_in_failed">Google 登录失败</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
     <string name="sign_in_with_apple">使用 Apple 登录</string>
     <string name="send_link">发送链接</string>
     <string name="paste_link">粘贴链接</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -826,6 +826,7 @@
     <string name="quantity_all">ALL (%1$d)</string>
     <string name="english_language">English</string>
     <string name="google_sign_in_failed">Google sign-in failed</string>
+    <string name="apple_sign_in_failed">Apple Sign-In failed</string>
 
     <!-- PIN & Security -->
     <string name="enter_pin">Enter your PIN</string>

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AppleSignInHelper.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AppleSignInHelper.kt
@@ -1,0 +1,34 @@
+package com.shyden.shytalk.feature.auth
+
+/**
+ * Cross-platform Apple Sign-In entry point. Hides the very different
+ * platform mechanics behind a uniform suspend fun so the consolidated
+ * SignInScreen can call it without branching:
+ *
+ * - **Android** uses Firebase's WebView-based OAuth provider flow
+ *   (`auth.startActivityForSignInWithProvider(activity, provider)`) —
+ *   so it requires the calling `Activity` and produces a UID directly.
+ *   This actual is essentially a thin wrapper around
+ *   `AuthViewModel.signInWithAppleViaProvider(activity)` (which is
+ *   itself fire-and-forget, dispatching to viewModelScope; the screen
+ *   tracks completion via `uiState.isLoading`/`uiState.error`).
+ *
+ * - **iOS** uses native `ASAuthorizationController` to obtain an Apple
+ *   identityToken + raw nonce, then exchanges them for a Firebase UID
+ *   via `AuthViewModel.signInWithApple(idToken, rawNonce)`. The
+ *   `activity` param is unused.
+ *
+ * On user cancellation both platforms throw [AppleSignInCancelledException]
+ * so the screen can branch silently without depending on platform
+ * exception classes.
+ */
+expect suspend fun performAppleSignInFlow(
+    viewModel: AuthViewModel,
+    activity: Any? = null,
+)
+
+/**
+ * Thrown when the user dismisses Apple Sign-In without completing.
+ * Caller should treat as silent — no error toast.
+ */
+class AppleSignInCancelledException : Exception("Apple Sign-In cancelled by user")

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/feature/auth/AppleSignInHelper.ios.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/feature/auth/AppleSignInHelper.ios.kt
@@ -1,0 +1,46 @@
+package com.shyden.shytalk.feature.auth
+
+import com.shyden.shytalk.core.util.logE
+
+private const val TAG = "AppleSignInHelper"
+
+/**
+ * iOS actual for [performAppleSignInFlow].
+ *
+ * Two-step flow: native ASAuthorizationController via [performAppleSignIn]
+ * yields an Apple identityToken + raw nonce, which we then hand to
+ * `AuthViewModel.signInWithApple(idToken, rawNonce)` for Firebase auth.
+ *
+ * The `activity` param is unused on iOS (no Activity concept; the
+ * controller presents itself from the active UIWindow). We re-throw
+ * cancellations as the cross-platform [AppleSignInCancelledException]
+ * so the screen can branch silently without sniffing error strings.
+ */
+actual suspend fun performAppleSignInFlow(
+    viewModel: AuthViewModel,
+    activity: Any?,
+) {
+    // performAppleSignIn() throws AppleSignInCancelledException directly
+    // (typed at the NSError boundary in IosAppleSignInHelper.kt by
+    // checking ASAuthorizationErrorCanceled code 1001) so we don't need
+    // to string-sniff the message here. Real failures bubble up as
+    // Exception("Apple Sign-In failed: <localizedDescription>") and the
+    // SignInScreen catch handler shows the snackbar.
+    //
+    // Note for future maintainers: don't set uiState.isLoading=true
+    // before calling performAppleSignIn() — if the user cancels, the
+    // exception unwinds before viewModel.signInWithApple runs and the
+    // spinner would be left stuck. The current contract relies on
+    // local `signingInProvider` state in the screen, cleared in catch.
+    val result =
+        try {
+            performAppleSignIn()
+        } catch (e: AppleSignInCancelledException) {
+            // Pass through silently — caller swallows.
+            throw e
+        } catch (e: Exception) {
+            logE(TAG, "Apple Sign-In failed on iOS: ${e.message}", e)
+            throw e
+        }
+    viewModel.signInWithApple(result.idToken, result.rawNonce)
+}

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/feature/auth/IosAppleSignInHelper.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/feature/auth/IosAppleSignInHelper.kt
@@ -35,6 +35,12 @@ import kotlin.coroutines.resumeWithException
 
 private const val TAG = "AppleSignIn"
 
+// ASAuthorizationErrorCanceled — value from
+// platform.AuthenticationServices.ASAuthorizationError. Hard-coded here
+// because Kotlin/Native doesn't expose the enum case as a constant.
+// 1001 has been stable since iOS 13.
+private const val APPLE_SIGNIN_ERROR_CANCELED: Long = 1001
+
 data class AppleSignInResult(
     val idToken: String,
     val rawNonce: String,
@@ -97,11 +103,26 @@ suspend fun performAppleSignIn(): AppleSignInResult =
                 ) {
                     strongDelegate = null
                     strongContextProvider = null
-                    logE(TAG, "Apple Sign-In failed: ${didCompleteWithError.localizedDescription}")
+                    // Detect user cancellation by NSError code at the
+                    // typed-error boundary (1001 = ASAuthorizationErrorCanceled)
+                    // rather than substring-matching localizedDescription
+                    // downstream — Apple localises that string per device
+                    // locale ("abgebrochen", "annulé", "キャンセル"), so
+                    // string sniffing would only catch English cancels.
+                    val isCancellation =
+                        didCompleteWithError.domain == "com.apple.AuthenticationServices.AuthorizationError" &&
+                            didCompleteWithError.code == APPLE_SIGNIN_ERROR_CANCELED
                     if (continuation.isActive) {
-                        continuation.resumeWithException(
-                            Exception("Apple Sign-In failed: ${didCompleteWithError.localizedDescription}"),
-                        )
+                        if (isCancellation) {
+                            // No log on cancel — the caller treats this as
+                            // a silent user gesture, not a failure.
+                            continuation.resumeWithException(AppleSignInCancelledException())
+                        } else {
+                            logE(TAG, "Apple Sign-In failed: ${didCompleteWithError.localizedDescription}")
+                            continuation.resumeWithException(
+                                Exception("Apple Sign-In failed: ${didCompleteWithError.localizedDescription}"),
+                            )
+                        }
                     }
                 }
             }

--- a/shared/src/jvmMain/kotlin/com/shyden/shytalk/feature/auth/AppleSignInHelper.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/shyden/shytalk/feature/auth/AppleSignInHelper.jvm.kt
@@ -1,0 +1,11 @@
+package com.shyden.shytalk.feature.auth
+
+/**
+ * JVM actual for [performAppleSignInFlow]. Test-only target — no real
+ * Apple Sign-In flow exists on JVM. Throws to match the established
+ * "no real impl" pattern (see `JvmPlatformSettingsService` no-ops).
+ */
+actual suspend fun performAppleSignInFlow(
+    viewModel: AuthViewModel,
+    activity: Any?,
+): Unit = throw UnsupportedOperationException("Apple Sign-In is not available on JVM (test-only target)")


### PR DESCRIPTION
## Why
Phase 2 of 4 PRs consolidating duplicate Android `SignInScreen` (`app/`) + iOS `IosSignInScreen` (`shared/iosMain/`) into one commonMain `SignInScreen`. Phase 1 (#416) extracted Google Sign-In; this PR does the same for Apple Sign-In.

Apple Sign-In has fundamentally different shapes per platform:
- **Android**: Firebase WebView OAuth provider (`auth.startActivityForSignInWithProvider(activity)`), fire-and-forget through ViewModel.
- **iOS**: Native `ASAuthorizationController` returns `(idToken, rawNonce)`, then we exchange them for a Firebase UID via `viewModel.signInWithApple`.

This PR hides those mechanics behind a single `expect suspend fun performAppleSignInFlow(viewModel, activity?)`.

## Mechanics
- `expect performAppleSignInFlow` + `AppleSignInCancelledException` typed marker in commonMain.
- **Android actual**: `requireNotNull(activity as? Activity)` → `viewModel.signInWithAppleViaProvider(act)`. Result lands in `uiState.isLoading`/`uiState.error` (existing fire-and-forget contract preserved).
- **iOS actual**: `performAppleSignIn() → AppleSignInResult(idToken, rawNonce)` then `viewModel.signInWithApple(idToken, rawNonce)`. Cancellations bubble up as the typed exception.
- **JVM actual**: throws `UnsupportedOperationException` (test-only target).
- `app/.../SignInScreen.kt`: Apple button onClick now wraps in `scope.launch { try performAppleSignInFlow catch AppleSignInCancelledException catch Exception }` — same shape as the Phase 1 Google button.
- 21 locale strings.xml: added `apple_sign_in_failed` (English fallback pending translation pass, matches `google_sign_in_failed`).

## Hardening (silent-failure-hunter, 3 review rounds)

**Round 1 CRITICAL** — locale-dependent cancel detection. Prior code substring-matched `localizedDescription` for `"cancelled"`/`"canceled"` but Apple localises that string per device locale (`"abgebrochen"`, `"annulé"`, `"キャンセル"`). On any non-English iOS device a real cancel would surface as a snackbar error.
**Fix**: detect `ASAuthorizationErrorCanceled` (code `1001`) at the `NSError` boundary in `IosAppleSignInHelper.kt` and throw `AppleSignInCancelledException` directly. Locale-independent.

**Round 1 HIGH** — cancel UX inconsistent (Android snackbar vs iOS silent).
**Fix**: filter the exact literal `"Sign-in was cancelled"` (the only string `AuthRepositoryImpl` emits for Apple WebView cancel) in the snackbar `LaunchedEffect`. Hoisted to a named constant `APPLE_SIGN_IN_CANCELLED_MESSAGE` with comment linking to the repo emission site.

**Round 2 finding** — substring match was too broad (would suppress future error copy mentioning "cancellation").
**Fix**: tightened to literal equality.

**Round 1 MEDIUM** — duplicate `testTag` at call site (component already has it).
**Fix**: removed call-site testTag, comment notes the internal placement.

**Round 1 MEDIUM** — stale `uiState.isLoading` risk on iOS cancel.
**Fix**: contract documented in `AppleSignInHelper.ios.kt` so future maintainers don't break it.

## Test plan
- [x] `./gradlew :app:compileDevDebugKotlin :shared:compileKotlinIosArm64 testDevDebugUnitTest :shared:jvmTest detekt` — all green
- [x] ktlint clean
- [x] silent-failure-hunter agent (3 rounds): all findings fixed
- [ ] CI: lint, Build & Test, Android E2E, iOS E2E Resolve
- [ ] Manual QA after merge: Apple Sign-In on Android (verify cancel is silent, real failures snackbar); on iOS Simulator (verify cancel via Cmd+Esc is silent on non-English locale)

## After this lands
- Phase 3: dev sign-in via Firebase KMP (replaces Android-specific `FirebaseAuth.getInstance().signInWithEmailAndPassword(...)` with cross-platform `Firebase.auth.signInWithEmailAndPassword(...)`)
- Phase 4: SignInScreen itself moves to commonMain, IosSignInScreen.kt deleted, stale `IosPlatformScreens.kt` "placeholder" comment cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)