### PR TITLE
fix(ios): pending-reports parser uses correct JSON keys + lowercases type

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -137,7 +137,7 @@ android {
     }
     sourceSets {
         getByName("androidTest") {
-            assets.srcDirs("src/androidTest/assets")
+            assets.directories.add("src/androidTest/assets")
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ credentials = "1.6.0"
 googleid = "1.2.0"
 koin = "4.2.1"
 kotlinxDatetime = "0.7.1"
+kotlinxSerialization = "1.9.0"
 mockk = "1.14.9"
 turbine = "1.2.1"
 junit = "4.13.2"
@@ -90,6 +91,7 @@ kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "ko
 # KMP
 firebase-common = { group = "com.google.firebase", name = "firebase-common", version = "22.0.1" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 
 # Coil (image loading - KMP)
 coil3-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil3" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
             api(compose.components.resources)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.datetime)
+            implementation(libs.kotlinx.serialization.json)
             implementation(libs.androidx.lifecycle.viewmodel)
             implementation(libs.androidx.lifecycle.runtime.compose)
             implementation(libs.koin.compose.viewmodel)

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/ReportJsonParser.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/ReportJsonParser.kt
@@ -1,0 +1,34 @@
+package com.shyden.shytalk.data.repository
+
+import com.shyden.shytalk.feature.messaging.Report
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+
+/**
+ * Parses a single report JSON object as emitted by `GET /api/reports`
+ * (Express route at `express-api/src/routes/reports.js`). Lives in
+ * commonMain so the iOS-side parser stays in sync with what the admin
+ * web client expects — the previous bespoke iOS parsing diverged from
+ * Android (wrong JSON key for the timestamp; missing `.lowercase()` on
+ * the `type` field that admin filters compare case-insensitively).
+ */
+internal fun parseReportFromApi(obj: JsonObject): Report =
+    Report(
+        reportId = obj["id"]?.jsonPrimitive?.contentOrNull ?: "",
+        reporterId = obj["reporterId"]?.jsonPrimitive?.contentOrNull ?: "",
+        reporterName = obj["reporterName"]?.jsonPrimitive?.contentOrNull ?: "",
+        reporterUniqueId = obj["reporterUniqueId"]?.jsonPrimitive?.longOrNull ?: 0L,
+        reportedUserId = obj["reportedUserId"]?.jsonPrimitive?.contentOrNull ?: "",
+        reportedUserName = obj["reportedUserName"]?.jsonPrimitive?.contentOrNull ?: "",
+        reportedUserUniqueId = obj["reportedUserUniqueId"]?.jsonPrimitive?.longOrNull ?: 0L,
+        conversationId = obj["conversationId"]?.jsonPrimitive?.contentOrNull ?: "",
+        messageId = obj["messageId"]?.jsonPrimitive?.contentOrNull ?: "",
+        messageText = obj["messageText"]?.jsonPrimitive?.contentOrNull ?: "",
+        reason = obj["reason"]?.jsonPrimitive?.contentOrNull ?: "",
+        description = obj["description"]?.jsonPrimitive?.contentOrNull ?: "",
+        type = (obj["type"]?.jsonPrimitive?.contentOrNull ?: "").lowercase(),
+        timestamp = obj["createdAt"]?.jsonPrimitive?.longOrNull ?: 0L,
+        status = obj["status"]?.jsonPrimitive?.contentOrNull ?: "pending",
+    )

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/data/repository/ReportJsonParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/data/repository/ReportJsonParserTest.kt
@@ -1,0 +1,74 @@
+package com.shyden.shytalk.data.repository
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Lock down the `GET /api/reports` JSON contract on the iOS-shared parser.
+ * The two cases below regression-test the bugs the parser had before:
+ *
+ *  1. `type` was returned verbatim from the JSON — admin filters
+ *     compare case-insensitively, so the iOS list lost matches against
+ *     the Android-produced lowercase variants. Now lower-cased here.
+ *  2. `timestamp` was read from the `timestamp` JSON key, but the
+ *     Express endpoint emits `createdAt` (see `reports.js:202`). The
+ *     iOS list always saw `0L` and the chronological sort silently
+ *     broke. Now reads from `createdAt`.
+ */
+class ReportJsonParserTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `type is lower-cased to match Android admin filter parity`() {
+        val obj =
+            json.parseToJsonElement(
+                """{"id":"r1","type":"Sexual","createdAt":1700000000}""",
+            ) as JsonObject
+        val report = parseReportFromApi(obj)
+        assertEquals("sexual", report.type)
+    }
+
+    @Test
+    fun `timestamp is read from createdAt JSON key (not legacy timestamp)`() {
+        val obj =
+            json.parseToJsonElement(
+                """{"id":"r1","createdAt":1700000000,"timestamp":42}""",
+            ) as JsonObject
+        val report = parseReportFromApi(obj)
+        // Must be createdAt's value, NOT timestamp's 42.
+        assertEquals(1700000000L, report.timestamp)
+    }
+
+    @Test
+    fun `missing optional string fields default to empty string`() {
+        val obj =
+            json.parseToJsonElement(
+                """{"id":"r1"}""",
+            ) as JsonObject
+        val report = parseReportFromApi(obj)
+        assertEquals("", report.reporterId)
+        assertEquals("", report.reportedUserName)
+        assertEquals("", report.reason)
+        assertEquals("", report.description)
+        assertEquals("", report.type)
+        assertEquals("", report.messageText)
+    }
+
+    @Test
+    fun `missing status defaults to pending`() {
+        val obj = json.parseToJsonElement("""{"id":"r1"}""") as JsonObject
+        val report = parseReportFromApi(obj)
+        assertEquals("pending", report.status)
+    }
+
+    @Test
+    fun `missing numeric fields default to zero`() {
+        val obj = json.parseToJsonElement("""{"id":"r1"}""") as JsonObject
+        val report = parseReportFromApi(obj)
+        assertEquals(0L, report.reporterUniqueId)
+        assertEquals(0L, report.reportedUserUniqueId)
+        assertEquals(0L, report.timestamp)
+    }
+}

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosSmallRepositories.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosSmallRepositories.kt
@@ -189,26 +189,7 @@ class IosReportRepositoryImpl(
     override suspend fun getPendingReports(): Resource<List<com.shyden.shytalk.feature.messaging.Report>> =
         firebaseCall("Failed to load reports") {
             val arr = api.getArray("/api/reports")
-            arr.map { element ->
-                val obj = element.jsonObject
-                com.shyden.shytalk.feature.messaging.Report(
-                    reportId = obj["id"]?.jsonPrimitive?.contentOrNull ?: "",
-                    reporterId = obj["reporterId"]?.jsonPrimitive?.contentOrNull ?: "",
-                    reporterName = obj["reporterName"]?.jsonPrimitive?.contentOrNull ?: "",
-                    reporterUniqueId = obj["reporterUniqueId"]?.jsonPrimitive?.longOrNull ?: 0L,
-                    reportedUserId = obj["reportedUserId"]?.jsonPrimitive?.contentOrNull ?: "",
-                    reportedUserName = obj["reportedUserName"]?.jsonPrimitive?.contentOrNull ?: "",
-                    reportedUserUniqueId = obj["reportedUserUniqueId"]?.jsonPrimitive?.longOrNull ?: 0L,
-                    conversationId = obj["conversationId"]?.jsonPrimitive?.contentOrNull ?: "",
-                    messageId = obj["messageId"]?.jsonPrimitive?.contentOrNull ?: "",
-                    messageText = obj["messageText"]?.jsonPrimitive?.contentOrNull ?: "",
-                    reason = obj["reason"]?.jsonPrimitive?.contentOrNull ?: "",
-                    description = obj["description"]?.jsonPrimitive?.contentOrNull ?: "",
-                    type = obj["type"]?.jsonPrimitive?.contentOrNull ?: "",
-                    timestamp = obj["timestamp"]?.jsonPrimitive?.longOrNull ?: 0L,
-                    status = obj["status"]?.jsonPrimitive?.contentOrNull ?: "pending",
-                )
-            }
+            arr.map { element -> parseReportFromApi(element.jsonObject) }
         }
 
     override suspend fun resolveReport(


### PR DESCRIPTION
## Summary

Two iOS divergences from Android in `getPendingReports` were silently breaking the admin moderation queue on iPhone:

1. **`timestamp` parsed from wrong JSON key.** Express emits `createdAt` (`reports.js:202`); iOS read `obj["timestamp"]` so every report timestamp defaulted to `0L` and the chronological sort was broken.
2. **`type` not lowercased.** Android lowercases at parse-time so admin filters compare case-insensitively; iOS preserved JSON casing → mismatched filter matches.

Extracted the parser into `commonMain` (`parseReportFromApi`) so iOS and tests share one source of truth. 5 new commonTest cases lock down both bug fixes + missing-field defaults. Adds `kotlinx-serialization-json` to commonMain (was previously only on iosMain via ktor transitive).

Plus an AGP deprecation lift the verification build surfaced: `assets.srcDirs(...)` → `assets.directories.add(...)`.

## Test plan
- [x] `./gradlew :app:compileDevDebugKotlin :app:compileLocalDebugAndroidTestKotlin :shared:compileKotlinIosArm64 :shared:compileKotlinJvm testDevDebugUnitTest :shared:jvmTest detekt` — all green, zero `w:` lines
- [x] `ktlint --relative` — clean
- [x] 5 new `ReportJsonParserTest` cases pass
- [ ] Manual QA: load admin report list on iOS — verify timestamps non-zero + chronological sort works (covered by upcoming /manual-qa pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)