### PR TITLE
fix(ios): real deviceId via eager Swift-side compute + BuildVariant slot

### DIFF
--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -45,17 +45,27 @@ struct iOSApp: App {
         // is `local/seed.js` — keep them in sync.
         let emulatorSeed = "localdev123"
         let emulatorEmail = "claude-test@shytalk.dev"
+        // Eager device-ID compute. Calling UIDevice.identifierForVendor
+        // here (after UIApplication setup, before doInitKoin → Firebase init)
+        // is the safe pattern — the previous attempt to read it lazily from
+        // a Koin `single` factory inside AuthViewModel construction crashed
+        // with a K/N CPointer cast bug (PR #406, reverted by 043cdf47ce).
+        // See `project-ios-device-id-revert-rca.md`.
+        let deviceId = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
         KoinHelperKt.doInitKoin(
             useEmulators: true,
             devSignInPassword: emulatorSeed,
-            devSignInEmail: emulatorEmail
+            devSignInEmail: emulatorEmail,
+            deviceId: deviceId
         )
         #else
         FirebaseApp.configure()
+        let deviceId = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
         KoinHelperKt.doInitKoin(
             useEmulators: false,
             devSignInPassword: nil,
-            devSignInEmail: nil
+            devSignInEmail: nil,
+            deviceId: deviceId
         )
         #endif
         setupGoogleSignIn()

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/BuildVariant.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/BuildVariant.kt
@@ -38,6 +38,21 @@ object BuildVariant {
         private set
 
     /**
+     * iOS-only stable per-device identifier, eagerly computed in
+     * `iOSApp.swift` and passed in via `KoinHelper.doInitKoin`. The Koin
+     * factory at `IosPlatformModule.kt`'s `named("deviceId")` reads from
+     * this slot rather than calling `UIDevice.currentDevice.identifierForVendor`
+     * lazily — PR #406 attempted that and crashed the Firebase Firestore
+     * init with a `ClassCastException: HashMap cannot be cast to CPointer`
+     * (K/N + GitLive Firebase + Kotlin 2.4.0-Beta2 timing fragility, see
+     * `project-ios-device-id-revert-rca.md`). On Android this slot is
+     * unused — `Settings.Secure.ANDROID_ID` is read directly elsewhere.
+     */
+    @kotlin.concurrent.Volatile
+    var iosDeviceId: String? = null
+        private set
+
+    /**
      * One-shot initialiser called from platform entry points before UI mounts.
      * Public (rather than `internal`) so the `app` module's MainActivity (and
      * iOS's `KoinHelper.doInitKoin`) can invoke it; the named function makes
@@ -65,5 +80,17 @@ object BuildVariant {
         localDevPassword = devPassword?.takeIf { it.isNotEmpty() }
         localDevEmail = devEmail?.takeIf { it.isNotEmpty() }
         this.googleWebClientId = googleWebClientId?.takeIf { it.isNotEmpty() }
+    }
+
+    /**
+     * One-shot iOS deviceId initialiser. Called from
+     * `KoinHelper.doInitKoin(deviceId = ...)`, which is in turn called from
+     * Swift's `iOSApp.swift` `init()` after `UIApplication` is fully set up
+     * but before Firebase init runs. Empty/blank values are coerced to
+     * null so a downstream `?: error(...)` in the Koin factory fails
+     * loudly rather than passing an empty string to the Express API.
+     */
+    fun initIosDeviceId(value: String?) {
+        iosDeviceId = value?.takeIf { it.isNotBlank() }
     }
 }

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/BuildVariantTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/BuildVariantTest.kt
@@ -11,6 +11,7 @@ class BuildVariantTest {
     @AfterTest
     fun resetState() {
         BuildVariant.initLocalEmulator(false)
+        BuildVariant.initIosDeviceId(null)
     }
 
     @Test
@@ -85,6 +86,43 @@ class BuildVariantTest {
     fun `googleWebClientId coerces empty string to null`() {
         BuildVariant.initLocalEmulator(value = false, googleWebClientId = "")
         assertNull(BuildVariant.googleWebClientId)
+    }
+
+    @Test
+    fun `iosDeviceId defaults to null`() {
+        assertNull(BuildVariant.iosDeviceId)
+    }
+
+    @Test
+    fun `iosDeviceId captures non-blank value`() {
+        BuildVariant.initIosDeviceId("AAAA-BBBB-CCCC-DDDD")
+        assertEquals("AAAA-BBBB-CCCC-DDDD", BuildVariant.iosDeviceId)
+    }
+
+    @Test
+    fun `iosDeviceId coerces empty string to null so Koin factory fails closed`() {
+        BuildVariant.initIosDeviceId("")
+        assertNull(BuildVariant.iosDeviceId)
+    }
+
+    @Test
+    fun `iosDeviceId coerces blank-whitespace string to null`() {
+        // Defends against a future Swift bridge bug that forwards "   " for
+        // a UUID stringification edge case — the Koin factory's `?: error`
+        // fail-closed gate must trigger, not pass a junk ID to the Express
+        // API where it would land in deviceBindings/<deviceId>.
+        BuildVariant.initIosDeviceId("   ")
+        assertNull(BuildVariant.iosDeviceId)
+    }
+
+    @Test
+    fun `iosDeviceId persists independently of initLocalEmulator state`() {
+        // Boot order in iOSApp.swift sets deviceId BEFORE doInitKoin's
+        // emulator flag — verify the deviceId isn't clobbered by a
+        // subsequent initLocalEmulator(false) reset.
+        BuildVariant.initIosDeviceId("device-uuid-1")
+        BuildVariant.initLocalEmulator(value = false, devPassword = null)
+        assertEquals("device-uuid-1", BuildVariant.iosDeviceId)
     }
 
     @Test

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/IosPlatformModule.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/IosPlatformModule.kt
@@ -1,5 +1,6 @@
 package com.shyden.shytalk.core.di
 
+import com.shyden.shytalk.core.BuildVariant
 import com.shyden.shytalk.core.push.PushTokenManager
 import com.shyden.shytalk.core.push.getPushBridge
 import com.shyden.shytalk.core.room.ActiveRoomManager
@@ -91,18 +92,27 @@ val iosPlatformModule =
             )
         }
 
-        // Named qualifiers required by AuthViewModel
-        // Stable per-device identifier: `UIDevice.identifierForVendor` returns
-        // the same UUID for every app from the same vendor on the same device,
-        // and persists across app launches. It IS reset when the user uninstalls
-        // every app from this vendor, which matches Android's `ANDROID_ID`
-        // behaviour after a factory reset / settings reset. Falls back to a
-        // generated UUID if iOS returns null (rare — happens before the device
-        // is unlocked for the first time after boot).
+        // Named qualifiers required by AuthViewModel.
+        //
+        // The deviceId is computed eagerly in `iOSApp.swift` `init()`
+        // (`UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString`),
+        // passed via `KoinHelper.doInitKoin(deviceId:)`, and stored in
+        // `BuildVariant.iosDeviceId`. This Koin factory just reads the
+        // pre-computed value — it does NOT call `UIDevice.currentDevice`
+        // here. A previous attempt to invoke UIKit lazily inside this
+        // factory crashed with `ClassCastException: HashMap cannot be cast
+        // to CPointer` during AuthViewModel construction → Firebase
+        // Firestore init (K/N + GitLive Firebase + Kotlin 2.4.0-Beta2
+        // timing fragility). See `project-ios-device-id-revert-rca.md`.
+        // The `?: error(...)` fail-closed gate surfaces a misconfigured
+        // boot order rather than passing a placeholder to the Express API.
         single(named("deviceId")) {
-            platform.UIKit.UIDevice.currentDevice.identifierForVendor
-                ?.UUIDString
-                ?: platform.Foundation.NSUUID().UUIDString
+            BuildVariant.iosDeviceId
+                ?: error(
+                    "BuildVariant.iosDeviceId not set — iOSApp.swift must call " +
+                        "KoinHelper.doInitKoin(deviceId:) before any Koin " +
+                        "resolution that depends on `named(\"deviceId\")`",
+                )
         }
         single(named("bypassDeviceChecks")) { true }
 

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/KoinHelper.kt
@@ -37,6 +37,7 @@ fun doInitKoin(
     useEmulators: Boolean = false,
     devSignInPassword: String? = null,
     devSignInEmail: String? = null,
+    deviceId: String? = null,
 ) {
     BuildVariant.initLocalEmulator(
         value = useEmulators,
@@ -46,6 +47,13 @@ fun doInitKoin(
         // — the Android-only CredentialManager webClientId is not needed.
         googleWebClientId = null,
     )
+    // Eagerly persist the iOS deviceId before any Firebase / Koin
+    // resolution. PR #406 attempted lazy `UIDevice.identifierForVendor`
+    // inside the Koin factory and crashed with `ClassCastException:
+    // HashMap cannot be cast to CPointer` — see
+    // `project-ios-device-id-revert-rca.md`. Eager Swift-side compute +
+    // BuildVariant slot avoids the K/N + GitLive Firebase init race.
+    BuildVariant.initIosDeviceId(deviceId)
     if (KoinPlatformTools.defaultContext().getOrNull() != null) {
         logI("KoinHelper", "Koin already initialised — skipping")
         return


### PR DESCRIPTION
## Summary

Re-implementation of B6.9 (iOS deviceId) using the eager Swift-side compute + `BuildVariant` slot pattern instead of a lazy UIKit invocation inside the Koin factory.

## Background

PR #406 (2026-04-30) put `UIDevice.identifierForVendor` inside a Koin `single { ... }` factory. That same pattern had crashed the app with `ClassCastException: HashMap cannot be cast to CPointer` during AuthViewModel construction → Firebase Firestore initialization (revert at commit `043cdf47ce`, 2026-04-24). The K/N + GitLive Firebase 2.4.0 + Kotlin 2.4.0-Beta2 interop has a fragile timing window where lazy UIKit calls during Firebase init can corrupt CFType bridges. PR #406 may have shipped working in some cases, but it's playing in the same minefield.

## Fix — same pattern Phases 3-4 used for dev credentials

* `BuildVariant.iosDeviceId` slot (eager-set, blank-coerce-to-null fail-closed)
* `KoinHelper.doInitKoin(deviceId:)` accepts the value before any Firebase init
* `iOSApp.swift` `init()` computes `UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString` after `UIApplication` is set up, passes it in
* `IosPlatformModule.kt` Koin factory just reads `BuildVariant.iosDeviceId ?: error(...)` — no UIKit invocation in the lazy path

## Test plan

- [x] `:shared:compileKotlinIosArm64` — green
- [x] `:app:compileDevDebugKotlin :app:compileLocalDebugAndroidTestKotlin testDevDebugUnitTest :shared:jvmTest detekt` — all green, zero warnings
- [x] `ktlint --relative` — clean
- [x] 5 new `BuildVariantTest` cases: default null, captures non-blank, coerces empty/whitespace to null, persists across re-init
- [ ] Manual QA on real iOS device — verify app launches without ClassCastException AND verify the deviceId binding works on /api/device-info (covered by the upcoming /manual-qa pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)