### PR TITLE
feat(express): Apple App Store receipt validator + platform branch in /economy/purchase (B6.10a)

### DIFF
--- a/express-api/.env.example
+++ b/express-api/.env.example
@@ -77,6 +77,30 @@ API_BASE_URL=https://api.shytalk.shyden.co.uk
 # LibreTranslate instance URL (default: http://localhost:5000)
 LIBRETRANSLATE_URL=http://localhost:5000
 
+# ── Apple App Store / StoreKit 2 receipt verification ────────
+# Required in production for /api/economy/purchase with platform=apple.
+# Without these, iOS purchase verification fails closed (returns 403).
+#
+# Directory containing Apple Root CA certs. Download all four
+# (AppleIncRootCertificate, AppleComputerRootCertificate, AppleRootCA-G2,
+# AppleRootCA-G3) from https://www.apple.com/certificateauthority/
+# and place them in this directory as .cer or .pem files.
+APPLE_ROOT_CERTS_DIR=./certs/apple
+
+# Production or sandbox. Defaults to sandbox so a misconfigured prod
+# deploy fails closed instead of accepting sandbox-signed transactions
+# as real purchases.
+APPLE_APP_STORE_ENV=sandbox
+
+# App Store Connect API credentials (required for refund webhooks /
+# server-side notifications via AppStoreServerAPIClient — not needed
+# for client-forwarded JWS verification handled by SignedDataVerifier).
+# Generate at App Store Connect → Users and Access → Integrations →
+# In-App Purchase. The .p8 private key is single-use download-only.
+# APPLE_APP_STORE_KEY_ID=
+# APPLE_APP_STORE_ISSUER_ID=
+# APPLE_APP_STORE_PRIVATE_KEY=
+
 # ── Testing (dev only) ───────────────────────────────────────
 # API key for test helper endpoints (dev environment only)
 # TEST_API_KEY=your-test-api-key

--- a/express-api/package-lock.json
+++ b/express-api/package-lock.json
@@ -8,6 +8,7 @@
       "name": "shytalk-api",
       "version": "2.0.0",
       "dependencies": {
+        "@apple/app-store-server-library": "^3.0.0",
         "@aws-sdk/client-s3": "^3.1037.0",
         "archiver": "^7.0.1",
         "bcrypt": "^6.0.0",
@@ -33,6 +34,22 @@
         "jest": "^30.2.0",
         "prettier": "^3.8.3",
         "supertest": "^7.2.2"
+      }
+    },
+    "node_modules/@apple/app-store-server-library": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apple/app-store-server-library/-/app-store-server-library-3.0.0.tgz",
+      "integrity": "sha512-H7WYYxA5PXXDjTA0WPa2e+8yQzY3loXF+71PslshJgggJnR0Dpt5bZFCTEYC542Rx03wmnj5e4PHk0AWaU9hFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.5",
+        "@types/jsrsasign": "^10.5.12",
+        "@types/node": "^25.4.0",
+        "@types/node-fetch": "^2.6.13",
+        "base64url": "^3.0.1",
+        "jsonwebtoken": "^9.0.2",
+        "jsrsasign": "^11.0.0",
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -3950,6 +3967,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/jsrsasign": {
+      "version": "10.5.15",
+      "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.15.tgz",
+      "integrity": "sha512-3stUTaSRtN09PPzVWR6aySD9gNnuymz+WviNHoTb85dKu+BjaV4uBbWWGykBBJkfwPtcNZVfTn2lbX00U+yhpQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -3970,6 +3993,53 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@types/request": {
@@ -4557,7 +4627,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/b4a": {
@@ -4789,6 +4858,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.8",
@@ -5267,7 +5345,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -5534,7 +5611,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -5728,7 +5804,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7021,7 +7096,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -8164,6 +8238,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/jsrsasign": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.3.tgz",
+      "integrity": "sha512-nPnK5D/4lv0Dwr7TlzrKtAd8JlLZwFTqTUUB3NQCbtdobcRcohGFxjbPySDVh74iWUudcCsapYT6OxoyhJLhhA==",
+      "license": "MIT"
+    },
     "node_modules/jsx-ast-utils-x": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
@@ -8762,7 +8842,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -10333,8 +10412,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -10582,8 +10660,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -10613,7 +10690,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/express-api/package.json
+++ b/express-api/package.json
@@ -16,6 +16,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@apple/app-store-server-library": "^3.0.0",
     "@aws-sdk/client-s3": "^3.1037.0",
     "archiver": "^7.0.1",
     "bcrypt": "^6.0.0",

--- a/express-api/src/routes/economy.js
+++ b/express-api/src/routes/economy.js
@@ -27,6 +27,7 @@ const { generateId, now, todayStr, yesterdayStr } = require('../utils/helpers');
 const { requireAdmin } = require('../middleware/auth');
 const log = require('../utils/log');
 const { verifyProductPurchase, verifySubscription } = require('../utils/playStore');
+const { verifyApplePurchase } = require('../utils/appleStore');
 
 // ─── Constants ────────────────────────────────────────────────────
 
@@ -1272,10 +1273,14 @@ router.post('/economy/purchase', async (req, res) => {
   try {
     const uniqueId = req.auth.uniqueId;
     const body = req.body;
-    const { productId, purchaseToken, isSubscription } = body || {};
+    const { productId, purchaseToken, isSubscription, platform } = body || {};
 
     if (!productId || !purchaseToken)
       return res.status(400).json({ error: 'productId and purchaseToken required' });
+
+    // Default to Google Play for backward-compat — every Android client
+    // historically omitted the field. iOS clients MUST send `platform: 'apple'`.
+    const purchasePlatform = platform === 'apple' ? 'apple' : 'google';
 
     // Check for duplicate purchase token to prevent replay attacks
     const existingSnap = await db
@@ -1288,12 +1293,17 @@ router.post('/economy/purchase', async (req, res) => {
       return res.status(409).json({ error: 'Purchase already processed' });
     }
 
-    // Verify purchase with Google Play
+    // Verify purchase with the appropriate store (Google Play or Apple App Store)
     const packageName = 'com.shyden.shytalk';
     let verification;
     if (process.env.NODE_ENV === 'production') {
       try {
-        if (isSubscription) {
+        if (purchasePlatform === 'apple') {
+          // iOS sends `Transaction.jwsRepresentation` as `purchaseToken`.
+          // verifyApplePurchase enforces bundleId, productId, revocation,
+          // and (for subs) expiry — see appleStore.js.
+          verification = await verifyApplePurchase(productId, purchaseToken, !!isSubscription);
+        } else if (isSubscription) {
           verification = await verifySubscription(packageName, productId, purchaseToken);
         } else {
           verification = await verifyProductPurchase(packageName, productId, purchaseToken);
@@ -1302,6 +1312,7 @@ router.post('/economy/purchase', async (req, res) => {
         log.warn('economy', 'Purchase verification rejected', {
           userId: uniqueId,
           productId,
+          platform: purchasePlatform,
           isSubscription: !!isSubscription,
           error: verifyErr.message,
         });
@@ -1311,6 +1322,7 @@ router.post('/economy/purchase', async (req, res) => {
       log.warn('economy', 'Skipping purchase verification in non-production environment', {
         userId: uniqueId,
         productId,
+        platform: purchasePlatform,
         isSubscription: !!isSubscription,
       });
       verification = { orderId: 'dev-unverified' };
@@ -1324,6 +1336,7 @@ router.post('/economy/purchase', async (req, res) => {
       userId: uniqueId,
       productId,
       purchaseToken,
+      platform: purchasePlatform,
       isSubscription: !!isSubscription,
       createdAt: now(),
       verified: true,

--- a/express-api/src/utils/appleStore.js
+++ b/express-api/src/utils/appleStore.js
@@ -1,0 +1,157 @@
+/**
+ * Apple App Store StoreKit 2 receipt verification.
+ *
+ * iOS clients send `Transaction.jwsRepresentation` (a signed JWS payload)
+ * as the `purchaseToken`. Server-side we use the official Apple library
+ * `@apple/app-store-server-library` to verify the JWS signature against
+ * Apple's root CA certificates, decode the transaction, and validate
+ * bundleId / productId / revocationReason. Mirrors the role of
+ * `playStore.js` for Google Play.
+ *
+ * **Required environment variables (production):**
+ * - `APPLE_ROOT_CERTS_DIR` — directory containing Apple Root CA certs
+ *   (`AppleRootCA-G3.cer`, `AppleRootCA-G2.cer`, plus the legacy
+ *   `AppleIncRootCertificate.cer` and `AppleComputerRootCertificate.cer`).
+ *   Download from {@link https://www.apple.com/certificateauthority/}.
+ * - `APPLE_APP_STORE_ENV` — `production` or `sandbox` (defaults to
+ *   `sandbox` so a misconfigured prod deploy fails closed instead of
+ *   accepting sandbox-signed transactions as real purchases).
+ *
+ * Note: This module verifies signed transactions the client passes in.
+ * For server-side App Store Server Notifications (refund webhooks,
+ * subscription renewals), use `AppStoreServerAPIClient` separately —
+ * that path also needs `APPLE_APP_STORE_KEY_ID`, `APPLE_APP_STORE_ISSUER_ID`,
+ * `APPLE_APP_STORE_PRIVATE_KEY` (the P8 private key downloaded from
+ * App Store Connect → Users and Access → Integrations → In-App Purchase).
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { SignedDataVerifier, Environment } = require('@apple/app-store-server-library');
+const log = require('./log');
+
+const BUNDLE_ID = 'com.shyden.shytalk';
+
+let verifier = null;
+
+function getVerifier() {
+  if (verifier) return verifier;
+
+  const certsDir = process.env.APPLE_ROOT_CERTS_DIR;
+  if (!certsDir) {
+    throw new Error(
+      'APPLE_ROOT_CERTS_DIR environment variable is required — set to a directory ' +
+        'containing the Apple Root CA certificates (downloadable from ' +
+        'https://www.apple.com/certificateauthority/). Defence-in-depth fail-closed ' +
+        'so a misconfigured prod deploy never accepts unverified Apple receipts.',
+    );
+  }
+
+  const certFiles = fs
+    .readdirSync(certsDir)
+    .filter((f) => f.endsWith('.cer') || f.endsWith('.pem'));
+
+  if (certFiles.length === 0) {
+    throw new Error(
+      `APPLE_ROOT_CERTS_DIR (${certsDir}) contains no .cer or .pem files — ` +
+        'cannot construct SignedDataVerifier without Apple root certs.',
+    );
+  }
+
+  const rootCerts = certFiles.map((f) => fs.readFileSync(path.join(certsDir, f)));
+
+  // Default to SANDBOX so a misconfigured prod environment that forgot the
+  // env var doesn't accept real-money purchases without verification —
+  // sandbox-signed JWS payloads will fail the signature check against
+  // production root certs.
+  const environment =
+    process.env.APPLE_APP_STORE_ENV === 'production' ? Environment.PRODUCTION : Environment.SANDBOX;
+
+  // SignedDataVerifier(rootCerts, performOnlineRevocationChecking, environment, bundleId)
+  verifier = new SignedDataVerifier(rootCerts, true, environment, BUNDLE_ID);
+  return verifier;
+}
+
+/**
+ * Verify an Apple StoreKit 2 signed transaction and return normalised data.
+ *
+ * @param {string} expectedProductId - Product ID the client claimed to purchase
+ * @param {string} signedTransactionInfo - JWS from `Transaction.jwsRepresentation`
+ * @param {boolean} isSubscription - Whether this is a subscription product
+ * @returns {Promise<{orderId: string, productId: string, purchaseDate: number, expiresDate?: number}>}
+ * @throws {Error} If JWS signature is invalid, productId/bundleId mismatch, transaction revoked, or subscription expired
+ */
+async function verifyApplePurchase(expectedProductId, signedTransactionInfo, isSubscription) {
+  const v = getVerifier();
+  const transaction = await v.verifyAndDecodeTransaction(signedTransactionInfo);
+
+  // The library already enforces bundleId at the SignedDataVerifier level, but
+  // re-check here so a future library version that loosens this contract still
+  // fails closed at our layer.
+  if (transaction.bundleId !== BUNDLE_ID) {
+    log.warn('appleStore', 'bundleId mismatch in verified transaction', {
+      expectedBundleId: BUNDLE_ID,
+      actualBundleId: transaction.bundleId,
+      productId: transaction.productId,
+    });
+    throw new Error(
+      `Apple transaction bundleId mismatch: expected ${BUNDLE_ID}, got ${transaction.bundleId}`,
+    );
+  }
+
+  if (transaction.productId !== expectedProductId) {
+    log.warn('appleStore', 'productId mismatch in verified transaction', {
+      expectedProductId,
+      actualProductId: transaction.productId,
+      orderId: transaction.transactionId,
+    });
+    throw new Error(
+      `Apple transaction productId mismatch: expected ${expectedProductId}, got ${transaction.productId}`,
+    );
+  }
+
+  // Reject refunds and family-share revokes — `revocationReason` is a number
+  // (1 = refund, 2 = family-share revoke, etc.) per Apple's docs. Both `null`
+  // and `undefined` mean "not revoked".
+  if (transaction.revocationReason !== undefined && transaction.revocationReason !== null) {
+    log.warn('appleStore', 'transaction revoked', {
+      productId: transaction.productId,
+      orderId: transaction.transactionId,
+      revocationReason: transaction.revocationReason,
+    });
+    throw new Error(
+      `Apple transaction revoked (reason=${transaction.revocationReason}, ` +
+        `orderId=${transaction.transactionId})`,
+    );
+  }
+
+  // For subscriptions, refuse expired tokens at validation time. The client
+  // shouldn't send expired tokens, but this is the server-side guarantee the
+  // grant logic relies on.
+  if (isSubscription && transaction.expiresDate) {
+    const now = Date.now();
+    if (transaction.expiresDate < now) {
+      log.warn('appleStore', 'subscription transaction expired', {
+        productId: transaction.productId,
+        orderId: transaction.transactionId,
+        expiresDate: transaction.expiresDate,
+        now,
+      });
+      throw new Error(`Apple subscription expired at ${transaction.expiresDate} (now=${now})`);
+    }
+  }
+
+  return {
+    orderId: transaction.transactionId,
+    productId: transaction.productId,
+    purchaseDate: transaction.purchaseDate,
+    expiresDate: transaction.expiresDate,
+  };
+}
+
+// Exposed for testing — allows resetting the cached verifier instance
+function _resetVerifier() {
+  verifier = null;
+}
+
+module.exports = { verifyApplePurchase, _resetVerifier };

--- a/express-api/tests/routes/economy-purchase.test.js
+++ b/express-api/tests/routes/economy-purchase.test.js
@@ -80,6 +80,12 @@ jest.mock('../../src/utils/playStore', () => ({
   verifySubscription: jest.fn(),
 }));
 
+// appleStore likewise — iOS purchase verification needs Apple root certs
+// in production; tests stay decoupled from real cert files.
+jest.mock('../../src/utils/appleStore', () => ({
+  verifyApplePurchase: jest.fn(),
+}));
+
 jest.mock('../../src/utils/log', () => ({
   info: jest.fn(),
   warn: jest.fn(),
@@ -371,9 +377,157 @@ describe('POST /api/economy/purchase', () => {
         userId: 'user-A',
         productId: 'coins_100',
         purchaseToken: 'receipt-token',
+        platform: 'google',
         verified: true,
       }),
     );
+  });
+
+  // ─── Apple / iOS branch ────────────────────────────────────────
+
+  describe('platform=apple branch', () => {
+    const { verifyApplePurchase } = require('../../src/utils/appleStore');
+    const { verifyProductPurchase } = require('../../src/utils/playStore');
+
+    test('routes consumable purchase through verifyApplePurchase, NOT playStore', async () => {
+      let collectionCallCount = 0;
+      mockCollectionGet = jest.fn().mockImplementation(() => {
+        collectionCallCount++;
+        if (collectionCallCount === 1) return Promise.resolve({ empty: true, docs: [] });
+        return Promise.resolve({
+          empty: false,
+          docs: [
+            {
+              id: 'pkg-100',
+              data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 0 }),
+            },
+          ],
+        });
+      });
+      mockDocGet.mockResolvedValue({ exists: true, data: () => ({ shyCoins: 0, shyBeans: 0 }) });
+
+      // Force production branch — non-prod skips verification entirely.
+      const prevEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      verifyApplePurchase.mockResolvedValueOnce({
+        orderId: '2000000123456789',
+        productId: 'coins_100',
+        purchaseDate: 1700000000000,
+      });
+
+      try {
+        const app = createApp('user-A');
+        const res = await request(app).post('/api/economy/purchase').send({
+          productId: 'coins_100',
+          purchaseToken: 'mock-jws-payload',
+          platform: 'apple',
+        });
+        expect(res.status).toBe(200);
+        expect(verifyApplePurchase).toHaveBeenCalledWith('coins_100', 'mock-jws-payload', false);
+        expect(verifyProductPurchase).not.toHaveBeenCalled();
+      } finally {
+        process.env.NODE_ENV = prevEnv;
+      }
+    });
+
+    test('records platform: apple on the purchaseReceipts doc', async () => {
+      let collectionCallCount = 0;
+      mockCollectionGet = jest.fn().mockImplementation(() => {
+        collectionCallCount++;
+        if (collectionCallCount === 1) return Promise.resolve({ empty: true, docs: [] });
+        return Promise.resolve({
+          empty: false,
+          docs: [
+            {
+              id: 'pkg-100',
+              data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 0 }),
+            },
+          ],
+        });
+      });
+      mockDocGet.mockResolvedValue({ exists: true, data: () => ({ shyCoins: 0, shyBeans: 0 }) });
+
+      const prevEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      verifyApplePurchase.mockResolvedValueOnce({
+        orderId: '2000000abcdef',
+        productId: 'coins_100',
+        purchaseDate: 1700000000000,
+      });
+
+      try {
+        const app = createApp('user-A');
+        await request(app)
+          .post('/api/economy/purchase')
+          .send({
+            productId: 'coins_100',
+            purchaseToken: 'mock-jws',
+            platform: 'apple',
+          })
+          .expect(200);
+
+        expect(mockDocSet).toHaveBeenCalledWith(
+          expect.objectContaining({
+            platform: 'apple',
+            orderId: '2000000abcdef',
+          }),
+        );
+      } finally {
+        process.env.NODE_ENV = prevEnv;
+      }
+    });
+
+    test('returns 403 when verifyApplePurchase rejects (e.g. revoked transaction)', async () => {
+      mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
+
+      const prevEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      verifyApplePurchase.mockRejectedValueOnce(new Error('Apple transaction revoked'));
+
+      try {
+        const app = createApp('user-A');
+        const res = await request(app).post('/api/economy/purchase').send({
+          productId: 'coins_100',
+          purchaseToken: 'mock-jws',
+          platform: 'apple',
+        });
+        expect(res.status).toBe(403);
+        expect(res.body.error).toMatch(/verification failed/i);
+      } finally {
+        process.env.NODE_ENV = prevEnv;
+      }
+    });
+
+    test('routes subscription through verifyApplePurchase with isSubscription=true', async () => {
+      mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
+      mockDocGet.mockResolvedValue({ exists: true, data: () => ({}) });
+
+      const prevEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      verifyApplePurchase.mockResolvedValueOnce({
+        orderId: '2000000sub',
+        productId: 'super_shy_monthly',
+        purchaseDate: 1700000000000,
+        expiresDate: 1700000000000 + 30 * 86400000,
+      });
+
+      try {
+        const app = createApp('user-A');
+        await request(app)
+          .post('/api/economy/purchase')
+          .send({
+            productId: 'super_shy_monthly',
+            purchaseToken: 'mock-jws-sub',
+            platform: 'apple',
+            isSubscription: true,
+          })
+          .expect(200);
+
+        expect(verifyApplePurchase).toHaveBeenCalledWith('super_shy_monthly', 'mock-jws-sub', true);
+      } finally {
+        process.env.NODE_ENV = prevEnv;
+      }
+    });
   });
 });
 

--- a/express-api/tests/utils/appleStore.test.js
+++ b/express-api/tests/utils/appleStore.test.js
@@ -1,0 +1,226 @@
+// Mock the Apple library before requiring the validator. The real
+// `SignedDataVerifier` needs Apple root CA certs + a signed JWS to verify
+// against — neither of which is practical to produce in CI. Our wrapper's
+// job is the validation logic ON TOP of `verifyAndDecodeTransaction`'s
+// output (productId match, revocation, subscription expiry, bundleId), so
+// we mock the library and unit-test our wrapper.
+
+const mockVerifyAndDecodeTransaction = jest.fn();
+
+jest.mock('@apple/app-store-server-library', () => ({
+  SignedDataVerifier: jest.fn().mockImplementation(() => ({
+    verifyAndDecodeTransaction: mockVerifyAndDecodeTransaction,
+  })),
+  Environment: { PRODUCTION: 'PRODUCTION', SANDBOX: 'SANDBOX' },
+  VerificationException: class VerificationException extends Error {
+    constructor(message, status) {
+      super(message);
+      this.status = status;
+    }
+  },
+  VerificationStatus: {
+    OK: 0,
+    INVALID_SIGNATURE: 1,
+    INVALID_CERTIFICATE: 2,
+    INVALID_CHAIN_LENGTH: 3,
+    INVALID_CHAIN: 4,
+  },
+}));
+
+jest.mock('node:fs', () => ({
+  readdirSync: jest.fn().mockReturnValue(['AppleRootCA-G3.cer']),
+  readFileSync: jest.fn().mockReturnValue(Buffer.from('mock-cert')),
+  existsSync: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const { verifyApplePurchase, _resetVerifier } = require('../../src/utils/appleStore');
+const log = require('../../src/utils/log');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _resetVerifier();
+  process.env.APPLE_ROOT_CERTS_DIR = '/mock/apple-certs';
+  process.env.APPLE_APP_STORE_ENV = 'sandbox';
+});
+
+afterEach(() => {
+  delete process.env.APPLE_ROOT_CERTS_DIR;
+  delete process.env.APPLE_APP_STORE_ENV;
+});
+
+// ─── Happy paths ──────────────────────────────────────────────
+
+describe('verifyApplePurchase — consumable (one-shot purchase)', () => {
+  test('returns normalised purchase data on valid JWS', async () => {
+    const jws = 'mock-jws-payload';
+    mockVerifyAndDecodeTransaction.mockResolvedValueOnce({
+      transactionId: '2000000123456789',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+      purchaseDate: 1700000000000,
+      expiresDate: undefined,
+      revocationReason: undefined,
+    });
+
+    const result = await verifyApplePurchase('medium_pack', jws, false);
+
+    expect(result.orderId).toBe('2000000123456789');
+    expect(result.productId).toBe('medium_pack');
+    expect(result.purchaseDate).toBe(1700000000000);
+    expect(mockVerifyAndDecodeTransaction).toHaveBeenCalledWith(jws);
+  });
+});
+
+describe('verifyApplePurchase — subscription (auto-renewable)', () => {
+  test('returns normalised purchase data on valid active subscription', async () => {
+    const jws = 'mock-jws-sub';
+    const expiresDate = Date.now() + 30 * 24 * 60 * 60 * 1000; // 30 days
+    mockVerifyAndDecodeTransaction.mockResolvedValueOnce({
+      transactionId: '2000000999999999',
+      productId: 'super_shy_monthly',
+      bundleId: 'com.shyden.shytalk',
+      purchaseDate: Date.now(),
+      expiresDate,
+      revocationReason: undefined,
+    });
+
+    const result = await verifyApplePurchase('super_shy_monthly', jws, true);
+
+    expect(result.orderId).toBe('2000000999999999');
+    expect(result.productId).toBe('super_shy_monthly');
+    expect(result.expiresDate).toBe(expiresDate);
+  });
+});
+
+// ─── Rejection paths ──────────────────────────────────────────
+
+describe('verifyApplePurchase — rejection paths', () => {
+  test('rejects when productId in JWS does not match expected', async () => {
+    mockVerifyAndDecodeTransaction.mockResolvedValueOnce({
+      transactionId: '2000000111111111',
+      productId: 'small_pack',
+      bundleId: 'com.shyden.shytalk',
+      purchaseDate: 1700000000000,
+    });
+
+    await expect(verifyApplePurchase('large_pack', 'mock-jws', false)).rejects.toThrow(
+      /productId mismatch/i,
+    );
+    expect(log.warn).toHaveBeenCalled();
+  });
+
+  test('rejects when transaction is revoked (refund or family-share revoke)', async () => {
+    mockVerifyAndDecodeTransaction.mockResolvedValueOnce({
+      transactionId: '2000000222222222',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+      purchaseDate: 1700000000000,
+      revocationReason: 1, // Apple: refund
+    });
+
+    await expect(verifyApplePurchase('medium_pack', 'mock-jws', false)).rejects.toThrow(/revoked/i);
+  });
+
+  test('rejects expired subscription', async () => {
+    mockVerifyAndDecodeTransaction.mockResolvedValueOnce({
+      transactionId: '2000000333333333',
+      productId: 'super_shy_monthly',
+      bundleId: 'com.shyden.shytalk',
+      purchaseDate: 1700000000000,
+      expiresDate: 1700000000000, // way in the past
+    });
+
+    await expect(verifyApplePurchase('super_shy_monthly', 'mock-jws', true)).rejects.toThrow(
+      /expired/i,
+    );
+  });
+
+  test('rejects bundleId mismatch (defence-in-depth — verifier already enforces this)', async () => {
+    mockVerifyAndDecodeTransaction.mockResolvedValueOnce({
+      transactionId: '2000000444444444',
+      productId: 'medium_pack',
+      bundleId: 'com.example.spoofed',
+      purchaseDate: 1700000000000,
+    });
+
+    await expect(verifyApplePurchase('medium_pack', 'mock-jws', false)).rejects.toThrow(
+      /bundleId mismatch/i,
+    );
+  });
+
+  test('propagates VerificationException from the Apple library', async () => {
+    const { VerificationException } = require('@apple/app-store-server-library');
+    mockVerifyAndDecodeTransaction.mockRejectedValueOnce(
+      new VerificationException('Invalid signature', 1),
+    );
+
+    await expect(verifyApplePurchase('medium_pack', 'bad-jws', false)).rejects.toThrow(
+      /Invalid signature/,
+    );
+  });
+});
+
+// ─── Configuration ────────────────────────────────────────────
+
+describe('verifyApplePurchase — configuration', () => {
+  test('throws fast when APPLE_ROOT_CERTS_DIR is unset', async () => {
+    delete process.env.APPLE_ROOT_CERTS_DIR;
+    _resetVerifier();
+
+    await expect(verifyApplePurchase('medium_pack', 'mock-jws', false)).rejects.toThrow(
+      /APPLE_ROOT_CERTS_DIR/,
+    );
+  });
+
+  test('uses PRODUCTION environment when APPLE_APP_STORE_ENV=production', async () => {
+    process.env.APPLE_APP_STORE_ENV = 'production';
+    _resetVerifier();
+    const { SignedDataVerifier } = require('@apple/app-store-server-library');
+
+    mockVerifyAndDecodeTransaction.mockResolvedValueOnce({
+      transactionId: 'x',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+      purchaseDate: 1,
+    });
+
+    await verifyApplePurchase('medium_pack', 'mock-jws', false);
+
+    // SignedDataVerifier(rootCerts, performRevocationChecking, environment, bundleId)
+    expect(SignedDataVerifier).toHaveBeenCalledWith(
+      expect.any(Array),
+      true,
+      'PRODUCTION',
+      'com.shyden.shytalk',
+    );
+  });
+
+  test('uses SANDBOX environment by default', async () => {
+    delete process.env.APPLE_APP_STORE_ENV;
+    _resetVerifier();
+    const { SignedDataVerifier } = require('@apple/app-store-server-library');
+
+    mockVerifyAndDecodeTransaction.mockResolvedValueOnce({
+      transactionId: 'x',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+      purchaseDate: 1,
+    });
+
+    await verifyApplePurchase('medium_pack', 'mock-jws', false);
+
+    expect(SignedDataVerifier).toHaveBeenCalledWith(
+      expect.any(Array),
+      true,
+      'SANDBOX',
+      'com.shyden.shytalk',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

First of three PRs to unblock B6.10 (iOS StoreKit billing). This PR is the **Express side** — server-side verification of Apple StoreKit 2 signed transactions and the platform branch in `/economy/purchase` so iOS clients can join the existing flow.

## Changes

* `express-api/src/utils/appleStore.js` (new) — `verifyApplePurchase` using `@apple/app-store-server-library` 3.0.0's `SignedDataVerifier`. Validates JWS signature against Apple Root CA certs, then enforces bundleId, productId, revocationReason, and (for subs) expiry. Defaults to SANDBOX env so a misconfigured prod deploy fails closed.
* `economy.js /economy/purchase` — reads optional `platform` field. iOS sends `platform: 'apple'`; Android omits it (defaults to `'google'` for back-compat). `purchaseReceipts/<id>` now records `platform`.
* 14 new tests (10 unit + 4 integration). 4397 Express tests pass total, no regressions.

## Setup steps (manual, one-time, before iOS purchases work in prod)

1. Apple Developer Program membership (you confirmed this exists)
2. App Store Connect record for `com.shyden.shytalk`, banking/tax forms `Active`
3. Create 7 IAP products with matching SKUs to Google Play
4. Download 4 Apple Root CA certs from https://www.apple.com/certificateauthority/ → place in `\$APPLE_ROOT_CERTS_DIR` on the prod VM
5. Set `APPLE_APP_STORE_ENV=production`

## Test plan

- [x] `npm test` — 4397 / 179 suites pass
- [x] Prettier + ESLint clean
- [ ] CI all green
- [ ] Manual smoke test against sandbox once IAP products + Apple root certs are configured (will be part of /manual-qa)

Next PRs: **B6.10b** (iOS StoreKit 2 bridge), **B6.10c** (refund/Transaction.updates listener).

🤖 Generated with [Claude Code](https://claude.com/claude-code)