### PR TITLE
feat(express): Apple App Store Server Notifications V2 webhook (B6.10c of #20)

### DIFF
--- a/express-api/.env.example
+++ b/express-api/.env.example
@@ -92,6 +92,13 @@ APPLE_ROOT_CERTS_DIR=./certs/apple
 # as real purchases.
 APPLE_APP_STORE_ENV=sandbox
 
+# Numeric Apple App ID from App Store Connect → App Information →
+# "Apple ID". Required when APPLE_APP_STORE_ENV=production — Apple's
+# SignedDataVerifier constructor throws without it in PRODUCTION mode,
+# and the notification verifier uses it to bind the JWS to our specific
+# app identity. Not required for sandbox.
+# APPLE_APP_STORE_APP_ID=
+
 # App Store Connect API credentials (required for refund webhooks /
 # server-side notifications via AppStoreServerAPIClient — not needed
 # for client-forwarded JWS verification handled by SignedDataVerifier).

--- a/express-api/src/index.js
+++ b/express-api/src/index.js
@@ -154,6 +154,7 @@ app.use('/api', portalRoutes);
 app.use('/api', require('./routes/config'));
 app.use('/api', require('./routes/users'));
 app.use('/api', require('./routes/economy'));
+app.use('/api', require('./routes/apple-notifications'));
 app.use('/api', require('./routes/livekit'));
 app.use('/api', require('./routes/reports'));
 app.use('/api', require('./routes/notifications'));

--- a/express-api/src/index.js
+++ b/express-api/src/index.js
@@ -90,6 +90,10 @@ app.use('/api', (req, res, next) => {
       req.path !== '/suggestions/mine') ||
     // One-click email unsubscribe (token-based, no auth)
     (req.method === 'POST' && req.path === '/subscriptions/unsubscribe') ||
+    // Apple App Store Server Notifications V2 webhook — auth is the JWS
+    // signature verified inside the route, not a Bearer token (Apple does
+    // not send one). Without this skip, every notification would 401.
+    (req.method === 'POST' && req.path === '/apple-notifications/v2') ||
     // Portal TOTP recovery (unauthenticated — user has lost their TOTP device)
     req.path.startsWith('/portal/totp-recovery/')
   )

--- a/express-api/src/routes/apple-notifications.js
+++ b/express-api/src/routes/apple-notifications.js
@@ -1,0 +1,321 @@
+/**
+ * Apple App Store Server Notifications V2 webhook receiver.
+ *
+ * Apple POSTs signed JWS payloads to this endpoint when subscription /
+ * purchase events happen server-side (refunds, renewals, revokes, etc.).
+ * This is the **authoritative** path for refund handling — `Transaction.updates`
+ * on the iOS client is a redundancy that only fires while the app is
+ * running.
+ *
+ * **Setup (manual, one-time):** in App Store Connect → App Information →
+ * App Store Server Notifications, set production + sandbox notification
+ * URLs to the prod and dev API base URLs respectively, both with the path
+ * `/api/apple-notifications/v2` (e.g. on local dev:
+ * `http://localhost:3000/api/apple-notifications/v2` via an ngrok tunnel
+ * if Apple needs to reach it).
+ *
+ * Idempotency: Apple may retry up to 5 times. Dedupe by `notificationUUID`
+ * stored in `appleNotifications/<uuid>`. Repeated POSTs of the same
+ * notification return 200 immediately without re-applying the side effect.
+ */
+
+const express = require('express');
+const router = express.Router();
+const { db, FieldValue } = require('../utils/firebase');
+const log = require('../utils/log');
+const { generateId, now } = require('../utils/helpers');
+const { verifyAppleNotification, verifyAppleSignedTransaction } = require('../utils/appleStore');
+
+// Subscription productId → tier mapping (mirrors economy.js purchase grant logic).
+const SUBSCRIPTION_TIERS = {
+  super_shy_monthly: { tier: 'monthly', days: 30 },
+  super_shy_yearly: { tier: 'yearly', days: 365 },
+  super_shy_lifetime: { tier: 'lifetime', days: null },
+};
+
+/**
+ * Look up the user that originally received the entitlement for a given
+ * Apple transaction, by joining on `purchaseReceipts.orderId` (which we
+ * record at /economy/purchase time as `transaction.transactionId`).
+ *
+ * Apple notifications can carry `originalTransactionId` (the ID of the
+ * first purchase in a subscription chain) plus a fresh `transactionId`
+ * for the renewal event — try both so renewal/refund notifications find
+ * the right user even when the receipt was recorded under the original.
+ */
+async function findUserAndReceipt(transaction) {
+  const candidateOrderIds = [transaction.transactionId, transaction.originalTransactionId].filter(
+    Boolean,
+  );
+  for (const orderId of candidateOrderIds) {
+    const snap = await db
+      .collection('purchaseReceipts')
+      .where('orderId', '==', orderId)
+      .limit(1)
+      .get();
+    if (!snap.empty) {
+      const doc = snap.docs[0];
+      return { receiptId: doc.id, receipt: doc.data(), userId: doc.data().userId };
+    }
+  }
+  return null;
+}
+
+/**
+ * Reverse a coin-pack purchase. Decrement coins, write a REFUND
+ * transaction. Coins go negative if the user has already spent them —
+ * the in-arrears state is intentional (we can't claw back spent coins,
+ * but the negative balance prevents further spending until topped up).
+ */
+async function reverseCoinPackEntitlement(receipt, transaction) {
+  const userId = receipt.userId;
+  const productId = transaction.productId;
+
+  const pkgSnap = await db
+    .collection('coinPackages')
+    .where('productId', '==', productId)
+    .limit(1)
+    .get();
+  if (pkgSnap.empty) {
+    log.warn('apple-notifications', 'Refund for unknown coin package', { productId, userId });
+    return;
+  }
+  const pkg = pkgSnap.docs[0].data();
+  const totalCoins = (pkg.coins || 0) + (pkg.bonusCoins || 0);
+
+  await db.doc(`users/${userId}`).update({
+    shyCoins: FieldValue.increment(-totalCoins),
+  });
+
+  const userSnap = await db.doc(`users/${userId}`).get();
+  const balanceAfter = userSnap.exists ? userSnap.data().shyCoins || 0 : 0;
+
+  await db.doc(`users/${userId}/transactions/${generateId()}`).set({
+    type: 'REFUND',
+    amount: -totalCoins,
+    currency: 'COINS',
+    balanceAfter,
+    details: `Refund: ${pkg.coins} + ${pkg.bonusCoins || 0} bonus coins (${productId})`,
+    timestamp: now(),
+    originOrderId: transaction.transactionId,
+  });
+
+  log.info('apple-notifications', 'Reversed coin-pack entitlement', {
+    userId,
+    productId,
+    coinsRemoved: totalCoins,
+    balanceAfter,
+  });
+}
+
+/**
+ * Reverse a subscription purchase. Clear isSuperShy / superShyExpiry /
+ * superShyTier and write a REFUND transaction. Refunds for subscriptions
+ * always end the entitlement immediately regardless of expiry date —
+ * matches Apple's UX where the user gets the money back AND loses access.
+ */
+async function reverseSubscriptionEntitlement(receipt, transaction) {
+  const userId = receipt.userId;
+  const productId = transaction.productId;
+  const sub = SUBSCRIPTION_TIERS[productId];
+  if (!sub) {
+    log.warn('apple-notifications', 'Refund for unknown subscription', { productId, userId });
+    return;
+  }
+
+  await db.doc(`users/${userId}`).update({
+    isSuperShy: false,
+    superShyExpiry: null,
+    superShyTier: null,
+  });
+
+  await db.doc(`users/${userId}/transactions/${generateId()}`).set({
+    type: 'REFUND',
+    amount: 0,
+    currency: 'COINS',
+    balanceAfter: 0,
+    details: `Subscription refund: Super Shy ${sub.tier} (${productId})`,
+    timestamp: now(),
+    originOrderId: transaction.transactionId,
+  });
+
+  log.info('apple-notifications', 'Reversed subscription entitlement', {
+    userId,
+    productId,
+    tier: sub.tier,
+  });
+}
+
+/**
+ * Apply a notification's side effect. Switch on `notificationType`.
+ * Unknown types are logged and acknowledged — Apple expects 200 so it
+ * doesn't keep retrying.
+ */
+async function handleNotification(notification, transaction) {
+  const { notificationType } = notification;
+
+  // REFUND/REVOKE/REFUND_REVERSED/EXPIRED/DID_FAIL_TO_RENEW all need a
+  // transaction to identify the affected user. If absent, ack and log so
+  // Apple stops retrying — there's nothing actionable.
+  const needsTransaction = [
+    'REFUND',
+    'REVOKE',
+    'REFUND_REVERSED',
+    'EXPIRED',
+    'DID_FAIL_TO_RENEW',
+  ].includes(notificationType);
+  if (needsTransaction && !transaction) {
+    log.warn('apple-notifications', 'Notification of impactful type missing transaction', {
+      notificationType,
+      notificationUUID: notification.notificationUUID,
+    });
+    return;
+  }
+
+  switch (notificationType) {
+    case 'REFUND':
+    case 'REVOKE': {
+      const found = await findUserAndReceipt(transaction);
+      if (!found) {
+        log.warn('apple-notifications', 'No purchaseReceipt found for refund/revoke', {
+          orderId: transaction.transactionId,
+          originalTransactionId: transaction.originalTransactionId,
+          productId: transaction.productId,
+        });
+        return;
+      }
+      if (found.receipt.isSubscription) {
+        await reverseSubscriptionEntitlement(found.receipt, transaction);
+      } else {
+        await reverseCoinPackEntitlement(found.receipt, transaction);
+      }
+      break;
+    }
+
+    case 'REFUND_REVERSED':
+      // Apple un-refunded — the entitlement should be restored. Re-running
+      // the original grant is the cleanest path; leaving as TODO for now
+      // since this is rare and needs careful idempotency design.
+      log.warn('apple-notifications', 'REFUND_REVERSED received — manual restoration needed', {
+        orderId: transaction.transactionId,
+        productId: transaction.productId,
+      });
+      break;
+
+    case 'EXPIRED':
+    case 'DID_FAIL_TO_RENEW': {
+      const found = await findUserAndReceipt(transaction);
+      if (found && found.receipt.isSubscription) {
+        await db.doc(`users/${found.userId}`).update({
+          isSuperShy: false,
+          superShyExpiry: null,
+          superShyTier: null,
+        });
+        log.info('apple-notifications', 'Subscription expired', {
+          userId: found.userId,
+          productId: transaction.productId,
+        });
+      }
+      break;
+    }
+
+    case 'TEST':
+      log.info('apple-notifications', 'Received TEST notification', {
+        notificationUUID: notification.notificationUUID,
+      });
+      break;
+
+    default:
+      // SUBSCRIBED / DID_RENEW / DID_CHANGE_RENEWAL_* / OFFER_REDEEMED /
+      // GRACE_PERIOD_EXPIRED / PRICE_INCREASE / CONSUMPTION_REQUEST /
+      // RENEWAL_EXTENDED / RENEWAL_EXTENSION / EXTERNAL_PURCHASE_TOKEN /
+      // ONE_TIME_CHARGE / RESCIND_CONSENT / REFUND_DECLINED — log and ack.
+      // SUBSCRIBED + DID_RENEW could grant/extend the subscription server-side
+      // (currently the client-side purchase flow handles that path); follow-up
+      // work tracked in roadmap B6.10c follow-up.
+      log.info('apple-notifications', 'Acknowledged notification (no side effect)', {
+        notificationType,
+        notificationUUID: notification.notificationUUID,
+      });
+  }
+}
+
+/**
+ * Apple App Store Server Notifications V2 webhook.
+ *
+ * NOT auth-gated — the JWS signature IS the authentication. We verify
+ * the signature against Apple Root CA certs before doing anything.
+ */
+router.post('/apple-notifications/v2', async (req, res) => {
+  try {
+    const { signedPayload } = req.body || {};
+    if (!signedPayload) {
+      return res.status(400).json({ error: 'signedPayload required' });
+    }
+
+    let notification;
+    try {
+      notification = await verifyAppleNotification(signedPayload);
+    } catch (e) {
+      log.warn('apple-notifications', 'Notification signature verification failed', {
+        error: e.message,
+      });
+      return res.status(400).json({ error: 'Invalid notification signature' });
+    }
+
+    const { notificationUUID } = notification;
+    if (!notificationUUID) {
+      log.warn('apple-notifications', 'Notification missing notificationUUID');
+      return res.status(400).json({ error: 'Notification missing notificationUUID' });
+    }
+
+    // Idempotency: Apple may retry. Skip if we've seen this UUID.
+    const dedupeRef = db.collection('appleNotifications').doc(notificationUUID);
+    const dedupeSnap = await dedupeRef.get();
+    if (dedupeSnap.exists) {
+      log.info('apple-notifications', 'Duplicate notification ignored', { notificationUUID });
+      return res.status(200).json({ ok: true, deduped: true });
+    }
+
+    let transaction = null;
+    if (notification.data && notification.data.signedTransactionInfo) {
+      try {
+        transaction = await verifyAppleSignedTransaction(notification.data.signedTransactionInfo);
+      } catch (e) {
+        log.warn('apple-notifications', 'Embedded transaction signature failed', {
+          notificationUUID,
+          error: e.message,
+        });
+        return res.status(400).json({ error: 'Invalid embedded transaction' });
+      }
+    }
+
+    // Always call the handler — some notification types (TEST,
+    // EXTERNAL_PURCHASE_TOKEN, RESCIND_CONSENT, summary-only renewal-
+    // extension responses) legitimately have no embedded transaction.
+    // The handler logs + acks for those.
+    await handleNotification(notification, transaction);
+
+    // Record after handler completes so a handler crash doesn't write a
+    // dedupe row that prevents retry. If `set` itself fails, Apple will
+    // retry and we'll attempt the handler again — idempotency is then
+    // up to each handler (e.g., reverseCoinPackEntitlement uses
+    // FieldValue.increment which would double-deduct on retry — that's
+    // a known limitation tracked separately).
+    await dedupeRef.set({
+      notificationType: notification.notificationType,
+      notificationUUID,
+      orderId: transaction ? transaction.transactionId : null,
+      receivedAt: now(),
+    });
+
+    res.status(200).json({ ok: true });
+  } catch (err) {
+    log.error('apple-notifications', 'Notification handler crashed', { error: err.message });
+    // Return 500 so Apple retries — better to double-process than to
+    // silently drop a refund notification.
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/express-api/src/routes/apple-notifications.js
+++ b/express-api/src/routes/apple-notifications.js
@@ -120,29 +120,46 @@ async function reverseCoinPackEntitlement(found, transaction, dedupePayload, ded
     return { ok: false, reason: 'zero_coins' };
   }
 
-  const batch = db.batch();
-  batch.update(db.doc(`users/${userId}`), { shyCoins: FieldValue.increment(-totalCoins) });
-  batch.set(db.doc(`users/${userId}/transactions/${generateId()}`), {
-    type: 'REFUND',
-    amount: -totalCoins,
-    currency: 'COINS',
-    // Negative balance is acceptable here — the post-update balance is
-    // not knowable inside a batch without an extra read, and surfacing a
-    // misleading zero would be worse than omitting it. UI reads the
-    // user's live `shyCoins` field anyway.
-    balanceAfter: null,
-    details: `Refund: ${detailSuffix}`,
-    timestamp: now(),
-    originOrderId: transaction.transactionId,
+  // Wrap dedupe-check + state mutation in a Firestore transaction so a
+  // concurrent retry (Apple times out our response and re-sends within
+  // milliseconds) can't pass the dedupe check twice and double-debit.
+  // The pre-handler `dedupeRef.get()` at the route level is a fast-path
+  // optimisation; this is the load-bearing safety check.
+  const txRefundDocRef = db.doc(`users/${userId}/transactions/${generateId()}`);
+  const userRef = db.doc(`users/${userId}`);
+  const applied = await db.runTransaction(async (tx) => {
+    const snap = await tx.get(dedupeRef);
+    if (snap.exists) return false;
+    tx.update(userRef, { shyCoins: FieldValue.increment(-totalCoins) });
+    tx.set(txRefundDocRef, {
+      type: 'REFUND',
+      amount: -totalCoins,
+      currency: 'COINS',
+      // Negative balance is acceptable here — the post-update balance is
+      // not knowable inside a transaction without re-reading after the
+      // increment, and surfacing a misleading zero would be worse than
+      // omitting it. UI reads the user's live `shyCoins` field anyway.
+      balanceAfter: null,
+      details: `Refund: ${detailSuffix}`,
+      timestamp: now(),
+      originOrderId: transaction.transactionId,
+    });
+    tx.set(dedupeRef, dedupePayload);
+    return true;
   });
-  batch.set(dedupeRef, dedupePayload);
-  await batch.commit();
 
-  log.info('apple-notifications', 'Reversed coin-pack entitlement', {
-    userId,
-    productId,
-    coinsRemoved: totalCoins,
-  });
+  if (applied) {
+    log.info('apple-notifications', 'Reversed coin-pack entitlement', {
+      userId,
+      productId,
+      coinsRemoved: totalCoins,
+    });
+  } else {
+    log.info('apple-notifications', 'Coin-pack refund skipped (race-resolved duplicate)', {
+      userId,
+      productId,
+    });
+  }
   return { ok: true };
 }
 
@@ -189,42 +206,67 @@ async function reverseSubscriptionEntitlement(found, transaction, dedupePayload,
     }
   }
 
-  const batch = db.batch();
-  batch.update(db.doc(`users/${userId}`), {
-    isSuperShy: false,
-    superShyExpiry: null,
-    superShyTier: null,
+  // Wrap dedupe-check + state mutation in a Firestore transaction so a
+  // concurrent retry can't pass the dedupe check twice and clear an
+  // already-cleared entitlement (idempotent in practice but writes a
+  // duplicate REFUND tx row, which would mislead transaction history).
+  const userRef = db.doc(`users/${userId}`);
+  const txRefundDocRef = db.doc(`users/${userId}/transactions/${generateId()}`);
+  const applied = await db.runTransaction(async (tx) => {
+    const snap = await tx.get(dedupeRef);
+    if (snap.exists) return false;
+    tx.update(userRef, {
+      isSuperShy: false,
+      superShyExpiry: null,
+      superShyTier: null,
+    });
+    tx.set(txRefundDocRef, {
+      type: 'REFUND',
+      amount: 0,
+      currency: 'COINS',
+      balanceAfter: null,
+      details: `Subscription refund: Super Shy ${tier} (${productId})`,
+      timestamp: now(),
+      originOrderId: transaction.transactionId,
+    });
+    tx.set(dedupeRef, dedupePayload);
+    return true;
   });
-  batch.set(db.doc(`users/${userId}/transactions/${generateId()}`), {
-    type: 'REFUND',
-    amount: 0,
-    currency: 'COINS',
-    balanceAfter: null,
-    details: `Subscription refund: Super Shy ${tier} (${productId})`,
-    timestamp: now(),
-    originOrderId: transaction.transactionId,
-  });
-  batch.set(dedupeRef, dedupePayload);
-  await batch.commit();
 
-  log.info('apple-notifications', 'Reversed subscription entitlement', { userId, productId, tier });
+  if (applied) {
+    log.info('apple-notifications', 'Reversed subscription entitlement', {
+      userId,
+      productId,
+      tier,
+    });
+  } else {
+    log.info('apple-notifications', 'Subscription refund skipped (race-resolved duplicate)', {
+      userId,
+      productId,
+    });
+  }
   return { ok: tier !== 'unknown', reason: tier === 'unknown' ? 'unknown_subscription' : null };
 }
 
 /**
  * Clear a subscription entitlement atomically with the dedupe-row write.
  * Used by EXPIRED / DID_FAIL_TO_RENEW / GRACE_PERIOD_EXPIRED — no REFUND
- * transaction is written because no money moved.
+ * transaction is written because no money moved. Wrapped in a transaction
+ * so a concurrent retry can't apply the clear twice (idempotent but
+ * pollutes audit trails with redundant updates).
  */
 async function clearSubscriptionAtomic(userId, dedupePayload, dedupeRef) {
-  const batch = db.batch();
-  batch.update(db.doc(`users/${userId}`), {
-    isSuperShy: false,
-    superShyExpiry: null,
-    superShyTier: null,
+  const userRef = db.doc(`users/${userId}`);
+  await db.runTransaction(async (tx) => {
+    const snap = await tx.get(dedupeRef);
+    if (snap.exists) return;
+    tx.update(userRef, {
+      isSuperShy: false,
+      superShyExpiry: null,
+      superShyTier: null,
+    });
+    tx.set(dedupeRef, dedupePayload);
   });
-  batch.set(dedupeRef, dedupePayload);
-  await batch.commit();
 }
 
 /**

--- a/express-api/src/routes/apple-notifications.js
+++ b/express-api/src/routes/apple-notifications.js
@@ -14,161 +14,258 @@
  * `http://localhost:3000/api/apple-notifications/v2` via an ngrok tunnel
  * if Apple needs to reach it).
  *
- * Idempotency: Apple may retry up to 5 times. Dedupe by `notificationUUID`
- * stored in `appleNotifications/<uuid>`. Repeated POSTs of the same
- * notification return 200 immediately without re-applying the side effect.
+ * Idempotency: Apple may retry up to 5 times. Side effect + dedupe row
+ * are committed in a single Firestore batch so retries are safe — either
+ * both happen or neither does. Repeated POSTs of the same notificationUUID
+ * return 200 immediately without re-applying the side effect.
+ *
+ * Money safety: refund amounts are read from the original `purchaseReceipt`
+ * (which records `coinsGranted` / `tierGranted` at purchase time) rather
+ * than from the live `coinPackages` / `SUBSCRIPTION_TIERS` config — so a
+ * later price change cannot retroactively rewrite the refund. Orphan
+ * refunds (no matching receipt) and unknown product configs page an
+ * operator via `alertManager` and persist to a queryable worklist
+ * (`orphanRefunds`, `pendingRefundReversals`).
  */
 
 const express = require('express');
 const router = express.Router();
 const { db, FieldValue } = require('../utils/firebase');
 const log = require('../utils/log');
+const alertManager = require('../utils/alertManagerInstance');
 const { generateId, now } = require('../utils/helpers');
 const { verifyAppleNotification, verifyAppleSignedTransaction } = require('../utils/appleStore');
-
-// Subscription productId → tier mapping (mirrors economy.js purchase grant logic).
-const SUBSCRIPTION_TIERS = {
-  super_shy_monthly: { tier: 'monthly', days: 30 },
-  super_shy_yearly: { tier: 'yearly', days: 365 },
-  super_shy_lifetime: { tier: 'lifetime', days: null },
-};
+const { SUBSCRIPTION_TIERS } = require('../utils/subscriptionTiers');
 
 /**
  * Look up the user that originally received the entitlement for a given
- * Apple transaction, by joining on `purchaseReceipts.orderId` (which we
- * record at /economy/purchase time as `transaction.transactionId`).
+ * Apple transaction. Receipts are joined by `purchaseReceipts.orderId`
+ * (recorded at /economy/purchase time as the verified `transactionId`).
  *
- * Apple notifications can carry `originalTransactionId` (the ID of the
- * first purchase in a subscription chain) plus a fresh `transactionId`
- * for the renewal event — try both so renewal/refund notifications find
- * the right user even when the receipt was recorded under the original.
+ * Apple notifications carry both the renewal `transactionId` and the
+ * `originalTransactionId` (the first purchase in a subscription chain).
+ * We coalesce both into a single `where('orderId', 'in', […])` query so
+ * the renewal-refund case costs one Firestore read instead of two.
  */
 async function findUserAndReceipt(transaction) {
-  const candidateOrderIds = [transaction.transactionId, transaction.originalTransactionId].filter(
-    Boolean,
-  );
-  for (const orderId of candidateOrderIds) {
-    const snap = await db
-      .collection('purchaseReceipts')
-      .where('orderId', '==', orderId)
-      .limit(1)
-      .get();
-    if (!snap.empty) {
-      const doc = snap.docs[0];
-      return { receiptId: doc.id, receipt: doc.data(), userId: doc.data().userId };
-    }
-  }
-  return null;
+  const candidates = [transaction.transactionId, transaction.originalTransactionId]
+    .filter(Boolean)
+    .filter((v, i, a) => a.indexOf(v) === i);
+  if (candidates.length === 0) return null;
+
+  const snap = await db
+    .collection('purchaseReceipts')
+    .where('orderId', 'in', candidates)
+    .limit(1)
+    .get();
+  if (snap.empty) return null;
+  const doc = snap.docs[0];
+  return { receiptId: doc.id, receipt: doc.data(), userId: doc.data().userId };
 }
 
 /**
- * Reverse a coin-pack purchase. Decrement coins, write a REFUND
- * transaction. Coins go negative if the user has already spent them —
- * the in-arrears state is intentional (we can't claw back spent coins,
- * but the negative balance prevents further spending until topped up).
+ * Reverse a coin-pack purchase atomically with the dedupe-row write.
+ *
+ * Reads `coinsGranted` / `bonusCoinsGranted` from the original receipt
+ * so the reversal matches what the user actually received, even if the
+ * `coinPackages` config has changed since purchase. Legacy receipts
+ * (pre-`coinsGranted` schema) fall back to the live `coinPackages`
+ * lookup with a logged warning so operators can spot the migration tail.
+ *
+ * The user's coin balance can go negative if they've already spent the
+ * refunded coins — the in-arrears state is intentional (we can't claw
+ * back spent coins, but the negative balance prevents further spending
+ * until topped up).
+ *
+ * Returns `{ ok: true }` on success, `{ ok: false, reason }` if the
+ * refund cannot be applied safely (caller decides whether to alert).
  */
-async function reverseCoinPackEntitlement(receipt, transaction) {
-  const userId = receipt.userId;
+async function reverseCoinPackEntitlement(found, transaction, dedupePayload, dedupeRef) {
+  const { receipt, userId } = found;
   const productId = transaction.productId;
 
-  const pkgSnap = await db
-    .collection('coinPackages')
-    .where('productId', '==', productId)
-    .limit(1)
-    .get();
-  if (pkgSnap.empty) {
-    log.warn('apple-notifications', 'Refund for unknown coin package', { productId, userId });
-    return;
+  let totalCoins;
+  let detailSuffix;
+  if (receipt.coinsGranted !== undefined) {
+    const coins = receipt.coinsGranted || 0;
+    const bonus = receipt.bonusCoinsGranted || 0;
+    totalCoins = coins + bonus;
+    detailSuffix = `${coins} + ${bonus} bonus coins (${productId})`;
+  } else {
+    log.warn(
+      'apple-notifications',
+      'Legacy receipt without coinsGranted; falling back to live coinPackages',
+      {
+        receiptId: found.receiptId,
+        userId,
+        productId,
+      },
+    );
+    const pkgSnap = await db
+      .collection('coinPackages')
+      .where('productId', '==', productId)
+      .limit(1)
+      .get();
+    if (pkgSnap.empty) {
+      return { ok: false, reason: 'unknown_product' };
+    }
+    const pkg = pkgSnap.docs[0].data();
+    const coins = pkg.coins || 0;
+    const bonus = pkg.bonusCoins || 0;
+    totalCoins = coins + bonus;
+    detailSuffix = `${coins} + ${bonus} bonus coins (${productId}, legacy fallback)`;
   }
-  const pkg = pkgSnap.docs[0].data();
-  const totalCoins = (pkg.coins || 0) + (pkg.bonusCoins || 0);
 
-  await db.doc(`users/${userId}`).update({
-    shyCoins: FieldValue.increment(-totalCoins),
-  });
+  if (totalCoins <= 0) {
+    return { ok: false, reason: 'zero_coins' };
+  }
 
-  const userSnap = await db.doc(`users/${userId}`).get();
-  const balanceAfter = userSnap.exists ? userSnap.data().shyCoins || 0 : 0;
-
-  await db.doc(`users/${userId}/transactions/${generateId()}`).set({
+  const batch = db.batch();
+  batch.update(db.doc(`users/${userId}`), { shyCoins: FieldValue.increment(-totalCoins) });
+  batch.set(db.doc(`users/${userId}/transactions/${generateId()}`), {
     type: 'REFUND',
     amount: -totalCoins,
     currency: 'COINS',
-    balanceAfter,
-    details: `Refund: ${pkg.coins} + ${pkg.bonusCoins || 0} bonus coins (${productId})`,
+    // Negative balance is acceptable here — the post-update balance is
+    // not knowable inside a batch without an extra read, and surfacing a
+    // misleading zero would be worse than omitting it. UI reads the
+    // user's live `shyCoins` field anyway.
+    balanceAfter: null,
+    details: `Refund: ${detailSuffix}`,
     timestamp: now(),
     originOrderId: transaction.transactionId,
   });
+  batch.set(dedupeRef, dedupePayload);
+  await batch.commit();
 
   log.info('apple-notifications', 'Reversed coin-pack entitlement', {
     userId,
     productId,
     coinsRemoved: totalCoins,
-    balanceAfter,
   });
+  return { ok: true };
 }
 
 /**
- * Reverse a subscription purchase. Clear isSuperShy / superShyExpiry /
- * superShyTier and write a REFUND transaction. Refunds for subscriptions
- * always end the entitlement immediately regardless of expiry date —
- * matches Apple's UX where the user gets the money back AND loses access.
+ * Reverse a subscription purchase atomically with the dedupe-row write.
+ *
+ * Reads `tierGranted` from the original receipt so the reversal matches
+ * the tier the user actually purchased. If the receipt predates the
+ * `tierGranted` schema, falls back to `SUBSCRIPTION_TIERS[productId]`
+ * with a logged warning. If the productId is unknown to both, the
+ * entitlement is **still cleared defensively** (we know it's a refund —
+ * the safe action is to revoke even if we can't write a perfect
+ * REFUND transaction details string), and an operator is paged.
  */
-async function reverseSubscriptionEntitlement(receipt, transaction) {
-  const userId = receipt.userId;
+async function reverseSubscriptionEntitlement(found, transaction, dedupePayload, dedupeRef) {
+  const { receipt, userId } = found;
   const productId = transaction.productId;
-  const sub = SUBSCRIPTION_TIERS[productId];
-  if (!sub) {
-    log.warn('apple-notifications', 'Refund for unknown subscription', { productId, userId });
-    return;
+
+  let tier = receipt.tierGranted;
+  if (!tier) {
+    const sub = SUBSCRIPTION_TIERS[productId];
+    if (sub) {
+      tier = sub.tier;
+      log.warn(
+        'apple-notifications',
+        'Legacy subscription receipt without tierGranted; using SUBSCRIPTION_TIERS',
+        {
+          receiptId: found.receiptId,
+          userId,
+          productId,
+        },
+      );
+    } else {
+      log.error(
+        'apple-notifications',
+        'Refund for subscription not in SUBSCRIPTION_TIERS — clearing defensively',
+        {
+          userId,
+          productId,
+          orderId: transaction.transactionId,
+        },
+      );
+      tier = 'unknown';
+    }
   }
 
-  await db.doc(`users/${userId}`).update({
+  const batch = db.batch();
+  batch.update(db.doc(`users/${userId}`), {
     isSuperShy: false,
     superShyExpiry: null,
     superShyTier: null,
   });
-
-  await db.doc(`users/${userId}/transactions/${generateId()}`).set({
+  batch.set(db.doc(`users/${userId}/transactions/${generateId()}`), {
     type: 'REFUND',
     amount: 0,
     currency: 'COINS',
-    balanceAfter: 0,
-    details: `Subscription refund: Super Shy ${sub.tier} (${productId})`,
+    balanceAfter: null,
+    details: `Subscription refund: Super Shy ${tier} (${productId})`,
     timestamp: now(),
     originOrderId: transaction.transactionId,
   });
+  batch.set(dedupeRef, dedupePayload);
+  await batch.commit();
 
-  log.info('apple-notifications', 'Reversed subscription entitlement', {
-    userId,
-    productId,
-    tier: sub.tier,
-  });
+  log.info('apple-notifications', 'Reversed subscription entitlement', { userId, productId, tier });
+  return { ok: tier !== 'unknown', reason: tier === 'unknown' ? 'unknown_subscription' : null };
 }
 
 /**
- * Apply a notification's side effect. Switch on `notificationType`.
- * Unknown types are logged and acknowledged — Apple expects 200 so it
- * doesn't keep retrying.
+ * Clear a subscription entitlement atomically with the dedupe-row write.
+ * Used by EXPIRED / DID_FAIL_TO_RENEW / GRACE_PERIOD_EXPIRED — no REFUND
+ * transaction is written because no money moved.
  */
-async function handleNotification(notification, transaction) {
-  const { notificationType } = notification;
+async function clearSubscriptionAtomic(userId, dedupePayload, dedupeRef) {
+  const batch = db.batch();
+  batch.update(db.doc(`users/${userId}`), {
+    isSuperShy: false,
+    superShyExpiry: null,
+    superShyTier: null,
+  });
+  batch.set(dedupeRef, dedupePayload);
+  await batch.commit();
+}
 
-  // REFUND/REVOKE/REFUND_REVERSED/EXPIRED/DID_FAIL_TO_RENEW all need a
-  // transaction to identify the affected user. If absent, ack and log so
-  // Apple stops retrying — there's nothing actionable.
+/**
+ * Persist the dedupe row only — no side effect. Used for notification
+ * types that we ack without entitlement changes (TEST, CONSUMPTION_REQUEST,
+ * RESCIND_CONSENT, etc.) and for the early-return paths (orphan refund,
+ * REFUND_REVERSED) where the side effect is delegated to a worklist
+ * collection that ops resolves manually.
+ */
+async function writeDedupeOnly(dedupePayload, dedupeRef) {
+  await dedupeRef.set(dedupePayload);
+}
+
+/**
+ * Apply a notification's side effect. Switch on `notificationType`. Each
+ * branch is responsible for committing its own dedupe row atomically with
+ * any state mutation, so a mid-handler crash leaves nothing half-applied.
+ *
+ * Returns nothing on success; throws to let the caller return 500 (Apple
+ * will retry).
+ */
+async function handleNotification(notification, transaction, dedupePayload, dedupeRef) {
+  const { notificationType, notificationUUID } = notification;
+
+  // Types that need a transaction to identify the affected user. If
+  // absent, ack with a logged warning so Apple stops retrying — there's
+  // nothing actionable.
   const needsTransaction = [
     'REFUND',
     'REVOKE',
     'REFUND_REVERSED',
     'EXPIRED',
     'DID_FAIL_TO_RENEW',
+    'GRACE_PERIOD_EXPIRED',
   ].includes(notificationType);
   if (needsTransaction && !transaction) {
     log.warn('apple-notifications', 'Notification of impactful type missing transaction', {
       notificationType,
-      notificationUUID: notification.notificationUUID,
+      notificationUUID,
     });
+    await writeDedupeOnly(dedupePayload, dedupeRef);
     return;
   }
 
@@ -177,76 +274,215 @@ async function handleNotification(notification, transaction) {
     case 'REVOKE': {
       const found = await findUserAndReceipt(transaction);
       if (!found) {
-        log.warn('apple-notifications', 'No purchaseReceipt found for refund/revoke', {
+        log.error('apple-notifications', 'Orphan refund — no purchaseReceipt matched', {
+          orderId: transaction.transactionId,
+          originalTransactionId: transaction.originalTransactionId,
+          productId: transaction.productId,
+          notificationUUID,
+        });
+        await db
+          .collection('orphanRefunds')
+          .doc(notificationUUID)
+          .set({
+            orderId: transaction.transactionId,
+            originalTransactionId: transaction.originalTransactionId || null,
+            productId: transaction.productId,
+            notificationType,
+            receivedAt: now(),
+            resolved: false,
+          });
+        await alertManager.createAlert(
+          'orphan_refund',
+          'high',
+          'Apple refund with no matching purchaseReceipt',
+          `productId=${transaction.productId}, orderId=${transaction.transactionId}`,
+          {
+            orderId: transaction.transactionId,
+            originalTransactionId: transaction.originalTransactionId || null,
+            productId: transaction.productId,
+            notificationUUID,
+          },
+        );
+        await writeDedupeOnly(dedupePayload, dedupeRef);
+        return;
+      }
+      let result;
+      if (found.receipt.isSubscription) {
+        result = await reverseSubscriptionEntitlement(found, transaction, dedupePayload, dedupeRef);
+        if (!result.ok) {
+          await alertManager.createAlert(
+            'refund_unknown_subscription',
+            'high',
+            'Apple refund for subscription not in SUBSCRIPTION_TIERS',
+            `productId=${transaction.productId}, userId=${found.userId}`,
+            {
+              productId: transaction.productId,
+              userId: found.userId,
+              orderId: transaction.transactionId,
+              notificationUUID,
+            },
+          );
+        }
+      } else {
+        result = await reverseCoinPackEntitlement(found, transaction, dedupePayload, dedupeRef);
+        if (!result.ok) {
+          // Coin-pack reverse couldn't determine totalCoins — write the
+          // dedupe row so Apple stops retrying, then alert ops to handle
+          // manually. Without the dedupe write, every retry would re-fail
+          // and re-alert, drowning ops.
+          await writeDedupeOnly(dedupePayload, dedupeRef);
+          await alertManager.createAlert(
+            'refund_coin_pack_failed',
+            'high',
+            'Apple coin-pack refund could not be reversed automatically',
+            `reason=${result.reason}, productId=${transaction.productId}, userId=${found.userId}`,
+            {
+              reason: result.reason,
+              productId: transaction.productId,
+              userId: found.userId,
+              receiptId: found.receiptId,
+              orderId: transaction.transactionId,
+              notificationUUID,
+            },
+          );
+        }
+      }
+      return;
+    }
+
+    case 'REFUND_REVERSED': {
+      // Apple un-refunded — the customer paid again. The entitlement
+      // must be restored, but the safe re-grant path requires reading
+      // the original receipt's granted amounts and re-applying them.
+      // For correctness we delegate to ops via a worklist + alert
+      // rather than risk a buggy auto-restore on a money-affecting
+      // event. See B6.10c follow-up tracker.
+      log.error(
+        'apple-notifications',
+        'REFUND_REVERSED received — manual entitlement restoration required',
+        {
+          orderId: transaction.transactionId,
+          productId: transaction.productId,
+          notificationUUID,
+        },
+      );
+      await db.collection('pendingRefundReversals').doc(notificationUUID).set({
+        orderId: transaction.transactionId,
+        productId: transaction.productId,
+        receivedAt: now(),
+        resolved: false,
+      });
+      await alertManager.createAlert(
+        'refund_reversed',
+        'critical',
+        'Apple refund reversed — manual entitlement restoration required',
+        `productId=${transaction.productId}, orderId=${transaction.transactionId}`,
+        {
+          orderId: transaction.transactionId,
+          productId: transaction.productId,
+          notificationUUID,
+        },
+      );
+      await writeDedupeOnly(dedupePayload, dedupeRef);
+      return;
+    }
+
+    case 'EXPIRED':
+    case 'DID_FAIL_TO_RENEW':
+    case 'GRACE_PERIOD_EXPIRED': {
+      const found = await findUserAndReceipt(transaction);
+      if (!found) {
+        log.warn('apple-notifications', 'Subscription expiry with no matching receipt', {
+          notificationType,
           orderId: transaction.transactionId,
           originalTransactionId: transaction.originalTransactionId,
           productId: transaction.productId,
         });
+        await writeDedupeOnly(dedupePayload, dedupeRef);
         return;
       }
-      if (found.receipt.isSubscription) {
-        await reverseSubscriptionEntitlement(found.receipt, transaction);
-      } else {
-        await reverseCoinPackEntitlement(found.receipt, transaction);
+      if (!found.receipt.isSubscription) {
+        log.error(
+          'apple-notifications',
+          'Expiry notification for non-subscription receipt — data inconsistency',
+          {
+            receiptId: found.receiptId,
+            userId: found.userId,
+            productId: transaction.productId,
+            notificationType,
+          },
+        );
+        await writeDedupeOnly(dedupePayload, dedupeRef);
+        return;
       }
-      break;
-    }
-
-    case 'REFUND_REVERSED':
-      // Apple un-refunded — the entitlement should be restored. Re-running
-      // the original grant is the cleanest path; leaving as TODO for now
-      // since this is rare and needs careful idempotency design.
-      log.warn('apple-notifications', 'REFUND_REVERSED received — manual restoration needed', {
-        orderId: transaction.transactionId,
+      await clearSubscriptionAtomic(found.userId, dedupePayload, dedupeRef);
+      log.info('apple-notifications', 'Subscription entitlement cleared', {
+        userId: found.userId,
         productId: transaction.productId,
+        notificationType,
       });
-      break;
-
-    case 'EXPIRED':
-    case 'DID_FAIL_TO_RENEW': {
-      const found = await findUserAndReceipt(transaction);
-      if (found && found.receipt.isSubscription) {
-        await db.doc(`users/${found.userId}`).update({
-          isSuperShy: false,
-          superShyExpiry: null,
-          superShyTier: null,
-        });
-        log.info('apple-notifications', 'Subscription expired', {
-          userId: found.userId,
-          productId: transaction.productId,
-        });
-      }
-      break;
+      return;
     }
+
+    case 'CONSUMPTION_REQUEST':
+      // Apple is asking us whether the user is owed a refund. We have 12h
+      // to respond via the App Store Server API or Apple decides for us.
+      // Auto-decline policy is not implemented yet; surface to ops so
+      // they can respond manually for now.
+      log.warn(
+        'apple-notifications',
+        'CONSUMPTION_REQUEST — must respond within 12h or Apple auto-decides',
+        {
+          notificationUUID,
+          orderId: transaction ? transaction.transactionId : null,
+          productId: transaction ? transaction.productId : null,
+        },
+      );
+      await alertManager.createAlert(
+        'consumption_request',
+        'high',
+        'Apple wants consumption decision (12h SLA)',
+        `productId=${transaction ? transaction.productId : 'n/a'}, orderId=${transaction ? transaction.transactionId : 'n/a'}`,
+        {
+          notificationUUID,
+          orderId: transaction ? transaction.transactionId : null,
+          productId: transaction ? transaction.productId : null,
+        },
+      );
+      await writeDedupeOnly(dedupePayload, dedupeRef);
+      return;
 
     case 'TEST':
-      log.info('apple-notifications', 'Received TEST notification', {
-        notificationUUID: notification.notificationUUID,
-      });
-      break;
+      log.info('apple-notifications', 'Received TEST notification', { notificationUUID });
+      await writeDedupeOnly(dedupePayload, dedupeRef);
+      return;
 
     default:
       // SUBSCRIBED / DID_RENEW / DID_CHANGE_RENEWAL_* / OFFER_REDEEMED /
-      // GRACE_PERIOD_EXPIRED / PRICE_INCREASE / CONSUMPTION_REQUEST /
-      // RENEWAL_EXTENDED / RENEWAL_EXTENSION / EXTERNAL_PURCHASE_TOKEN /
-      // ONE_TIME_CHARGE / RESCIND_CONSENT / REFUND_DECLINED — log and ack.
-      // SUBSCRIBED + DID_RENEW could grant/extend the subscription server-side
-      // (currently the client-side purchase flow handles that path); follow-up
-      // work tracked in roadmap B6.10c follow-up.
+      // PRICE_INCREASE / RENEWAL_EXTENDED / RENEWAL_EXTENSION /
+      // EXTERNAL_PURCHASE_TOKEN / ONE_TIME_CHARGE / RESCIND_CONSENT /
+      // REFUND_DECLINED — log and ack. Server-side grant on SUBSCRIBED /
+      // DID_RENEW is currently the client's responsibility (StoreKit 2
+      // Transaction.updates listener); follow-up tracked separately.
       log.info('apple-notifications', 'Acknowledged notification (no side effect)', {
         notificationType,
-        notificationUUID: notification.notificationUUID,
+        notificationUUID,
       });
+      await writeDedupeOnly(dedupePayload, dedupeRef);
   }
 }
 
 /**
  * Apple App Store Server Notifications V2 webhook.
  *
- * NOT auth-gated — the JWS signature IS the authentication. We verify
- * the signature against Apple Root CA certs before doing anything.
+ * NOT auth-gated by Bearer token — the JWS signature IS the
+ * authentication. We verify against Apple Root CA certs before doing
+ * anything. The auth-middleware allow-list in `index.js` skips this
+ * route for that reason.
  */
 router.post('/apple-notifications/v2', async (req, res) => {
+  let notificationUUID = null;
+  let notificationType = null;
   try {
     const { signedPayload } = req.body || {};
     if (!signedPayload) {
@@ -263,7 +499,8 @@ router.post('/apple-notifications/v2', async (req, res) => {
       return res.status(400).json({ error: 'Invalid notification signature' });
     }
 
-    const { notificationUUID } = notification;
+    notificationUUID = notification.notificationUUID;
+    notificationType = notification.notificationType;
     if (!notificationUUID) {
       log.warn('apple-notifications', 'Notification missing notificationUUID');
       return res.status(400).json({ error: 'Notification missing notificationUUID' });
@@ -290,30 +527,49 @@ router.post('/apple-notifications/v2', async (req, res) => {
       }
     }
 
-    // Always call the handler — some notification types (TEST,
-    // EXTERNAL_PURCHASE_TOKEN, RESCIND_CONSENT, summary-only renewal-
-    // extension responses) legitimately have no embedded transaction.
-    // The handler logs + acks for those.
-    await handleNotification(notification, transaction);
-
-    // Record after handler completes so a handler crash doesn't write a
-    // dedupe row that prevents retry. If `set` itself fails, Apple will
-    // retry and we'll attempt the handler again — idempotency is then
-    // up to each handler (e.g., reverseCoinPackEntitlement uses
-    // FieldValue.increment which would double-deduct on retry — that's
-    // a known limitation tracked separately).
-    await dedupeRef.set({
-      notificationType: notification.notificationType,
+    const dedupePayload = {
+      notificationType,
       notificationUUID,
       orderId: transaction ? transaction.transactionId : null,
       receivedAt: now(),
-    });
+    };
+
+    // Each branch in handleNotification commits its own atomic batch
+    // (state mutation + dedupe write together) so a mid-handler crash
+    // leaves nothing half-applied. On Apple retry, the dedupe row check
+    // above short-circuits.
+    await handleNotification(notification, transaction, dedupePayload, dedupeRef);
 
     res.status(200).json({ ok: true });
   } catch (err) {
-    log.error('apple-notifications', 'Notification handler crashed', { error: err.message });
-    // Return 500 so Apple retries — better to double-process than to
-    // silently drop a refund notification.
+    // Defensive: protect against logger-throw paths so the response
+    // always sends. Without this, a logger bug would hang the request
+    // until Apple times out — invisible to ops.
+    try {
+      log.error('apple-notifications', 'Notification handler crashed', {
+        error: err.message,
+        stack: err.stack,
+        notificationUUID,
+        notificationType,
+      });
+    } catch {
+      // eslint-disable-next-line no-console
+      console.error('apple-notifications: log.error itself threw', err);
+    }
+    try {
+      await alertManager.createAlert(
+        'apple_notification_crash',
+        'critical',
+        'Apple notification handler crashed',
+        err.message || 'unknown error',
+        { notificationUUID, notificationType, stack: err.stack },
+      );
+    } catch {
+      // Alert firing is best-effort — must not mask the original error.
+    }
+    // Return 500 so Apple retries — better to retry than to silently
+    // drop. The atomic batch guarantees no partial side effect was
+    // applied, so the retry is safe.
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/express-api/src/routes/economy.js
+++ b/express-api/src/routes/economy.js
@@ -28,6 +28,7 @@ const { requireAdmin } = require('../middleware/auth');
 const log = require('../utils/log');
 const { verifyProductPurchase, verifySubscription } = require('../utils/playStore');
 const { verifyApplePurchase } = require('../utils/appleStore');
+const { SUBSCRIPTION_TIERS } = require('../utils/subscriptionTiers');
 
 // ─── Constants ────────────────────────────────────────────────────
 
@@ -1329,33 +1330,31 @@ router.post('/economy/purchase', async (req, res) => {
     }
 
     const orderId = verification.orderId || verification.latestOrderId || null;
-
-    // Store receipt for audit trail
-    const receiptId = generateId();
-    await db.doc(`purchaseReceipts/${receiptId}`).set({
-      userId: uniqueId,
-      productId,
-      purchaseToken,
-      platform: purchasePlatform,
-      isSubscription: !!isSubscription,
-      createdAt: now(),
-      verified: true,
-      orderId,
-    });
-
     const timestamp = now();
+    const receiptId = generateId();
 
     if (isSubscription) {
-      const tierMap = {
-        super_shy_monthly: { tier: 'monthly', days: 30 },
-        super_shy_yearly: { tier: 'yearly', days: 365 },
-        super_shy_lifetime: { tier: 'lifetime', days: null },
-      };
-
-      const sub = tierMap[productId];
+      const sub = SUBSCRIPTION_TIERS[productId];
       if (!sub) return res.status(400).json({ error: 'Unknown subscription product' });
 
       const expiry = sub.days ? timestamp + sub.days * 86400000 : null;
+
+      // Store receipt AFTER tier resolution so we can persist the granted
+      // tier + days. The refund handler reads from the receipt instead of
+      // re-deriving from the (mutable) SUBSCRIPTION_TIERS map, so a future
+      // tier change cannot retroactively rewrite the refund's reversal.
+      await db.doc(`purchaseReceipts/${receiptId}`).set({
+        userId: uniqueId,
+        productId,
+        purchaseToken,
+        platform: purchasePlatform,
+        isSubscription: true,
+        createdAt: timestamp,
+        verified: true,
+        orderId,
+        tierGranted: sub.tier,
+        daysGranted: sub.days,
+      });
 
       await db.doc(`users/${uniqueId}`).update({
         isSuperShy: true,
@@ -1385,13 +1384,33 @@ router.post('/economy/purchase', async (req, res) => {
     const pkg = pkgSnap.empty ? null : { id: pkgSnap.docs[0].id, ...pkgSnap.docs[0].data() };
     if (!pkg) return res.status(404).json({ error: 'Unknown coin package' });
 
-    const totalCoins = (pkg.coins || 0) + (pkg.bonusCoins || 0);
+    const coinsGranted = pkg.coins || 0;
+    const bonusCoinsGranted = pkg.bonusCoins || 0;
+    const totalCoins = coinsGranted + bonusCoinsGranted;
 
     const userSnap = await db.doc(`users/${uniqueId}`).get();
     if (!userSnap.exists) return res.status(404).json({ error: 'User not found' });
     const user = userSnap.data();
 
     const shyCoins = userField(user, 'shyCoins', 'shy_coins') || 0;
+
+    // Persist the actual granted amounts on the receipt so the refund
+    // handler can reverse the original entitlement even if `coinPackages`
+    // is later mutated (price changes, promotional bonus weekends,
+    // deprecated SKUs). Without this the refund would reverse today's
+    // package config, not what the user originally received.
+    await db.doc(`purchaseReceipts/${receiptId}`).set({
+      userId: uniqueId,
+      productId,
+      purchaseToken,
+      platform: purchasePlatform,
+      isSubscription: false,
+      createdAt: timestamp,
+      verified: true,
+      orderId,
+      coinsGranted,
+      bonusCoinsGranted,
+    });
 
     await db.doc(`users/${uniqueId}`).update({ shyCoins: FieldValue.increment(totalCoins) });
 

--- a/express-api/src/utils/appleStore.js
+++ b/express-api/src/utils/appleStore.js
@@ -149,9 +149,37 @@ async function verifyApplePurchase(expectedProductId, signedTransactionInfo, isS
   };
 }
 
+/**
+ * Verify an App Store Server Notifications V2 signed payload and return
+ * the decoded notification body. Used by the
+ * `/api/apple-notifications/v2` webhook to handle refunds, renewals,
+ * revokes, etc. Reuses the same `SignedDataVerifier` instance as
+ * `verifyApplePurchase`.
+ */
+async function verifyAppleNotification(signedPayload) {
+  return getVerifier().verifyAndDecodeNotification(signedPayload);
+}
+
+/**
+ * Verify a standalone signed transaction payload (e.g.
+ * `data.signedTransactionInfo` from an App Store Server Notification)
+ * and return the decoded transaction. Convenience wrapper for
+ * notification handlers that need the embedded transaction without
+ * the productId / bundleId / revocation enforcement that
+ * `verifyApplePurchase` runs (those are caller-controlled here).
+ */
+async function verifyAppleSignedTransaction(signedTransactionInfo) {
+  return getVerifier().verifyAndDecodeTransaction(signedTransactionInfo);
+}
+
 // Exposed for testing — allows resetting the cached verifier instance
 function _resetVerifier() {
   verifier = null;
 }
 
-module.exports = { verifyApplePurchase, _resetVerifier };
+module.exports = {
+  verifyApplePurchase,
+  verifyAppleNotification,
+  verifyAppleSignedTransaction,
+  _resetVerifier,
+};

--- a/express-api/src/utils/appleStore.js
+++ b/express-api/src/utils/appleStore.js
@@ -16,6 +16,11 @@
  * - `APPLE_APP_STORE_ENV` — `production` or `sandbox` (defaults to
  *   `sandbox` so a misconfigured prod deploy fails closed instead of
  *   accepting sandbox-signed transactions as real purchases).
+ * - `APPLE_APP_STORE_APP_ID` — numeric Apple App ID from App Store Connect
+ *   (App Information → "Apple ID"). **Required when `APPLE_APP_STORE_ENV=production`** —
+ *   Apple's `SignedDataVerifier` constructor throws without it in PRODUCTION
+ *   mode, and the notification verifier needs it to bind the JWS to our
+ *   specific app identity (defence-in-depth against cross-app payload reuse).
  *
  * Note: This module verifies signed transactions the client passes in.
  * For server-side App Store Server Notifications (refund webhooks,
@@ -67,8 +72,32 @@ function getVerifier() {
   const environment =
     process.env.APPLE_APP_STORE_ENV === 'production' ? Environment.PRODUCTION : Environment.SANDBOX;
 
-  // SignedDataVerifier(rootCerts, performOnlineRevocationChecking, environment, bundleId)
-  verifier = new SignedDataVerifier(rootCerts, true, environment, BUNDLE_ID);
+  // Apple's SignedDataVerifier constructor THROWS if environment is
+  // PRODUCTION and appAppleId is undefined. The notification verifier
+  // also uses appAppleId to bind the JWS to our specific app identity.
+  // Sandbox doesn't require it (and passing undefined there is fine —
+  // the library validates the requirement only in PRODUCTION).
+  let appAppleId;
+  if (environment === Environment.PRODUCTION) {
+    const raw = process.env.APPLE_APP_STORE_APP_ID;
+    if (!raw) {
+      throw new Error(
+        'APPLE_APP_STORE_APP_ID environment variable is required when ' +
+          'APPLE_APP_STORE_ENV=production. Find it in App Store Connect → ' +
+          'App Information → "Apple ID" (numeric).',
+      );
+    }
+    appAppleId = Number(raw);
+    if (!Number.isFinite(appAppleId)) {
+      throw new Error(
+        `APPLE_APP_STORE_APP_ID must be numeric (got "${raw}"). Take the ` +
+          'value from App Store Connect → App Information → "Apple ID".',
+      );
+    }
+  }
+
+  // SignedDataVerifier(rootCerts, performOnlineRevocationChecking, environment, bundleId, appAppleId?)
+  verifier = new SignedDataVerifier(rootCerts, true, environment, BUNDLE_ID, appAppleId);
   return verifier;
 }
 

--- a/express-api/src/utils/subscriptionTiers.js
+++ b/express-api/src/utils/subscriptionTiers.js
@@ -1,0 +1,22 @@
+/**
+ * Single source of truth for the productId → subscription-tier map.
+ *
+ * Both `routes/economy.js` (purchase grant path) and
+ * `routes/apple-notifications.js` (refund / expiry / revoke path) read
+ * from this. Previously the same map was duplicated in both files; that
+ * meant adding a new tier (e.g. a quarterly SKU or a localised
+ * promotional offer) only on the purchase side would silently break the
+ * refund side — the refund handler would log a warning, ack with 200,
+ * and the user would keep their entitlement after a refund. Centralising
+ * the map here makes that drift impossible.
+ *
+ * `tier` is the value persisted to `users.superShyTier`.
+ * `days` is the entitlement length (`null` = lifetime / never expires).
+ */
+const SUBSCRIPTION_TIERS = Object.freeze({
+  super_shy_monthly: { tier: 'monthly', days: 30 },
+  super_shy_yearly: { tier: 'yearly', days: 365 },
+  super_shy_lifetime: { tier: 'lifetime', days: null },
+});
+
+module.exports = { SUBSCRIPTION_TIERS };

--- a/express-api/tests/routes/apple-notifications.test.js
+++ b/express-api/tests/routes/apple-notifications.test.js
@@ -1,0 +1,377 @@
+const express = require('express');
+const request = require('supertest');
+
+const mockDocGet = jest.fn();
+const mockDocUpdate = jest.fn().mockResolvedValue();
+const mockDocSet = jest.fn().mockResolvedValue();
+let mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    doc: jest.fn(() => ({
+      get: mockDocGet,
+      update: mockDocUpdate,
+      set: mockDocSet,
+    })),
+    collection: jest.fn(() => ({
+      doc: jest.fn(() => ({
+        get: mockDocGet,
+        set: mockDocSet,
+      })),
+      where: jest.fn(() => ({
+        limit: jest.fn(() => ({
+          get: mockCollectionGet,
+        })),
+      })),
+    })),
+  },
+  FieldValue: {
+    increment: jest.fn((n) => `increment(${n})`),
+  },
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('../../src/utils/helpers', () => ({
+  generateId: () => 'tx-refund-123',
+  now: () => 1709913600000,
+}));
+
+const mockVerifyAppleNotification = jest.fn();
+const mockVerifyAppleSignedTransaction = jest.fn();
+
+jest.mock('../../src/utils/appleStore', () => ({
+  verifyAppleNotification: mockVerifyAppleNotification,
+  verifyAppleSignedTransaction: mockVerifyAppleSignedTransaction,
+}));
+
+const appleNotificationsRouter = require('../../src/routes/apple-notifications');
+const log = require('../../src/utils/log');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
+});
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', appleNotificationsRouter);
+  return app;
+}
+
+// ─── Validation ──────────────────────────────────────────────────
+
+describe('POST /api/apple-notifications/v2 — validation', () => {
+  test('returns 400 when signedPayload is missing', async () => {
+    const app = createApp();
+    const res = await request(app).post('/api/apple-notifications/v2').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/signedPayload required/i);
+  });
+
+  test('returns 400 when JWS verification fails', async () => {
+    mockVerifyAppleNotification.mockRejectedValueOnce(new Error('Invalid signature'));
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'bad-jws' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid notification signature/i);
+    expect(log.warn).toHaveBeenCalled();
+  });
+
+  test('returns 400 when notification missing notificationUUID', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REFUND',
+      // notificationUUID intentionally absent
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/notificationUUID/i);
+  });
+});
+
+// ─── Idempotency ─────────────────────────────────────────────────
+
+describe('POST /api/apple-notifications/v2 — idempotency', () => {
+  test('returns deduped:true when notificationUUID was already seen', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REFUND',
+      notificationUUID: 'uuid-already-seen',
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: true, data: () => ({}) });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, deduped: true });
+    expect(mockVerifyAppleSignedTransaction).not.toHaveBeenCalled();
+  });
+});
+
+// ─── REFUND handling ─────────────────────────────────────────────
+
+describe('POST /api/apple-notifications/v2 — REFUND', () => {
+  test('reverses coin-pack entitlement: decrements coins + writes REFUND transaction', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REFUND',
+      notificationUUID: 'uuid-refund-1',
+      data: { signedTransactionInfo: 'mock-jws' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: '2000000123456789',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+    });
+
+    // Dedupe doc absent
+    mockDocGet
+      .mockResolvedValueOnce({ exists: false })
+      // user doc post-update for balanceAfter
+      .mockResolvedValueOnce({ exists: true, data: () => ({ shyCoins: -500 }) });
+
+    // First collection lookup: purchaseReceipts (find by orderId)
+    // Second collection lookup: coinPackages
+    let callCount = 0;
+    mockCollectionGet = jest.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // purchaseReceipts lookup
+        return Promise.resolve({
+          empty: false,
+          docs: [
+            {
+              id: 'receipt-1',
+              data: () => ({
+                userId: 'user-A',
+                productId: 'medium_pack',
+                isSubscription: false,
+                orderId: '2000000123456789',
+              }),
+            },
+          ],
+        });
+      }
+      // coinPackages lookup
+      return Promise.resolve({
+        empty: false,
+        docs: [
+          {
+            id: 'pkg-medium',
+            data: () => ({ productId: 'medium_pack', coins: 500, bonusCoins: 0 }),
+          },
+        ],
+      });
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(mockDocUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ shyCoins: 'increment(-500)' }),
+    );
+    // REFUND transaction written
+    expect(mockDocSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'REFUND',
+        amount: -500,
+        currency: 'COINS',
+        originOrderId: '2000000123456789',
+      }),
+    );
+  });
+
+  test('reverses subscription entitlement: clears isSuperShy + writes REFUND', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REFUND',
+      notificationUUID: 'uuid-refund-sub',
+      data: { signedTransactionInfo: 'mock-jws-sub' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: '2000000sub',
+      productId: 'super_shy_monthly',
+      bundleId: 'com.shyden.shytalk',
+    });
+
+    mockDocGet.mockResolvedValueOnce({ exists: false }); // dedupe
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'receipt-2',
+          data: () => ({
+            userId: 'user-B',
+            productId: 'super_shy_monthly',
+            isSubscription: true,
+            orderId: '2000000sub',
+          }),
+        },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(mockDocUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isSuperShy: false,
+        superShyExpiry: null,
+        superShyTier: null,
+      }),
+    );
+    expect(mockDocSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'REFUND',
+        details: expect.stringContaining('Super Shy monthly'),
+      }),
+    );
+  });
+
+  test('logs and continues when no purchaseReceipt matches the orderId', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REFUND',
+      notificationUUID: 'uuid-orphan',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: 'unknown-id',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+    // purchaseReceipts lookup returns empty
+    mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(log.warn).toHaveBeenCalledWith(
+      'apple-notifications',
+      expect.stringContaining('No purchaseReceipt'),
+      expect.any(Object),
+    );
+    // No update or transaction write
+    expect(mockDocUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// ─── EXPIRED / DID_FAIL_TO_RENEW ─────────────────────────────────
+
+describe('POST /api/apple-notifications/v2 — EXPIRED', () => {
+  test('clears subscription state when EXPIRED and receipt is a subscription', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'EXPIRED',
+      notificationUUID: 'uuid-expired',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: '2000sub',
+      productId: 'super_shy_monthly',
+      bundleId: 'com.shyden.shytalk',
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'receipt-exp',
+          data: () => ({ userId: 'user-C', isSubscription: true, orderId: '2000sub' }),
+        },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(mockDocUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isSuperShy: false,
+        superShyExpiry: null,
+        superShyTier: null,
+      }),
+    );
+  });
+});
+
+// ─── TEST notification ───────────────────────────────────────────
+
+describe('POST /api/apple-notifications/v2 — TEST', () => {
+  test('acknowledges TEST notification with 200, no side effect', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'TEST',
+      notificationUUID: 'uuid-test',
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(log.info).toHaveBeenCalledWith(
+      'apple-notifications',
+      expect.stringContaining('TEST notification'),
+      expect.any(Object),
+    );
+    expect(mockDocUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Unknown notification type ───────────────────────────────────
+
+describe('POST /api/apple-notifications/v2 — unknown type', () => {
+  test('logs and returns 200 for unhandled notification types (so Apple stops retrying)', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'OFFER_REDEEMED',
+      notificationUUID: 'uuid-unknown',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: '2000offer',
+      productId: 'super_shy_monthly',
+      bundleId: 'com.shyden.shytalk',
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(log.info).toHaveBeenCalledWith(
+      'apple-notifications',
+      expect.stringContaining('Acknowledged'),
+      expect.any(Object),
+    );
+  });
+});

--- a/express-api/tests/routes/apple-notifications.test.js
+++ b/express-api/tests/routes/apple-notifications.test.js
@@ -1,10 +1,14 @@
 const express = require('express');
 const request = require('supertest');
 
+// ── Firebase mock ────────────────────────────────────────────────
 const mockDocGet = jest.fn();
 const mockDocUpdate = jest.fn().mockResolvedValue();
 const mockDocSet = jest.fn().mockResolvedValue();
 let mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
+const mockBatchUpdate = jest.fn();
+const mockBatchSet = jest.fn();
+const mockBatchCommit = jest.fn().mockResolvedValue();
 
 jest.mock('../../src/utils/firebase', () => ({
   db: {
@@ -24,23 +28,31 @@ jest.mock('../../src/utils/firebase', () => ({
         })),
       })),
     })),
+    batch: jest.fn(() => ({
+      update: mockBatchUpdate,
+      set: mockBatchSet,
+      commit: mockBatchCommit,
+    })),
   },
   FieldValue: {
     increment: jest.fn((n) => `increment(${n})`),
   },
 }));
 
+// ── Log mock ─────────────────────────────────────────────────────
 jest.mock('../../src/utils/log', () => ({
   info: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),
 }));
 
+// ── Helpers mock (deterministic ids/timestamps) ──────────────────
 jest.mock('../../src/utils/helpers', () => ({
   generateId: () => 'tx-refund-123',
   now: () => 1709913600000,
 }));
 
+// ── Apple verifiers ──────────────────────────────────────────────
 const mockVerifyAppleNotification = jest.fn();
 const mockVerifyAppleSignedTransaction = jest.fn();
 
@@ -49,12 +61,20 @@ jest.mock('../../src/utils/appleStore', () => ({
   verifyAppleSignedTransaction: mockVerifyAppleSignedTransaction,
 }));
 
+// ── Alert manager ────────────────────────────────────────────────
+const mockCreateAlert = jest.fn().mockResolvedValue();
+
+jest.mock('../../src/utils/alertManagerInstance', () => ({
+  createAlert: mockCreateAlert,
+}));
+
 const appleNotificationsRouter = require('../../src/routes/apple-notifications');
 const log = require('../../src/utils/log');
 
 beforeEach(() => {
   jest.clearAllMocks();
   mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
+  mockBatchCommit.mockResolvedValue();
 });
 
 function createApp() {
@@ -101,6 +121,25 @@ describe('POST /api/apple-notifications/v2 — validation', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/notificationUUID/i);
   });
+
+  test('returns 400 when embedded transaction signature fails', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REFUND',
+      notificationUUID: 'uuid-bad-tx',
+      data: { signedTransactionInfo: 'mock-bad-jws' },
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+    mockVerifyAppleSignedTransaction.mockRejectedValueOnce(new Error('Bad tx sig'));
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid embedded transaction/i);
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
 });
 
 // ─── Idempotency ─────────────────────────────────────────────────
@@ -121,13 +160,58 @@ describe('POST /api/apple-notifications/v2 — idempotency', () => {
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ ok: true, deduped: true });
     expect(mockVerifyAppleSignedTransaction).not.toHaveBeenCalled();
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  test('side effect + dedupe row commit atomically (single batch)', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REFUND',
+      notificationUUID: 'uuid-atomic',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: '2000atomic',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'receipt-atom',
+          data: () => ({
+            userId: 'user-atom',
+            isSubscription: false,
+            orderId: '2000atomic',
+            coinsGranted: 500,
+            bonusCoinsGranted: 0,
+          }),
+        },
+      ],
+    });
+
+    const app = createApp();
+    await request(app).post('/api/apple-notifications/v2').send({ signedPayload: 'mock' });
+
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+    // Batch must include the dedupe-row write so a partial commit can never
+    // leave the side effect applied without the dedupe row (or vice versa).
+    expect(mockBatchSet).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        notificationType: 'REFUND',
+        notificationUUID: 'uuid-atomic',
+        orderId: '2000atomic',
+      }),
+    );
   });
 });
 
-// ─── REFUND handling ─────────────────────────────────────────────
+// ─── REFUND — coin pack ──────────────────────────────────────────
 
-describe('POST /api/apple-notifications/v2 — REFUND', () => {
-  test('reverses coin-pack entitlement: decrements coins + writes REFUND transaction', async () => {
+describe('POST /api/apple-notifications/v2 — REFUND coin pack', () => {
+  test('reverses coin-pack entitlement using receipt.coinsGranted (not live coinPackages)', async () => {
     mockVerifyAppleNotification.mockResolvedValueOnce({
       notificationType: 'REFUND',
       notificationUUID: 'uuid-refund-1',
@@ -139,42 +223,88 @@ describe('POST /api/apple-notifications/v2 — REFUND', () => {
       bundleId: 'com.shyden.shytalk',
     });
 
-    // Dedupe doc absent
-    mockDocGet
-      .mockResolvedValueOnce({ exists: false })
-      // user doc post-update for balanceAfter
-      .mockResolvedValueOnce({ exists: true, data: () => ({ shyCoins: -500 }) });
+    mockDocGet.mockResolvedValueOnce({ exists: false }); // dedupe absent
 
-    // First collection lookup: purchaseReceipts (find by orderId)
-    // Second collection lookup: coinPackages
+    // Receipt with persisted coinsGranted — refund must use 500 (receipt)
+    // even if today's coinPackages config says 600.
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'receipt-1',
+          data: () => ({
+            userId: 'user-A',
+            productId: 'medium_pack',
+            isSubscription: false,
+            orderId: '2000000123456789',
+            coinsGranted: 500,
+            bonusCoinsGranted: 0,
+          }),
+        },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(mockBatchUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ shyCoins: 'increment(-500)' }),
+    );
+    expect(mockBatchSet).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        type: 'REFUND',
+        amount: -500,
+        currency: 'COINS',
+        originOrderId: '2000000123456789',
+      }),
+    );
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+  });
+
+  test('legacy receipt (no coinsGranted) falls back to live coinPackages with logged warning', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REFUND',
+      notificationUUID: 'uuid-legacy',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: 'legacy-tx',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+    });
+
+    mockDocGet.mockResolvedValueOnce({ exists: false }); // dedupe
+
+    // Two collection.where lookups: 1) purchaseReceipts, 2) coinPackages fallback
     let callCount = 0;
     mockCollectionGet = jest.fn().mockImplementation(() => {
       callCount++;
       if (callCount === 1) {
-        // purchaseReceipts lookup
         return Promise.resolve({
           empty: false,
           docs: [
             {
-              id: 'receipt-1',
+              id: 'receipt-legacy',
               data: () => ({
-                userId: 'user-A',
+                userId: 'user-legacy',
                 productId: 'medium_pack',
                 isSubscription: false,
-                orderId: '2000000123456789',
+                orderId: 'legacy-tx',
+                // coinsGranted intentionally absent
               }),
             },
           ],
         });
       }
-      // coinPackages lookup
       return Promise.resolve({
         empty: false,
         docs: [
-          {
-            id: 'pkg-medium',
-            data: () => ({ productId: 'medium_pack', coins: 500, bonusCoins: 0 }),
-          },
+          { id: 'pkg', data: () => ({ productId: 'medium_pack', coins: 500, bonusCoins: 0 }) },
         ],
       });
     });
@@ -185,22 +315,76 @@ describe('POST /api/apple-notifications/v2 — REFUND', () => {
       .send({ signedPayload: 'mock' });
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ ok: true });
-    expect(mockDocUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ shyCoins: 'increment(-500)' }),
+    expect(log.warn).toHaveBeenCalledWith(
+      'apple-notifications',
+      expect.stringContaining('Legacy receipt'),
+      expect.any(Object),
     );
-    // REFUND transaction written
-    expect(mockDocSet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'REFUND',
-        amount: -500,
-        currency: 'COINS',
-        originOrderId: '2000000123456789',
-      }),
+    expect(mockBatchUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ shyCoins: 'increment(-500)' }),
     );
   });
 
-  test('reverses subscription entitlement: clears isSuperShy + writes REFUND', async () => {
+  test('legacy receipt with unknown product writes dedupe + alerts ops, no balance change', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REFUND',
+      notificationUUID: 'uuid-orphan-pkg',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: 'orphan-pkg-tx',
+      productId: 'discontinued_pack',
+      bundleId: 'com.shyden.shytalk',
+    });
+
+    mockDocGet.mockResolvedValueOnce({ exists: false }); // dedupe
+
+    let callCount = 0;
+    mockCollectionGet = jest.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve({
+          empty: false,
+          docs: [
+            {
+              id: 'receipt-d',
+              data: () => ({
+                userId: 'user-d',
+                productId: 'discontinued_pack',
+                isSubscription: false,
+                orderId: 'orphan-pkg-tx',
+              }),
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ empty: true, docs: [] }); // coinPackages empty
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(mockCreateAlert).toHaveBeenCalledWith(
+      'refund_coin_pack_failed',
+      'high',
+      expect.any(String),
+      expect.stringContaining('unknown_product'),
+      expect.any(Object),
+    );
+    // Balance must NOT change — but dedupe row IS written so Apple stops retrying.
+    expect(mockBatchUpdate).not.toHaveBeenCalled();
+    expect(mockDocSet).toHaveBeenCalled();
+  });
+});
+
+// ─── REFUND — subscription ───────────────────────────────────────
+
+describe('POST /api/apple-notifications/v2 — REFUND subscription', () => {
+  test('reverses subscription entitlement using receipt.tierGranted', async () => {
     mockVerifyAppleNotification.mockResolvedValueOnce({
       notificationType: 'REFUND',
       notificationUUID: 'uuid-refund-sub',
@@ -223,6 +407,8 @@ describe('POST /api/apple-notifications/v2 — REFUND', () => {
             productId: 'super_shy_monthly',
             isSubscription: true,
             orderId: '2000000sub',
+            tierGranted: 'monthly',
+            daysGranted: 30,
           }),
         },
       ],
@@ -234,22 +420,77 @@ describe('POST /api/apple-notifications/v2 — REFUND', () => {
       .send({ signedPayload: 'mock' });
 
     expect(res.status).toBe(200);
-    expect(mockDocUpdate).toHaveBeenCalledWith(
+    expect(mockBatchUpdate).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
         isSuperShy: false,
         superShyExpiry: null,
         superShyTier: null,
       }),
     );
-    expect(mockDocSet).toHaveBeenCalledWith(
+    expect(mockBatchSet).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
         type: 'REFUND',
         details: expect.stringContaining('Super Shy monthly'),
       }),
     );
+    expect(mockBatchCommit).toHaveBeenCalled();
   });
 
-  test('logs and continues when no purchaseReceipt matches the orderId', async () => {
+  test('subscription not in SUBSCRIPTION_TIERS still clears entitlement defensively + alerts ops', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REFUND',
+      notificationUUID: 'uuid-unknown-sub',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: 'unk-sub',
+      productId: 'super_shy_quarterly_promo50', // not in SUBSCRIPTION_TIERS
+      bundleId: 'com.shyden.shytalk',
+    });
+
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'r-unk',
+          data: () => ({
+            userId: 'user-unk',
+            isSubscription: true,
+            orderId: 'unk-sub',
+            // tierGranted intentionally absent (legacy)
+          }),
+        },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    // Defensive clear must still happen.
+    expect(mockBatchUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ isSuperShy: false }),
+    );
+    expect(mockCreateAlert).toHaveBeenCalledWith(
+      'refund_unknown_subscription',
+      'high',
+      expect.any(String),
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+});
+
+// ─── REFUND — orphan (no receipt) ────────────────────────────────
+
+describe('POST /api/apple-notifications/v2 — REFUND orphan', () => {
+  test('orphan refund persists to orphanRefunds collection + critical-style alert', async () => {
     mockVerifyAppleNotification.mockResolvedValueOnce({
       notificationType: 'REFUND',
       notificationUUID: 'uuid-orphan',
@@ -257,11 +498,11 @@ describe('POST /api/apple-notifications/v2 — REFUND', () => {
     });
     mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
       transactionId: 'unknown-id',
+      originalTransactionId: 'unknown-orig',
       productId: 'medium_pack',
       bundleId: 'com.shyden.shytalk',
     });
     mockDocGet.mockResolvedValueOnce({ exists: false });
-    // purchaseReceipts lookup returns empty
     mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
 
     const app = createApp();
@@ -270,20 +511,117 @@ describe('POST /api/apple-notifications/v2 — REFUND', () => {
       .send({ signedPayload: 'mock' });
 
     expect(res.status).toBe(200);
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.error).toHaveBeenCalledWith(
       'apple-notifications',
-      expect.stringContaining('No purchaseReceipt'),
+      expect.stringContaining('Orphan refund'),
       expect.any(Object),
     );
-    // No update or transaction write
-    expect(mockDocUpdate).not.toHaveBeenCalled();
+    expect(mockCreateAlert).toHaveBeenCalledWith(
+      'orphan_refund',
+      'high',
+      expect.any(String),
+      expect.any(String),
+      expect.any(Object),
+    );
+    // Worklist row written + dedupe row written. Both via mockDocSet.
+    expect(mockDocSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderId: 'unknown-id',
+        productId: 'medium_pack',
+        resolved: false,
+      }),
+    );
+    expect(mockBatchUpdate).not.toHaveBeenCalled();
   });
 });
 
-// ─── EXPIRED / DID_FAIL_TO_RENEW ─────────────────────────────────
+// ─── REVOKE (same path as REFUND) ────────────────────────────────
 
-describe('POST /api/apple-notifications/v2 — EXPIRED', () => {
-  test('clears subscription state when EXPIRED and receipt is a subscription', async () => {
+describe('POST /api/apple-notifications/v2 — REVOKE', () => {
+  test('REVOKE reverses entitlement just like REFUND', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REVOKE',
+      notificationUUID: 'uuid-revoke',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: 'rev-tx',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'r-rev',
+          data: () => ({
+            userId: 'user-rev',
+            isSubscription: false,
+            orderId: 'rev-tx',
+            coinsGranted: 200,
+            bonusCoinsGranted: 0,
+          }),
+        },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(mockBatchUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ shyCoins: 'increment(-200)' }),
+    );
+  });
+});
+
+// ─── REFUND_REVERSED ─────────────────────────────────────────────
+
+describe('POST /api/apple-notifications/v2 — REFUND_REVERSED', () => {
+  test('REFUND_REVERSED writes worklist row + critical alert + dedupe (no auto-restore)', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REFUND_REVERSED',
+      notificationUUID: 'uuid-rev-rev',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: '2000rev-rev',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(log.error).toHaveBeenCalledWith(
+      'apple-notifications',
+      expect.stringContaining('REFUND_REVERSED'),
+      expect.any(Object),
+    );
+    expect(mockCreateAlert).toHaveBeenCalledWith(
+      'refund_reversed',
+      'critical',
+      expect.any(String),
+      expect.any(String),
+      expect.any(Object),
+    );
+    // No batch commit — the auto-restore is delegated to ops via worklist.
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+});
+
+// ─── EXPIRED / DID_FAIL_TO_RENEW / GRACE_PERIOD_EXPIRED ─────────
+
+describe('POST /api/apple-notifications/v2 — subscription expiry', () => {
+  test('EXPIRED clears subscription state when receipt is a subscription', async () => {
     mockVerifyAppleNotification.mockResolvedValueOnce({
       notificationType: 'EXPIRED',
       notificationUUID: 'uuid-expired',
@@ -311,7 +649,8 @@ describe('POST /api/apple-notifications/v2 — EXPIRED', () => {
       .send({ signedPayload: 'mock' });
 
     expect(res.status).toBe(200);
-    expect(mockDocUpdate).toHaveBeenCalledWith(
+    expect(mockBatchUpdate).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
         isSuperShy: false,
         superShyExpiry: null,
@@ -319,12 +658,143 @@ describe('POST /api/apple-notifications/v2 — EXPIRED', () => {
       }),
     );
   });
+
+  test('GRACE_PERIOD_EXPIRED behaves the same as EXPIRED (clears entitlement)', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'GRACE_PERIOD_EXPIRED',
+      notificationUUID: 'uuid-grace',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: '2000grace',
+      productId: 'super_shy_monthly',
+      bundleId: 'com.shyden.shytalk',
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'r-grace',
+          data: () => ({ userId: 'user-grace', isSubscription: true, orderId: '2000grace' }),
+        },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(mockBatchUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ isSuperShy: false }),
+    );
+  });
+
+  test('EXPIRED for non-subscription receipt logs error + writes dedupe (no clear)', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'EXPIRED',
+      notificationUUID: 'uuid-exp-mismatch',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: '2000mis',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'r-mis',
+          data: () => ({ userId: 'user-mis', isSubscription: false, orderId: '2000mis' }),
+        },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(log.error).toHaveBeenCalledWith(
+      'apple-notifications',
+      expect.stringContaining('non-subscription'),
+      expect.any(Object),
+    );
+    // No entitlement mutation.
+    expect(mockBatchUpdate).not.toHaveBeenCalled();
+  });
+
+  test('EXPIRED with no matching receipt logs warning + writes dedupe', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'EXPIRED',
+      notificationUUID: 'uuid-exp-orphan',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: 'orphan-exp',
+      productId: 'super_shy_monthly',
+      bundleId: 'com.shyden.shytalk',
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+    mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(log.warn).toHaveBeenCalledWith(
+      'apple-notifications',
+      expect.stringContaining('expiry with no matching receipt'),
+      expect.any(Object),
+    );
+    expect(mockBatchUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// ─── CONSUMPTION_REQUEST ─────────────────────────────────────────
+
+describe('POST /api/apple-notifications/v2 — CONSUMPTION_REQUEST', () => {
+  test('alerts ops with high severity (12h SLA) + writes dedupe', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'CONSUMPTION_REQUEST',
+      notificationUUID: 'uuid-consumption',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: 'cons-tx',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    expect(mockCreateAlert).toHaveBeenCalledWith(
+      'consumption_request',
+      'high',
+      expect.stringContaining('12h'),
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
 });
 
 // ─── TEST notification ───────────────────────────────────────────
 
 describe('POST /api/apple-notifications/v2 — TEST', () => {
-  test('acknowledges TEST notification with 200, no side effect', async () => {
+  test('acknowledges TEST with 200, writes dedupe, no alert', async () => {
     mockVerifyAppleNotification.mockResolvedValueOnce({
       notificationType: 'TEST',
       notificationUUID: 'uuid-test',
@@ -342,14 +812,17 @@ describe('POST /api/apple-notifications/v2 — TEST', () => {
       expect.stringContaining('TEST notification'),
       expect.any(Object),
     );
-    expect(mockDocUpdate).not.toHaveBeenCalled();
+    expect(mockBatchUpdate).not.toHaveBeenCalled();
+    expect(mockCreateAlert).not.toHaveBeenCalled();
+    // dedupe row IS written.
+    expect(mockDocSet).toHaveBeenCalled();
   });
 });
 
 // ─── Unknown notification type ───────────────────────────────────
 
 describe('POST /api/apple-notifications/v2 — unknown type', () => {
-  test('logs and returns 200 for unhandled notification types (so Apple stops retrying)', async () => {
+  test('logs and returns 200 for unhandled notification types (Apple stops retrying)', async () => {
     mockVerifyAppleNotification.mockResolvedValueOnce({
       notificationType: 'OFFER_REDEEMED',
       notificationUUID: 'uuid-unknown',
@@ -371,6 +844,64 @@ describe('POST /api/apple-notifications/v2 — unknown type', () => {
     expect(log.info).toHaveBeenCalledWith(
       'apple-notifications',
       expect.stringContaining('Acknowledged'),
+      expect.any(Object),
+    );
+    expect(mockBatchUpdate).not.toHaveBeenCalled();
+    expect(mockCreateAlert).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Crash → 500 + alert ─────────────────────────────────────────
+
+describe('POST /api/apple-notifications/v2 — crash handling', () => {
+  test('returns 500 + critical alert when batch commit fails (so Apple retries)', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REFUND',
+      notificationUUID: 'uuid-crash',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: 'crash-tx',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+    });
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'r-crash',
+          data: () => ({
+            userId: 'user-crash',
+            isSubscription: false,
+            orderId: 'crash-tx',
+            coinsGranted: 100,
+            bonusCoinsGranted: 0,
+          }),
+        },
+      ],
+    });
+    mockBatchCommit.mockRejectedValueOnce(new Error('Firestore down'));
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(500);
+    expect(log.error).toHaveBeenCalledWith(
+      'apple-notifications',
+      expect.stringContaining('crashed'),
+      expect.objectContaining({
+        notificationUUID: 'uuid-crash',
+        notificationType: 'REFUND',
+      }),
+    );
+    expect(mockCreateAlert).toHaveBeenCalledWith(
+      'apple_notification_crash',
+      'critical',
+      expect.any(String),
+      'Firestore down',
       expect.any(Object),
     );
   });

--- a/express-api/tests/routes/apple-notifications.test.js
+++ b/express-api/tests/routes/apple-notifications.test.js
@@ -6,9 +6,19 @@ const mockDocGet = jest.fn();
 const mockDocUpdate = jest.fn().mockResolvedValue();
 const mockDocSet = jest.fn().mockResolvedValue();
 let mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-const mockBatchUpdate = jest.fn();
-const mockBatchSet = jest.fn();
-const mockBatchCommit = jest.fn().mockResolvedValue();
+
+// Transaction tracking: every `tx.update`/`tx.set` call inside the
+// runTransaction callback is recorded against these mocks so tests can
+// assert what the atomic state mutation contained.
+const mockTxGet = jest.fn();
+const mockTxUpdate = jest.fn();
+const mockTxSet = jest.fn();
+// Each runTransaction call returns the callback's return value, mirroring
+// the real Firestore SDK contract so the helper can branch on whether
+// the dedupe check short-circuited (false) or the side effect ran (true).
+const mockRunTransaction = jest.fn(async (fn) => {
+  return fn({ get: mockTxGet, update: mockTxUpdate, set: mockTxSet });
+});
 
 jest.mock('../../src/utils/firebase', () => ({
   db: {
@@ -28,11 +38,7 @@ jest.mock('../../src/utils/firebase', () => ({
         })),
       })),
     })),
-    batch: jest.fn(() => ({
-      update: mockBatchUpdate,
-      set: mockBatchSet,
-      commit: mockBatchCommit,
-    })),
+    runTransaction: mockRunTransaction,
   },
   FieldValue: {
     increment: jest.fn((n) => `increment(${n})`),
@@ -74,7 +80,15 @@ const log = require('../../src/utils/log');
 beforeEach(() => {
   jest.clearAllMocks();
   mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-  mockBatchCommit.mockResolvedValue();
+  // Default: inside-transaction dedupe check sees no prior row (proceed
+  // with the side effect). Tests for the race-resolved-duplicate path
+  // override with `mockTxGet.mockResolvedValueOnce({ exists: true })`.
+  mockTxGet.mockResolvedValue({ exists: false });
+  // Re-bind the runTransaction mock so each test starts with the default
+  // pass-through behaviour after `clearAllMocks` resets it to a bare fn.
+  mockRunTransaction.mockImplementation(async (fn) => {
+    return fn({ get: mockTxGet, update: mockTxUpdate, set: mockTxSet });
+  });
 });
 
 function createApp() {
@@ -138,7 +152,7 @@ describe('POST /api/apple-notifications/v2 — validation', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/Invalid embedded transaction/i);
-    expect(mockBatchCommit).not.toHaveBeenCalled();
+    expect(mockRunTransaction).not.toHaveBeenCalled();
   });
 });
 
@@ -160,10 +174,10 @@ describe('POST /api/apple-notifications/v2 — idempotency', () => {
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ ok: true, deduped: true });
     expect(mockVerifyAppleSignedTransaction).not.toHaveBeenCalled();
-    expect(mockBatchCommit).not.toHaveBeenCalled();
+    expect(mockRunTransaction).not.toHaveBeenCalled();
   });
 
-  test('side effect + dedupe row commit atomically (single batch)', async () => {
+  test('side effect + dedupe row commit atomically inside a single transaction', async () => {
     mockVerifyAppleNotification.mockResolvedValueOnce({
       notificationType: 'REFUND',
       notificationUUID: 'uuid-atomic',
@@ -194,10 +208,12 @@ describe('POST /api/apple-notifications/v2 — idempotency', () => {
     const app = createApp();
     await request(app).post('/api/apple-notifications/v2').send({ signedPayload: 'mock' });
 
-    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
-    // Batch must include the dedupe-row write so a partial commit can never
-    // leave the side effect applied without the dedupe row (or vice versa).
-    expect(mockBatchSet).toHaveBeenCalledWith(
+    expect(mockRunTransaction).toHaveBeenCalledTimes(1);
+    // The transaction must include the dedupe-row write so a partial
+    // commit can never leave the side effect applied without the
+    // dedupe row (or vice versa). Concurrent retries are serialised by
+    // Firestore on the dedupe-ref read.
+    expect(mockTxSet).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         notificationType: 'REFUND',
@@ -205,6 +221,50 @@ describe('POST /api/apple-notifications/v2 — idempotency', () => {
         orderId: '2000atomic',
       }),
     );
+  });
+
+  test('inside-transaction dedupe sees concurrent retry → side effect skipped (race resolved)', async () => {
+    mockVerifyAppleNotification.mockResolvedValueOnce({
+      notificationType: 'REFUND',
+      notificationUUID: 'uuid-race',
+      data: { signedTransactionInfo: 'mock' },
+    });
+    mockVerifyAppleSignedTransaction.mockResolvedValueOnce({
+      transactionId: 'race-tx',
+      productId: 'medium_pack',
+      bundleId: 'com.shyden.shytalk',
+    });
+    // Outer dedupe check passes (concurrent request hasn't yet written),
+    // but by the time we're inside the transaction the OTHER concurrent
+    // request has already written the dedupe row.
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+    mockTxGet.mockResolvedValueOnce({ exists: true });
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'r-race',
+          data: () => ({
+            userId: 'user-race',
+            isSubscription: false,
+            orderId: 'race-tx',
+            coinsGranted: 500,
+            bonusCoinsGranted: 0,
+          }),
+        },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/apple-notifications/v2')
+      .send({ signedPayload: 'mock' });
+
+    expect(res.status).toBe(200);
+    // Side effect must NOT have been applied — the concurrent request
+    // already did it. No update, no transaction row write.
+    expect(mockTxUpdate).not.toHaveBeenCalled();
+    expect(mockTxSet).not.toHaveBeenCalled();
   });
 });
 
@@ -250,11 +310,11 @@ describe('POST /api/apple-notifications/v2 — REFUND coin pack', () => {
       .send({ signedPayload: 'mock' });
 
     expect(res.status).toBe(200);
-    expect(mockBatchUpdate).toHaveBeenCalledWith(
+    expect(mockTxUpdate).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ shyCoins: 'increment(-500)' }),
     );
-    expect(mockBatchSet).toHaveBeenCalledWith(
+    expect(mockTxSet).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         type: 'REFUND',
@@ -263,7 +323,7 @@ describe('POST /api/apple-notifications/v2 — REFUND coin pack', () => {
         originOrderId: '2000000123456789',
       }),
     );
-    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+    expect(mockRunTransaction).toHaveBeenCalledTimes(1);
   });
 
   test('legacy receipt (no coinsGranted) falls back to live coinPackages with logged warning', async () => {
@@ -320,7 +380,7 @@ describe('POST /api/apple-notifications/v2 — REFUND coin pack', () => {
       expect.stringContaining('Legacy receipt'),
       expect.any(Object),
     );
-    expect(mockBatchUpdate).toHaveBeenCalledWith(
+    expect(mockTxUpdate).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ shyCoins: 'increment(-500)' }),
     );
@@ -376,7 +436,7 @@ describe('POST /api/apple-notifications/v2 — REFUND coin pack', () => {
       expect.any(Object),
     );
     // Balance must NOT change — but dedupe row IS written so Apple stops retrying.
-    expect(mockBatchUpdate).not.toHaveBeenCalled();
+    expect(mockTxUpdate).not.toHaveBeenCalled();
     expect(mockDocSet).toHaveBeenCalled();
   });
 });
@@ -420,7 +480,7 @@ describe('POST /api/apple-notifications/v2 — REFUND subscription', () => {
       .send({ signedPayload: 'mock' });
 
     expect(res.status).toBe(200);
-    expect(mockBatchUpdate).toHaveBeenCalledWith(
+    expect(mockTxUpdate).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         isSuperShy: false,
@@ -428,14 +488,14 @@ describe('POST /api/apple-notifications/v2 — REFUND subscription', () => {
         superShyTier: null,
       }),
     );
-    expect(mockBatchSet).toHaveBeenCalledWith(
+    expect(mockTxSet).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         type: 'REFUND',
         details: expect.stringContaining('Super Shy monthly'),
       }),
     );
-    expect(mockBatchCommit).toHaveBeenCalled();
+    expect(mockRunTransaction).toHaveBeenCalled();
   });
 
   test('subscription not in SUBSCRIPTION_TIERS still clears entitlement defensively + alerts ops', async () => {
@@ -473,7 +533,7 @@ describe('POST /api/apple-notifications/v2 — REFUND subscription', () => {
 
     expect(res.status).toBe(200);
     // Defensive clear must still happen.
-    expect(mockBatchUpdate).toHaveBeenCalledWith(
+    expect(mockTxUpdate).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ isSuperShy: false }),
     );
@@ -531,7 +591,7 @@ describe('POST /api/apple-notifications/v2 — REFUND orphan', () => {
         resolved: false,
       }),
     );
-    expect(mockBatchUpdate).not.toHaveBeenCalled();
+    expect(mockTxUpdate).not.toHaveBeenCalled();
   });
 });
 
@@ -572,7 +632,7 @@ describe('POST /api/apple-notifications/v2 — REVOKE', () => {
       .send({ signedPayload: 'mock' });
 
     expect(res.status).toBe(200);
-    expect(mockBatchUpdate).toHaveBeenCalledWith(
+    expect(mockTxUpdate).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ shyCoins: 'increment(-200)' }),
     );
@@ -614,7 +674,7 @@ describe('POST /api/apple-notifications/v2 — REFUND_REVERSED', () => {
       expect.any(Object),
     );
     // No batch commit — the auto-restore is delegated to ops via worklist.
-    expect(mockBatchCommit).not.toHaveBeenCalled();
+    expect(mockRunTransaction).not.toHaveBeenCalled();
   });
 });
 
@@ -649,7 +709,7 @@ describe('POST /api/apple-notifications/v2 — subscription expiry', () => {
       .send({ signedPayload: 'mock' });
 
     expect(res.status).toBe(200);
-    expect(mockBatchUpdate).toHaveBeenCalledWith(
+    expect(mockTxUpdate).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         isSuperShy: false,
@@ -687,7 +747,7 @@ describe('POST /api/apple-notifications/v2 — subscription expiry', () => {
       .send({ signedPayload: 'mock' });
 
     expect(res.status).toBe(200);
-    expect(mockBatchUpdate).toHaveBeenCalledWith(
+    expect(mockTxUpdate).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ isSuperShy: false }),
     );
@@ -727,7 +787,7 @@ describe('POST /api/apple-notifications/v2 — subscription expiry', () => {
       expect.any(Object),
     );
     // No entitlement mutation.
-    expect(mockBatchUpdate).not.toHaveBeenCalled();
+    expect(mockTxUpdate).not.toHaveBeenCalled();
   });
 
   test('EXPIRED with no matching receipt logs warning + writes dedupe', async () => {
@@ -755,7 +815,7 @@ describe('POST /api/apple-notifications/v2 — subscription expiry', () => {
       expect.stringContaining('expiry with no matching receipt'),
       expect.any(Object),
     );
-    expect(mockBatchUpdate).not.toHaveBeenCalled();
+    expect(mockTxUpdate).not.toHaveBeenCalled();
   });
 });
 
@@ -812,7 +872,7 @@ describe('POST /api/apple-notifications/v2 — TEST', () => {
       expect.stringContaining('TEST notification'),
       expect.any(Object),
     );
-    expect(mockBatchUpdate).not.toHaveBeenCalled();
+    expect(mockTxUpdate).not.toHaveBeenCalled();
     expect(mockCreateAlert).not.toHaveBeenCalled();
     // dedupe row IS written.
     expect(mockDocSet).toHaveBeenCalled();
@@ -846,7 +906,7 @@ describe('POST /api/apple-notifications/v2 — unknown type', () => {
       expect.stringContaining('Acknowledged'),
       expect.any(Object),
     );
-    expect(mockBatchUpdate).not.toHaveBeenCalled();
+    expect(mockTxUpdate).not.toHaveBeenCalled();
     expect(mockCreateAlert).not.toHaveBeenCalled();
   });
 });
@@ -881,7 +941,7 @@ describe('POST /api/apple-notifications/v2 — crash handling', () => {
         },
       ],
     });
-    mockBatchCommit.mockRejectedValueOnce(new Error('Firestore down'));
+    mockRunTransaction.mockRejectedValueOnce(new Error('Firestore down'));
 
     const app = createApp();
     const res = await request(app)

--- a/express-api/tests/routes/economy-purchase.test.js
+++ b/express-api/tests/routes/economy-purchase.test.js
@@ -466,10 +466,54 @@ describe('POST /api/economy/purchase', () => {
           })
           .expect(200);
 
+        // Refund handler reads coinsGranted/bonusCoinsGranted from this
+        // receipt at refund time — assert they're persisted so a future
+        // economy.js refactor can't silently break the refund path.
         expect(mockDocSet).toHaveBeenCalledWith(
           expect.objectContaining({
             platform: 'apple',
             orderId: '2000000abcdef',
+            coinsGranted: 100,
+            bonusCoinsGranted: 0,
+            isSubscription: false,
+          }),
+        );
+      } finally {
+        process.env.NODE_ENV = prevEnv;
+      }
+    });
+
+    test('subscription receipt persists tierGranted + daysGranted for refund handler', async () => {
+      mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
+      mockDocGet.mockResolvedValue({ exists: true, data: () => ({ shyCoins: 0, shyBeans: 0 }) });
+
+      const prevEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      verifyApplePurchase.mockResolvedValueOnce({
+        orderId: '2000000sub-monthly',
+        productId: 'super_shy_monthly',
+        purchaseDate: 1700000000000,
+      });
+
+      try {
+        const app = createApp('user-A');
+        await request(app)
+          .post('/api/economy/purchase')
+          .send({
+            productId: 'super_shy_monthly',
+            purchaseToken: 'mock-jws-sub',
+            platform: 'apple',
+            isSubscription: true,
+          })
+          .expect(200);
+
+        expect(mockDocSet).toHaveBeenCalledWith(
+          expect.objectContaining({
+            platform: 'apple',
+            orderId: '2000000sub-monthly',
+            isSubscription: true,
+            tierGranted: 'monthly',
+            daysGranted: 30,
           }),
         );
       } finally {

--- a/express-api/tests/utils/appleStore.test.js
+++ b/express-api/tests/utils/appleStore.test.js
@@ -181,6 +181,7 @@ describe('verifyApplePurchase — configuration', () => {
 
   test('uses PRODUCTION environment when APPLE_APP_STORE_ENV=production', async () => {
     process.env.APPLE_APP_STORE_ENV = 'production';
+    process.env.APPLE_APP_STORE_APP_ID = '1234567890';
     _resetVerifier();
     const { SignedDataVerifier } = require('@apple/app-store-server-library');
 
@@ -193,17 +194,39 @@ describe('verifyApplePurchase — configuration', () => {
 
     await verifyApplePurchase('medium_pack', 'mock-jws', false);
 
-    // SignedDataVerifier(rootCerts, performRevocationChecking, environment, bundleId)
+    // SignedDataVerifier(rootCerts, performRevocationChecking, environment, bundleId, appAppleId)
     expect(SignedDataVerifier).toHaveBeenCalledWith(
       expect.any(Array),
       true,
       'PRODUCTION',
       'com.shyden.shytalk',
+      1234567890,
     );
   });
 
-  test('uses SANDBOX environment by default', async () => {
+  test('throws when APPLE_APP_STORE_ENV=production but APPLE_APP_STORE_APP_ID unset', async () => {
+    process.env.APPLE_APP_STORE_ENV = 'production';
+    delete process.env.APPLE_APP_STORE_APP_ID;
+    _resetVerifier();
+
+    await expect(verifyApplePurchase('medium_pack', 'mock-jws', false)).rejects.toThrow(
+      /APPLE_APP_STORE_APP_ID/,
+    );
+  });
+
+  test('throws when APPLE_APP_STORE_APP_ID is non-numeric', async () => {
+    process.env.APPLE_APP_STORE_ENV = 'production';
+    process.env.APPLE_APP_STORE_APP_ID = 'not-a-number';
+    _resetVerifier();
+
+    await expect(verifyApplePurchase('medium_pack', 'mock-jws', false)).rejects.toThrow(
+      /must be numeric/,
+    );
+  });
+
+  test('uses SANDBOX environment by default (no appAppleId required)', async () => {
     delete process.env.APPLE_APP_STORE_ENV;
+    delete process.env.APPLE_APP_STORE_APP_ID;
     _resetVerifier();
     const { SignedDataVerifier } = require('@apple/app-store-server-library');
 
@@ -221,6 +244,7 @@ describe('verifyApplePurchase — configuration', () => {
       true,
       'SANDBOX',
       'com.shyden.shytalk',
+      undefined,
     );
   });
 });

--- a/firestore.rules
+++ b/firestore.rules
@@ -420,5 +420,28 @@ service cloud.firestore {
       allow read: if request.auth != null && request.auth.token.admin == true;
       allow write: if false;
     }
+
+    // ── Apple notifications dedup — server-only (webhook idempotency)
+    match /appleNotifications/{notificationUUID} {
+      allow read, write: if false;
+    }
+
+    // ── Orphan refunds worklist — admin read, server write ─────
+    // Apple-side refunds with no matching purchaseReceipt. Ops resolves
+    // these manually; the admin panel surfaces them via this collection.
+    match /orphanRefunds/{notificationUUID} {
+      allow read: if request.auth != null && request.auth.token.admin == true;
+      allow write: if false;
+    }
+
+    // ── Pending refund reversals — admin read, server write ────
+    // Apple REFUND_REVERSED events (customer charged back the refund or
+    // App Review reversed it). Auto-restoration of entitlement is risky
+    // for money-affecting paths, so the webhook delegates to ops via
+    // this worklist + a critical alert.
+    match /pendingRefundReversals/{notificationUUID} {
+      allow read: if request.auth != null && request.auth.token.admin == true;
+      allow write: if false;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `POST /api/apple-notifications/v2` to receive Apple's signed JWS notifications (refunds, revokes, expiries, renewals, TEST). JWS signature is verified against the existing `SignedDataVerifier`; idempotency dedup via `appleNotifications/<notificationUUID>` so Apple's retry-up-to-5 is safe.
- `REFUND` / `REVOKE` reverse the matching `purchaseReceipt` entitlement — coin-pack via `FieldValue.increment(-totalCoins)` + REFUND transaction; subscription via clearing `isSuperShy`/`superShyExpiry`/`superShyTier` + REFUND transaction. The receipt lookup tries both `transactionId` and `originalTransactionId` so renewal events still find the right user.
- `EXPIRED` / `DID_FAIL_TO_RENEW` clear subscription state. `TEST` + unknown types are ack'd with 200 so Apple stops retrying. Crashes return 500 so Apple retries — better to double-process than to silently drop a refund.
- 11 new tests cover validation, idempotency, REFUND for both coin/subscription, no-receipt-found, EXPIRED, TEST, and unknown types. All 4407 Express tests pass locally.

This is the **authoritative** refund path — `Transaction.updates` on the iOS client (B6.10b) is a redundancy that only fires while the app is running.

Closes B6.10c of #20.

## Manual setup (NOT in this PR)
- App Store Connect → App Information → App Store Server Notifications: set the prod and sandbox notification URLs to the prod and dev API base URLs respectively, both with path `/api/apple-notifications/v2`.
- Deploy Apple Root CA certs (`AppleRootCA-G3.cer`, `AppleRootCA-G2.cer`, plus the legacy `AppleIncRootCertificate.cer` and `AppleComputerRootCertificate.cer`) to prod and dev VMs at `${APPLE_ROOT_CERTS_DIR}`.
- Set `APPLE_APP_STORE_ENV=production` on prod (default is sandbox so misconfigured deploys fail closed).

## Test plan
- [x] `npm test` passes locally (4407/4407)
- [x] New unit tests cover REFUND/REVOKE/EXPIRED/TEST/unknown
- [x] No real notification URLs in this PR (manual config step)
- [ ] Deploy to dev → Apple sandbox sends TEST notification → verify 200 + dedupe row written
- [ ] Trigger a sandbox refund → verify coin reversal + REFUND transaction
- [ ] Trigger a sandbox subscription refund → verify isSuperShy cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)