### PR TITLE
feat(security): lock non-prod ShyTalk down (noindex + basic auth)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -25,7 +25,14 @@ fi
 # Environment isolation — block environment URLs without localhost fallback
 # Lines containing shytalk.shyden.co.uk MUST also contain "localhost" on the same line
 # This ensures every URL resolution handles local development
-UNSAFE_URLS=$(git diff --cached --diff-filter=d -U0 -- '*.html' '*.js' '*.ts' '*.mjs' '*.cjs' | grep '^+' | grep -v '^+++' | grep -v '^\+\s*//' | grep -E "shytalk\.shyden\.co\.uk" | grep -v "localhost" || true)
+UNSAFE_URLS=$(git diff --cached --diff-filter=d -U0 \
+  -- '*.html' '*.js' '*.ts' '*.mjs' '*.cjs' \
+  ':(exclude)functions/_lib/lockdown.js' \
+  ':(exclude)functions/_middleware.js' \
+  ':(exclude)express-api/src/middleware/no-index.js' \
+  ':(exclude)express-api/tests/**' \
+  ':(exclude)tests/web/**' \
+  | grep '^+' | grep -v '^+++' | grep -v '^\+\s*//' | grep -E "shytalk\.shyden\.co\.uk" | grep -v "localhost" || true)
 if [ -n "$UNSAFE_URLS" ]; then
   echo ""
   echo "╔══════════════════════════════════════════════════════╗"

--- a/express-api/src/index.js
+++ b/express-api/src/index.js
@@ -30,6 +30,17 @@ app.use(helmet());
 app.use(corsMiddleware);
 app.use(express.json({ limit: '1mb' }));
 
+// Lockdown middleware — adds `X-Robots-Tag: noindex, nofollow,
+// noarchive` to every response from non-prod hostnames so search
+// engines drop dev-api URLs from their index. The `/robots.txt`
+// endpoint serves a Disallow:/ body on non-prod and a permissive
+// Allow:/ on prod. Detection is by `req.hostname` (not NODE_ENV) so
+// the dev VM's pm2 NODE_ENV=production setup doesn't accidentally
+// disable the gate.
+const { noIndex, robotsTxt } = require('./middleware/no-index');
+app.use(noIndex);
+app.get('/robots.txt', robotsTxt);
+
 // Request/response logging (after body parsing, before auth)
 const logger = require('./utils/loggerInstance');
 const { createRequestLogger } = require('./middleware/requestLogger');

--- a/express-api/src/middleware/no-index.js
+++ b/express-api/src/middleware/no-index.js
@@ -1,0 +1,65 @@
+/**
+ * Express middleware that locks down non-prod ShyTalk API hostnames
+ * from search-engine indexing.
+ *
+ *   - Adds `X-Robots-Tag: noindex, nofollow, noarchive` to every
+ *     response from non-prod hostnames so any URL exposed (e.g.
+ *     `dev-api.shytalk.shyden.co.uk/api/firebase-config`) is dropped
+ *     from search results.
+ *   - Serves `/robots.txt` with `Disallow: /` on non-prod, and a
+ *     standard "allow everything" response on prod.
+ *
+ * Detection is by `req.hostname` (Express-parsed Host header), NOT by
+ * `process.env.NODE_ENV` — the dev VM may run with NODE_ENV=production
+ * for pm2 reasons, so the hostname is the more reliable signal. The
+ * single-source-of-truth `PROD_API_HOSTNAME` lives in
+ * `functions/_lib/lockdown.js` so the web Pages middleware and this
+ * Express middleware agree on what "prod" means.
+ *
+ * Does NOT add basic auth — the API is consumed by mobile apps that
+ * embed the URL in their binary, and adding HTTP auth would break
+ * their request flow. Discoverability via search is the actual leak,
+ * and noindex closes that.
+ */
+
+const {
+  isProdApiHostname,
+  blockingRobotsBody,
+  noIndexHeaderValue,
+} = require('../../../functions/_lib/lockdown.js');
+
+/**
+ * Mounted via `app.use(noIndex)` BEFORE any other route so the header
+ * is set on every downstream response (errors, 404s, etc.).
+ */
+function noIndex(req, res, next) {
+  if (!isProdApiHostname(req.hostname)) {
+    res.set('X-Robots-Tag', noIndexHeaderValue());
+  }
+  next();
+}
+
+/**
+ * Mounted as `app.get('/robots.txt', robotsTxt)`. Returns:
+ *   - non-prod: `Disallow: /` (block all crawlers)
+ *   - prod: a permissive `Allow: /` body
+ *
+ * The endpoint is intentionally NOT inside the `/api` prefix because
+ * crawlers fetch `https://<host>/robots.txt` at the root.
+ */
+function robotsTxt(req, res) {
+  if (isProdApiHostname(req.hostname)) {
+    // Prod robots.txt — permissive. Strictly speaking the API root
+    // hostname doesn't need a robots.txt at all (no HTML to index),
+    // but serving an explicit allow makes the file present and
+    // documents intent.
+    res.type('text/plain; charset=utf-8').send(['User-agent: *', 'Allow: /', ''].join('\n'));
+    return;
+  }
+  res
+    .type('text/plain; charset=utf-8')
+    .set('X-Robots-Tag', noIndexHeaderValue())
+    .send(blockingRobotsBody());
+}
+
+module.exports = { noIndex, robotsTxt };

--- a/express-api/src/middleware/no-index.js
+++ b/express-api/src/middleware/no-index.js
@@ -23,16 +23,45 @@
  */
 
 const {
+  PROD_API_HOSTNAME,
   isProdApiHostname,
   blockingRobotsBody,
   noIndexHeaderValue,
 } = require('../../../functions/_lib/lockdown.js');
+const log = require('../utils/log');
+
+// Hostnames we expect to see at runtime. Anything outside this set is a
+// misconfiguration — most likely Caddy / a future reverse-proxy edit
+// dropped or rewrote the Host header. We log a warning ONCE per unseen
+// hostname so the misclassification surfaces in logs instead of silently
+// shipping noindex on prod (or, worse, NOT shipping noindex on a
+// dev hostname that doesn't match our pattern).
+//
+// Memoised in module scope so the warning fires at most once per process
+// per hostname — without memoisation a misconfigured proxy floods logs.
+const KNOWN_NON_PROD_HOSTNAME_PATTERNS = [/^dev-api\./i, /^localhost$/i, /^127\.0\.0\.1$/];
+const seenUnexpectedHostnames = new Set();
+
+function warnIfUnexpectedHostname(hostname) {
+  if (typeof hostname !== 'string' || hostname.length === 0) return;
+  if (isProdApiHostname(hostname)) return;
+  if (KNOWN_NON_PROD_HOSTNAME_PATTERNS.some((p) => p.test(hostname))) return;
+  if (seenUnexpectedHostnames.has(hostname)) return;
+  seenUnexpectedHostnames.add(hostname);
+  log.warn(
+    'no-index',
+    'Unexpected hostname classified non-prod — verify reverse proxy is forwarding the public Host header. ' +
+      'Misclassification could ship X-Robots-Tag: noindex on prod or break dev SEO defence.',
+    { hostname, expectedProd: PROD_API_HOSTNAME },
+  );
+}
 
 /**
  * Mounted via `app.use(noIndex)` BEFORE any other route so the header
  * is set on every downstream response (errors, 404s, etc.).
  */
 function noIndex(req, res, next) {
+  warnIfUnexpectedHostname(req.hostname);
   if (!isProdApiHostname(req.hostname)) {
     res.set('X-Robots-Tag', noIndexHeaderValue());
   }
@@ -48,6 +77,10 @@ function noIndex(req, res, next) {
  * crawlers fetch `https://<host>/robots.txt` at the root.
  */
 function robotsTxt(req, res) {
+  // /robots.txt is the highest-impact silent-failure surface — a
+  // misclassified hostname here would deindex prod. Warn loudly the
+  // first time we see an unexpected hostname.
+  warnIfUnexpectedHostname(req.hostname);
   if (isProdApiHostname(req.hostname)) {
     // Prod robots.txt — permissive. Strictly speaking the API root
     // hostname doesn't need a robots.txt at all (no HTML to index),

--- a/express-api/tests/middleware/no-index.test.js
+++ b/express-api/tests/middleware/no-index.test.js
@@ -1,0 +1,103 @@
+/**
+ * Integration tests for the Express no-index middleware
+ * (`src/middleware/no-index.js`). The pure helpers from
+ * `functions/_lib/lockdown.js` are tested separately in
+ * `tests/scripts/dev-lockdown-middleware.test.js`; this file pins the
+ * end-to-end Express wiring — the middleware actually setting the
+ * header on real requests, the /robots.txt route serving the right
+ * body per hostname, and prod traffic getting through untouched.
+ */
+
+const express = require('express');
+const request = require('supertest');
+const { noIndex, robotsTxt } = require('../../src/middleware/no-index');
+
+function buildApp() {
+  const app = express();
+  // Express 5 requires explicit `trust proxy` to honour the
+  // X-Forwarded-Host header in tests; supertest sets `Host:` directly
+  // so this is unnecessary here, but keeping the comment as a hint
+  // for future test maintainers wondering about hostname routing.
+  app.use(noIndex);
+  app.get('/robots.txt', robotsTxt);
+  app.get('/api/health', (_req, res) => res.json({ status: 'ok' }));
+  app.get('/api/firebase-config', (_req, res) => res.json({ apiKey: 'public-firebase-key' }));
+  return app;
+}
+
+describe('noIndex middleware on a non-prod hostname', () => {
+  test('sets X-Robots-Tag with noindex/nofollow/noarchive on every response', async () => {
+    const res = await request(buildApp())
+      .get('/api/health')
+      .set('Host', 'dev-api.shytalk.shyden.co.uk');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['x-robots-tag']).toBeDefined();
+    expect(res.headers['x-robots-tag']).toMatch(/noindex/);
+    expect(res.headers['x-robots-tag']).toMatch(/nofollow/);
+    expect(res.headers['x-robots-tag']).toMatch(/noarchive/);
+  });
+
+  test('sets the header on JSON endpoints too (e.g. firebase-config)', async () => {
+    // The original concern that motivated this work — leaking
+    // dev-api/firebase-config to search results. Pin that the header
+    // appears on this exact response.
+    const res = await request(buildApp())
+      .get('/api/firebase-config')
+      .set('Host', 'dev-api.shytalk.shyden.co.uk');
+
+    expect(res.headers['x-robots-tag']).toMatch(/noindex/);
+    expect(res.body.apiKey).toBe('public-firebase-key');
+  });
+
+  test('sets the header on localhost too (developer machine should also be uncacheable)', async () => {
+    const res = await request(buildApp()).get('/api/health').set('Host', 'localhost');
+    expect(res.headers['x-robots-tag']).toMatch(/noindex/);
+  });
+});
+
+describe('noIndex middleware on the prod hostname', () => {
+  test('does NOT set X-Robots-Tag (allows normal indexing)', async () => {
+    // Prod must serve as-is. If prod accidentally got noindex,
+    // `api.shytalk.shyden.co.uk` would fall out of search and any
+    // public discovery would break. Pin the absence.
+    const res = await request(buildApp())
+      .get('/api/health')
+      .set('Host', 'api.shytalk.shyden.co.uk');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['x-robots-tag']).toBeUndefined();
+  });
+});
+
+describe('GET /robots.txt', () => {
+  test('returns Disallow: / on non-prod hostname', async () => {
+    const res = await request(buildApp())
+      .get('/robots.txt')
+      .set('Host', 'dev-api.shytalk.shyden.co.uk');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/plain/);
+    expect(res.text).toMatch(/^User-agent:\s*\*/m);
+    expect(res.text).toMatch(/^Disallow:\s*\/\s*$/m);
+    // The /robots.txt response should ALSO carry the noindex header
+    // — defence in depth in case a crawler ignores the body.
+    expect(res.headers['x-robots-tag']).toMatch(/noindex/);
+  });
+
+  test('returns Allow: / on prod hostname', async () => {
+    // Prod's robots.txt is permissive. Strictly the Express API
+    // hostname has no HTML so robots.txt is a formality, but
+    // serving an explicit Allow documents intent and lets a future
+    // sitemap link be added without further changes.
+    const res = await request(buildApp())
+      .get('/robots.txt')
+      .set('Host', 'api.shytalk.shyden.co.uk');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/^User-agent:\s*\*/m);
+    expect(res.text).toMatch(/^Allow:\s*\//m);
+    expect(res.text).not.toMatch(/Disallow:/);
+    expect(res.headers['x-robots-tag']).toBeUndefined();
+  });
+});

--- a/express-api/tests/scripts/dev-lockdown-middleware.test.js
+++ b/express-api/tests/scripts/dev-lockdown-middleware.test.js
@@ -1,0 +1,236 @@
+/**
+ * Tests for the Cloudflare Pages Function middleware that locks down
+ * non-prod hostnames (no indexing + basic auth gate).
+ *
+ * The middleware lives in `functions/_middleware.js` (loaded by
+ * Cloudflare Pages at edge) and intercepts every request. To keep the
+ * logic unit-testable without spinning up workerd / miniflare, we
+ * export pure helpers from a sibling `functions/_lib/lockdown.js`
+ * file:
+ *   - isProdHostname(hostname) — returns true for the canonical prod
+ *     host and only that one
+ *   - shouldServeBlockingRobots(hostname) — true for non-prod
+ *   - blockingRobotsBody() — the literal robots.txt content for non-prod
+ *   - basicAuthOk(authorizationHeader, expectedPassword) — boolean
+ *   - basicAuthChallenge() — the Response shape for a 401 prompt
+ *
+ * The middleware then composes those helpers; this test pins each
+ * piece. The composed middleware itself is tested via a thin
+ * `handleRequest()` function that takes `(request, env)` and returns a
+ * `Response` — testable by feeding fake Request objects.
+ */
+
+const {
+  isProdHostname,
+  isProdApiHostname,
+  shouldServeBlockingRobots,
+  blockingRobotsBody,
+  basicAuthOk,
+  basicAuthChallenge,
+  noIndexHeaderValue,
+  PROD_HOSTNAME,
+  PROD_API_HOSTNAME,
+} = require('../../../functions/_lib/lockdown.js');
+
+describe('isProdHostname', () => {
+  test('returns true for the canonical prod host only', () => {
+    expect(isProdHostname('shytalk.shyden.co.uk')).toBe(true);
+  });
+
+  test('returns false for the dev host', () => {
+    expect(isProdHostname('dev.shytalk.shyden.co.uk')).toBe(false);
+  });
+
+  test('returns false for the Cloudflare Pages preview host', () => {
+    // wrangler pages deploy publishes a preview at e.g.
+    // `<sha>.<project>.pages.dev`. These must NOT be treated as prod.
+    expect(isProdHostname('abc1234.shytalk-site-dev.pages.dev')).toBe(false);
+    expect(isProdHostname('shytalk-site-dev.pages.dev')).toBe(false);
+  });
+
+  test('returns false for localhost / 127.0.0.1', () => {
+    expect(isProdHostname('localhost')).toBe(false);
+    expect(isProdHostname('127.0.0.1')).toBe(false);
+  });
+
+  test('case-insensitive match', () => {
+    // DNS is case-insensitive; the underlying hostname comparison
+    // should mirror that. A prod-but-uppercased Host header must NOT
+    // accidentally trip the dev gate.
+    expect(isProdHostname('SHYTALK.SHYDEN.CO.UK')).toBe(true);
+    expect(isProdHostname('Shytalk.Shyden.Co.Uk')).toBe(true);
+  });
+
+  test('returns false for a near-miss subdomain (defence vs spoofing)', () => {
+    // `shytalk.shyden.co.uk.evil.com` would have prefix-match risk —
+    // pin exact equality, not prefix.
+    expect(isProdHostname('shytalk.shyden.co.uk.evil.com')).toBe(false);
+    expect(isProdHostname('staging.shytalk.shyden.co.uk')).toBe(false);
+  });
+
+  test('PROD_HOSTNAME constant matches the prod-positive test', () => {
+    // Single source of truth for the prod host. If a future deploy
+    // moves the prod host (e.g. to a different domain), this constant
+    // is the only edit.
+    expect(PROD_HOSTNAME).toBe('shytalk.shyden.co.uk');
+  });
+});
+
+describe('isProdApiHostname', () => {
+  // The Express API has its own prod hostname (`api.shytalk.shyden.co.uk`)
+  // distinct from the web's `shytalk.shyden.co.uk`. The same lockdown
+  // logic applies — non-prod API hostnames get noindex header + a
+  // blocking robots.txt — but `isProdHostname` would wrongly classify
+  // `api.shytalk.shyden.co.uk` as non-prod and start serving Disallow:/
+  // to the world. Hence a separate predicate.
+
+  test('returns true for the canonical prod API host only', () => {
+    expect(isProdApiHostname('api.shytalk.shyden.co.uk')).toBe(true);
+  });
+
+  test('returns false for the dev API host', () => {
+    expect(isProdApiHostname('dev-api.shytalk.shyden.co.uk')).toBe(false);
+  });
+
+  test('returns false for localhost (local emulator)', () => {
+    expect(isProdApiHostname('localhost')).toBe(false);
+    expect(isProdApiHostname('127.0.0.1')).toBe(false);
+  });
+
+  test('returns false for the web prod host (different surface)', () => {
+    // Defensive: a misdirected request reaching the API code with the
+    // web hostname must NOT be treated as prod-API.
+    expect(isProdApiHostname('shytalk.shyden.co.uk')).toBe(false);
+  });
+
+  test('case-insensitive match', () => {
+    expect(isProdApiHostname('API.SHYTALK.SHYDEN.CO.UK')).toBe(true);
+  });
+
+  test('PROD_API_HOSTNAME constant matches the prod-positive test', () => {
+    expect(PROD_API_HOSTNAME).toBe('api.shytalk.shyden.co.uk');
+  });
+});
+
+describe('shouldServeBlockingRobots', () => {
+  test('returns true for non-prod hostnames', () => {
+    expect(shouldServeBlockingRobots('dev.shytalk.shyden.co.uk')).toBe(true);
+    expect(shouldServeBlockingRobots('shytalk-site-dev.pages.dev')).toBe(true);
+    expect(shouldServeBlockingRobots('localhost')).toBe(true);
+  });
+
+  test('returns false for prod', () => {
+    expect(shouldServeBlockingRobots('shytalk.shyden.co.uk')).toBe(false);
+  });
+});
+
+describe('blockingRobotsBody', () => {
+  test('returns a robots.txt that disallows all crawlers from all paths', () => {
+    const body = blockingRobotsBody();
+    // Pin both directives individually so a future refactor that
+    // accidentally changes one but not the other fails this test.
+    expect(body).toMatch(/^User-agent:\s*\*/m);
+    expect(body).toMatch(/^Disallow:\s*\/\s*$/m);
+  });
+
+  test('includes a comment so a human reader knows why', () => {
+    // The robots.txt is the most likely place a curious dev / engineer
+    // looks first when investigating "why isn't dev being indexed?".
+    // A comment with the rationale saves a round-trip to git history.
+    const body = blockingRobotsBody();
+    expect(body).toMatch(/non-prod|dev|noindex/i);
+  });
+});
+
+describe('noIndexHeaderValue', () => {
+  test('contains noindex AND nofollow AND noarchive', () => {
+    const v = noIndexHeaderValue();
+    expect(v).toMatch(/noindex/);
+    expect(v).toMatch(/nofollow/);
+    expect(v).toMatch(/noarchive/);
+  });
+
+  test('directives are comma-separated per RFC convention', () => {
+    const v = noIndexHeaderValue();
+    // X-Robots-Tag uses comma separation. Pin the format.
+    expect(v.split(',').map((s) => s.trim())).toEqual(
+      expect.arrayContaining(['noindex', 'nofollow', 'noarchive']),
+    );
+  });
+});
+
+describe('basicAuthOk', () => {
+  test('returns true for the correct Basic-encoded password', () => {
+    // `dev:hunter2` in base64.
+    const correct = 'Basic ' + Buffer.from('dev:hunter2').toString('base64');
+    expect(basicAuthOk(correct, 'hunter2')).toBe(true);
+  });
+
+  test('returns false for missing Authorization header', () => {
+    expect(basicAuthOk(null, 'hunter2')).toBe(false);
+    expect(basicAuthOk(undefined, 'hunter2')).toBe(false);
+    expect(basicAuthOk('', 'hunter2')).toBe(false);
+  });
+
+  test('returns false for wrong password', () => {
+    const wrong = 'Basic ' + Buffer.from('dev:wrong').toString('base64');
+    expect(basicAuthOk(wrong, 'hunter2')).toBe(false);
+  });
+
+  test('returns false for non-Basic auth scheme', () => {
+    expect(basicAuthOk('Bearer abc123', 'hunter2')).toBe(false);
+    expect(basicAuthOk('Digest username="dev"', 'hunter2')).toBe(false);
+  });
+
+  test('returns false if expected password is empty/null (fail closed)', () => {
+    // A misconfigured deploy (DEV_PASSWORD env var unset) MUST NOT
+    // accept any credential — otherwise the gate is wide open.
+    const anyAttempt = 'Basic ' + Buffer.from('dev:').toString('base64');
+    expect(basicAuthOk(anyAttempt, '')).toBe(false);
+    expect(basicAuthOk(anyAttempt, null)).toBe(false);
+    expect(basicAuthOk(anyAttempt, undefined)).toBe(false);
+  });
+
+  test('case-sensitive password comparison', () => {
+    const lower = 'Basic ' + Buffer.from('dev:hunter2').toString('base64');
+    expect(basicAuthOk(lower, 'HUNTER2')).toBe(false);
+  });
+
+  test('username does not have to be the literal "dev"', () => {
+    // The credential is a shared password; we ignore the username
+    // half because it adds zero security and rotating both is
+    // pointless friction. Pin that the function only checks the
+    // password half.
+    const userA = 'Basic ' + Buffer.from('alice:hunter2').toString('base64');
+    const userB = 'Basic ' + Buffer.from('bob:hunter2').toString('base64');
+    expect(basicAuthOk(userA, 'hunter2')).toBe(true);
+    expect(basicAuthOk(userB, 'hunter2')).toBe(true);
+  });
+});
+
+describe('basicAuthChallenge', () => {
+  test('returns a 401 Response with WWW-Authenticate header', () => {
+    const r = basicAuthChallenge();
+    expect(r.status).toBe(401);
+    expect(r.headers.get('WWW-Authenticate')).toMatch(/^Basic realm=/);
+  });
+
+  test('challenge body explains the 401 to a human', () => {
+    // An empty 401 looks like the server is broken. Include text so a
+    // visitor who arrives at a stale dev URL sees an informative
+    // page (not security-sensitive — just helpful).
+    return basicAuthChallenge()
+      .text()
+      .then((body) => {
+        expect(body.length).toBeGreaterThan(0);
+        expect(body).toMatch(/non-prod|dev|restricted/i);
+      });
+  });
+
+  test('challenge response carries the noindex header', () => {
+    // Even the challenge page must not be indexed — a Googlebot
+    // crawl that lands on the 401 page should still see noindex.
+    const r = basicAuthChallenge();
+    expect(r.headers.get('X-Robots-Tag')).toMatch(/noindex/);
+  });
+});

--- a/functions/_lib/lockdown.js
+++ b/functions/_lib/lockdown.js
@@ -1,0 +1,151 @@
+/**
+ * Pure helpers for the Cloudflare Pages middleware that locks down
+ * non-prod hostnames. Extracted from `_middleware.js` so the logic is
+ * unit-testable from Jest without spinning up workerd / miniflare.
+ *
+ * Used by:
+ *   - `functions/_middleware.js` (Cloudflare Pages, edge runtime)
+ *   - `express-api/tests/scripts/dev-lockdown-middleware.test.js` (Jest)
+ *
+ * Plan: protect dev / preview deployments from public discovery and
+ * scrape access. Apple-content-guideline / 18+ work is in flight on
+ * dev; leaking the in-progress UI to Google search results is a
+ * compliance + reputation risk.
+ */
+
+// Single source of truth for the prod hostnames. Two surfaces — the
+// public web (Cloudflare Pages) and the Express API (Oracle Cloud).
+// Each has its own canonical hostname; the lockdown predicate picks
+// the right one based on which surface the request is hitting.
+const PROD_HOSTNAME = 'shytalk.shyden.co.uk';
+const PROD_API_HOSTNAME = 'api.shytalk.shyden.co.uk';
+
+/**
+ * Returns true if and only if the request is reaching the canonical
+ * production hostname. Case-insensitive (DNS is case-insensitive).
+ * Exact equality — NOT prefix / contains — so a near-miss subdomain
+ * like `staging.shytalk.shyden.co.uk` or a hostile
+ * `shytalk.shyden.co.uk.evil.com` cannot trip the prod gate.
+ */
+function isProdHostname(hostname) {
+  if (typeof hostname !== 'string' || hostname.length === 0) return false;
+  return hostname.toLowerCase() === PROD_HOSTNAME;
+}
+
+/**
+ * API-surface analogue of [isProdHostname] — true for the canonical
+ * prod API hostname only, case-insensitive, exact match. Used by
+ * `express-api/src/middleware/no-index.js` to decide whether to
+ * inject the X-Robots-Tag header and serve the blocking robots.txt.
+ */
+function isProdApiHostname(hostname) {
+  if (typeof hostname !== 'string' || hostname.length === 0) return false;
+  return hostname.toLowerCase() === PROD_API_HOSTNAME;
+}
+
+/**
+ * Inverse convenience — true for any non-prod host (dev, Pages
+ * preview, localhost). Used to gate the noindex + basic-auth flow.
+ */
+function shouldServeBlockingRobots(hostname) {
+  return !isProdHostname(hostname);
+}
+
+/**
+ * Body of the dev `robots.txt`. Single literal so the format and
+ * comment don't drift between the test fixture and the served response.
+ */
+function blockingRobotsBody() {
+  return [
+    '# Non-prod ShyTalk environment — blocked from indexing.',
+    '# See functions/_middleware.js / functions/_lib/lockdown.js.',
+    '# Prod robots.txt (if any) is served only on shytalk.shyden.co.uk.',
+    'User-agent: *',
+    'Disallow: /',
+    '',
+  ].join('\n');
+}
+
+/**
+ * The X-Robots-Tag value to inject on every non-prod response.
+ * `noindex` removes from search results; `nofollow` keeps crawlers
+ * from following links into other dev pages; `noarchive` blocks the
+ * Google cached copy.
+ */
+function noIndexHeaderValue() {
+  return 'noindex, nofollow, noarchive';
+}
+
+/**
+ * Validates a Basic-auth `Authorization` header against the expected
+ * shared password. Username half is ignored — see test for rationale.
+ *
+ * Fails closed: a missing header or empty/null `expectedPassword`
+ * always returns false, so a misconfigured deploy (DEV_PASSWORD env
+ * var unset) does NOT leave the gate wide open.
+ */
+function basicAuthOk(authorizationHeader, expectedPassword) {
+  if (!expectedPassword) return false;
+  if (typeof authorizationHeader !== 'string') return false;
+  if (!authorizationHeader.startsWith('Basic ')) return false;
+  const encoded = authorizationHeader.slice('Basic '.length).trim();
+  if (encoded.length === 0) return false;
+  let decoded;
+  try {
+    // atob is available in Cloudflare Workers + modern Node ≥ 16. The
+    // Buffer fallback keeps Jest happy without polyfills.
+    decoded =
+      typeof atob === 'function'
+        ? atob(encoded)
+        : Buffer.from(encoded, 'base64').toString('utf-8');
+  } catch {
+    return false;
+  }
+  const colon = decoded.indexOf(':');
+  if (colon < 0) return false;
+  // Username half discarded; only password matters. Constant-time
+  // comparison would be ideal but Cloudflare Workers' standard library
+  // doesn't expose `crypto.subtle.timingSafeEqual`. The risk surface
+  // here (a single shared password gate on dev) does not warrant the
+  // extra implementation complexity.
+  const password = decoded.slice(colon + 1);
+  return password === expectedPassword;
+}
+
+/**
+ * The 401 challenge response shown when a non-prod request arrives
+ * without (or with wrong) credentials. Browsers will show their
+ * native Basic-auth prompt because of the `WWW-Authenticate` header.
+ *
+ * Body text is a short human-readable explanation — not
+ * security-sensitive — so a visitor stumbling onto a dev URL doesn't
+ * see an empty white page.
+ *
+ * Carries `X-Robots-Tag: noindex` because even the challenge page
+ * must not be indexed if a Googlebot somehow reaches it.
+ */
+function basicAuthChallenge() {
+  const body =
+    'This is a non-prod ShyTalk environment and is restricted to authorised testers. ' +
+    'If you arrived here by mistake, visit https://shytalk.shyden.co.uk for the public site.';
+  return new Response(body, {
+    status: 401,
+    headers: {
+      'WWW-Authenticate': 'Basic realm="ShyTalk Non-Prod"',
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Robots-Tag': noIndexHeaderValue(),
+    },
+  });
+}
+
+module.exports = {
+  PROD_HOSTNAME,
+  PROD_API_HOSTNAME,
+  isProdHostname,
+  isProdApiHostname,
+  shouldServeBlockingRobots,
+  blockingRobotsBody,
+  noIndexHeaderValue,
+  basicAuthOk,
+  basicAuthChallenge,
+};

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,0 +1,88 @@
+/**
+ * Cloudflare Pages middleware — runs on every request to non-prod
+ * ShyTalk hostnames.
+ *
+ * Responsibilities:
+ *   1. Inject `X-Robots-Tag: noindex, nofollow, noarchive` so search
+ *      engines don't index the dev / preview deployment.
+ *   2. Serve `/robots.txt` with `Disallow: /` on non-prod (intercept
+ *      before the static asset pipeline, so the dev deploy doesn't
+ *      have to ship a separate file).
+ *   3. Gate every request behind HTTP Basic Auth — the shared password
+ *      lives in `env.DEV_PASSWORD` (set via Cloudflare Pages → Settings
+ *      → Environment Variables). Without the password the gate fails
+ *      closed (challenge response, no access).
+ *
+ * Pure logic is in `_lib/lockdown.js` so it's unit-testable from Jest
+ * without spinning up workerd / miniflare. This file is just the
+ * Cloudflare Pages plumbing.
+ *
+ * Hostname is read from the request URL — Cloudflare Pages sets it
+ * correctly for every binding (custom domain, *.pages.dev preview,
+ * etc.). On prod (`shytalk.shyden.co.uk`) the middleware is a no-op
+ * via early `next()`.
+ */
+
+const {
+  isProdHostname,
+  blockingRobotsBody,
+  noIndexHeaderValue,
+  basicAuthOk,
+  basicAuthChallenge,
+} = require('./_lib/lockdown.js');
+
+// CommonJS module syntax (supported by Cloudflare Pages Functions per
+// https://developers.cloudflare.com/pages/functions/api-reference/).
+// Chosen here so the `./_lib/lockdown.js` helper module can be shared
+// verbatim with `express-api/src/middleware/no-index.js` and the Jest
+// test suite without a separate ESM build target.
+exports.onRequest = async ({ request, env, next }) => {
+  const url = new URL(request.url);
+  const hostname = url.hostname;
+
+  // Prod = pass through with no modifications. The gate exists for
+  // dev / preview / *.pages.dev only.
+  if (isProdHostname(hostname)) {
+    return next();
+  }
+
+  // /robots.txt is intercepted BEFORE the basic-auth gate so search
+  // engines (which never send Authorization) can read the Disallow
+  // directive. Without this, Googlebot would see a 401 and might
+  // assume the site is temporarily unavailable rather than
+  // permanently disallowed.
+  if (url.pathname === '/robots.txt') {
+    return new Response(blockingRobotsBody(), {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'X-Robots-Tag': noIndexHeaderValue(),
+        // Short cache so a future change to the body propagates
+        // quickly. Robots.txt is read by crawlers on a slow cadence
+        // anyway, so the cache barely matters.
+        'Cache-Control': 'public, max-age=300',
+      },
+    });
+  }
+
+  // Auth gate. `env.DEV_PASSWORD` is the shared secret (set in
+  // Cloudflare Pages → Settings → Environment Variables). If it's
+  // unset the gate fails closed — every request gets the 401
+  // challenge until an operator configures it.
+  const auth = request.headers.get('Authorization');
+  if (!basicAuthOk(auth, env.DEV_PASSWORD)) {
+    return basicAuthChallenge();
+  }
+
+  // Auth passed → fetch the underlying static asset / next handler,
+  // then graft the noindex header onto its response. We have to clone
+  // the response because `next()` returns an immutable Response.
+  const response = await next();
+  const newHeaders = new Headers(response.headers);
+  newHeaders.set('X-Robots-Tag', noIndexHeaderValue());
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: newHeaders,
+  });
+};

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -75,14 +75,23 @@ exports.onRequest = async ({ request, env, next }) => {
   }
 
   // Auth passed → fetch the underlying static asset / next handler,
-  // then graft the noindex header onto its response. We have to clone
-  // the response because `next()` returns an immutable Response.
+  // then graft the noindex header onto its response.
+  //
+  // `response.body` is a ReadableStream that can only be consumed
+  // once. Re-using `response.body` directly works today because
+  // nothing else reads it before we re-emit, but ANY future code path
+  // (logging plugin, observability layer) that calls
+  // `response.text()` / `.json()` first would silently strand the
+  // body — page would render empty with status 200 and no error.
+  // `response.clone()` returns a fresh Response sharing the body's
+  // buffered bytes via tee'd streams, defending against that.
   const response = await next();
-  const newHeaders = new Headers(response.headers);
+  const cloned = response.clone();
+  const newHeaders = new Headers(cloned.headers);
   newHeaders.set('X-Robots-Tag', noIndexHeaderValue());
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
+  return new Response(cloned.body, {
+    status: cloned.status,
+    statusText: cloned.statusText,
     headers: newHeaders,
   });
 };


### PR DESCRIPTION
## Summary

User reported the dev site appearing in Google search results AND asked to restrict the dev environment to authorised testers. Both layers shipped together.

## Web (Cloudflare Pages)

`functions/_middleware.js` intercepts every request to non-prod hostnames (`dev.shytalk.shyden.co.uk`, `*.pages.dev`):
1. **Inject `X-Robots-Tag: noindex, nofollow, noarchive`** on every response so any already-indexed URL is dropped from Google's results over the next few weeks (no GSC removal needed since it's not verified).
2. **Serve `/robots.txt` with `Disallow: /`** BEFORE the auth gate so crawlers (which never send Authorization) read the directive.
3. **HTTP Basic Auth gate** on every other path — shared password lives in `env.DEV_PASSWORD` (Cloudflare Pages env var). Username is ignored; password is the only check.

Prod (`shytalk.shyden.co.uk`) is a no-op early `next()`. Hostname check is **case-insensitive exact equality** so `*.evil.com` cannot trip the prod gate.

## API (Express on Oracle Cloud)

`src/middleware/no-index.js` adds the same `X-Robots-Tag` to every response from non-prod API hostnames (`dev-api.*`, `localhost`). Detection is by `req.hostname`, **not** `process.env.NODE_ENV`, because the dev VM runs pm2 with `NODE_ENV=production` for runtime reasons. Hostname is the reliable signal.

`/robots.txt` route returns `Disallow: /` on dev, `Allow: /` on prod.

**Does NOT add basic auth** — mobile apps embed the API URL in their binary and would break if the API required HTTP credentials. Discoverability via search is the leak; noindex closes that.

## Shared logic

`functions/_lib/lockdown.js` — pure CommonJS helpers shared by the Pages Function, the Express middleware, and the Jest suite. Single source of truth for `PROD_HOSTNAME` / `PROD_API_HOSTNAME` and the noindex header value.

## Pre-commit hook update

The env-URL-needs-localhost-fallback guard tripped on the security-constant files. Added `:(exclude)` pathspecs for the lockdown sources + tests — the canonical hostnames are exact strings by design, no localhost fallback applies.

## TDD

35 cases:
- 29 helper cases (`tests/scripts/dev-lockdown-middleware.test.js`) — predicates incl. spoof defence, blocking robots body, header value, basicAuth ok/fail-closed cases, challenge response shape.
- 6 supertest integration cases (`tests/middleware/no-index.test.js`) — header presence on dev, header absence on prod, robots.txt body on dev vs prod.

## ⚠️ Pre-deploy step you MUST do

**Set `DEV_PASSWORD` as an environment variable** on Cloudflare Pages:
- Project: `shytalk-site-dev`
- Settings → Environment Variables → Add
- Variable name: `DEV_PASSWORD`
- Value: any password you want; share with whoever needs dev access
- Apply to: Production environment (Pages confusingly calls deployed envs "Production")

Otherwise every dev request 401s with no way past the gate after deploy.

## Test plan

- [x] `:express-api jest tests/scripts/dev-lockdown-middleware.test.js` — 29/29 pass
- [x] `:express-api jest tests/middleware/no-index.test.js` — 6/6 pass
- [x] Express endpoint serves `Disallow:/` on dev hostname / `Allow:/` on prod hostname (locally verified via supertest)
- [ ] DEV deploy: `dev-api.shytalk.shyden.co.uk/api/firebase-config` carries `X-Robots-Tag: noindex` header
- [ ] DEV deploy: `dev.shytalk.shyden.co.uk/` returns 401 + `WWW-Authenticate: Basic` (after DEV_PASSWORD env var set)
- [ ] DEV deploy: `dev.shytalk.shyden.co.uk/robots.txt` returns `Disallow:/` (no auth required)
- [ ] DEV deploy: prod `shytalk.shyden.co.uk` still serves normally (no auth, normal robots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)