### PR TITLE
fix(deploy): convert Pages Functions to ESM so wrangler compiles them

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -643,4 +643,11 @@ jobs:
         env:
           WEB_BASE_URL: https://dev.shytalk.shyden.co.uk
           API_BASE_URL: https://dev-api.shytalk.shyden.co.uk
+          # Dev web is behind HTTP Basic auth as part of the lockdown
+          # (PR #441 — Cloudflare Pages Function `_middleware.js`). The
+          # spec passes this via Playwright's `httpCredentials` option
+          # so the sanity check can reach the page after deploy. The
+          # API surface (dev-api) does NOT have basic auth, so it's
+          # untouched.
+          DEV_BASIC_AUTH_PASSWORD: ${{ secrets.DEV_BASIC_AUTH_PASSWORD }}
         run: npx playwright test tests/web/dev-sanity.spec.ts --project=chromium --reporter=list

--- a/express-api/src/middleware/no-index.js
+++ b/express-api/src/middleware/no-index.js
@@ -29,8 +29,8 @@
 // this middleware (run 25276782190) crashed the dev API at startup
 // with `MODULE_NOT_FOUND: ../../functions/_lib/lockdown.js`. The
 // Cloudflare Pages middleware in `functions/_middleware.js` continues
-// to use the shared `_lib/lockdown.js` because Pages deploys both
-// `public/` and `functions/` together.
+// to use the shared `_lib/lockdown.js` because Pages deploys it from
+// the `functions/` directory at the project root (sibling of `public/`).
 //
 // Drift risk between the two copies is mitigated by `dev-lockdown-middleware.test.js`
 // pinning the rules from one side and `no-index.test.js` pinning the

--- a/functions/_lib/lockdown.js
+++ b/functions/_lib/lockdown.js
@@ -7,6 +7,14 @@
  *   - `functions/_middleware.js` (Cloudflare Pages, edge runtime)
  *   - `express-api/tests/scripts/dev-lockdown-middleware.test.js` (Jest)
  *
+ * Location convention: `functions/` MUST sit at the project root, NOT
+ * inside the deploy directory (`public/`). `wrangler pages deploy public`
+ * scans `<repo>/functions/` for routes; a sibling `public/functions/`
+ * is silently ignored (and was the cause of the first failed deploy
+ * after the lockdown rewrite — run 25282826361, 2026-05-03). The
+ * Cloudflare docs are explicit about this:
+ *   https://developers.cloudflare.com/pages/functions/get-started/
+ *
  * Plan: protect dev / preview deployments from public discovery and
  * scrape access. Apple-content-guideline / 18+ work is in flight on
  * dev; leaking the in-progress UI to Google search results is a

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -23,20 +23,22 @@
  * via early `next()`.
  */
 
-const {
-  isProdHostname,
-  blockingRobotsBody,
-  noIndexHeaderValue,
-  basicAuthOk,
-  basicAuthChallenge,
-} = require('./_lib/lockdown.js');
+// ESM exports are required: Cloudflare Pages wrangler refuses to
+// compile a Function file that uses CommonJS `exports.onRequest` and
+// silently logs `WARNING: No routes found when building Functions
+// directory ... - skipping`. The deploy then completes "successfully"
+// but ships zero Functions. Discovered 2026-05-03 in run 25277707676
+// (PR #439's first deploy). Helper module `_lib/lockdown.js` stays
+// CommonJS so the Jest test suite (`dev-lockdown-middleware.test.js`)
+// can `require()` it without an ESM transform — Pages Functions
+// support `import`-from-CommonJS via wrangler's bundler, so the cross-
+// module-system call works at runtime.
+import lockdown from './_lib/lockdown.js';
 
-// CommonJS module syntax (supported by Cloudflare Pages Functions per
-// https://developers.cloudflare.com/pages/functions/api-reference/).
-// Chosen here so the `./_lib/lockdown.js` helper module can be shared
-// verbatim with `express-api/src/middleware/no-index.js` and the Jest
-// test suite without a separate ESM build target.
-exports.onRequest = async ({ request, env, next }) => {
+const { isProdHostname, blockingRobotsBody, noIndexHeaderValue, basicAuthOk, basicAuthChallenge } =
+  lockdown;
+
+export const onRequest = async ({ request, env, next }) => {
   const url = new URL(request.url);
   const hostname = url.hostname;
 

--- a/tests/web/dev-sanity.spec.ts
+++ b/tests/web/dev-sanity.spec.ts
@@ -5,10 +5,27 @@ import { test, expect } from '@playwright/test';
  * are up and pages load after deployment. NOT a full test suite.
  *
  * Used by deploy-dev.yml instead of the full Playwright matrix.
+ *
+ * Auth: dev web is gated behind HTTP Basic auth (PR #441 lockdown).
+ * The deploy workflow passes the shared password via
+ * DEV_BASIC_AUTH_PASSWORD; we plug it into Playwright's built-in
+ * `httpCredentials` option via `test.use(...)` so every page.goto() /
+ * request.get() against WEB_BASE includes the Authorization header.
+ * When the env var is unset (e.g. running locally against
+ * `localhost:8888`), the conditional `use` is skipped — localhost has
+ * no Pages Function gate.
  */
 
 const WEB_BASE = process.env.WEB_BASE_URL || 'http://localhost:8888';
 const API_BASE = process.env.API_BASE_URL || 'http://localhost:3000';
+const DEV_BASIC_AUTH_PASSWORD = process.env.DEV_BASIC_AUTH_PASSWORD;
+
+if (DEV_BASIC_AUTH_PASSWORD) {
+  // Username is ignored by the lockdown helper — only the password
+  // matters — but 'dev' is a stable canonical value so the
+  // Authorization header has a fixed shape between runs.
+  test.use({ httpCredentials: { username: 'dev', password: DEV_BASIC_AUTH_PASSWORD } });
+}
 
 test.describe('Dev Sanity Checks', () => {
 


### PR DESCRIPTION
## Summary

Two distinct bugs prevented the lockdown shipped in PRs #439/#440 from actually running on the Cloudflare Pages side. The Express API side was working — only the public web was leaking.

### Bug 1 (root cause) — CommonJS exports rejected by wrangler

`functions/_middleware.js` used CommonJS `exports.onRequest = ...`. wrangler 4.87 silently rejects it:

```
WARNING: No routes found when building Functions directory: /home/runner/work/ShyTalk/ShyTalk/functions - skipping
```

Visible in run 25277707676's deploy log but the deploy itself completed "successfully" — a textbook silent failure shipping zero Functions.

### Bug 2 (red herring chased earlier on this branch)

The first attempted fix moved `functions/` into `public/functions/` on the (wrong) assumption that wrangler needed Functions inside the deploy dir. Cloudflare Pages docs are explicit: `functions/` MUST sit at PROJECT ROOT, sibling of `public/`, NOT inside it. Reverted that move.

### Bug 3 (surfaced by Bug 1's fix) — sanity check couldn't auth

Once the Pages Function actually started running, the post-deploy `Dev Sanity Check` job started returning 401 on every page.goto(). Wired Playwright's built-in `httpCredentials` option through a new `DEV_BASIC_AUTH_PASSWORD` GitHub secret so the sanity check authenticates against the lockdown gate.

### The real fix

- `functions/_middleware.js` now uses ESM: `import lockdown from './_lib/lockdown.js'` + `export const onRequest`
- Helper `functions/_lib/lockdown.js` stays CommonJS (`module.exports = {...}`) so the existing 29 Jest helper tests can `require()` it without ESM transform setup. Pages Functions support `import`-from-CommonJS via wrangler's bundler.
- Doc comments updated documenting both the location convention AND the ESM/CJS interop boundary so future maintainers don't repeat either mistake.
- `tests/web/dev-sanity.spec.ts` reads `DEV_BASIC_AUTH_PASSWORD` and applies `test.use({ httpCredentials })` when set; falls back to no auth for localhost.

## Verification (manually run against deployed DEV after the fix)

```
$ curl -i https://dev.shytalk.shyden.co.uk/
HTTP/2 401
www-authenticate: Basic realm="ShyTalk Non-Prod"
x-robots-tag: noindex, nofollow, noarchive

$ curl -u "x:<DEV_PASSWORD>" -i https://dev.shytalk.shyden.co.uk/
HTTP/2 200
x-robots-tag: noindex, nofollow, noarchive

$ curl -u "x:wrong" -o /dev/null -w "HTTP %{http_code}" https://dev.shytalk.shyden.co.uk/
HTTP 401   # fails closed

$ curl -I https://dev-api.shytalk.shyden.co.uk/api/health
HTTP/2 200
x-robots-tag: noindex, nofollow, noarchive

$ curl -I https://api.shytalk.shyden.co.uk/api/health
HTTP/2 200
# (no x-robots-tag — prod unaffected, indexable)

$ curl -I https://shytalk.shyden.co.uk/
HTTP/2 200
# (no auth, no noindex — prod web fully accessible)
```

Wrangler now logs `✨ Compiled Worker successfully` + `✨ Uploading Functions bundle` (run 25284946259).

## Test plan
- [x] All 35 lockdown tests still green (29 helper unit + 6 supertest integration)
- [x] DEV deploy succeeds with Functions bundle
- [x] DEV web → 401 + WWW-Authenticate + X-Robots-Tag noindex
- [x] DEV web with correct auth → 200 + X-Robots-Tag noindex
- [x] DEV web with wrong auth → 401 (fails closed)
- [x] DEV API → 200 + X-Robots-Tag noindex (mobile-app accessible)
- [x] PROD web → 200, no noindex, no auth
- [x] PROD API → 200, no noindex
- [x] Post-deploy Dev Sanity Check passes against the locked-down dev

## Outstanding (separate concern, not blocking this PR)

The dev `/robots.txt` still falls through to Cloudflare's zone-level "Content Signals" managed body (`Content-Signal: search=yes,ai-train=no` + `Allow: /`). The Pages Function intercepts /robots.txt for non-prod hosts but the zone-level managed feature pre-empts it. The Basic-auth gate is the primary discovery prevention; the X-Robots-Tag header is the secondary. The robots.txt body is tertiary and can be addressed by toggling the Cloudflare zone setting in the dashboard if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)