### PR TITLE
fix(deploy): wrap if: gates in always() so backend=false skip propagates

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -155,7 +155,20 @@ jobs:
     # `inputs.backend=false` case where the operator deliberately runs
     # web-only / mobile-only. Block only on `failure` / `cancelled` so
     # a crashed backend deploy can't ship a working-looking client.
-    if: inputs.web && (needs.deploy-backend-dev.result == 'success' || needs.deploy-backend-dev.result == 'skipped')
+    #
+    # `always()` is required: GitHub Actions's implicit "needs success"
+    # gate skips dependent jobs whenever ANY upstream is non-success
+    # (including `skipped`). The implicit gate fires BEFORE the explicit
+    # `if:` evaluates, so a custom condition checking
+    # `result == 'skipped'` is silently ignored. `always()` opts out of
+    # the implicit gate and lets the explicit comparisons run. Discovered
+    # 2026-05-03 in run 25280868804 (web=true backend=false → web
+    # silently skipped).
+    if: |
+      always() &&
+      inputs.web &&
+      needs.deploy-backend-dev.result != 'failure' &&
+      needs.deploy-backend-dev.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -206,7 +219,12 @@ jobs:
     needs: deploy-backend-dev
     # See deploy-web-dev for `success || skipped` rationale (preserves
     # `inputs.backend=false` Android-only hotfix path).
-    if: inputs.android-testers && (needs.deploy-backend-dev.result == 'success' || needs.deploy-backend-dev.result == 'skipped')
+    # See deploy-web-dev `always()` rationale (run 25280868804).
+    if: |
+      always() &&
+      inputs.android-testers &&
+      needs.deploy-backend-dev.result != 'failure' &&
+      needs.deploy-backend-dev.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -341,7 +359,12 @@ jobs:
     needs: deploy-backend-dev
     # See deploy-web-dev for `success || skipped` rationale (preserves
     # `inputs.backend=false` iOS-only hotfix path).
-    if: inputs.ios-testers && (needs.deploy-backend-dev.result == 'success' || needs.deploy-backend-dev.result == 'skipped')
+    # See deploy-web-dev `always()` rationale (run 25280868804).
+    if: |
+      always() &&
+      inputs.ios-testers &&
+      needs.deploy-backend-dev.result != 'failure' &&
+      needs.deploy-backend-dev.result != 'cancelled'
     runs-on: [self-hosted, macOS, ARM64, shytalk-mac]
     # Bumped from 45 -> 90 on 2026-04-28: K/Native linkReleaseFrameworkIosArm64
     # has been taking 24-29 min on the macos-15 runner pool (was ~10 min in

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -164,11 +164,13 @@ jobs:
     # the implicit gate and lets the explicit comparisons run. Discovered
     # 2026-05-03 in run 25280868804 (web=true backend=false → web
     # silently skipped).
+    # Allowlist (not denylist) so a typo'd `needs:` reference — which
+    # would make `result` evaluate to empty/null — fails closed instead
+    # of running with no gate. Defence in depth on top of `always()`.
     if: |
       always() &&
       inputs.web &&
-      needs.deploy-backend-dev.result != 'failure' &&
-      needs.deploy-backend-dev.result != 'cancelled'
+      (needs.deploy-backend-dev.result == 'success' || needs.deploy-backend-dev.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -219,12 +221,11 @@ jobs:
     needs: deploy-backend-dev
     # See deploy-web-dev for `success || skipped` rationale (preserves
     # `inputs.backend=false` Android-only hotfix path).
-    # See deploy-web-dev `always()` rationale (run 25280868804).
+    # See deploy-web-dev `always()` + allowlist rationale (run 25280868804).
     if: |
       always() &&
       inputs.android-testers &&
-      needs.deploy-backend-dev.result != 'failure' &&
-      needs.deploy-backend-dev.result != 'cancelled'
+      (needs.deploy-backend-dev.result == 'success' || needs.deploy-backend-dev.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -359,12 +360,11 @@ jobs:
     needs: deploy-backend-dev
     # See deploy-web-dev for `success || skipped` rationale (preserves
     # `inputs.backend=false` iOS-only hotfix path).
-    # See deploy-web-dev `always()` rationale (run 25280868804).
+    # See deploy-web-dev `always()` + allowlist rationale (run 25280868804).
     if: |
       always() &&
       inputs.ios-testers &&
-      needs.deploy-backend-dev.result != 'failure' &&
-      needs.deploy-backend-dev.result != 'cancelled'
+      (needs.deploy-backend-dev.result == 'success' || needs.deploy-backend-dev.result == 'skipped')
     runs-on: [self-hosted, macOS, ARM64, shytalk-mac]
     # Bumped from 45 -> 90 on 2026-04-28: K/Native linkReleaseFrameworkIosArm64
     # has been taking 24-29 min on the macos-15 runner pool (was ~10 min in

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -194,7 +194,15 @@ jobs:
     # `inputs.backend=false` web-only redeploy. Block only on `failure`
     # / `cancelled` so a crashed backend can't ship a working-looking
     # client (incident 2026-05-03 run 25276782190).
-    if: inputs.web && (needs.deploy-backend-prod.result == 'success' || needs.deploy-backend-prod.result == 'skipped')
+    # See deploy-dev.yml deploy-web-dev for `always()` rationale
+    # (run 25280868804 — implicit "needs success" gate skips dependent
+    # jobs whenever upstream is `skipped`, even when explicit `if:`
+    # checks for `result == 'skipped'`).
+    if: |
+      always() &&
+      inputs.web &&
+      needs.deploy-backend-prod.result != 'failure' &&
+      needs.deploy-backend-prod.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -225,7 +233,12 @@ jobs:
     # be visible to every prod user on next app open.
     needs: [validate-release, build-android, deploy-backend-prod]
     # See deploy-web-prod for `success || skipped` rationale.
-    if: inputs.android && (needs.deploy-backend-prod.result == 'success' || needs.deploy-backend-prod.result == 'skipped')
+    # See deploy-web-prod / deploy-dev.yml for `always()` rationale.
+    if: |
+      always() &&
+      inputs.android &&
+      needs.deploy-backend-prod.result != 'failure' &&
+      needs.deploy-backend-prod.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -266,7 +279,12 @@ jobs:
     # against the live backend; a broken-backend build risks rejection.
     needs: [validate-release, deploy-backend-prod]
     # See deploy-web-prod for `success || skipped` rationale.
-    if: inputs.ios && (needs.deploy-backend-prod.result == 'success' || needs.deploy-backend-prod.result == 'skipped')
+    # See deploy-web-prod / deploy-dev.yml for `always()` rationale.
+    if: |
+      always() &&
+      inputs.ios &&
+      needs.deploy-backend-prod.result != 'failure' &&
+      needs.deploy-backend-prod.result != 'cancelled'
     runs-on: [self-hosted, macOS, ARM64, shytalk-mac]
     # Bumped from 45 -> 90 on 2026-04-28: K/Native linkReleaseFrameworkIosArm64
     # plus xcodebuild archive plus App Store upload total ~50 min worst case

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -194,15 +194,14 @@ jobs:
     # `inputs.backend=false` web-only redeploy. Block only on `failure`
     # / `cancelled` so a crashed backend can't ship a working-looking
     # client (incident 2026-05-03 run 25276782190).
-    # See deploy-dev.yml deploy-web-dev for `always()` rationale
-    # (run 25280868804 — implicit "needs success" gate skips dependent
-    # jobs whenever upstream is `skipped`, even when explicit `if:`
-    # checks for `result == 'skipped'`).
+    # See deploy-dev.yml deploy-web-dev for `always()` + allowlist
+    # rationale (run 25280868804 — implicit "needs success" gate skips
+    # dependent jobs whenever upstream is `skipped`, even when explicit
+    # `if:` checks for `result == 'skipped'`).
     if: |
       always() &&
       inputs.web &&
-      needs.deploy-backend-prod.result != 'failure' &&
-      needs.deploy-backend-prod.result != 'cancelled'
+      (needs.deploy-backend-prod.result == 'success' || needs.deploy-backend-prod.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -233,12 +232,11 @@ jobs:
     # be visible to every prod user on next app open.
     needs: [validate-release, build-android, deploy-backend-prod]
     # See deploy-web-prod for `success || skipped` rationale.
-    # See deploy-web-prod / deploy-dev.yml for `always()` rationale.
+    # See deploy-web-prod / deploy-dev.yml for `always()` + allowlist rationale.
     if: |
       always() &&
       inputs.android &&
-      needs.deploy-backend-prod.result != 'failure' &&
-      needs.deploy-backend-prod.result != 'cancelled'
+      (needs.deploy-backend-prod.result == 'success' || needs.deploy-backend-prod.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -279,12 +277,11 @@ jobs:
     # against the live backend; a broken-backend build risks rejection.
     needs: [validate-release, deploy-backend-prod]
     # See deploy-web-prod for `success || skipped` rationale.
-    # See deploy-web-prod / deploy-dev.yml for `always()` rationale.
+    # See deploy-web-prod / deploy-dev.yml for `always()` + allowlist rationale.
     if: |
       always() &&
       inputs.ios &&
-      needs.deploy-backend-prod.result != 'failure' &&
-      needs.deploy-backend-prod.result != 'cancelled'
+      (needs.deploy-backend-prod.result == 'success' || needs.deploy-backend-prod.result == 'skipped')
     runs-on: [self-hosted, macOS, ARM64, shytalk-mac]
     # Bumped from 45 -> 90 on 2026-04-28: K/Native linkReleaseFrameworkIosArm64
     # plus xcodebuild archive plus App Store upload total ~50 min worst case


### PR DESCRIPTION
## Summary
- Run 25280868804 (web=true, backend=false) silently skipped Deploy Web to Dev despite the explicit `if: ... result == 'skipped'` check added in PR #440. Root cause: GitHub Actions has an implicit "needs success" gate that fires BEFORE the explicit `if:` evaluates whenever ANY upstream is non-success (including \`skipped\`). Documented [here](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution): "you must include the always() function within the if condition".
- Wraps all 6 affected deploy gates with \`always() && ... != 'failure' && != 'cancelled'\` so the explicit comparisons actually get a chance to run.
- Behaviour matrix is unchanged from PR #440's intent; only the gating mechanism is fixed:
  - backend=true + success → web/android/ios run ✓
  - backend=true + failure → web/android/ios skipped (block) ✓
  - backend=true + cancelled → web/android/ios skipped (block) ✓
  - backend=false → backend skipped → web/android/ios run **(now actually works)** ✓

## Files changed
- \`.github/workflows/deploy-dev.yml\` — \`deploy-web-dev\`, \`distribute-android\`, \`distribute-ios\`
- \`.github/workflows/deploy-prod.yml\` — \`deploy-web-prod\`, \`deploy-android-prod\`, \`deploy-ios-prod\`

## Test plan
- [x] actionlint clean locally
- [ ] Re-run deploy-dev with web=true, backend=false → Deploy Web to Dev should actually execute (currently the only way to validate the dev lockdown PR #441)
- [ ] Visual sanity check on the next backend=true deploy (existing behaviour preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)