### PR TITLE
feat(age-verif): User model fields for ageVerified (PR 2/14)

### DIFF
--- a/app/src/androidTest/java/com/shyden/shytalk/journey/AuthFlowTest.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/journey/AuthFlowTest.kt
@@ -47,6 +47,14 @@ class AuthFlowTest : KoinTest {
             fakeUserEmail = "test@example.com"
         }
         (userRepository as FakeUserRepository).userFlagsFlow.value = UserFlags()
+        // The local flavor's `BuildConfig.WEB_CLIENT_ID = ""` (PR #42 /
+        // B6.14) makes `BuildVariant.isGoogleSignInAvailable` false, so
+        // the SignIn screen hides the Google button. E2E tests run on
+        // the local flavor (`connectedLocalDebugAndroidTest`) and want
+        // to assert the Google button — inject a non-empty fake so the
+        // button renders. This does not exercise the real Google flow,
+        // it just makes the visibility check pass.
+        BuildVariant.initLocalEmulator(true, googleWebClientId = "test-google-client-id")
     }
 
     @Test
@@ -92,12 +100,18 @@ class AuthFlowTest : KoinTest {
         // Test fixtures must not leak isLocalEmulator=true into other suites,
         // since the dev sign-in path is unreachable on prod and a leaked
         // `true` would let unrelated tests trip the dev-only branch.
+        // Also clear the test-only googleWebClientId so subsequent test
+        // classes pick up the real (or empty) flavor value via setUp().
         BuildVariant.initLocalEmulator(false)
     }
 
     @Test
     fun signInScreen_devButton_hiddenWhenNotLocalEmulator() {
-        BuildVariant.initLocalEmulator(false)
+        // Pass through the fake googleWebClientId so the Google button
+        // remains rendered (the assertion below is on `dev_sign_in`,
+        // not on Google, but `waitForTag("signIn_googleButton")` is
+        // used as a "page is fully rendered" anchor).
+        BuildVariant.initLocalEmulator(false, googleWebClientId = "test-google-client-id")
         val fakeAuth = authRepository as FakeAuthRepository
         fakeAuth.fakeAuthenticated = false
         fakeAuth.fakeUserId = null
@@ -112,7 +126,7 @@ class AuthFlowTest : KoinTest {
 
     @Test
     fun signInScreen_devButton_visibleOnLocalEmulator() {
-        BuildVariant.initLocalEmulator(true)
+        BuildVariant.initLocalEmulator(true, googleWebClientId = "test-google-client-id")
         val fakeAuth = authRepository as FakeAuthRepository
         fakeAuth.fakeAuthenticated = false
         fakeAuth.fakeUserId = null

--- a/app/src/androidTest/java/com/shyden/shytalk/journey/IdentityFlowTest.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/journey/IdentityFlowTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.shyden.shytalk.core.BuildVariant
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.DeviceRepository
@@ -47,6 +48,10 @@ class IdentityFlowTest : KoinTest {
         fakeAuth.fakeUserId = null
         fakeAuth.fakeUserEmail = null
         fakeAuth.resolvedUniqueId = null
+        // The local flavor's empty `WEB_CLIENT_ID` (PR #42 / B6.14)
+        // hides the Google sign-in button. Inject a non-empty fake so
+        // the visibility-based test assertions below can find it.
+        BuildVariant.initLocalEmulator(true, googleWebClientId = "test-google-client-id")
     }
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
@@ -5,6 +5,85 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
+/**
+ * Single source of truth for the expected `User.toMap()` shape. Any
+ * change to the User data class fields MUST update this set. The two
+ * pinning tests (count + key set) reference this so a mismatch surfaces
+ * the specific missing / extra key, not just a number.
+ */
+private val EXPECTED_USER_MAP_KEYS =
+    setOf(
+        "uid",
+        "displayName",
+        "avatarUrl",
+        "profilePhotoUrl",
+        "coverPhotoUrl",
+        "description",
+        "nationality",
+        "uniqueId",
+        "firebaseUid",
+        "providers",
+        "blockedUserIds",
+        "followingIds",
+        "followerIds",
+        "dateOfBirth",
+        "hideFollowing",
+        "hideOnlineStatus",
+        "hideAge",
+        "email",
+        "currentRoomId",
+        "lastRoomName",
+        "userType",
+        "createdAt",
+        "lastSeenAt",
+        "stalkerCount",
+        "newStalkerCount",
+        "stalkersLastViewedAt",
+        "isSuspended",
+        "suspensionReason",
+        "suspensionStartDate",
+        "suspensionEndDate",
+        "suspensionCanAppeal",
+        "suspendedBy",
+        "suspensionAppealStatus",
+        "fcmTokens",
+        "pmNotificationsEnabled",
+        "pmPrivacy",
+        "pmSoundEnabled",
+        "pmShowTimestamps",
+        "pmShowDateSeparators",
+        "pmNotificationPreview",
+        "acceptedLegalVersion",
+        "dndEnabled",
+        "dndStartHour",
+        "dndStartMinute",
+        "dndEndHour",
+        "dndEndMinute",
+        "shyCoins",
+        "shyBeans",
+        "isSuperShy",
+        "superShyExpiry",
+        "superShyTier",
+        "tempUniqueId",
+        "tempUniqueIdExpiry",
+        "luckScore",
+        "pityCounter",
+        "loginStreak",
+        "lastLoginDate",
+        "lastLoginRewardDate",
+        "aliases",
+        "minGiftAnimationValue",
+        "selfDestructAlertEnabled",
+        "hasClaimedSuperShyTrial",
+        "language",
+        "deletionScheduledAt",
+        "deletionReason",
+        "deletionExecuteAt",
+        "ageVerified",
+        "ageVerifiedAt",
+        "ageVerificationMethod",
+    )
+
 class UserToMapTest {
     @Test
     fun `toMap contains all fields`() {
@@ -64,85 +143,21 @@ class UserToMapTest {
     }
 
     @Test
-    fun `toMap contains exactly 63 keys`() {
+    fun `toMap key count matches the expected key set size`() {
+        // Single source of truth for the expected count is the
+        // expectedKeys set in the test below. This test guards against
+        // a User.toMap() change that adds a key without updating the
+        // set, OR removing a key without updating the set. Either way
+        // the size mismatch will trip first, then the set-equality
+        // test will surface the specific delta.
         val user = TestData.createTestUser()
-        val map = user.toMap()
-        assertEquals(66, map.size)
+        assertEquals(EXPECTED_USER_MAP_KEYS.size, user.toMap().keys.size)
     }
 
     @Test
     fun `toMap keys match expected field names`() {
-        val expectedKeys =
-            setOf(
-                "uid",
-                "displayName",
-                "avatarUrl",
-                "profilePhotoUrl",
-                "coverPhotoUrl",
-                "description",
-                "nationality",
-                "uniqueId",
-                "firebaseUid",
-                "providers",
-                "blockedUserIds",
-                "followingIds",
-                "followerIds",
-                "dateOfBirth",
-                "hideFollowing",
-                "hideOnlineStatus",
-                "hideAge",
-                "email",
-                "currentRoomId",
-                "lastRoomName",
-                "userType",
-                "createdAt",
-                "lastSeenAt",
-                "stalkerCount",
-                "newStalkerCount",
-                "stalkersLastViewedAt",
-                "isSuspended",
-                "suspensionReason",
-                "suspensionStartDate",
-                "suspensionEndDate",
-                "suspensionCanAppeal",
-                "suspendedBy",
-                "suspensionAppealStatus",
-                "fcmTokens",
-                "pmNotificationsEnabled",
-                "pmPrivacy",
-                "pmSoundEnabled",
-                "pmShowTimestamps",
-                "pmShowDateSeparators",
-                "pmNotificationPreview",
-                "acceptedLegalVersion",
-                "dndEnabled",
-                "dndStartHour",
-                "dndStartMinute",
-                "dndEndHour",
-                "dndEndMinute",
-                "shyCoins",
-                "shyBeans",
-                "isSuperShy",
-                "superShyExpiry",
-                "superShyTier",
-                "tempUniqueId",
-                "tempUniqueIdExpiry",
-                "luckScore",
-                "pityCounter",
-                "loginStreak",
-                "lastLoginDate",
-                "lastLoginRewardDate",
-                "aliases",
-                "minGiftAnimationValue",
-                "selfDestructAlertEnabled",
-                "hasClaimedSuperShyTrial",
-                "language",
-                "deletionScheduledAt",
-                "deletionReason",
-                "deletionExecuteAt",
-            )
         val user = TestData.createTestUser()
-        assertEquals(expectedKeys, user.toMap().keys)
+        assertEquals(EXPECTED_USER_MAP_KEYS, user.toMap().keys)
     }
 
     @Test

--- a/express-api/src/routes/users.js
+++ b/express-api/src/routes/users.js
@@ -140,6 +140,12 @@ router.post('/users', async (req, res) => {
         language: language || 'en',
         stalkerCount: 0,
         newStalkerCount: 0,
+        // Age verification (Apple App Store 18+ enforcement on PMs +
+        // gacha). New users start unverified; admin approves a manual
+        // ID review to flip to verified. See age-verification PR plan.
+        ageVerified: false,
+        ageVerifiedAt: null,
+        ageVerificationMethod: null,
         createdAt: timestamp,
         lastSeenAt: timestamp,
       });

--- a/express-api/tests/routes/users.test.js
+++ b/express-api/tests/routes/users.test.js
@@ -105,6 +105,34 @@ describe('POST /api/users', () => {
     expect(res.body.uniqueId).toBeGreaterThanOrEqual(10000000);
   });
 
+  test('new users start unverified (ageVerified: false defaults)', async () => {
+    // Apple App Store guideline 1.1.4: 18+ enforcement on private
+    // messages + gacha. New accounts must default to unverified so an
+    // admin manual ID review is required to flip the flag. Pin the
+    // exact field shape — the User model + Firestore rules match.
+    mockTransactionGet.mockResolvedValue({ exists: false });
+
+    const app = createApp('new-user-uid', null);
+    await request(app)
+      .post('/api/users')
+      .send({
+        provider: 'google',
+        identifier: 'newcomer@gmail.com',
+        displayName: 'Newcomer',
+        dateOfBirth: '2000-01-01',
+      })
+      .expect(200);
+
+    const userDocSet = mockTransactionSet.mock.calls.find(([path]) => path?.startsWith?.('users/'));
+    expect(userDocSet).toBeDefined();
+    const docPayload = userDocSet[1];
+    expect(docPayload).toMatchObject({
+      ageVerified: false,
+      ageVerifiedAt: null,
+      ageVerificationMethod: null,
+    });
+  });
+
   test('rejects missing provider', async () => {
     const app = createApp('new-user-uid', null);
     await request(app).post('/api/users').send({ identifier: 'alice@gmail.com' }).expect(400);

--- a/firestore.rules
+++ b/firestore.rules
@@ -39,7 +39,12 @@ service cloud.firestore {
                      // admin approval. Clients writing these directly
                      // would bypass the manual ID review and unlock 18+
                      // gated features. See `2026-05-03-age-verification.md`.
-                     'ageVerified', 'ageVerifiedAt', 'ageVerificationMethod']);
+                     // Both camel and snake variants — matches the
+                     // dual-read pattern other server-only fields use
+                     // (e.g. `gcsScore` / `gcs_score`) so a future
+                     // legacy-compat fallback can't open the gate.
+                     'ageVerified', 'ageVerifiedAt', 'ageVerificationMethod',
+                     'age_verified', 'age_verified_at', 'age_verification_method']);
 
       // Backpack — read own, write only via API
       match /backpack/{giftId} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -34,7 +34,12 @@ service cloud.firestore {
                      'preSuspensionCoverPhotoUrl', 'roleChanged',
                      'unique_id', 'firebase_uid',
                      'fcmTokens',
-                     'pmNotificationsEnabled']);
+                     'pmNotificationsEnabled',
+                     // Age verification — server-only, set by Express on
+                     // admin approval. Clients writing these directly
+                     // would bypass the manual ID review and unlock 18+
+                     // gated features. See `2026-05-03-age-verification.md`.
+                     'ageVerified', 'ageVerifiedAt', 'ageVerificationMethod']);
 
       // Backpack — read own, write only via API
       match /backpack/{giftId} {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
@@ -75,6 +75,14 @@ data class User(
     val deletionScheduledAt: Long? = null,
     val deletionReason: String? = null,
     val deletionExecuteAt: Long? = null,
+    // Age verification (Apple App Store 18+ enforcement on PMs + gacha).
+    // Server-side only — Firestore rules block client write of these
+    // three fields. `ageVerificationMethod` is one of "passport" /
+    // "drivers-license" / "national-id" when set; null when unverified
+    // (or when admin reverts a verification with a reason note).
+    val ageVerified: Boolean = false,
+    val ageVerifiedAt: Long? = null,
+    val ageVerificationMethod: String? = null,
 ) {
     val isActivelySuspended: Boolean
         get() {
@@ -173,6 +181,9 @@ data class User(
             "deletionScheduledAt" to deletionScheduledAt,
             "deletionReason" to deletionReason,
             "deletionExecuteAt" to deletionExecuteAt,
+            "ageVerified" to ageVerified,
+            "ageVerifiedAt" to ageVerifiedAt,
+            "ageVerificationMethod" to ageVerificationMethod,
         )
 
     companion object {
@@ -283,6 +294,9 @@ data class User(
                 deletionScheduledAt = map["deletionScheduledAt"]?.let { timestampToMillis(it) },
                 deletionReason = map["deletionReason"] as? String,
                 deletionExecuteAt = map["deletionExecuteAt"]?.let { timestampToMillis(it) },
+                ageVerified = map["ageVerified"].asBool(),
+                ageVerifiedAt = map["ageVerifiedAt"]?.let { timestampToMillis(it) },
+                ageVerificationMethod = map["ageVerificationMethod"] as? String,
             )
     }
 }

--- a/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/model/UserTest.kt
+++ b/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/model/UserTest.kt
@@ -573,4 +573,107 @@ class UserTest {
             assertTrue(user.isPendingDeletion)
         }
     }
+
+    // ── Age verification fields ──────────────────────────────────────
+    //
+    // Apple App Store guidelines require 18+ enforcement on the gated
+    // private-message + gacha features. The verification status is held
+    // server-side via the API; the client never writes these fields
+    // directly (Firestore rules enforce that — see firestore.rules diff
+    // alongside this PR). Method strings are an enumerated set of
+    // "passport" / "drivers-license" / "national-id" — the admin panel
+    // picks one when approving a submission.
+
+    @Test
+    fun `default age verification fields are unverified`() {
+        val user = User()
+        assertFalse(user.ageVerified)
+        assertNull(user.ageVerifiedAt)
+        assertNull(user.ageVerificationMethod)
+    }
+
+    @Test
+    fun `fromMap parses age verification fields`() {
+        val map =
+            mapOf<String, Any?>(
+                "ageVerified" to true,
+                "ageVerifiedAt" to 1705326600000L,
+                "ageVerificationMethod" to "passport",
+            )
+        val user = User.fromMap(map, "u1")
+        assertTrue(user.ageVerified)
+        assertEquals(1705326600000L, user.ageVerifiedAt)
+        assertEquals("passport", user.ageVerificationMethod)
+    }
+
+    @Test
+    fun `fromMap handles null age verification fields`() {
+        // Reverted-to-unverified shape: admin can revert ageVerified to
+        // false with a reason note, in which case we want the timestamp
+        // and method cleared. Pin that null on the wire round-trips to
+        // null on the model.
+        val map =
+            mapOf<String, Any?>(
+                "ageVerified" to false,
+                "ageVerifiedAt" to null,
+                "ageVerificationMethod" to null,
+            )
+        val user = User.fromMap(map, "u1")
+        assertFalse(user.ageVerified)
+        assertNull(user.ageVerifiedAt)
+        assertNull(user.ageVerificationMethod)
+    }
+
+    @Test
+    fun `fromMap handles missing age verification fields`() {
+        // Existing user docs in Firestore predate this feature. They
+        // have NO `ageVerified` field at all — must default to false.
+        val map = emptyMap<String, Any?>()
+        val user = User.fromMap(map, "u1")
+        assertFalse(user.ageVerified)
+        assertNull(user.ageVerifiedAt)
+        assertNull(user.ageVerificationMethod)
+    }
+
+    @Test
+    fun `toMap includes age verification fields when verified`() {
+        val user =
+            User(
+                ageVerified = true,
+                ageVerifiedAt = 1705326600000L,
+                ageVerificationMethod = "drivers-license",
+            )
+        val map = user.toMap()
+        assertEquals(true, map["ageVerified"])
+        assertEquals(1705326600000L, map["ageVerifiedAt"])
+        assertEquals("drivers-license", map["ageVerificationMethod"])
+    }
+
+    @Test
+    fun `toMap includes default age verification fields when unverified`() {
+        // The default-unverified shape MUST round-trip cleanly so a
+        // newly-created user document writes the explicit `ageVerified:
+        // false`. Without it Firestore queries that filter on
+        // `ageVerified == false` (admin "find unverified users" view)
+        // would silently miss legacy / new accounts.
+        val user = User()
+        val map = user.toMap()
+        assertEquals(false, map["ageVerified"])
+        assertNull(map["ageVerifiedAt"])
+        assertNull(map["ageVerificationMethod"])
+    }
+
+    @Test
+    fun `ageVerificationMethod accepts the three approved id types`() {
+        listOf("passport", "drivers-license", "national-id").forEach { method ->
+            val user =
+                User(
+                    ageVerified = true,
+                    ageVerifiedAt = currentTimeMillis(),
+                    ageVerificationMethod = method,
+                )
+            assertEquals(method, user.ageVerificationMethod)
+            assertTrue(user.ageVerified)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Part 2 of the [Age Verification multi-PR plan](.project/plans/2026-05-03-age-verification.md). Introduces the data model fields the rest of the verification flow will hang off.

### Fields added to `User`

- `ageVerified: Boolean` (default `false`) — flips to `true` only after admin approves a manual ID review. Sub-18 (16-17) accounts can never flip this; they age in.
- `ageVerifiedAt: Long?` — ms timestamp of approval, audit trail
- `ageVerificationMethod: String?` — one of `passport` / `drivers-license` / `national-id`, recorded for audit. Cleared (null) when admin reverts a verification.

### Server-side only

- `firestore.rules` blocks client write of all three fields — a malicious client cannot flip `ageVerified: true` without going through the manual ID review.
- Express `POST /api/users` now writes the explicit `ageVerified: false` default so admin "find unverified users" queries on `where('ageVerified', '==', false)` catch new accounts (not just legacy docs that happen to lack the field).

### TDD

- 7 new JVM tests on `User` model (defaults, fromMap parse w/ data, fromMap parse w/ nulls, fromMap parse w/ missing fields, toMap round-trip verified, toMap round-trip default, three-method enumeration)
- 1 new Express route test asserting `POST /api/users` writes `ageVerified: false` + null timestamp + null method
- All pre-existing tests still pass
- `:shared:compileKotlinIosArm64` clean

## Order constraint

Per the multi-PR plan, this PR is **data-model only**. No UI gating, no admin approval flow, no migration. Existing-user behaviour is unchanged — the gate flips on at PR 11 (migration). No deployment of this PR by itself; the work-completion DEV+PROD deploy is at PR 14.

## Test plan
- [x] 7 new \`UserTest\` JVM tests pass (TDD red → green confirmed)
- [x] 1 new \`users.test.js\` route test passes
- [x] All pre-existing User + users tests still pass (37 total green)
- [x] iOS shared compile clean (\`:shared:compileKotlinIosArm64\`)
- [ ] CI green
- [ ] Code review clean
- [ ] Merge — no DEV deploy yet (multi-PR sequence; deploy at PR 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)