### PR TITLE
feat(age-verif): audit-log helper for verification decisions (PR 3/14)

### DIFF
--- a/express-api/src/utils/age-verification-audit.js
+++ b/express-api/src/utils/age-verification-audit.js
@@ -1,0 +1,91 @@
+/**
+ * Audit-log helper for the three age-verification admin decisions
+ * (approve / reject / dob-modify).
+ *
+ * Schema lives in `tests/utils/age-verification-audit.test.js`. The
+ * helper exists so callers (admin routes added in PR 4) write the
+ * exact same shape every time — drift between the three call sites
+ * is the failure mode this guards against.
+ *
+ * Image / submission contents are NEVER passed in. The user spec
+ * required image deletion on decision; only metadata is persisted.
+ */
+
+const { now } = require('./helpers');
+
+const APPROVED = 'age_verification_approved';
+const REJECTED = 'age_verification_rejected';
+const DOB_MODIFIED = 'age_verification_dob_modified';
+
+const AGE_VERIFICATION_ACTIONS = Object.freeze({
+  APPROVED,
+  REJECTED,
+  DOB_MODIFIED,
+});
+
+const APPROVED_METHODS = ['passport', 'drivers-license', 'national-id'];
+
+function requireString(value, name) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`age-verification-audit: ${name} is required`);
+  }
+}
+
+function requireNonBlankString(value, name) {
+  requireString(value, name);
+  if (value.trim().length === 0) {
+    throw new Error(`age-verification-audit: ${name} must not be blank`);
+  }
+}
+
+function requireNumber(value, name) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    throw new Error(`age-verification-audit: ${name} is required`);
+  }
+}
+
+function writeEntry(db, action, adminUid, targetUserId, details) {
+  requireNumber(adminUid, 'adminUid');
+  requireString(targetUserId, 'targetUserId');
+  return db.collection('auditLog').add({
+    adminUid,
+    action,
+    actionType: action,
+    targetType: 'user',
+    targetId: targetUserId,
+    details,
+    timestamp: now(),
+  });
+}
+
+async function logVerificationApproved(db, { adminUid, targetUserId, method }) {
+  if (!APPROVED_METHODS.includes(method)) {
+    throw new Error(
+      `age-verification-audit: method must be one of ${APPROVED_METHODS.join(', ')}; got "${method}"`,
+    );
+  }
+  return writeEntry(db, APPROVED, adminUid, targetUserId, { method });
+}
+
+async function logVerificationRejected(db, { adminUid, targetUserId, reason }) {
+  requireNonBlankString(reason, 'reason');
+  return writeEntry(db, REJECTED, adminUid, targetUserId, { reason });
+}
+
+async function logVerificationDobModified(db, { adminUid, targetUserId, oldDob, newDob, reason }) {
+  if (oldDob !== null) requireNumber(oldDob, 'oldDob');
+  requireNumber(newDob, 'newDob');
+  requireNonBlankString(reason, 'reason');
+  return writeEntry(db, DOB_MODIFIED, adminUid, targetUserId, {
+    oldDob,
+    newDob,
+    reason,
+  });
+}
+
+module.exports = {
+  AGE_VERIFICATION_ACTIONS,
+  logVerificationApproved,
+  logVerificationRejected,
+  logVerificationDobModified,
+};

--- a/express-api/src/utils/age-verification-audit.js
+++ b/express-api/src/utils/age-verification-audit.js
@@ -9,8 +9,21 @@
  *
  * Image / submission contents are NEVER passed in. The user spec
  * required image deletion on decision; only metadata is persisted.
+ * The helper signatures only accept the named typed params below;
+ * extra fields on the input object are silently ignored (pinned by
+ * the "unknown fields ignored" test) so a caller cannot inject
+ * `imageUrl` / `imageBase64` / etc. via a stray spread.
+ *
+ * IMPORTANT — callers MUST `await` these helpers. Each returns the
+ * Firestore `add()` Promise so a write failure (rules violation,
+ * network drop) propagates to the caller. Unhandled rejection means
+ * "decision made but audit not written" — a compliance gap. The
+ * helpers also `.catch()` and re-throw with a logger entry so a
+ * silent Firestore failure surfaces in pm2 logs even if a caller
+ * forgets the await chain.
  */
 
+const log = require('./log');
 const { now } = require('./helpers');
 
 const APPROVED = 'age_verification_approved';
@@ -25,29 +38,46 @@ const AGE_VERIFICATION_ACTIONS = Object.freeze({
 
 const APPROVED_METHODS = ['passport', 'drivers-license', 'national-id'];
 
-function requireString(value, name) {
-  if (typeof value !== 'string' || value.length === 0) {
-    throw new Error(`age-verification-audit: ${name} is required`);
-  }
-}
+// Lower bound: 1900-01-01 (oldest plausible DOB for a living user).
+// Upper bound: now (DOB cannot be in the future). The wider ms epoch
+// range allows distant-past / distant-future values that no real
+// user would have, masking mis-typed inputs as data instead of
+// surfacing them as errors. Reject anything outside.
+const MIN_PLAUSIBLE_DOB_MS = -2208988800000; // 1900-01-01T00:00:00Z
 
 function requireNonBlankString(value, name) {
-  requireString(value, name);
-  if (value.trim().length === 0) {
-    throw new Error(`age-verification-audit: ${name} must not be blank`);
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`age-verification-audit: ${name} must be a non-blank string`);
   }
 }
 
-function requireNumber(value, name) {
-  if (typeof value !== 'number' || Number.isNaN(value)) {
-    throw new Error(`age-verification-audit: ${name} is required`);
+function requirePositiveInteger(value, name) {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value <= 0
+  ) {
+    throw new Error(`age-verification-audit: ${name} must be a positive integer`);
+  }
+}
+
+function requirePlausibleDob(value, name) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`age-verification-audit: ${name} must be a number (ms epoch)`);
+  }
+  if (value < MIN_PLAUSIBLE_DOB_MS) {
+    throw new Error(`age-verification-audit: ${name} predates 1900 — implausible`);
+  }
+  if (value > now()) {
+    throw new Error(`age-verification-audit: ${name} is in the future — implausible`);
   }
 }
 
 function writeEntry(db, action, adminUid, targetUserId, details) {
-  requireNumber(adminUid, 'adminUid');
-  requireString(targetUserId, 'targetUserId');
-  return db.collection('auditLog').add({
+  requirePositiveInteger(adminUid, 'adminUid');
+  requireNonBlankString(targetUserId, 'targetUserId');
+  const entry = {
     adminUid,
     action,
     actionType: action,
@@ -55,9 +85,31 @@ function writeEntry(db, action, adminUid, targetUserId, details) {
     targetId: targetUserId,
     details,
     timestamp: now(),
-  });
+  };
+  return db
+    .collection('auditLog')
+    .add(entry)
+    .catch((err) => {
+      // Surface in pm2 logs even if a caller forgets to await — a
+      // silent Firestore-rules / network failure here is a
+      // compliance gap (decision made, audit not written).
+      log.error('age-verification-audit', 'Failed to write audit entry', {
+        action,
+        targetId: targetUserId,
+        error: err?.message,
+      });
+      throw err; // re-throw so awaiting callers still see the failure
+    });
 }
 
+/**
+ * @param {Object} db Firestore database instance.
+ * @param {Object} params
+ * @param {number} params.adminUid Admin's uniqueId (positive integer).
+ * @param {string} params.targetUserId Target user's uniqueId, stringified.
+ * @param {('passport'|'drivers-license'|'national-id')} params.method
+ * @returns {Promise} Caller MUST await — see file header.
+ */
 async function logVerificationApproved(db, { adminUid, targetUserId, method }) {
   if (!APPROVED_METHODS.includes(method)) {
     throw new Error(
@@ -67,14 +119,32 @@ async function logVerificationApproved(db, { adminUid, targetUserId, method }) {
   return writeEntry(db, APPROVED, adminUid, targetUserId, { method });
 }
 
+/**
+ * @param {Object} db
+ * @param {Object} params
+ * @param {number} params.adminUid
+ * @param {string} params.targetUserId
+ * @param {string} params.reason Non-blank justification (admin policy).
+ * @returns {Promise} Caller MUST await.
+ */
 async function logVerificationRejected(db, { adminUid, targetUserId, reason }) {
   requireNonBlankString(reason, 'reason');
   return writeEntry(db, REJECTED, adminUid, targetUserId, { reason });
 }
 
+/**
+ * @param {Object} db
+ * @param {Object} params
+ * @param {number} params.adminUid
+ * @param {string} params.targetUserId
+ * @param {number|null} params.oldDob ms epoch, or null for legacy users with no prior DOB.
+ * @param {number} params.newDob ms epoch, must be plausible (1900 <= dob <= now).
+ * @param {string} params.reason
+ * @returns {Promise} Caller MUST await.
+ */
 async function logVerificationDobModified(db, { adminUid, targetUserId, oldDob, newDob, reason }) {
-  if (oldDob !== null) requireNumber(oldDob, 'oldDob');
-  requireNumber(newDob, 'newDob');
+  if (oldDob !== null) requirePlausibleDob(oldDob, 'oldDob');
+  requirePlausibleDob(newDob, 'newDob');
   requireNonBlankString(reason, 'reason');
   return writeEntry(db, DOB_MODIFIED, adminUid, targetUserId, {
     oldDob,

--- a/express-api/tests/utils/age-verification-audit.test.js
+++ b/express-api/tests/utils/age-verification-audit.test.js
@@ -97,6 +97,79 @@ describe('logVerificationApproved', () => {
     await expect(logVerificationApproved(fakeDb, {})).rejects.toThrow();
     expect(mockAdd).not.toHaveBeenCalled();
   });
+
+  test('rejects empty / blank targetUserId', async () => {
+    // A blank target uid would persist a useless audit row
+    // ("approved nobody"). Pin that the validator catches it.
+    await expect(
+      logVerificationApproved(fakeDb, {
+        adminUid: 10000001,
+        targetUserId: '',
+        method: 'passport',
+      }),
+    ).rejects.toThrow(/targetUserId/i);
+    await expect(
+      logVerificationApproved(fakeDb, {
+        adminUid: 10000001,
+        targetUserId: '   ',
+        method: 'passport',
+      }),
+    ).rejects.toThrow(/targetUserId/i);
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-positive / non-integer adminUid', async () => {
+    // Real adminUids are always positive 8-digit integers. Block
+    // 0, negatives, NaN, Infinity, and floats.
+    for (const bad of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      await expect(
+        logVerificationApproved(fakeDb, {
+          adminUid: bad,
+          targetUserId: '10000050',
+          method: 'passport',
+        }),
+      ).rejects.toThrow(/adminUid/i);
+    }
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  test('extra unknown input fields are NOT persisted (no-image contract)', async () => {
+    // Compliance: image / id contents must never reach auditLog.
+    // The helper signatures destructure only the named typed params;
+    // any extra fields the caller spreads in must be ignored. Pin
+    // that contract so a future refactor that switches to spread-
+    // through can't silently leak.
+    await logVerificationApproved(fakeDb, {
+      adminUid: 10000001,
+      targetUserId: '10000050',
+      method: 'passport',
+      // Hostile / accidental extras:
+      imageUrl: 'https://r2/evil.jpg',
+      imageBase64: 'data:image/png;base64,iVBORw0K...',
+      ssn: '123-45-6789',
+    });
+    const written = mockAdd.mock.calls[0][0];
+    expect(written.details).toEqual({ method: 'passport' });
+    expect(written).not.toHaveProperty('imageUrl');
+    expect(written).not.toHaveProperty('imageBase64');
+    expect(written).not.toHaveProperty('ssn');
+    expect(written.details).not.toHaveProperty('imageUrl');
+  });
+
+  test('Firestore write failure is logged AND propagated', async () => {
+    // A Firestore rules violation / network drop would otherwise be
+    // silent at this layer if a caller forgot to await. The helper
+    // catches and logs (visible in pm2) before re-throwing — so the
+    // compliance gap "decision made, audit not written" can't hide.
+    const failingDb = { collection: () => ({ add: () => Promise.reject(new Error('boom')) }) };
+    await expect(
+      logVerificationApproved(failingDb, {
+        adminUid: 10000001,
+        targetUserId: '10000050',
+        method: 'passport',
+      }),
+    ).rejects.toThrow('boom');
+  });
 });
 
 describe('logVerificationRejected', () => {

--- a/express-api/tests/utils/age-verification-audit.test.js
+++ b/express-api/tests/utils/age-verification-audit.test.js
@@ -1,0 +1,216 @@
+/**
+ * Tests for the age-verification audit-log helper. Three decision
+ * shapes — approved / rejected / DOB-modified — each must produce an
+ * auditLog entry with the contracted fields so the admin "audit
+ * trail" tab can render them consistently with all other audit
+ * actions (suggestion_merge, dispute_resolve, etc.).
+ *
+ * Schema (per `auditLog` collection):
+ *   {
+ *     adminUid:   number      // admin's uniqueId — NOT firebaseUid
+ *     action:     string      // canonical action name (snake_case)
+ *     actionType: string      // === action (legacy duplicate)
+ *     targetType: 'user'      // verification always targets a user
+ *     targetId:   string      // target user's uniqueId, stringified
+ *     details:    object      // action-specific payload (see below)
+ *     timestamp:  number      // ms epoch (from `now()`)
+ *   }
+ *
+ * details payload per action:
+ *   age_verification_approved   → { method: 'passport'|'drivers-license'|'national-id' }
+ *   age_verification_rejected   → { reason: string }
+ *   age_verification_dob_modified → { oldDob: number|null, newDob: number, reason: string }
+ *
+ * Image content is NEVER logged — the spec requires images to be
+ * deleted on decision and only metadata persisted.
+ */
+
+const mockAdd = jest.fn().mockResolvedValue();
+const mockCollection = jest.fn(() => ({ add: mockAdd }));
+
+const fakeDb = {
+  collection: mockCollection,
+};
+
+jest.mock('../../src/utils/helpers', () => ({
+  now: () => 1709913600000,
+}));
+
+const {
+  logVerificationApproved,
+  logVerificationRejected,
+  logVerificationDobModified,
+  AGE_VERIFICATION_ACTIONS,
+} = require('../../src/utils/age-verification-audit');
+
+beforeEach(() => {
+  mockAdd.mockClear();
+  mockCollection.mockClear();
+});
+
+describe('AGE_VERIFICATION_ACTIONS constants', () => {
+  test('exposes the three action names as snake_case strings', () => {
+    expect(AGE_VERIFICATION_ACTIONS.APPROVED).toBe('age_verification_approved');
+    expect(AGE_VERIFICATION_ACTIONS.REJECTED).toBe('age_verification_rejected');
+    expect(AGE_VERIFICATION_ACTIONS.DOB_MODIFIED).toBe('age_verification_dob_modified');
+  });
+});
+
+describe('logVerificationApproved', () => {
+  test('writes a typed approval entry to auditLog', async () => {
+    await logVerificationApproved(fakeDb, {
+      adminUid: 10000001,
+      targetUserId: '10000050',
+      method: 'passport',
+    });
+
+    expect(mockCollection).toHaveBeenCalledWith('auditLog');
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    expect(mockAdd).toHaveBeenCalledWith({
+      adminUid: 10000001,
+      action: 'age_verification_approved',
+      actionType: 'age_verification_approved',
+      targetType: 'user',
+      targetId: '10000050',
+      details: { method: 'passport' },
+      timestamp: 1709913600000,
+    });
+  });
+
+  test('rejects unknown method values', async () => {
+    // Method must be one of the three approved id types — the admin
+    // panel picks from a dropdown but a hand-rolled API call could
+    // pass anything. Fail loudly so a stray value can't be persisted
+    // to the auditLog (which is the source of truth for compliance
+    // reviews).
+    await expect(
+      logVerificationApproved(fakeDb, {
+        adminUid: 10000001,
+        targetUserId: '10000050',
+        method: 'birth-certificate',
+      }),
+    ).rejects.toThrow(/method/i);
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  test('rejects missing required fields', async () => {
+    await expect(logVerificationApproved(fakeDb, {})).rejects.toThrow();
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+});
+
+describe('logVerificationRejected', () => {
+  test('writes a typed rejection entry to auditLog', async () => {
+    await logVerificationRejected(fakeDb, {
+      adminUid: 10000001,
+      targetUserId: '10000050',
+      reason: 'Image was unreadable',
+    });
+
+    expect(mockAdd).toHaveBeenCalledWith({
+      adminUid: 10000001,
+      action: 'age_verification_rejected',
+      actionType: 'age_verification_rejected',
+      targetType: 'user',
+      targetId: '10000050',
+      details: { reason: 'Image was unreadable' },
+      timestamp: 1709913600000,
+    });
+  });
+
+  test('rejects an empty reason (admin must justify)', async () => {
+    // The user spec explicitly required: "Yes reason is required".
+    // A typed audit entry with an empty reason would let an admin
+    // dodge the policy via API without going through the panel.
+    await expect(
+      logVerificationRejected(fakeDb, {
+        adminUid: 10000001,
+        targetUserId: '10000050',
+        reason: '',
+      }),
+    ).rejects.toThrow(/reason/i);
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  test('rejects whitespace-only reason', async () => {
+    await expect(
+      logVerificationRejected(fakeDb, {
+        adminUid: 10000001,
+        targetUserId: '10000050',
+        reason: '   ',
+      }),
+    ).rejects.toThrow(/reason/i);
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+});
+
+describe('logVerificationDobModified', () => {
+  test('writes a typed dob-modified entry with both old and new DOB', async () => {
+    await logVerificationDobModified(fakeDb, {
+      adminUid: 10000001,
+      targetUserId: '10000050',
+      oldDob: 946684800000, // 2000-01-01
+      newDob: 978307200000, // 2001-01-01
+      reason: 'User submitted ID with different DOB than profile',
+    });
+
+    expect(mockAdd).toHaveBeenCalledWith({
+      adminUid: 10000001,
+      action: 'age_verification_dob_modified',
+      actionType: 'age_verification_dob_modified',
+      targetType: 'user',
+      targetId: '10000050',
+      details: {
+        oldDob: 946684800000,
+        newDob: 978307200000,
+        reason: 'User submitted ID with different DOB than profile',
+      },
+      timestamp: 1709913600000,
+    });
+  });
+
+  test('accepts null oldDob (for users with no prior DOB on record)', async () => {
+    // Legacy accounts predate the required-DOB enforcement and may
+    // have null DOB. The audit entry should record the null
+    // explicitly rather than omitting the field — preserves the
+    // shape so a reader doesn't have to special-case missing keys.
+    await logVerificationDobModified(fakeDb, {
+      adminUid: 10000001,
+      targetUserId: '10000050',
+      oldDob: null,
+      newDob: 978307200000,
+      reason: 'First DOB recorded via verification',
+    });
+
+    expect(mockAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ oldDob: null }),
+      }),
+    );
+  });
+
+  test('rejects empty reason on DOB modification', async () => {
+    await expect(
+      logVerificationDobModified(fakeDb, {
+        adminUid: 10000001,
+        targetUserId: '10000050',
+        oldDob: 946684800000,
+        newDob: 978307200000,
+        reason: '',
+      }),
+    ).rejects.toThrow(/reason/i);
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  test('rejects when newDob is missing', async () => {
+    await expect(
+      logVerificationDobModified(fakeDb, {
+        adminUid: 10000001,
+        targetUserId: '10000050',
+        oldDob: 946684800000,
+        reason: 'Just changing it',
+      }),
+    ).rejects.toThrow();
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Part 3 of the [Age Verification multi-PR plan](.project/plans/2026-05-03-age-verification.md). Adds the typed audit-log helper that the admin approval/rejection/DOB-modification routes (shipping in PR 4) will all call.

## What's new

- \`express-api/src/utils/age-verification-audit.js\` — three helpers:
  - \`logVerificationApproved(db, { adminUid, targetUserId, method })\`
  - \`logVerificationRejected(db, { adminUid, targetUserId, reason })\`
  - \`logVerificationDobModified(db, { adminUid, targetUserId, oldDob, newDob, reason })\`
- \`AGE_VERIFICATION_ACTIONS\` constants exporting the three canonical action names

Each helper:
- Validates required fields (admin uid is a number, target user id is a string, method is one of the three approved id types, reason is non-blank)
- Refuses bad input with a clear error so a hand-rolled API call can't dodge the policy via the audit trail
- Writes a uniform shape: \`{ adminUid, action, actionType, targetType: 'user', targetId, details, timestamp }\` (mirrors the existing audit pattern from \`suggestions.js\` / \`reports.js\`)
- NEVER takes image / submission contents — spec requires images deleted on decision and only metadata persisted

## Tests

11 new Jest tests pinning:
- Action constant values
- Approved entry shape (incl. method enumeration)
- Rejected entry shape (incl. blank reason rejection)
- DOB-modified entry shape (incl. nullable oldDob, blank reason rejection, missing newDob rejection)

## Order constraint

This PR is utility-only. The routes that consume it ship in PR 4. No DEV deploy yet — the multi-PR work-completion deploy is at PR 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)