### PR TITLE
feat(age-verif): R2 signed-PUT + submit/upload endpoints (PR 4a/14)

### DIFF
--- a/express-api/package-lock.json
+++ b/express-api/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@apple/app-store-server-library": "^3.0.0",
         "@aws-sdk/client-s3": "^3.1037.0",
+        "@aws-sdk/s3-request-presigner": "^3.1041.0",
         "archiver": "^7.0.1",
         "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
@@ -321,13 +322,13 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.5.tgz",
-      "integrity": "sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==",
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.19",
+        "@aws-sdk/xml-builder": "^3.972.22",
         "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/property-provider": "^4.2.14",
@@ -337,7 +338,7 @@
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -634,12 +635,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.34.tgz",
-      "integrity": "sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
         "@smithy/core": "^3.23.17",
@@ -757,13 +758,32 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.22.tgz",
-      "integrity": "sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==",
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1041.0.tgz",
+      "integrity": "sha512-DlKsPQ8Z75wgeDSHbjUPNDQCYUF0OLBkqllZqFei61KIoQDqEeKUCwuCf6RhNLjaP4b8oSpBA9+FmUS+zm3xUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.34",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-format-url": "^3.972.10",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
@@ -833,6 +853,21 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.965.5",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
@@ -883,13 +918,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
-      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@nodable/entities": "2.1.0",
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.1",
+        "fast-xml-parser": "5.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3754,9 +3790,9 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.5.tgz",
-      "integrity": "sha512-h1IJsbgMDA+jaTjrco/JsyfWOgHRJBv8myB1y4AEI2fjIzD6ktZ7pFAyTw+gwN9GKIAygvC6db0mq0j8N2rFOg==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
+      "integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/service-error-classification": "^4.3.1",

--- a/express-api/package.json
+++ b/express-api/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@apple/app-store-server-library": "^3.0.0",
     "@aws-sdk/client-s3": "^3.1037.0",
+    "@aws-sdk/s3-request-presigner": "^3.1041.0",
     "archiver": "^7.0.1",
     "bcrypt": "^6.0.0",
     "cors": "^2.8.5",

--- a/express-api/src/index.js
+++ b/express-api/src/index.js
@@ -152,6 +152,11 @@ app.use('/api/reports', sensitiveLimiter);
 app.use('/api/appeals', sensitiveLimiter);
 app.use('/api/users/:uniqueId/delete', sensitiveLimiter);
 app.use('/api/users/:uniqueId/data-export', sensitiveLimiter);
+// Age verification — sensitive because it issues short-lived R2
+// upload tokens and creates pending submissions. Rate limit prevents
+// a malicious client from spamming submissions or harvesting upload
+// URLs.
+app.use('/api/age-verification', sensitiveLimiter);
 
 // Portal rate limiter (no admin exemption) — skip for recovery routes
 app.use('/api/portal', (req, res, next) => {
@@ -175,6 +180,7 @@ app.use('/api', require('./routes/reports'));
 app.use('/api', require('./routes/notifications'));
 app.use('/api', require('./routes/rooms'));
 app.use('/api', require('./routes/data-export'));
+app.use('/api', require('./routes/age-verification'));
 app.use('/api', require('./routes/conversations'));
 app.use('/api', require('./routes/banners'));
 app.use('/api', require('./routes/fun-facts'));

--- a/express-api/src/routes/age-verification.js
+++ b/express-api/src/routes/age-verification.js
@@ -4,25 +4,35 @@
  *   POST /api/age-verification/upload-url
  *     Body: { contentType: 'image/jpeg' | 'image/png' | 'image/webp' }
  *     Returns: { uploadUrl, r2Key, expiresInSec }
- *     Generates an R2 signed PUT URL the client can upload the ID
- *     image directly to. Path is forced under
- *     `age-verification/<uniqueId>/` so the server-side `submit`
- *     handler can re-validate ownership.
+ *     Generates an R2 signed PUT URL the client uploads the ID image
+ *     directly to. Path is forced under
+ *     `age-verification/<uniqueId>/<random>.<ext>` so the server-side
+ *     `submit` handler can re-validate ownership.
  *
  *   POST /api/age-verification/submit
  *     Body: { r2Key, idMethod }
  *     Returns: { submissionId, status: 'pending' }
  *     Creates a pending submission doc in
- *     `ageVerificationSubmissions/`. Admin reviews via the routes in
- *     PR 4b. Image is deleted on decision; only metadata persists.
+ *     `ageVerificationSubmissions/`. Admin reviews via routes shipped
+ *     in PR 4b. The R2 image is deleted on admin decision (approve OR
+ *     reject) — that responsibility lives in PR 4b's `r2.deleteObject`
+ *     call inside the approve/reject handlers. This route's tests pin
+ *     that the `r2Key` is preserved on the doc so 4b's handlers can
+ *     find and delete it; that contract is intentionally NOT enforced
+ *     here (no leak-risk test) because the deletion itself is in 4b.
  *
  * Server-side enforcement (in addition to client gates):
- *   - User must be 18+ on the DOB on file. 16-17-y/o cohort sees the
- *     "Contact support" copy; the API refuses regardless of client.
+ *   - User must be 18+ on the DOB on file (calendar-aware comparison
+ *     mirroring `isAtLeast16` in `shared/.../DateUtils.kt`). 16-17-y/o
+ *     cohort sees the "Contact support" copy; the API refuses
+ *     regardless of client.
  *   - User must NOT already be verified.
- *   - Only one pending submission at a time (user spec).
- *   - Submitted r2Key MUST be under the user's prefix (defence vs a
- *     hand-rolled API call submitting someone else's image).
+ *   - Only one pending submission at a time. Enforced atomically via
+ *     a Firestore transaction (check-then-add was a TOCTOU race
+ *     window; two concurrent submits could create two pending docs).
+ *   - Submitted r2Key MUST be under the user's prefix AND must NOT
+ *     contain `..` / `//` path-traversal segments (defence vs hand-
+ *     rolled API caller smuggling another user's image).
  *
  * No image content is read here — the upload happens client → R2
  * directly via the signed PUT URL. The handler only sees the R2 key.
@@ -38,12 +48,27 @@ const log = require('../utils/log');
 
 const ALLOWED_CONTENT_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
 const ALLOWED_ID_METHODS = ['passport', 'drivers-license', 'national-id'];
-const MIN_VERIFY_AGE_YEARS = 18;
-const MS_PER_YEAR = 365.25 * 86400 * 1000;
 
-function isAtLeast18(dateOfBirthMs) {
+/**
+ * Calendar-aware "user is 18+" check, mirroring `isAtLeast16` in
+ * `shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/DateUtils.kt`.
+ * Doing this with the `365.25 * MS_PER_DAY` approximation drifts the
+ * 18th-birthday boundary by ~6 hours per leap window, which is exactly
+ * the kind of off-by-one a user would hit on their actual birthday and
+ * be told to "contact support" while the client says they're eligible.
+ */
+function isAtLeast18FromDob(dateOfBirthMs) {
   if (typeof dateOfBirthMs !== 'number' || !Number.isFinite(dateOfBirthMs)) return false;
-  return Date.now() - dateOfBirthMs >= MIN_VERIFY_AGE_YEARS * MS_PER_YEAR;
+  const today = new Date();
+  const dob = new Date(dateOfBirthMs);
+  let age = today.getUTCFullYear() - dob.getUTCFullYear();
+  if (
+    today.getUTCMonth() < dob.getUTCMonth() ||
+    (today.getUTCMonth() === dob.getUTCMonth() && today.getUTCDate() < dob.getUTCDate())
+  ) {
+    age -= 1;
+  }
+  return age >= 18;
 }
 
 async function loadUserGate(uniqueId) {
@@ -52,7 +77,7 @@ async function loadUserGate(uniqueId) {
     return { ok: false, status: 404, error: 'User not found' };
   }
   const data = docSnap.data();
-  if (!isAtLeast18(data?.dateOfBirth)) {
+  if (!isAtLeast18FromDob(data?.dateOfBirth)) {
     return {
       ok: false,
       status: 403,
@@ -67,6 +92,7 @@ async function loadUserGate(uniqueId) {
 }
 
 router.post('/age-verification/upload-url', async (req, res) => {
+  const errorId = 'AGE_VERIF_UPLOAD_URL';
   try {
     const { contentType } = req.body || {};
     if (!contentType || !ALLOWED_CONTENT_TYPES.has(contentType)) {
@@ -89,12 +115,16 @@ router.post('/age-verification/upload-url', async (req, res) => {
 
     return res.json({ uploadUrl, r2Key, expiresInSec: 300 });
   } catch (err) {
-    log.error('age-verification', 'upload-url failed', { error: err?.message });
-    return res.status(500).json({ error: 'Failed to issue upload URL' });
+    log.error('age-verification', `${errorId} failed`, {
+      uid: req.auth?.uniqueId,
+      error: err?.message,
+    });
+    return res.status(500).json({ error: 'Failed to issue upload URL', errorId });
   }
 });
 
 router.post('/age-verification/submit', async (req, res) => {
+  const errorId = 'AGE_VERIF_SUBMIT';
   try {
     const { r2Key, idMethod } = req.body || {};
     if (typeof r2Key !== 'string' || r2Key.length === 0) {
@@ -106,11 +136,22 @@ router.post('/age-verification/submit', async (req, res) => {
         .json({ error: `idMethod must be one of ${ALLOWED_ID_METHODS.join(', ')}` });
     }
 
-    // Defence in depth: re-check the prefix even though the signed URL
-    // would have forced it. A malicious client could call submit
-    // directly with another user's key.
+    // Defence in depth on the R2 key:
+    //  1. Must start with the caller's user prefix
+    //  2. Must NOT contain `..` or `//` path-traversal sequences (the
+    //     literal key would store as-is in R2, but downstream
+    //     consumers — admin viewer, signed-GET, CDN — may normalise
+    //     and resolve to another user's prefix).
+    //  3. The portion after the prefix must be a single segment (no
+    //     additional `/`) so a valid prefix can't be extended into
+    //     another user's directory.
     const expectedPrefix = `age-verification/${req.auth.uniqueId}/`;
-    if (!r2Key.startsWith(expectedPrefix)) {
+    if (
+      !r2Key.startsWith(expectedPrefix) ||
+      r2Key.includes('..') ||
+      r2Key.includes('//') ||
+      r2Key.slice(expectedPrefix.length).indexOf('/') !== -1
+    ) {
       return res.status(403).json({ error: 'r2Key is not under your user prefix' });
     }
 
@@ -119,37 +160,54 @@ router.post('/age-verification/submit', async (req, res) => {
       return res.status(gate.status).json({ error: gate.error });
     }
 
-    // Only one pending submission at a time (user spec).
-    const pendingSnap = await db
+    // Atomic check-and-create — a transaction prevents the
+    // check-then-add TOCTOU window where two concurrent submits
+    // could both pass the empty check and create duplicate pending
+    // docs. The query inside `runTransaction` is a snapshot read; if
+    // a concurrent transaction commits a pending doc between the
+    // read and the create, our transaction retries.
+    const pendingQuery = db
       .collection('ageVerificationSubmissions')
       .where('userId', '==', String(req.auth.uniqueId))
       .where('status', '==', 'pending')
-      .limit(1)
-      .get();
-    if (!pendingSnap.empty) {
+      .limit(1);
+    const newDocRef = db.collection('ageVerificationSubmissions').doc();
+
+    let conflict = false;
+    await db.runTransaction(async (tx) => {
+      const pendingSnap = await tx.get(pendingQuery);
+      if (!pendingSnap.empty) {
+        conflict = true;
+        return;
+      }
+      tx.set(newDocRef, {
+        userId: String(req.auth.uniqueId),
+        r2Key,
+        idMethod,
+        status: 'pending',
+        submittedAt: now(),
+      });
+    });
+
+    if (conflict) {
       return res
         .status(409)
         .json({ error: 'You already have a pending submission. Wait for the admin decision.' });
     }
 
-    const ref = await db.collection('ageVerificationSubmissions').add({
-      userId: String(req.auth.uniqueId),
-      r2Key,
-      idMethod,
-      status: 'pending',
-      submittedAt: now(),
-    });
-
     log.info('age-verification', 'Submission created', {
-      submissionId: ref.id,
+      submissionId: newDocRef.id,
       userId: req.auth.uniqueId,
       idMethod,
     });
 
-    return res.json({ submissionId: ref.id, status: 'pending' });
+    return res.json({ submissionId: newDocRef.id, status: 'pending' });
   } catch (err) {
-    log.error('age-verification', 'submit failed', { error: err?.message });
-    return res.status(500).json({ error: 'Failed to record submission' });
+    log.error('age-verification', `${errorId} failed`, {
+      uid: req.auth?.uniqueId,
+      error: err?.message,
+    });
+    return res.status(500).json({ error: 'Failed to record submission', errorId });
   }
 });
 

--- a/express-api/src/routes/age-verification.js
+++ b/express-api/src/routes/age-verification.js
@@ -1,0 +1,156 @@
+/**
+ * User-facing age-verification routes.
+ *
+ *   POST /api/age-verification/upload-url
+ *     Body: { contentType: 'image/jpeg' | 'image/png' | 'image/webp' }
+ *     Returns: { uploadUrl, r2Key, expiresInSec }
+ *     Generates an R2 signed PUT URL the client can upload the ID
+ *     image directly to. Path is forced under
+ *     `age-verification/<uniqueId>/` so the server-side `submit`
+ *     handler can re-validate ownership.
+ *
+ *   POST /api/age-verification/submit
+ *     Body: { r2Key, idMethod }
+ *     Returns: { submissionId, status: 'pending' }
+ *     Creates a pending submission doc in
+ *     `ageVerificationSubmissions/`. Admin reviews via the routes in
+ *     PR 4b. Image is deleted on decision; only metadata persists.
+ *
+ * Server-side enforcement (in addition to client gates):
+ *   - User must be 18+ on the DOB on file. 16-17-y/o cohort sees the
+ *     "Contact support" copy; the API refuses regardless of client.
+ *   - User must NOT already be verified.
+ *   - Only one pending submission at a time (user spec).
+ *   - Submitted r2Key MUST be under the user's prefix (defence vs a
+ *     hand-rolled API call submitting someone else's image).
+ *
+ * No image content is read here — the upload happens client → R2
+ * directly via the signed PUT URL. The handler only sees the R2 key.
+ */
+
+const express = require('express');
+const router = express.Router();
+
+const { db } = require('../utils/firebase');
+const { getSignedPutUrl } = require('../utils/r2');
+const { now, generateId } = require('../utils/helpers');
+const log = require('../utils/log');
+
+const ALLOWED_CONTENT_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+const ALLOWED_ID_METHODS = ['passport', 'drivers-license', 'national-id'];
+const MIN_VERIFY_AGE_YEARS = 18;
+const MS_PER_YEAR = 365.25 * 86400 * 1000;
+
+function isAtLeast18(dateOfBirthMs) {
+  if (typeof dateOfBirthMs !== 'number' || !Number.isFinite(dateOfBirthMs)) return false;
+  return Date.now() - dateOfBirthMs >= MIN_VERIFY_AGE_YEARS * MS_PER_YEAR;
+}
+
+async function loadUserGate(uniqueId) {
+  const docSnap = await db.doc(`users/${uniqueId}`).get();
+  if (!docSnap.exists) {
+    return { ok: false, status: 404, error: 'User not found' };
+  }
+  const data = docSnap.data();
+  if (!isAtLeast18(data?.dateOfBirth)) {
+    return {
+      ok: false,
+      status: 403,
+      error:
+        'Must be 18 or older to start age verification. If you believe this is wrong, contact support.',
+    };
+  }
+  if (data?.ageVerified === true) {
+    return { ok: false, status: 409, error: 'Account is already age-verified' };
+  }
+  return { ok: true };
+}
+
+router.post('/age-verification/upload-url', async (req, res) => {
+  try {
+    const { contentType } = req.body || {};
+    if (!contentType || !ALLOWED_CONTENT_TYPES.has(contentType)) {
+      return res
+        .status(400)
+        .json({ error: 'contentType must be one of image/jpeg, image/png, image/webp' });
+    }
+
+    const gate = await loadUserGate(req.auth.uniqueId);
+    if (!gate.ok) {
+      return res.status(gate.status).json({ error: gate.error });
+    }
+
+    const ext = contentType.split('/')[1].replace('jpeg', 'jpg');
+    // Random component prevents an attacker who knows the user's
+    // uniqueId from guessing past keys (R2 is bucket-private but the
+    // signed URL flow returns the key — keep it unguessable).
+    const r2Key = `age-verification/${req.auth.uniqueId}/${generateId()}.${ext}`;
+    const uploadUrl = await getSignedPutUrl(r2Key, contentType);
+
+    return res.json({ uploadUrl, r2Key, expiresInSec: 300 });
+  } catch (err) {
+    log.error('age-verification', 'upload-url failed', { error: err?.message });
+    return res.status(500).json({ error: 'Failed to issue upload URL' });
+  }
+});
+
+router.post('/age-verification/submit', async (req, res) => {
+  try {
+    const { r2Key, idMethod } = req.body || {};
+    if (typeof r2Key !== 'string' || r2Key.length === 0) {
+      return res.status(400).json({ error: 'r2Key is required' });
+    }
+    if (!ALLOWED_ID_METHODS.includes(idMethod)) {
+      return res
+        .status(400)
+        .json({ error: `idMethod must be one of ${ALLOWED_ID_METHODS.join(', ')}` });
+    }
+
+    // Defence in depth: re-check the prefix even though the signed URL
+    // would have forced it. A malicious client could call submit
+    // directly with another user's key.
+    const expectedPrefix = `age-verification/${req.auth.uniqueId}/`;
+    if (!r2Key.startsWith(expectedPrefix)) {
+      return res.status(403).json({ error: 'r2Key is not under your user prefix' });
+    }
+
+    const gate = await loadUserGate(req.auth.uniqueId);
+    if (!gate.ok) {
+      return res.status(gate.status).json({ error: gate.error });
+    }
+
+    // Only one pending submission at a time (user spec).
+    const pendingSnap = await db
+      .collection('ageVerificationSubmissions')
+      .where('userId', '==', String(req.auth.uniqueId))
+      .where('status', '==', 'pending')
+      .limit(1)
+      .get();
+    if (!pendingSnap.empty) {
+      return res
+        .status(409)
+        .json({ error: 'You already have a pending submission. Wait for the admin decision.' });
+    }
+
+    const ref = await db.collection('ageVerificationSubmissions').add({
+      userId: String(req.auth.uniqueId),
+      r2Key,
+      idMethod,
+      status: 'pending',
+      submittedAt: now(),
+    });
+
+    log.info('age-verification', 'Submission created', {
+      submissionId: ref.id,
+      userId: req.auth.uniqueId,
+      idMethod,
+    });
+
+    return res.json({ submissionId: ref.id, status: 'pending' });
+  } catch (err) {
+    log.error('age-verification', 'submit failed', { error: err?.message });
+    return res.status(500).json({ error: 'Failed to record submission' });
+  }
+});
+
+module.exports = router;

--- a/express-api/src/utils/r2.js
+++ b/express-api/src/utils/r2.js
@@ -14,6 +14,7 @@ const {
   DeleteObjectsCommand,
   ListObjectsV2Command,
 } = require('@aws-sdk/client-s3');
+const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 
 const isLocal = process.env.NODE_ENV === 'local';
 const bucketName = process.env.R2_BUCKET_NAME || 'shytalk-media';
@@ -132,6 +133,34 @@ async function listObjectsWithMetadata(prefix) {
   return objects;
 }
 
+/**
+ * Issues a short-lived signed PUT URL the client can upload directly
+ * to (no Express proxy). Used by age-verification submission flow:
+ * the client gets a URL for `age-verification/<uid>/<random>.jpg`,
+ * PUTs the ID image, then notifies the API of the R2 key.
+ *
+ * Defaults to 5-minute expiry to limit replay if the URL is
+ * intercepted. Hard-caps overrides at 1 hour — anything longer is a
+ * code smell and the helper refuses.
+ */
+async function getSignedPutUrl(key, contentType, expiresInSec = 300) {
+  if (typeof key !== 'string' || key.length === 0) {
+    throw new Error('r2.getSignedPutUrl: key must be a non-empty string');
+  }
+  if (typeof contentType !== 'string' || contentType.length === 0) {
+    throw new Error('r2.getSignedPutUrl: contentType must be a non-empty string');
+  }
+  if (typeof expiresInSec !== 'number' || expiresInSec <= 0 || expiresInSec > 3600) {
+    throw new Error('r2.getSignedPutUrl: expiresInSec must be in (0, 3600]');
+  }
+  const command = new PutObjectCommand({
+    Bucket: bucketName,
+    Key: key,
+    ContentType: contentType,
+  });
+  return getSignedUrl(s3, command, { expiresIn: expiresInSec });
+}
+
 module.exports = {
   s3,
   bucketName,
@@ -141,5 +170,6 @@ module.exports = {
   deleteObjects,
   listObjects,
   listObjectsWithMetadata,
+  getSignedPutUrl,
   CDN_URL,
 };

--- a/express-api/tests/routes/age-verification.test.js
+++ b/express-api/tests/routes/age-verification.test.js
@@ -18,9 +18,13 @@ const request = require('supertest');
 
 const mockDocGet = jest.fn();
 const mockDocSet = jest.fn().mockResolvedValue();
-const mockCollectionAdd = jest.fn();
-const mockCollectionWhere = jest.fn();
-const mockCollectionGet = jest.fn();
+// Used by the submit handler's transaction. The transaction shape is
+// `await db.runTransaction(async (tx) => { tx.get(query); tx.set(ref, ...); })`.
+// We control the snapshot returned by `tx.get(...)` and capture the
+// `tx.set` payload so tests can assert it.
+const mockTxGet = jest.fn();
+const mockTxSet = jest.fn();
+const mockNewDocRef = { id: 'new-submission-id' };
 
 jest.mock('../../src/utils/firebase', () => ({
   db: {
@@ -29,20 +33,22 @@ jest.mock('../../src/utils/firebase', () => ({
       get: () => mockDocGet(path),
       set: (...args) => mockDocSet(path, ...args),
     })),
-    collection: jest.fn((name) => ({
-      add: (...args) => mockCollectionAdd(name, ...args),
-      where: (...args) => {
-        mockCollectionWhere(name, ...args);
-        return {
-          where: (...inner) => {
-            mockCollectionWhere(name, ...inner);
-            return { limit: () => ({ get: () => mockCollectionGet() }) };
-          },
-          limit: () => ({ get: () => mockCollectionGet() }),
-          get: () => mockCollectionGet(),
-        };
-      },
+    collection: jest.fn(() => ({
+      // For submit: `db.collection(...).doc()` returns a fresh ref.
+      doc: jest.fn(() => mockNewDocRef),
+      // For submit: `db.collection(...).where(...).where(...).limit(1)`
+      // returns a query passed to `tx.get(...)` — we don't need the
+      // chain to do anything because the tx mock handles it.
+      where: () => ({
+        where: () => ({ limit: () => ({}) }),
+      }),
     })),
+    runTransaction: jest.fn(async (fn) => {
+      return fn({
+        get: () => mockTxGet(),
+        set: (ref, payload) => mockTxSet(ref, payload),
+      });
+    }),
   },
 }));
 
@@ -60,8 +66,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockGetSignedPutUrl.mockResolvedValue('https://r2-signed/abc');
   mockDocGet.mockResolvedValue({ exists: false });
-  mockCollectionGet.mockResolvedValue({ empty: true, docs: [] });
-  mockCollectionAdd.mockResolvedValue({ id: 'new-submission-id' });
+  mockTxGet.mockResolvedValue({ empty: true, docs: [] });
 });
 
 // ─── App setup ──────────────────────────────────────────────────────
@@ -103,7 +108,10 @@ function createApp(authOverride = {}, userDoc = null) {
 
 describe('POST /api/age-verification/upload-url', () => {
   test('returns a signed URL + r2Key for the authenticated user', async () => {
-    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    // 25 years ago to be safely past the calendar 18+ boundary.
+    const dob = new Date();
+    dob.setUTCFullYear(dob.getUTCFullYear() - 25);
+    const eighteenYearsAgo = dob.getTime();
     const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
 
     const res = await request(app)
@@ -121,7 +129,10 @@ describe('POST /api/age-verification/upload-url', () => {
   });
 
   test('rejects unsupported contentType (only image/* allowed)', async () => {
-    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    // 25 years ago to be safely past the calendar 18+ boundary.
+    const dob = new Date();
+    dob.setUTCFullYear(dob.getUTCFullYear() - 25);
+    const eighteenYearsAgo = dob.getTime();
     const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
 
     await request(app)
@@ -133,7 +144,10 @@ describe('POST /api/age-verification/upload-url', () => {
   });
 
   test('rejects missing contentType', async () => {
-    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    // 25 years ago to be safely past the calendar 18+ boundary.
+    const dob = new Date();
+    dob.setUTCFullYear(dob.getUTCFullYear() - 25);
+    const eighteenYearsAgo = dob.getTime();
     const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
 
     await request(app).post('/api/age-verification/upload-url').send({}).expect(400);
@@ -143,8 +157,9 @@ describe('POST /api/age-verification/upload-url', () => {
   test('rejects sub-18 user (cannot start verification)', async () => {
     // User spec: 16-17 cohort cannot submit; tap on restricted feature
     // shows "Contact support" copy. Must enforce server-side too.
-    const sixteenYearsAgo = new Date(Date.now() - 16 * 365.25 * 86400 * 1000).getTime();
-    const app = createApp({}, { dateOfBirth: sixteenYearsAgo, ageVerified: false });
+    const sixteen = new Date();
+    sixteen.setUTCFullYear(sixteen.getUTCFullYear() - 16);
+    const app = createApp({}, { dateOfBirth: sixteen.getTime(), ageVerified: false });
 
     const res = await request(app)
       .post('/api/age-verification/upload-url')
@@ -156,7 +171,10 @@ describe('POST /api/age-verification/upload-url', () => {
   });
 
   test('rejects already-verified user (no re-submission needed)', async () => {
-    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    // 25 years ago to be safely past the calendar 18+ boundary.
+    const dob = new Date();
+    dob.setUTCFullYear(dob.getUTCFullYear() - 25);
+    const eighteenYearsAgo = dob.getTime();
     const app = createApp(
       {},
       { dateOfBirth: eighteenYearsAgo, ageVerified: true, ageVerifiedAt: 1700000000000 },
@@ -174,9 +192,20 @@ describe('POST /api/age-verification/upload-url', () => {
 // ─── POST /api/age-verification/submit ──────────────────────────────
 
 describe('POST /api/age-verification/submit', () => {
+  // Helper — 25 years ago is safely past the calendar 18+ boundary
+  // and avoids leap-year drift that the 365.25*MS approximation
+  // produced. See `isAtLeast18FromDob` calendar-aware comparison.
+  function dobAge(years) {
+    const d = new Date();
+    d.setUTCFullYear(d.getUTCFullYear() - years);
+    return d.getTime();
+  }
+
   test('creates pending submission for valid 18+ unverified user', async () => {
-    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
-    const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
+    // Use 25 years ago to be safely past the calendar 18+ boundary.
+    const dob = new Date();
+    dob.setUTCFullYear(dob.getUTCFullYear() - 25);
+    const app = createApp({}, { dateOfBirth: dob.getTime(), ageVerified: false });
 
     const res = await request(app)
       .post('/api/age-verification/submit')
@@ -186,8 +215,8 @@ describe('POST /api/age-verification/submit', () => {
     expect(res.body.submissionId).toBe('new-submission-id');
     expect(res.body.status).toBe('pending');
 
-    expect(mockCollectionAdd).toHaveBeenCalledWith(
-      'ageVerificationSubmissions',
+    expect(mockTxSet).toHaveBeenCalledWith(
+      mockNewDocRef,
       expect.objectContaining({
         userId: '10000001',
         status: 'pending',
@@ -199,7 +228,10 @@ describe('POST /api/age-verification/submit', () => {
   });
 
   test('rejects unknown idMethod', async () => {
-    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    // 25 years ago to be safely past the calendar 18+ boundary.
+    const dob = new Date();
+    dob.setUTCFullYear(dob.getUTCFullYear() - 25);
+    const eighteenYearsAgo = dob.getTime();
     const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
 
     await request(app)
@@ -207,14 +239,17 @@ describe('POST /api/age-verification/submit', () => {
       .send({ r2Key: 'x', idMethod: 'birth-certificate' })
       .expect(400);
 
-    expect(mockCollectionAdd).not.toHaveBeenCalled();
+    expect(mockTxSet).not.toHaveBeenCalled();
   });
 
   test("rejects r2Key not under user prefix (cannot upload someone else's image)", async () => {
     // The signed URL forces the prefix on upload; pin server-side
     // re-validation so a hand-rolled API call can't smuggle a key
     // under another user's prefix.
-    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    // 25 years ago to be safely past the calendar 18+ boundary.
+    const dob = new Date();
+    dob.setUTCFullYear(dob.getUTCFullYear() - 25);
+    const eighteenYearsAgo = dob.getTime();
     const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
 
     await request(app)
@@ -222,23 +257,25 @@ describe('POST /api/age-verification/submit', () => {
       .send({ r2Key: 'age-verification/99999999/abc.jpg', idMethod: 'passport' })
       .expect(403);
 
-    expect(mockCollectionAdd).not.toHaveBeenCalled();
+    expect(mockTxSet).not.toHaveBeenCalled();
   });
 
   test('rejects sub-18 user', async () => {
-    const sixteenYearsAgo = new Date(Date.now() - 16 * 365.25 * 86400 * 1000).getTime();
-    const app = createApp({}, { dateOfBirth: sixteenYearsAgo, ageVerified: false });
+    const app = createApp({}, { dateOfBirth: dobAge(16), ageVerified: false });
 
     await request(app)
       .post('/api/age-verification/submit')
       .send({ r2Key: 'age-verification/10000001/abc.jpg', idMethod: 'passport' })
       .expect(403);
 
-    expect(mockCollectionAdd).not.toHaveBeenCalled();
+    expect(mockTxSet).not.toHaveBeenCalled();
   });
 
   test('rejects already-verified user', async () => {
-    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    // 25 years ago to be safely past the calendar 18+ boundary.
+    const dob = new Date();
+    dob.setUTCFullYear(dob.getUTCFullYear() - 25);
+    const eighteenYearsAgo = dob.getTime();
     const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: true });
 
     await request(app)
@@ -246,20 +283,87 @@ describe('POST /api/age-verification/submit', () => {
       .send({ r2Key: 'age-verification/10000001/abc.jpg', idMethod: 'passport' })
       .expect(409);
 
-    expect(mockCollectionAdd).not.toHaveBeenCalled();
+    expect(mockTxSet).not.toHaveBeenCalled();
   });
 
   test('rejects when there is already a pending submission (only 1 at a time)', async () => {
-    // User spec: "can only submit 1 attempt at a time".
-    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
-    const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
-    mockCollectionGet.mockResolvedValue({ empty: false, docs: [{ id: 'existing-pending' }] });
+    // User spec: "can only submit 1 attempt at a time". Now enforced
+    // atomically inside `db.runTransaction` so the check is consistent
+    // with the create — a check-then-add TOCTOU window can't let
+    // duplicates through.
+    const app = createApp({}, { dateOfBirth: dobAge(25), ageVerified: false });
+    mockTxGet.mockResolvedValue({ empty: false, docs: [{ id: 'existing-pending' }] });
 
     await request(app)
       .post('/api/age-verification/submit')
       .send({ r2Key: 'age-verification/10000001/abc.jpg', idMethod: 'passport' })
       .expect(409);
 
-    expect(mockCollectionAdd).not.toHaveBeenCalled();
+    expect(mockTxSet).not.toHaveBeenCalled();
+  });
+
+  test('allows re-submission after a previous submission was rejected', async () => {
+    // User spec: "Retry as many times as they want." A rejected
+    // submission has status 'rejected', which the 'pending'-only
+    // query inside the transaction does NOT match, so a fresh
+    // submit succeeds.
+    const app = createApp({}, { dateOfBirth: dobAge(25), ageVerified: false });
+    // tx.get returns empty (no pending) — same default as setup; the
+    // rejected historical doc would be at a different status.
+    mockTxGet.mockResolvedValue({ empty: true, docs: [] });
+
+    await request(app)
+      .post('/api/age-verification/submit')
+      .send({ r2Key: 'age-verification/10000001/retry.jpg', idMethod: 'national-id' })
+      .expect(200);
+
+    expect(mockTxSet).toHaveBeenCalled();
+  });
+
+  test('rejects path-traversal attempt in r2Key (cannot escape user prefix)', async () => {
+    // The startsWith() check passes for `age-verification/<uid>/../<other>/x.jpg`
+    // — pin the explicit `..` rejection that defends against R2 / CDN
+    // path normalisation collapsing the segment.
+    const app = createApp({}, { dateOfBirth: dobAge(25), ageVerified: false });
+
+    await request(app)
+      .post('/api/age-verification/submit')
+      .send({
+        r2Key: 'age-verification/10000001/../99999999/img.jpg',
+        idMethod: 'passport',
+      })
+      .expect(403);
+
+    expect(mockTxSet).not.toHaveBeenCalled();
+  });
+
+  test('rejects multi-segment r2Key under user prefix (must be single file)', async () => {
+    // `age-verification/<uid>/sub/dir/x.jpg` could escape into
+    // unintended bucket areas if a CDN config strips the prefix
+    // boundary. Require a single segment after the prefix.
+    const app = createApp({}, { dateOfBirth: dobAge(25), ageVerified: false });
+
+    await request(app)
+      .post('/api/age-verification/submit')
+      .send({ r2Key: 'age-verification/10000001/sub/x.jpg', idMethod: 'passport' })
+      .expect(403);
+
+    expect(mockTxSet).not.toHaveBeenCalled();
+  });
+
+  test('returns errorId in 500 response so support can correlate logs', async () => {
+    // A Firestore failure inside the transaction propagates here.
+    // Pin that the response body includes `errorId: 'AGE_VERIF_SUBMIT'`
+    // so a user reporting a failure can quote it to support and the
+    // engineer can find the pm2 log entry by the same code.
+    const app = createApp({}, { dateOfBirth: dobAge(25), ageVerified: false });
+    mockTxGet.mockRejectedValue(new Error('firestore-down'));
+
+    const res = await request(app)
+      .post('/api/age-verification/submit')
+      .send({ r2Key: 'age-verification/10000001/abc.jpg', idMethod: 'passport' })
+      .expect(500);
+
+    expect(res.body).toMatchObject({ errorId: 'AGE_VERIF_SUBMIT' });
   });
 });

--- a/express-api/tests/routes/age-verification.test.js
+++ b/express-api/tests/routes/age-verification.test.js
@@ -1,0 +1,265 @@
+/**
+ * Tests for the user-facing age-verification routes:
+ *   - POST /api/age-verification/upload-url
+ *   - POST /api/age-verification/submit
+ *
+ * Admin-side routes (list / approve / reject / modify-DOB) ship in PR
+ * 4b — out of scope here.
+ *
+ * The 18+ gating logic (sub-18 users cannot submit) is enforced
+ * server-side in addition to the client-side gate, since a malicious
+ * client could call this API directly. Tests pin both paths.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// ─── Firebase mock (path-aware) ─────────────────────────────────────
+
+const mockDocGet = jest.fn();
+const mockDocSet = jest.fn().mockResolvedValue();
+const mockCollectionAdd = jest.fn();
+const mockCollectionWhere = jest.fn();
+const mockCollectionGet = jest.fn();
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    doc: jest.fn((path) => ({
+      _path: path,
+      get: () => mockDocGet(path),
+      set: (...args) => mockDocSet(path, ...args),
+    })),
+    collection: jest.fn((name) => ({
+      add: (...args) => mockCollectionAdd(name, ...args),
+      where: (...args) => {
+        mockCollectionWhere(name, ...args);
+        return {
+          where: (...inner) => {
+            mockCollectionWhere(name, ...inner);
+            return { limit: () => ({ get: () => mockCollectionGet() }) };
+          },
+          limit: () => ({ get: () => mockCollectionGet() }),
+          get: () => mockCollectionGet(),
+        };
+      },
+    })),
+  },
+}));
+
+const mockGetSignedPutUrl = jest.fn();
+jest.mock('../../src/utils/r2', () => ({
+  getSignedPutUrl: (...args) => mockGetSignedPutUrl(...args),
+}));
+
+jest.mock('../../src/utils/helpers', () => ({
+  now: () => 1709913600000,
+  generateId: () => 'gen-id-abc',
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetSignedPutUrl.mockResolvedValue('https://r2-signed/abc');
+  mockDocGet.mockResolvedValue({ exists: false });
+  mockCollectionGet.mockResolvedValue({ empty: true, docs: [] });
+  mockCollectionAdd.mockResolvedValue({ id: 'new-submission-id' });
+});
+
+// ─── App setup ──────────────────────────────────────────────────────
+
+const ageVerificationRouter = require('../../src/routes/age-verification');
+
+/**
+ * Creates a test app with injected auth.
+ * @param {Object} authOverride
+ * @param {Object} userDoc Body returned by mockDocGet for users/<uid>
+ */
+function createApp(authOverride = {}, userDoc = null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.auth = {
+      uid: 'fb-uid-1',
+      uniqueId: 10000001,
+      token: {},
+      ...authOverride,
+    };
+    next();
+  });
+
+  if (userDoc !== null) {
+    mockDocGet.mockImplementation((path) => {
+      if (path === `users/${10000001}`) {
+        return Promise.resolve({ exists: true, data: () => userDoc });
+      }
+      return Promise.resolve({ exists: false });
+    });
+  }
+
+  app.use('/api', ageVerificationRouter);
+  return app;
+}
+
+// ─── POST /api/age-verification/upload-url ──────────────────────────
+
+describe('POST /api/age-verification/upload-url', () => {
+  test('returns a signed URL + r2Key for the authenticated user', async () => {
+    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
+
+    const res = await request(app)
+      .post('/api/age-verification/upload-url')
+      .send({ contentType: 'image/jpeg' })
+      .expect(200);
+
+    expect(res.body.uploadUrl).toBe('https://r2-signed/abc');
+    expect(res.body.r2Key).toMatch(/^age-verification\/10000001\//);
+    expect(res.body.expiresInSec).toBe(300);
+    expect(mockGetSignedPutUrl).toHaveBeenCalledWith(
+      expect.stringMatching(/^age-verification\/10000001\//),
+      'image/jpeg',
+    );
+  });
+
+  test('rejects unsupported contentType (only image/* allowed)', async () => {
+    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
+
+    await request(app)
+      .post('/api/age-verification/upload-url')
+      .send({ contentType: 'application/pdf' })
+      .expect(400);
+
+    expect(mockGetSignedPutUrl).not.toHaveBeenCalled();
+  });
+
+  test('rejects missing contentType', async () => {
+    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
+
+    await request(app).post('/api/age-verification/upload-url').send({}).expect(400);
+    expect(mockGetSignedPutUrl).not.toHaveBeenCalled();
+  });
+
+  test('rejects sub-18 user (cannot start verification)', async () => {
+    // User spec: 16-17 cohort cannot submit; tap on restricted feature
+    // shows "Contact support" copy. Must enforce server-side too.
+    const sixteenYearsAgo = new Date(Date.now() - 16 * 365.25 * 86400 * 1000).getTime();
+    const app = createApp({}, { dateOfBirth: sixteenYearsAgo, ageVerified: false });
+
+    const res = await request(app)
+      .post('/api/age-verification/upload-url')
+      .send({ contentType: 'image/jpeg' })
+      .expect(403);
+
+    expect(res.body.error).toMatch(/18/);
+    expect(mockGetSignedPutUrl).not.toHaveBeenCalled();
+  });
+
+  test('rejects already-verified user (no re-submission needed)', async () => {
+    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    const app = createApp(
+      {},
+      { dateOfBirth: eighteenYearsAgo, ageVerified: true, ageVerifiedAt: 1700000000000 },
+    );
+
+    await request(app)
+      .post('/api/age-verification/upload-url')
+      .send({ contentType: 'image/jpeg' })
+      .expect(409);
+
+    expect(mockGetSignedPutUrl).not.toHaveBeenCalled();
+  });
+});
+
+// ─── POST /api/age-verification/submit ──────────────────────────────
+
+describe('POST /api/age-verification/submit', () => {
+  test('creates pending submission for valid 18+ unverified user', async () => {
+    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
+
+    const res = await request(app)
+      .post('/api/age-verification/submit')
+      .send({ r2Key: 'age-verification/10000001/abc.jpg', idMethod: 'passport' })
+      .expect(200);
+
+    expect(res.body.submissionId).toBe('new-submission-id');
+    expect(res.body.status).toBe('pending');
+
+    expect(mockCollectionAdd).toHaveBeenCalledWith(
+      'ageVerificationSubmissions',
+      expect.objectContaining({
+        userId: '10000001',
+        status: 'pending',
+        idMethod: 'passport',
+        r2Key: 'age-verification/10000001/abc.jpg',
+        submittedAt: 1709913600000,
+      }),
+    );
+  });
+
+  test('rejects unknown idMethod', async () => {
+    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
+
+    await request(app)
+      .post('/api/age-verification/submit')
+      .send({ r2Key: 'x', idMethod: 'birth-certificate' })
+      .expect(400);
+
+    expect(mockCollectionAdd).not.toHaveBeenCalled();
+  });
+
+  test("rejects r2Key not under user prefix (cannot upload someone else's image)", async () => {
+    // The signed URL forces the prefix on upload; pin server-side
+    // re-validation so a hand-rolled API call can't smuggle a key
+    // under another user's prefix.
+    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
+
+    await request(app)
+      .post('/api/age-verification/submit')
+      .send({ r2Key: 'age-verification/99999999/abc.jpg', idMethod: 'passport' })
+      .expect(403);
+
+    expect(mockCollectionAdd).not.toHaveBeenCalled();
+  });
+
+  test('rejects sub-18 user', async () => {
+    const sixteenYearsAgo = new Date(Date.now() - 16 * 365.25 * 86400 * 1000).getTime();
+    const app = createApp({}, { dateOfBirth: sixteenYearsAgo, ageVerified: false });
+
+    await request(app)
+      .post('/api/age-verification/submit')
+      .send({ r2Key: 'age-verification/10000001/abc.jpg', idMethod: 'passport' })
+      .expect(403);
+
+    expect(mockCollectionAdd).not.toHaveBeenCalled();
+  });
+
+  test('rejects already-verified user', async () => {
+    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: true });
+
+    await request(app)
+      .post('/api/age-verification/submit')
+      .send({ r2Key: 'age-verification/10000001/abc.jpg', idMethod: 'passport' })
+      .expect(409);
+
+    expect(mockCollectionAdd).not.toHaveBeenCalled();
+  });
+
+  test('rejects when there is already a pending submission (only 1 at a time)', async () => {
+    // User spec: "can only submit 1 attempt at a time".
+    const eighteenYearsAgo = new Date(Date.now() - 18 * 365.25 * 86400 * 1000).getTime();
+    const app = createApp({}, { dateOfBirth: eighteenYearsAgo, ageVerified: false });
+    mockCollectionGet.mockResolvedValue({ empty: false, docs: [{ id: 'existing-pending' }] });
+
+    await request(app)
+      .post('/api/age-verification/submit')
+      .send({ r2Key: 'age-verification/10000001/abc.jpg', idMethod: 'passport' })
+      .expect(409);
+
+    expect(mockCollectionAdd).not.toHaveBeenCalled();
+  });
+});

--- a/express-api/tests/utils/r2-signed-put.test.js
+++ b/express-api/tests/utils/r2-signed-put.test.js
@@ -1,0 +1,85 @@
+/**
+ * Tests for the R2 signed-PUT URL helper. Used by the age-verification
+ * upload-url endpoint so the client can PUT the ID image directly to
+ * R2 without proxying through Express (saves bandwidth on the cheap
+ * Oracle VM).
+ *
+ * Runtime delegates to @aws-sdk/s3-request-presigner. We mock that
+ * out so the test doesn't need real R2 / MinIO credentials and so we
+ * can pin the exact arguments passed (bucket, key, content type,
+ * expires-in seconds).
+ */
+
+const mockGetSignedUrl = jest.fn();
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: (...args) => mockGetSignedUrl(...args),
+}));
+
+const mockS3Send = jest.fn();
+jest.mock('@aws-sdk/client-s3', () => {
+  const original = jest.requireActual('@aws-sdk/client-s3');
+  return {
+    ...original,
+    S3Client: jest.fn().mockImplementation(() => ({
+      send: mockS3Send,
+    })),
+  };
+});
+
+const { getSignedPutUrl, bucketName } = require('../../src/utils/r2');
+
+beforeEach(() => {
+  mockGetSignedUrl.mockClear();
+  mockGetSignedUrl.mockResolvedValue('https://r2-signed/abc?expires=1h');
+});
+
+describe('getSignedPutUrl', () => {
+  test('returns the signed URL string from the presigner', async () => {
+    const url = await getSignedPutUrl('age-verification/u1/abc.jpg', 'image/jpeg');
+    expect(url).toBe('https://r2-signed/abc?expires=1h');
+  });
+
+  test('passes bucket + key + content-type to PutObjectCommand', async () => {
+    await getSignedPutUrl('age-verification/u1/abc.jpg', 'image/jpeg');
+
+    expect(mockGetSignedUrl).toHaveBeenCalledTimes(1);
+    const [, command] = mockGetSignedUrl.mock.calls[0];
+    expect(command.input).toMatchObject({
+      Bucket: bucketName,
+      Key: 'age-verification/u1/abc.jpg',
+      ContentType: 'image/jpeg',
+    });
+  });
+
+  test('default expiry is 5 minutes (short-lived to limit replay window)', async () => {
+    // The signed URL is single-use in spirit but R2 doesn't enforce
+    // single-use semantics — only an expiry. Keeping the window
+    // tight (5min) limits exposure if a URL is intercepted.
+    await getSignedPutUrl('age-verification/u1/abc.jpg', 'image/jpeg');
+    const [, , options] = mockGetSignedUrl.mock.calls[0];
+    expect(options).toEqual({ expiresIn: 300 });
+  });
+
+  test('caller can override expiry but not exceed 1 hour (defense-in-depth)', async () => {
+    await getSignedPutUrl('age-verification/u1/abc.jpg', 'image/jpeg', 600);
+    const [, , options] = mockGetSignedUrl.mock.calls[0];
+    expect(options).toEqual({ expiresIn: 600 });
+  });
+
+  test('rejects expiry > 1 hour', async () => {
+    await expect(
+      getSignedPutUrl('age-verification/u1/abc.jpg', 'image/jpeg', 7200),
+    ).rejects.toThrow(/expiresInSec/);
+    expect(mockGetSignedUrl).not.toHaveBeenCalled();
+  });
+
+  test('rejects empty key', async () => {
+    await expect(getSignedPutUrl('', 'image/jpeg')).rejects.toThrow(/key/);
+    expect(mockGetSignedUrl).not.toHaveBeenCalled();
+  });
+
+  test('rejects empty contentType', async () => {
+    await expect(getSignedPutUrl('age-verification/u1/abc.jpg', '')).rejects.toThrow(/contentType/);
+    expect(mockGetSignedUrl).not.toHaveBeenCalled();
+  });
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -453,5 +453,22 @@ service cloud.firestore {
       allow read: if request.auth != null && request.auth.token.admin == true;
       allow write: if false;
     }
+
+    // ── Age verification submissions — admin read, server write ──
+    // Apple-content-guideline 18+ enforcement (PR #441 plan). Holds
+    // the in-flight ID-review submission per user (status: pending /
+    // approved / rejected / dob_modified). The doc references an R2
+    // image key; the image itself is deleted on admin decision so
+    // the doc is the only persistent record.
+    //
+    // Clients DO NOT read or write this collection directly — both
+    // sides go through Express. The submitter's user doc surfaces
+    // their verification status via the `ageVerified` field instead.
+    // Admin reads via the Express admin route (which uses Firebase
+    // Admin SDK; rules are bypassed).
+    match /ageVerificationSubmissions/{submissionId} {
+      allow read: if request.auth != null && request.auth.token.admin == true;
+      allow write: if false;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Part 4a of the [Age Verification multi-PR plan](.project/plans/2026-05-03-age-verification.md). The original plan had this as one big PR 4 covering user + admin endpoints together — split into 4a (user) + 4b (admin) for reviewability per the small-PRs convention.

## What's new

- \`r2.getSignedPutUrl(key, contentType, expiresInSec=300)\` — short-lived signed PUT URL backed by \`@aws-sdk/s3-request-presigner\`. Hard-caps expiry at 1 hour, defaults to 5 min.
- \`POST /api/age-verification/upload-url\` — issues a signed URL with the key forced under \`age-verification/<uniqueId>/<random>.<ext>\`. Allowed \`contentType\` values: \`image/jpeg\`, \`image/png\`, \`image/webp\`.
- \`POST /api/age-verification/submit\` — creates a pending submission doc in the new \`ageVerificationSubmissions/\` Firestore collection. Server-side gates (in addition to client-side):
  - 18+ on file (16-17 cohort gets the "Contact support" copy)
  - Not already \`ageVerified\`
  - No other pending submission (1-at-a-time per user spec)
  - \`r2Key\` MUST be under the caller's prefix (defence vs hand-rolled API caller submitting another user's image)
- Firestore rules: \`ageVerificationSubmissions/\` admin-read, server-write only.
- Rate-limited under \`sensitiveLimiter\` (same tier as account-deletion / data-export).

## TDD

- 18 new tests (7 R2 helper + 11 routes) all green
- Full Express suite (4523 tests) re-runs green after implementation
- iOS shared compile not affected (backend-only PR)

## Order constraint

PR 4b (admin list / approve / reject / modify-DOB) ships next. Existing-user behaviour is unchanged through PRs 1-13; the gate flips on at PR 11. No DEV deploy on this PR — multi-PR work-completion deploy is at PR 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)