### PR TITLE
feat(age-verif): admin endpoints (PR 4b/14)

### DIFF
--- a/express-api/src/index.js
+++ b/express-api/src/index.js
@@ -185,6 +185,7 @@ app.use('/api', require('./routes/conversations'));
 app.use('/api', require('./routes/banners'));
 app.use('/api', require('./routes/fun-facts'));
 app.use('/api', require('./routes/admin-users'));
+app.use('/api', require('./routes/admin-age-verification'));
 app.use('/api', require('./routes/admin-economy'));
 app.use('/api', require('./routes/admin-gifts'));
 app.use('/api', require('./routes/admin-cleanup'));

--- a/express-api/src/routes/admin-age-verification.js
+++ b/express-api/src/routes/admin-age-verification.js
@@ -5,34 +5,45 @@
  *     List all pending submissions (oldest first).
  *
  *   POST /api/admin/age-verification/:id/approve
+ *     Body: { reason: string }
  *     Marks the submission approved. Flips `ageVerified=true` on the
  *     target user, records `ageVerifiedAt` + `ageVerificationMethod`.
- *     Deletes the R2 ID image. Writes an audit-log entry.
+ *     Best-effort: deletes R2 ID image and writes audit-log entry.
  *
  *   POST /api/admin/age-verification/:id/reject
  *     Body: { reason: string }
  *     Marks the submission rejected. User stays unverified. Image is
- *     still deleted (privacy: user spec required image destruction on
+ *     still deleted (privacy: spec required image destruction on
  *     decision regardless of outcome). Writes audit entry.
  *
  *   POST /api/admin/age-verification/:id/modify-dob
  *     Body: { newDob: number (ms), reason: string }
- *     Admin found the ID's DOB doesn't match what's on file. Updates
- *     `users/<uid>.dateOfBirth` to the new value. If the new DOB
- *     makes the user 18+, behaves like approve. If <18, the account
- *     is reverted to unverified (ageVerified=false, ageVerifiedAt=null,
- *     method=null) — they age in. Existing PMs locked out is a
- *     follow-on side-effect handled by PR 11 migration logic.
+ *     Updates `users/<uid>.dateOfBirth` to the new value. If the new
+ *     DOB makes the user 18+, behaves like approve. If <18, the
+ *     account is reverted to unverified — they age in. PMs lock-out
+ *     is downstream (PR 11 migration). DOB plausibility (1900 ≤ dob
+ *     ≤ now) is validated PRE-transaction; an implausible DOB cannot
+ *     get past the user-doc mutation only to fail at the audit-log
+ *     stage.
  *
  * Concurrency: each decision endpoint uses `db.runTransaction(...)`
  * to atomically read submission + user docs and write both updates.
- * R2 deletion + audit log run AFTER the transaction commits — the
- * Firestore write is the source of truth for compliance, and a failed
- * post-commit cleanup logs but doesn't roll back the decision.
  *
- * Image deletion is documented as best-effort: if R2 errors out we
- * log the failure with the leaked key + submission id for ops to
- * sweep, rather than rolling back the user-facing decision.
+ * Partial-failure contract: the route returns success with explicit
+ * `auditWritten` / `imageDeleted` flags when post-commit cleanup
+ * partially fails. The Firestore decision is the source of truth;
+ * a failed audit-log write or R2 deletion is logged for ops sweep
+ * and surfaced to the admin UI via the response flags rather than
+ * masked as a 500. Crash-window between the transaction commit and
+ * the post-commit cleanup leaves the decision recorded with no
+ * audit / a leaked image — see follow-up task for a reconciliation
+ * job that detects gaps.
+ *
+ * Submission-doc lifecycle: after a decision commits, the
+ * `r2Key` field is set to null in the same transaction so a future
+ * reader (admin audit-trail tab) doesn't see a stale reference to a
+ * deleted object. The original key is preserved in the audit-log
+ * entry for compliance traceability.
  */
 
 const express = require('express');
@@ -60,18 +71,39 @@ function isAtLeast18FromDob(dateOfBirthMs) {
 }
 
 async function deleteImageBestEffort(r2Key, submissionId) {
+  if (!r2Key) return true;
   try {
     await r2.deleteObject(r2Key);
+    return true;
   } catch (err) {
-    // Do NOT fail the request — the Firestore decision already
-    // committed and the user is now (un)verified. A leaked image is a
-    // hygiene issue, not a correctness one. Logged so ops can sweep.
     log.error('admin-age-verification', 'R2 image deletion failed', {
       submissionId,
       r2Key,
       error: err?.message,
     });
+    return false;
   }
+}
+
+async function writeAuditBestEffort(action, submissionId, payload) {
+  try {
+    await action(db, payload);
+    return true;
+  } catch (err) {
+    // The decision is already committed in Firestore. An audit-log
+    // failure means the compliance trail is incomplete. Logged with
+    // submissionId so ops can locate the decision and back-fill.
+    log.error('admin-age-verification', 'Audit-log write failed', {
+      submissionId,
+      payload,
+      error: err?.message,
+    });
+    return false;
+  }
+}
+
+function requireNonBlankReason(reason) {
+  return typeof reason === 'string' && reason.trim().length > 0;
 }
 
 // ─── GET /pending ───────────────────────────────────────────────────
@@ -101,14 +133,19 @@ router.post('/admin/age-verification/:id/approve', async (req, res) => {
   const { id } = req.params;
   const errorId = 'AGE_VERIF_APPROVE';
   try {
+    const reason = (req.body?.reason || '').toString();
+    if (!requireNonBlankReason(reason)) {
+      // Symmetric with reject / modify-dob — every admin decision must
+      // carry a justification for the OSA / GDPR audit trail.
+      return res.status(400).json({ error: 'reason is required' });
+    }
+
     let submission;
     let approved = false;
     await db.runTransaction(async (tx) => {
       const subRef = db.doc(`ageVerificationSubmissions/${id}`);
       const subSnap = await tx.get(subRef);
-      if (!subSnap.exists) {
-        return; // 404 path — handled below
-      }
+      if (!subSnap.exists) return;
       const data = subSnap.data();
       if (data.status !== 'pending') {
         submission = { ...data, _conflict: true };
@@ -120,6 +157,9 @@ router.post('/admin/age-verification/:id/approve', async (req, res) => {
         status: 'approved',
         decisionAt: now(),
         decidedBy: req.auth.uniqueId,
+        decisionReason: reason,
+        // r2Key tombstoned — original preserved in audit-log entry.
+        r2Key: null,
       });
       tx.update(db.doc(`users/${data.userId}`), {
         ageVerified: true,
@@ -133,17 +173,14 @@ router.post('/admin/age-verification/:id/approve', async (req, res) => {
     if (submission._conflict) return res.status(409).json({ error: 'Submission already decided' });
     if (!approved) return res.status(500).json({ error: 'Approval did not commit', errorId });
 
-    // Best-effort post-commit cleanup. The Firestore decision is the
-    // source of truth; an R2 deletion or audit-log failure is logged
-    // but doesn't roll back.
-    await deleteImageBestEffort(submission.r2Key, id);
-    await audit.logVerificationApproved(db, {
+    const imageDeleted = await deleteImageBestEffort(submission.r2Key, id);
+    const auditWritten = await writeAuditBestEffort(audit.logVerificationApproved, id, {
       adminUid: req.auth.uniqueId,
       targetUserId: submission.userId,
       method: submission.idMethod,
     });
 
-    return res.json({ ok: true });
+    return res.json({ ok: true, imageDeleted, auditWritten });
   } catch (err) {
     log.error('admin-age-verification', `${errorId} failed`, { id, error: err?.message });
     return res.status(500).json({ error: 'Failed to approve submission', errorId });
@@ -158,7 +195,7 @@ router.post('/admin/age-verification/:id/reject', async (req, res) => {
   const errorId = 'AGE_VERIF_REJECT';
   try {
     const reason = (req.body?.reason || '').toString();
-    if (!reason.trim()) {
+    if (!requireNonBlankReason(reason)) {
       return res.status(400).json({ error: 'reason is required' });
     }
 
@@ -180,6 +217,7 @@ router.post('/admin/age-verification/:id/reject', async (req, res) => {
         decisionAt: now(),
         decidedBy: req.auth.uniqueId,
         decisionReason: reason,
+        r2Key: null,
       });
       // User doc intentionally NOT touched — they stay unverified.
       rejected = true;
@@ -189,14 +227,14 @@ router.post('/admin/age-verification/:id/reject', async (req, res) => {
     if (submission._conflict) return res.status(409).json({ error: 'Submission already decided' });
     if (!rejected) return res.status(500).json({ error: 'Rejection did not commit', errorId });
 
-    await deleteImageBestEffort(submission.r2Key, id);
-    await audit.logVerificationRejected(db, {
+    const imageDeleted = await deleteImageBestEffort(submission.r2Key, id);
+    const auditWritten = await writeAuditBestEffort(audit.logVerificationRejected, id, {
       adminUid: req.auth.uniqueId,
       targetUserId: submission.userId,
       reason,
     });
 
-    return res.json({ ok: true });
+    return res.json({ ok: true, imageDeleted, auditWritten });
   } catch (err) {
     log.error('admin-age-verification', `${errorId} failed`, { id, error: err?.message });
     return res.status(500).json({ error: 'Failed to reject submission', errorId });
@@ -215,7 +253,17 @@ router.post('/admin/age-verification/:id/modify-dob', async (req, res) => {
     if (typeof newDob !== 'number' || !Number.isFinite(newDob)) {
       return res.status(400).json({ error: 'newDob is required (ms epoch)' });
     }
-    if (!reason.trim()) {
+    // Plausibility: 1900 <= newDob <= now. Throws if out of range.
+    // Validated up-front so an implausible DOB never reaches the user
+    // doc — without this, the transaction would commit the bogus
+    // value, then the audit-log helper's bounds check would throw and
+    // the route would 500 with the mutation already persisted.
+    try {
+      audit.requirePlausibleDob(newDob, 'newDob');
+    } catch (err) {
+      return res.status(400).json({ error: err.message });
+    }
+    if (!requireNonBlankReason(reason)) {
       return res.status(400).json({ error: 'reason is required' });
     }
 
@@ -243,11 +291,9 @@ router.post('/admin/age-verification/:id/modify-dob', async (req, res) => {
         decisionAt: now(),
         decidedBy: req.auth.uniqueId,
         decisionReason: reason,
-        // Capture the modification on the submission doc too so the
-        // admin audit trail is self-contained even if the auditLog
-        // collection is later compacted.
         oldDob,
         newDob,
+        r2Key: null,
       });
       tx.update(userRef, {
         dateOfBirth: newDob,
@@ -263,8 +309,8 @@ router.post('/admin/age-verification/:id/modify-dob', async (req, res) => {
     if (!committed)
       return res.status(500).json({ error: 'DOB modification did not commit', errorId });
 
-    await deleteImageBestEffort(submission.r2Key, id);
-    await audit.logVerificationDobModified(db, {
+    const imageDeleted = await deleteImageBestEffort(submission.r2Key, id);
+    const auditWritten = await writeAuditBestEffort(audit.logVerificationDobModified, id, {
       adminUid: req.auth.uniqueId,
       targetUserId: submission.userId,
       oldDob,
@@ -272,7 +318,12 @@ router.post('/admin/age-verification/:id/modify-dob', async (req, res) => {
       reason,
     });
 
-    return res.json({ ok: true, ageVerified: isAtLeast18FromDob(newDob) });
+    return res.json({
+      ok: true,
+      ageVerified: isAtLeast18FromDob(newDob),
+      imageDeleted,
+      auditWritten,
+    });
   } catch (err) {
     log.error('admin-age-verification', `${errorId} failed`, { id, error: err?.message });
     return res.status(500).json({ error: 'Failed to modify DOB', errorId });

--- a/express-api/src/routes/admin-age-verification.js
+++ b/express-api/src/routes/admin-age-verification.js
@@ -1,0 +1,282 @@
+/**
+ * Admin-side age-verification routes (PR 4b/14).
+ *
+ *   GET  /api/admin/age-verification/pending
+ *     List all pending submissions (oldest first).
+ *
+ *   POST /api/admin/age-verification/:id/approve
+ *     Marks the submission approved. Flips `ageVerified=true` on the
+ *     target user, records `ageVerifiedAt` + `ageVerificationMethod`.
+ *     Deletes the R2 ID image. Writes an audit-log entry.
+ *
+ *   POST /api/admin/age-verification/:id/reject
+ *     Body: { reason: string }
+ *     Marks the submission rejected. User stays unverified. Image is
+ *     still deleted (privacy: user spec required image destruction on
+ *     decision regardless of outcome). Writes audit entry.
+ *
+ *   POST /api/admin/age-verification/:id/modify-dob
+ *     Body: { newDob: number (ms), reason: string }
+ *     Admin found the ID's DOB doesn't match what's on file. Updates
+ *     `users/<uid>.dateOfBirth` to the new value. If the new DOB
+ *     makes the user 18+, behaves like approve. If <18, the account
+ *     is reverted to unverified (ageVerified=false, ageVerifiedAt=null,
+ *     method=null) — they age in. Existing PMs locked out is a
+ *     follow-on side-effect handled by PR 11 migration logic.
+ *
+ * Concurrency: each decision endpoint uses `db.runTransaction(...)`
+ * to atomically read submission + user docs and write both updates.
+ * R2 deletion + audit log run AFTER the transaction commits — the
+ * Firestore write is the source of truth for compliance, and a failed
+ * post-commit cleanup logs but doesn't roll back the decision.
+ *
+ * Image deletion is documented as best-effort: if R2 errors out we
+ * log the failure with the leaked key + submission id for ops to
+ * sweep, rather than rolling back the user-facing decision.
+ */
+
+const express = require('express');
+const router = express.Router();
+
+const { db } = require('../utils/firebase');
+const r2 = require('../utils/r2');
+const audit = require('../utils/age-verification-audit');
+const { now } = require('../utils/helpers');
+const log = require('../utils/log');
+const { requireAdmin } = require('../middleware/auth');
+
+function isAtLeast18FromDob(dateOfBirthMs) {
+  if (typeof dateOfBirthMs !== 'number' || !Number.isFinite(dateOfBirthMs)) return false;
+  const today = new Date();
+  const dob = new Date(dateOfBirthMs);
+  let age = today.getUTCFullYear() - dob.getUTCFullYear();
+  if (
+    today.getUTCMonth() < dob.getUTCMonth() ||
+    (today.getUTCMonth() === dob.getUTCMonth() && today.getUTCDate() < dob.getUTCDate())
+  ) {
+    age -= 1;
+  }
+  return age >= 18;
+}
+
+async function deleteImageBestEffort(r2Key, submissionId) {
+  try {
+    await r2.deleteObject(r2Key);
+  } catch (err) {
+    // Do NOT fail the request — the Firestore decision already
+    // committed and the user is now (un)verified. A leaked image is a
+    // hygiene issue, not a correctness one. Logged so ops can sweep.
+    log.error('admin-age-verification', 'R2 image deletion failed', {
+      submissionId,
+      r2Key,
+      error: err?.message,
+    });
+  }
+}
+
+// ─── GET /pending ───────────────────────────────────────────────────
+
+router.get('/admin/age-verification/pending', async (req, res) => {
+  if (requireAdmin(req, res)) return;
+  try {
+    const snap = await db
+      .collection('ageVerificationSubmissions')
+      .where('status', '==', 'pending')
+      .orderBy('submittedAt', 'asc')
+      .get();
+    const submissions = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    return res.json({ submissions });
+  } catch (err) {
+    log.error('admin-age-verification', 'list pending failed', { error: err?.message });
+    return res
+      .status(500)
+      .json({ error: 'Failed to list pending submissions', errorId: 'AGE_VERIF_LIST' });
+  }
+});
+
+// ─── POST /:id/approve ──────────────────────────────────────────────
+
+router.post('/admin/age-verification/:id/approve', async (req, res) => {
+  if (requireAdmin(req, res)) return;
+  const { id } = req.params;
+  const errorId = 'AGE_VERIF_APPROVE';
+  try {
+    let submission;
+    let approved = false;
+    await db.runTransaction(async (tx) => {
+      const subRef = db.doc(`ageVerificationSubmissions/${id}`);
+      const subSnap = await tx.get(subRef);
+      if (!subSnap.exists) {
+        return; // 404 path — handled below
+      }
+      const data = subSnap.data();
+      if (data.status !== 'pending') {
+        submission = { ...data, _conflict: true };
+        return;
+      }
+      submission = { ...data, id };
+
+      tx.update(subRef, {
+        status: 'approved',
+        decisionAt: now(),
+        decidedBy: req.auth.uniqueId,
+      });
+      tx.update(db.doc(`users/${data.userId}`), {
+        ageVerified: true,
+        ageVerifiedAt: now(),
+        ageVerificationMethod: data.idMethod,
+      });
+      approved = true;
+    });
+
+    if (!submission) return res.status(404).json({ error: 'Submission not found' });
+    if (submission._conflict) return res.status(409).json({ error: 'Submission already decided' });
+    if (!approved) return res.status(500).json({ error: 'Approval did not commit', errorId });
+
+    // Best-effort post-commit cleanup. The Firestore decision is the
+    // source of truth; an R2 deletion or audit-log failure is logged
+    // but doesn't roll back.
+    await deleteImageBestEffort(submission.r2Key, id);
+    await audit.logVerificationApproved(db, {
+      adminUid: req.auth.uniqueId,
+      targetUserId: submission.userId,
+      method: submission.idMethod,
+    });
+
+    return res.json({ ok: true });
+  } catch (err) {
+    log.error('admin-age-verification', `${errorId} failed`, { id, error: err?.message });
+    return res.status(500).json({ error: 'Failed to approve submission', errorId });
+  }
+});
+
+// ─── POST /:id/reject ───────────────────────────────────────────────
+
+router.post('/admin/age-verification/:id/reject', async (req, res) => {
+  if (requireAdmin(req, res)) return;
+  const { id } = req.params;
+  const errorId = 'AGE_VERIF_REJECT';
+  try {
+    const reason = (req.body?.reason || '').toString();
+    if (!reason.trim()) {
+      return res.status(400).json({ error: 'reason is required' });
+    }
+
+    let submission;
+    let rejected = false;
+    await db.runTransaction(async (tx) => {
+      const subRef = db.doc(`ageVerificationSubmissions/${id}`);
+      const subSnap = await tx.get(subRef);
+      if (!subSnap.exists) return;
+      const data = subSnap.data();
+      if (data.status !== 'pending') {
+        submission = { ...data, _conflict: true };
+        return;
+      }
+      submission = { ...data, id };
+
+      tx.update(subRef, {
+        status: 'rejected',
+        decisionAt: now(),
+        decidedBy: req.auth.uniqueId,
+        decisionReason: reason,
+      });
+      // User doc intentionally NOT touched — they stay unverified.
+      rejected = true;
+    });
+
+    if (!submission) return res.status(404).json({ error: 'Submission not found' });
+    if (submission._conflict) return res.status(409).json({ error: 'Submission already decided' });
+    if (!rejected) return res.status(500).json({ error: 'Rejection did not commit', errorId });
+
+    await deleteImageBestEffort(submission.r2Key, id);
+    await audit.logVerificationRejected(db, {
+      adminUid: req.auth.uniqueId,
+      targetUserId: submission.userId,
+      reason,
+    });
+
+    return res.json({ ok: true });
+  } catch (err) {
+    log.error('admin-age-verification', `${errorId} failed`, { id, error: err?.message });
+    return res.status(500).json({ error: 'Failed to reject submission', errorId });
+  }
+});
+
+// ─── POST /:id/modify-dob ───────────────────────────────────────────
+
+router.post('/admin/age-verification/:id/modify-dob', async (req, res) => {
+  if (requireAdmin(req, res)) return;
+  const { id } = req.params;
+  const errorId = 'AGE_VERIF_MODIFY_DOB';
+  try {
+    const newDob = req.body?.newDob;
+    const reason = (req.body?.reason || '').toString();
+    if (typeof newDob !== 'number' || !Number.isFinite(newDob)) {
+      return res.status(400).json({ error: 'newDob is required (ms epoch)' });
+    }
+    if (!reason.trim()) {
+      return res.status(400).json({ error: 'reason is required' });
+    }
+
+    let submission;
+    let oldDob;
+    let committed = false;
+    await db.runTransaction(async (tx) => {
+      const subRef = db.doc(`ageVerificationSubmissions/${id}`);
+      const subSnap = await tx.get(subRef);
+      if (!subSnap.exists) return;
+      const data = subSnap.data();
+      if (data.status !== 'pending') {
+        submission = { ...data, _conflict: true };
+        return;
+      }
+      submission = { ...data, id };
+
+      const userRef = db.doc(`users/${data.userId}`);
+      const userSnap = await tx.get(userRef);
+      oldDob = userSnap.exists ? (userSnap.data()?.dateOfBirth ?? null) : null;
+      const verifiedNow = isAtLeast18FromDob(newDob);
+
+      tx.update(subRef, {
+        status: 'dob_modified',
+        decisionAt: now(),
+        decidedBy: req.auth.uniqueId,
+        decisionReason: reason,
+        // Capture the modification on the submission doc too so the
+        // admin audit trail is self-contained even if the auditLog
+        // collection is later compacted.
+        oldDob,
+        newDob,
+      });
+      tx.update(userRef, {
+        dateOfBirth: newDob,
+        ageVerified: verifiedNow,
+        ageVerifiedAt: verifiedNow ? now() : null,
+        ageVerificationMethod: verifiedNow ? data.idMethod : null,
+      });
+      committed = true;
+    });
+
+    if (!submission) return res.status(404).json({ error: 'Submission not found' });
+    if (submission._conflict) return res.status(409).json({ error: 'Submission already decided' });
+    if (!committed)
+      return res.status(500).json({ error: 'DOB modification did not commit', errorId });
+
+    await deleteImageBestEffort(submission.r2Key, id);
+    await audit.logVerificationDobModified(db, {
+      adminUid: req.auth.uniqueId,
+      targetUserId: submission.userId,
+      oldDob,
+      newDob,
+      reason,
+    });
+
+    return res.json({ ok: true, ageVerified: isAtLeast18FromDob(newDob) });
+  } catch (err) {
+    log.error('admin-age-verification', `${errorId} failed`, { id, error: err?.message });
+    return res.status(500).json({ error: 'Failed to modify DOB', errorId });
+  }
+});
+
+module.exports = router;

--- a/express-api/src/utils/age-verification-audit.js
+++ b/express-api/src/utils/age-verification-audit.js
@@ -155,6 +155,12 @@ async function logVerificationDobModified(db, { adminUid, targetUserId, oldDob, 
 
 module.exports = {
   AGE_VERIFICATION_ACTIONS,
+  // Re-exported so route handlers can validate DOB bounds BEFORE
+  // committing the decision transaction. Catching an out-of-range
+  // DOB at the audit-write stage means the user doc is already
+  // mutated with the bogus value (silent-failure-hunter HIGH on PR
+  // #446). Routes call this up-front instead.
+  requirePlausibleDob,
   logVerificationApproved,
   logVerificationRejected,
   logVerificationDobModified,

--- a/express-api/tests/routes/admin-age-verification.test.js
+++ b/express-api/tests/routes/admin-age-verification.test.js
@@ -1,0 +1,383 @@
+/**
+ * Tests for the admin age-verification routes (PR 4b/14):
+ *   GET  /api/admin/age-verification/pending
+ *   POST /api/admin/age-verification/:id/approve
+ *   POST /api/admin/age-verification/:id/reject
+ *   POST /api/admin/age-verification/:id/modify-dob
+ *
+ * Each decision endpoint is responsible for the contracted clean-up:
+ *   - Update submission doc (status, decisionAt, decidedBy)
+ *   - Mutate target user doc (ageVerified, ageVerifiedAt, method,
+ *     dateOfBirth as relevant)
+ *   - Delete the R2 image (privacy: spec says image is destroyed on
+ *     admin decision)
+ *   - Write a typed audit log entry via age-verification-audit
+ *
+ * Tests pin all four side effects so a future refactor that drops the
+ * R2 deletion or the audit write can't ship silently.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// ─── Firebase mock (path-aware) ─────────────────────────────────────
+
+const mockDocGet = jest.fn();
+const mockDocSet = jest.fn().mockResolvedValue();
+const mockDocUpdate = jest.fn().mockResolvedValue();
+const mockTxGet = jest.fn();
+const mockTxUpdate = jest.fn();
+const mockCollectionGet = jest.fn();
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    doc: jest.fn((path) => ({
+      _path: path,
+      get: () => mockDocGet(path),
+      set: (...args) => mockDocSet(path, ...args),
+      update: (...args) => mockDocUpdate(path, ...args),
+    })),
+    collection: jest.fn((name) => ({
+      _name: name,
+      where: () => ({
+        orderBy: () => ({
+          limit: () => ({
+            get: () => mockCollectionGet(),
+          }),
+          get: () => mockCollectionGet(),
+        }),
+        get: () => mockCollectionGet(),
+      }),
+    })),
+    runTransaction: jest.fn(async (fn) => {
+      return fn({
+        get: (ref) => mockTxGet(ref?._path),
+        update: (ref, payload) => mockTxUpdate(ref?._path, payload),
+        set: (ref, payload) => mockTxUpdate(ref?._path, payload),
+      });
+    }),
+  },
+}));
+
+const mockDeleteObject = jest.fn().mockResolvedValue();
+jest.mock('../../src/utils/r2', () => ({
+  deleteObject: (...args) => mockDeleteObject(...args),
+}));
+
+const mockLogApproved = jest.fn().mockResolvedValue();
+const mockLogRejected = jest.fn().mockResolvedValue();
+const mockLogDobModified = jest.fn().mockResolvedValue();
+jest.mock('../../src/utils/age-verification-audit', () => ({
+  logVerificationApproved: (...args) => mockLogApproved(...args),
+  logVerificationRejected: (...args) => mockLogRejected(...args),
+  logVerificationDobModified: (...args) => mockLogDobModified(...args),
+}));
+
+jest.mock('../../src/utils/helpers', () => ({
+  now: () => 1709913600000,
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const adminAgeVerificationRouter = require('../../src/routes/admin-age-verification');
+
+function createApp({ admin = true, uniqueId = 10000001 } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.auth = { uid: 'admin-uid', uniqueId, token: { admin } };
+    next();
+  });
+  app.use('/api', adminAgeVerificationRouter);
+  return app;
+}
+
+function pendingSubmissionDoc(overrides = {}) {
+  return {
+    id: 'sub-1',
+    userId: '10000050',
+    idMethod: 'passport',
+    r2Key: 'age-verification/10000050/abc.jpg',
+    status: 'pending',
+    submittedAt: 1709800000000,
+    ...overrides,
+  };
+}
+
+// ─── GET /pending ───────────────────────────────────────────────────
+
+describe('GET /api/admin/age-verification/pending', () => {
+  test('returns list of pending submissions for admin', async () => {
+    mockCollectionGet.mockResolvedValue({
+      docs: [
+        { id: 'sub-1', data: () => pendingSubmissionDoc() },
+        { id: 'sub-2', data: () => pendingSubmissionDoc({ userId: '10000060' }) },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app).get('/api/admin/age-verification/pending').expect(200);
+
+    expect(res.body.submissions).toHaveLength(2);
+    expect(res.body.submissions[0]).toMatchObject({
+      id: 'sub-1',
+      userId: '10000050',
+      idMethod: 'passport',
+    });
+  });
+
+  test('rejects non-admin with 403', async () => {
+    const app = createApp({ admin: false });
+    await request(app).get('/api/admin/age-verification/pending').expect(403);
+    expect(mockCollectionGet).not.toHaveBeenCalled();
+  });
+});
+
+// ─── POST /:id/approve ──────────────────────────────────────────────
+
+describe('POST /api/admin/age-verification/:id/approve', () => {
+  beforeEach(() => {
+    mockTxGet.mockImplementation((path) => {
+      if (path === 'ageVerificationSubmissions/sub-1') {
+        return Promise.resolve({ exists: true, data: () => pendingSubmissionDoc() });
+      }
+      if (path === 'users/10000050') {
+        return Promise.resolve({
+          exists: true,
+          data: () => ({ dateOfBirth: 946684800000, ageVerified: false }),
+        });
+      }
+      return Promise.resolve({ exists: false });
+    });
+  });
+
+  test('flips ageVerified=true on user, marks submission approved, deletes image, writes audit', async () => {
+    const app = createApp();
+    await request(app).post('/api/admin/age-verification/sub-1/approve').expect(200);
+
+    // Submission doc updated
+    expect(mockTxUpdate).toHaveBeenCalledWith(
+      'ageVerificationSubmissions/sub-1',
+      expect.objectContaining({
+        status: 'approved',
+        decisionAt: 1709913600000,
+        decidedBy: 10000001,
+      }),
+    );
+    // User doc updated
+    expect(mockTxUpdate).toHaveBeenCalledWith(
+      'users/10000050',
+      expect.objectContaining({
+        ageVerified: true,
+        ageVerifiedAt: 1709913600000,
+        ageVerificationMethod: 'passport',
+      }),
+    );
+    // Image deleted (privacy contract)
+    expect(mockDeleteObject).toHaveBeenCalledWith('age-verification/10000050/abc.jpg');
+    // Audit entry written
+    expect(mockLogApproved).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        adminUid: 10000001,
+        targetUserId: '10000050',
+        method: 'passport',
+      }),
+    );
+  });
+
+  test('rejects when submission is not pending (already decided)', async () => {
+    mockTxGet.mockImplementation((path) => {
+      if (path === 'ageVerificationSubmissions/sub-1') {
+        return Promise.resolve({
+          exists: true,
+          data: () => pendingSubmissionDoc({ status: 'approved' }),
+        });
+      }
+      return Promise.resolve({ exists: false });
+    });
+
+    const app = createApp();
+    await request(app).post('/api/admin/age-verification/sub-1/approve').expect(409);
+
+    expect(mockTxUpdate).not.toHaveBeenCalled();
+    expect(mockDeleteObject).not.toHaveBeenCalled();
+    expect(mockLogApproved).not.toHaveBeenCalled();
+  });
+
+  test('rejects unknown submission (404)', async () => {
+    mockTxGet.mockResolvedValue({ exists: false });
+    const app = createApp();
+    await request(app).post('/api/admin/age-verification/missing/approve').expect(404);
+  });
+
+  test('rejects non-admin with 403', async () => {
+    const app = createApp({ admin: false });
+    await request(app).post('/api/admin/age-verification/sub-1/approve').expect(403);
+    expect(mockTxUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// ─── POST /:id/reject ───────────────────────────────────────────────
+
+describe('POST /api/admin/age-verification/:id/reject', () => {
+  beforeEach(() => {
+    mockTxGet.mockImplementation((path) => {
+      if (path === 'ageVerificationSubmissions/sub-1') {
+        return Promise.resolve({ exists: true, data: () => pendingSubmissionDoc() });
+      }
+      return Promise.resolve({ exists: false });
+    });
+  });
+
+  test('marks submission rejected, deletes image, writes audit (user unchanged)', async () => {
+    const app = createApp();
+    await request(app)
+      .post('/api/admin/age-verification/sub-1/reject')
+      .send({ reason: 'Image was unreadable' })
+      .expect(200);
+
+    expect(mockTxUpdate).toHaveBeenCalledWith(
+      'ageVerificationSubmissions/sub-1',
+      expect.objectContaining({
+        status: 'rejected',
+        decisionAt: 1709913600000,
+        decidedBy: 10000001,
+        decisionReason: 'Image was unreadable',
+      }),
+    );
+    // User doc NOT touched on reject — they stay unverified
+    expect(mockTxUpdate).not.toHaveBeenCalledWith('users/10000050', expect.anything());
+    expect(mockDeleteObject).toHaveBeenCalledWith('age-verification/10000050/abc.jpg');
+    expect(mockLogRejected).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        adminUid: 10000001,
+        targetUserId: '10000050',
+        reason: 'Image was unreadable',
+      }),
+    );
+  });
+
+  test('rejects empty reason (admin must justify)', async () => {
+    const app = createApp();
+    await request(app)
+      .post('/api/admin/age-verification/sub-1/reject')
+      .send({ reason: '' })
+      .expect(400);
+
+    expect(mockTxUpdate).not.toHaveBeenCalled();
+    expect(mockDeleteObject).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-pending submission with 409', async () => {
+    mockTxGet.mockImplementation((path) => {
+      if (path === 'ageVerificationSubmissions/sub-1') {
+        return Promise.resolve({
+          exists: true,
+          data: () => pendingSubmissionDoc({ status: 'rejected' }),
+        });
+      }
+      return Promise.resolve({ exists: false });
+    });
+    const app = createApp();
+    await request(app)
+      .post('/api/admin/age-verification/sub-1/reject')
+      .send({ reason: 'no good' })
+      .expect(409);
+  });
+});
+
+// ─── POST /:id/modify-dob ───────────────────────────────────────────
+
+describe('POST /api/admin/age-verification/:id/modify-dob', () => {
+  beforeEach(() => {
+    mockTxGet.mockImplementation((path) => {
+      if (path === 'ageVerificationSubmissions/sub-1') {
+        return Promise.resolve({ exists: true, data: () => pendingSubmissionDoc() });
+      }
+      if (path === 'users/10000050') {
+        return Promise.resolve({
+          exists: true,
+          data: () => ({ dateOfBirth: 946684800000, ageVerified: false }),
+        });
+      }
+      return Promise.resolve({ exists: false });
+    });
+  });
+
+  test('updates user DOB and approves when new DOB is 18+', async () => {
+    // User submitted with DOB on file = 2000-01-01 (which makes them
+    // 25+ now). Admin sees the ID shows 1995-01-01 instead, modifies
+    // DOB to 1995, still >= 18 so account gets approved.
+    const dob1995 = new Date('1995-01-01T00:00:00Z').getTime();
+    const app = createApp();
+    await request(app)
+      .post('/api/admin/age-verification/sub-1/modify-dob')
+      .send({ newDob: dob1995, reason: 'ID showed different DOB' })
+      .expect(200);
+
+    expect(mockTxUpdate).toHaveBeenCalledWith(
+      'users/10000050',
+      expect.objectContaining({
+        dateOfBirth: dob1995,
+        ageVerified: true,
+        ageVerifiedAt: 1709913600000,
+        ageVerificationMethod: 'passport',
+      }),
+    );
+    expect(mockDeleteObject).toHaveBeenCalled();
+    expect(mockLogDobModified).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        adminUid: 10000001,
+        targetUserId: '10000050',
+        oldDob: 946684800000,
+        newDob: dob1995,
+        reason: 'ID showed different DOB',
+      }),
+    );
+  });
+
+  test('reverts to unverified when new DOB makes user <18', async () => {
+    // ID showed user is 16; admin sets DOB accordingly. ageVerified
+    // must NOT flip to true; the user is too young for full access.
+    const sixteenYearsAgo = new Date();
+    sixteenYearsAgo.setUTCFullYear(sixteenYearsAgo.getUTCFullYear() - 16);
+    const newDob = sixteenYearsAgo.getTime();
+
+    const app = createApp();
+    await request(app)
+      .post('/api/admin/age-verification/sub-1/modify-dob')
+      .send({ newDob, reason: 'ID confirms <18' })
+      .expect(200);
+
+    expect(mockTxUpdate).toHaveBeenCalledWith(
+      'users/10000050',
+      expect.objectContaining({
+        dateOfBirth: newDob,
+        ageVerified: false,
+        ageVerifiedAt: null,
+        ageVerificationMethod: null,
+      }),
+    );
+  });
+
+  test('rejects empty reason', async () => {
+    const app = createApp();
+    await request(app)
+      .post('/api/admin/age-verification/sub-1/modify-dob')
+      .send({ newDob: 946684800000, reason: '' })
+      .expect(400);
+  });
+
+  test('rejects missing newDob', async () => {
+    const app = createApp();
+    await request(app)
+      .post('/api/admin/age-verification/sub-1/modify-dob')
+      .send({ reason: 'forgot dob' })
+      .expect(400);
+  });
+});

--- a/express-api/tests/routes/admin-age-verification.test.js
+++ b/express-api/tests/routes/admin-age-verification.test.js
@@ -67,11 +67,19 @@ jest.mock('../../src/utils/r2', () => ({
 const mockLogApproved = jest.fn().mockResolvedValue();
 const mockLogRejected = jest.fn().mockResolvedValue();
 const mockLogDobModified = jest.fn().mockResolvedValue();
-jest.mock('../../src/utils/age-verification-audit', () => ({
-  logVerificationApproved: (...args) => mockLogApproved(...args),
-  logVerificationRejected: (...args) => mockLogRejected(...args),
-  logVerificationDobModified: (...args) => mockLogDobModified(...args),
-}));
+// `requirePlausibleDob` is preserved (not mocked) — the route's
+// pre-transaction bounds check needs real validation logic, not a
+// no-op stub. The three log* helpers are mocked because tests assert
+// on calls and we don't want real Firestore writes.
+jest.mock('../../src/utils/age-verification-audit', () => {
+  const actual = jest.requireActual('../../src/utils/age-verification-audit');
+  return {
+    requirePlausibleDob: actual.requirePlausibleDob,
+    logVerificationApproved: (...args) => mockLogApproved(...args),
+    logVerificationRejected: (...args) => mockLogRejected(...args),
+    logVerificationDobModified: (...args) => mockLogDobModified(...args),
+  };
+});
 
 jest.mock('../../src/utils/helpers', () => ({
   now: () => 1709913600000,
@@ -155,7 +163,10 @@ describe('POST /api/admin/age-verification/:id/approve', () => {
 
   test('flips ageVerified=true on user, marks submission approved, deletes image, writes audit', async () => {
     const app = createApp();
-    await request(app).post('/api/admin/age-verification/sub-1/approve').expect(200);
+    await request(app)
+      .post('/api/admin/age-verification/sub-1/approve')
+      .send({ reason: 'ID verified by passport' })
+      .expect(200);
 
     // Submission doc updated
     expect(mockTxUpdate).toHaveBeenCalledWith(
@@ -200,7 +211,10 @@ describe('POST /api/admin/age-verification/:id/approve', () => {
     });
 
     const app = createApp();
-    await request(app).post('/api/admin/age-verification/sub-1/approve').expect(409);
+    await request(app)
+      .post('/api/admin/age-verification/sub-1/approve')
+      .send({ reason: 'ok' })
+      .expect(409);
 
     expect(mockTxUpdate).not.toHaveBeenCalled();
     expect(mockDeleteObject).not.toHaveBeenCalled();
@@ -210,13 +224,51 @@ describe('POST /api/admin/age-verification/:id/approve', () => {
   test('rejects unknown submission (404)', async () => {
     mockTxGet.mockResolvedValue({ exists: false });
     const app = createApp();
-    await request(app).post('/api/admin/age-verification/missing/approve').expect(404);
+    await request(app)
+      .post('/api/admin/age-verification/missing/approve')
+      .send({ reason: 'ok' })
+      .expect(404);
   });
 
   test('rejects non-admin with 403', async () => {
     const app = createApp({ admin: false });
-    await request(app).post('/api/admin/age-verification/sub-1/approve').expect(403);
+    await request(app)
+      .post('/api/admin/age-verification/sub-1/approve')
+      .send({ reason: 'ok' })
+      .expect(403);
     expect(mockTxUpdate).not.toHaveBeenCalled();
+  });
+
+  test('rejects empty reason on approve (symmetric audit trail)', async () => {
+    const app = createApp();
+    await request(app)
+      .post('/api/admin/age-verification/sub-1/approve')
+      .send({ reason: '' })
+      .expect(400);
+    expect(mockTxUpdate).not.toHaveBeenCalled();
+  });
+
+  test('returns auditWritten=false flag when audit-log write fails (decision still committed)', async () => {
+    // Per partial-failure-contracts feedback rule: a failed audit
+    // write must be surfaced as a flag, not masked as 500. Decision
+    // is committed; ops sees the flag and back-fills.
+    mockLogApproved.mockRejectedValue(new Error('auditLog write rejected by rules'));
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/admin/age-verification/sub-1/approve')
+      .send({ reason: 'ok' })
+      .expect(200);
+    expect(res.body).toMatchObject({ ok: true, auditWritten: false });
+  });
+
+  test('returns imageDeleted=false flag when R2 delete fails (decision still committed)', async () => {
+    mockDeleteObject.mockRejectedValue(new Error('R2 timeout'));
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/admin/age-verification/sub-1/approve')
+      .send({ reason: 'ok' })
+      .expect(200);
+    expect(res.body).toMatchObject({ ok: true, imageDeleted: false });
   });
 });
 
@@ -379,5 +431,22 @@ describe('POST /api/admin/age-verification/:id/modify-dob', () => {
       .post('/api/admin/age-verification/sub-1/modify-dob')
       .send({ reason: 'forgot dob' })
       .expect(400);
+  });
+
+  test('rejects implausible newDob (pre-1900 / far-future) BEFORE the transaction commits', async () => {
+    // Validation must happen pre-transaction; otherwise the user doc
+    // is mutated with a bogus DOB and the audit write throws after.
+    // -1e15 ms is ~year -29688 (well pre-1900); 99999999999999 ms is
+    // ~year 5138 (far future). Both must be rejected.
+    const app = createApp();
+    await request(app)
+      .post('/api/admin/age-verification/sub-1/modify-dob')
+      .send({ newDob: -1e15, reason: 'pre-1900 fail' })
+      .expect(400);
+    await request(app)
+      .post('/api/admin/age-verification/sub-1/modify-dob')
+      .send({ newDob: 99999999999999, reason: 'far-future fail' })
+      .expect(400);
+    expect(mockTxUpdate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

PR 4b of the [Age Verification multi-PR plan](.project/plans/2026-05-03-age-verification.md). Admin-side counterpart to PR 4a's user submit flow — covers the four admin decision routes that own the contracted clean-up (status update + user mutation + R2 image delete + audit log entry).

## Routes

- \`GET /api/admin/age-verification/pending\` — oldest-first list of pending submissions
- \`POST /api/admin/age-verification/:id/approve\` — flips ageVerified=true, deletes image, writes audit
- \`POST /api/admin/age-verification/:id/reject\` — body \`{ reason }\`, user stays unverified, image still deleted (privacy), writes audit
- \`POST /api/admin/age-verification/:id/modify-dob\` — body \`{ newDob, reason }\`. Recomputes 18+ on new DOB. If 18+ behaves like approve, if <18 reverts user to unverified (ageVerified=false / ageVerifiedAt=null / method=null). Existing-PMs lock-out is downstream (PR 11 migration).

## Concurrency

Each decision uses \`db.runTransaction(...)\`. Pending-only gate is enforced inside the transaction; a duplicate decision request returns 409 instead of double-committing.

## Privacy contract

Image deletion runs post-commit and is best-effort. The Firestore decision is the source of truth — a failed R2 delete logs the leaked key for ops sweep but does NOT roll back the user-facing decision.

## TDD

- 13 new tests (4 endpoints × happy path + side-effects + gate cases)
- Full Express suite (4540 tests) re-runs green

## Order constraint

No DEV deploy on this PR — multi-PR work-completion deploy is at PR 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)