### PR TITLE
feat(age-verif): system PM templates + admin handler wire-up (PR 5/14)

### DIFF
--- a/express-api/src/routes/admin-age-verification.js
+++ b/express-api/src/routes/admin-age-verification.js
@@ -52,6 +52,7 @@ const router = express.Router();
 const { db } = require('../utils/firebase');
 const r2 = require('../utils/r2');
 const audit = require('../utils/age-verification-audit');
+const systemPm = require('../utils/age-verification-system-pm');
 const { now } = require('../utils/helpers');
 const log = require('../utils/log');
 const { requireAdmin } = require('../middleware/auth');
@@ -90,12 +91,25 @@ async function writeAuditBestEffort(action, submissionId, payload) {
     await action(db, payload);
     return true;
   } catch (err) {
-    // The decision is already committed in Firestore. An audit-log
-    // failure means the compliance trail is incomplete. Logged with
-    // submissionId so ops can locate the decision and back-fill.
     log.error('admin-age-verification', 'Audit-log write failed', {
       submissionId,
       payload,
+      error: err?.message,
+    });
+    return false;
+  }
+}
+
+async function sendPmBestEffort(action, submissionId, args) {
+  // Same partial-failure shape as audit / R2 — a failed PM doesn't
+  // roll back the decision. Surfaced via the response so the admin
+  // UI can flag "decision committed, user not notified".
+  try {
+    await action(...args);
+    return true;
+  } catch (err) {
+    log.error('admin-age-verification', 'System PM send failed', {
+      submissionId,
       error: err?.message,
     });
     return false;
@@ -179,8 +193,12 @@ router.post('/admin/age-verification/:id/approve', async (req, res) => {
       targetUserId: submission.userId,
       method: submission.idMethod,
     });
+    const userNotified = await sendPmBestEffort(systemPm.sendAgeVerificationApprovedPm, id, [
+      submission.userId,
+      submission.idMethod,
+    ]);
 
-    return res.json({ ok: true, imageDeleted, auditWritten });
+    return res.json({ ok: true, imageDeleted, auditWritten, userNotified });
   } catch (err) {
     log.error('admin-age-verification', `${errorId} failed`, { id, error: err?.message });
     return res.status(500).json({ error: 'Failed to approve submission', errorId });
@@ -233,8 +251,12 @@ router.post('/admin/age-verification/:id/reject', async (req, res) => {
       targetUserId: submission.userId,
       reason,
     });
+    const userNotified = await sendPmBestEffort(systemPm.sendAgeVerificationRejectedPm, id, [
+      submission.userId,
+      reason,
+    ]);
 
-    return res.json({ ok: true, imageDeleted, auditWritten });
+    return res.json({ ok: true, imageDeleted, auditWritten, userNotified });
   } catch (err) {
     log.error('admin-age-verification', `${errorId} failed`, { id, error: err?.message });
     return res.status(500).json({ error: 'Failed to reject submission', errorId });
@@ -317,12 +339,21 @@ router.post('/admin/age-verification/:id/modify-dob', async (req, res) => {
       newDob,
       reason,
     });
+    const userNotified = await sendPmBestEffort(systemPm.sendAgeVerificationDobModifiedPm, id, [
+      submission.userId,
+      {
+        ageVerified: isAtLeast18FromDob(newDob),
+        method: submission.idMethod,
+        reason,
+      },
+    ]);
 
     return res.json({
       ok: true,
       ageVerified: isAtLeast18FromDob(newDob),
       imageDeleted,
       auditWritten,
+      userNotified,
     });
   } catch (err) {
     log.error('admin-age-verification', `${errorId} failed`, { id, error: err?.message });

--- a/express-api/src/utils/age-verification-system-pm.js
+++ b/express-api/src/utils/age-verification-system-pm.js
@@ -4,8 +4,23 @@
  * have one call site per outcome and the message copy lives in one
  * file (easier review, easier i18n in PR 13).
  *
- * i18n: English-only at this PR. PR 13 of the multi-PR plan adds the
- * 20 locales the rest of the app supports.
+ * Templates use a `{token}` placeholder shape so PR 13's i18n pass
+ * only swaps the lookup table — no refactor of the call sites or the
+ * helper signatures.
+ *
+ * Sanitisation: admin-supplied `reason` text is echoed into the PM
+ * body. We strip `<` / `>` / `&` characters at template-render time
+ * to defend against any current or future client renderer that
+ * interprets the text as HTML. Compose / iOS today render as plain
+ * text (safe), but the web inbox / future admin-replay surface is an
+ * unknown — sanitising once at the source is cheaper than trusting
+ * every renderer.
+ *
+ * Lock-bypass: `sendSystemPm` writes via firebase-admin
+ * (`db.doc(...).set(...)`), which bypasses Firestore rules. So the
+ * "your PMs are locked" PM in the under-18 variant DOES land in the
+ * user's inbox even after PR 11's rules-level lock. Pin this property
+ * with a test in PR 11.
  */
 
 const { sendSystemPm } = require('./system-pm');
@@ -14,6 +29,35 @@ const FRIENDLY_METHOD_LABEL = Object.freeze({
   passport: 'passport',
   'drivers-license': "driver's licence",
   'national-id': 'national ID card',
+});
+
+const TEMPLATES = Object.freeze({
+  approved: [
+    "Your age verification has been approved. We confirmed your {method} and you now have full access to ShyTalk's 18+ features (private messages and gacha).",
+    '',
+    'Your ID image has been deleted from our servers. Welcome aboard.',
+  ].join('\n'),
+  rejected: [
+    "Your age verification wasn't approved this time.",
+    '',
+    'Reason: {reason}',
+    '',
+    'You can submit a new ID image any time from your profile. Your previous image has been deleted from our servers.',
+  ].join('\n'),
+  dobModifiedApproved: [
+    "An admin has updated your date of birth on file based on the ID you submitted ({method}). Your account is approved for ShyTalk's 18+ features (private messages and gacha).",
+    '',
+    'Reason for the change: {reason}',
+    '',
+    'Your ID image has been deleted from our servers.',
+  ].join('\n'),
+  dobModifiedUnder18: [
+    "An admin has adjusted your date of birth on file based on the ID you submitted, and you are under 18. We're keeping you on ShyTalk, but the 18+ features (private messages and gacha) are no longer available to you. Existing private-message threads have been locked.",
+    '',
+    'Reason for the change: {reason}',
+    '',
+    "Once you turn 18, full access will be restored automatically. Your ID image has been deleted from our servers. If you believe the date of birth on file is wrong, please contact support — don't submit another ID until you've spoken to us.",
+  ].join('\n'),
 });
 
 function friendlyMethod(method) {
@@ -33,58 +77,55 @@ function requireNonBlankReason(reason) {
   }
 }
 
+/**
+ * Strip the three characters that turn plain text into HTML / entity-
+ * encoded markup if a downstream renderer treats the text as HTML.
+ * Replaces with a space so word boundaries survive the sanitise.
+ */
+function sanitiseReason(raw) {
+  return raw.replace(/[<>&]/g, ' ');
+}
+
+function interpolate(template, vars) {
+  return template.replace(/\{(\w+)\}/g, (match, key) => {
+    if (!Object.prototype.hasOwnProperty.call(vars, key)) {
+      throw new Error(`age-verification-system-pm: missing template var "${key}"`);
+    }
+    return vars[key];
+  });
+}
+
 async function sendAgeVerificationApprovedPm(uid, method) {
-  const label = friendlyMethod(method);
-  const text = [
-    `Your age verification has been approved. We confirmed your ${label} and you now have full access to ShyTalk's 18+ features (private messages and gacha).`,
-    '',
-    'Your ID image has been deleted from our servers. Welcome aboard.',
-  ].join('\n');
+  const text = interpolate(TEMPLATES.approved, { method: friendlyMethod(method) });
   return sendSystemPm(uid, text);
 }
 
 async function sendAgeVerificationRejectedPm(uid, reason) {
   requireNonBlankReason(reason);
-  const text = [
-    "Your age verification wasn't approved this time.",
-    '',
-    `Reason: ${reason}`,
-    '',
-    'You can submit a new ID image any time from your profile. Your previous image has been deleted from our servers.',
-  ].join('\n');
+  const text = interpolate(TEMPLATES.rejected, { reason: sanitiseReason(reason) });
   return sendSystemPm(uid, text);
 }
 
 async function sendAgeVerificationDobModifiedPm(uid, { ageVerified, method, reason }) {
   requireNonBlankReason(reason);
-  // method is informational here — only used in the approved variant.
-  // We still validate it through `friendlyMethod` to keep the input
-  // contract symmetric with the other helpers.
+  // method is informational here — only used in the approved variant
+  // copy. We still validate it through `friendlyMethod` to keep the
+  // input contract symmetric with the other helpers.
   const label = friendlyMethod(method);
-
-  let text;
-  if (ageVerified) {
-    text = [
-      `An admin has updated your date of birth on file based on the ID you submitted (${label}). Your account is approved for ShyTalk's 18+ features (private messages and gacha).`,
-      '',
-      `Reason for the change: ${reason}`,
-      '',
-      'Your ID image has been deleted from our servers.',
-    ].join('\n');
-  } else {
-    text = [
-      "An admin has adjusted your date of birth on file based on the ID you submitted, and you are under 18. We're keeping you on ShyTalk, but the 18+ features (private messages and gacha) are no longer available to you. Existing private-message threads have been locked.",
-      '',
-      `Reason for the change: ${reason}`,
-      '',
-      "Once you turn 18, full access will be restored automatically. Your ID image has been deleted from our servers. If you believe the date of birth on file is wrong, please contact support — don't submit another ID until you've spoken to us.",
-    ].join('\n');
-  }
+  const safeReason = sanitiseReason(reason);
+  const template = ageVerified ? TEMPLATES.dobModifiedApproved : TEMPLATES.dobModifiedUnder18;
+  // Both templates accept `{reason}`; only the approved variant uses
+  // `{method}`. Pass both so the under-18 template can ignore method
+  // without the interpolator throwing.
+  const text = interpolate(template, { method: label, reason: safeReason });
   return sendSystemPm(uid, text);
 }
 
 module.exports = {
   FRIENDLY_METHOD_LABEL,
+  TEMPLATES,
+  sanitiseReason,
+  interpolate,
   sendAgeVerificationApprovedPm,
   sendAgeVerificationRejectedPm,
   sendAgeVerificationDobModifiedPm,

--- a/express-api/src/utils/age-verification-system-pm.js
+++ b/express-api/src/utils/age-verification-system-pm.js
@@ -1,0 +1,91 @@
+/**
+ * System-PM templates for the three age-verification decision
+ * outcomes. Wraps `system-pm.sendSystemPm` so admin-route handlers
+ * have one call site per outcome and the message copy lives in one
+ * file (easier review, easier i18n in PR 13).
+ *
+ * i18n: English-only at this PR. PR 13 of the multi-PR plan adds the
+ * 20 locales the rest of the app supports.
+ */
+
+const { sendSystemPm } = require('./system-pm');
+
+const FRIENDLY_METHOD_LABEL = Object.freeze({
+  passport: 'passport',
+  'drivers-license': "driver's licence",
+  'national-id': 'national ID card',
+});
+
+function friendlyMethod(method) {
+  if (!Object.prototype.hasOwnProperty.call(FRIENDLY_METHOD_LABEL, method)) {
+    throw new Error(
+      `age-verification-system-pm: unknown method "${method}" — must be one of ${Object.keys(
+        FRIENDLY_METHOD_LABEL,
+      ).join(', ')}`,
+    );
+  }
+  return FRIENDLY_METHOD_LABEL[method];
+}
+
+function requireNonBlankReason(reason) {
+  if (typeof reason !== 'string' || reason.trim().length === 0) {
+    throw new Error('age-verification-system-pm: reason must be a non-blank string');
+  }
+}
+
+async function sendAgeVerificationApprovedPm(uid, method) {
+  const label = friendlyMethod(method);
+  const text = [
+    `Your age verification has been approved. We confirmed your ${label} and you now have full access to ShyTalk's 18+ features (private messages and gacha).`,
+    '',
+    'Your ID image has been deleted from our servers. Welcome aboard.',
+  ].join('\n');
+  return sendSystemPm(uid, text);
+}
+
+async function sendAgeVerificationRejectedPm(uid, reason) {
+  requireNonBlankReason(reason);
+  const text = [
+    "Your age verification wasn't approved this time.",
+    '',
+    `Reason: ${reason}`,
+    '',
+    'You can submit a new ID image any time from your profile. Your previous image has been deleted from our servers.',
+  ].join('\n');
+  return sendSystemPm(uid, text);
+}
+
+async function sendAgeVerificationDobModifiedPm(uid, { ageVerified, method, reason }) {
+  requireNonBlankReason(reason);
+  // method is informational here — only used in the approved variant.
+  // We still validate it through `friendlyMethod` to keep the input
+  // contract symmetric with the other helpers.
+  const label = friendlyMethod(method);
+
+  let text;
+  if (ageVerified) {
+    text = [
+      `An admin has updated your date of birth on file based on the ID you submitted (${label}). Your account is approved for ShyTalk's 18+ features (private messages and gacha).`,
+      '',
+      `Reason for the change: ${reason}`,
+      '',
+      'Your ID image has been deleted from our servers.',
+    ].join('\n');
+  } else {
+    text = [
+      "An admin has adjusted your date of birth on file based on the ID you submitted, and you are under 18. We're keeping you on ShyTalk, but the 18+ features (private messages and gacha) are no longer available to you. Existing private-message threads have been locked.",
+      '',
+      `Reason for the change: ${reason}`,
+      '',
+      "Once you turn 18, full access will be restored automatically. Your ID image has been deleted from our servers. If you believe the date of birth on file is wrong, please contact support — don't submit another ID until you've spoken to us.",
+    ].join('\n');
+  }
+  return sendSystemPm(uid, text);
+}
+
+module.exports = {
+  FRIENDLY_METHOD_LABEL,
+  sendAgeVerificationApprovedPm,
+  sendAgeVerificationRejectedPm,
+  sendAgeVerificationDobModifiedPm,
+};

--- a/express-api/tests/routes/admin-age-verification.test.js
+++ b/express-api/tests/routes/admin-age-verification.test.js
@@ -81,6 +81,15 @@ jest.mock('../../src/utils/age-verification-audit', () => {
   };
 });
 
+const mockSendApprovedPm = jest.fn().mockResolvedValue();
+const mockSendRejectedPm = jest.fn().mockResolvedValue();
+const mockSendDobModifiedPm = jest.fn().mockResolvedValue();
+jest.mock('../../src/utils/age-verification-system-pm', () => ({
+  sendAgeVerificationApprovedPm: (...args) => mockSendApprovedPm(...args),
+  sendAgeVerificationRejectedPm: (...args) => mockSendRejectedPm(...args),
+  sendAgeVerificationDobModifiedPm: (...args) => mockSendDobModifiedPm(...args),
+}));
+
 jest.mock('../../src/utils/helpers', () => ({
   now: () => 1709913600000,
 }));
@@ -161,7 +170,7 @@ describe('POST /api/admin/age-verification/:id/approve', () => {
     });
   });
 
-  test('flips ageVerified=true on user, marks submission approved, deletes image, writes audit', async () => {
+  test('flips ageVerified=true on user, marks submission approved, deletes image, writes audit, sends PM', async () => {
     const app = createApp();
     await request(app)
       .post('/api/admin/age-verification/sub-1/approve')
@@ -197,6 +206,8 @@ describe('POST /api/admin/age-verification/:id/approve', () => {
         method: 'passport',
       }),
     );
+    // User notified via system PM
+    expect(mockSendApprovedPm).toHaveBeenCalledWith('10000050', 'passport');
   });
 
   test('rejects when submission is not pending (already decided)', async () => {
@@ -269,6 +280,19 @@ describe('POST /api/admin/age-verification/:id/approve', () => {
       .send({ reason: 'ok' })
       .expect(200);
     expect(res.body).toMatchObject({ ok: true, imageDeleted: false });
+  });
+
+  test('returns userNotified=false flag when system PM fails (decision still committed)', async () => {
+    // Same partial-failure shape as audit / R2 — failed PM doesn't
+    // roll back the decision; admin UI surfaces "decision committed,
+    // user not notified" so ops can DM the user manually.
+    mockSendApprovedPm.mockRejectedValue(new Error('conversations write rejected'));
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/admin/age-verification/sub-1/approve')
+      .send({ reason: 'ok' })
+      .expect(200);
+    expect(res.body).toMatchObject({ ok: true, userNotified: false });
   });
 });
 

--- a/express-api/tests/utils/age-verification-system-pm.test.js
+++ b/express-api/tests/utils/age-verification-system-pm.test.js
@@ -1,0 +1,119 @@
+/**
+ * Tests for the age-verification system-PM templates (PR 5/14).
+ *
+ * Wraps `sendSystemPm` with the three approved/rejected/dob-modified
+ * shapes. Tests pin (a) the template content (so a copy change has to
+ * touch the test, surfacing reviewer attention) and (b) that the
+ * helper actually delegates to `sendSystemPm` with the right uid +
+ * text so admin-route integration is end-to-end.
+ *
+ * i18n: this PR ships English-only. PR 13 of the multi-PR plan adds
+ * 20 locales.
+ */
+
+const mockSendSystemPm = jest.fn().mockResolvedValue();
+jest.mock('../../src/utils/system-pm', () => ({
+  sendSystemPm: (...args) => mockSendSystemPm(...args),
+}));
+
+const {
+  sendAgeVerificationApprovedPm,
+  sendAgeVerificationRejectedPm,
+  sendAgeVerificationDobModifiedPm,
+} = require('../../src/utils/age-verification-system-pm');
+
+beforeEach(() => {
+  mockSendSystemPm.mockClear();
+});
+
+describe('sendAgeVerificationApprovedPm', () => {
+  test('sends a positive confirmation with method', async () => {
+    await sendAgeVerificationApprovedPm('u1', 'passport');
+    expect(mockSendSystemPm).toHaveBeenCalledTimes(1);
+    const [recipient, text] = mockSendSystemPm.mock.calls[0];
+    expect(recipient).toBe('u1');
+    expect(text).toMatch(/approved/i);
+    // Method name appears so the user knows which ID type unlocked
+    // their account; helps if they have multiple submissions over
+    // time.
+    expect(text).toMatch(/passport/i);
+  });
+
+  test('substitutes the friendly method label, not the raw id-method key', async () => {
+    // Internal id-method keys are `passport` / `drivers-license` /
+    // `national-id`. The user-facing PM should read like English,
+    // not like the API enum.
+    await sendAgeVerificationApprovedPm('u1', 'drivers-license');
+    const [, text] = mockSendSystemPm.mock.calls[0];
+    expect(text).toMatch(/driver's licen[cs]e/i);
+    expect(text).not.toMatch(/drivers-license/);
+  });
+
+  test("throws on unknown method (defence vs caller bypassing the audit helper's enum)", async () => {
+    await expect(sendAgeVerificationApprovedPm('u1', 'birth-certificate')).rejects.toThrow(
+      /method/i,
+    );
+    expect(mockSendSystemPm).not.toHaveBeenCalled();
+  });
+});
+
+describe('sendAgeVerificationRejectedPm', () => {
+  test('sends rejection with admin-supplied reason', async () => {
+    await sendAgeVerificationRejectedPm('u1', 'Image was unreadable');
+    expect(mockSendSystemPm).toHaveBeenCalledWith(
+      'u1',
+      expect.stringMatching(/(rejected|wasn't approved)/i),
+    );
+    const [, text] = mockSendSystemPm.mock.calls[0];
+    expect(text).toContain('Image was unreadable');
+    // Re-submission encouragement so the user knows they CAN retry
+    expect(text).toMatch(/(submit|try again|resubmit)/i);
+  });
+
+  test('refuses blank reason (admin policy enforced upstream + here)', async () => {
+    await expect(sendAgeVerificationRejectedPm('u1', '')).rejects.toThrow();
+    await expect(sendAgeVerificationRejectedPm('u1', '   ')).rejects.toThrow();
+    expect(mockSendSystemPm).not.toHaveBeenCalled();
+  });
+});
+
+describe('sendAgeVerificationDobModifiedPm', () => {
+  test('approved-after-modify variant when ageVerified=true', async () => {
+    await sendAgeVerificationDobModifiedPm('u1', {
+      ageVerified: true,
+      method: 'passport',
+      reason: 'ID showed different DOB than profile',
+    });
+    expect(mockSendSystemPm).toHaveBeenCalledTimes(1);
+    const [, text] = mockSendSystemPm.mock.calls[0];
+    expect(text).toMatch(/(updated|adjusted) your date of birth/i);
+    expect(text).toMatch(/approved/i);
+    expect(text).toContain('ID showed different DOB than profile');
+  });
+
+  test('reverted-to-under-18 variant when ageVerified=false', async () => {
+    // The harshest flow — admin found user under-18 via ID. Existing
+    // PMs lock out (PR 11). Copy must explain WHY they lost access.
+    await sendAgeVerificationDobModifiedPm('u1', {
+      ageVerified: false,
+      method: 'passport',
+      reason: "ID confirmed you're under 18",
+    });
+    const [, text] = mockSendSystemPm.mock.calls[0];
+    // Both pieces of context surface
+    expect(text).toMatch(/(under 18|under eighteen|too young)/i);
+    expect(text).toMatch(/messages|gacha|features/i);
+    expect(text).toContain("ID confirmed you're under 18");
+  });
+
+  test('refuses blank reason', async () => {
+    await expect(
+      sendAgeVerificationDobModifiedPm('u1', {
+        ageVerified: true,
+        method: 'passport',
+        reason: '',
+      }),
+    ).rejects.toThrow();
+    expect(mockSendSystemPm).not.toHaveBeenCalled();
+  });
+});

--- a/express-api/tests/utils/age-verification-system-pm.test.js
+++ b/express-api/tests/utils/age-verification-system-pm.test.js
@@ -117,3 +117,31 @@ describe('sendAgeVerificationDobModifiedPm', () => {
     expect(mockSendSystemPm).not.toHaveBeenCalled();
   });
 });
+
+describe('sanitiseReason', () => {
+  // Required for HIGH XSS finding on PR #447: admin-supplied reason
+  // text is echoed into the PM body. If any current or future client
+  // renderer treats `text` as HTML, an admin pasting `<script>...`
+  // into the reason would inject. Strip <, >, & at template-render
+  // time so the message is safe regardless of renderer.
+  const {
+    sanitiseReason,
+    sendAgeVerificationRejectedPm,
+  } = require('../../src/utils/age-verification-system-pm');
+
+  test('strips HTML angle brackets and ampersand from reason', () => {
+    expect(sanitiseReason('<script>alert(1)</script>')).toBe(' script alert(1) /script ');
+    expect(sanitiseReason('a & b < c > d')).toBe('a   b   c   d');
+  });
+
+  test('preserves non-HTML special characters (quotes, slashes, etc.)', () => {
+    expect(sanitiseReason("can't / won't")).toBe("can't / won't");
+  });
+
+  test('rejection PM text is sanitised end-to-end', async () => {
+    await sendAgeVerificationRejectedPm('u1', '<img src=x onerror=alert(1)>');
+    const [, text] = mockSendSystemPm.mock.calls[0];
+    expect(text).not.toContain('<');
+    expect(text).not.toContain('>');
+  });
+});


### PR DESCRIPTION
## Summary

PR 5 of the [Age Verification multi-PR plan](.project/plans/2026-05-03-age-verification.md). Adds three system-PM templates and wires them into the admin-route handlers as best-effort post-commit notifications.

## Templates

\`express-api/src/utils/age-verification-system-pm.js\`:

- \`sendAgeVerificationApprovedPm(uid, method)\` — confirms approval, names the ID method (\`passport\` / driver's licence / national ID card), notes image deleted
- \`sendAgeVerificationRejectedPm(uid, reason)\` — surfaces admin's reason, encourages re-submission, notes image deleted
- \`sendAgeVerificationDobModifiedPm(uid, { ageVerified, method, reason })\` — two variants:
  - approved-after-modify: full access granted
  - reverted-to-under-18: PMs lock out, gacha disabled, "until 18" explanation

## Wire-up

Each admin endpoint calls the matching helper via \`sendPmBestEffort\` after the audit-log write. A failed PM returns \`{ ok: true, userNotified: false }\` instead of 500 — same partial-failure contract as audit / image deletion. Decision stays committed; admin UI surfaces the flag.

Method-name mapping (\`id-key\` → friendly label) lives in the helper so user-facing copy doesn't read like an API enum.

## i18n note

PR 5 ships English-only. Plan PR 13 covers the 20-locale translation pass.

## Test plan
- [x] 8 new template tests (content + delegation + validation)
- [x] 1 new admin-handler integration test (PM failure surfaces \`userNotified=false\`)
- [x] Full Express suite (4553 tests across 190 suites) green
- [ ] CI green
- [ ] Code review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)