### PR TITLE
feat(age-verif): AgeRestrictionDialog + state holder (PR 8/14)

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -935,4 +935,13 @@
     <string name="seasonal_khmer_new_year_cta">Learn about Choul Chnam Thmey</string>
     <string name="seasonal_event_dismiss">Dismiss</string>
 
+    <!-- Age verification dialog (PR 8 of age-verification feature). PR 13 ships translations for the remaining 19 locales. -->
+    <string name="age_restriction_needs_verification_title">Verify your age</string>
+    <string name="age_restriction_needs_verification_body">Private messages and gacha are 18+ features. To use them, please verify your age by submitting a government-issued ID. The image is reviewed by a human and deleted as soon as a decision is made.</string>
+    <string name="age_restriction_needs_verification_confirm">Verify now</string>
+    <string name="age_restriction_sub_eighteen_title">Feature unavailable</string>
+    <string name="age_restriction_sub_eighteen_body">Private messages and gacha are only available to users 18 or older. Based on the date of birth on your account, you are not yet eligible. If you believe this is wrong, please contact support — we cannot accept ID submissions to override the date of birth on file.</string>
+    <string name="age_restriction_sub_eighteen_confirm">Contact support</string>
+    <string name="age_restriction_dismiss">Cancel</string>
+
 </resources>

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeRestrictionDialog.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeRestrictionDialog.kt
@@ -1,0 +1,123 @@
+package com.shyden.shytalk.feature.ageverification
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import com.shyden.shytalk.resources.Res
+import com.shyden.shytalk.resources.age_restriction_dismiss
+import com.shyden.shytalk.resources.age_restriction_needs_verification_body
+import com.shyden.shytalk.resources.age_restriction_needs_verification_confirm
+import com.shyden.shytalk.resources.age_restriction_needs_verification_title
+import com.shyden.shytalk.resources.age_restriction_sub_eighteen_body
+import com.shyden.shytalk.resources.age_restriction_sub_eighteen_confirm
+import com.shyden.shytalk.resources.age_restriction_sub_eighteen_title
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Two-variant alert dialog rendered when an [AgeRestrictionDialogState]
+ * is non-Hidden.
+ *
+ * - [AgeRestrictionDialogState.NeedsVerification] → "Verify now" CTA
+ *   that should route to the verification submit flow (PR 9).
+ * - [AgeRestrictionDialogState.SubEighteen] → "Contact support" CTA.
+ *   The user CANNOT enter the verification flow until they age in.
+ *
+ * Renders nothing on [AgeRestrictionDialogState.Hidden] — the host
+ * Composable just holds onto the dialog and lets the state transition
+ * make it appear.
+ */
+@Composable
+fun AgeRestrictionDialog(
+    state: AgeRestrictionDialogState,
+    onDismiss: () -> Unit,
+    onVerifyNow: () -> Unit,
+    onContactSupport: () -> Unit,
+) {
+    when (state) {
+        AgeRestrictionDialogState.Hidden -> Unit
+
+        AgeRestrictionDialogState.NeedsVerification -> {
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                title = {
+                    Text(
+                        stringResource(Res.string.age_restriction_needs_verification_title),
+                        fontWeight = FontWeight.Bold,
+                    )
+                },
+                text = {
+                    Text(
+                        stringResource(Res.string.age_restriction_needs_verification_body),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            onDismiss()
+                            onVerifyNow()
+                        },
+                        modifier = Modifier.testTag(TAG_NEEDS_VERIFICATION_CONFIRM),
+                    ) {
+                        Text(stringResource(Res.string.age_restriction_needs_verification_confirm))
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.testTag(TAG_NEEDS_VERIFICATION_DISMISS),
+                    ) {
+                        Text(stringResource(Res.string.age_restriction_dismiss))
+                    }
+                },
+            )
+        }
+
+        AgeRestrictionDialogState.SubEighteen -> {
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                title = {
+                    Text(
+                        stringResource(Res.string.age_restriction_sub_eighteen_title),
+                        fontWeight = FontWeight.Bold,
+                    )
+                },
+                text = {
+                    Text(
+                        stringResource(Res.string.age_restriction_sub_eighteen_body),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            onDismiss()
+                            onContactSupport()
+                        },
+                        modifier = Modifier.testTag(TAG_SUB_EIGHTEEN_CONFIRM),
+                    ) {
+                        Text(stringResource(Res.string.age_restriction_sub_eighteen_confirm))
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.testTag(TAG_SUB_EIGHTEEN_DISMISS),
+                    ) {
+                        Text(stringResource(Res.string.age_restriction_dismiss))
+                    }
+                },
+            )
+        }
+    }
+}
+
+const val TAG_NEEDS_VERIFICATION_CONFIRM = "ageRestriction_needsVerification_confirm"
+const val TAG_NEEDS_VERIFICATION_DISMISS = "ageRestriction_needsVerification_dismiss"
+const val TAG_SUB_EIGHTEEN_CONFIRM = "ageRestriction_subEighteen_confirm"
+const val TAG_SUB_EIGHTEEN_DISMISS = "ageRestriction_subEighteen_dismiss"

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeRestrictionDialogState.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeRestrictionDialogState.kt
@@ -1,0 +1,42 @@
+package com.shyden.shytalk.feature.ageverification
+
+/**
+ * Pure state for the age-restriction dialog. ViewModels expose this as
+ * a `StateFlow<AgeRestrictionDialogState>` and the screen's Composable
+ * watches it to decide whether to render [AgeRestrictionDialog].
+ *
+ * The conversion from [AgeRestrictionState] (pure restriction logic)
+ * to [AgeRestrictionDialogState] (UI presence) lives here so the
+ * dialog rendering and the restriction-check call sites remain
+ * decoupled — a VM can hold an [AgeRestrictionState] in one flow and
+ * transform it via [showOnBlocked] only when an entry-point method
+ * actually fires (otherwise the dialog never appears even if the user
+ * is restricted).
+ */
+sealed interface AgeRestrictionDialogState {
+    /** Dialog not visible. The user has either not attempted a gated action, or they are [AgeRestrictionState.Allowed]. */
+    data object Hidden : AgeRestrictionDialogState
+
+    /** Dialog visible in the "submit your ID" mode (user is 18+ but unverified). */
+    data object NeedsVerification : AgeRestrictionDialogState
+
+    /** Dialog visible in the "contact support" mode (user is sub-18 or has no DOB on file). */
+    data object SubEighteen : AgeRestrictionDialogState
+
+    val isVisible: Boolean get() = this != Hidden
+
+    companion object {
+        /**
+         * Maps an [AgeRestrictionState] to the dialog state to show
+         * when the user TRIES to use a gated feature. [Allowed] users
+         * never see the dialog — the entry-point method should
+         * proceed normally instead of calling this.
+         */
+        fun showOnBlocked(state: AgeRestrictionState): AgeRestrictionDialogState =
+            when (state) {
+                AgeRestrictionState.Allowed -> Hidden
+                AgeRestrictionState.NeedsVerification -> NeedsVerification
+                AgeRestrictionState.SubEighteen -> SubEighteen
+            }
+    }
+}

--- a/shared/src/jvmTest/kotlin/com/shyden/shytalk/feature/ageverification/AgeRestrictionDialogStateTest.kt
+++ b/shared/src/jvmTest/kotlin/com/shyden/shytalk/feature/ageverification/AgeRestrictionDialogStateTest.kt
@@ -1,0 +1,65 @@
+package com.shyden.shytalk.feature.ageverification
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pure-state transition tests. The [AgeRestrictionDialog] Composable
+ * is rendered against this state by the host screen; the conversion
+ * function pinned here is what VMs use to decide whether to show the
+ * dialog when an entry-point method fires.
+ */
+class AgeRestrictionDialogStateTest {
+    @Test
+    fun `Hidden is the default and is not visible`() {
+        assertEquals(AgeRestrictionDialogState.Hidden, AgeRestrictionDialogState.Hidden)
+        assertFalse(AgeRestrictionDialogState.Hidden.isVisible)
+    }
+
+    @Test
+    fun `NeedsVerification and SubEighteen are visible`() {
+        assertTrue(AgeRestrictionDialogState.NeedsVerification.isVisible)
+        assertTrue(AgeRestrictionDialogState.SubEighteen.isVisible)
+    }
+
+    @Test
+    fun `showOnBlocked maps Allowed to Hidden`() {
+        // The host VM only calls showOnBlocked when an entry-point
+        // method fires AND the user is restricted. But mapping
+        // Allowed → Hidden defensively means a defensive call site
+        // can't accidentally show a dialog for a fully-allowed user.
+        assertEquals(
+            AgeRestrictionDialogState.Hidden,
+            AgeRestrictionDialogState.showOnBlocked(AgeRestrictionState.Allowed),
+        )
+    }
+
+    @Test
+    fun `showOnBlocked maps NeedsVerification to NeedsVerification`() {
+        assertEquals(
+            AgeRestrictionDialogState.NeedsVerification,
+            AgeRestrictionDialogState.showOnBlocked(AgeRestrictionState.NeedsVerification),
+        )
+    }
+
+    @Test
+    fun `showOnBlocked maps SubEighteen to SubEighteen`() {
+        assertEquals(
+            AgeRestrictionDialogState.SubEighteen,
+            AgeRestrictionDialogState.showOnBlocked(AgeRestrictionState.SubEighteen),
+        )
+    }
+
+    @Test
+    fun `showOnBlocked is exhaustive across all AgeRestrictionState values`() {
+        // Pin that every enum value has a case so a future addition
+        // (say, AgeRestrictionState.Suspended) trips this test rather
+        // than silently defaulting to Hidden.
+        AgeRestrictionState.entries.forEach { state ->
+            val dialogState = AgeRestrictionDialogState.showOnBlocked(state)
+            assertEquals(state.isBlocked, dialogState.isVisible)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR 8 of the [Age Verification multi-PR plan](.project/plans/2026-05-03-age-verification.md). KMP Compose dialog that consumes PR 7's \`AgeRestrictionState\`.

## Two variants

- **NeedsVerification** — "Verify now" CTA. Routes the user to the verification submit flow (PR 9 ships the screen; PR 8's CTA invokes a callback the host wires).
- **SubEighteen** — "Contact support" CTA. Sub-18 users cannot enter the verification flow; the copy explicitly says ID submission won't override the DOB on file.

## Pure-state holder

\`AgeRestrictionDialogState\` (sealed: \`Hidden\` / \`NeedsVerification\` / \`SubEighteen\`) is what VMs hold in a StateFlow. The conversion \`showOnBlocked(AgeRestrictionState)\` maps \`Allowed\` → \`Hidden\` defensively so a careless call site can't show the dialog to a fully-allowed user.

## E2E reliability

Both buttons in both variants have testTags (`ageRestriction_needsVerification_confirm`, `_dismiss`, `ageRestriction_subEighteen_confirm`, `_dismiss`).

## i18n

Ships English-only. PR 13 covers the remaining 19 locales — default-locale fallback keeps non-English users from crashing in the interim.

## Wiring deferred

Wiring into ViewModels (GachaViewModel, PrivateMessageViewModel) is intentionally deferred so each VM diff stays small and reviewable.

## Test plan
- [x] 6 jvmTest cases pin state transitions + exhaustiveness across \`AgeRestrictionState.entries\`
- [x] iOS shared compile clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)