### PR TITLE
feat(age-verif): PrivateChatViewModel send gates (PR 8c/14)

### DIFF
--- a/.project/plans/2026-03-29-feature-roadmap.md
+++ b/.project/plans/2026-03-29-feature-roadmap.md
@@ -76,6 +76,7 @@ roadmap — user-facing web features previously listed here have moved to Phase 
 | T-S  | **Retroactive exhaustive testing** — apply the full testing depth standard (see `feedback-testing-depth.md`) to ALL existing areas. Audit every feature, screen, API endpoint, cron job, utility, middleware, admin panel section, and CI workflow against all testing dimensions (functional, security, accessibility, i18n, performance, chaos, state machine, absence, contracts, regression). Decompose into sub-tasks per feature area | 4 | Large |  |
 | T-T  | **Suggestions board test data fix** — `suggestions-board.spec.ts` + `admin-suggestions.spec.ts` selector mismatches (10.5s timeouts). See `project-playwright-test-data.md`. Not in original testing-roadmap memory | 1 | Small | DONE (verified 2026-05-03) — `suggestions-board.spec.ts` passes 137/137 chromium locally (1.7m); admin-suggestions only flake remaining is the badge-count timing case fixed in PR #427 (commit 1e726f60c4). Selectors and route mocking aligned in prior PRs |
 | T-U  | **Test mock-isolation cleanup** — outstanding cases of cross-test mock bleed (`feedback-test-mock-isolation.md` was reactive; sweep for prevention). Not in original testing-roadmap memory | 2 | Small |  |
+| T-V  | **Full cross-platform manual QA regression cycle** — run the complete `/manual-qa` skill end-to-end (37 cross-platform journeys + 312 manual TCs across Chrome/Firefox/Safari/Android device/iOS Simulator/admin panel/portal), achieve two consecutive zero-failure cycles per the skill's gate. Deferred from 2026-05-04 dev bug-triage session — surfaced 7 user-reported bugs (DMs, voice connect, follow, photo upload, voice-error auto-close, banner gaps, toast UX) that escaped because the last clean full regression was Cycle 4 on 2026-04-16; cycles 5–6 never re-converged. Multi-day work. Treat the pass as a coverage-discovery exercise — every undocumented finding adds a TC + an automated test before its fix lands | 1 | Large |  |
 
 ---
 
@@ -177,6 +178,7 @@ Retention and UX improvements.
 | 10  | **Granular suspensions** — suspend specific features per user                                                                               | Medium |        |
 | 11  | **Report reliability score** — track report accuracy per user                                                                               | Medium |        |
 | B22 | **App startup redesign** — prevent login screen flash on auto-login (race condition), improve perceived startup time, better loading states | Medium |        |
+| B23 | **Error notification UX redesign** — replace the current red, opaque, blocking error toast with a lighter, transparent, tap-through notification: dark text on a low-alpha (≤0.6) blurred/translucent background, no card chrome, no input interception. Buttons rendered underneath must remain clickable while the notification is visible. Add Compose UI test asserting hit-testing passes through, plus a snapshot test to lock the styling. Deferred from 2026-05-04 bug-triage session | Small  |        |
 
 ---
 

--- a/app/src/androidTest/java/com/shyden/shytalk/di/TestKoinModule.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/di/TestKoinModule.kt
@@ -164,6 +164,7 @@ val testModule =
                 storageRepository = get(),
                 initialConversationId = values.getOrNull(1) as? String,
                 translationRepository = get(),
+                ageRestrictionService = get(),
             )
         }
         viewModel { ReportReviewViewModel(get(), get()) }

--- a/app/src/test/java/com/shyden/shytalk/feature/messaging/PrivateChatViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/messaging/PrivateChatViewModelTest.kt
@@ -2057,4 +2057,142 @@ class PrivateChatViewModelTest {
             assertNull("error should be null for empty messages (not an error)", state.error)
             assertFalse("isBlocked should be false", state.isBlocked)
         }
+
+    // ===== Age-restriction gate (PR 8c) =====
+
+    private fun createViewModelWithAgeGate(currentUser: com.shyden.shytalk.core.model.User): PrivateChatViewModel =
+        PrivateChatViewModel(
+            otherUserId = otherUserId,
+            pmRepository = pmRepository,
+            userRepository = userRepository,
+            authRepository = authRepository,
+            typingRepository = typingRepository,
+            reportRepository = reportRepository,
+            storageRepository = storageRepository,
+            ageRestrictionService =
+                com.shyden.shytalk.feature.ageverification
+                    .AgeRestrictionService(),
+        ).also { vm ->
+            // Override the userRepository to return our test user when
+            // looked up by current uid.
+            io.mockk.coEvery { userRepository.getUser(currentUserId) } returns
+                com.shyden.shytalk.core.util.Resource
+                    .Success(currentUser)
+            activeViewModels.add(vm)
+        }
+
+    private fun userOfAge(
+        years: Int,
+        ageVerified: Boolean,
+    ): com.shyden.shytalk.core.model.User {
+        val cal = java.util.Calendar.getInstance()
+        cal.add(java.util.Calendar.YEAR, -years)
+        cal.add(java.util.Calendar.DAY_OF_YEAR, -7) // safely past calendar boundary
+        return com.shyden.shytalk.core.model.User(
+            uid = currentUserId,
+            dateOfBirth = cal.timeInMillis,
+            ageVerified = ageVerified,
+        )
+    }
+
+    @Test
+    fun `sendMessage blocked with NeedsVerification dialog for unverified 18+ user`() =
+        runTest {
+            val vm = createViewModelWithAgeGate(userOfAge(25, ageVerified = false))
+            advanceUntilIdle()
+            vm.sendMessage("hi")
+            advanceUntilIdle()
+
+            assertEquals(
+                com.shyden.shytalk.feature.ageverification.AgeRestrictionDialogState.NeedsVerification,
+                vm.ageRestrictionDialogState.value,
+            )
+            // Repository send NOT called
+            io.mockk.coVerify(exactly = 0) {
+                pmRepository.sendTextMessage(
+                    conversationId = any(),
+                    senderId = any(),
+                    senderName = any(),
+                    text = any(),
+                    replyToMessageId = any(),
+                    replyToText = any(),
+                    replyToSenderName = any(),
+                )
+            }
+        }
+
+    @Test
+    fun `sendMessage blocked with SubEighteen dialog for sub-18 user`() =
+        runTest {
+            val vm = createViewModelWithAgeGate(userOfAge(16, ageVerified = false))
+            advanceUntilIdle()
+            vm.sendMessage("hi")
+            advanceUntilIdle()
+
+            assertEquals(
+                com.shyden.shytalk.feature.ageverification.AgeRestrictionDialogState.SubEighteen,
+                vm.ageRestrictionDialogState.value,
+            )
+        }
+
+    @Test
+    fun `sendMessage proceeds for verified user — dialog stays Hidden`() =
+        runTest {
+            val vm = createViewModelWithAgeGate(userOfAge(25, ageVerified = true))
+            advanceUntilIdle()
+            vm.sendMessage("hi")
+            advanceUntilIdle()
+
+            assertEquals(
+                com.shyden.shytalk.feature.ageverification.AgeRestrictionDialogState.Hidden,
+                vm.ageRestrictionDialogState.value,
+            )
+            // Repository send WAS called
+            io.mockk.coVerify(atLeast = 1) {
+                pmRepository.sendTextMessage(
+                    conversationId = any(),
+                    senderId = any(),
+                    senderName = any(),
+                    text = "hi",
+                    replyToMessageId = any(),
+                    replyToText = any(),
+                    replyToSenderName = any(),
+                )
+            }
+        }
+
+    @Test
+    fun `gate is no-op when ageRestrictionService is null (legacy contexts)`() =
+        runTest {
+            // The default test setup uses createViewModel() which does
+            // NOT pass an ageRestrictionService. Legacy / opt-out
+            // behaviour: send proceeds unconditionally.
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.sendMessage("hello")
+            advanceUntilIdle()
+
+            assertEquals(
+                com.shyden.shytalk.feature.ageverification.AgeRestrictionDialogState.Hidden,
+                vm.ageRestrictionDialogState.value,
+            )
+        }
+
+    @Test
+    fun `dismissAgeRestrictionDialog resets to Hidden`() =
+        runTest {
+            val vm = createViewModelWithAgeGate(userOfAge(25, ageVerified = false))
+            advanceUntilIdle()
+            vm.sendMessage("hi")
+            advanceUntilIdle()
+            assertEquals(
+                com.shyden.shytalk.feature.ageverification.AgeRestrictionDialogState.NeedsVerification,
+                vm.ageRestrictionDialogState.value,
+            )
+            vm.dismissAgeRestrictionDialog()
+            assertEquals(
+                com.shyden.shytalk.feature.ageverification.AgeRestrictionDialogState.Hidden,
+                vm.ageRestrictionDialogState.value,
+            )
+        }
 }

--- a/public/roadmap-data.json
+++ b/public/roadmap-data.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-03",
+  "lastUpdated": "2026-05-04",
   "currentlyWorkingOn": [
     {
       "name": "`resolveReport` partial-failure flag surfacing",
@@ -1827,7 +1827,7 @@
       "status": "planned",
       "progress": {
         "done": 0,
-        "total": 10
+        "total": 11
       },
       "features": [
         {
@@ -2580,6 +2580,12 @@
         {
           "name": "App startup redesign",
           "description": "prevent login screen flash on auto-login (race condition), improve perceived startup time, better loading states",
+          "status": "planned",
+          "i18n": {}
+        },
+        {
+          "name": "Error notification UX redesign",
+          "description": "replace the current red, opaque, blocking error toast with a lighter, transparent, tap-through notification: dark text on a low-alpha (≤0.6) blurred/translucent background, no card chrome, no input interception. Buttons rendered underneath must remain clickable while the notification is visible. Add Compose UI test asserting hit-testing passes through, plus a snapshot test to lock the styling. Deferred from 2026-05-04 bug-triage session",
           "status": "planned",
           "i18n": {}
         }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/di/ViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/di/ViewModelModule.kt
@@ -69,6 +69,7 @@ val viewModelModule =
                 conversationWs = get(),
                 roomRepository = get(),
                 translationRepository = get(),
+                ageRestrictionService = get(),
             )
         }
         viewModel { ReportReviewViewModel(get(), get()) }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatViewModel.kt
@@ -34,6 +34,8 @@ import com.shyden.shytalk.data.repository.StorageRepository
 import com.shyden.shytalk.data.repository.TranslationRepository
 import com.shyden.shytalk.data.repository.TypingRepository
 import com.shyden.shytalk.data.repository.UserRepository
+import com.shyden.shytalk.feature.ageverification.AgeRestrictionDialogState
+import com.shyden.shytalk.feature.ageverification.AgeRestrictionService
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsBytes
@@ -119,6 +121,14 @@ class PrivateChatViewModel(
     private val conversationWs: ConversationWebSocketService? = null,
     private val roomRepository: RoomRepository? = null,
     private val translationRepository: TranslationRepository? = null,
+    /**
+     * Age-verification gate. Unset = optional in tests / fakes / older
+     * call sites. When provided, every send entry point checks the
+     * gate before invoking the repository — restricted users see the
+     * verification dialog instead of sending. Apple guideline 1.1.4
+     * compliance (PR 8c of the age-verification multi-PR plan).
+     */
+    private val ageRestrictionService: AgeRestrictionService? = null,
 ) : ViewModel() {
     companion object {
         private const val TAG = "PrivateChatViewModel"
@@ -126,6 +136,17 @@ class PrivateChatViewModel(
 
     private val _uiState = MutableStateFlow(PrivateChatUiState())
     val uiState: StateFlow<PrivateChatUiState> = _uiState.asStateFlow()
+
+    /**
+     * Age-restriction dialog state. The screen observes this and
+     * renders [com.shyden.shytalk.feature.ageverification.AgeRestrictionDialog]
+     * when non-Hidden. Set by [shouldBlockSend] when a user attempts a
+     * send action and fails the 18+ gate.
+     */
+    private val _ageRestrictionDialogState =
+        MutableStateFlow<AgeRestrictionDialogState>(AgeRestrictionDialogState.Hidden)
+    val ageRestrictionDialogState: StateFlow<AgeRestrictionDialogState> =
+        _ageRestrictionDialogState.asStateFlow()
 
     private val currentUserId: String = authRepository.currentUserId ?: ""
     private var messagesJob: Job? = null
@@ -377,6 +398,7 @@ class PrivateChatViewModel(
         clearTyping()
 
         viewModelScope.launch {
+            if (shouldBlockSend()) return@launch
             logI(TAG, "Sending message in conversation=$conversationId")
             when (
                 pmRepository.sendTextMessage(
@@ -408,6 +430,7 @@ class PrivateChatViewModel(
         cancelReply()
 
         viewModelScope.launch {
+            if (shouldBlockSend()) return@launch
             when (
                 pmRepository.sendImageMessage(
                     conversationId = conversationId,
@@ -956,6 +979,7 @@ class PrivateChatViewModel(
         val conversationId = _uiState.value.conversationId
         if (conversationId.isEmpty()) return
         viewModelScope.launch {
+            if (shouldBlockSend()) return@launch
             when (
                 pmRepository.sendStickerMessage(
                     conversationId = conversationId,
@@ -1064,6 +1088,7 @@ class PrivateChatViewModel(
         val conversationId = _uiState.value.conversationId
         if (conversationId.isEmpty()) return
         viewModelScope.launch {
+            if (shouldBlockSend()) return@launch
             when (
                 pmRepository.sendRoomInviteMessage(
                     conversationId = conversationId,
@@ -1377,5 +1402,48 @@ class PrivateChatViewModel(
                 else -> { /* Loading or Error — silently fail */ }
             }
         }
+    }
+
+    // ── Age-restriction gate (PR 8c) ──────────────────────────────
+
+    /**
+     * If the gate is wired (Koin-injected `ageRestrictionService` is
+     * non-null) AND the current user is restricted, sets the dialog
+     * state and returns true to short-circuit the calling send method.
+     * Returns false (proceed) when:
+     *   - The gate is not wired (legacy / test contexts that opt out)
+     *   - The current user is allowed
+     *
+     * Fail-closed when the user load errors or the uid is missing —
+     * surface SubEighteen rather than letting the send through.
+     */
+    private suspend fun shouldBlockSend(): Boolean {
+        val service = ageRestrictionService ?: return false
+        val uid = authRepository.currentUserId
+        if (uid.isNullOrEmpty()) {
+            _ageRestrictionDialogState.value = AgeRestrictionDialogState.SubEighteen
+            return true
+        }
+        val user =
+            when (val result = userRepository.getUser(uid)) {
+                is Resource.Success -> result.data
+
+                else -> {
+                    _ageRestrictionDialogState.value = AgeRestrictionDialogState.SubEighteen
+                    return true
+                }
+            }
+        val state = service.checkPmAccess(user)
+        val dialogState = AgeRestrictionDialogState.showOnBlocked(state)
+        if (dialogState != AgeRestrictionDialogState.Hidden) {
+            _ageRestrictionDialogState.value = dialogState
+            logI(TAG, "PM send blocked by age restriction: $dialogState")
+            return true
+        }
+        return false
+    }
+
+    fun dismissAgeRestrictionDialog() {
+        _ageRestrictionDialogState.value = AgeRestrictionDialogState.Hidden
     }
 }


### PR DESCRIPTION
## Summary

PR 8c of the [Age Verification multi-PR plan](.project/plans/2026-05-03-age-verification.md). Wires \`AgeRestrictionService\` into \`PrivateChatViewModel\`'s five send entry points so the 18+ gate fires before any send-message API is invoked.

Mirrors PR 8b's GachaViewModel pattern.

## Gated entry points

- \`sendMessage(text)\`
- \`sendImages(urls)\`
- \`sendStickerMessage(url)\` — covers both \`sendSticker(Sticker)\` URL-path and \`sendSticker(stickerUrl)\`
- \`sendRoomInvite(roomId, roomName)\`

Each opens its \`viewModelScope.launch\` block with a single \`if (shouldBlockSend()) return@launch\` guard.

## Wiring

- New optional \`ageRestrictionService\` constructor param (default null). Nullable so the existing 60+ test constructions don't need updating; production call sites get the gate via Koin.
- New read-only \`StateFlow<AgeRestrictionDialogState>\` for the screen to observe.
- \`shouldBlockSend()\` suspend helper consulted by every send path.
- \`dismissAgeRestrictionDialog()\` resets to Hidden.
- ViewModelModule + TestKoinModule pass \`ageRestrictionService = get()\`.

## Fail-closed

null \`currentUserId\` / \`userRepository.getUser\` Error → \`SubEighteen\` dialog. The send is short-circuited; the API is never invoked.

## Skipped intentionally

- \`ConversationListViewModel\` / \`NewMessageViewModel\` — they only show conversation list / start new chat. Gating them would block users from seeing existing-thread previews. PR 11 (migration) handles thread-level lockout for revoked users.
- \`sendSticker(Sticker)\` local-upload path — niche flow that eventually calls \`sendStickerMessage(url)\`, so the URL gate catches it.

## Test plan

- 5 new jvmTest cases pin gate states (verified proceeds / unverified-18+ → NeedsVerification / sub-18 → SubEighteen / no-service-injected → no-op gate / dismiss resets)
- Pre-existing 60+ \`PrivateChatViewModelTest\` cases remain green (nullable param protects them)
- iOS shared compile clean
- androidTest compile clean

## Order constraint

No DEV deploy on this PR — work-completion deploy is at PR 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)