### PR TITLE
refactor(age-verif): drop reason on Approve

### DIFF
--- a/express-api/src/routes/admin-age-verification.js
+++ b/express-api/src/routes/admin-age-verification.js
@@ -147,12 +147,12 @@ router.post('/admin/age-verification/:id/approve', async (req, res) => {
   const { id } = req.params;
   const errorId = 'AGE_VERIF_APPROVE';
   try {
-    const reason = (req.body?.reason || '').toString();
-    if (!requireNonBlankReason(reason)) {
-      // Symmetric with reject / modify-dob — every admin decision must
-      // carry a justification for the OSA / GDPR audit trail.
-      return res.status(400).json({ error: 'reason is required' });
-    }
+    // Approve does NOT require a reason. Original spec only asked for
+    // an admin justification on outcomes the user needs explained
+    // (Reject / DOB-modified). Approve is the "everything is fine"
+    // path; the audit log records WHO approved + WHEN, sufficient for
+    // the compliance trail. (Question 1 from 2026-05-04 spec
+    // follow-up — revisit if regulators ever ask for it.)
 
     let submission;
     let approved = false;
@@ -171,7 +171,6 @@ router.post('/admin/age-verification/:id/approve', async (req, res) => {
         status: 'approved',
         decisionAt: now(),
         decidedBy: req.auth.uniqueId,
-        decisionReason: reason,
         // r2Key tombstoned — original preserved in audit-log entry.
         r2Key: null,
       });

--- a/express-api/tests/routes/admin-age-verification.test.js
+++ b/express-api/tests/routes/admin-age-verification.test.js
@@ -172,10 +172,7 @@ describe('POST /api/admin/age-verification/:id/approve', () => {
 
   test('flips ageVerified=true on user, marks submission approved, deletes image, writes audit, sends PM', async () => {
     const app = createApp();
-    await request(app)
-      .post('/api/admin/age-verification/sub-1/approve')
-      .send({ reason: 'ID verified by passport' })
-      .expect(200);
+    await request(app).post('/api/admin/age-verification/sub-1/approve').expect(200);
 
     // Submission doc updated
     expect(mockTxUpdate).toHaveBeenCalledWith(
@@ -222,10 +219,7 @@ describe('POST /api/admin/age-verification/:id/approve', () => {
     });
 
     const app = createApp();
-    await request(app)
-      .post('/api/admin/age-verification/sub-1/approve')
-      .send({ reason: 'ok' })
-      .expect(409);
+    await request(app).post('/api/admin/age-verification/sub-1/approve').expect(409);
 
     expect(mockTxUpdate).not.toHaveBeenCalled();
     expect(mockDeleteObject).not.toHaveBeenCalled();
@@ -235,63 +229,60 @@ describe('POST /api/admin/age-verification/:id/approve', () => {
   test('rejects unknown submission (404)', async () => {
     mockTxGet.mockResolvedValue({ exists: false });
     const app = createApp();
-    await request(app)
-      .post('/api/admin/age-verification/missing/approve')
-      .send({ reason: 'ok' })
-      .expect(404);
+    await request(app).post('/api/admin/age-verification/missing/approve').expect(404);
   });
 
   test('rejects non-admin with 403', async () => {
     const app = createApp({ admin: false });
-    await request(app)
-      .post('/api/admin/age-verification/sub-1/approve')
-      .send({ reason: 'ok' })
-      .expect(403);
+    await request(app).post('/api/admin/age-verification/sub-1/approve').expect(403);
     expect(mockTxUpdate).not.toHaveBeenCalled();
   });
 
-  test('rejects empty reason on approve (symmetric audit trail)', async () => {
+  test('approve does NOT require a reason — empty body succeeds', async () => {
+    // 2026-05-04 spec follow-up: original spec only required reason
+    // on outcomes the user needs explained (Reject / DOB-modified).
+    // Approve is the "everything is fine" path. Pin that the route
+    // accepts an empty body so a future regression that adds the
+    // reason gate trips this test.
+    const app = createApp();
+    await request(app).post('/api/admin/age-verification/sub-1/approve').expect(200);
+    expect(mockTxUpdate).toHaveBeenCalled();
+  });
+
+  test('approve does NOT persist decisionReason on the submission doc', async () => {
     const app = createApp();
     await request(app)
       .post('/api/admin/age-verification/sub-1/approve')
-      .send({ reason: '' })
-      .expect(400);
-    expect(mockTxUpdate).not.toHaveBeenCalled();
+      .send({ reason: 'ignored if sent' })
+      .expect(200);
+    // The submission update payload must NOT carry decisionReason.
+    const submissionUpdateCall = mockTxUpdate.mock.calls.find(
+      ([path]) => path === 'ageVerificationSubmissions/sub-1',
+    );
+    expect(submissionUpdateCall).toBeDefined();
+    expect(submissionUpdateCall[1]).not.toHaveProperty('decisionReason');
   });
 
   test('returns auditWritten=false flag when audit-log write fails (decision still committed)', async () => {
     // Per partial-failure-contracts feedback rule: a failed audit
-    // write must be surfaced as a flag, not masked as 500. Decision
-    // is committed; ops sees the flag and back-fills.
+    // write must be surfaced as a flag, not masked as 500.
     mockLogApproved.mockRejectedValue(new Error('auditLog write rejected by rules'));
     const app = createApp();
-    const res = await request(app)
-      .post('/api/admin/age-verification/sub-1/approve')
-      .send({ reason: 'ok' })
-      .expect(200);
+    const res = await request(app).post('/api/admin/age-verification/sub-1/approve').expect(200);
     expect(res.body).toMatchObject({ ok: true, auditWritten: false });
   });
 
   test('returns imageDeleted=false flag when R2 delete fails (decision still committed)', async () => {
     mockDeleteObject.mockRejectedValue(new Error('R2 timeout'));
     const app = createApp();
-    const res = await request(app)
-      .post('/api/admin/age-verification/sub-1/approve')
-      .send({ reason: 'ok' })
-      .expect(200);
+    const res = await request(app).post('/api/admin/age-verification/sub-1/approve').expect(200);
     expect(res.body).toMatchObject({ ok: true, imageDeleted: false });
   });
 
   test('returns userNotified=false flag when system PM fails (decision still committed)', async () => {
-    // Same partial-failure shape as audit / R2 — failed PM doesn't
-    // roll back the decision; admin UI surfaces "decision committed,
-    // user not notified" so ops can DM the user manually.
     mockSendApprovedPm.mockRejectedValue(new Error('conversations write rejected'));
     const app = createApp();
-    const res = await request(app)
-      .post('/api/admin/age-verification/sub-1/approve')
-      .send({ reason: 'ok' })
-      .expect(200);
+    const res = await request(app).post('/api/admin/age-verification/sub-1/approve').expect(200);
     expect(res.body).toMatchObject({ ok: true, userNotified: false });
   });
 });


### PR DESCRIPTION
Per 2026-05-04 spec follow-up — Approve does not need an admin-supplied reason. Original spec only asked for it on Reject + DOB-Modified (outcomes the user needs explained). Audit log already records who/when, sufficient for compliance.

19 admin tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)