### PR TITLE
feat(age-verif): block sign-in for verified-but-no-DOB inconsistency (PR 5b/14)

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -935,6 +935,12 @@
     <string name="seasonal_khmer_new_year_cta">Learn about Choul Chnam Thmey</string>
     <string name="seasonal_event_dismiss">Dismiss</string>
 
+    <!-- Account error screen (PR 5b — null-DOB-but-verified inconsistency guard). -->
+    <string name="account_error_title">Account needs attention</string>
+    <string name="account_error_body">There is a problem with your account that we cannot fix automatically. Please contact our support team and quote the error code below — they will resolve it for you.</string>
+    <string name="account_error_code_label">Error code: %1$s</string>
+    <string name="account_error_sign_out">Sign out</string>
+
     <!-- Age verification dialog (PR 8 of age-verification feature). PR 13 ships translations for the remaining 19 locales. -->
     <string name="age_restriction_needs_verification_title">Verify your age</string>
     <string name="age_restriction_needs_verification_body">Private messages and gacha are 18+ features. To use them, please verify your age by submitting a government-issued ID. The image is reviewed by a human and deleted as soon as a decision is made.</string>

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AccountErrorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AccountErrorScreen.kt
@@ -1,0 +1,102 @@
+package com.shyden.shytalk.feature.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.shyden.shytalk.resources.Res
+import com.shyden.shytalk.resources.account_error_body
+import com.shyden.shytalk.resources.account_error_code_label
+import com.shyden.shytalk.resources.account_error_sign_out
+import com.shyden.shytalk.resources.account_error_title
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Generic "your account is in a state we cannot resolve from the
+ * client" screen. Shown by [SignInScreen] when sign-in resolution
+ * detected an inconsistent server-side state — currently only
+ * triggered by `ageVerified=true` AND `dateOfBirth=null`
+ * (`AGE_VERIF_NO_DOB_E001`), but the screen is generic so future
+ * inconsistency codes can route through the same surface.
+ *
+ * The user is shown a static error code to quote to support; the code
+ * resolves to a specific underlying cause in our internal docs so
+ * support can fix the data without the user having to describe the
+ * symptom.
+ */
+@Composable
+fun AccountErrorScreen(
+    errorCode: String,
+    onSignOut: () -> Unit,
+) {
+    Scaffold { padding ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(horizontal = 32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                stringResource(Res.string.account_error_title),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(16.dp))
+            Text(
+                stringResource(Res.string.account_error_body),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(24.dp))
+            // Code is shown in a Surface so users can read + screenshot
+            // it without it visually merging into the body copy. testTag
+            // for E2E reliability.
+            Surface(
+                shape = RoundedCornerShape(8.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                modifier = Modifier.testTag(TAG_ACCOUNT_ERROR_CODE),
+            ) {
+                Box(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                ) {
+                    Text(
+                        text = stringResource(Res.string.account_error_code_label, errorCode),
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+            Spacer(Modifier.height(32.dp))
+            Button(
+                onClick = onSignOut,
+                modifier = Modifier.testTag(TAG_ACCOUNT_ERROR_SIGN_OUT),
+            ) {
+                Text(stringResource(Res.string.account_error_sign_out))
+            }
+        }
+    }
+}
+
+const val TAG_ACCOUNT_ERROR_CODE = "accountError_code"
+const val TAG_ACCOUNT_ERROR_SIGN_OUT = "accountError_signOut"

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AuthViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AuthViewModel.kt
@@ -33,6 +33,18 @@ data class AuthUiState(
     val isAuthenticated: Boolean = false,
     val hasProfile: Boolean = false,
     val hasDOB: Boolean = false,
+    /**
+     * Set true when the user has `ageVerified = true` BUT
+     * `dateOfBirth = null`. This is an inconsistent server-side state
+     * — verification flow always records DOB. Block the user from
+     * proceeding into the app and surface the static error code
+     * `AGE_VERIF_NO_DOB_E001` so support can identify the exact
+     * cause from the user's screenshot. Resolution requires admin
+     * intervention (set DOB via the admin panel + re-trigger
+     * verification flow if needed).
+     */
+    val isBlockedByVerifiedNoDob: Boolean = false,
+    val blockedErrorCode: String? = null,
     val needsLegalAcceptance: Boolean = false,
     val isDeviceLocked: Boolean = false,
     val isBackendUnreachable: Boolean = false,
@@ -521,6 +533,26 @@ class AuthViewModel(
                             }
                             // Check if user needs PIN setup (migration or new device)
                             val needsPin = appLockRepository?.hasCredential == false
+                            // Inconsistent state guard (PR 5b 2026-05-04): a user
+                            // with `ageVerified = true` AND `dateOfBirth = null`
+                            // is in a state the verification flow cannot have
+                            // produced — verification always records the DOB.
+                            // This typically means manual Firestore tampering or
+                            // a partial migration. Block sign-in and surface a
+                            // static error code so support can fix the data.
+                            val verifiedButNoDob = user.ageVerified && user.dateOfBirth == null
+                            if (verifiedButNoDob) {
+                                _uiState.update {
+                                    it.copy(
+                                        isLoading = false,
+                                        isBackendUnreachable = false,
+                                        isAuthenticated = false,
+                                        isBlockedByVerifiedNoDob = true,
+                                        blockedErrorCode = "AGE_VERIF_NO_DOB_E001",
+                                    )
+                                }
+                                return
+                            }
                             _uiState.update {
                                 it.copy(
                                     isLoading = false,

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/SignInScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/SignInScreen.kt
@@ -128,6 +128,18 @@ fun SignInScreen(
         return
     }
 
+    // Inconsistent-state guard (PR 5b 2026-05-04): user has
+    // ageVerified=true but no dateOfBirth on file. Block them; surface
+    // the static error code so support can identify the data
+    // inconsistency from a screenshot.
+    if (uiState.isBlockedByVerifiedNoDob) {
+        AccountErrorScreen(
+            errorCode = uiState.blockedErrorCode ?: "AGE_VERIF_NO_DOB_E001",
+            onSignOut = { viewModel.signOut() },
+        )
+        return
+    }
+
     if (uiState.isBackendUnreachable) {
         Scaffold { padding ->
             Column(


### PR DESCRIPTION
Per 2026-05-04 spec follow-up question 5. When a user has `ageVerified=true` AND `dateOfBirth=null` — an inconsistent state the verification flow can't have produced — block sign-in with static error code `AGE_VERIF_NO_DOB_E001`. New `AccountErrorScreen` Composable; SignInScreen routes to it after suspension/ban checks.

iOS shared compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)