### PR TITLE
feat(age-verif): PR 11 — PM-lock migration + auto-unlock + fail-closed UX

### DIFF
--- a/app/src/androidTest/java/com/shyden/shytalk/fake/FakeUserRepository.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/fake/FakeUserRepository.kt
@@ -134,6 +134,8 @@ class FakeUserRepository : UserRepository {
 
     override suspend fun liftExpiredSuspension(userId: String): Resource<Unit> = Resource.Success(Unit)
 
+    override suspend fun checkPmLockOnLogin(userId: String): Resource<Unit> = Resource.Success(Unit)
+
     override suspend fun getAliases(userId: String): Resource<Map<String, String>> = Resource.Success(emptyMap())
 
     override suspend fun setAlias(

--- a/app/src/main/java/com/shyden/shytalk/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/UserRepositoryImpl.kt
@@ -85,6 +85,11 @@ class UserRepositoryImpl(
             api.post("/api/users/$userId/lift-suspension")
         }
 
+    override suspend fun checkPmLockOnLogin(userId: String): Resource<Unit> =
+        firebaseCall("Failed to check PM lock state") {
+            api.post("/api/users/$userId/pm-lock-check")
+        }
+
     // ---- Read methods (unchanged — all use Firestore SDK) ----
 
     // Read from Firestore (offline cache replaces in-memory LRU cache)

--- a/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
@@ -82,6 +82,8 @@ private val EXPECTED_USER_MAP_KEYS =
         "ageVerified",
         "ageVerifiedAt",
         "ageVerificationMethod",
+        "pmLocked",
+        "lastPmLockCheck",
     )
 
 class UserToMapTest {

--- a/app/src/test/java/com/shyden/shytalk/data/repository/UserRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/UserRepositoryImplTest.kt
@@ -288,6 +288,41 @@ class UserRepositoryImplTest {
             assertTrue(result is Resource.Success)
         }
 
+    // region PM-lock auto-unlock (PR 11)
+
+    @Test
+    fun `checkPmLockOnLogin posts to pm-lock-check endpoint`() =
+        runTest {
+            // Route is server-only because Firestore rules deny client
+            // writes to `pmLocked` / `lastPmLockCheck`. Body is empty —
+            // the server identifies the user from the auth context.
+            // Note: WorkerApiClient.post has a default JSONObject() body,
+            // so calling `api.post(path)` actually invokes the 2-arg form
+            // at runtime. coVerify matches the 2-arg form here; we pass
+            // any() for the body because JSONObject lacks value equality.
+            coEvery { api.post(any(), any<JSONObject>()) } returns JSONObject()
+
+            val result = repo.checkPmLockOnLogin("user-1")
+
+            assertTrue(result is Resource.Success)
+            coVerify { api.post("/api/users/user-1/pm-lock-check", any<JSONObject>()) }
+        }
+
+    @Test
+    fun `checkPmLockOnLogin returns Error on API failure`() =
+        runTest {
+            // Failure is non-fatal at the AuthViewModel call site (next
+            // launch / counterparty surfaces state) but the repo MUST
+            // surface an Error so unit-tests / future callers can react.
+            coEvery { api.post(any(), any<JSONObject>()) } throws RuntimeException("Network error")
+
+            val result = repo.checkPmLockOnLogin("user-1")
+
+            assertTrue(result is Resource.Error)
+        }
+
+    // endregion
+
     @Test
     fun `acknowledgeWarning returns Success`() =
         runTest {

--- a/app/src/test/java/com/shyden/shytalk/feature/messaging/ConversationListViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/messaging/ConversationListViewModelTest.kt
@@ -150,6 +150,65 @@ class ConversationListViewModelTest {
             assertEquals("FAILED_PRECONDITION: index required", vm.uiState.value.error)
         }
 
+    // ===== PM-lock — sub-18 currentUser sees no threads (PR 11) =====
+    //
+    // The migration script + admin Modify-DOB path mark sub-18 users
+    // with `pmLocked=true`. Their PM list must be empty: even seeing
+    // a conversation summary leaks counterparty identity, and the
+    // chat-screen second-line gate would only fire after a tap.
+
+    @Test
+    fun `currentUser pmLocked hides all conversations from list`() =
+        runTest {
+            val currentUser = TestData.createTestUser(uid = currentUserId).copy(pmLocked = true)
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(currentUser)
+
+            val otherUser = TestData.createTestUser(uid = "other-user")
+            coEvery { userRepository.getUsers(any()) } returns Resource.Success(listOf(otherUser))
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val conv =
+                TestData.createTestConversation(
+                    conversationId = "conv-1",
+                    participantIds = listOf(currentUserId, "other-user"),
+                )
+            conversationsFlow.emit(listOf(conv))
+            advanceUntilIdle()
+
+            assertEquals(0, vm.uiState.value.conversations.size)
+            assertEquals(0L, vm.uiState.value.totalUnreadCount)
+        }
+
+    @Test
+    fun `getUser failure fails CLOSED — list is empty until verified`() =
+        runTest {
+            // Regulatory boundary (Apple guideline 1.1.4): if we cannot
+            // read the user-doc to check pmLocked, we must NOT render
+            // any threads. A transient Firestore error (offline / rate
+            // limit / brief permission glitch) would otherwise leak PMs
+            // to a sub-18 account. Fail-closed.
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Error("transient firestore error")
+
+            val otherUser = TestData.createTestUser(uid = "other-user")
+            coEvery { userRepository.getUsers(any()) } returns Resource.Success(listOf(otherUser))
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val conv =
+                TestData.createTestConversation(
+                    conversationId = "conv-1",
+                    participantIds = listOf(currentUserId, "other-user"),
+                )
+            conversationsFlow.emit(listOf(conv))
+            advanceUntilIdle()
+
+            assertEquals(0, vm.uiState.value.conversations.size)
+            assertEquals(0L, vm.uiState.value.totalUnreadCount)
+        }
+
     // ===== Blocked conversations filtered =====
 
     @Test
@@ -713,8 +772,14 @@ class ConversationListViewModelTest {
     // ===== Graceful degradation on user fetch failures =====
 
     @Test
-    fun `conversations still load when current user fetch fails for blocklist`() =
+    fun `current user fetch failure now fails CLOSED — conversations hidden`() =
         runTest {
+            // Updated for PR 11: this test previously asserted fail-OPEN
+            // (conversations rendered with empty-blocklist fallback) but
+            // that semantic leaks PMs to a possibly-locked sub-18 user
+            // when getUser hits a transient Firestore error. The new
+            // contract is fail-CLOSED — return empty list until we can
+            // verify pmLocked. Apple guideline 1.1.4.
             coEvery { userRepository.getUser(currentUserId) } returns Resource.Error("Network error")
 
             val otherUser = TestData.createTestUser(uid = "other-user", displayName = "Other")
@@ -731,9 +796,8 @@ class ConversationListViewModelTest {
             conversationsFlow.emit(listOf(conv))
             advanceUntilIdle()
 
-            // Should still show conversations (empty blocklist fallback)
             assertFalse(vm.uiState.value.isLoading)
-            assertEquals(1, vm.uiState.value.conversations.size)
+            assertEquals(0, vm.uiState.value.conversations.size)
         }
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/feature/messaging/PrivateChatViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/messaging/PrivateChatViewModelTest.kt
@@ -265,6 +265,127 @@ class PrivateChatViewModelTest {
             assertFalse(vm.uiState.value.isBlocked)
         }
 
+    // ===== PM-lock (PR 11) =====
+    //
+    // Two distinct visible states drive UI behaviour:
+    //
+    // 1) `otherUserPmLocked` — the COUNTERPARTY is sub-18 / locked. The
+    //    18+ viewer still sees the conversation but the input is
+    //    disabled with a message explaining we believe the recipient is
+    //    under 18. Critically: this is NOT modelled as `isBlocked`,
+    //    because `isBlocked` shows a hard "you cannot message" blocker
+    //    that hides history and the input row entirely. We want history
+    //    + a softer notice.
+    // 2) `isBlocked` (with a pmLocked-specific reason) — the CURRENT
+    //    user is locked. They cannot view the conversation at all.
+    //    Falling through the conv-list filter is the primary path; this
+    //    second-line gate handles deep-link / restored navigation.
+
+    @Test
+    fun `otherUser pmLocked surfaces otherUserPmLocked but not isBlocked`() =
+        runTest {
+            val otherUser = TestData.createTestUser(uid = otherUserId).copy(pmLocked = true)
+            coEvery { userRepository.getUser(otherUserId) } returns Resource.Success(otherUser)
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertTrue(
+                "Counterparty PM-lock must surface otherUserPmLocked",
+                vm.uiState.value.otherUserPmLocked,
+            )
+            assertFalse(
+                "otherUserPmLocked is the soft-disabled-input state — must NOT trigger isBlocked",
+                vm.uiState.value.isBlocked,
+            )
+        }
+
+    @Test
+    fun `currentUser pmLocked sets isBlocked with PM-lock reason`() =
+        runTest {
+            val currentUser = TestData.createTestUser(uid = currentUserId).copy(pmLocked = true)
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(currentUser)
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.isBlocked)
+            // The conv-list filters most paths out, but a deep-link or
+            // a restored Saver could land a pmLocked user here. Pin the
+            // hard-block as the second-line defense.
+            assertNotNull(vm.uiState.value.blockReason)
+        }
+
+    @Test
+    fun `sendMessage is gated when otherUserPmLocked`() =
+        runTest {
+            // Backstop: even if the screen disables the input, a deep-
+            // link / automation / restored Saver could still call
+            // sendMessage. Refuse — PM-lock is a regulatory boundary,
+            // not a UI hint.
+            val otherUser = TestData.createTestUser(uid = otherUserId).copy(pmLocked = true)
+            coEvery { userRepository.getUser(otherUserId) } returns Resource.Success(otherUser)
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.sendMessage("Hi")
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                pmRepository.sendTextMessage(
+                    conversationId = any(),
+                    senderId = any(),
+                    senderName = any(),
+                    text = any(),
+                    replyToMessageId = any(),
+                    replyToText = any(),
+                    replyToSenderName = any(),
+                )
+            }
+        }
+
+    @Test
+    fun `neither user pmLocked leaves both fields false`() =
+        runTest {
+            // Default seed: TestData.createTestUser builds users with
+            // pmLocked=false. Pin the negative — sanity check that the
+            // new flag doesn't fire on existing happy-path inputs.
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.otherUserPmLocked)
+            assertFalse(vm.uiState.value.isBlocked)
+        }
+
+    @Test
+    fun `getUser failure on currentUser fails CLOSED — isBlocked is set`() =
+        runTest {
+            // Regulatory boundary (Apple guideline 1.1.4): if we cannot
+            // read the user-doc to evaluate pmLocked, the screen MUST
+            // refuse send instead of falling through with no restriction.
+            // A transient Firestore error would otherwise let a sub-18
+            // user message in violation of the lock. Fail-closed.
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Error("transient firestore error")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.isBlocked)
+            assertNotNull(vm.uiState.value.blockReason)
+        }
+
+    @Test
+    fun `getUser failure on otherUser fails CLOSED — isBlocked is set`() =
+        runTest {
+            coEvery { userRepository.getUser(otherUserId) } returns Resource.Error("transient firestore error")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.isBlocked)
+            assertNotNull(vm.uiState.value.blockReason)
+        }
+
     @Test
     fun `pmPrivacy EVERYONE does not block`() =
         runTest {

--- a/express-api/scripts/migrate-pm-lock.js
+++ b/express-api/scripts/migrate-pm-lock.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * One-shot migration: lock PMs for all sub-18 users in the user
+ * collection. Part of PR 11 of the age-verification feature.
+ *
+ * Background: ShyTalk's old min-signup-age was 13. PR 1 (#436) bumped
+ * it to 16 for new accounts, but legacy 13-15 accounts still exist.
+ * The age-verification spec gates 18+ features behind the verification
+ * flow; for sub-18 users (whether 13-15 legacy or 16-17 new) PMs are
+ * inaccessible — their list hides + counterparties see disabled input.
+ *
+ * This script flips `pmLocked = true` for every user whose
+ * `dateOfBirth` indicates they are currently below 18. Idempotent:
+ * already-locked users are skipped, 18+ users are skipped, users with
+ * null DOB are skipped (those are blocked at sign-in via
+ * AGE_VERIF_NO_DOB_E001 if also ageVerified, or routed to the
+ * RequiredDOBScreen if not — the migration doesn't need to touch
+ * them).
+ *
+ * Usage:
+ *   node scripts/migrate-pm-lock.js --dry-run    # print, don't write
+ *   node scripts/migrate-pm-lock.js --apply      # write
+ *
+ * Fail-safety:
+ *   - --apply requires the env var MIGRATION_CONFIRM=yes to actually
+ *     touch Firestore. Prevents accidental run.
+ *   - Pre-flight: writes a JSON snapshot of every doc that WOULD be
+ *     touched to `migration-snapshots/pm-lock-<timestamp>.json` so a
+ *     bad run can be reverted.
+ *   - Batches writes in chunks of 400 (Firestore's per-batch ceiling
+ *     is 500, leaving headroom for rule-side validation overhead).
+ *   - Each batch logged with start/end uid range so a partial failure
+ *     can be resumed.
+ *
+ * Counter-party concern: this script does NOT touch conversations or
+ * other-user-side state. Counterparties see the lock at READ time via
+ * the user-doc field; no fan-out write needed.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Load Firebase Admin SDK from the project's existing util.
+const { db } = require('../src/utils/firebase');
+const log = require('../src/utils/log');
+
+const BATCH_SIZE = 400;
+
+function isCurrentlyUnder18(dateOfBirthMs) {
+  if (typeof dateOfBirthMs !== 'number' || !Number.isFinite(dateOfBirthMs)) return false;
+  // Calendar-aware: matches `isAtLeast18FromDob` in the route handler
+  // and `calculateAge` in shared/. Don't approximate with 365.25 ms
+  // multiplication — leap years drift the boundary by hours.
+  const today = new Date();
+  const dob = new Date(dateOfBirthMs);
+  let age = today.getUTCFullYear() - dob.getUTCFullYear();
+  if (
+    today.getUTCMonth() < dob.getUTCMonth() ||
+    (today.getUTCMonth() === dob.getUTCMonth() && today.getUTCDate() < dob.getUTCDate())
+  ) {
+    age -= 1;
+  }
+  return age < 18;
+}
+
+async function scanCandidates() {
+  // Pull every user. The collection isn't huge (a few-thousand at most
+  // on dev / a few hundred on prod given current scale). If it ever
+  // grows past ~50k users we should switch to a where-filtered query
+  // on `dateOfBirth` ranges, but that requires a Firestore index — for
+  // the one-time migration the simple full-scan is fine.
+  const snap = await db.collection('users').get();
+  const candidates = [];
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const dob = typeof data.dateOfBirth === 'number' ? data.dateOfBirth : null;
+    if (dob === null) continue; // null DOB is handled by other paths
+    if (data.pmLocked === true) continue; // already locked, idempotent
+    if (!isCurrentlyUnder18(dob)) continue; // 18+ users not affected
+    candidates.push({ id: doc.id, dob, snapshot: data });
+  }
+  return candidates;
+}
+
+async function writeSnapshot(candidates) {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const dir = path.resolve(__dirname, '../migration-snapshots');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `pm-lock-${ts}.json`);
+  fs.writeFileSync(
+    file,
+    JSON.stringify(
+      {
+        migration: 'pm-lock',
+        ranAt: ts,
+        candidateCount: candidates.length,
+        // Snapshot only the fields we're about to touch + the doc id.
+        // Full-doc snapshots leak unrelated data into git-ignored
+        // backup files, which is fine for ops but unnecessary.
+        candidates: candidates.map((c) => ({
+          id: c.id,
+          dateOfBirth: c.dob,
+          previousPmLocked: c.snapshot.pmLocked === true,
+          previousLastPmLockCheck: c.snapshot.lastPmLockCheck ?? null,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+  return file;
+}
+
+async function applyBatched(candidates) {
+  const stamp = Date.now();
+  for (let i = 0; i < candidates.length; i += BATCH_SIZE) {
+    const slice = candidates.slice(i, i + BATCH_SIZE);
+    const batchIndex = Math.floor(i / BATCH_SIZE);
+    const batch = db.batch();
+    for (const c of slice) {
+      batch.update(db.doc(`users/${c.id}`), {
+        pmLocked: true,
+        lastPmLockCheck: stamp,
+      });
+    }
+    // Per-batch try/catch so a partial failure logs the exact UID
+    // range that died. Without this the outer .catch() at main()
+    // surfaces only the error message — operators have no way to
+    // resume the migration from the failed batch boundary. The
+    // re-throw preserves the existing fail-fast semantics; we just
+    // add context first.
+    try {
+      await batch.commit();
+      log.info('migrate-pm-lock', 'Batch committed', {
+        batchIndex,
+        from: i,
+        to: i + slice.length,
+        total: candidates.length,
+        firstUid: slice[0]?.id,
+        lastUid: slice[slice.length - 1]?.id,
+      });
+    } catch (err) {
+      log.error('migrate-pm-lock', 'Batch FAILED', {
+        batchIndex,
+        from: i,
+        to: i + slice.length,
+        total: candidates.length,
+        firstUid: slice[0]?.id,
+        lastUid: slice[slice.length - 1]?.id,
+        error: err?.message,
+        code: err?.code,
+      });
+      throw err;
+    }
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const apply = args.includes('--apply');
+
+  if (!dryRun && !apply) {
+    log.error('migrate-pm-lock', 'Specify --dry-run or --apply');
+    process.exit(2);
+  }
+
+  if (apply && process.env.MIGRATION_CONFIRM !== 'yes') {
+    log.error(
+      'migrate-pm-lock',
+      'Refusing to run --apply without MIGRATION_CONFIRM=yes env var. Pre-flight: run --dry-run first, review the snapshot, then re-run with both flags.',
+    );
+    process.exit(3);
+  }
+
+  log.info('migrate-pm-lock', dryRun ? 'Starting dry-run scan' : 'Starting --apply pass');
+  const candidates = await scanCandidates();
+  log.info('migrate-pm-lock', `Scan complete: ${candidates.length} sub-18 users to lock`);
+
+  const snapshotFile = await writeSnapshot(candidates);
+  log.info('migrate-pm-lock', `Snapshot written: ${snapshotFile}`);
+
+  if (dryRun) {
+    log.info('migrate-pm-lock', 'Dry-run complete — no writes performed');
+    return;
+  }
+
+  await applyBatched(candidates);
+  log.info('migrate-pm-lock', 'Migration complete');
+}
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      log.error('migrate-pm-lock', 'Migration failed', { error: err.message, stack: err.stack });
+      process.exit(1);
+    });
+}
+
+module.exports = { isCurrentlyUnder18, scanCandidates };

--- a/express-api/src/index.js
+++ b/express-api/src/index.js
@@ -152,6 +152,11 @@ app.use('/api/reports', sensitiveLimiter);
 app.use('/api/appeals', sensitiveLimiter);
 app.use('/api/users/:uniqueId/delete', sensitiveLimiter);
 app.use('/api/users/:uniqueId/data-export', sensitiveLimiter);
+// First-of-day PM-lock auto-unlock check (PR 11). Sensitive: it can
+// flip a server-only field (`pmLocked`). Throttled inside the route
+// to one Firestore write per user per UTC day, but the limiter caps
+// any one client from spinning the auth-then-403 path in a tight loop.
+app.use('/api/users/:uniqueId/pm-lock-check', sensitiveLimiter);
 // Age verification — sensitive because it issues short-lived R2
 // upload tokens and creates pending submissions. Rate limit prevents
 // a malicious client from spamming submissions or harvesting upload
@@ -181,6 +186,7 @@ app.use('/api', require('./routes/notifications'));
 app.use('/api', require('./routes/rooms'));
 app.use('/api', require('./routes/data-export'));
 app.use('/api', require('./routes/age-verification'));
+app.use('/api', require('./routes/pm-lock-check'));
 app.use('/api', require('./routes/conversations'));
 app.use('/api', require('./routes/banners'));
 app.use('/api', require('./routes/fun-facts'));

--- a/express-api/src/routes/admin-age-verification.js
+++ b/express-api/src/routes/admin-age-verification.js
@@ -322,6 +322,11 @@ router.post('/admin/age-verification/:id/modify-dob', async (req, res) => {
         ageVerified: verifiedNow,
         ageVerifiedAt: verifiedNow ? now() : null,
         ageVerificationMethod: verifiedNow ? data.idMethod : null,
+        // PR 11 PM-lock side effect. New DOB <18 → lock the user out
+        // of PMs (their list hides + counterparties see disabled
+        // input). New DOB ≥18 → unlock. Same transaction so the
+        // ageVerified flip and the lock state can never diverge.
+        pmLocked: !verifiedNow,
       });
       committed = true;
     });

--- a/express-api/src/routes/pm-lock-check.js
+++ b/express-api/src/routes/pm-lock-check.js
@@ -1,0 +1,116 @@
+/**
+ * POST /api/users/:uniqueId/pm-lock-check
+ *
+ * First-of-day auto-unlock check (PR 11). Called by the client right
+ * after successful sign-in. Reads the user doc, decides whether the
+ * pmLocked state should change, and writes if yes — all server-side
+ * because Firestore rules deny client writes to `pmLocked` /
+ * `lastPmLockCheck`.
+ *
+ * Throttling: when `lastPmLockCheck` falls in the same UTC day as
+ * `now()`, we skip the Firestore write entirely. Active users only
+ * pay the cost once per day; dormant accounts pay nothing.
+ *
+ * Authorisation: the path uniqueId MUST match the caller's
+ * `req.auth.uniqueId`. Defends against a malicious client trying to
+ * trigger an unlock check on another user's behalf (would be moot
+ * since rules deny direct writes anyway, but gate at the route layer
+ * for defence in depth).
+ */
+
+const express = require('express');
+const router = express.Router();
+
+const { db } = require('../utils/firebase');
+const { now } = require('../utils/helpers');
+const log = require('../utils/log');
+
+/** UTC midnight (start-of-day) for the timestamp `ms`. */
+function utcDayStart(ms) {
+  const d = new Date(ms);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}
+
+function isAtLeast18FromDob(dobMs, nowMs) {
+  if (typeof dobMs !== 'number' || !Number.isFinite(dobMs)) return false;
+  const today = new Date(nowMs);
+  const dob = new Date(dobMs);
+  let age = today.getUTCFullYear() - dob.getUTCFullYear();
+  if (
+    today.getUTCMonth() < dob.getUTCMonth() ||
+    (today.getUTCMonth() === dob.getUTCMonth() && today.getUTCDate() < dob.getUTCDate())
+  ) {
+    age -= 1;
+  }
+  return age >= 18;
+}
+
+router.post('/users/:uniqueId/pm-lock-check', async (req, res) => {
+  const pathUniqueId = parseInt(req.params.uniqueId, 10);
+  if (!Number.isFinite(pathUniqueId) || pathUniqueId !== req.auth?.uniqueId) {
+    return res.status(403).json({ error: 'You can only check your own pm-lock state' });
+  }
+
+  try {
+    const nowMs = now();
+    const todayStart = utcDayStart(nowMs);
+    let result = { pmLocked: false, unlocked: false };
+
+    await db.runTransaction(async (tx) => {
+      const userRef = db.doc(`users/${pathUniqueId}`);
+      const snap = await tx.get(userRef);
+      if (!snap.exists) {
+        result = { __notFound: true };
+        return;
+      }
+      const data = snap.data();
+      const currentlyLocked = data.pmLocked === true;
+      const last = typeof data.lastPmLockCheck === 'number' ? data.lastPmLockCheck : null;
+      const lastDay = last !== null ? utcDayStart(last) : null;
+
+      // Already-unlocked user: no-op. Don't bump throttle (no need —
+      // next read won't change outcome unless the user gets re-locked
+      // by an admin, in which case the lock side sets the stamp).
+      if (!currentlyLocked) {
+        result = { pmLocked: false, unlocked: false };
+        return;
+      }
+
+      // Already checked today: idempotent skip.
+      if (lastDay === todayStart) {
+        result = { pmLocked: true, unlocked: false, alreadyCheckedToday: true };
+        return;
+      }
+
+      // First check of the day for a locked user. Decide.
+      const eligible = isAtLeast18FromDob(data.dateOfBirth, nowMs);
+      if (eligible) {
+        tx.update(userRef, { pmLocked: false, lastPmLockCheck: nowMs });
+        result = { pmLocked: false, unlocked: true };
+      } else {
+        // Still <18, just bump throttle so we don't re-scan today
+        tx.update(userRef, { lastPmLockCheck: nowMs });
+        result = { pmLocked: true, unlocked: false };
+      }
+    });
+
+    if (result.__notFound) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    return res.json(result);
+  } catch (err) {
+    // Include err.code + err.stack so Sentry/dashboards can triage by
+    // failure class — Firestore SDK errors carry codes like ABORTED
+    // (transaction-retry exhaustion), FAILED_PRECONDITION,
+    // UNAUTHENTICATED. Without them every failure looks identical.
+    log.error('pm-lock-check', 'failed', {
+      uid: req.auth?.uniqueId,
+      error: err?.message,
+      code: err?.code,
+      stack: err?.stack,
+    });
+    return res.status(500).json({ error: 'pm-lock-check failed', errorId: 'PM_LOCK_CHECK' });
+  }
+});
+
+module.exports = router;

--- a/express-api/tests/routes/admin-age-verification.test.js
+++ b/express-api/tests/routes/admin-age-verification.test.js
@@ -402,6 +402,9 @@ describe('POST /api/admin/age-verification/:id/modify-dob', () => {
         ageVerified: true,
         ageVerifiedAt: 1709913600000,
         ageVerificationMethod: 'passport',
+        // PR 11: ≥18 ⇒ unlock. Defends against the modify-DOB path
+        // leaving a now-aged-up user permanently locked.
+        pmLocked: false,
       }),
     );
     expect(mockDeleteObject).toHaveBeenCalled();
@@ -437,6 +440,10 @@ describe('POST /api/admin/age-verification/:id/modify-dob', () => {
         ageVerified: false,
         ageVerifiedAt: null,
         ageVerificationMethod: null,
+        // PR 11: <18 ⇒ lock. The modify-DOB path is the primary
+        // entry point for retroactively age-gating a user whose ID
+        // contradicted their self-reported DOB.
+        pmLocked: true,
       }),
     );
   });

--- a/express-api/tests/routes/pm-lock-check.test.js
+++ b/express-api/tests/routes/pm-lock-check.test.js
@@ -1,0 +1,186 @@
+/**
+ * Tests for the PM-lock first-of-day auto-unlock endpoint.
+ *
+ *   POST /api/users/:uniqueId/pm-lock-check
+ *
+ * Called by the client AFTER successful sign-in. Server-side because
+ * Firestore rules deny client writes to `pmLocked` / `lastPmLockCheck`
+ * (PR 11 spec — those are server-only). The endpoint reads the user
+ * doc, decides whether the lock should lift (user has aged in to 18+
+ * since the lock was applied), and writes the unlock atomically.
+ *
+ * Throttling: skips the calendar age recompute when
+ * `lastPmLockCheck` is in the same UTC day as `now()`. Saves the
+ * Firestore quota on active users without taking a daily-cron hit
+ * for dormant accounts (per the user's "minimize Firestore ops" rule
+ * and the 2026-05-04 spec answer #4).
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// ─── Firebase mock ─────────────────────────────────────────────────
+
+const mockTxGet = jest.fn();
+const mockTxUpdate = jest.fn();
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    doc: jest.fn((path) => ({ _path: path })),
+    runTransaction: jest.fn(async (fn) => {
+      return fn({
+        get: (ref) => mockTxGet(ref?._path),
+        update: (ref, payload) => mockTxUpdate(ref?._path, payload),
+      });
+    }),
+  },
+}));
+
+jest.mock('../../src/utils/helpers', () => ({
+  // Pinned to a fixed timestamp so the day-bucket calculation is
+  // deterministic across runs. 2026-05-04T12:00:00Z = 1777896000000.
+  now: () => 1777896000000,
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const pmLockRouter = require('../../src/routes/pm-lock-check');
+
+function createApp({ uniqueId = 10000050 } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.auth = { uid: 'fb-uid', uniqueId, token: {} };
+    next();
+  });
+  app.use('/api', pmLockRouter);
+  return app;
+}
+
+const TODAY_UTC_START = Date.UTC(2026, 4, 4); // 2026-05-04 00:00:00 UTC
+const YESTERDAY_UTC_START = TODAY_UTC_START - 86_400_000;
+
+function dobYearsAgo(years) {
+  const d = new Date('2026-05-04T00:00:00Z');
+  d.setUTCFullYear(d.getUTCFullYear() - years);
+  return d.getTime();
+}
+
+// ── Happy path: aged-in user gets unlocked ──────────────────────
+
+describe('POST /api/users/:uniqueId/pm-lock-check', () => {
+  test('unlocks pmLocked=true user who is now 18+ and has not been checked today', async () => {
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        dateOfBirth: dobYearsAgo(18), // just turned 18
+        pmLocked: true,
+        lastPmLockCheck: YESTERDAY_UTC_START,
+      }),
+    });
+
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+
+    expect(res.body).toMatchObject({ pmLocked: false, unlocked: true });
+    expect(mockTxUpdate).toHaveBeenCalledWith(
+      'users/10000050',
+      expect.objectContaining({ pmLocked: false, lastPmLockCheck: 1777896000000 }),
+    );
+  });
+
+  test('keeps lock for sub-18 user but updates lastPmLockCheck (throttle)', async () => {
+    // 16-y/o user: still locked but the day-bucket bump means we don't
+    // re-scan again until tomorrow. Pin the no-unlock + throttle bump.
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        dateOfBirth: dobYearsAgo(16),
+        pmLocked: true,
+        lastPmLockCheck: YESTERDAY_UTC_START,
+      }),
+    });
+
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+
+    expect(res.body).toMatchObject({ pmLocked: true, unlocked: false });
+    // The doc is still updated — but only the throttle stamp, not the lock state
+    expect(mockTxUpdate).toHaveBeenCalledWith(
+      'users/10000050',
+      expect.objectContaining({ lastPmLockCheck: 1777896000000 }),
+    );
+    // Verify pmLocked was NOT downgraded
+    const updateArgs = mockTxUpdate.mock.calls[0][1];
+    expect(updateArgs.pmLocked).not.toBe(false);
+  });
+
+  test('skips Firestore write when already checked today (idempotent + cheap)', async () => {
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        dateOfBirth: dobYearsAgo(20),
+        pmLocked: true,
+        lastPmLockCheck: TODAY_UTC_START + 100, // earlier today
+      }),
+    });
+
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+
+    expect(res.body).toMatchObject({ pmLocked: true, unlocked: false, alreadyCheckedToday: true });
+    expect(mockTxUpdate).not.toHaveBeenCalled();
+  });
+
+  test('no-op for users who are not pmLocked (most common case)', async () => {
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        dateOfBirth: dobYearsAgo(25),
+        pmLocked: false,
+        lastPmLockCheck: null,
+      }),
+    });
+
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+
+    expect(res.body).toMatchObject({ pmLocked: false, unlocked: false });
+    // No Firestore write at all — already-unlocked users don't need
+    // their throttle stamp bumped because the next read won't change
+    // outcome. (Would change if we ever needed to re-lock; not today.)
+    expect(mockTxUpdate).not.toHaveBeenCalled();
+  });
+
+  test('rejects request from a different user (uniqueId mismatch)', async () => {
+    // /api/users/10000050/pm-lock-check called by user 10000099 →
+    // 403. Defends against a malicious client unlocking another
+    // user's PMs (would be moot since rules deny client writes
+    // anyway, but gate at the route layer too — defence in depth).
+    const app = createApp({ uniqueId: 10000099 });
+    await request(app).post('/api/users/10000050/pm-lock-check').expect(403);
+    expect(mockTxUpdate).not.toHaveBeenCalled();
+  });
+
+  test('returns 404 for missing user doc', async () => {
+    mockTxGet.mockResolvedValue({ exists: false });
+    const app = createApp();
+    await request(app).post('/api/users/10000050/pm-lock-check').expect(404);
+    expect(mockTxUpdate).not.toHaveBeenCalled();
+  });
+
+  test('null DOB → no unlock, throttle bumped', async () => {
+    // Null DOB users are routed to RequiredDOBScreen / blocked at
+    // sign-in (PR 5b). If somehow they reach this endpoint, just
+    // bump the throttle stamp and don't touch lock state.
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ dateOfBirth: null, pmLocked: true, lastPmLockCheck: null }),
+    });
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+    expect(res.body).toMatchObject({ pmLocked: true, unlocked: false });
+  });
+});

--- a/express-api/tests/scripts/migrate-pm-lock.test.js
+++ b/express-api/tests/scripts/migrate-pm-lock.test.js
@@ -1,0 +1,164 @@
+/**
+ * Tests for the one-shot PM-lock migration (`scripts/migrate-pm-lock.js`).
+ *
+ * Coverage focuses on the pure logic that decides which user docs are
+ * candidates for locking — the read-side of the migration. The actual
+ * batch-write path is exercised separately by integration tests
+ * because it touches firestore.batch() directly.
+ */
+
+const mockGet = jest.fn();
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    collection: jest.fn(() => ({ get: mockGet })),
+    batch: jest.fn(),
+    doc: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+}));
+
+const { isCurrentlyUnder18, scanCandidates } = require('../../scripts/migrate-pm-lock');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('isCurrentlyUnder18', () => {
+  // The ms-per-year shorthand drifts by ~6 hours per leap cycle. The
+  // function must use calendar arithmetic, not a fixed-ms multiplier.
+  // These tests pin both that it returns the right answer AND that
+  // it agrees with the route handler's `isAtLeast18FromDob` (parity).
+
+  test('returns false for null / non-numeric / NaN DOB', () => {
+    expect(isCurrentlyUnder18(null)).toBe(false);
+    expect(isCurrentlyUnder18(undefined)).toBe(false);
+    expect(isCurrentlyUnder18('not-a-number')).toBe(false);
+    expect(isCurrentlyUnder18(NaN)).toBe(false);
+    expect(isCurrentlyUnder18(Infinity)).toBe(false);
+  });
+
+  test('returns true for a clearly-under-18 DOB (10 years ago)', () => {
+    const tenYearsAgo = new Date();
+    tenYearsAgo.setUTCFullYear(tenYearsAgo.getUTCFullYear() - 10);
+    expect(isCurrentlyUnder18(tenYearsAgo.getTime())).toBe(true);
+  });
+
+  test('returns false for a clearly-18+ DOB (30 years ago)', () => {
+    const thirtyYearsAgo = new Date();
+    thirtyYearsAgo.setUTCFullYear(thirtyYearsAgo.getUTCFullYear() - 30);
+    expect(isCurrentlyUnder18(thirtyYearsAgo.getTime())).toBe(false);
+  });
+
+  test('returns true for a 17-y/o DOB whose 18th birthday is tomorrow', () => {
+    // DOB = today + 1 day, 18 years ago. Calendar comparison says
+    // age = 17 (still under by one day).
+    const dob = new Date();
+    dob.setUTCFullYear(dob.getUTCFullYear() - 18);
+    dob.setUTCDate(dob.getUTCDate() + 1);
+    expect(isCurrentlyUnder18(dob.getTime())).toBe(true);
+  });
+
+  test('returns false for a DOB whose 18th birthday was yesterday', () => {
+    // DOB = today - 1 day, 18 years ago. Calendar comparison says
+    // age = 18 (just turned).
+    const dob = new Date();
+    dob.setUTCFullYear(dob.getUTCFullYear() - 18);
+    dob.setUTCDate(dob.getUTCDate() - 1);
+    expect(isCurrentlyUnder18(dob.getTime())).toBe(false);
+  });
+});
+
+describe('scanCandidates', () => {
+  function dobYearsAgo(years) {
+    const d = new Date();
+    d.setUTCFullYear(d.getUTCFullYear() - years);
+    return d.getTime();
+  }
+
+  function mockUserDocs(users) {
+    mockGet.mockResolvedValue({
+      docs: users.map((u) => ({
+        id: u.id,
+        data: () => u.data,
+      })),
+    });
+  }
+
+  test('includes sub-18 users with valid DOB and no existing pmLocked', async () => {
+    mockUserDocs([
+      { id: '10000001', data: { dateOfBirth: dobYearsAgo(15), pmLocked: false } },
+      { id: '10000002', data: { dateOfBirth: dobYearsAgo(13), pmLocked: false } },
+    ]);
+
+    const candidates = await scanCandidates();
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates.map((c) => c.id).sort()).toEqual(['10000001', '10000002']);
+  });
+
+  test('skips users already pmLocked (idempotency)', async () => {
+    mockUserDocs([
+      { id: '10000001', data: { dateOfBirth: dobYearsAgo(15), pmLocked: true } },
+      { id: '10000002', data: { dateOfBirth: dobYearsAgo(13), pmLocked: false } },
+    ]);
+
+    const candidates = await scanCandidates();
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].id).toBe('10000002');
+  });
+
+  test('skips 18+ users (not affected by the migration)', async () => {
+    mockUserDocs([
+      { id: '10000001', data: { dateOfBirth: dobYearsAgo(25), pmLocked: false } },
+      { id: '10000002', data: { dateOfBirth: dobYearsAgo(40), pmLocked: false } },
+      { id: '10000003', data: { dateOfBirth: dobYearsAgo(15), pmLocked: false } },
+    ]);
+
+    const candidates = await scanCandidates();
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].id).toBe('10000003');
+  });
+
+  test('skips users with null / missing DOB (handled by other paths)', async () => {
+    mockUserDocs([
+      { id: '10000001', data: { dateOfBirth: null, pmLocked: false } },
+      { id: '10000002', data: { pmLocked: false } }, // missing DOB field entirely
+      { id: '10000003', data: { dateOfBirth: dobYearsAgo(15), pmLocked: false } },
+    ]);
+
+    const candidates = await scanCandidates();
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].id).toBe('10000003');
+  });
+
+  test('captures the pre-migration snapshot for revert visibility', async () => {
+    // The snapshot writer relies on this — each candidate carries the
+    // raw doc data so the JSON dumped to disk can show what the previous
+    // pmLocked / lastPmLockCheck values were before the script ran.
+    mockUserDocs([
+      {
+        id: '10000001',
+        data: { dateOfBirth: dobYearsAgo(15), pmLocked: false, lastPmLockCheck: 12345 },
+      },
+    ]);
+
+    const candidates = await scanCandidates();
+
+    expect(candidates[0]).toMatchObject({
+      id: '10000001',
+      dob: expect.any(Number),
+      snapshot: expect.objectContaining({
+        pmLocked: false,
+        lastPmLockCheck: 12345,
+      }),
+    });
+  });
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -44,7 +44,14 @@ service cloud.firestore {
                      // (e.g. `gcsScore` / `gcs_score`) so a future
                      // legacy-compat fallback can't open the gate.
                      'ageVerified', 'ageVerifiedAt', 'ageVerificationMethod',
-                     'age_verified', 'age_verified_at', 'age_verification_method']);
+                     'age_verified', 'age_verified_at', 'age_verification_method',
+                     // PM-lock state (PR 11). Sub-18 users have these
+                     // set by the migration / modify-DOB handler / cron;
+                     // a client write to either bypasses the lock and
+                     // re-grants PM access. Both camelCase and
+                     // snake_case for the dual-read defence.
+                     'pmLocked', 'lastPmLockCheck',
+                     'pm_locked', 'last_pm_lock_check']);
 
       // Backpack — read own, write only via API
       match /backpack/{giftId} {

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">جميع المشرفين &amp; المراقبين</string>
     <string name="attach_evidence">إرفاق دليل</string>
     <string name="cant_message_user">لا يمكنك مراسلة هذا المستخدم</string>
+    <string name="pm_locked_other_user_notice">لا يمكنك مراسلة هذا الشخص لأننا نعتقد أنه دون سن 18 عامًا.</string>
     <string name="chat">محادثة</string>
     <string name="close_group">إغلاق المجموعة</string>
     <string name="close_group_warning">سيؤدي هذا إلى إغلاق المجموعة للجميع. يتم الاحتفاظ بالرسائل للإشراف.</string>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Alle Admins &amp; Mods</string>
     <string name="attach_evidence">Beweis anhängen</string>
     <string name="cant_message_user">Du kannst diesem Benutzer keine Nachricht senden</string>
+    <string name="pm_locked_other_user_notice">Sie können diese Person nicht anschreiben, da wir glauben, dass sie unter 18 Jahre alt ist.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Gruppe schließen</string>
     <string name="close_group_warning">Dies schließt die Gruppe für alle. Nachrichten bleiben zur Moderation erhalten.</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Todos los admins &amp; mods</string>
     <string name="attach_evidence">Adjuntar evidencia</string>
     <string name="cant_message_user">No puedes enviar mensajes a este usuario</string>
+    <string name="pm_locked_other_user_notice">No puedes enviar mensajes a esta persona porque creemos que es menor de 18 años.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Cerrar grupo</string>
     <string name="close_group_warning">Esto cerrar&#225; el grupo para todos. Los mensajes se conservan para moderaci&#243;n.</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Tous les admins &amp; mods</string>
     <string name="attach_evidence">Joindre une preuve</string>
     <string name="cant_message_user">Vous ne pouvez pas envoyer de message &#224; cet utilisateur</string>
+    <string name="pm_locked_other_user_notice">Vous ne pouvez pas envoyer de message à cette personne car nous pensons qu\'elle a moins de 18 ans.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Fermer le groupe</string>
     <string name="close_group_warning">Cela fermera le groupe pour tout le monde. Les messages sont conserv&#233;s pour la mod&#233;ration.</string>

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">सभी एडमिन &amp; मॉड</string>
     <string name="attach_evidence">सबूत संलग्न करें</string>
     <string name="cant_message_user">आप इस उपयोगकर्ता को संदेश नहीं भेज सकते</string>
+    <string name="pm_locked_other_user_notice">आप इस व्यक्ति को संदेश नहीं भेज सकते क्योंकि हमें लगता है कि वे 18 वर्ष से कम के हैं।</string>
     <string name="chat">चैट</string>
     <string name="close_group">ग्रुप बंद करें</string>
     <string name="close_group_warning">यह सभी के लिए ग्रुप बंद कर देगा। संदेश मॉडरेशन के लिए सुरक्षित रहेंगे।</string>

--- a/shared/src/commonMain/composeResources/values-id/strings.xml
+++ b/shared/src/commonMain/composeResources/values-id/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Semua admin &amp; mod</string>
     <string name="attach_evidence">Lampirkan Bukti</string>
     <string name="cant_message_user">Kamu tidak bisa mengirim pesan ke pengguna ini</string>
+    <string name="pm_locked_other_user_notice">Anda tidak dapat mengirim pesan ke orang ini karena kami yakin mereka di bawah 18 tahun.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Tutup Grup</string>
     <string name="close_group_warning">Ini akan menutup grup untuk semua orang. Pesan akan disimpan untuk moderasi.</string>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Tutti gli admin &amp; mod</string>
     <string name="attach_evidence">Allega prova</string>
     <string name="cant_message_user">Non puoi inviare messaggi a questo utente</string>
+    <string name="pm_locked_other_user_notice">Non puoi inviare messaggi a questa persona perché crediamo abbia meno di 18 anni.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Chiudi gruppo</string>
     <string name="close_group_warning">Questo chiuderà il gruppo per tutti. I messaggi vengono conservati per la moderazione.</string>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">すべての管理者 &amp; モデレーター</string>
     <string name="attach_evidence">証拠を添付</string>
     <string name="cant_message_user">このユーザーにメッセージを送れません</string>
+    <string name="pm_locked_other_user_notice">この人物は18歳未満と判断されているため、メッセージを送ることができません。</string>
     <string name="chat">チャット</string>
     <string name="close_group">グループを閉じる</string>
     <string name="close_group_warning">グループが全員に対して閉じられます。メッセージはモデレーションのために保持されます。</string>

--- a/shared/src/commonMain/composeResources/values-km/strings.xml
+++ b/shared/src/commonMain/composeResources/values-km/strings.xml
@@ -260,6 +260,7 @@
     <string name="all_admins_and_mods">អ្នកគ្រប់គ្រង &amp; ម៉ូដ</string>
     <string name="attach_evidence">ភ្ជាប់ភស្តុតាង</string>
     <string name="cant_message_user">អ្នកមិនអាចផ្ញើសារទៅអ្នកប្រើនេះ</string>
+    <string name="pm_locked_other_user_notice">អ្នកមិនអាចផ្ញើសារទៅកាន់មនុស្សនេះបានទេ ព្រោះយើងគិតថាគាត់មានអាយុក្រោម 18 ឆ្នាំ។</string>
     <string name="chat">ជំនួញ</string>
     <string name="close_group">បិទក្រុម</string>
     <string name="close_group_warning">នេះនឹងបិទក្រុមសម្រាប់អ្នកទាំងអស់។</string>

--- a/shared/src/commonMain/composeResources/values-ko/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ko/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">모든 관리자 &amp; 운영자</string>
     <string name="attach_evidence">증거 첨부</string>
     <string name="cant_message_user">이 사용자에게 메시지를 보낼 수 없습니다</string>
+    <string name="pm_locked_other_user_notice">이 사용자는 18세 미만인 것으로 판단되어 메시지를 보낼 수 없습니다.</string>
     <string name="chat">채팅</string>
     <string name="close_group">그룹 닫기</string>
     <string name="close_group_warning">모든 사람의 그룹이 닫힙니다. 메시지는 관리 목적으로 보존됩니다.</string>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Alle beheerders &amp; moderators</string>
     <string name="attach_evidence">Bewijs bijvoegen</string>
     <string name="cant_message_user">Je kunt deze gebruiker geen bericht sturen</string>
+    <string name="pm_locked_other_user_notice">Je kunt deze persoon geen bericht sturen omdat wij denken dat zij jonger zijn dan 18.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Groep sluiten</string>
     <string name="close_group_warning">Dit sluit de groep voor iedereen. Berichten worden bewaard voor moderatie.</string>

--- a/shared/src/commonMain/composeResources/values-pl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pl/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Wszyscy admini &amp; moderatorzy</string>
     <string name="attach_evidence">Dołącz dowody</string>
     <string name="cant_message_user">Nie możesz napisać do tego użytkownika</string>
+    <string name="pm_locked_other_user_notice">Nie możesz wysłać wiadomości do tej osoby, ponieważ uważamy, że ma mniej niż 18 lat.</string>
     <string name="chat">Czat</string>
     <string name="close_group">Zamknij grupę</string>
     <string name="close_group_warning">To zamknie grupę dla wszystkich. Wiadomości zostaną zachowane na potrzeby moderacji.</string>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Todos os admins &amp; mods</string>
     <string name="attach_evidence">Anexar evidência</string>
     <string name="cant_message_user">Você não pode enviar mensagem para este usuário</string>
+    <string name="pm_locked_other_user_notice">Você não pode enviar mensagens para esta pessoa porque acreditamos que ela tenha menos de 18 anos.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Fechar grupo</string>
     <string name="close_group_warning">Isso fechará o grupo para todos. As mensagens serão preservadas para moderação.</string>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Все админы &amp; модераторы</string>
     <string name="attach_evidence">Прикрепить доказательство</string>
     <string name="cant_message_user">Вы не можете написать этому пользователю</string>
+    <string name="pm_locked_other_user_notice">Вы не можете отправить сообщение этому пользователю, потому что мы считаем, что ему меньше 18 лет.</string>
     <string name="chat">Чат</string>
     <string name="close_group">Закрыть группу</string>
     <string name="close_group_warning">Это закроет группу для всех. Сообщения сохраняются для модерации.</string>

--- a/shared/src/commonMain/composeResources/values-sv/strings.xml
+++ b/shared/src/commonMain/composeResources/values-sv/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Alla admins &amp; mods</string>
     <string name="attach_evidence">Bifoga bevis</string>
     <string name="cant_message_user">Du kan inte skicka meddelande till denna användare</string>
+    <string name="pm_locked_other_user_notice">Du kan inte skicka meddelanden till den här personen eftersom vi tror att de är under 18 år.</string>
     <string name="chat">Chatt</string>
     <string name="close_group">Stäng grupp</string>
     <string name="close_group_warning">Detta stänger gruppen för alla. Meddelanden bevaras för moderering.</string>

--- a/shared/src/commonMain/composeResources/values-th/strings.xml
+++ b/shared/src/commonMain/composeResources/values-th/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">แอดมิน &amp; ผู้ดูแลทั้งหมด</string>
     <string name="attach_evidence">แนบหลักฐาน</string>
     <string name="cant_message_user">คุณไม่สามารถส่งข้อความถึงผู้ใช้นี้ได้</string>
+    <string name="pm_locked_other_user_notice">คุณไม่สามารถส่งข้อความถึงบุคคลนี้ได้ เพราะเราเชื่อว่าพวกเขาอายุต่ำกว่า 18 ปี</string>
     <string name="chat">แชท</string>
     <string name="close_group">ปิดกลุ่ม</string>
     <string name="close_group_warning">การกระทำนี้จะปิดกลุ่มสำหรับทุกคน ข้อความจะถูกเก็บไว้สำหรับการตรวจสอบ</string>

--- a/shared/src/commonMain/composeResources/values-tr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tr/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Tüm yöneticiler &amp; moderatörler</string>
     <string name="attach_evidence">Kanıt Ekle</string>
     <string name="cant_message_user">Bu kullanıcıya mesaj gönderemezsiniz</string>
+    <string name="pm_locked_other_user_notice">Bu kişiyi 18 yaşından küçük olduğuna inandığımız için mesaj gönderemezsiniz.</string>
     <string name="chat">Sohbet</string>
     <string name="close_group">Grubu Kapat</string>
     <string name="close_group_warning">Bu, grubu herkes için kapatacaktır. Mesajlar moderasyon için korunur.</string>

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Усі адміни &amp; модератори</string>
     <string name="attach_evidence">Прикріпити доказ</string>
     <string name="cant_message_user">Ви не можете написати цьому користувачу</string>
+    <string name="pm_locked_other_user_notice">Ви не можете надіслати повідомлення цій особі, оскільки ми вважаємо, що їй менше 18 років.</string>
     <string name="chat">Чат</string>
     <string name="close_group">Закрити групу</string>
     <string name="close_group_warning">Це закриє групу для всіх. Повідомлення зберігаються для модерації.</string>

--- a/shared/src/commonMain/composeResources/values-vi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-vi/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Tất cả quản trị viên &amp; điều hành viên</string>
     <string name="attach_evidence">Đính kèm Bằng chứng</string>
     <string name="cant_message_user">Bạn không thể nhắn tin cho người dùng này</string>
+    <string name="pm_locked_other_user_notice">Bạn không thể nhắn tin cho người này vì chúng tôi tin rằng họ dưới 18 tuổi.</string>
     <string name="chat">Trò chuyện</string>
     <string name="close_group">Đóng Nhóm</string>
     <string name="close_group_warning">Điều này sẽ đóng nhóm cho tất cả mọi người. Tin nhắn được giữ lại để kiểm duyệt.</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">所有管理员 &amp; 版主</string>
     <string name="attach_evidence">附上证据</string>
     <string name="cant_message_user">无法向此用户发送消息</string>
+    <string name="pm_locked_other_user_notice">您无法向此人发送消息，因为我们认为他们未满18岁。</string>
     <string name="chat">聊天</string>
     <string name="close_group">关闭群组</string>
     <string name="close_group_warning">这将为所有人关闭群组。消息将保留以供审核。</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -259,6 +259,7 @@
     <string name="all_admins_and_mods">All admins &amp; mods</string>
     <string name="attach_evidence">Attach Evidence</string>
     <string name="cant_message_user">You can't message this user</string>
+    <string name="pm_locked_other_user_notice">You cannot message this person because we believe they are under 18.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Close Group</string>
     <string name="close_group_warning">This will close the group for everyone. Messages are preserved for moderation.</string>

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
@@ -83,6 +83,27 @@ data class User(
     val ageVerified: Boolean = false,
     val ageVerifiedAt: Long? = null,
     val ageVerificationMethod: String? = null,
+    /**
+     * PM-lock flag (PR 11). Set true for users currently below 18; the
+     * `conversations/{id}/messages/...` write+read paths gate on this.
+     * Sub-18 user view: their conversation list and thread contents
+     * are hidden. 18+ counter-party view: thread visible but input
+     * disabled with the "this user cannot receive messages" copy.
+     *
+     * Set by the migration script (PR 11) for legacy 13-17 accounts,
+     * by the modify-DOB handler when admin reverts a user to <18, and
+     * cleared automatically by the auth login first-of-day check when
+     * a previously-locked user has aged in.
+     */
+    val pmLocked: Boolean = false,
+    /**
+     * Day-of-year stamp (UTC ms at start of day) of the most recent
+     * first-login auto-unlock check. Used to throttle the aging-in
+     * scan to once per user per day — dormant accounts don't pay the
+     * Firestore-quota cost, and active users don't pay it on every
+     * launch.
+     */
+    val lastPmLockCheck: Long? = null,
 ) {
     val isActivelySuspended: Boolean
         get() {
@@ -184,6 +205,8 @@ data class User(
             "ageVerified" to ageVerified,
             "ageVerifiedAt" to ageVerifiedAt,
             "ageVerificationMethod" to ageVerificationMethod,
+            "pmLocked" to pmLocked,
+            "lastPmLockCheck" to lastPmLockCheck,
         )
 
     companion object {
@@ -297,6 +320,8 @@ data class User(
                 ageVerified = map["ageVerified"].asBool(),
                 ageVerifiedAt = map["ageVerifiedAt"]?.let { timestampToMillis(it) },
                 ageVerificationMethod = map["ageVerificationMethod"] as? String,
+                pmLocked = map["pmLocked"].asBool(),
+                lastPmLockCheck = map["lastPmLockCheck"]?.let { timestampToMillis(it) },
             )
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/UserRepository.kt
@@ -93,6 +93,22 @@ interface UserRepository {
 
     suspend fun liftExpiredSuspension(userId: String): Resource<Unit>
 
+    /**
+     * First-of-day PM-lock auto-unlock check (PR 11).
+     *
+     * Calls `POST /api/users/:uniqueId/pm-lock-check`. The server
+     * reads the user doc, decides whether the user has aged into 18+
+     * since the lock was set, and writes the unlock atomically.
+     * Server-side because Firestore rules deny client writes to
+     * `pmLocked` / `lastPmLockCheck`.
+     *
+     * Throttled inside the route to one Firestore op per UTC day per
+     * user — calling this every launch is safe but cheap. Failure is
+     * non-fatal: the next launch or a counterparty's gate will surface
+     * the current state.
+     */
+    suspend fun checkPmLockOnLogin(userId: String): Resource<Unit>
+
     suspend fun getAliases(userId: String): Resource<Map<String, String>>
 
     suspend fun setAlias(

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AuthViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AuthViewModel.kt
@@ -503,6 +503,23 @@ class AuthViewModel(
                             if (user.isSuspended) {
                                 userRepository.liftExpiredSuspension(userId)
                             }
+                            // Age-in auto-unlock check (PR 11). Once per
+                            // user per UTC day: the server-side endpoint
+                            // at `POST /api/users/:uniqueId/pm-lock-check`
+                            // reads the user doc, computes whether to
+                            // lift the lock, and writes if yes. Client
+                            // cannot write `pmLocked` (Firestore rules
+                            // deny it), so the auto-unlock has to go
+                            // through Express. Failure is non-fatal —
+                            // the next login or a counterparty's send
+                            // will surface the current state — but we
+                            // still log so a permanently-broken endpoint
+                            // is visible in Sentry rather than vanishing
+                            // into a silent fire-and-forget.
+                            when (val r = userRepository.checkPmLockOnLogin(userId)) {
+                                is Resource.Error -> logW(TAG, "PM-lock check failed (non-fatal): ${r.message}")
+                                else -> Unit
+                            }
                             var needsLegal = user.acceptedLegalVersion < CURRENT_LEGAL_VERSION
                             // If user already accepted locally (pre-sign-in screen),
                             // sync to Firestore and skip showing the legal screen again

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ConversationListViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ConversationListViewModel.kt
@@ -108,19 +108,40 @@ class ConversationListViewModel(
     }
 
     private suspend fun loadConversationDetails(conversations: List<Conversation>) {
-        // Get current user's blocked list
+        // Get current user's doc — needed for both blocked-list AND
+        // pmLocked checks. Failure is regulatory-boundary critical.
+        // We treat Resource.Error AND Resource.Loading identically as
+        // "could not verify" — Loading shouldn't be observable from a
+        // suspend `getUser`, but pinning it explicitly avoids future
+        // surprises if the repository is rewritten to streaming.
+        val userResult = userRepository.getUser(currentUserId)
         val currentUser =
-            when (val result = userRepository.getUser(currentUserId)) {
-                is Resource.Success -> result.data
-
-                is Resource.Error -> {
-                    logW(TAG, "Failed to fetch current user for blocklist: ${result.message}")
-                    null
-                }
-
-                else -> null
+            when (userResult) {
+                is Resource.Success -> userResult.data
+                is Resource.Error -> null
+                is Resource.Loading -> null
             }
-        val blockedByMe = currentUser?.blockedUserIds ?: emptySet()
+
+        // Fail-CLOSED if we can't verify pmLocked state (PR 11 / Apple
+        // guideline 1.1.4). A transient Firestore error must NOT leak
+        // PM threads to a possibly-locked account. Bumped from logW to
+        // logE because this is a regulatory boundary failure that
+        // ops/Sentry must surface, not a routine warning.
+        if (currentUser == null) {
+            logE(TAG, "PM-lock fail-closed: getUser failed for $currentUserId")
+            _uiState.update { it.copy(isLoading = false, conversations = emptyList(), totalUnreadCount = 0L) }
+            return
+        }
+
+        // Sub-18 (currentUser PM-locked): emit an empty list and skip
+        // counterparty fetches. PR 11 — minors cannot see PM threads
+        // at all; even surfacing a conversation summary would leak the
+        // counterparty's identity to a locked account.
+        if (currentUser.pmLocked) {
+            _uiState.update { it.copy(isLoading = false, conversations = emptyList(), totalUnreadCount = 0L) }
+            return
+        }
+        val blockedByMe = currentUser.blockedUserIds
 
         // Collect other user IDs we need to fetch (for 1-on-1 only)
         val otherUserIds = conversations.filter { !it.isGroup }.mapNotNull { it.otherUserId(currentUserId) }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatScreen.kt
@@ -813,8 +813,34 @@ fun PrivateChatScreen(
                 }
             }
 
-            // Input row (hidden for blocked users, system conversations, muted users, and permission-restricted)
-            if (!uiState.isBlocked && !uiState.isSystemConversation && uiState.currentUserMuteInfo == null && canSend) {
+            // PM-lock notice (PR 11) — counterparty is sub-18 / locked.
+            // Replaces the input row with a softer notice that keeps the
+            // history visible. Distinct from the hard `isBlocked` banner
+            // at the top because the user CAN still scroll their old
+            // messages, just can't send new ones.
+            if (uiState.otherUserPmLocked && !uiState.isBlocked && !uiState.isSystemConversation) {
+                Surface(
+                    modifier = Modifier.fillMaxWidth().testTag("privateChat_pmLockedNotice"),
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                ) {
+                    Text(
+                        text = stringResource(Res.string.pm_locked_other_user_notice),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    )
+                }
+            }
+
+            // Input row (hidden for blocked users, system conversations, muted users,
+            // permission-restricted, and counterparty PM-lock — see notice above)
+            val canRenderInput =
+                !uiState.isBlocked &&
+                    !uiState.isSystemConversation &&
+                    uiState.currentUserMuteInfo == null &&
+                    canSend &&
+                    !uiState.otherUserPmLocked
+            if (canRenderInput) {
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
                     tonalElevation = 3.dp,

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatViewModel.kt
@@ -60,6 +60,18 @@ data class PrivateChatUiState(
     val error: String? = null,
     val isBlocked: Boolean = false,
     val blockReason: String? = null,
+    /**
+     * The COUNTERPARTY is sub-18 and PM-locked (PR 11). Distinct from
+     * `isBlocked`: the input is disabled and a notice is shown, but
+     * the conversation history remains visible. This is the soft-
+     * disabled-input state for an 18+ viewer messaging a minor.
+     *
+     * Mirrors the user-doc `pmLocked` field at the moment the chat is
+     * opened. Not reactive to live counterparty state changes — that
+     * would be a future enhancement (server moderation lifting a lock
+     * mid-session is rare).
+     */
+    val otherUserPmLocked: Boolean = false,
     val isMuted: Boolean = false,
     val isPinned: Boolean = false,
     val conversationId: String = "",
@@ -205,6 +217,15 @@ class PrivateChatViewModel(
                     otherUser = otherUser,
                     currentUserName = currentUser?.displayName ?: "",
                     isSystemConversation = isSystem,
+                    // Counterparty PM-lock: 18+ viewer keeps conversation
+                    // history but the input row is disabled. (PR 11.)
+                    // Fail-closed: a null `otherUser` (failed fetch) is
+                    // treated as locked here too — defence-in-depth so
+                    // that even if `checkRestrictions` is bypassed the
+                    // soft-disabled-input state still kicks in. The
+                    // hard-block isBlocked path takes precedence in the
+                    // screen via `if (canRenderInput)`.
+                    otherUserPmLocked = otherUser == null || otherUser.pmLocked,
                 )
             }
 
@@ -304,8 +325,29 @@ class PrivateChatViewModel(
         currentUser: User?,
         otherUser: User?,
     ): String? {
-        if (currentUser == null || otherUser == null) return null
+        // Fail-CLOSED on either user-doc fetch failure (PR 11 / Apple
+        // guideline 1.1.4). The previous `return null` here let the
+        // input render with no restriction, which would let a sub-18
+        // user message via deep-link if their getUser hit a transient
+        // Firestore error. The blockReason here drives `isBlocked` in
+        // the caller, so a non-null return triggers the same hard-
+        // block UI as a real ban.
+        if (currentUser == null) {
+            logE(TAG, "PM-lock fail-closed: currentUser null in checkRestrictions")
+            return "Could not verify your account. Please try again."
+        }
+        if (otherUser == null) {
+            logE(TAG, "PM-lock fail-closed: otherUser null in checkRestrictions")
+            return "Could not load this conversation. Please try again."
+        }
 
+        // Sub-18 (currentUser PM-locked): hard-block all PM access.
+        // The conversation list filter normally hides these threads,
+        // but a deep-link / Saver restore could land here — second-line
+        // defence. (PR 11.)
+        if (currentUser.pmLocked) {
+            return "Private messages are not available for your account."
+        }
         // Check if blocked by target
         if (otherUser.blockedUserIds.contains(currentUserId)) {
             return "You are blocked by this user and cannot send messages."
@@ -381,6 +423,10 @@ class PrivateChatViewModel(
         if (trimmed.isEmpty() || trimmed.length > Constants.MAX_PM_MESSAGE_LENGTH) return
         val conversationId = _uiState.value.conversationId
         if (conversationId.isEmpty()) return
+        // Counterparty PM-lock backstop (PR 11). The screen disables
+        // the input when otherUserPmLocked is true, but a deep-link or
+        // automation could still call sendMessage. Refuse here.
+        if (_uiState.value.otherUserPmLocked) return
 
         // Moderation checks
         val moderationWarning = ModerationFilter.checkMessage(trimmed)

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/auth/AuthViewModelIdentityTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/auth/AuthViewModelIdentityTest.kt
@@ -272,6 +272,8 @@ class AuthViewModelIdentityTest {
 
         override suspend fun liftExpiredSuspension(userId: String) = Resource.Success(Unit)
 
+        override suspend fun checkPmLockOnLogin(userId: String) = Resource.Success(Unit)
+
         override suspend fun getAliases(userId: String) = Resource.Success(emptyMap<String, String>())
 
         override suspend fun setAlias(

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosUserRepositoryImpl.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosUserRepositoryImpl.kt
@@ -351,6 +351,11 @@ class IosUserRepositoryImpl(
             api.post("/api/users/$userId/lift-suspension")
         }
 
+    override suspend fun checkPmLockOnLogin(userId: String): Resource<Unit> =
+        firebaseCall("Failed to check PM lock state") {
+            api.post("/api/users/$userId/pm-lock-check")
+        }
+
     override suspend fun setAlias(
         userId: String,
         targetUserId: String,

--- a/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/model/UserTest.kt
+++ b/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/model/UserTest.kt
@@ -676,4 +676,57 @@ class UserTest {
             assertTrue(user.ageVerified)
         }
     }
+
+    // ── PM-lock fields (PR 11) ──────────────────────────────────────
+
+    @Test
+    fun `default pmLocked is false and lastPmLockCheck is null`() {
+        val user = User()
+        assertFalse(user.pmLocked)
+        assertNull(user.lastPmLockCheck)
+    }
+
+    @Test
+    fun `fromMap parses pmLocked + lastPmLockCheck`() {
+        val map =
+            mapOf<String, Any?>(
+                "pmLocked" to true,
+                "lastPmLockCheck" to 1709913600000L,
+            )
+        val user = User.fromMap(map, "u1")
+        assertTrue(user.pmLocked)
+        assertEquals(1709913600000L, user.lastPmLockCheck)
+    }
+
+    @Test
+    fun `fromMap defaults pmLocked false when absent`() {
+        // Existing user docs predate PR 11 and have neither field.
+        // Default fail-OPEN here — sub-18 users got their lock applied
+        // by the migration script; an unmigrated 18+ user should NOT
+        // be locked. The migration is idempotent so any subsequent
+        // run catches anyone the first run missed.
+        val user = User.fromMap(emptyMap(), "u1")
+        assertFalse(user.pmLocked)
+        assertNull(user.lastPmLockCheck)
+    }
+
+    @Test
+    fun `toMap round-trips pmLocked + lastPmLockCheck`() {
+        val user = User(pmLocked = true, lastPmLockCheck = 1709913600000L)
+        val map = user.toMap()
+        assertEquals(true, map["pmLocked"])
+        assertEquals(1709913600000L, map["lastPmLockCheck"])
+    }
+
+    @Test
+    fun `toMap includes default pmLocked false for new users`() {
+        // Pin that newly-created user docs write the explicit `pmLocked
+        // = false` field so an admin "find unlocked users" query on
+        // `where('pmLocked', '==', false)` catches them. Same defence
+        // as the ageVerified pattern.
+        val user = User()
+        val map = user.toMap()
+        assertEquals(false, map["pmLocked"])
+        assertNull(map["lastPmLockCheck"])
+    }
 }


### PR DESCRIPTION
## Summary
- Adds the PM-lock side of the age-verification multi-PR feature: server-side endpoint + client wiring so under-18 users cannot send/view PMs.
- Includes the one-shot Firestore migration to retroactively lock existing sub-18 accounts (idempotent, dry-run + apply gates).
- Hardens both ConversationListViewModel + PrivateChatViewModel to **fail closed** when the user-doc fetch errors — the previous fail-open path could leak PM access on a transient Firestore error (Apple guideline 1.1.4).

## What's in
**Server (Express)**
- `POST /api/users/:uniqueId/pm-lock-check` — first-of-day auto-unlock for users who have aged into 18+. Throttled to one Firestore op per UTC day per user. Mounted under `sensitiveLimiter`.
- `scripts/migrate-pm-lock.js` — one-shot lock migration. `--dry-run`, `--apply`, `MIGRATION_CONFIRM=yes` env-var gate, pre-flight JSON snapshot, per-batch try/catch with structured logging.
- `admin-age-verification.modify-DOB` now writes `pmLocked: !verifiedNow` so an admin DOB correction retroactively locks/unlocks PMs.
- `firestore.rules` — `pmLocked` + `lastPmLockCheck` added to the deny list (server-only fields, both camelCase and snake_case).

**Client (KMP)**
- `User` model gains `pmLocked` + `lastPmLockCheck`.
- `UserRepository.checkPmLockOnLogin` → POSTs the new endpoint at first-login `resolveProfileState`, logged on `Resource.Error`.
- `PrivateChatViewModel` exposes `otherUserPmLocked` (soft disabled-input notice for an 18+ viewer messaging a sub-18 counterparty) and hard-blocks via `isBlocked` when `currentUser.pmLocked`. `sendMessage` has a backstop guard.
- `ConversationListViewModel` emits an empty list for sub-18 users.
- `PrivateChatScreen` renders the PM-lock notice + hides input.
- New string `pm_locked_other_user_notice` translated into all 20 locales.

**Fail-closed regulatory boundary**
When `getUser` returns an error (network blip, transient permission glitch, etc.), the conversation list + chat screen now refuse access (with `logE`) instead of falling through with no restriction.

## Test plan
- [x] `npm test` (Express, 4573 tests across 192 suites)
- [x] `./gradlew :shared:jvmTest :app:testLocalDebugUnitTest detekt`
- [x] `./gradlew :shared:compileKotlinIosArm64`
- [x] `ktlint --relative`
- [x] code-reviewer + silent-failure-hunter agents (no remaining findings)

## Manual QA (post-merge)
- [ ] Local: seeded sub-18 user → conversation list empty
- [ ] Local: 18+ user opening chat with sub-18 counterparty → input row replaced by notice
- [ ] Local: aged-in user (DOB pinned to just-turned-18) signs in → next session shows PMs unlocked
- [ ] Migration dry-run vs apply on local emulators (snapshot file written)
- [ ] iOS simulator parity for the same scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)