### PR TITLE
feat(age-verif): PR 6 — admin Age Verification sub-tab in Users panel

### DIFF
--- a/express-api/src/routes/admin-age-verification.js
+++ b/express-api/src/routes/admin-age-verification.js
@@ -140,6 +140,46 @@ router.get('/admin/age-verification/pending', async (req, res) => {
   }
 });
 
+// ─── GET /:id/image-url ─────────────────────────────────────────────
+//
+// Returns a short-lived signed URL the admin browser can use to view
+// the submitted ID image directly from R2. Stored privately; no
+// long-lived URLs leave the API surface. 5-minute expiry mirrors the
+// upload PUT URL.
+//
+// Returns 404 if the submission's r2Key is null — that happens after
+// a decision commits (key is wiped post-decision; the image is also
+// deleted from R2 best-effort).
+
+router.get('/admin/age-verification/:id/image-url', async (req, res) => {
+  if (requireAdmin(req, res)) return;
+  const { id } = req.params;
+  try {
+    const subRef = db.doc(`ageVerificationSubmissions/${id}`);
+    const snap = await subRef.get();
+    if (!snap.exists) {
+      return res.status(404).json({ error: 'Submission not found' });
+    }
+    const data = snap.data();
+    if (!data.r2Key) {
+      // Post-decision: image has been deleted (best-effort) and key
+      // wiped from the doc. Admin can still read the audit log for
+      // compliance traceability.
+      return res.status(404).json({ error: 'Image already removed' });
+    }
+    const url = await r2.getSignedGetUrl(data.r2Key, 300);
+    return res.json({ url, expiresInSec: 300 });
+  } catch (err) {
+    log.error('admin-age-verification', 'image-url failed', {
+      submissionId: id,
+      error: err?.message,
+    });
+    return res
+      .status(500)
+      .json({ error: 'Failed to issue image URL', errorId: 'AGE_VERIF_IMAGE_URL' });
+  }
+});
+
 // ─── POST /:id/approve ──────────────────────────────────────────────
 
 router.post('/admin/age-verification/:id/approve', async (req, res) => {

--- a/express-api/src/routes/test-helpers.js
+++ b/express-api/src/routes/test-helpers.js
@@ -319,6 +319,7 @@ router.get('/test/verify/:collection/:id', async (req, res) => {
       'reports',
       'suspensionAppeals',
       'alerts',
+      'ageVerificationSubmissions',
     ];
     if (!ALLOWED_COLLECTIONS.includes(collection)) {
       return res.status(400).json({ error: 'Collection not allowed' });
@@ -399,6 +400,7 @@ router.post('/test/write/:collection', async (req, res) => {
       'suspensionAppeals',
       'alerts',
       'suggestions',
+      'ageVerificationSubmissions',
     ];
     if (!ALLOWED_COLLECTIONS.includes(collection)) {
       return res.status(400).json({ error: 'Collection not allowed' });

--- a/express-api/src/utils/r2.js
+++ b/express-api/src/utils/r2.js
@@ -143,6 +143,28 @@ async function listObjectsWithMetadata(prefix) {
  * intercepted. Hard-caps overrides at 1 hour — anything longer is a
  * code smell and the helper refuses.
  */
+/**
+ * Pre-sign a GET to a private R2 object (admin-only viewing).
+ *
+ * Used for age-verification ID image preview in the admin panel: the
+ * browser fetches the image directly from R2 with a short-lived URL
+ * rather than streaming through Express. Cuts server load and lets
+ * the browser cache normally.
+ *
+ * Default 5-minute expiry mirrors getSignedPutUrl. Hard-caps at 1h —
+ * anything longer is a code smell for ID-image preview.
+ */
+async function getSignedGetUrl(key, expiresInSec = 300) {
+  if (typeof key !== 'string' || key.length === 0) {
+    throw new Error('r2.getSignedGetUrl: key must be a non-empty string');
+  }
+  if (typeof expiresInSec !== 'number' || expiresInSec <= 0 || expiresInSec > 3600) {
+    throw new Error('r2.getSignedGetUrl: expiresInSec must be in (0, 3600]');
+  }
+  const command = new GetObjectCommand({ Bucket: bucketName, Key: key });
+  return getSignedUrl(s3, command, { expiresIn: expiresInSec });
+}
+
 async function getSignedPutUrl(key, contentType, expiresInSec = 300) {
   if (typeof key !== 'string' || key.length === 0) {
     throw new Error('r2.getSignedPutUrl: key must be a non-empty string');
@@ -171,5 +193,6 @@ module.exports = {
   listObjects,
   listObjectsWithMetadata,
   getSignedPutUrl,
+  getSignedGetUrl,
   CDN_URL,
 };

--- a/express-api/tests/routes/admin-age-verification.test.js
+++ b/express-api/tests/routes/admin-age-verification.test.js
@@ -60,8 +60,10 @@ jest.mock('../../src/utils/firebase', () => ({
 }));
 
 const mockDeleteObject = jest.fn().mockResolvedValue();
+const mockGetSignedGetUrl = jest.fn();
 jest.mock('../../src/utils/r2', () => ({
   deleteObject: (...args) => mockDeleteObject(...args),
+  getSignedGetUrl: (...args) => mockGetSignedGetUrl(...args),
 }));
 
 const mockLogApproved = jest.fn().mockResolvedValue();
@@ -149,6 +151,53 @@ describe('GET /api/admin/age-verification/pending', () => {
     const app = createApp({ admin: false });
     await request(app).get('/api/admin/age-verification/pending').expect(403);
     expect(mockCollectionGet).not.toHaveBeenCalled();
+  });
+});
+
+// ─── GET /:id/image-url ─────────────────────────────────────────────
+
+describe('GET /api/admin/age-verification/:id/image-url', () => {
+  test('returns short-lived signed URL for admin', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => pendingSubmissionDoc(),
+    });
+    mockGetSignedGetUrl.mockResolvedValue('https://r2.example/age-verification/abc.jpg?sig=xyz');
+
+    const app = createApp();
+    const res = await request(app).get('/api/admin/age-verification/sub-1/image-url').expect(200);
+
+    expect(res.body).toEqual({
+      url: 'https://r2.example/age-verification/abc.jpg?sig=xyz',
+      expiresInSec: 300,
+    });
+    expect(mockGetSignedGetUrl).toHaveBeenCalledWith('age-verification/10000050/abc.jpg', 300);
+  });
+
+  test('rejects non-admin with 403', async () => {
+    const app = createApp({ admin: false });
+    await request(app).get('/api/admin/age-verification/sub-1/image-url').expect(403);
+    expect(mockGetSignedGetUrl).not.toHaveBeenCalled();
+  });
+
+  test('returns 404 when submission does not exist', async () => {
+    mockDocGet.mockResolvedValue({ exists: false });
+    const app = createApp();
+    await request(app).get('/api/admin/age-verification/missing/image-url').expect(404);
+    expect(mockGetSignedGetUrl).not.toHaveBeenCalled();
+  });
+
+  test('returns 404 when r2Key has been wiped (post-decision state)', async () => {
+    // After a decision commits, r2Key is set to null in the same
+    // transaction. Admin requesting the image after that point gets
+    // a clean 404 rather than a confusing signed URL to a deleted obj.
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => pendingSubmissionDoc({ status: 'approved', r2Key: null }),
+    });
+    const app = createApp();
+    await request(app).get('/api/admin/age-verification/sub-1/image-url').expect(404);
+    expect(mockGetSignedGetUrl).not.toHaveBeenCalled();
   });
 });
 

--- a/express-api/tests/utils/r2-signed-get.test.js
+++ b/express-api/tests/utils/r2-signed-get.test.js
@@ -1,0 +1,82 @@
+/**
+ * Tests for the R2 signed-GET URL helper. Used by the admin
+ * age-verification image-url endpoint so the admin browser can preview
+ * the submitted ID directly from R2 without streaming through Express.
+ *
+ * Mirrors `r2-signed-put.test.js` — same presigner mock, same shape.
+ */
+
+const mockGetSignedUrl = jest.fn();
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: (...args) => mockGetSignedUrl(...args),
+}));
+
+const mockS3Send = jest.fn();
+jest.mock('@aws-sdk/client-s3', () => {
+  const original = jest.requireActual('@aws-sdk/client-s3');
+  return {
+    ...original,
+    S3Client: jest.fn().mockImplementation(() => ({
+      send: mockS3Send,
+    })),
+  };
+});
+
+const { getSignedGetUrl, bucketName } = require('../../src/utils/r2');
+
+beforeEach(() => {
+  mockGetSignedUrl.mockClear();
+  mockGetSignedUrl.mockResolvedValue('https://r2-signed-get/abc?expires=5m');
+});
+
+describe('getSignedGetUrl', () => {
+  test('returns the signed URL string from the presigner', async () => {
+    const url = await getSignedGetUrl('age-verification/u1/abc.jpg');
+    expect(url).toBe('https://r2-signed-get/abc?expires=5m');
+  });
+
+  test('passes bucket + key to GetObjectCommand', async () => {
+    await getSignedGetUrl('age-verification/u1/abc.jpg');
+
+    expect(mockGetSignedUrl).toHaveBeenCalledTimes(1);
+    const [, command] = mockGetSignedUrl.mock.calls[0];
+    expect(command.input).toMatchObject({
+      Bucket: bucketName,
+      Key: 'age-verification/u1/abc.jpg',
+    });
+  });
+
+  test('default expiry is 5 minutes', async () => {
+    await getSignedGetUrl('age-verification/u1/abc.jpg');
+    const [, , options] = mockGetSignedUrl.mock.calls[0];
+    expect(options).toEqual({ expiresIn: 300 });
+  });
+
+  test('caller can override expiry but not exceed 1 hour (defense-in-depth)', async () => {
+    await getSignedGetUrl('age-verification/u1/abc.jpg', 600);
+    const [, , options] = mockGetSignedUrl.mock.calls[0];
+    expect(options).toEqual({ expiresIn: 600 });
+  });
+
+  test('rejects expiry > 1 hour', async () => {
+    await expect(getSignedGetUrl('age-verification/u1/abc.jpg', 7200)).rejects.toThrow(
+      /expiresInSec/,
+    );
+    expect(mockGetSignedUrl).not.toHaveBeenCalled();
+  });
+
+  test('rejects expiry <= 0', async () => {
+    await expect(getSignedGetUrl('age-verification/u1/abc.jpg', 0)).rejects.toThrow(/expiresInSec/);
+    expect(mockGetSignedUrl).not.toHaveBeenCalled();
+  });
+
+  test('rejects empty key', async () => {
+    await expect(getSignedGetUrl('')).rejects.toThrow(/key/);
+    expect(mockGetSignedUrl).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-string key', async () => {
+    await expect(getSignedGetUrl(undefined)).rejects.toThrow(/key/);
+    expect(mockGetSignedUrl).not.toHaveBeenCalled();
+  });
+});

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -2390,6 +2390,7 @@
         .user-subtab { padding: 8px 16px; border-radius: 6px; cursor: pointer; font-size: 13px; background: var(--surface2); color: var(--text2); border: none; transition: background 0.2s; min-height: 36px; min-width: 36px; }
         .user-subtab:hover { background: var(--surface3, #444); }
         .user-subtab.active { background: var(--accent); color: #fff; }
+        .age-verif-badge { display: inline-block; min-width: 18px; padding: 1px 6px; margin-left: 6px; font-size: 11px; font-weight: 600; border-radius: 9px; background: var(--danger, #dc2626); color: #fff; vertical-align: middle; }
         /* Sub-tab change indicators removed — replaced by auto-save */
         .user-subpanel { display: none; }
         .user-subpanel.visible { display: block; }
@@ -3145,6 +3146,7 @@
                 <button class="user-subtab" data-subtab="security" data-i18n="subtab_security">Security</button>
                 <button class="user-subtab" data-subtab="economy" data-i18n="subtab_economy">Economy</button>
                 <button class="user-subtab" data-subtab="identity" data-i18n="subtab_identity">Identity</button>
+                <button class="user-subtab" data-subtab="age-verif" data-i18n="subtab_age_verification">Age Verification <span id="age-verif-pending-badge" class="age-verif-badge" hidden></span></button>
             </div>
 
             <div class="user-subpanel visible" data-subtab="profile">
@@ -3702,6 +3704,90 @@
                     </div>
                 </div>
             </div><!-- end identity subpanel -->
+
+            <!-- Age Verification subpanel (PR 6/14) — per-user review of pending ID submission -->
+            <div class="user-subpanel" data-subtab="age-verif">
+                <div class="form-section">
+                    <h3 data-i18n="age_verif_panel_title">Age Verification</h3>
+                    <p style="color:var(--text2);font-size:13px;margin-bottom:12px;" data-i18n="age_verif_panel_subtitle">
+                        Review the user's submitted government ID and decide. Approve confirms the user is 18+. Reject keeps them sub-18 and notifies them. If the ID shows a different DOB, use Modify-DOB to correct the record.
+                    </p>
+
+                    <!-- Empty state — user has no pending submission -->
+                    <div id="age-verif-empty" data-testid="ageVerif_empty" style="padding:16px;border:1px dashed var(--border);border-radius:8px;color:var(--text2);font-size:13px;display:none;">
+                        <p style="margin:0 0 8px 0;" data-i18n="age_verif_no_pending_for_user">No pending verification submission for this user.</p>
+                        <p style="margin:0;font-size:12px;color:var(--text3);">
+                            <span data-i18n="age_verif_other_pending_label">Other pending submissions across the system:</span>
+                            <span id="age-verif-other-count">0</span>.
+                            <button type="button" id="age-verif-jump-next" class="btn-sm" style="font-size:12px;margin-left:8px;display:none;" data-i18n="age_verif_jump_next">Jump to next pending</button>
+                        </p>
+                    </div>
+
+                    <!-- Review form — shown when this user has a pending submission -->
+                    <div id="age-verif-form" data-testid="ageVerif_form" style="display:none;">
+                        <div style="display:grid;grid-template-columns:minmax(180px,320px) 1fr;gap:16px;margin-bottom:16px;align-items:start;">
+                            <div>
+                                <a id="age-verif-id-image-link" href="#" target="_blank" rel="noopener" style="display:block;">
+                                    <img id="age-verif-id-image" data-testid="ageVerif_idImage" src="" alt="Submitted ID" style="width:100%;border-radius:8px;border:1px solid var(--border);background:var(--surface2);"/>
+                                </a>
+                                <p style="font-size:11px;color:var(--text3);margin:4px 0 0 0;" data-i18n="age_verif_image_disclaimer">Image is destroyed when the decision is recorded.</p>
+                            </div>
+                            <div style="font-size:13px;line-height:1.6;">
+                                <div><strong data-i18n="age_verif_field_method">ID method:</strong> <span id="age-verif-method"></span></div>
+                                <div><strong data-i18n="age_verif_field_recorded_dob">Recorded DOB:</strong> <span id="age-verif-current-dob"></span></div>
+                                <div><strong data-i18n="age_verif_field_submitted_at">Submitted at:</strong> <span id="age-verif-submitted-at"></span></div>
+                                <div><strong data-i18n="age_verif_field_submission_id">Submission ID:</strong> <span id="age-verif-submission-id" style="font-family:monospace;font-size:11px;color:var(--text2);"></span></div>
+                            </div>
+                        </div>
+
+                        <!-- Gate question: does the ID confirm the recorded DOB? -->
+                        <div class="field-group" style="margin-bottom:12px;">
+                            <label style="font-weight:600;display:block;margin-bottom:8px;" data-i18n="age_verif_match_question">Does the ID confirm the user's recorded date of birth?</label>
+                            <label style="margin-right:16px;cursor:pointer;">
+                                <input type="radio" name="age-verif-match" value="yes" data-testid="ageVerif_matchYes"/>
+                                <span data-i18n="age_verif_match_yes">Yes — DOB on the ID matches the recorded value</span>
+                            </label>
+                            <label style="cursor:pointer;display:block;margin-top:6px;">
+                                <input type="radio" name="age-verif-match" value="no" data-testid="ageVerif_matchNo"/>
+                                <span data-i18n="age_verif_match_no">No — the ID shows a different DOB</span>
+                            </label>
+                        </div>
+
+                        <!-- YES branch — Approve / Reject -->
+                        <div id="age-verif-yes-actions" data-testid="ageVerif_yesActions" style="display:none;border-top:1px solid var(--border);padding-top:12px;margin-bottom:12px;">
+                            <p style="font-size:12px;color:var(--text2);margin:0 0 8px 0;" data-i18n="age_verif_approve_help">Approve: confirms the user as 18+ verified. Reject: keeps them sub-18 and sends a system PM with the reason.</p>
+                            <button type="button" id="age-verif-approve-btn" data-testid="ageVerif_approveBtn" class="btn-primary" style="margin-right:8px;" data-i18n="age_verif_approve_button">Approve (mark verified)</button>
+                            <details style="display:inline-block;vertical-align:top;">
+                                <summary style="cursor:pointer;font-size:13px;color:var(--text2);" data-i18n="age_verif_reject_summary">Reject instead…</summary>
+                                <div style="margin-top:8px;max-width:480px;">
+                                    <textarea id="age-verif-reject-reason-yes" data-testid="ageVerif_rejectReasonYes" placeholder="Reason for rejection (required, shown to user)" style="width:100%;min-height:60px;font-family:inherit;font-size:13px;"></textarea>
+                                    <button type="button" id="age-verif-reject-btn-yes" data-testid="ageVerif_rejectBtnYes" class="btn-danger" style="margin-top:6px;" data-i18n="age_verif_reject_button">Reject submission</button>
+                                </div>
+                            </details>
+                        </div>
+
+                        <!-- NO branch — Modify-DOB / Reject -->
+                        <div id="age-verif-no-actions" data-testid="ageVerif_noActions" style="display:none;border-top:1px solid var(--border);padding-top:12px;">
+                            <p style="font-size:12px;color:var(--text2);margin:0 0 8px 0;" data-i18n="age_verif_modify_help">Update the user's DOB to match the value shown on the ID. The user is unlocked or kept locked automatically based on the new age.</p>
+                            <div class="field-group" style="margin-bottom:8px;">
+                                <label for="age-verif-new-dob" data-i18n="age_verif_new_dob_label">Date of birth on the ID:</label>
+                                <input type="date" id="age-verif-new-dob" data-testid="ageVerif_newDob" style="width:200px;"/>
+                            </div>
+                            <textarea id="age-verif-modify-reason" data-testid="ageVerif_modifyReason" placeholder="Reason / notes (required, audit log entry)" style="width:100%;max-width:480px;min-height:60px;font-family:inherit;font-size:13px;margin-bottom:6px;"></textarea>
+                            <div>
+                                <button type="button" id="age-verif-modify-btn" data-testid="ageVerif_modifyBtn" class="btn-primary" style="margin-right:8px;" data-i18n="age_verif_modify_button">Update DOB & decide</button>
+                                <details style="display:inline-block;vertical-align:top;">
+                                    <summary style="cursor:pointer;font-size:13px;color:var(--text2);" data-i18n="age_verif_reject_summary">Reject instead…</summary>
+                                    <div style="margin-top:8px;max-width:480px;">
+                                        <textarea id="age-verif-reject-reason-no" data-testid="ageVerif_rejectReasonNo" placeholder="Reason for rejection (required, shown to user)" style="width:100%;min-height:60px;font-family:inherit;font-size:13px;"></textarea>
+                                        <button type="button" id="age-verif-reject-btn-no" data-testid="ageVerif_rejectBtnNo" class="btn-danger" style="margin-top:6px;" data-i18n="age_verif_reject_button">Reject submission</button>
+                                    </div>
+                                </details>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div><!-- end age-verif subpanel -->
 
             <!-- Identity suspend dialog -->
             <div id="identity-suspend-dialog" class="modal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:1000;align-items:center;justify-content:center;">

--- a/public/admin/js/main.js
+++ b/public/admin/js/main.js
@@ -21,6 +21,10 @@ import { showScreen, registerScreen } from '/js/core/ui.js';
 
 // Static import — ensures users module is loaded before auth handler fires
 import * as usersModule from '/admin/js/tabs/users.js';
+// Age Verification subtab — also static so the pending-count badge
+// renders the moment login completes (without waiting on a dynamic
+// import). Registered as a sub-feature of the Users tab.
+import * as ageVerificationModule from '/admin/js/tabs/age-verification.js';
 // Maintenance sub-features (not tabs — initialised once after login)
 import * as syncProd from '/admin/js/sync-prod.js';
 import * as nuclearReset from '/admin/js/nuclear-reset.js';
@@ -304,6 +308,28 @@ onAuthStateChanged(auth, async (user) => {
     };
     syncProd.init(maintenanceDeps);
     nuclearReset.init(maintenanceDeps);
+
+    // Age-verification subtab (PR 6/14) — wires its event listeners
+    // and registers the onSubtabOpen callback into the Users tab.
+    // Initialised as a sub-feature alongside maintenance because it's
+    // owned by the Users tab and needs to fire its initial badge
+    // refresh as soon as login completes.
+    ageVerificationModule.init({
+      searchUserByUniqueId: (uid) => usersModule.searchUserByUniqueId?.(uid),
+      refreshAfterDecision: async (uid) => {
+        // Re-search the user so the read-only DOB / verified-badge
+        // section in the Users tab updates after Modify-DOB or
+        // Approve-flips-verified.
+        try {
+          await usersModule.searchUserByUniqueId?.(uid);
+        } catch (_err) {
+          // Non-fatal — toast shown at the call site.
+        }
+      },
+    });
+    usersModule._register?.('onAgeVerifSubtabOpen', (uid) =>
+      ageVerificationModule.onSubtabOpen(uid),
+    );
 
     // Eagerly load economy config so pity limit is available for spin monitor
     await activateTabModule('economy');

--- a/public/admin/js/tabs/age-verification.js
+++ b/public/admin/js/tabs/age-verification.js
@@ -1,0 +1,331 @@
+/**
+ * Age Verification sub-tab (PR 6/14).
+ *
+ * Renders pending verification review UI as a sub-tab inside the
+ * Users tab. Per spec answer #5 from 2026-05-04: this is a sub-tab,
+ * not a top-level tab. The "Does ID match the recorded DOB?" gate
+ * controls whether Approve/Reject or Modify-DOB is exposed.
+ *
+ * Discovery: a global pending-count badge on the sub-tab header
+ * tracks how many submissions are awaiting review across the
+ * system. When the currently-loaded user has no pending submission,
+ * a "Jump to next pending" button hops the admin to the oldest one.
+ *
+ * Decision endpoints (admin-age-verification route):
+ *   POST /api/admin/age-verification/:id/approve  body: {}
+ *   POST /api/admin/age-verification/:id/reject   body: {reason}
+ *   POST /api/admin/age-verification/:id/modify-dob body: {newDob, reason}
+ *
+ * Image preview endpoint added in this PR:
+ *   GET /api/admin/age-verification/:id/image-url → 5-min signed URL
+ */
+
+import { apiCall } from '/js/core/api.js';
+import { showToast, escapeHtml } from '/js/core/ui.js';
+
+// ── State ──────────────────────────────────────────────────────────
+
+let _searchUserByUniqueId = null;
+let _refreshAfterDecisionCallback = null;
+
+// Cached pending list. Refreshed on subtab open + after decisions.
+// Index lookup: by submission.userId (string keyed).
+let _pending = [];
+
+// ── DOM refs ───────────────────────────────────────────────────────
+
+const $ = (id) => document.getElementById(id);
+
+// ── Init / dependencies ────────────────────────────────────────────
+
+/**
+ * Wire dependencies and event listeners.
+ *
+ * @param {Object} deps
+ * @param {Function} deps.searchUserByUniqueId — re-load a user into the
+ *   Users tab. Used by "Jump to next pending" to swap the current user.
+ * @param {Function} deps.refreshAfterDecision — repopulate Users tab
+ *   after a decision so the read-only DOB / verified badge updates.
+ */
+export function init(deps) {
+  _searchUserByUniqueId = deps?.searchUserByUniqueId || null;
+  _refreshAfterDecisionCallback = deps?.refreshAfterDecision || null;
+
+  // Wire match-question radios
+  document.querySelectorAll('input[name="age-verif-match"]').forEach((r) =>
+    r.addEventListener('change', onMatchChange),
+  );
+
+  // Wire decision buttons
+  $('age-verif-approve-btn')?.addEventListener('click', onApprove);
+  $('age-verif-reject-btn-yes')?.addEventListener('click', () => onReject('yes'));
+  $('age-verif-reject-btn-no')?.addEventListener('click', () => onReject('no'));
+  $('age-verif-modify-btn')?.addEventListener('click', onModifyDob);
+
+  // Wire jump-next
+  $('age-verif-jump-next')?.addEventListener('click', onJumpNext);
+
+  // Initial pending count fetch (for the badge); silent on failure —
+  // the admin can always force a refresh by opening the subtab.
+  refreshPendingList().catch(() => {});
+}
+
+// ── Pending list / badge ───────────────────────────────────────────
+
+/**
+ * Pull the current pending list from the API and refresh both the
+ * sub-tab badge and the cached list.
+ */
+export async function refreshPendingList() {
+  try {
+    const data = await apiCall('GET', '/api/admin/age-verification/pending');
+    _pending = Array.isArray(data?.submissions) ? data.submissions : [];
+  } catch (_err) {
+    // Non-fatal — leave the cache as-is. The admin can retry by
+    // re-opening the sub-tab. Don't toast here; this is a background
+    // refresh and a noisy toast on every failure would be annoying.
+    _pending = _pending || [];
+  }
+  renderPendingBadge();
+}
+
+function renderPendingBadge() {
+  const badge = $('age-verif-pending-badge');
+  if (!badge) return;
+  const total = _pending.length;
+  if (total === 0) {
+    badge.hidden = true;
+    badge.textContent = '';
+  } else {
+    badge.hidden = false;
+    badge.textContent = String(total);
+  }
+}
+
+// ── Subtab activation ──────────────────────────────────────────────
+
+/**
+ * Called when the admin clicks the Age Verification sub-tab. Decides
+ * which view to render: the per-user form (if THIS user has a
+ * pending submission), or the empty state with a Jump-to-next link.
+ *
+ * @param {string|number|null} currentUid — the unique ID of the user
+ *   currently loaded in the Users tab. May be null for the "no user
+ *   selected yet" branch.
+ */
+export async function onSubtabOpen(currentUid) {
+  await refreshPendingList();
+  const uidStr = currentUid != null ? String(currentUid) : null;
+  const submission = uidStr ? _pending.find((s) => String(s.userId) === uidStr) : null;
+  if (submission) {
+    await renderForm(submission, uidStr);
+  } else {
+    renderEmpty();
+  }
+}
+
+function renderEmpty() {
+  const empty = $('age-verif-empty');
+  const form = $('age-verif-form');
+  const otherCountEl = $('age-verif-other-count');
+  const jumpBtn = $('age-verif-jump-next');
+  if (form) form.style.display = 'none';
+  if (empty) empty.style.display = 'block';
+  if (otherCountEl) otherCountEl.textContent = String(_pending.length);
+  if (jumpBtn) jumpBtn.style.display = _pending.length > 0 ? 'inline-block' : 'none';
+}
+
+async function renderForm(submission, uidStr) {
+  const empty = $('age-verif-empty');
+  const form = $('age-verif-form');
+  if (empty) empty.style.display = 'none';
+  if (form) form.style.display = 'block';
+
+  $('age-verif-method').textContent = submission.idMethod || '—';
+  $('age-verif-current-dob').textContent = formatDob(submission.currentDob);
+  $('age-verif-submitted-at').textContent = formatTimestamp(submission.submittedAt);
+  $('age-verif-submission-id').textContent = submission.id;
+
+  // Reset the gate question + branch UI on re-open so a previous
+  // decision-in-progress doesn't leak into a new submission.
+  document.querySelectorAll('input[name="age-verif-match"]').forEach((r) => (r.checked = false));
+  $('age-verif-yes-actions').style.display = 'none';
+  $('age-verif-no-actions').style.display = 'none';
+  $('age-verif-reject-reason-yes').value = '';
+  $('age-verif-reject-reason-no').value = '';
+  $('age-verif-modify-reason').value = '';
+  $('age-verif-new-dob').value = '';
+
+  // Remember which submission is being reviewed so the decision
+  // handlers know which ID to POST to. Stored on the form element
+  // rather than a module-level variable to defend against stale state
+  // when the admin switches users mid-review.
+  form.dataset.submissionId = submission.id;
+  form.dataset.uniqueId = uidStr;
+
+  // Fetch & display the signed image URL. Failure = show a placeholder
+  // and keep the rest of the form usable; the admin can still decide
+  // based on whatever they remember from a prior load.
+  await loadIdImage(submission.id);
+}
+
+async function loadIdImage(submissionId) {
+  const img = $('age-verif-id-image');
+  const link = $('age-verif-id-image-link');
+  if (!img) return;
+  img.removeAttribute('src');
+  img.alt = 'Loading…';
+  try {
+    const data = await apiCall('GET', `/api/admin/age-verification/${submissionId}/image-url`);
+    if (!data?.url) throw new Error('no url returned');
+    img.src = data.url;
+    img.alt = 'Submitted ID';
+    if (link) link.href = data.url;
+  } catch (err) {
+    img.alt = 'Failed to load image';
+    showToast(`Failed to load ID image: ${err.message}`, 'error');
+  }
+}
+
+// ── Gate question ──────────────────────────────────────────────────
+
+function onMatchChange(e) {
+  const value = e.target.value;
+  $('age-verif-yes-actions').style.display = value === 'yes' ? 'block' : 'none';
+  $('age-verif-no-actions').style.display = value === 'no' ? 'block' : 'none';
+}
+
+// ── Decision actions ───────────────────────────────────────────────
+
+async function onApprove() {
+  const id = currentSubmissionId();
+  if (!id) return;
+  if (!confirm('Mark this user as 18+ verified?')) return;
+  try {
+    // Approve takes no reason (per spec answer #6 — admin doesn't
+    // need to justify a confirmation). Reject + Modify-DOB still do.
+    await apiCall('POST', `/api/admin/age-verification/${id}/approve`, {});
+    showToast('Age verification approved', 'success');
+    await afterDecision();
+  } catch (err) {
+    showToast(`Approve failed: ${err.message}`, 'error');
+  }
+}
+
+async function onReject(branch) {
+  const id = currentSubmissionId();
+  if (!id) return;
+  const reasonEl = branch === 'no' ? $('age-verif-reject-reason-no') : $('age-verif-reject-reason-yes');
+  const reason = (reasonEl?.value || '').trim();
+  if (!reason) {
+    showToast('Rejection reason is required.', 'error');
+    return;
+  }
+  if (!confirm('Reject this submission? The user is notified by system PM.')) return;
+  try {
+    await apiCall('POST', `/api/admin/age-verification/${id}/reject`, { reason });
+    showToast('Age verification rejected', 'success');
+    await afterDecision();
+  } catch (err) {
+    showToast(`Reject failed: ${err.message}`, 'error');
+  }
+}
+
+async function onModifyDob() {
+  const id = currentSubmissionId();
+  if (!id) return;
+  const newDobInput = $('age-verif-new-dob')?.value;
+  const reason = ($('age-verif-modify-reason')?.value || '').trim();
+  if (!newDobInput) {
+    showToast('New DOB is required.', 'error');
+    return;
+  }
+  if (!reason) {
+    showToast('Reason / notes are required for the audit trail.', 'error');
+    return;
+  }
+  // <input type="date"> returns YYYY-MM-DD. Convert to UTC midnight ms
+  // so the value matches how the rest of the app stores DOBs.
+  const newDobMs = Date.parse(newDobInput + 'T00:00:00Z');
+  if (!Number.isFinite(newDobMs)) {
+    showToast('Invalid date.', 'error');
+    return;
+  }
+  if (!confirm('Update the user\'s DOB to the value above? Their access is unlocked or kept locked automatically.')) return;
+  try {
+    await apiCall('POST', `/api/admin/age-verification/${id}/modify-dob`, {
+      newDob: newDobMs,
+      reason,
+    });
+    showToast('DOB updated', 'success');
+    await afterDecision();
+  } catch (err) {
+    showToast(`Modify-DOB failed: ${err.message}`, 'error');
+  }
+}
+
+async function afterDecision() {
+  // Refresh the pending list so the badge / next-jump are accurate.
+  await refreshPendingList();
+  // Re-render the empty state — this user's submission is gone from
+  // the pending list now.
+  renderEmpty();
+  // Let the Users tab update its read-only fields (verified badge,
+  // DOB if Modify-DOB ran, etc.).
+  const uid = $('age-verif-form')?.dataset?.uniqueId;
+  if (_refreshAfterDecisionCallback && uid) {
+    try {
+      await _refreshAfterDecisionCallback(uid);
+    } catch (err) {
+      // Non-fatal — admin can manually re-search. Don't block the
+      // decision flow on a stale-form refresh hiccup.
+      // eslint-disable-next-line no-console
+      console.warn('refreshAfterDecision failed', err);
+    }
+  }
+}
+
+// ── Jump-to-next ───────────────────────────────────────────────────
+
+function onJumpNext() {
+  const next = _pending[0]; // oldest first (the GET endpoint sorts asc)
+  if (!next) return;
+  if (!_searchUserByUniqueId) {
+    showToast('Cannot jump — search hook missing', 'error');
+    return;
+  }
+  _searchUserByUniqueId(next.userId);
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function currentSubmissionId() {
+  const form = $('age-verif-form');
+  const id = form?.dataset?.submissionId;
+  if (!id) {
+    showToast('No submission loaded — re-open the sub-tab.', 'error');
+    return null;
+  }
+  return id;
+}
+
+function formatDob(ms) {
+  if (!Number.isFinite(ms)) return '—';
+  const d = new Date(ms);
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+}
+
+function formatTimestamp(ms) {
+  if (!Number.isFinite(ms)) return '—';
+  return new Date(ms).toLocaleString();
+}
+
+function pad(n) {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+// Small helper used by callers to escape values that might contain
+// HTML when the form is re-populated. Currently unused but exported
+// for future enhancements (e.g., a notes field that could echo user
+// input). Keeping it imported quiets the lint rule.
+export const _internal = { escapeHtml };

--- a/public/admin/js/tabs/users.js
+++ b/public/admin/js/tabs/users.js
@@ -41,6 +41,7 @@ let _populateFormFull = async (/* data */) => {};
 let _flushNotifications = async () => {};
 let _loadSecurityPanel = async () => {};
 let _loadIdentitySubtabGraph = async () => {};
+let _onAgeVerifSubtabOpen = async (/* uid */) => {};
 
 /**
  * Register a function from a later migration chunk.
@@ -52,6 +53,7 @@ export function _register(name, fn) {
     flushNotifications: (f) => { _flushNotifications = f; },
     loadSecurityPanel: (f) => { _loadSecurityPanel = f; },
     loadIdentitySubtabGraph: (f) => { _loadIdentitySubtabGraph = f; },
+    onAgeVerifSubtabOpen: (f) => { _onAgeVerifSubtabOpen = f; },
   };
   if (map[name]) map[name](fn);
 }
@@ -148,6 +150,7 @@ export function switchUserSubtab(subtab) {
     p.classList.toggle("visible", p.dataset.subtab === subtab));
   if (subtab === "security") _loadSecurityPanel();
   if (subtab === "identity") _loadIdentitySubtabGraph();
+  if (subtab === "age-verif") _onAgeVerifSubtabOpen(currentUid);
 }
 
 // ── Search ─────────────────────────────────────────────────────────

--- a/tests/web/admin-age-verification.spec.ts
+++ b/tests/web/admin-age-verification.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Admin Age Verification sub-tab (PR 6/14).
+ *
+ * Lives inside the Users tab. Verifies that the per-user review form
+ * appears for the searched user when they have a pending submission,
+ * the gate question conditionally reveals the YES/NO action branches,
+ * and that approve/reject/modify-DOB POST to the right endpoints.
+ *
+ * Pre-existing endpoints (PR 4b) drive the decisions; this test
+ * focuses on the new admin UI layer added in PR 6.
+ */
+
+import { test, expect, TestData } from './fixtures/admin';
+import { adminLogin, navigateToTab, searchUser } from './helpers/admin-auth';
+import { Page } from '@playwright/test';
+
+async function createPendingSubmission(testData: TestData, opts: { dobMs?: number } = {}): Promise<string> {
+  const dobMs =
+    opts.dobMs !== undefined
+      ? opts.dobMs
+      : Date.UTC(2008, 0, 1); // ~17yo as of 2026 — borderline locked
+  const result = await testData.api.testWrite('ageVerificationSubmissions', {
+    userId: String(testData.user.uniqueId),
+    idMethod: 'passport',
+    r2Key: `age-verification/${testData.user.uniqueId}/test-${Date.now()}.jpg`,
+    status: 'pending',
+    submittedAt: Date.now(),
+    currentDob: dobMs,
+    _testRun: testData.testRunId,
+  });
+  return result.id;
+}
+
+/**
+ * Mark all pending submissions for the test user as 'cleaned-by-test'
+ * so the next test starts from an empty state. Idempotent — safe to
+ * call when no pending submissions exist.
+ *
+ * Cannot use the admin approve/reject endpoint because it expects a
+ * real R2 image (deletion is part of the decision flow). testWrite
+ * with the same id field overwrites status and clears r2Key, which is
+ * enough for the pending-list filter to drop the row.
+ */
+async function clearPending(testData: TestData): Promise<void> {
+  try {
+    const list = await testData.api.get('/api/admin/age-verification/pending');
+    const submissions = (list?.submissions || []).filter(
+      (s: any) => String(s.userId) === String(testData.user.uniqueId),
+    );
+    for (const s of submissions) {
+      await testData.api.testWrite('ageVerificationSubmissions', {
+        id: s.id,
+        userId: s.userId,
+        status: 'cleaned-by-test',
+        r2Key: null,
+        _testRun: testData.testRunId,
+      });
+    }
+  } catch (_err) {
+    // Best-effort.
+  }
+}
+
+// Cleanup is handled by the global teardown via the _testRun tag on
+// each document. No per-test teardown needed — tests filter pending
+// submissions by userId so accumulation in the collection doesn't
+// cause cross-test interference.
+
+async function openAgeVerifSubtab(page: Page): Promise<void> {
+  const btn = page.locator('.user-subtab[data-subtab="age-verif"]');
+  await btn.click();
+  await expect(btn).toHaveClass(/active/);
+}
+
+test.describe('Admin Age Verification subtab', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeEach(async ({ page, testData }) => {
+    // Wipe any leftover pending submissions for this user before each
+    // test runs. Otherwise a retry of the form-renders test creates a
+    // doc that breaks the next empty-state assertion.
+    await clearPending(testData);
+    await adminLogin(page);
+    await navigateToTab(page, 'Users');
+  });
+
+  test('subtab button + empty state render when no pending submission for user', async ({ page, testData }) => {
+    await searchUser(page, String(testData.user.uniqueId));
+    await openAgeVerifSubtab(page);
+
+    // Empty state visible — no pending for this user
+    const empty = page.locator('[data-testid="ageVerif_empty"]');
+    await expect(empty).toBeVisible();
+    const form = page.locator('[data-testid="ageVerif_form"]');
+    await expect(form).toBeHidden();
+  });
+
+  test('pending submission for searched user → form renders with submitted data', async ({ page, testData }) => {
+    const dob = Date.UTC(2008, 0, 1);
+    const submissionId = await createPendingSubmission(testData, { dobMs: dob });
+
+    await searchUser(page, String(testData.user.uniqueId));
+    await openAgeVerifSubtab(page);
+
+    const form = page.locator('[data-testid="ageVerif_form"]');
+    await expect(form).toBeVisible();
+
+    // Verify the metadata fields populate
+    await expect(page.locator('#age-verif-method')).toHaveText('passport');
+    await expect(page.locator('#age-verif-current-dob')).toHaveText('2008-01-01');
+    await expect(page.locator('#age-verif-submission-id')).toHaveText(submissionId);
+
+    // Pending badge on the sub-tab now shows ≥1
+    const badge = page.locator('#age-verif-pending-badge');
+    await expect(badge).toBeVisible();
+    const badgeText = (await badge.textContent()) || '';
+    expect(parseInt(badgeText, 10)).toBeGreaterThanOrEqual(1);
+  });
+
+  test('gate question controls action branch visibility', async ({ page, testData }) => {
+    await createPendingSubmission(testData);
+    await searchUser(page, String(testData.user.uniqueId));
+    await openAgeVerifSubtab(page);
+
+    const yesActions = page.locator('[data-testid="ageVerif_yesActions"]');
+    const noActions = page.locator('[data-testid="ageVerif_noActions"]');
+
+    // Initially both branches hidden
+    await expect(yesActions).toBeHidden();
+    await expect(noActions).toBeHidden();
+
+    // Pick YES → only yes-actions shows
+    await page.locator('[data-testid="ageVerif_matchYes"]').check();
+    await expect(yesActions).toBeVisible();
+    await expect(noActions).toBeHidden();
+
+    // Switch to NO → swap visibility
+    await page.locator('[data-testid="ageVerif_matchNo"]').check();
+    await expect(noActions).toBeVisible();
+    await expect(yesActions).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the "Age Verification" sub-tab inside the Users admin panel — per spec answer #5 (sub-tab, not top-level).
- Reviewer sees the user's submitted ID image, a gate question ("Does the ID confirm the user's recorded DOB?"), and the appropriate action set: **YES** → Approve / collapsible Reject. **NO** → New-DOB picker + reason → Modify-DOB / collapsible Reject.
- Sub-tab shows a global pending-count badge for at-a-glance triage; empty state offers "Jump to next pending" navigation.

## What's in
**Server**
- New `GET /api/admin/age-verification/:id/image-url` returns a 5-min signed R2 URL so the browser previews the ID directly (no streaming through Express).
- New `r2.getSignedGetUrl(key, expiresInSec)` helper, mirrors `getSignedPutUrl`.
- `test-helpers` allowlist gains `ageVerificationSubmissions` so Playwright can seed pending submissions.

**Frontend**
- `public/admin/js/tabs/age-verification.js` — new module owns the sub-tab logic, badge refresh, decision submit, and after-decision refresh of the Users tab. Initialised statically from `main.js` so the badge is accurate at login.
- `users.js` — `data-subtab="age-verif"` switch + new `_register('onAgeVerifSubtabOpen', ...)` hook so the sub-feature module wires its lazy-load callback into the existing pattern.
- `index.html` — sub-tab button (with badge) + sub-panel layout.

## Test plan
- [x] `npx jest tests/routes/admin-age-verification.test.js` — 23 passed (4 new for `image-url`)
- [x] `npm test` (full Express suite) — 4578 passed
- [x] `API_BASE_URL=… npx playwright test admin-age-verification.spec.ts --project=chromium` — 3 passed
- [x] Pre-push hook chromium suite — 1124 passed, no "did not run", flakies recovered

## Manual QA (post-merge)
- [ ] Sign in to admin, search a user with no pending submission → sub-tab shows empty state + "Jump to next pending" button (when others exist)
- [ ] Search a user with a pending submission → form renders with image, method, recorded DOB
- [ ] YES gate → Approve flips `ageVerified=true`, image deleted, audit entry written, system PM sent
- [ ] NO gate → Modify-DOB updates DOB, auto-(un)locks PM access via PR 11
- [ ] Reject path (both YES/NO branches) → reason field required, system PM sent

i18n keys are added via `data-i18n`; non-EN locale translations land in PR 13 per the multi-PR plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)