### PR TITLE
feat(age-verif): PR 9 — user verification submit screen

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/core/di/AppKoinModule.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/di/AppKoinModule.kt
@@ -28,6 +28,8 @@ import com.shyden.shytalk.data.remote.RtdbPresenceService
 import com.shyden.shytalk.data.remote.TokenService
 import com.shyden.shytalk.data.remote.VoiceService
 import com.shyden.shytalk.data.remote.WorkerApiClient
+import com.shyden.shytalk.data.repository.AgeVerificationRepository
+import com.shyden.shytalk.data.repository.AgeVerificationRepositoryImpl
 import com.shyden.shytalk.data.repository.AppLockRepository
 import com.shyden.shytalk.data.repository.AppLockRepositoryImpl
 import com.shyden.shytalk.data.repository.AuthRepository
@@ -141,6 +143,7 @@ val appModule =
         singleOf(::MessageRepositoryImpl) bind MessageRepository::class
         singleOf(::SeatRequestRepositoryImpl) bind SeatRequestRepository::class
         single<StorageRepository> { StorageRepositoryImpl(get(), BuildConfig.WORKER_URL, get()) }
+        singleOf(::AgeVerificationRepositoryImpl) bind AgeVerificationRepository::class
         singleOf(::DeviceRepositoryImpl) bind DeviceRepository::class
         singleOf(::IdentityRepositoryImpl) bind IdentityRepository::class
         singleOf(::PrivateMessageRepositoryImpl) bind PrivateMessageRepository::class

--- a/app/src/main/java/com/shyden/shytalk/data/repository/AgeVerificationRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/AgeVerificationRepositoryImpl.kt
@@ -1,0 +1,94 @@
+package com.shyden.shytalk.data.repository
+
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.core.util.firebaseCall
+import com.shyden.shytalk.data.remote.WorkerApiClient
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.json.JSONObject
+import java.io.IOException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+class AgeVerificationRepositoryImpl(
+    private val api: WorkerApiClient,
+    private val httpClient: OkHttpClient,
+) : AgeVerificationRepository {
+    override suspend fun requestUploadUrl(
+        contentType: AgeVerificationRepository.ContentType,
+    ): Resource<AgeVerificationRepository.UploadHandle> =
+        firebaseCall("Failed to request upload URL") {
+            val resp =
+                api.post(
+                    "/api/age-verification/upload-url",
+                    JSONObject().put("contentType", contentType.wireValue),
+                )
+            AgeVerificationRepository.UploadHandle(
+                uploadUrl = resp.getString("uploadUrl"),
+                r2Key = resp.getString("r2Key"),
+                expiresInSec = resp.optInt("expiresInSec", 300),
+            )
+        }
+
+    override suspend fun uploadImage(
+        uploadUrl: String,
+        contentType: AgeVerificationRepository.ContentType,
+        bytes: ByteArray,
+    ): Resource<Unit> =
+        firebaseCall("Failed to upload ID image") {
+            // The signed URL IS the auth — no Bearer header. PUT the
+            // bytes raw with the matching Content-Type so R2's signature
+            // verification passes.
+            val response =
+                httpClient
+                    .newCall(
+                        Request
+                            .Builder()
+                            .url(uploadUrl)
+                            .put(bytes.toRequestBody(contentType.wireValue.toMediaType()))
+                            .build(),
+                    ).executeAsync()
+            response.use {
+                if (!it.isSuccessful) {
+                    throw RuntimeException("R2 PUT failed: HTTP ${it.code}")
+                }
+            }
+        }
+
+    override suspend fun submit(
+        idMethod: AgeVerificationRepository.IdMethod,
+        r2Key: String,
+    ): Resource<Unit> =
+        firebaseCall("Failed to submit verification") {
+            api.post(
+                "/api/age-verification/submit",
+                JSONObject()
+                    .put("idMethod", idMethod.wireValue)
+                    .put("r2Key", r2Key),
+            )
+        }
+}
+
+private suspend fun Call.executeAsync(): Response =
+    suspendCancellableCoroutine { cont ->
+        cont.invokeOnCancellation { cancel() }
+        enqueue(
+            object : Callback {
+                override fun onFailure(
+                    call: Call,
+                    e: IOException,
+                ) = cont.resumeWithException(e)
+
+                override fun onResponse(
+                    call: Call,
+                    response: Response,
+                ) = cont.resume(response)
+            },
+        )
+    }

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -951,4 +951,32 @@
     <string name="age_restriction_sub_eighteen_confirm">Contact support</string>
     <string name="age_restriction_dismiss">Cancel</string>
 
+    <!-- Age verification submit flow (PR 9 of age-verification feature). PR 13 ships translations for the remaining 19 locales. -->
+    <string name="age_verif_submit_title">Verify your age</string>
+    <string name="age_verif_step_explanation_title">How this works</string>
+    <string name="age_verif_step_explanation_body">We need a photo of a government-issued ID to confirm you are at least 18. The image is encrypted in transit, reviewed by a human moderator, and permanently deleted as soon as a decision is recorded — usually within 24 hours. Only the date of birth and verification outcome are kept.</string>
+    <string name="age_verif_step_explanation_continue">I understand — continue</string>
+    <string name="age_verif_step_method_title">Which document?</string>
+    <string name="age_verif_step_method_body">Pick the type of ID you will submit. The DOB on the document must match the one on your account.</string>
+    <string name="age_verif_method_passport">Passport</string>
+    <string name="age_verif_method_drivers_license">Driver\'s license</string>
+    <string name="age_verif_method_national_id">National ID card</string>
+    <string name="age_verif_step_image_title">Add the photo</string>
+    <string name="age_verif_step_image_body">Choose a clear photo of the ID. Make sure the date of birth is fully readable.</string>
+    <string name="age_verif_step_image_pick">Choose photo</string>
+    <string name="age_verif_step_image_replace">Replace photo</string>
+    <string name="age_verif_step_confirm_title">Ready to submit?</string>
+    <string name="age_verif_step_confirm_body">Once submitted, the photo is sent for review. You\'ll get a system message when a decision is recorded.</string>
+    <string name="age_verif_field_method">ID type:</string>
+    <string name="age_verif_field_photo">Photo:</string>
+    <string name="age_verif_photo_attached">attached</string>
+    <string name="age_verif_step_confirm_submit">Submit for review</string>
+    <string name="age_verif_step_submitted_title">Thank you</string>
+    <string name="age_verif_step_submitted_body">Your submission is in the queue. We will message you here when a decision is recorded.</string>
+    <string name="age_verif_step_submitted_done">Done</string>
+    <string name="age_verif_back">Back</string>
+    <string name="age_verif_submit_error_no_method">Please pick an ID type before submitting.</string>
+    <string name="age_verif_submit_error_no_image">Please add a photo before submitting.</string>
+    <string name="age_verif_submit_error_generic">Could not submit — please check your connection and try again.</string>
+
 </resources>

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/di/ViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/di/ViewModelModule.kt
@@ -1,6 +1,7 @@
 package com.shyden.shytalk.core.di
 
 import com.shyden.shytalk.feature.ageverification.AgeRestrictionService
+import com.shyden.shytalk.feature.ageverification.AgeVerificationSubmitViewModel
 import com.shyden.shytalk.feature.auth.AuthViewModel
 import com.shyden.shytalk.feature.auth.EmailOtpViewModel
 import com.shyden.shytalk.feature.auth.LockScreenViewModel
@@ -49,6 +50,7 @@ val viewModelModule =
         viewModel { HomeViewModel(get(), get(), get(), get()) }
         viewModel { ProfileViewModel(get(), get(), get(), get(), get(), get(), get()) }
         viewModel { RequiredDOBViewModel(get(), get()) }
+        viewModel { AgeVerificationSubmitViewModel(get()) }
         viewModel { params -> FollowListViewModel(params[0], params[1], get(), get()) }
         viewModel { params -> RoomViewModel(params[0], get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
         viewModel { AppSettingsViewModel(get(), get(), get(), get()) }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/AgeVerificationRepository.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/AgeVerificationRepository.kt
@@ -1,0 +1,79 @@
+package com.shyden.shytalk.data.repository
+
+import com.shyden.shytalk.core.util.Resource
+
+/**
+ * Two-step submit flow for the user-facing age-verification screen
+ * (PR 9 of the multi-PR plan).
+ *
+ *   1. [requestUploadUrl] — server issues a 5-min signed PUT URL plus
+ *      the R2 key the image will live at.
+ *   2. [uploadImage] — client PUTs the bytes directly to R2.
+ *   3. [submit] — server marks the submission pending; an admin reviews
+ *      via the panel built in PR 6.
+ *
+ * Splitting the two HTTP calls keeps the API surface small and matches
+ * the existing photo-upload pattern (avatars, evidence) so the same
+ * Ktor client / okhttp client owns the byte transfer.
+ */
+interface AgeVerificationRepository {
+    /**
+     * Allowed values for [submit]'s `idMethod` argument. Mirrors the
+     * server-side allowlist in `express-api/src/routes/age-verification.js`.
+     */
+    enum class IdMethod(
+        val wireValue: String,
+    ) {
+        Passport("passport"),
+        DriversLicense("drivers-license"),
+        NationalId("national-id"),
+    }
+
+    /**
+     * MIME types the server accepts for the ID image. Same list as the
+     * R2 PUT-URL pre-check on the server.
+     */
+    enum class ContentType(
+        val wireValue: String,
+    ) {
+        Jpeg("image/jpeg"),
+        Png("image/png"),
+        Webp("image/webp"),
+    }
+
+    data class UploadHandle(
+        val uploadUrl: String,
+        val r2Key: String,
+        val expiresInSec: Int,
+    )
+
+    /**
+     * Step 1 — ask the API for a short-lived signed PUT URL. The
+     * returned `r2Key` MUST be passed back to [submit] verbatim — it
+     * encodes the caller's user prefix and is validated server-side
+     * against `req.auth.uniqueId`.
+     */
+    suspend fun requestUploadUrl(contentType: ContentType): Resource<UploadHandle>
+
+    /**
+     * Step 2 — PUT the image bytes to the signed URL. No auth header
+     * (the URL is the auth). Failure here is generally network/expiry
+     * related, NOT auth.
+     */
+    suspend fun uploadImage(
+        uploadUrl: String,
+        contentType: ContentType,
+        bytes: ByteArray,
+    ): Resource<Unit>
+
+    /**
+     * Step 3 — tell the API the upload finished. Server flips status
+     * to 'pending' and notifies admins. Idempotent: a second submit
+     * for the same user while the first is pending returns 409 (the
+     * route only allows one pending submission per user).
+     */
+    suspend fun submit(
+        idMethod: IdMethod,
+        r2Key: String,
+    ): Resource<Unit>
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitScreen.kt
@@ -1,0 +1,363 @@
+package com.shyden.shytalk.feature.ageverification
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.shyden.shytalk.core.platform.PlatformImagePicker
+import com.shyden.shytalk.core.util.UiText
+import com.shyden.shytalk.data.repository.AgeVerificationRepository.ContentType
+import com.shyden.shytalk.data.repository.AgeVerificationRepository.IdMethod
+import com.shyden.shytalk.resources.Res
+import com.shyden.shytalk.resources.age_verif_back
+import com.shyden.shytalk.resources.age_verif_field_method
+import com.shyden.shytalk.resources.age_verif_field_photo
+import com.shyden.shytalk.resources.age_verif_method_drivers_license
+import com.shyden.shytalk.resources.age_verif_method_national_id
+import com.shyden.shytalk.resources.age_verif_method_passport
+import com.shyden.shytalk.resources.age_verif_photo_attached
+import com.shyden.shytalk.resources.age_verif_step_confirm_body
+import com.shyden.shytalk.resources.age_verif_step_confirm_submit
+import com.shyden.shytalk.resources.age_verif_step_confirm_title
+import com.shyden.shytalk.resources.age_verif_step_explanation_body
+import com.shyden.shytalk.resources.age_verif_step_explanation_continue
+import com.shyden.shytalk.resources.age_verif_step_explanation_title
+import com.shyden.shytalk.resources.age_verif_step_image_body
+import com.shyden.shytalk.resources.age_verif_step_image_pick
+import com.shyden.shytalk.resources.age_verif_step_image_replace
+import com.shyden.shytalk.resources.age_verif_step_image_title
+import com.shyden.shytalk.resources.age_verif_step_method_body
+import com.shyden.shytalk.resources.age_verif_step_method_title
+import com.shyden.shytalk.resources.age_verif_step_submitted_body
+import com.shyden.shytalk.resources.age_verif_step_submitted_done
+import com.shyden.shytalk.resources.age_verif_step_submitted_title
+import com.shyden.shytalk.resources.age_verif_submit_title
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+
+const val TAG_AGE_VERIF_CONTINUE = "ageVerif_continue"
+const val TAG_AGE_VERIF_METHOD_PASSPORT = "ageVerif_method_passport"
+const val TAG_AGE_VERIF_METHOD_DRIVERS = "ageVerif_method_drivers"
+const val TAG_AGE_VERIF_METHOD_NATIONAL = "ageVerif_method_national"
+const val TAG_AGE_VERIF_PICK_IMAGE = "ageVerif_pickImage"
+const val TAG_AGE_VERIF_SUBMIT = "ageVerif_submit"
+const val TAG_AGE_VERIF_DONE = "ageVerif_done"
+const val TAG_AGE_VERIF_BACK = "ageVerif_back"
+
+/**
+ * 4-step user-facing verification flow (PR 9).
+ *
+ * State machine in [AgeVerificationSubmitViewModel] drives which step
+ * renders. Navigation pop happens when:
+ *  - user hits the back button on the Explanation step (which is a
+ *    no-op in the VM — the screen interprets it as "exit"), OR
+ *  - user lands on Submitted and hits Done.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AgeVerificationSubmitScreen(
+    onClose: () -> Unit,
+    viewModel: AgeVerificationSubmitViewModel = koinViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(Res.string.age_verif_submit_title)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = {
+                            // Map "back from Explanation / Submitted" to a screen-pop.
+                            // Other steps step backwards through the VM state machine.
+                            when (uiState.step) {
+                                AgeVerificationSubmitStep.Explanation -> onClose()
+                                AgeVerificationSubmitStep.Submitted -> onClose()
+                                else -> viewModel.back()
+                            }
+                        },
+                        modifier = Modifier.testTag(TAG_AGE_VERIF_BACK),
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(Res.string.age_verif_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
+        ) {
+            when (uiState.step) {
+                AgeVerificationSubmitStep.Explanation -> ExplanationStep(viewModel::acknowledgeExplanation)
+
+                AgeVerificationSubmitStep.PickMethod -> PickMethodStep(viewModel::selectMethod)
+
+                AgeVerificationSubmitStep.PickImage ->
+                    PickImageStep(uiState.imageBytes != null) { bytes, ct ->
+                        viewModel.setImage(bytes, ct)
+                    }
+
+                AgeVerificationSubmitStep.Confirm ->
+                    ConfirmStep(
+                        method = uiState.selectedMethod,
+                        photoAttached = uiState.imageBytes != null,
+                        isSubmitting = uiState.isSubmitting,
+                        error = uiState.error,
+                        onSubmit = viewModel::submit,
+                    )
+
+                AgeVerificationSubmitStep.Submitted -> SubmittedStep(onClose)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExplanationStep(onContinue: () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text(
+            stringResource(Res.string.age_verif_step_explanation_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            stringResource(Res.string.age_verif_step_explanation_body),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Spacer(Modifier.height(8.dp))
+        Button(
+            onClick = onContinue,
+            modifier = Modifier.fillMaxWidth().testTag(TAG_AGE_VERIF_CONTINUE),
+        ) {
+            Text(stringResource(Res.string.age_verif_step_explanation_continue))
+        }
+    }
+}
+
+@Composable
+private fun PickMethodStep(onMethodSelected: (IdMethod) -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text(
+            stringResource(Res.string.age_verif_step_method_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            stringResource(Res.string.age_verif_step_method_body),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Spacer(Modifier.height(4.dp))
+        OutlinedButton(
+            onClick = { onMethodSelected(IdMethod.Passport) },
+            modifier = Modifier.fillMaxWidth().testTag(TAG_AGE_VERIF_METHOD_PASSPORT),
+        ) {
+            Text(stringResource(Res.string.age_verif_method_passport))
+        }
+        OutlinedButton(
+            onClick = { onMethodSelected(IdMethod.DriversLicense) },
+            modifier = Modifier.fillMaxWidth().testTag(TAG_AGE_VERIF_METHOD_DRIVERS),
+        ) {
+            Text(stringResource(Res.string.age_verif_method_drivers_license))
+        }
+        OutlinedButton(
+            onClick = { onMethodSelected(IdMethod.NationalId) },
+            modifier = Modifier.fillMaxWidth().testTag(TAG_AGE_VERIF_METHOD_NATIONAL),
+        ) {
+            Text(stringResource(Res.string.age_verif_method_national_id))
+        }
+    }
+}
+
+@Composable
+private fun PickImageStep(
+    photoAlreadyAttached: Boolean,
+    onImagePicked: (ByteArray, ContentType) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text(
+            stringResource(Res.string.age_verif_step_image_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            stringResource(Res.string.age_verif_step_image_body),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Spacer(Modifier.height(4.dp))
+        // PlatformImagePicker emits JPEG bytes via the gallery picker.
+        // Camera support is a follow-up — the existing
+        // ActivityResultContracts.PickVisualMedia path is gallery-only.
+        // Treat all picked bytes as image/jpeg for now; the upload-url
+        // endpoint accepts that content type and the user uploaded
+        // through the system picker so it should be a real image.
+        PlatformImagePicker(
+            onImageSelected = { bytes ->
+                if (bytes != null && bytes.isNotEmpty()) {
+                    onImagePicked(bytes, ContentType.Jpeg)
+                }
+            },
+        ) { launchPicker ->
+            Button(
+                onClick = launchPicker,
+                modifier = Modifier.fillMaxWidth().testTag(TAG_AGE_VERIF_PICK_IMAGE),
+            ) {
+                Text(
+                    stringResource(
+                        if (photoAlreadyAttached) {
+                            Res.string.age_verif_step_image_replace
+                        } else {
+                            Res.string.age_verif_step_image_pick
+                        },
+                    ),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConfirmStep(
+    method: IdMethod?,
+    photoAttached: Boolean,
+    isSubmitting: Boolean,
+    error: UiText?,
+    onSubmit: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            stringResource(Res.string.age_verif_step_confirm_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            stringResource(Res.string.age_verif_step_confirm_body),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Spacer(Modifier.height(4.dp))
+        Row(
+            label = stringResource(Res.string.age_verif_field_method),
+            value = method?.let { stringResource(it.labelRes()) } ?: "—",
+        )
+        Row(
+            label = stringResource(Res.string.age_verif_field_photo),
+            value = if (photoAttached) stringResource(Res.string.age_verif_photo_attached) else "—",
+        )
+        Spacer(Modifier.height(4.dp))
+        if (error != null) {
+            Text(
+                error.resolve(),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        Button(
+            onClick = onSubmit,
+            enabled = !isSubmitting,
+            modifier = Modifier.fillMaxWidth().testTag(TAG_AGE_VERIF_SUBMIT),
+        ) {
+            if (isSubmitting) {
+                CircularProgressIndicator(
+                    modifier = Modifier.height(20.dp).width(20.dp),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                Text(stringResource(Res.string.age_verif_step_confirm_submit))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SubmittedStep(onDone: () -> Unit) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .height(64.dp)
+                    .width(64.dp)
+                    .background(MaterialTheme.colorScheme.primaryContainer, CircleShape),
+        )
+        Text(
+            stringResource(Res.string.age_verif_step_submitted_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            stringResource(Res.string.age_verif_step_submitted_body),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Spacer(Modifier.height(8.dp))
+        Button(
+            onClick = onDone,
+            modifier = Modifier.fillMaxWidth().testTag(TAG_AGE_VERIF_DONE),
+        ) {
+            Text(stringResource(Res.string.age_verif_step_submitted_done))
+        }
+    }
+}
+
+@Composable
+private fun Row(
+    label: String,
+    value: String,
+) {
+    androidx.compose.foundation.layout.Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp))
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodySmall)
+        Text(value, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+    }
+}
+
+private fun IdMethod.labelRes() =
+    when (this) {
+        IdMethod.Passport -> Res.string.age_verif_method_passport
+        IdMethod.DriversLicense -> Res.string.age_verif_method_drivers_license
+        IdMethod.NationalId -> Res.string.age_verif_method_national_id
+    }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitViewModel.kt
@@ -1,0 +1,253 @@
+package com.shyden.shytalk.feature.ageverification
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.core.util.UiText
+import com.shyden.shytalk.core.util.logE
+import com.shyden.shytalk.core.util.logI
+import com.shyden.shytalk.data.repository.AgeVerificationRepository
+import com.shyden.shytalk.data.repository.AgeVerificationRepository.ContentType
+import com.shyden.shytalk.data.repository.AgeVerificationRepository.IdMethod
+import com.shyden.shytalk.resources.Res
+import com.shyden.shytalk.resources.age_verif_submit_error_generic
+import com.shyden.shytalk.resources.age_verif_submit_error_no_image
+import com.shyden.shytalk.resources.age_verif_submit_error_no_method
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Linear 4-step state machine for the user-facing verification submit
+ * flow (PR 9 of the multi-PR plan).
+ *
+ * Transitions only go forward via the gate methods (next/back), so the
+ * UI stays simple — render whatever step is current. No skipping.
+ */
+enum class AgeVerificationSubmitStep {
+    /** "Why we need this / what happens to the image" copy. */
+    Explanation,
+
+    /** Pick passport / driver's license / national ID. */
+    PickMethod,
+
+    /** Pick image bytes (gallery — camera deferred to follow-up). */
+    PickImage,
+
+    /** Show recap + Submit. */
+    Confirm,
+
+    /** Terminal — server accepted; the user is back at sign-in. */
+    Submitted,
+}
+
+data class AgeVerificationSubmitUiState(
+    val step: AgeVerificationSubmitStep = AgeVerificationSubmitStep.Explanation,
+    val selectedMethod: IdMethod? = null,
+    val imageBytes: ByteArray? = null,
+    /** Detected content type. Present only after [setImage]. */
+    val imageContentType: ContentType? = null,
+    val isSubmitting: Boolean = false,
+    val error: UiText? = null,
+) {
+    /**
+     * Custom equals to compare by reference / size for [imageBytes] —
+     * deep array equality is expensive and we only need state-change
+     * detection for Compose recomposition.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AgeVerificationSubmitUiState) return false
+        return step == other.step &&
+            selectedMethod == other.selectedMethod &&
+            imageBytes === other.imageBytes &&
+            imageContentType == other.imageContentType &&
+            isSubmitting == other.isSubmitting &&
+            error == other.error
+    }
+
+    override fun hashCode(): Int {
+        var result = step.hashCode()
+        result = 31 * result + (selectedMethod?.hashCode() ?: 0)
+        result = 31 * result + (imageBytes?.size ?: 0)
+        result = 31 * result + (imageContentType?.hashCode() ?: 0)
+        result = 31 * result + isSubmitting.hashCode()
+        result = 31 * result + (error?.hashCode() ?: 0)
+        return result
+    }
+}
+
+class AgeVerificationSubmitViewModel(
+    private val repository: AgeVerificationRepository,
+) : ViewModel() {
+    companion object {
+        private const val TAG = "AgeVerifSubmitVM"
+    }
+
+    private val _uiState = MutableStateFlow(AgeVerificationSubmitUiState())
+    val uiState: StateFlow<AgeVerificationSubmitUiState> = _uiState.asStateFlow()
+
+    /**
+     * Advance past the explanation step. No validation — the user just
+     * acknowledged the copy.
+     */
+    fun acknowledgeExplanation() {
+        if (_uiState.value.step == AgeVerificationSubmitStep.Explanation) {
+            _uiState.update { it.copy(step = AgeVerificationSubmitStep.PickMethod, error = null) }
+        }
+    }
+
+    /**
+     * Lock in the picked ID method and advance to image picking.
+     * Re-pickable until the user confirms (back button reverts here).
+     */
+    fun selectMethod(method: IdMethod) {
+        _uiState.update {
+            it.copy(
+                step = AgeVerificationSubmitStep.PickImage,
+                selectedMethod = method,
+                error = null,
+            )
+        }
+    }
+
+    /**
+     * Store the picked image bytes + detected content type and advance
+     * to the Confirm step. Caller is responsible for sniffing the
+     * content type from the platform picker (JPEG is the default but
+     * iOS PHPicker can return PNG / WebP).
+     */
+    fun setImage(
+        bytes: ByteArray,
+        contentType: ContentType,
+    ) {
+        _uiState.update {
+            it.copy(
+                step = AgeVerificationSubmitStep.Confirm,
+                imageBytes = bytes,
+                imageContentType = contentType,
+                error = null,
+            )
+        }
+    }
+
+    /**
+     * Step back one. The Confirm step backs to PickImage so the user
+     * can swap the photo without re-picking the method. PickImage
+     * backs to PickMethod. PickMethod backs to Explanation. Explanation
+     * is a no-op — the screen-level back handler should pop navigation.
+     */
+    fun back() {
+        _uiState.update {
+            when (it.step) {
+                AgeVerificationSubmitStep.Confirm ->
+                    it.copy(step = AgeVerificationSubmitStep.PickImage, error = null)
+
+                AgeVerificationSubmitStep.PickImage ->
+                    it.copy(step = AgeVerificationSubmitStep.PickMethod, error = null)
+
+                AgeVerificationSubmitStep.PickMethod ->
+                    it.copy(step = AgeVerificationSubmitStep.Explanation, error = null)
+
+                AgeVerificationSubmitStep.Explanation,
+                AgeVerificationSubmitStep.Submitted,
+                -> it
+            }
+        }
+    }
+
+    /**
+     * Final action — runs the 3-call submit flow inside the VM scope.
+     * Sets [AgeVerificationSubmitUiState.isSubmitting] to true while
+     * any of the calls is in flight so the UI can disable the button.
+     *
+     * On success, transitions to [AgeVerificationSubmitStep.Submitted]
+     * and the screen is expected to navigate away (back to the
+     * pending-state UI / home).
+     *
+     * On failure, sets an error UiText and stays on the Confirm step
+     * so the user can retry.
+     */
+    fun submit() {
+        val state = _uiState.value
+        val method = state.selectedMethod
+        val bytes = state.imageBytes
+        val contentType = state.imageContentType
+        if (method == null) {
+            _uiState.update { it.copy(error = UiText.Res(Res.string.age_verif_submit_error_no_method)) }
+            return
+        }
+        if (bytes == null || contentType == null) {
+            _uiState.update { it.copy(error = UiText.Res(Res.string.age_verif_submit_error_no_image)) }
+            return
+        }
+        _uiState.update { it.copy(isSubmitting = true, error = null) }
+
+        viewModelScope.launch {
+            val handle =
+                when (val r = repository.requestUploadUrl(contentType)) {
+                    is Resource.Success -> r.data
+
+                    is Resource.Error -> {
+                        logE(TAG, "Upload-URL failed: ${r.message}")
+                        _uiState.update {
+                            it.copy(
+                                isSubmitting = false,
+                                error = UiText.Res(Res.string.age_verif_submit_error_generic),
+                            )
+                        }
+                        return@launch
+                    }
+
+                    is Resource.Loading -> return@launch
+                }
+
+            when (val r = repository.uploadImage(handle.uploadUrl, contentType, bytes)) {
+                is Resource.Success -> Unit
+
+                is Resource.Error -> {
+                    logE(TAG, "R2 PUT failed: ${r.message}")
+                    _uiState.update {
+                        it.copy(
+                            isSubmitting = false,
+                            error = UiText.Res(Res.string.age_verif_submit_error_generic),
+                        )
+                    }
+                    return@launch
+                }
+
+                is Resource.Loading -> return@launch
+            }
+
+            when (val r = repository.submit(method, handle.r2Key)) {
+                is Resource.Success -> {
+                    logI(TAG, "Submission accepted, transitioning to Submitted")
+                    _uiState.update {
+                        it.copy(
+                            step = AgeVerificationSubmitStep.Submitted,
+                            isSubmitting = false,
+                        )
+                    }
+                }
+
+                is Resource.Error -> {
+                    logE(TAG, "Submit failed: ${r.message}")
+                    _uiState.update {
+                        it.copy(
+                            isSubmitting = false,
+                            error = UiText.Res(Res.string.age_verif_submit_error_generic),
+                        )
+                    }
+                }
+
+                is Resource.Loading -> Unit
+            }
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(error = null) }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatScreen.kt
@@ -98,6 +98,7 @@ fun PrivateChatScreen(
     onPickImages: (() -> Unit)? = null,
     onPickStickerImage: (() -> Unit)? = null,
     onNavigateToRoom: ((String) -> Unit)? = null,
+    onNavigateToAgeVerification: () -> Unit = {},
     activeRoomId: String? = null,
     activeRoomName: String? = null,
     conversationId: String? = null,
@@ -105,6 +106,7 @@ fun PrivateChatScreen(
     viewModel: PrivateChatViewModel = koinViewModel(key = conversationId ?: otherUserId) { parametersOf(otherUserId) },
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val ageRestrictionDialogState by viewModel.ageRestrictionDialogState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val listState = rememberLazyListState()
     val timeStrings = rememberRelativeTimeStrings()
@@ -981,6 +983,18 @@ fun PrivateChatScreen(
             _onAddParticipant = { viewModel.addGroupParticipant(it) },
         )
     }
+
+    // Age-verification gate dialog (PR 9). The dialog's own interactive
+    // elements carry testTags inside AgeRestrictionDialog.kt
+    // (TAG_NEEDS_VERIFICATION_CONFIRM etc.). NeedsVerification routes to
+    // the submit screen; SubEighteen offers contact-support (no entry
+    // into the verification flow — they need to age in).
+    com.shyden.shytalk.feature.ageverification.AgeRestrictionDialog(
+        state = ageRestrictionDialogState,
+        onDismiss = { viewModel.dismissAgeRestrictionDialog() },
+        onVerifyNow = onNavigateToAgeVerification,
+        onContactSupport = { viewModel.dismissAgeRestrictionDialog() },
+    )
 }
 
 private val reportReasons = listOf("Spam", "Harassment", "Inappropriate Content", "Other")

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/navigation/Screen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/navigation/Screen.kt
@@ -77,4 +77,8 @@ sealed class Screen(
     data object PinSetup : Screen("pin_setup")
 
     data object SecuritySettings : Screen("security_settings")
+
+    /** Age-verification submit flow (PR 9). User reaches it from the
+     *  AgeRestrictionDialog "Verify now" CTA in PM / gacha. */
+    data object AgeVerificationSubmit : Screen("age_verification_submit")
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/navigation/SharedNavGraph.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/navigation/SharedNavGraph.kt
@@ -36,6 +36,7 @@ import com.shyden.shytalk.core.util.currentTimeMillis
 import com.shyden.shytalk.data.remote.VoiceService
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.UserRepository
+import com.shyden.shytalk.feature.ageverification.AgeVerificationSubmitScreen
 import com.shyden.shytalk.feature.auth.EmailOtpScreen
 import com.shyden.shytalk.feature.daily.DailyRewardCelebrationDialog
 import com.shyden.shytalk.feature.daily.DailyRewardDialog
@@ -219,6 +220,16 @@ fun SharedNavGraph(
                             popUpTo(Screen.RequiredDOB.route) { inclusive = true }
                         }
                     },
+                )
+            }
+
+            // ── Age Verification submit (PR 9) ──
+            // Reached from the AgeRestrictionDialog "Verify now" CTA
+            // when the user is 18+ but unverified. The screen handles
+            // its own back/done navigation via onClose.
+            composable(Screen.AgeVerificationSubmit.route) {
+                AgeVerificationSubmitScreen(
+                    onClose = { navController.popBackStack() },
                 )
             }
 
@@ -447,6 +458,9 @@ fun SharedNavGraph(
                         }
                     },
                     onNavigateToRoom = { roomId -> navigateToRoom(roomId) },
+                    onNavigateToAgeVerification = {
+                        navController.navigate(Screen.AgeVerificationSubmit.route)
+                    },
                     activeRoomId = activeRoomId,
                     activeRoomName = activeRoom?.name,
                     viewModel = chatViewModel,

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/IosPlatformModule.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/IosPlatformModule.kt
@@ -23,6 +23,7 @@ import com.shyden.shytalk.data.remote.IosTypingRepositoryImpl
 import com.shyden.shytalk.data.remote.PresenceService
 import com.shyden.shytalk.data.remote.TokenService
 import com.shyden.shytalk.data.remote.VoiceService
+import com.shyden.shytalk.data.repository.AgeVerificationRepository
 import com.shyden.shytalk.data.repository.AppLockRepository
 import com.shyden.shytalk.data.repository.AppLockRepositoryImpl
 import com.shyden.shytalk.data.repository.AuthRepository
@@ -33,6 +34,7 @@ import com.shyden.shytalk.data.repository.EconomyRepository
 import com.shyden.shytalk.data.repository.FunFactRepository
 import com.shyden.shytalk.data.repository.GiftRepository
 import com.shyden.shytalk.data.repository.IdentityRepository
+import com.shyden.shytalk.data.repository.IosAgeVerificationRepositoryImpl
 import com.shyden.shytalk.data.repository.IosAuthRepositoryImpl
 import com.shyden.shytalk.data.repository.IosBannerRepositoryImpl
 import com.shyden.shytalk.data.repository.IosBiometricRepositoryImpl
@@ -140,6 +142,7 @@ val iosPlatformModule =
         single<MessageRepository> { IosMessageRepositoryImpl(get()) }
         single<SeatRequestRepository> { IosSeatRequestRepositoryImpl(get(), get()) }
         single<StorageRepository> { IosStorageRepositoryImpl(get()) }
+        single<AgeVerificationRepository> { IosAgeVerificationRepositoryImpl(get()) }
         single<DeviceRepository> { IosDeviceRepositoryImpl(get(), get()) }
         single<IdentityRepository> { IosIdentityRepositoryImpl(get(), get()) }
         single<PrivateMessageRepository> { IosPrivateMessageRepositoryImpl(get(), get(), get()) }

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosSmallRepositories.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosSmallRepositories.kt
@@ -11,6 +11,9 @@ import com.shyden.shytalk.data.firestore.dataMap
 import com.shyden.shytalk.data.remote.ApiException
 import com.shyden.shytalk.data.remote.IosApiClient
 import dev.gitlive.firebase.firestore.FirebaseFirestore
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.contentType
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -478,4 +481,73 @@ class IosStorageRepositoryImpl(
             logW("StorageRepository", "Best-effort image delete failed", e)
         }
     }
+}
+
+// ── AgeVerificationRepository (PR 9) ───────────────────────────────
+
+/**
+ * iOS impl of the user-facing age-verification submit flow. Uses
+ * [IosApiClient] for the two server-side calls and a fresh Ktor
+ * [io.ktor.client.HttpClient] for the direct R2 PUT (the signed URL
+ * IS the auth — no Bearer header to attach).
+ */
+class IosAgeVerificationRepositoryImpl(
+    private val api: IosApiClient,
+) : AgeVerificationRepository {
+    override suspend fun requestUploadUrl(
+        contentType: AgeVerificationRepository.ContentType,
+    ): Resource<AgeVerificationRepository.UploadHandle> =
+        firebaseCall("Failed to request upload URL") {
+            val body =
+                JsonObject(mapOf("contentType" to JsonPrimitive(contentType.wireValue)))
+            val resp = api.post("/api/age-verification/upload-url", body)
+            AgeVerificationRepository.UploadHandle(
+                uploadUrl =
+                    resp["uploadUrl"]?.jsonPrimitive?.contentOrNull
+                        ?: throw RuntimeException("uploadUrl missing"),
+                r2Key =
+                    resp["r2Key"]?.jsonPrimitive?.contentOrNull
+                        ?: throw RuntimeException("r2Key missing"),
+                expiresInSec = resp["expiresInSec"]?.jsonPrimitive?.int ?: 300,
+            )
+        }
+
+    override suspend fun uploadImage(
+        uploadUrl: String,
+        contentType: AgeVerificationRepository.ContentType,
+        bytes: ByteArray,
+    ): Resource<Unit> =
+        firebaseCall("Failed to upload ID image") {
+            val client = io.ktor.client.HttpClient()
+            try {
+                val response =
+                    client.put(uploadUrl) {
+                        contentType(
+                            io.ktor.http.ContentType
+                                .parse(contentType.wireValue),
+                        )
+                        setBody(bytes)
+                    }
+                if (response.status.value !in 200..299) {
+                    throw RuntimeException("R2 PUT failed: HTTP ${response.status.value}")
+                }
+            } finally {
+                client.close()
+            }
+        }
+
+    override suspend fun submit(
+        idMethod: AgeVerificationRepository.IdMethod,
+        r2Key: String,
+    ): Resource<Unit> =
+        firebaseCall("Failed to submit verification") {
+            val body =
+                JsonObject(
+                    mapOf(
+                        "idMethod" to JsonPrimitive(idMethod.wireValue),
+                        "r2Key" to JsonPrimitive(r2Key),
+                    ),
+                )
+            api.post("/api/age-verification/submit", body)
+        }
 }

--- a/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/di/ViewModelModuleTest.kt
+++ b/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/di/ViewModelModuleTest.kt
@@ -9,6 +9,7 @@ import com.shyden.shytalk.data.remote.ConversationWebSocketService
 import com.shyden.shytalk.data.remote.PresenceService
 import com.shyden.shytalk.data.remote.TokenService
 import com.shyden.shytalk.data.remote.VoiceService
+import com.shyden.shytalk.data.repository.AgeVerificationRepository
 import com.shyden.shytalk.data.repository.AppLockRepository
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.BannerRepository
@@ -53,6 +54,7 @@ class ViewModelModuleTest {
                     MessageRepository::class,
                     SeatRequestRepository::class,
                     StorageRepository::class,
+                    AgeVerificationRepository::class,
                     DeviceRepository::class,
                     IdentityRepository::class,
                     PrivateMessageRepository::class,

--- a/shared/src/jvmTest/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitViewModelTest.kt
+++ b/shared/src/jvmTest/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitViewModelTest.kt
@@ -1,0 +1,300 @@
+package com.shyden.shytalk.feature.ageverification
+
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.data.repository.AgeVerificationRepository
+import com.shyden.shytalk.data.repository.AgeVerificationRepository.ContentType
+import com.shyden.shytalk.data.repository.AgeVerificationRepository.IdMethod
+import com.shyden.shytalk.data.repository.AgeVerificationRepository.UploadHandle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the user-facing age-verification submit flow ViewModel
+ * (PR 9). Pin the state-machine transitions, the back-button rules,
+ * and the failure paths through the 3-call submit sequence.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AgeVerificationSubmitViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repo: FakeAgeVerificationRepository
+    private lateinit var viewModel: AgeVerificationSubmitViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        repo = FakeAgeVerificationRepository()
+        viewModel = AgeVerificationSubmitViewModel(repo)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // ─── Initial state ──────────────────────────────────────────
+
+    @Test
+    fun `initial state is Explanation step`() {
+        assertEquals(AgeVerificationSubmitStep.Explanation, viewModel.uiState.value.step)
+        assertNull(viewModel.uiState.value.selectedMethod)
+        assertNull(viewModel.uiState.value.imageBytes)
+        assertFalse(viewModel.uiState.value.isSubmitting)
+        assertNull(viewModel.uiState.value.error)
+    }
+
+    // ─── Forward transitions ────────────────────────────────────
+
+    @Test
+    fun `acknowledgeExplanation moves to PickMethod`() {
+        viewModel.acknowledgeExplanation()
+        assertEquals(AgeVerificationSubmitStep.PickMethod, viewModel.uiState.value.step)
+    }
+
+    @Test
+    fun `selectMethod stores choice and moves to PickImage`() {
+        viewModel.acknowledgeExplanation()
+        viewModel.selectMethod(IdMethod.Passport)
+        assertEquals(AgeVerificationSubmitStep.PickImage, viewModel.uiState.value.step)
+        assertEquals(IdMethod.Passport, viewModel.uiState.value.selectedMethod)
+    }
+
+    @Test
+    fun `setImage stores bytes and moves to Confirm`() {
+        viewModel.acknowledgeExplanation()
+        viewModel.selectMethod(IdMethod.NationalId)
+        viewModel.setImage(byteArrayOf(0x01, 0x02), ContentType.Jpeg)
+        assertEquals(AgeVerificationSubmitStep.Confirm, viewModel.uiState.value.step)
+        assertEquals(
+            2,
+            viewModel.uiState.value.imageBytes
+                ?.size,
+        )
+        assertEquals(ContentType.Jpeg, viewModel.uiState.value.imageContentType)
+    }
+
+    // ─── Back transitions ──────────────────────────────────────
+
+    @Test
+    fun `back from Confirm returns to PickImage and keeps image data`() {
+        viewModel.acknowledgeExplanation()
+        viewModel.selectMethod(IdMethod.Passport)
+        viewModel.setImage(byteArrayOf(0x01), ContentType.Jpeg)
+        viewModel.back()
+        assertEquals(AgeVerificationSubmitStep.PickImage, viewModel.uiState.value.step)
+        // Image data is preserved so the user can decide to keep or
+        // replace it without re-picking from scratch.
+        assertNotNull(viewModel.uiState.value.imageBytes)
+    }
+
+    @Test
+    fun `back from PickImage returns to PickMethod`() {
+        viewModel.acknowledgeExplanation()
+        viewModel.selectMethod(IdMethod.Passport)
+        viewModel.back()
+        assertEquals(AgeVerificationSubmitStep.PickMethod, viewModel.uiState.value.step)
+    }
+
+    @Test
+    fun `back from PickMethod returns to Explanation`() {
+        viewModel.acknowledgeExplanation()
+        viewModel.back()
+        assertEquals(AgeVerificationSubmitStep.Explanation, viewModel.uiState.value.step)
+    }
+
+    @Test
+    fun `back from Explanation is a no-op (screen pops navigation instead)`() {
+        viewModel.back()
+        assertEquals(AgeVerificationSubmitStep.Explanation, viewModel.uiState.value.step)
+    }
+
+    @Test
+    fun `back from Submitted is a no-op`() {
+        // Force Submitted state and verify back() doesn't reset.
+        runTest(testDispatcher) {
+            primeRepoForSuccess()
+            viewModel.acknowledgeExplanation()
+            viewModel.selectMethod(IdMethod.Passport)
+            viewModel.setImage(byteArrayOf(0x01), ContentType.Jpeg)
+            viewModel.submit()
+            advanceUntilIdle()
+            assertEquals(AgeVerificationSubmitStep.Submitted, viewModel.uiState.value.step)
+
+            viewModel.back()
+            assertEquals(AgeVerificationSubmitStep.Submitted, viewModel.uiState.value.step)
+        }
+    }
+
+    // ─── submit() pre-validation ────────────────────────────────
+
+    @Test
+    fun `submit without method sets error_no_method and stays on step`() {
+        viewModel.submit()
+        assertNotNull(viewModel.uiState.value.error)
+        assertFalse(viewModel.uiState.value.isSubmitting)
+    }
+
+    @Test
+    fun `submit with method but no image sets error_no_image`() {
+        viewModel.acknowledgeExplanation()
+        viewModel.selectMethod(IdMethod.Passport)
+        viewModel.submit()
+        assertNotNull(viewModel.uiState.value.error)
+        assertFalse(viewModel.uiState.value.isSubmitting)
+    }
+
+    // ─── submit() happy path ───────────────────────────────────
+
+    @Test
+    fun `submit happy path runs all three calls in order and reaches Submitted`() =
+        runTest(testDispatcher) {
+            primeRepoForSuccess()
+            viewModel.acknowledgeExplanation()
+            viewModel.selectMethod(IdMethod.DriversLicense)
+            viewModel.setImage(byteArrayOf(0x01, 0x02, 0x03), ContentType.Jpeg)
+
+            viewModel.submit()
+            advanceUntilIdle()
+
+            assertEquals(AgeVerificationSubmitStep.Submitted, viewModel.uiState.value.step)
+            assertFalse(viewModel.uiState.value.isSubmitting)
+            assertEquals(1, repo.requestUploadUrlCalls)
+            assertEquals(1, repo.uploadImageCalls)
+            assertEquals(1, repo.submitCalls)
+            assertEquals(IdMethod.DriversLicense, repo.lastSubmitMethod)
+        }
+
+    @Test
+    fun `submit failure on requestUploadUrl stays at Confirm with error`() =
+        runTest(testDispatcher) {
+            repo.uploadUrlResult = Resource.Error("offline")
+            viewModel.acknowledgeExplanation()
+            viewModel.selectMethod(IdMethod.Passport)
+            viewModel.setImage(byteArrayOf(0x01), ContentType.Jpeg)
+
+            viewModel.submit()
+            advanceUntilIdle()
+
+            assertEquals(AgeVerificationSubmitStep.Confirm, viewModel.uiState.value.step)
+            assertNotNull(viewModel.uiState.value.error)
+            assertFalse(viewModel.uiState.value.isSubmitting)
+            assertEquals(0, repo.uploadImageCalls)
+            assertEquals(0, repo.submitCalls)
+        }
+
+    @Test
+    fun `submit failure on uploadImage skips submit() and stays at Confirm with error`() =
+        runTest(testDispatcher) {
+            repo.uploadUrlResult =
+                Resource.Success(UploadHandle("https://r2/sig", "age-verification/u1/k.jpg", 300))
+            repo.uploadImageResult = Resource.Error("R2 timeout")
+            viewModel.acknowledgeExplanation()
+            viewModel.selectMethod(IdMethod.Passport)
+            viewModel.setImage(byteArrayOf(0x01), ContentType.Jpeg)
+
+            viewModel.submit()
+            advanceUntilIdle()
+
+            assertEquals(AgeVerificationSubmitStep.Confirm, viewModel.uiState.value.step)
+            assertNotNull(viewModel.uiState.value.error)
+            assertFalse(viewModel.uiState.value.isSubmitting)
+            // Crucially: submit() must NOT have been called — without
+            // bytes in R2, marking the submission pending would surface
+            // a broken record to the admin.
+            assertEquals(0, repo.submitCalls)
+        }
+
+    @Test
+    fun `submit failure on submit() stays at Confirm with error`() =
+        runTest(testDispatcher) {
+            repo.uploadUrlResult =
+                Resource.Success(UploadHandle("https://r2/sig", "age-verification/u1/k.jpg", 300))
+            repo.uploadImageResult = Resource.Success(Unit)
+            repo.submitResult = Resource.Error("server error")
+            viewModel.acknowledgeExplanation()
+            viewModel.selectMethod(IdMethod.Passport)
+            viewModel.setImage(byteArrayOf(0x01), ContentType.Jpeg)
+
+            viewModel.submit()
+            advanceUntilIdle()
+
+            assertEquals(AgeVerificationSubmitStep.Confirm, viewModel.uiState.value.step)
+            assertNotNull(viewModel.uiState.value.error)
+            assertFalse(viewModel.uiState.value.isSubmitting)
+        }
+
+    @Test
+    fun `clearError nulls the error`() =
+        runTest(testDispatcher) {
+            repo.uploadUrlResult = Resource.Error("offline")
+            viewModel.acknowledgeExplanation()
+            viewModel.selectMethod(IdMethod.Passport)
+            viewModel.setImage(byteArrayOf(0x01), ContentType.Jpeg)
+            viewModel.submit()
+            advanceUntilIdle()
+            assertNotNull(viewModel.uiState.value.error)
+
+            viewModel.clearError()
+            assertNull(viewModel.uiState.value.error)
+        }
+
+    private fun primeRepoForSuccess() {
+        repo.uploadUrlResult =
+            Resource.Success(UploadHandle("https://r2/sig", "age-verification/u1/key.jpg", 300))
+        repo.uploadImageResult = Resource.Success(Unit)
+        repo.submitResult = Resource.Success(Unit)
+    }
+
+    /**
+     * In-memory fake of [AgeVerificationRepository]. Captures call
+     * counts + last arguments; pre-set the `*Result` properties to
+     * shape the response for each test.
+     */
+    private class FakeAgeVerificationRepository : AgeVerificationRepository {
+        var uploadUrlResult: Resource<UploadHandle> = Resource.Error("not configured")
+        var uploadImageResult: Resource<Unit> = Resource.Error("not configured")
+        var submitResult: Resource<Unit> = Resource.Error("not configured")
+
+        var requestUploadUrlCalls = 0
+        var uploadImageCalls = 0
+        var submitCalls = 0
+        var lastSubmitMethod: IdMethod? = null
+        var lastSubmitR2Key: String? = null
+
+        override suspend fun requestUploadUrl(contentType: ContentType): Resource<UploadHandle> {
+            requestUploadUrlCalls++
+            return uploadUrlResult
+        }
+
+        override suspend fun uploadImage(
+            uploadUrl: String,
+            contentType: ContentType,
+            bytes: ByteArray,
+        ): Resource<Unit> {
+            uploadImageCalls++
+            return uploadImageResult
+        }
+
+        override suspend fun submit(
+            idMethod: IdMethod,
+            r2Key: String,
+        ): Resource<Unit> {
+            submitCalls++
+            lastSubmitMethod = idMethod
+            lastSubmitR2Key = r2Key
+            return submitResult
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the 4-step KMP user-facing verification submit flow that the user enters via the AgeRestrictionDialog "Verify now" CTA.
- Hooks the dialog into PrivateChatScreen so the gate now works end-to-end (Gacha screen wiring follows in a small later PR).
- Per spec answer #6 from 2026-05-04: multi-step explanation with informed consent before submission.

## What's in
**Repository (KMP)**
- `AgeVerificationRepository` interface in `commonMain` with three calls: `requestUploadUrl`, `uploadImage` (direct R2 PUT), `submit`.
- Android impl uses OkHttp + `WorkerApiClient`.
- iOS impl uses Ktor Darwin + `IosApiClient`.

**ViewModel**
- `AgeVerificationSubmitViewModel` — linear state machine `Explanation → PickMethod → PickImage → Confirm → Submitted`.
- `submit()` runs the three calls in order; any failure stays at Confirm with a localised error so the user can retry without re-picking.

**Screen**
- `AgeVerificationSubmitScreen` — Compose Multiplatform, identical on Android + iOS.
- Each step is its own private composable with testTags for E2E.
- Uses existing `PlatformImagePicker` (gallery only — camera is a follow-up since `PickVisualMedia` / `PHPicker` are gallery-bound).

**Wiring**
- `Screen.AgeVerificationSubmit` route added to `SharedNavGraph`.
- `PrivateChatScreen` collects `ageRestrictionDialogState` and renders `AgeRestrictionDialog`. `onVerifyNow` navigates to the new screen.

**i18n**
- 25 EN strings added. PR 13 ships translations for the 19 non-EN locales.

## Test plan
- [x] `:shared:jvmTest` — 13 new tests for the ViewModel state machine (forward, back, pre-submit validation, happy path, every failure branch, clearError)
- [x] `:shared:compileKotlinIosArm64` — iOS shared compiles
- [x] `:app:compileLocalDebugKotlin :app:testLocalDebugUnitTest` — Android compiles + existing tests pass
- [x] `detekt` clean
- [x] `ktlint --relative` clean
- [x] Pre-push Playwright chromium suite — 1124 passed

## Manual QA (post-merge)
- [ ] Sign in as sub-18-with-DOB user → tap PM input → AgeRestrictionDialog SubEighteen variant shows
- [ ] Sign in as 18+ unverified user → tap PM input → AgeRestrictionDialog NeedsVerification → tap Verify Now → submit screen opens
- [ ] Walk Explanation → PickMethod (Passport) → PickImage (gallery) → Confirm → Submit → Submitted screen
- [ ] Back from Confirm preserves photo data; Back from PickImage rewinds to PickMethod
- [ ] Force a network failure → error shown on Confirm; retry succeeds

## Follow-ups
- Camera support for ID upload (gallery-only today)
- Wire AgeRestrictionDialog into GachaScreen + GachaViewModel render path
- Translate 25 new strings × 19 locales (PR 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)