### PR TITLE
feat(age-verif): wire AgeRestrictionDialog into RoomScreen for Gacha gate

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/navigation/NavGraph.kt
+++ b/app/src/main/java/com/shyden/shytalk/navigation/NavGraph.kt
@@ -463,6 +463,9 @@ fun NavGraph(
                     onNavigateToWallet = {
                         navController.navigate(Screen.Wallet.route)
                     },
+                    onNavigateToAgeVerification = {
+                        navController.navigate(Screen.AgeVerificationSubmit.route)
+                    },
                 )
             }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -113,6 +113,7 @@ fun RoomScreen(
     onNavigateToUserProfile: (String) -> Unit = {},
     onNavigateToChat: (String) -> Unit = {},
     onNavigateToWallet: () -> Unit = {},
+    onNavigateToAgeVerification: () -> Unit = {},
     viewModel: RoomViewModel = koinViewModel { parametersOf(roomId) },
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -1236,4 +1237,17 @@ fun RoomScreen(
             }
         }
     }
+
+    // Age-verification gate dialog for Gacha (PR 9 follow-up). The
+    // dialog's interactive elements carry testTags inside
+    // AgeRestrictionDialog.kt (TAG_NEEDS_VERIFICATION_CONFIRM etc.).
+    // NeedsVerification routes to the submit screen; SubEighteen offers
+    // contact-support (no entry into the verification flow).
+    val gachaAgeRestrictionState by gachaViewModel.ageRestrictionDialogState.collectAsStateWithLifecycle()
+    com.shyden.shytalk.feature.ageverification.AgeRestrictionDialog(
+        state = gachaAgeRestrictionState,
+        onDismiss = { gachaViewModel.dismissAgeRestrictionDialog() },
+        onVerifyNow = onNavigateToAgeVerification,
+        onContactSupport = { gachaViewModel.dismissAgeRestrictionDialog() },
+    )
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/navigation/PlatformScreens.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/navigation/PlatformScreens.kt
@@ -54,6 +54,7 @@ data class RoomScreenParams(
     val onNavigateToUserProfile: (String) -> Unit = {},
     val onNavigateToChat: (String) -> Unit = {},
     val onNavigateToWallet: () -> Unit = {},
+    val onNavigateToAgeVerification: () -> Unit = {},
 )
 
 /**

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/navigation/SharedNavGraph.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/navigation/SharedNavGraph.kt
@@ -389,6 +389,9 @@ fun SharedNavGraph(
                         onNavigateToWallet = {
                             navController.navigate(Screen.Wallet.route)
                         },
+                        onNavigateToAgeVerification = {
+                            navController.navigate(Screen.AgeVerificationSubmit.route)
+                        },
                     ),
                 )
             }

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/navigation/IosPlatformScreens.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/navigation/IosPlatformScreens.kt
@@ -66,6 +66,7 @@ fun createIosPlatformScreens(): PlatformScreens =
                 onNavigateToUserProfile = params.onNavigateToUserProfile,
                 onNavigateToChat = params.onNavigateToChat,
                 onNavigateToWallet = params.onNavigateToWallet,
+                onNavigateToAgeVerification = params.onNavigateToAgeVerification,
             )
         },
     )


### PR DESCRIPTION
## Summary
Follow-up to PR 9 (#466). The Gacha entry point was missing its dialog renderer — `GachaViewModel` exposes `ageRestrictionDialogState` but no screen observed it, meaning a sub-18 user attempting a pull would silently no-op rather than seeing the SubEighteen dialog.

## What's in
- `RoomScreen` accepts a new `onNavigateToAgeVerification` callback and renders `AgeRestrictionDialog` at the end of its composition with state from `gachaViewModel.ageRestrictionDialogState`.
- `RoomScreenParams` (in `PlatformScreens.kt`) gains the callback so the iOS factory in `IosPlatformScreens` forwards it through.
- `SharedNavGraph` (iOS) and Android `NavGraph` both wire the new callback to `navController.navigate(Screen.AgeVerificationSubmit.route)`.

End-to-end gate is now active on both PM (PR 9) and Gacha (this PR) entry points.

## Test plan
- [x] `:shared:jvmTest :shared:compileKotlinIosArm64 :app:compileLocalDebugKotlin detekt` — all green
- [x] `ktlint --relative` clean

## Manual QA (post-merge)
- [ ] Sub-18 user enters a room → tap a gacha pull button → SubEighteen dialog appears with Contact-support CTA (no entry into the verification flow).
- [ ] 18+ unverified user enters a room → tap a gacha pull → NeedsVerification dialog → Verify Now → submit screen opens.
- [ ] Same scenarios on iOS Simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)