### PR TITLE
feat(age-verif): PR 13 — translate new strings via Google-first script

### DIFF
--- a/express-api/tests/scripts/translate-strings.test.js
+++ b/express-api/tests/scripts/translate-strings.test.js
@@ -1,0 +1,252 @@
+/**
+ * Unit tests for the Google-first translate-strings.js script.
+ * Mocks `fetch` so the test never hits Google Translate; pins the
+ * provenance-tag insertion / replacement logic + the untagged-as-
+ * Claude scan semantics.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+let tmpDir;
+let scriptPath;
+
+beforeAll(() => {
+  scriptPath = path.resolve(__dirname, '../../../scripts/translate-strings.js');
+});
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'translate-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  jest.resetModules();
+  delete global.fetch;
+});
+
+function loadScript() {
+  // Re-require so the module reads CWD fresh — the script reads
+  // COMPOSE_RES_BASE relative to process.cwd().
+  delete require.cache[scriptPath];
+  return require(scriptPath);
+}
+
+// ─── findNonGoogleStrings ────────────────────────────────────────
+
+describe('findNonGoogleStrings (untagged + claude-tagged)', () => {
+  test('untagged <string> is returned (untagged == claude per the rule)', () => {
+    const xml = `<resources>
+    <string name="key1">Bonjour</string>
+</resources>
+`;
+    const { findNonGoogleStrings } = jest.requireActual('../../../scripts/translate-strings.js');
+    expect(findNonGoogleStrings(xml)).toEqual([{ key: 'key1', value: 'Bonjour' }]);
+  });
+
+  test('claude-tagged <string> is returned', () => {
+    const xml = `<resources>
+    <!-- claude-translated 2026-05-04 -->
+    <string name="key2">Hola</string>
+</resources>
+`;
+    const { findNonGoogleStrings } = jest.requireActual('../../../scripts/translate-strings.js');
+    expect(findNonGoogleStrings(xml)).toEqual([{ key: 'key2', value: 'Hola' }]);
+  });
+
+  test('google-tagged <string> is SKIPPED (idempotent re-runs)', () => {
+    const xml = `<resources>
+    <!-- google-translated 2026-05-04 -->
+    <string name="key3">Hallo</string>
+</resources>
+`;
+    const { findNonGoogleStrings } = jest.requireActual('../../../scripts/translate-strings.js');
+    expect(findNonGoogleStrings(xml)).toEqual([]);
+  });
+
+  test('mixed file returns only non-google entries', () => {
+    const xml = `<resources>
+    <string name="bare">untagged</string>
+    <!-- claude-translated 2026-04-01 -->
+    <string name="claude_old">claude-only</string>
+    <!-- google-translated 2026-05-01 -->
+    <string name="google_done">already-google</string>
+    <string name="bare2">also-untagged</string>
+</resources>
+`;
+    const { findNonGoogleStrings } = jest.requireActual('../../../scripts/translate-strings.js');
+    expect(findNonGoogleStrings(xml)).toEqual([
+      { key: 'bare', value: 'untagged' },
+      { key: 'claude_old', value: 'claude-only' },
+      { key: 'bare2', value: 'also-untagged' },
+    ]);
+  });
+});
+
+// ─── upsertTranslation ────────────────────────────────────────────
+
+describe('upsertTranslation', () => {
+  test('inserts a new <string> + provenance comment before </resources>', () => {
+    const localePath = path.join(tmpDir, 'strings.xml');
+    fs.writeFileSync(
+      localePath,
+      `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="other">existing</string>
+</resources>
+`,
+    );
+    const { upsertTranslation } = loadScript();
+    upsertTranslation(localePath, 'newkey', 'Texte traduit', 'google');
+    const result = fs.readFileSync(localePath, 'utf8');
+    expect(result).toContain('<!-- google-translated ');
+    expect(result).toContain('<string name="newkey">Texte traduit</string>');
+    // Existing key untouched
+    expect(result).toContain('<string name="other">existing</string>');
+  });
+
+  test('replaces an existing <string> AND its preceding provenance comment', () => {
+    const localePath = path.join(tmpDir, 'strings.xml');
+    fs.writeFileSync(
+      localePath,
+      `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- claude-translated 2026-04-01 -->
+    <string name="key">old-value</string>
+</resources>
+`,
+    );
+    const { upsertTranslation } = loadScript();
+    upsertTranslation(localePath, 'key', 'new-google-value', 'google');
+    const result = fs.readFileSync(localePath, 'utf8');
+    // The claude tag is replaced, not duplicated.
+    expect(result.match(/claude-translated/g)).toBeNull();
+    expect(result).toContain('<!-- google-translated ');
+    expect(result).toContain('<string name="key">new-google-value</string>');
+    // No duplicate string entry.
+    expect((result.match(/<string name="key">/g) || []).length).toBe(1);
+  });
+
+  test('escapes XML-sensitive characters in translated value', () => {
+    const localePath = path.join(tmpDir, 'strings.xml');
+    fs.writeFileSync(
+      localePath,
+      `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>
+`,
+    );
+    const { upsertTranslation } = loadScript();
+    upsertTranslation(localePath, 'key', `5 < 10 & it's true`, 'google');
+    const result = fs.readFileSync(localePath, 'utf8');
+    expect(result).toContain("5 &lt; 10 &amp; it\\'s true");
+  });
+});
+
+// ─── readEnglishStrings ───────────────────────────────────────────
+
+describe('readEnglishStrings', () => {
+  test('parses one <string> entry per line', () => {
+    const localePath = path.join(tmpDir, 'strings.xml');
+    fs.writeFileSync(
+      localePath,
+      `<resources>
+    <string name="a">A value</string>
+    <string name="b">Another</string>
+    <string name="escaped">Pre &amp; post</string>
+</resources>
+`,
+    );
+    const { readEnglishStrings } = loadScript();
+    expect(readEnglishStrings(localePath)).toEqual({
+      a: 'A value',
+      b: 'Another',
+      escaped: 'Pre & post',
+    });
+  });
+});
+
+// ─── googleTranslate (with fetch mock) ────────────────────────────
+
+describe('googleTranslate', () => {
+  test('returns the translated text from the public endpoint', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [[['Bonjour le monde', 'Hello world', null, null]]],
+    });
+    const { googleTranslate } = loadScript();
+    const out = await googleTranslate('Hello world', 'fr');
+    expect(out).toBe('Bonjour le monde');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const url = fetch.mock.calls[0][0];
+    expect(url).toContain('tl=fr');
+    expect(url).toContain('q=Hello%20world');
+  });
+
+  test('maps zh → zh-CN for Google compatibility', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [[['你好', 'Hello', null, null]]],
+    });
+    const { googleTranslate } = loadScript();
+    await googleTranslate('Hello', 'zh');
+    expect(fetch.mock.calls[0][0]).toContain('tl=zh-CN');
+  });
+
+  test('throws GOOGLE_QUOTA_EXHAUSTED on HTTP 429', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 429 });
+    const { googleTranslate } = loadScript();
+    await expect(googleTranslate('Hello', 'fr')).rejects.toThrow('GOOGLE_QUOTA_EXHAUSTED');
+  });
+
+  test('joins multi-segment translations', async () => {
+    // Long inputs come back as multiple sub-arrays. Make sure we
+    // concatenate them rather than dropping all but the first.
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        [
+          ['First sentence. ', 'First.', null, null],
+          ['Second sentence.', 'Second.', null, null],
+        ],
+      ],
+    });
+    const { googleTranslate } = loadScript();
+    const out = await googleTranslate('First. Second.', 'fr');
+    expect(out).toBe('First sentence. Second sentence.');
+  });
+});
+
+// ─── parseArgs ────────────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  test('parses --keys, --strings-en, --apply', () => {
+    const { parseArgs } = loadScript();
+    const args = parseArgs([
+      'node',
+      'translate.js',
+      '--keys',
+      'k1,k2,k3',
+      '--strings-en',
+      'path/to/en.xml',
+      '--apply',
+    ]);
+    expect(args).toEqual({
+      keys: ['k1', 'k2', 'k3'],
+      stringsEn: 'path/to/en.xml',
+      apply: true,
+      retranslateClaude: false,
+    });
+  });
+
+  test('parses --retranslate-claude flag', () => {
+    const { parseArgs } = loadScript();
+    const args = parseArgs(['node', 'translate.js', '--retranslate-claude']);
+    expect(args.retranslateClaude).toBe(true);
+    expect(args.apply).toBe(false);
+  });
+});

--- a/scripts/translate-strings.js
+++ b/scripts/translate-strings.js
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+/**
+ * Translate compose-resources string keys across all 19 non-EN locales.
+ *
+ * Strategy (per the project's translation-source rule):
+ *   1. Try Google Translate's free public endpoint first
+ *      (https://translate.googleapis.com/translate_a/single).
+ *   2. On rate-limit / error, fall back to a `claude-translate.json`
+ *      manifest the user can fill in, and tag those entries with
+ *      `claude-translated` so a future re-run can replace them with
+ *      Google output once the free quota is back.
+ *
+ * Provenance is tracked via XML comments adjacent to each translated
+ * <string>:
+ *   <!-- google-translated 2026-05-04 -->
+ *   <string name="...">...</string>
+ *
+ * Usage:
+ *   node scripts/translate-strings.js \
+ *     --keys age_verif_submit_title,age_verif_step_explanation_title,... \
+ *     --strings-en shared/src/commonMain/composeResources/values/strings.xml \
+ *     --apply
+ *
+ * Without --apply, the script prints what it WOULD do.
+ *
+ * Re-translate-non-google mode:
+ *   node scripts/translate-strings.js \
+ *     --retranslate-claude \
+ *     --apply
+ *
+ * Scans every locale file for <string> entries that do NOT have a
+ * preceding `<!-- google-translated YYYY-MM-DD -->` comment, and
+ * retranslates them via Google. This catches:
+ *   - Strings explicitly tagged `<!-- claude-translated ... -->`.
+ *   - Strings with no provenance tag at all (pre-rule baseline; per
+ *     the translation-source rule, untagged == claude-translated by
+ *     default).
+ * Idempotent — already-google-tagged strings are skipped, so the run
+ * can be resumed after a quota hit.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const LOCALES = [
+  'ar',
+  'de',
+  'es',
+  'fr',
+  'hi',
+  'id',
+  'it',
+  'ja',
+  'km',
+  'ko',
+  'nl',
+  'pl',
+  'pt',
+  'ru',
+  'sv',
+  'th',
+  'tr',
+  'uk',
+  'vi',
+  'zh',
+];
+const COMPOSE_RES_BASE = 'shared/src/commonMain/composeResources';
+
+// ── CLI parsing ───────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const out = { keys: [], stringsEn: null, apply: false, retranslateClaude: false };
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--keys') out.keys = argv[++i].split(',').map((s) => s.trim()).filter(Boolean);
+    else if (arg === '--strings-en') out.stringsEn = argv[++i];
+    else if (arg === '--apply') out.apply = true;
+    else if (arg === '--retranslate-claude') out.retranslateClaude = true;
+  }
+  return out;
+}
+
+// ── XML parsing (regex-based — Compose strings.xml is line-oriented) ──
+
+function readEnglishStrings(filePath) {
+  const xml = fs.readFileSync(filePath, 'utf8');
+  const map = {};
+  // Match <string name="key">value</string> across one line. Compose
+  // strings.xml uses a simple flat layout — no CDATA, no plurals.
+  const re = /<string\s+name="([^"]+)">([^<]*)<\/string>/g;
+  let match;
+  while ((match = re.exec(xml)) !== null) {
+    map[match[1]] = unescapeXml(match[2]);
+  }
+  return map;
+}
+
+function unescapeXml(s) {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/\\'/g, "'");
+}
+
+function escapeXml(s) {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/'/g, "\\'");
+}
+
+// ── Google Translate free endpoint ────────────────────────────────
+
+/**
+ * Call Google Translate's undocumented public endpoint.
+ *
+ * This is the same endpoint used by https://translate.google.com/ for
+ * unauthenticated users. It's free, rate-limited (~100 req/min before
+ * a 429), and stable enough for batch CLI use. The official Cloud
+ * Translation API requires a paid GCP project + key — overkill for
+ * this volume.
+ *
+ * Throws on rate-limit / network failure so the caller can fall back
+ * to Claude.
+ */
+async function googleTranslate(text, targetLang) {
+  // Map our locale codes to Google's expectations.
+  const tl = targetLang === 'zh' ? 'zh-CN' : targetLang;
+  const url =
+    'https://translate.googleapis.com/translate_a/single' +
+    '?client=gtx&sl=en&dt=t' +
+    `&tl=${encodeURIComponent(tl)}` +
+    `&q=${encodeURIComponent(text)}`;
+  const resp = await fetch(url, {
+    headers: { 'User-Agent': 'Mozilla/5.0 (compatible; ShyTalk-Translate/1.0)' },
+  });
+  if (resp.status === 429) {
+    throw new Error('GOOGLE_QUOTA_EXHAUSTED');
+  }
+  if (!resp.ok) {
+    throw new Error(`Google Translate HTTP ${resp.status}`);
+  }
+  const json = await resp.json();
+  // The response shape is `[[[ "translated", "source", null, null, ... ], ...], ...]`
+  // Multiple sentences can come back as separate sub-arrays — concatenate them.
+  if (!Array.isArray(json) || !Array.isArray(json[0])) {
+    throw new Error('Unexpected Google Translate response shape');
+  }
+  return json[0]
+    .map((seg) => (Array.isArray(seg) ? seg[0] : ''))
+    .join('');
+}
+
+// ── Locale file mutation ──────────────────────────────────────────
+
+const TODAY = new Date().toISOString().slice(0, 10);
+
+/**
+ * Insert (or replace) a translated <string> in a locale file, tagged
+ * with `<!-- ${source}-translated YYYY-MM-DD -->`.
+ *
+ * If the key already exists, replace its value AND any preceding
+ * provenance comment. If new, append before `</resources>`.
+ */
+function upsertTranslation(localeXmlPath, key, translated, source) {
+  let xml = fs.readFileSync(localeXmlPath, 'utf8');
+  const escapedTranslation = escapeXml(translated);
+  const provenance = `<!-- ${source}-translated ${TODAY} -->`;
+  const stringLine = `<string name="${key}">${escapedTranslation}</string>`;
+
+  const existingRe = new RegExp(
+    `(?:    <!-- (?:google|claude)-translated [\\d-]+ -->\\n)?    <string name="${escapeRegex(key)}">[^<]*</string>`,
+    'g',
+  );
+  if (existingRe.test(xml)) {
+    xml = xml.replace(existingRe, `    ${provenance}\n    ${stringLine}`);
+  } else {
+    xml = xml.replace(/\n<\/resources>/, `\n    ${provenance}\n    ${stringLine}\n</resources>`);
+  }
+  fs.writeFileSync(localeXmlPath, xml);
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ── Driver ────────────────────────────────────────────────────────
+
+async function translateKeys(keys, englishMap, apply) {
+  const claudeTodo = []; // entries that fell back to Claude
+  let googleCount = 0;
+  let skipCount = 0;
+
+  for (const locale of LOCALES) {
+    const localePath = path.join(COMPOSE_RES_BASE, `values-${locale}`, 'strings.xml');
+    if (!fs.existsSync(localePath)) {
+      console.warn(`  ! ${locale}: strings.xml missing — skipping locale`);
+      continue;
+    }
+    for (const key of keys) {
+      const enValue = englishMap[key];
+      if (!enValue) {
+        console.warn(`  ! ${key}: not found in EN — skipping`);
+        skipCount++;
+        continue;
+      }
+      try {
+        const translated = await googleTranslate(enValue, locale);
+        if (apply) upsertTranslation(localePath, key, translated, 'google');
+        console.log(`  ✓ ${locale}/${key}: ${translated.slice(0, 60)}${translated.length > 60 ? '…' : ''}`);
+        googleCount++;
+      } catch (err) {
+        if (err.message === 'GOOGLE_QUOTA_EXHAUSTED') {
+          console.warn(`  ⚠ Google quota — fallback for ${locale}/${key}`);
+          claudeTodo.push({ locale, key, en: enValue });
+        } else {
+          console.error(`  ✗ ${locale}/${key}: ${err.message}`);
+          claudeTodo.push({ locale, key, en: enValue, error: err.message });
+        }
+      }
+      // Polite rate-limit — Google's free endpoint is forgiving but a
+      // 100ms delay keeps us comfortably below the soft cap.
+      await sleep(100);
+    }
+  }
+
+  return { googleCount, skipCount, claudeTodo };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ── Retranslate non-Google scan ───────────────────────────────────
+//
+// Per the project rule: any string WITHOUT a `google-translated` tag
+// is presumed Claude-translated and should be re-translated by Google
+// when the free quota is available. This includes:
+//   1. Strings explicitly tagged `<!-- claude-translated YYYY-MM-DD -->`.
+//   2. Strings with NO preceding provenance comment at all (the bulk
+//      of pre-existing translations done before the rule was set).
+//
+// Idempotent: strings with a `google-translated` tag are skipped, so
+// re-running this is safe.
+
+/**
+ * Find every <string ...>...</string> in the locale file that does
+ * NOT have an immediately-preceding `<!-- google-translated ... -->`
+ * comment. Returns an array of { key, value } for those strings.
+ */
+function findNonGoogleStrings(xml) {
+  const out = [];
+  // Match every <string> entry. The regex is line-anchored so we can
+  // look at the previous line for a provenance comment.
+  const lines = xml.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^\s*<string\s+name="([^"]+)">([^<]*)<\/string>/);
+    if (!m) continue;
+    const key = m[1];
+    const value = unescapeXml(m[2]);
+    // Look at the previous non-blank line for a provenance tag.
+    let provLine = null;
+    for (let j = i - 1; j >= 0; j--) {
+      const trimmed = lines[j].trim();
+      if (trimmed === '') continue;
+      if (trimmed.startsWith('<!--')) provLine = trimmed;
+      break;
+    }
+    const isGoogleTagged = provLine && /^<!--\s*google-translated\b/.test(provLine);
+    if (!isGoogleTagged) {
+      out.push({ key, value });
+    }
+  }
+  return out;
+}
+
+async function retranslateClaudeStrings(apply) {
+  const englishMap = readEnglishStrings(
+    path.join(COMPOSE_RES_BASE, 'values', 'strings.xml'),
+  );
+  let total = 0;
+  let upgraded = 0;
+  let quotaHit = false;
+  for (const locale of LOCALES) {
+    if (quotaHit) {
+      console.warn(`Stopping early — Google quota exhausted. Resume later.`);
+      break;
+    }
+    const localePath = path.join(COMPOSE_RES_BASE, `values-${locale}`, 'strings.xml');
+    if (!fs.existsSync(localePath)) continue;
+    const xml = fs.readFileSync(localePath, 'utf8');
+    const candidates = findNonGoogleStrings(xml);
+    if (candidates.length === 0) continue;
+    console.log(`${locale}: ${candidates.length} non-google entries`);
+    for (const { key } of candidates) {
+      total++;
+      const en = englishMap[key];
+      if (!en) {
+        // Locale has a key with no EN counterpart — leave it alone
+        // (it might be a locale-specific string with no translation
+        // intent, or a stale row pending cleanup).
+        console.warn(`  ! ${locale}/${key}: EN missing — skip`);
+        continue;
+      }
+      try {
+        const translated = await googleTranslate(en, locale);
+        if (apply) upsertTranslation(localePath, key, translated, 'google');
+        upgraded++;
+        if (upgraded % 50 === 0) console.log(`  ↑ ${locale} progress: ${upgraded}/${total}`);
+      } catch (err) {
+        if (err.message === 'GOOGLE_QUOTA_EXHAUSTED') {
+          console.warn(`  ⚠ Google quota — stopping. Resume with same command later.`);
+          quotaHit = true;
+          break;
+        }
+        console.warn(`  ⚠ ${locale}/${key}: keeping (${err.message})`);
+      }
+      await sleep(100);
+    }
+  }
+  return { total, upgraded, quotaHit };
+}
+
+// ── Main ──────────────────────────────────────────────────────────
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (args.retranslateClaude) {
+    console.log(`Retranslate-claude mode (apply=${args.apply}):`);
+    const { total, upgraded } = await retranslateClaudeStrings(args.apply);
+    console.log(`Found ${total} claude-translated entries; ${upgraded} upgraded to google.`);
+    return;
+  }
+
+  if (!args.stringsEn || args.keys.length === 0) {
+    console.error(
+      'Usage: node scripts/translate-strings.js --keys k1,k2 --strings-en path/to/values/strings.xml [--apply]\n' +
+        '       node scripts/translate-strings.js --retranslate-claude [--apply]',
+    );
+    process.exit(2);
+  }
+
+  const englishMap = readEnglishStrings(args.stringsEn);
+  console.log(
+    `Translating ${args.keys.length} keys × ${LOCALES.length} locales (apply=${args.apply}):`,
+  );
+  const { googleCount, skipCount, claudeTodo } = await translateKeys(
+    args.keys,
+    englishMap,
+    args.apply,
+  );
+  console.log(`\nDone. google: ${googleCount}, skipped: ${skipCount}, claude-fallback: ${claudeTodo.length}`);
+  if (claudeTodo.length > 0) {
+    const todoPath = path.resolve('translate-claude-todo.json');
+    fs.writeFileSync(todoPath, JSON.stringify(claudeTodo, null, 2));
+    console.log(`Claude-todo manifest written to ${todoPath}`);
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err.stack || err.message || err);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  parseArgs,
+  readEnglishStrings,
+  unescapeXml,
+  escapeXml,
+  upsertTranslation,
+  googleTranslate,
+  findNonGoogleStrings,
+  retranslateClaudeStrings,
+  translateKeys,
+};

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">جميع المشرفين &amp; المراقبين</string>
     <string name="attach_evidence">إرفاق دليل</string>
     <string name="cant_message_user">لا يمكنك مراسلة هذا المستخدم</string>
-    <string name="pm_locked_other_user_notice">لا يمكنك مراسلة هذا الشخص لأننا نعتقد أنه دون سن 18 عامًا.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">لا يمكنك مراسلة هذا الشخص لأننا نعتقد أن عمره أقل من 18 عامًا.</string>
     <string name="chat">محادثة</string>
     <string name="close_group">إغلاق المجموعة</string>
     <string name="close_group_warning">سيؤدي هذا إلى إغلاق المجموعة للجميع. يتم الاحتفاظ بالرسائل للإشراف.</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">تعرف على تشول تشنام ثمي</string>
     <string name="seasonal_event_dismiss">إغلاق</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">التحقق من عمرك</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">كيف يعمل هذا</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">نحتاج إلى صورة لبطاقة هوية صادرة عن جهة حكومية للتأكد من أن عمرك لا يقل عن 18 عامًا. ويتم تشفير الصورة أثناء النقل، ومراجعتها بواسطة وسيط بشري، وحذفها نهائيًا بمجرد تسجيل القرار - عادةً في غضون 24 ساعة. يتم الاحتفاظ فقط بتاريخ الميلاد ونتائج التحقق.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">أنا أفهم – استمر</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">أي وثيقة؟</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">اختر نوع الهوية التي ستقدمها. يجب أن يتطابق تاريخ الميلاد الموجود في المستند مع الرقم الموجود في حسابك.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">جواز سفر</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">رخصة السائق</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">بطاقة التعريف الوطنية</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">أضف الصورة</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">اختيار صورة واضحة لبطاقة الهوية. تأكد من أن تاريخ الميلاد قابل للقراءة بالكامل.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">اختر الصورة</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">استبدال الصورة</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">هل أنت جاهز للتقديم؟</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">بمجرد إرسالها، يتم إرسال الصورة للمراجعة. ستصلك رسالة النظام عند تسجيل القرار.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">نوع الهوية:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">صورة:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">مُرفَق</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">إرسال للمراجعة</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">شكرًا لك</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">إرسالك موجود في قائمة الانتظار. وسنقوم بمراسلتك هنا عند تسجيل القرار.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">منتهي</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">خلف</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">يرجى اختيار نوع الهوية قبل الإرسال.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">الرجاء إضافة صورة قبل الإرسال.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">تعذر الإرسال — يرجى التحقق من الاتصال والمحاولة مرة أخرى.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">Alle Admins &amp; Mods</string>
     <string name="attach_evidence">Beweis anhängen</string>
     <string name="cant_message_user">Du kannst diesem Benutzer keine Nachricht senden</string>
-    <string name="pm_locked_other_user_notice">Sie können diese Person nicht anschreiben, da wir glauben, dass sie unter 18 Jahre alt ist.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">Sie können dieser Person keine Nachricht senden, da wir davon ausgehen, dass sie unter 18 Jahre alt ist.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Gruppe schließen</string>
     <string name="close_group_warning">Dies schließt die Gruppe für alle. Nachrichten bleiben zur Moderation erhalten.</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">Erfahre mehr über Choul Chnam Thmey</string>
     <string name="seasonal_event_dismiss">Schließen</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">Überprüfen Sie Ihr Alter</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">Wie das funktioniert</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">Wir benötigen ein Foto eines amtlichen Ausweises, um zu bestätigen, dass Sie mindestens 18 Jahre alt sind. Das Bild wird während der Übertragung verschlüsselt, von einem menschlichen Moderator überprüft und endgültig gelöscht, sobald eine Entscheidung erfasst wird – normalerweise innerhalb von 24 Stunden. Lediglich das Geburtsdatum und das Ergebnis der Verifizierung werden gespeichert.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">Ich verstehe – fahren Sie fort</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">Welches Dokument?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">Wählen Sie die Art des Ausweises aus, den Sie einreichen möchten. Das Geburtsdatum auf dem Dokument muss mit dem auf Ihrem Konto übereinstimmen.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">Reisepass</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">Führerschein</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">Nationaler Personalausweis</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">Fügen Sie das Foto hinzu</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">Wählen Sie ein klares Foto des Ausweises. Stellen Sie sicher, dass das Geburtsdatum vollständig lesbar ist.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">Foto auswählen</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">Foto ersetzen</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">Bereit zum Einreichen?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">Nach der Übermittlung wird das Foto zur Überprüfung gesendet. Sie erhalten eine Systemmeldung, wenn eine Entscheidung erfasst wird.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">ID-Typ:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">Foto:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">beigefügt</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">Zur Überprüfung einreichen</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">Danke</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">Ihre Einreichung befindet sich in der Warteschlange. Wir werden Sie hier benachrichtigen, wenn eine Entscheidung erfasst wird.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">Erledigt</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">Zurück</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">Bitte wählen Sie vor dem Absenden einen ID-Typ aus.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">Bitte fügen Sie vor dem Absenden ein Foto hinzu.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">Konnte nicht gesendet werden. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">Todos los admins &amp; mods</string>
     <string name="attach_evidence">Adjuntar evidencia</string>
     <string name="cant_message_user">No puedes enviar mensajes a este usuario</string>
-    <string name="pm_locked_other_user_notice">No puedes enviar mensajes a esta persona porque creemos que es menor de 18 años.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">No puede enviar mensajes a esta persona porque creemos que es menor de 18 años.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Cerrar grupo</string>
     <string name="close_group_warning">Esto cerrar&#225; el grupo para todos. Los mensajes se conservan para moderaci&#243;n.</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">Descubre Choul Chnam Thmey</string>
     <string name="seasonal_event_dismiss">Cerrar</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">Verifica tu edad</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">¿Cómo funciona esto?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">Necesitamos una foto de una identificación emitida por el gobierno para confirmar que tienes al menos 18 años. La imagen se cifra en tránsito, es revisada por un moderador humano y se elimina permanentemente tan pronto como se registra una decisión, generalmente dentro de las 24 horas. Sólo se conservan la fecha de nacimiento y el resultado de la verificación.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">Entiendo – continúa</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">¿Qué documento?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">Elija el tipo de identificación que enviará. La fecha de nacimiento del documento debe coincidir con la de su cuenta.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">Pasaporte</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">Licencia de conducir</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">documento de identidad nacional</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">Agrega la foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">Elija una foto clara del documento de identidad. Asegúrese de que la fecha de nacimiento sea completamente legible.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">Elige foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">Reemplazar foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">¿Listo para enviar?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">Una vez enviada, la foto se envía para su revisión. Recibirá un mensaje del sistema cuando se registre una decisión.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">tipo de identificación:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">Foto:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">adjunto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">Enviar para revisión</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">Gracias</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">Su envío está en la cola. Le enviaremos un mensaje aquí cuando se registre una decisión.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">Hecho</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">Atrás</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">Elija un tipo de identificación antes de enviarlo.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">Por favor agregue una foto antes de enviarla.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">No se pudo enviar. Verifique su conexión e inténtelo nuevamente.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Tous les admins &amp; mods</string>
     <string name="attach_evidence">Joindre une preuve</string>
     <string name="cant_message_user">Vous ne pouvez pas envoyer de message &#224; cet utilisateur</string>
+    <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Vous ne pouvez pas envoyer de message à cette personne car nous pensons qu\'elle a moins de 18 ans.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Fermer le groupe</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">Découvrez Choul Chnam Thmey</string>
     <string name="seasonal_event_dismiss">Fermer</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">Vérifiez votre âge</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">Comment ça marche</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">Nous avons besoin d\'une photo d\'une pièce d\'identité émise par le gouvernement pour confirmer que vous avez au moins 18 ans. L\'image est cryptée pendant le transport, examinée par un modérateur humain et définitivement supprimée dès qu\'une décision est enregistrée, généralement dans les 24 heures. Seules la date de naissance et le résultat de la vérification sont conservés.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">Je comprends — continuez</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">Quel document ?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">Choisissez le type de pièce d\'identité que vous soumettrez. La date de naissance sur le document doit correspondre à celle de votre compte.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">Passeport</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">Le permis de conduire</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">Carte d\'identité nationale</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">Ajouter la photo</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">Choisissez une photo claire de la pièce d\'identité. Assurez-vous que la date de naissance est entièrement lisible.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">Choisir une photo</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">Remplacer la photo</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">Prêt à soumettre ?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">Une fois soumise, la photo est envoyée pour examen. Vous recevrez un message système lorsqu\'une décision sera enregistrée.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">Type d\'identification :</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">Photo:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">ci-joint</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">Soumettre pour examen</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">Merci</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">Votre soumission est dans la file d\'attente. Nous vous enverrons un message ici lorsqu’une décision sera enregistrée.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">Fait</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">Dos</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">Veuillez choisir un type d\'identification avant de soumettre.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">Veuillez ajouter une photo avant de soumettre.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">Impossible de soumettre. Veuillez vérifier votre connexion et réessayer.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">सभी एडमिन &amp; मॉड</string>
     <string name="attach_evidence">सबूत संलग्न करें</string>
     <string name="cant_message_user">आप इस उपयोगकर्ता को संदेश नहीं भेज सकते</string>
-    <string name="pm_locked_other_user_notice">आप इस व्यक्ति को संदेश नहीं भेज सकते क्योंकि हमें लगता है कि वे 18 वर्ष से कम के हैं।</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">आप इस व्यक्ति को संदेश नहीं भेज सकते क्योंकि हमारा मानना ​​है कि उनकी आयु 18 वर्ष से कम है।</string>
     <string name="chat">चैट</string>
     <string name="close_group">ग्रुप बंद करें</string>
     <string name="close_group_warning">यह सभी के लिए ग्रुप बंद कर देगा। संदेश मॉडरेशन के लिए सुरक्षित रहेंगे।</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">चौल छ्नाम थ्मेय के बारे में जानें</string>
     <string name="seasonal_event_dismiss">बंद करें</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">अपनी आयु सत्यापित करें</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">यह कैसे काम करता है</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">हमें यह पुष्टि करने के लिए सरकार द्वारा जारी आईडी की एक तस्वीर की आवश्यकता है कि आप कम से कम 18 वर्ष के हैं। छवि को पारगमन में एन्क्रिप्ट किया जाता है, एक मानव मॉडरेटर द्वारा समीक्षा की जाती है, और निर्णय दर्ज होते ही स्थायी रूप से हटा दिया जाता है - आमतौर पर 24 घंटों के भीतर। केवल जन्म तिथि और सत्यापन परिणाम रखा गया है।</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">मैं समझता हूं - जारी रखें</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">कौन सा दस्तावेज़?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">आप जिस प्रकार की आईडी सबमिट करेंगे उसे चुनें। दस्तावेज़ पर जन्मतिथि आपके खाते से मेल खाना चाहिए।</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">पासपोर्ट</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">ड्राइवर का लाइसेंस</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">राष्ट्रीय आईडी कार्ड</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">फ़ोटो जोड़ें</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">आईडी का स्पष्ट फोटो चुनें. सुनिश्चित करें कि जन्मतिथि पूरी तरह से पढ़ने योग्य है।</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">तस्विर का चयन करो</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">फ़ोटो बदलें</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">सबमिट करने के लिए तैयार हैं?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">एक बार सबमिट करने के बाद, फोटो को समीक्षा के लिए भेजा जाता है। निर्णय रिकॉर्ड होने पर आपको एक सिस्टम संदेश प्राप्त होगा।</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">आईडी प्रकार:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">तस्वीर:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">जुड़ा हुआ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">समीक्षा हेतु सबमिट करें</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">धन्यवाद</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">आपका सबमिशन कतार में है. निर्णय दर्ज होने पर हम आपको यहां संदेश भेजेंगे।</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">हो गया</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">पीछे</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">कृपया सबमिट करने से पहले एक आईडी प्रकार चुनें।</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">कृपया सबमिट करने से पहले एक फ़ोटो जोड़ें.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">सबमिट नहीं किया जा सका - कृपया अपना कनेक्शन जांचें और पुनः प्रयास करें।</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-id/strings.xml
+++ b/shared/src/commonMain/composeResources/values-id/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">Semua admin &amp; mod</string>
     <string name="attach_evidence">Lampirkan Bukti</string>
     <string name="cant_message_user">Kamu tidak bisa mengirim pesan ke pengguna ini</string>
-    <string name="pm_locked_other_user_notice">Anda tidak dapat mengirim pesan ke orang ini karena kami yakin mereka di bawah 18 tahun.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">Anda tidak dapat mengirim pesan kepada orang ini karena kami yakin mereka berusia di bawah 18 tahun.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Tutup Grup</string>
     <string name="close_group_warning">Ini akan menutup grup untuk semua orang. Pesan akan disimpan untuk moderasi.</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">Pelajari tentang Choul Chnam Thmey</string>
     <string name="seasonal_event_dismiss">Tutup</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">Verifikasi usia Anda</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">Cara kerjanya</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">Kami memerlukan foto tanda pengenal yang dikeluarkan pemerintah untuk mengonfirmasi bahwa Anda setidaknya berusia 18 tahun. Gambar tersebut dienkripsi saat transit, ditinjau oleh moderator manusia, dan dihapus secara permanen segera setelah keputusan diambil — biasanya dalam waktu 24 jam. Hanya tanggal lahir dan hasil verifikasi yang disimpan.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">Saya mengerti — lanjutkan</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">Dokumen yang mana?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">Pilih jenis ID yang akan Anda kirimkan. DOB pada dokumen harus sesuai dengan yang ada di akun Anda.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">Paspor</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">SIM</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">Kartu Tanda Penduduk Nasional</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">Tambahkan foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">Pilih foto KTP yang jelas. Pastikan tanggal lahir dapat dibaca sepenuhnya.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">Pilih foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">Ganti foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">Siap untuk mengirimkan?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">Setelah dikirimkan, foto dikirim untuk ditinjau. Anda akan mendapatkan pesan sistem saat keputusan dicatat.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">Jenis tanda pengenal:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">Foto:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">terlampir</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">Kirim untuk ditinjau</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">Terima kasih</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">Kiriman Anda sedang dalam antrian. Kami akan mengirimi Anda pesan di sini ketika keputusan telah dicatat.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">Selesai</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">Kembali</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">Silakan pilih jenis ID sebelum mengirimkan.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">Silakan tambahkan foto sebelum mengirimkan.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">Tidak dapat mengirimkan — harap periksa koneksi Anda dan coba lagi.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">Tutti gli admin &amp; mod</string>
     <string name="attach_evidence">Allega prova</string>
     <string name="cant_message_user">Non puoi inviare messaggi a questo utente</string>
-    <string name="pm_locked_other_user_notice">Non puoi inviare messaggi a questa persona perché crediamo abbia meno di 18 anni.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">Non puoi inviare messaggi a questa persona perché riteniamo che abbia meno di 18 anni.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Chiudi gruppo</string>
     <string name="close_group_warning">Questo chiuderà il gruppo per tutti. I messaggi vengono conservati per la moderazione.</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">Scopri Choul Chnam Thmey</string>
     <string name="seasonal_event_dismiss">Chiudi</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">Verifica la tua età</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">Come funziona</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">Abbiamo bisogno della foto di un documento d\'identità rilasciato dal governo per confermare che hai almeno 18 anni. L\'immagine viene crittografata durante il transito, esaminata da un moderatore umano ed eliminata definitivamente non appena viene registrata una decisione, di solito entro 24 ore. Vengono conservati solo la data di nascita e l\'esito della verifica.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">Capisco: continua</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">Quale documento?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">Scegli il tipo di documento d\'identità che invierai. Il DOB sul documento deve corrispondere a quello sul tuo account.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">Passaporto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">Patente di guida</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">Carta d\'identità nazionale</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">Aggiungi la foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">Scegli una foto nitida del documento d\'identità. Assicurati che la data di nascita sia completamente leggibile.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">Scegli la foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">Sostituisci foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">Pronto per inviare?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">Una volta inviata, la foto viene inviata per la revisione. Riceverai un messaggio di sistema quando viene registrata una decisione.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">Tipo di documento d\'identità:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">Foto:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">allegato</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">Invia per la revisione</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">Grazie</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">La tua presentazione è in coda. Ti invieremo un messaggio qui quando verrà registrata una decisione.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">Fatto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">Indietro</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">Scegli un tipo di ID prima di inviare.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">Si prega di aggiungere una foto prima di inviare.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">Impossibile inviare: controlla la connessione e riprova.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">すべての管理者 &amp; モデレーター</string>
     <string name="attach_evidence">証拠を添付</string>
     <string name="cant_message_user">このユーザーにメッセージを送れません</string>
-    <string name="pm_locked_other_user_notice">この人物は18歳未満と判断されているため、メッセージを送ることができません。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">この人は 18 歳未満であると思われるため、メッセージを送信できません。</string>
     <string name="chat">チャット</string>
     <string name="close_group">グループを閉じる</string>
     <string name="close_group_warning">グループが全員に対して閉じられます。メッセージはモデレーションのために保持されます。</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">チョル・チュナム・トゥメイについて学ぶ</string>
     <string name="seasonal_event_dismiss">閉じる</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">年齢を確認してください</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">仕組み</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">あなたが 18 歳以上であることを確認するには、政府発行の身分証明書の写真が必要です。画像は転送中に暗号化され、人間のモデレーターによって確認され、決定が記録されるとすぐに (通常は 24 時間以内) 永久に削除されます。生年月日と認証結果のみが保持されます。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">わかりました — 続けます</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">どの書類ですか？</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">送信する ID の種類を選択します。書類の生年月日はアカウントの生年月日と一致する必要があります。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">パスポート</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">運転免許証</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">国民IDカード</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">写真を追加</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">身分証明書の写真は鮮明なものを選択してください。生年月日が完全に判読できることを確認してください。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">写真を選択してください</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">写真を置き換える</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">提出する準備はできましたか?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">送信されると、写真は審査のために送信されます。決定が記録されると、システム メッセージが表示されます。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">IDタイプ:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">写真：</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">添付</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">レビューのために送信する</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">ありがとう</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">あなたの提出物はキューにあります。決定が記録されたら、ここでメッセージをお送りします。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">終わり</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">戻る</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">送信する前に ID タイプを選択してください。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">送信する前に写真を追加してください。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">送信できませんでした — 接続を確認して、もう一度試してください。</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-km/strings.xml
+++ b/shared/src/commonMain/composeResources/values-km/strings.xml
@@ -260,7 +260,8 @@
     <string name="all_admins_and_mods">អ្នកគ្រប់គ្រង &amp; ម៉ូដ</string>
     <string name="attach_evidence">ភ្ជាប់ភស្តុតាង</string>
     <string name="cant_message_user">អ្នកមិនអាចផ្ញើសារទៅអ្នកប្រើនេះ</string>
-    <string name="pm_locked_other_user_notice">អ្នកមិនអាចផ្ញើសារទៅកាន់មនុស្សនេះបានទេ ព្រោះយើងគិតថាគាត់មានអាយុក្រោម 18 ឆ្នាំ។</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">អ្នកមិនអាចផ្ញើសារទៅកាន់បុគ្គលនេះបានទេ ដោយសារយើងជឿថាពួកគេមានអាយុក្រោម 18 ឆ្នាំ។</string>
     <string name="chat">ជំនួញ</string>
     <string name="close_group">បិទក្រុម</string>
     <string name="close_group_warning">នេះនឹងបិទក្រុមសម្រាប់អ្នកទាំងអស់។</string>
@@ -942,4 +943,56 @@
     <string name="seasonal_khmer_new_year_cta">ស្វែងយល់អំពីចូលឆ្នាំថ្មើ</string>
     <string name="seasonal_event_dismiss">បដិសេធ</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">ផ្ទៀងផ្ទាត់អាយុរបស់អ្នក។</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">របៀបដែលវាដំណើរការ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">យើងត្រូវការរូបថតនៃអត្តសញ្ញាណប័ណ្ណដែលចេញដោយរដ្ឋាភិបាល ដើម្បីបញ្ជាក់ថាអ្នកមានអាយុយ៉ាងតិច 18 ឆ្នាំ។ រូបភាពនេះត្រូវបានអ៊ិនគ្រីបក្នុងពេលដឹកជញ្ជូន ពិនិត្យដោយអ្នកសម្របសម្រួលមនុស្ស ហើយត្រូវបានលុបជាអចិន្ត្រៃយ៍នៅពេលដែលការសម្រេចចិត្តត្រូវបានកត់ត្រា — ជាធម្មតាក្នុងរយៈពេល 24 ម៉ោង។ មានតែថ្ងៃខែឆ្នាំកំណើត និងលទ្ធផលផ្ទៀងផ្ទាត់ប៉ុណ្ណោះដែលត្រូវបានរក្សាទុក។</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">ខ្ញុំយល់ - បន្ត</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">ឯកសារមួយណា?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">ជ្រើសរើសប្រភេទ ID ដែលអ្នកនឹងដាក់ស្នើ។ DOB នៅលើឯកសារត្រូវតែផ្គូផ្គងមួយនៅលើគណនីរបស់អ្នក។</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">លិខិតឆ្លងដែន</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">ប័ណ្ណបើកបរ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">អត្តសញ្ញាណប័ណ្ណសញ្ជាតិខ្មែរ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">បន្ថែមរូបថត</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">ជ្រើសរើសរូបថតច្បាស់លាស់នៃអត្តសញ្ញាណប័ណ្ណ។ ត្រូវប្រាកដថាថ្ងៃខែឆ្នាំកំណើតអាចអានបានពេញលេញ។</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">ជ្រើសរើសរូបថត</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">ជំនួសរូបថត</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">ត្រៀម​ដាក់​បញ្ជូន​ហើយ​ឬ​នៅ?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">នៅពេលដាក់ស្នើ រូបថតត្រូវបានផ្ញើសម្រាប់ការពិនិត្យ។ អ្នកនឹងទទួលបានសារប្រព័ន្ធ នៅពេលដែលការសម្រេចចិត្តត្រូវបានកត់ត្រា។</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">ប្រភេទលេខសម្គាល់៖</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">រូបថត៖</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">ភ្ជាប់</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">ដាក់ស្នើសម្រាប់ការពិនិត្យឡើងវិញ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">សូមអរគុណ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">ការដាក់ស្នើរបស់អ្នកស្ថិតនៅក្នុងជួរ។ យើងនឹងផ្ញើសារទៅកាន់អ្នកនៅទីនេះ នៅពេលដែលការសម្រេចចិត្តត្រូវបានកត់ត្រា។</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">រួចរាល់</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">ត្រឡប់មកវិញ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">សូមជ្រើសរើសប្រភេទ ID មុនពេលបញ្ជូន។</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">សូមបន្ថែមរូបថតមុនពេលដាក់ស្នើ។</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">មិនអាចដាក់ស្នើបានទេ — សូមពិនិត្យមើលការតភ្ជាប់របស់អ្នក ហើយព្យាយាមម្តងទៀត។</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-ko/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ko/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">모든 관리자 &amp; 운영자</string>
     <string name="attach_evidence">증거 첨부</string>
     <string name="cant_message_user">이 사용자에게 메시지를 보낼 수 없습니다</string>
-    <string name="pm_locked_other_user_notice">이 사용자는 18세 미만인 것으로 판단되어 메시지를 보낼 수 없습니다.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">이 사람은 18세 미만인 것으로 판단되므로 메시지를 보낼 수 없습니다.</string>
     <string name="chat">채팅</string>
     <string name="close_group">그룹 닫기</string>
     <string name="close_group_warning">모든 사람의 그룹이 닫힙니다. 메시지는 관리 목적으로 보존됩니다.</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">쫄 츠남 트메이에 대해 알아보기</string>
     <string name="seasonal_event_dismiss">닫기</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">나이를 확인하세요</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">작동 방식</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">귀하가 18세 이상인지 확인하려면 정부 발급 신분증 사진이 필요합니다. 이미지는 전송 중에 암호화되고 조정자가 검토하며 결정이 기록되는 즉시 영구적으로 삭제됩니다(보통 24시간 이내). 생년월일과 인증결과만 보관됩니다.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">이해합니다 — 계속하세요</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">어떤 문서인가요?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">제출할 신분증 유형을 선택하세요. 문서의 DOB는 계정의 DOB와 일치해야 합니다.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">여권</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">운전면허증</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">주민등록증</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">사진 추가</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">선명한 신분증 사진을 선택하세요. 생년월일을 완전히 읽을 수 있는지 확인하세요.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">사진 선택</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">사진 교체</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">제출할 준비가 되셨나요?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">제출되면 검토를 위해 사진이 전송됩니다. 결정이 기록되면 시스템 메시지를 받게 됩니다.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">ID 유형:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">사진:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">첨부된</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">검토를 위해 제출</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">감사합니다</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">제출물이 대기열에 있습니다. 결정이 기록되면 여기에 메시지를 보내드리겠습니다.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">완료</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">뒤쪽에</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">제출하기 전에 ID 유형을 선택하세요.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">제출하기 전에 사진을 추가하세요.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">제출할 수 없습니다. 연결을 확인하고 다시 시도하십시오.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">Alle beheerders &amp; moderators</string>
     <string name="attach_evidence">Bewijs bijvoegen</string>
     <string name="cant_message_user">Je kunt deze gebruiker geen bericht sturen</string>
-    <string name="pm_locked_other_user_notice">Je kunt deze persoon geen bericht sturen omdat wij denken dat zij jonger zijn dan 18.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">Je kunt deze persoon geen bericht sturen omdat we denken dat hij/zij jonger is dan 18 jaar.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Groep sluiten</string>
     <string name="close_group_warning">Dit sluit de groep voor iedereen. Berichten worden bewaard voor moderatie.</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">Ontdek Choul Chnam Thmey</string>
     <string name="seasonal_event_dismiss">Sluiten</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">Controleer uw leeftijd</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">Hoe dit werkt</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">We hebben een foto nodig van een door de overheid uitgegeven identiteitsbewijs om te bevestigen dat u ten minste 18 jaar oud bent. De afbeelding wordt tijdens de verzending gecodeerd, beoordeeld door een menselijke moderator en permanent verwijderd zodra er een beslissing is vastgelegd – meestal binnen 24 uur. Alleen de geboortedatum en het verificatieresultaat worden bewaard.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">Ik begrijp het – ga door</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">Welk document?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">Kies het type identiteitsbewijs dat u indient. Het geboortedatum op het document moet overeenkomen met die op uw account.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">Paspoort</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">Rijbewijs</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">Nationale identiteitskaart</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">Voeg de foto toe</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">Kies een duidelijke foto van het identiteitsbewijs. Zorg ervoor dat de geboortedatum volledig leesbaar is.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">Kies foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">Vervang foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">Klaar om in te dienen?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">Nadat de foto is verzonden, wordt deze ter beoordeling verzonden. U krijgt een systeemmelding als er een besluit is vastgelegd.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">ID-type:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">Foto:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">bijgevoegd</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">Ter beoordeling indienen</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">Bedankt</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">Je inzending staat in de wachtrij. Wij zullen u hier berichten wanneer er een besluit is vastgelegd.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">Klaar</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">Rug</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">Kies een ID-type voordat u het verzendt.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">Voeg een foto toe voordat u deze verzendt.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">Kan niet verzenden. Controleer uw verbinding en probeer het opnieuw.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-pl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pl/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">Wszyscy admini &amp; moderatorzy</string>
     <string name="attach_evidence">Dołącz dowody</string>
     <string name="cant_message_user">Nie możesz napisać do tego użytkownika</string>
-    <string name="pm_locked_other_user_notice">Nie możesz wysłać wiadomości do tej osoby, ponieważ uważamy, że ma mniej niż 18 lat.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">Nie możesz wysłać wiadomości do tej osoby, ponieważ według nas ma ona mniej niż 18 lat.</string>
     <string name="chat">Czat</string>
     <string name="close_group">Zamknij grupę</string>
     <string name="close_group_warning">To zamknie grupę dla wszystkich. Wiadomości zostaną zachowane na potrzeby moderacji.</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">Dowiedz się o Choul Chnam Thmey</string>
     <string name="seasonal_event_dismiss">Zamknij</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">Sprawdź swój wiek</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">Jak to działa</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">Potrzebujemy zdjęcia dokumentu tożsamości wydanego przez organ państwowy, aby potwierdzić, że masz co najmniej 18 lat. Zdjęcie jest szyfrowane podczas przesyłania, sprawdzane przez moderatora i trwale usuwane natychmiast po zarejestrowaniu decyzji — zwykle w ciągu 24 godzin. Przechowywana jest jedynie data urodzenia i wynik weryfikacji.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">Rozumiem – kontynuuj</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">Który dokument?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">Wybierz typ dokumentu tożsamości, który prześlesz. Data urodzenia na dokumencie musi odpowiadać tej na Twoim koncie.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">Paszport</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">Prawo jazdy</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">Krajowy dowód osobisty</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">Dodaj zdjęcie</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">Wybierz wyraźne zdjęcie dokumentu tożsamości. Upewnij się, że data urodzenia jest w pełni czytelna.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">Wybierz zdjęcie</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">Zamień zdjęcie</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">Gotowy do przesłania?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">Po przesłaniu zdjęcie zostaje przesłane do sprawdzenia. Gdy decyzja zostanie zarejestrowana, otrzymasz wiadomość systemową.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">Typ identyfikatora:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">Zdjęcie:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">przyłączony</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">Prześlij do sprawdzenia</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">Dziękuję</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">Twoje zgłoszenie czeka w kolejce. Po zarejestrowaniu decyzji poinformujemy Cię tutaj.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">Zrobione</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">Z powrotem</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">Przed przesłaniem wybierz typ identyfikatora.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">Przed przesłaniem proszę dodać zdjęcie.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">Nie można przesłać — sprawdź połączenie i spróbuj ponownie.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">Todos os admins &amp; mods</string>
     <string name="attach_evidence">Anexar evidência</string>
     <string name="cant_message_user">Você não pode enviar mensagem para este usuário</string>
-    <string name="pm_locked_other_user_notice">Você não pode enviar mensagens para esta pessoa porque acreditamos que ela tenha menos de 18 anos.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">Você não pode enviar mensagens para essa pessoa porque acreditamos que ela tem menos de 18 anos.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Fechar grupo</string>
     <string name="close_group_warning">Isso fechará o grupo para todos. As mensagens serão preservadas para moderação.</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">Saiba mais sobre Choul Chnam Thmey</string>
     <string name="seasonal_event_dismiss">Fechar</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">Verifique sua idade</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">Como isso funciona</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">Precisamos de uma foto de um documento de identidade emitido pelo governo para confirmar que você tem pelo menos 18 anos. A imagem é criptografada em trânsito, revisada por um moderador humano e excluída permanentemente assim que uma decisão é registrada – geralmente dentro de 24 horas. Apenas a data de nascimento e o resultado da verificação são mantidos.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">Eu entendo – continue</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">Qual documento?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">Escolha o tipo de ID que você enviará. O DOB do documento deve corresponder ao da sua conta.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">Passaporte</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">Carteira de motorista</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">Carteira de identidade nacional</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">Adicione a foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">Escolha uma foto nítida do documento de identidade. Certifique-se de que a data de nascimento esteja totalmente legível.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">Escolha a foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">Substituir foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">Pronto para enviar?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">Depois de enviada, a foto é enviada para análise. Você receberá uma mensagem do sistema quando uma decisão for registrada.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">Tipo de identificação:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">Foto:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">apegado</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">Enviar para revisão</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">Obrigado</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">Seu envio está na fila. Enviaremos uma mensagem aqui quando uma decisão for registrada.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">Feito</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">Voltar</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">Escolha um tipo de ID antes de enviar.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">Adicione uma foto antes de enviar.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">Não foi possível enviar. Verifique sua conexão e tente novamente.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">Все админы &amp; модераторы</string>
     <string name="attach_evidence">Прикрепить доказательство</string>
     <string name="cant_message_user">Вы не можете написать этому пользователю</string>
-    <string name="pm_locked_other_user_notice">Вы не можете отправить сообщение этому пользователю, потому что мы считаем, что ему меньше 18 лет.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">Вы не можете отправить сообщение этому человеку, поскольку мы считаем, что ему меньше 18 лет.</string>
     <string name="chat">Чат</string>
     <string name="close_group">Закрыть группу</string>
     <string name="close_group_warning">Это закроет группу для всех. Сообщения сохраняются для модерации.</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">Узнайте о Чол Чнам Тхмэй</string>
     <string name="seasonal_event_dismiss">Закрыть</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">Подтвердите свой возраст</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">Как это работает</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">Нам нужна фотография государственного удостоверения личности, чтобы подтвердить, что вам уже исполнилось 18 лет. Изображение шифруется при передаче, проверяется модератором и безвозвратно удаляется, как только решение будет зафиксировано — обычно в течение 24 часов. Сохраняются только дата рождения и результат проверки.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">Я понял — продолжай</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">Какой документ?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">Выберите тип удостоверения личности, которое вы отправите. Дата рождения в документе должна совпадать с той, что указана в вашей учетной записи.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">Паспорт</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">Водительское удостоверение</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">Национальное удостоверение личности</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">Добавить фото</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">Выберите четкое фото удостоверения личности. Убедитесь, что дата рождения полностью читаема.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">Выбрать фото</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">Заменить фото</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">Готовы отправить?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">После отправки фотография отправляется на рассмотрение. Когда решение будет записано, вы получите системное сообщение.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">Тип идентификатора:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">Фото:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">прикрепил</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">Отправить на рассмотрение</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">Спасибо</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">Ваша заявка находится в очереди. Мы сообщим вам здесь, когда решение будет записано.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">Сделанный</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">Назад</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">Перед отправкой выберите тип идентификатора.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">Пожалуйста, добавьте фотографию перед отправкой.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">Не удалось отправить. Проверьте подключение и повторите попытку.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-sv/strings.xml
+++ b/shared/src/commonMain/composeResources/values-sv/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Alla admins &amp; mods</string>
     <string name="attach_evidence">Bifoga bevis</string>
     <string name="cant_message_user">Du kan inte skicka meddelande till denna användare</string>
+    <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Du kan inte skicka meddelanden till den här personen eftersom vi tror att de är under 18 år.</string>
     <string name="chat">Chatt</string>
     <string name="close_group">Stäng grupp</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">Lär dig om Choul Chnam Thmey</string>
     <string name="seasonal_event_dismiss">Stäng</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">Verifiera din ålder</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">Hur det här fungerar</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">Vi behöver ett foto av ett myndighetsutfärdat ID för att bekräfta att du är minst 18. Bilden krypteras under överföring, granskas av en mänsklig moderator och raderas permanent så snart ett beslut har registrerats – vanligtvis inom 24 timmar. Endast födelsedatum och verifieringsresultat sparas.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">Jag förstår - fortsätt</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">Vilket dokument?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">Välj vilken typ av ID du ska skicka. DOB på dokumentet måste matcha den på ditt konto.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">Pass</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">Körkort</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">Nationellt ID-kort</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">Lägg till fotot</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">Välj ett tydligt foto av ID:t. Se till att födelsedatumet är fullt läsbart.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">Välj foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">Byt ut foto</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">Redo att skicka in?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">När bilden har skickats in skickas den för granskning. Du får ett systemmeddelande när ett beslut registreras.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">ID-typ:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">Bild:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">bunden</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">Skicka in för granskning</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">Tack</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">Ditt bidrag står i kön. Vi kommer att meddela dig här när ett beslut har registrerats.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">Gjort</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">Tillbaka</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">Välj en ID-typ innan du skickar in.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">Lägg till ett foto innan du skickar in.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">Det gick inte att skicka – kontrollera din anslutning och försök igen.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-th/strings.xml
+++ b/shared/src/commonMain/composeResources/values-th/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">แอดมิน &amp; ผู้ดูแลทั้งหมด</string>
     <string name="attach_evidence">แนบหลักฐาน</string>
     <string name="cant_message_user">คุณไม่สามารถส่งข้อความถึงผู้ใช้นี้ได้</string>
-    <string name="pm_locked_other_user_notice">คุณไม่สามารถส่งข้อความถึงบุคคลนี้ได้ เพราะเราเชื่อว่าพวกเขาอายุต่ำกว่า 18 ปี</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">คุณไม่สามารถส่งข้อความถึงบุคคลนี้ได้เนื่องจากเราเชื่อว่าพวกเขาอายุต่ำกว่า 18 ปี</string>
     <string name="chat">แชท</string>
     <string name="close_group">ปิดกลุ่ม</string>
     <string name="close_group_warning">การกระทำนี้จะปิดกลุ่มสำหรับทุกคน ข้อความจะถูกเก็บไว้สำหรับการตรวจสอบ</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">เรียนรู้เกี่ยวกับจุลจนำทเมย</string>
     <string name="seasonal_event_dismiss">ปิด</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">ยืนยันอายุของคุณ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">วิธีการทำงานนี้</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">เราต้องการรูปถ่ายบัตรประจำตัวที่ออกโดยหน่วยงานราชการเพื่อยืนยันว่าคุณมีอายุไม่ต่ำกว่า 18 ปี รูปภาพดังกล่าวได้รับการเข้ารหัสระหว่างการส่ง ตรวจสอบโดยผู้ตรวจสอบที่เป็นมนุษย์ และจะถูกลบอย่างถาวรทันทีที่มีการบันทึกการตัดสินใจ ซึ่งโดยปกติจะใช้เวลาภายใน 24 ชั่วโมง จะเก็บเฉพาะวันเกิดและผลการตรวจสอบเท่านั้น</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">ฉันเข้าใจแล้ว - ดำเนินการต่อ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">เอกสารไหน?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">เลือกประเภทบัตรประจำตัวที่คุณจะส่ง วันเกิดในเอกสารจะต้องตรงกับวันเกิดในบัญชีของคุณ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">หนังสือเดินทาง</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">ใบขับขี่</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">บัตรประจำตัวประชาชน</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">เพิ่มรูปภาพ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">เลือกรูปถ่ายบัตรประจำตัวที่ชัดเจน ตรวจสอบให้แน่ใจว่าวันเกิดสามารถอ่านได้ครบถ้วน</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">เลือกรูปภาพ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">แทนที่รูปภาพ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">พร้อมส่งหรือยัง?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">เมื่อส่งแล้วภาพถ่ายจะถูกส่งไปตรวจสอบ คุณจะได้รับข้อความระบบเมื่อมีการบันทึกการตัดสินใจ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">ประเภทบัตรประจำตัว:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">รูปถ่าย:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">ที่แนบมา</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">ส่งเพื่อตรวจสอบ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">ขอบคุณ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">การส่งของคุณอยู่ในคิว เราจะส่งข้อความถึงคุณที่นี่เมื่อมีการบันทึกการตัดสินใจ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">เสร็จแล้ว</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">กลับ</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">โปรดเลือกประเภทรหัสก่อนส่ง</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">กรุณาเพิ่มภาพถ่ายก่อนที่จะส่ง</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">ไม่สามารถส่งได้ — โปรดตรวจสอบการเชื่อมต่อของคุณแล้วลองอีกครั้ง</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-tr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tr/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">Tüm yöneticiler &amp; moderatörler</string>
     <string name="attach_evidence">Kanıt Ekle</string>
     <string name="cant_message_user">Bu kullanıcıya mesaj gönderemezsiniz</string>
-    <string name="pm_locked_other_user_notice">Bu kişiyi 18 yaşından küçük olduğuna inandığımız için mesaj gönderemezsiniz.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">Bu kişiye mesaj gönderemezsiniz çünkü onun 18 yaşının altında olduğunu düşünüyoruz.</string>
     <string name="chat">Sohbet</string>
     <string name="close_group">Grubu Kapat</string>
     <string name="close_group_warning">Bu, grubu herkes için kapatacaktır. Mesajlar moderasyon için korunur.</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">Choul Chnam Thmey hakkında bilgi edinin</string>
     <string name="seasonal_event_dismiss">Kapat</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">Yaşınızı doğrulayın</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">Bu nasıl çalışır?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">En az 18 yaşında olduğunuzu doğrulamak için devlet tarafından verilmiş bir kimliğin fotoğrafına ihtiyacımız var. Görüntü aktarım sırasında şifrelenir, bir insan moderatör tarafından incelenir ve karar kaydedilir kaydedilmez, genellikle 24 saat içinde kalıcı olarak silinir. Yalnızca doğum tarihi ve doğrulama sonucu tutulur.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">Anladım - devam et</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">Hangi belge?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">Göndereceğiniz kimlik türünü seçin. Belgedeki DOB, hesabınızdaki DOB ile eşleşmelidir.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">Pasaport</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">Ehliyet</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">Ulusal kimlik kartı</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">Fotoğrafı ekle</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">Kimliğin net bir fotoğrafını seçin. Doğum tarihinin tamamen okunabilir olduğundan emin olun.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">Fotoğraf seç</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">Fotoğrafı değiştir</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">Göndermeye hazır mısınız?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">Fotoğraf gönderildikten sonra incelemeye gönderilir. Bir karar kaydedildiğinde bir sistem mesajı alırsınız.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">Kimlik türü:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">Fotoğraf:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">ekli</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">İnceleme için gönder</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">Teşekkür ederim</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">Gönderiminiz sırada. Bir karar kaydedildiğinde size buradan mesaj göndereceğiz.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">Tamamlamak</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">Geri</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">Lütfen göndermeden önce bir kimlik türü seçin.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">Lütfen göndermeden önce bir fotoğraf ekleyin.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">Gönderilemedi; lütfen bağlantınızı kontrol edip tekrar deneyin.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Усі адміни &amp; модератори</string>
     <string name="attach_evidence">Прикріпити доказ</string>
     <string name="cant_message_user">Ви не можете написати цьому користувачу</string>
+    <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Ви не можете надіслати повідомлення цій особі, оскільки ми вважаємо, що їй менше 18 років.</string>
     <string name="chat">Чат</string>
     <string name="close_group">Закрити групу</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">Дізнайтеся про Чол Чнам Тхмей</string>
     <string name="seasonal_event_dismiss">Закрити</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">Підтвердьте свій вік</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">Як це працює</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">Нам потрібна фотографія офіційного посвідчення особи, щоб підтвердити, що вам є принаймні 18 років. Зображення шифрується під час передачі, переглядається людиною-модератором і назавжди видаляється, щойно буде прийнято рішення — зазвичай протягом 24 годин. Зберігається лише дата народження та результат перевірки.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">Розумію — продовжуй</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">Який документ?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">Виберіть тип ідентифікатора, який ви надсилатимете. DOB у документі має збігатися з номером вашого облікового запису.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">Паспорт</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">Водійське посвідчення</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">Національне посвідчення особи</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">Додайте фото</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">Виберіть чітке фото посвідчення особи. Переконайтеся, що дата народження повністю читається.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">Виберіть фото</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">Замінити фото</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">Готові подати?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">Після надсилання фотографія надсилається на перевірку. Коли рішення буде записано, ви отримаєте системне повідомлення.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">Тип ідентифікатора:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">фото:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">додається</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">Надіслати на перевірку</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">дякую</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">Ваша заявка в черзі. Ми надішлемо вам повідомлення тут, коли буде записано рішення.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">Готово</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">Назад</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">Перш ніж надсилати, виберіть тип ідентифікатора.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">Перед надсиланням додайте фото.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">Не вдалося надіслати — перевірте з’єднання та повторіть спробу.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-vi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-vi/strings.xml
@@ -252,6 +252,7 @@
     <string name="all_admins_and_mods">Tất cả quản trị viên &amp; điều hành viên</string>
     <string name="attach_evidence">Đính kèm Bằng chứng</string>
     <string name="cant_message_user">Bạn không thể nhắn tin cho người dùng này</string>
+    <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Bạn không thể nhắn tin cho người này vì chúng tôi tin rằng họ dưới 18 tuổi.</string>
     <string name="chat">Trò chuyện</string>
     <string name="close_group">Đóng Nhóm</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">Tìm hiểu về Choul Chnam Thmey</string>
     <string name="seasonal_event_dismiss">Đóng</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">Xác minh tuổi của bạn</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">Cách thức hoạt động</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">Chúng tôi cần ảnh chụp giấy tờ tùy thân do chính phủ cấp để xác nhận bạn đủ 18 tuổi. Hình ảnh được mã hóa trong quá trình truyền, được người kiểm duyệt xem xét và xóa vĩnh viễn ngay sau khi quyết định được ghi lại — thường trong vòng 24 giờ. Chỉ có ngày sinh và kết quả xác minh được giữ lại.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">Tôi hiểu - tiếp tục</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">Tài liệu nào?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">Chọn loại ID bạn sẽ gửi. DOB trên tài liệu phải khớp với DOB trên tài khoản của bạn.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">Hộ chiếu</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">Bằng lái xe</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">Chứng minh nhân dân</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">Thêm ảnh</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">Chọn một bức ảnh rõ ràng về ID. Đảm bảo ngày sinh hoàn toàn có thể đọc được.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">Chọn ảnh</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">Thay thế ảnh</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">Sẵn sàng để nộp?</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">Sau khi gửi, ảnh sẽ được gửi để xem xét. Bạn sẽ nhận được thông báo hệ thống khi quyết định được ghi lại.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">Loại ID:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">Ảnh:</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">đính kèm</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">Gửi để xem xét</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">Cảm ơn</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">Nội dung gửi của bạn đang trong hàng đợi. Chúng tôi sẽ nhắn tin cho bạn tại đây khi quyết định được ghi lại.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">Xong</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">Mặt sau</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">Vui lòng chọn loại ID trước khi gửi.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">Vui lòng thêm ảnh trước khi gửi.</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">Không thể gửi - vui lòng kiểm tra kết nối của bạn và thử lại.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -252,7 +252,8 @@
     <string name="all_admins_and_mods">所有管理员 &amp; 版主</string>
     <string name="attach_evidence">附上证据</string>
     <string name="cant_message_user">无法向此用户发送消息</string>
-    <string name="pm_locked_other_user_notice">您无法向此人发送消息，因为我们认为他们未满18岁。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="pm_locked_other_user_notice">您不能向此人发送消息，因为我们认为他们未满 18 岁。</string>
     <string name="chat">聊天</string>
     <string name="close_group">关闭群组</string>
     <string name="close_group_warning">这将为所有人关闭群组。消息将保留以供审核。</string>
@@ -853,4 +854,56 @@
     <string name="seasonal_khmer_new_year_cta">了解柬埔寨新年</string>
     <string name="seasonal_event_dismiss">关闭</string>
 
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_title">验证您的年龄</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_title">这是如何运作的</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_body">我们需要一张政府颁发的身份证件照片来确认您已年满 18 岁。该图像在传输过程中会被加密，由人工审核员审核，并在记录决定后立即永久删除（通常在 24 小时内）。仅保留出生日期和验证结果。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_explanation_continue">我明白了——继续</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_title">哪个文件？</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_method_body">选择您要提交的 ID 类型。文件上的出生日期必须与您帐户上的出生日期相符。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_passport">护照</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_drivers_license">驾照</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_method_national_id">国民身份证</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_title">添加照片</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_body">选择一张清晰的身份证照片。确保出生日期清晰可读。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_pick">选择照片</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_image_replace">替换照片</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_title">准备好提交了吗？</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_body">提交后，照片将被发送以供审核。记录决定后，您将收到一条系统消息。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_method">身份证类型：</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_field_photo">照片：</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_photo_attached">随附的</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_confirm_submit">提交审核</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_title">谢谢</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_body">您的提交已在队列中。当决定被记录时，我们会在这里向您发送消息。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_step_submitted_done">完毕</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_back">后退</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_method">请在提交前选择 ID 类型。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_no_image">提交前请添加照片。</string>
+    <!-- google-translated 2026-05-04 -->
+    <string name="age_verif_submit_error_generic">无法提交 - 请检查您的连接并重试。</string>
 </resources>


### PR DESCRIPTION
## Summary
Per the new translation-source rule (memory: `feedback-translation-source-priority`):
- Use **Google Translate**'s free public endpoint as the primary source.
- Fall back to **Claude** only when Google's quota is exhausted.
- Tag every translated string with provenance (`<!-- google-translated YYYY-MM-DD -->`) so a future retranslation pass can swap Claude entries back to Google when free again.
- **Untagged == Claude** by default (per user clarification) — the retranslation pass covers untagged AND `claude-translated` tagged strings.

## What's in
**Tooling**
- `scripts/translate-strings.js` — Node CLI that:
  - Reads the EN strings.xml and translates via Google's undocumented public endpoint (`translate.googleapis.com/translate_a/single`). No API key required.
  - Tags new/updated `<string>` entries with `<!-- google-translated YYYY-MM-DD -->`.
  - `--retranslate-claude` mode: scans every locale, retranslates anything that isn't already google-tagged, resumable on quota hit.
- `express-api/tests/scripts/translate-strings.test.js` — **14 unit tests** with `fetch` mocked: arg parsing, XML round-trip, upsert insert/replace/escape, `googleTranslate` happy path + `zh→zh-CN` map + 429 quota + multi-segment join, `findNonGoogleStrings` (untagged, claude-tagged, google-tagged, mixed).

**Translations applied (520 entries via Google, 0 Claude fallback)**
- 26 new keys × 20 locales — strings added in PR 6 (admin sub-tab) and PR 9 (user verification submit screen).
- `pm_locked_other_user_notice` × 20 locales — re-translated via Google, replaces the Claude version shipped in PR 11.

## Test plan
- [x] `npx jest tests/scripts/translate-strings.test.js` — 14/14 passed
- [x] `:shared:compileCommonMainKotlinMetadata` — XML files parse correctly post-mutation
- [x] Spot-check fr/ja/zh — translations look correct, every entry has the `<!-- google-translated 2026-05-04 -->` provenance tag

## Follow-up
- Task #76 — full retranslation pass once PR 13 is merged. Runs the script in `--retranslate-claude` mode against ~1500 untagged strings × 20 locales (~30k API calls). Should be its own PR for diff cleanliness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)