### PR TITLE
feat(cron): age-verification audit-log reconciliation

### DIFF
--- a/express-api/src/cron/ageVerificationAuditReconcile.js
+++ b/express-api/src/cron/ageVerificationAuditReconcile.js
@@ -1,0 +1,251 @@
+/**
+ * Cron job: back-fill missing age-verification audit-log entries.
+ *
+ * The admin decision flow (`admin-age-verification.js`) commits the
+ * decision transaction first, then writes the audit-log entry as a
+ * post-commit best-effort step. If the audit write fails (Firestore
+ * outage, rules misconfig, network drop), the decision is committed
+ * but no audit-log row exists — a compliance gap (OSA / GDPR
+ * traceability).
+ *
+ * The route handler returns the failure to the admin via the
+ * `auditWritten=false` response flag, but if the admin doesn't notice
+ * (or if the failure happens AFTER the response is already sent), the
+ * gap silently persists.
+ *
+ * This job runs daily, scans submissions whose decision committed in
+ * the last 7 days, and writes a remediation audit entry for any that
+ * still have no matching `auditLog` row. The 7-day window is wide
+ * enough to absorb a multi-day Firestore outage but narrow enough that
+ * Firestore reads stay cheap.
+ *
+ * Idempotency: the matching key is the submission ID itself — every
+ * remediation entry stores `details.fromSubmissionId` and the query
+ * checks for that field before writing. A second run after a
+ * successful first-run write is a no-op.
+ */
+
+const { db } = require('../utils/firebase');
+const { now } = require('../utils/helpers');
+const log = require('../utils/log');
+
+const MS_PER_DAY = 86_400_000;
+const SCAN_WINDOW_MS = 7 * MS_PER_DAY;
+
+// Maps the submission-doc `status` field (written by the route
+// handlers) to the corresponding `action` string used by the audit
+// log. The handlers actually write `dob_modified` for the modify-DOB
+// path; the other entries are defensive in case the wire format
+// changes without an audit-side update.
+const STATUS_ACTION_MAP = Object.freeze({
+  approved: 'age_verification_approved',
+  rejected: 'age_verification_rejected',
+  dob_modified: 'age_verification_dob_modified',
+  'modify-dob': 'age_verification_dob_modified',
+  modifyDob: 'age_verification_dob_modified',
+});
+
+// Coerce a stored timestamp value to epoch ms. Submission writers in
+// `admin-age-verification.js` use plain `now()` (number), but a future
+// migration or backfill could land Firestore `Timestamp` objects or
+// the `{seconds, nanoseconds}` plain-object shape. Returning `null`
+// for unknown shapes lets callers explicitly choose how to handle the
+// gap (skip vs back-fill anyway) instead of silently treating it as
+// "no match" and writing a duplicate remediation row.
+function toMillis(v) {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (v && typeof v.toMillis === 'function') {
+    const ms = v.toMillis();
+    return typeof ms === 'number' && Number.isFinite(ms) ? ms : null;
+  }
+  if (v && typeof v.seconds === 'number') {
+    return v.seconds * 1000 + Math.floor((v.nanoseconds || 0) / 1_000_000);
+  }
+  return null;
+}
+
+/**
+ * Find an existing audit-log row that this submission's decision
+ * should have written. Two match paths:
+ *   1. Already-reconciled rows tag themselves with `fromSubmissionId`.
+ *      That's the cheap idempotency check — `where` query.
+ *   2. Original-write rows (from the route handler) have no
+ *      `fromSubmissionId` but match on `actionType + targetId +
+ *      timestamp ≈ decisionAt`. We accept ±10 min skew to absorb
+ *      clock drift between the route's `now()` and Firestore's
+ *      server-side timestamp.
+ */
+async function hasExistingAudit(submission, action) {
+  // Path 1: idempotency — already-reconciled tagged rows.
+  const tagged = await db
+    .collection('auditLog')
+    .where('details.fromSubmissionId', '==', submission.id)
+    .limit(1)
+    .get();
+  if (!tagged.empty) return true;
+
+  // Path 2: original write match. We can't index on `timestamp ≈ X`
+  // server-side without a composite index, so query on actionType +
+  // targetId and filter the timestamp client-side. Bounded by `limit`
+  // because age-verification decisions per user are rare (≤2-3 in
+  // realistic scenarios).
+  const decisionAt = toMillis(submission.decisionAt);
+  if (decisionAt === null) return false;
+
+  const candidates = await db
+    .collection('auditLog')
+    .where('actionType', '==', action)
+    .where('targetId', '==', String(submission.userId))
+    .limit(20)
+    .get();
+
+  const window = 10 * 60_000; // ±10 min
+  for (const doc of candidates.docs) {
+    const ts = toMillis(doc.data().timestamp);
+    if (ts !== null && Math.abs(ts - decisionAt) < window) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Build the remediation audit row for a submission missing its
+ * original entry. Mirrors what the route handler would have written,
+ * minus the admin's free-text reason (we don't have it on the
+ * submission doc — original reason is in the route's request body
+ * which is no longer accessible). Reason is replaced with a
+ * remediation marker.
+ */
+function buildRemediationEntry(submission, action) {
+  const details = {
+    fromSubmissionId: submission.id,
+    reconciledAt: now(),
+    originalDecisionAt: toMillis(submission.decisionAt),
+    note: 'Reconciled by ageVerificationAuditReconcile cron — original audit write failed at decision time.',
+  };
+  if (action === 'age_verification_approved') {
+    details.method = submission.idMethod || 'unknown';
+  }
+  if (action === 'age_verification_dob_modified') {
+    // Modify-DOB submissions don't store the new/old DOB on the
+    // submission doc — the user-doc has the new value but oldDob is
+    // lost once the transaction commits. Best-effort: omit and rely
+    // on the note + originalDecisionAt for traceability. Operators
+    // can cross-reference user-doc history if a real audit gap is
+    // discovered, but this remediation entry won't reconstruct the
+    // old DOB.
+    details.note += ' DOB delta not captured — see user-doc history.';
+  }
+  return {
+    adminUid: typeof submission.decidedBy === 'number' ? submission.decidedBy : 0,
+    action,
+    actionType: action,
+    targetType: 'user',
+    targetId: String(submission.userId),
+    details,
+    timestamp: now(),
+  };
+}
+
+async function ageVerificationAuditReconcile() {
+  const cutoff = now() - SCAN_WINDOW_MS;
+  const snap = await db
+    .collection('ageVerificationSubmissions')
+    .where('decisionAt', '>=', cutoff)
+    .get();
+
+  let scanned = 0;
+  let reconciled = 0;
+  let skippedPending = 0;
+  let skippedAlreadyAudited = 0;
+  let skippedUnknownStatus = 0;
+  let failed = 0;
+
+  // Per-doc isolation: a transient Firestore read failure or a
+  // single malformed submission must not abort the whole back-fill.
+  // This is a compliance remediation path — failing to remediate
+  // doc N+1 because doc N threw means another 23 hours of OSA/GDPR
+  // gap. Track failures in a counter so they surface in the summary
+  // and the catastrophic-failure alert in `cron/index.js` can still
+  // distinguish "everything broke" from "one row had bad data".
+  for (const doc of snap.docs) {
+    scanned++;
+    try {
+      const data = doc.data();
+
+      if (data.status === 'pending' || toMillis(data.decisionAt) === null) {
+        // Pending docs shouldn't reach this query (filtered by
+        // decisionAt) but defend anyway — a doc could be partially-
+        // committed if the route crashed mid-transaction.
+        skippedPending++;
+        continue;
+      }
+
+      const action = STATUS_ACTION_MAP[data.status];
+      if (!action) {
+        skippedUnknownStatus++;
+        log.warn('ageVerificationAuditReconcile', 'Unknown submission status', {
+          submissionId: doc.id,
+          status: data.status,
+        });
+        continue;
+      }
+
+      const submission = { id: doc.id, ...data };
+      const exists = await hasExistingAudit(submission, action);
+      if (exists) {
+        skippedAlreadyAudited++;
+        continue;
+      }
+
+      const entry = buildRemediationEntry(submission, action);
+      await db.collection('auditLog').add(entry);
+      reconciled++;
+      log.warn('ageVerificationAuditReconcile', 'Back-filled missing audit entry', {
+        submissionId: doc.id,
+        targetUserId: submission.userId,
+        action,
+        originalDecisionAt: toMillis(submission.decisionAt),
+      });
+    } catch (err) {
+      failed++;
+      log.error(
+        'ageVerificationAuditReconcile',
+        'Per-doc remediation failed — continuing to next submission',
+        {
+          submissionId: doc.id,
+          error: err && err.message ? err.message : String(err),
+        },
+      );
+    }
+  }
+
+  log.info('ageVerificationAuditReconcile', 'Scan complete', {
+    scanned,
+    reconciled,
+    skippedPending,
+    skippedAlreadyAudited,
+    skippedUnknownStatus,
+    failed,
+  });
+
+  return {
+    scanned,
+    reconciled,
+    skippedPending,
+    skippedAlreadyAudited,
+    skippedUnknownStatus,
+    failed,
+  };
+}
+
+module.exports = ageVerificationAuditReconcile;
+// Exported for unit-test access — tests stub `db` + `now` and assert
+// internal behaviour without exercising the wrapped cron.schedule
+// call.
+module.exports.STATUS_ACTION_MAP = STATUS_ACTION_MAP;
+module.exports.SCAN_WINDOW_MS = SCAN_WINDOW_MS;
+module.exports.hasExistingAudit = hasExistingAudit;
+module.exports.buildRemediationEntry = buildRemediationEntry;
+module.exports.toMillis = toMillis;

--- a/express-api/src/cron/index.js
+++ b/express-api/src/cron/index.js
@@ -16,6 +16,7 @@ const accountDeletion = require('./accountDeletion');
 const expireDataExports = require('./expireDataExports');
 const alertManager = require('../utils/alertManagerInstance');
 const dispatchNotifications = require('./notification-dispatch');
+const ageVerificationAuditReconcile = require('./ageVerificationAuditReconcile');
 
 function startCronJobs() {
   const isProd = process.env.NODE_ENV === 'production';
@@ -110,6 +111,36 @@ function startCronJobs() {
     dispatchNotifications().catch((err) =>
       log.error('cron', 'notification-dispatch failed', { error: err.message }),
     );
+  });
+
+  // Age-verification audit-log reconciliation — daily 05:00 UTC.
+  // Back-fills missing audit entries for decisions whose post-commit
+  // audit write failed (compliance gap fix). 7-day scan window so a
+  // multi-day Firestore outage is fully covered. Idempotent on
+  // re-runs via `details.fromSubmissionId` markers.
+  //
+  // Per-doc failures are isolated inside the job (see `failed`
+  // counter); only a catastrophic crash (Firestore unreachable,
+  // permission revoked, code bug) reaches this `.catch`. That kind
+  // of failure leaves the OSA/GDPR remediation gap unresolved for
+  // 24+ h, so route it through alertManager instead of relying on
+  // log-grep.
+  cron.schedule('0 5 * * *', () => {
+    log.info('cron', 'Running ageVerificationAuditReconcile');
+    ageVerificationAuditReconcile().catch((err) => {
+      log.error('cron', 'ageVerificationAuditReconcile failed', { error: err.message });
+      alertManager
+        .createAlert(
+          'compliance_cron_failed',
+          'critical',
+          'Age-verification audit reconcile cron crashed',
+          'Daily back-fill of missing age-verification audit-log entries did not complete. OSA/GDPR remediation paused until the next successful run. Investigate immediately.',
+          { error: err.message, cron: 'ageVerificationAuditReconcile' },
+        )
+        .catch((alertErr) =>
+          log.error('cron', 'alertManager.createAlert failed', { error: alertErr.message }),
+        );
+    });
   });
 
   log.info('cron', 'Cron jobs scheduled');

--- a/express-api/tests/cron/ageVerificationAuditReconcile.test.js
+++ b/express-api/tests/cron/ageVerificationAuditReconcile.test.js
@@ -1,0 +1,423 @@
+/**
+ * Tests for the age-verification audit-log reconciliation cron
+ * (`src/cron/ageVerificationAuditReconcile.js`).
+ *
+ * Pin the back-fill behaviour: scan submissions decided in the last
+ * 7 days, skip those with a matching audit row, write a remediation
+ * entry for the gaps. Idempotent on a second run via the
+ * `details.fromSubmissionId` marker.
+ */
+
+// ─── Firebase mock ────────────────────────────────────────────────
+
+const mockSubmissionsGet = jest.fn();
+const mockTaggedAuditGet = jest.fn();
+const mockOriginalAuditGet = jest.fn();
+const mockAuditAdd = jest.fn().mockResolvedValue();
+
+// `db.collection(name).where(...).where(...)?.limit(...)?.get()` —
+// we route by collection name + the query shape.
+const mockSubmissionsCollection = {
+  where: (field, op, value) => ({
+    get: () => mockSubmissionsGet({ field, op, value }),
+  }),
+};
+
+// `jest.mock()` is hoisted; only references that start with `mock`
+// (case-insensitive) are allowed. Naming this `mockBuild...` rather
+// than `buildAuditCollection` so Jest's hoist-safety check accepts.
+const mockBuildAuditCollection = () => ({
+  add: (...args) => mockAuditAdd(...args),
+  where: function whereFn(field, op, value) {
+    // Route the two query shapes to dedicated mocks so a test can
+    // stub them independently:
+    //   1) `details.fromSubmissionId` == X  → tagged-row idempotency
+    //   2) `actionType` == X (chained with another `where`) → original
+    if (field === 'details.fromSubmissionId') {
+      return {
+        limit: () => ({ get: () => mockTaggedAuditGet({ value }) }),
+      };
+    }
+    // actionType / targetId chain — return another `where`-like
+    // that captures both clauses then resolves via mockOriginalAuditGet.
+    const captured = [{ field, op, value }];
+    return {
+      where: (f2, o2, v2) => {
+        captured.push({ field: f2, op: o2, value: v2 });
+        return {
+          limit: () => ({ get: () => mockOriginalAuditGet({ captured }) }),
+        };
+      },
+    };
+  },
+});
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    collection: jest.fn((name) => {
+      if (name === 'ageVerificationSubmissions') return mockSubmissionsCollection;
+      if (name === 'auditLog') return mockBuildAuditCollection();
+      throw new Error(`Unexpected collection: ${name}`);
+    }),
+  },
+}));
+
+// Pin `now` so timestamp math is deterministic. 2026-05-04T12:00:00Z.
+jest.mock('../../src/utils/helpers', () => ({
+  now: () => 1777896000000,
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const ageVerificationAuditReconcile = require('../../src/cron/ageVerificationAuditReconcile');
+
+function submission(overrides = {}) {
+  return {
+    id: 'sub-1',
+    data: () => ({
+      userId: '10000050',
+      idMethod: 'passport',
+      status: 'approved',
+      decisionAt: 1777896000000 - 60_000, // 1 min before now
+      decidedBy: 10000001,
+      ...overrides,
+    }),
+  };
+}
+
+// ─── Empty / no-op cases ──────────────────────────────────────────
+
+describe('ageVerificationAuditReconcile — empty + idempotency', () => {
+  test('returns zero counts when no decided submissions are in the window', async () => {
+    mockSubmissionsGet.mockResolvedValue({ docs: [] });
+
+    const result = await ageVerificationAuditReconcile();
+
+    expect(result).toEqual({
+      scanned: 0,
+      reconciled: 0,
+      skippedPending: 0,
+      skippedAlreadyAudited: 0,
+      skippedUnknownStatus: 0,
+      failed: 0,
+    });
+    expect(mockAuditAdd).not.toHaveBeenCalled();
+  });
+
+  test('skips a submission whose audit row is already tagged with fromSubmissionId (idempotent re-run)', async () => {
+    mockSubmissionsGet.mockResolvedValue({ docs: [submission()] });
+    // Tagged-row query returns a hit → already reconciled.
+    mockTaggedAuditGet.mockResolvedValue({ empty: false, docs: [{ id: 'audit-tagged' }] });
+
+    const result = await ageVerificationAuditReconcile();
+
+    expect(result.scanned).toBe(1);
+    expect(result.reconciled).toBe(0);
+    expect(result.skippedAlreadyAudited).toBe(1);
+    expect(mockAuditAdd).not.toHaveBeenCalled();
+  });
+
+  test('skips a submission whose original audit row matches on actionType + targetId + timestamp window', async () => {
+    mockSubmissionsGet.mockResolvedValue({ docs: [submission()] });
+    mockTaggedAuditGet.mockResolvedValue({ empty: true, docs: [] });
+    // Original audit row, timestamp within ±10 min of decisionAt.
+    mockOriginalAuditGet.mockResolvedValue({
+      docs: [
+        {
+          data: () => ({ timestamp: 1777896000000 - 30_000 }), // 30s before now
+        },
+      ],
+    });
+
+    const result = await ageVerificationAuditReconcile();
+
+    expect(result.scanned).toBe(1);
+    expect(result.reconciled).toBe(0);
+    expect(result.skippedAlreadyAudited).toBe(1);
+    expect(mockAuditAdd).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Reconciliation paths ─────────────────────────────────────────
+
+describe('ageVerificationAuditReconcile — back-fill', () => {
+  test('writes a remediation entry when no audit row exists for an approved decision', async () => {
+    mockSubmissionsGet.mockResolvedValue({ docs: [submission()] });
+    mockTaggedAuditGet.mockResolvedValue({ empty: true, docs: [] });
+    mockOriginalAuditGet.mockResolvedValue({ docs: [] });
+
+    const result = await ageVerificationAuditReconcile();
+
+    expect(result.reconciled).toBe(1);
+    expect(mockAuditAdd).toHaveBeenCalledTimes(1);
+    const entry = mockAuditAdd.mock.calls[0][0];
+    expect(entry.action).toBe('age_verification_approved');
+    expect(entry.actionType).toBe('age_verification_approved');
+    expect(entry.targetId).toBe('10000050');
+    expect(entry.adminUid).toBe(10000001);
+    expect(entry.details.fromSubmissionId).toBe('sub-1');
+    expect(entry.details.method).toBe('passport');
+    expect(entry.details.note).toMatch(/Reconciled by ageVerificationAuditReconcile/);
+  });
+
+  test('rejected status maps to age_verification_rejected', async () => {
+    mockSubmissionsGet.mockResolvedValue({
+      docs: [submission({ status: 'rejected' })],
+    });
+    mockTaggedAuditGet.mockResolvedValue({ empty: true, docs: [] });
+    mockOriginalAuditGet.mockResolvedValue({ docs: [] });
+
+    await ageVerificationAuditReconcile();
+
+    const entry = mockAuditAdd.mock.calls[0][0];
+    expect(entry.action).toBe('age_verification_rejected');
+    // Method is approve-only metadata — must NOT leak into reject entries.
+    expect(entry.details.method).toBeUndefined();
+  });
+
+  test('modify-dob status maps to age_verification_dob_modified + adds DOB-delta caveat', async () => {
+    mockSubmissionsGet.mockResolvedValue({
+      docs: [submission({ status: 'modify-dob' })],
+    });
+    mockTaggedAuditGet.mockResolvedValue({ empty: true, docs: [] });
+    mockOriginalAuditGet.mockResolvedValue({ docs: [] });
+
+    await ageVerificationAuditReconcile();
+
+    const entry = mockAuditAdd.mock.calls[0][0];
+    expect(entry.action).toBe('age_verification_dob_modified');
+    expect(entry.details.note).toMatch(/DOB delta not captured/);
+  });
+
+  test('original-audit timestamp OUTSIDE the ±10 min window does not match — back-fill happens', async () => {
+    mockSubmissionsGet.mockResolvedValue({ docs: [submission()] });
+    mockTaggedAuditGet.mockResolvedValue({ empty: true, docs: [] });
+    // Timestamp 11 min before now — outside the window.
+    mockOriginalAuditGet.mockResolvedValue({
+      docs: [{ data: () => ({ timestamp: 1777896000000 - 11 * 60_000 }) }],
+    });
+
+    const result = await ageVerificationAuditReconcile();
+
+    expect(result.reconciled).toBe(1);
+  });
+
+  test('falls back to adminUid=0 when decidedBy is missing (legacy / corrupted submission)', async () => {
+    mockSubmissionsGet.mockResolvedValue({
+      docs: [submission({ decidedBy: undefined })],
+    });
+    mockTaggedAuditGet.mockResolvedValue({ empty: true, docs: [] });
+    mockOriginalAuditGet.mockResolvedValue({ docs: [] });
+
+    await ageVerificationAuditReconcile();
+
+    const entry = mockAuditAdd.mock.calls[0][0];
+    expect(entry.adminUid).toBe(0);
+  });
+});
+
+// ─── Defensive / unknown status ───────────────────────────────────
+
+describe('ageVerificationAuditReconcile — defensive', () => {
+  test('skips submissions with an unrecognised status without throwing', async () => {
+    mockSubmissionsGet.mockResolvedValue({
+      docs: [submission({ status: 'pending' })], // shouldn't be returned by query but defend anyway
+    });
+
+    const result = await ageVerificationAuditReconcile();
+
+    expect(result.skippedPending).toBe(1);
+    expect(mockAuditAdd).not.toHaveBeenCalled();
+  });
+
+  test('skips submissions with a status not in STATUS_ACTION_MAP', async () => {
+    mockSubmissionsGet.mockResolvedValue({
+      docs: [submission({ status: 'expired' })],
+    });
+
+    const result = await ageVerificationAuditReconcile();
+
+    expect(result.skippedUnknownStatus).toBe(1);
+    expect(mockAuditAdd).not.toHaveBeenCalled();
+  });
+
+  test('skips submissions missing decisionAt (partially-committed transaction)', async () => {
+    mockSubmissionsGet.mockResolvedValue({
+      docs: [submission({ decisionAt: undefined })],
+    });
+
+    const result = await ageVerificationAuditReconcile();
+
+    expect(result.skippedPending).toBe(1);
+  });
+});
+
+// ─── Per-doc isolation: one bad doc must not abort remediation ────
+
+describe('ageVerificationAuditReconcile — per-doc isolation', () => {
+  test('one failing doc does not abort the rest — failed counter increments, others reconciled', async () => {
+    const goodDoc = submission({ id: 'sub-good' });
+    const badDoc = {
+      id: 'sub-bad',
+      data: () => ({
+        userId: '10000051',
+        idMethod: 'passport',
+        status: 'approved',
+        decisionAt: 1777896000000 - 60_000,
+        decidedBy: 10000001,
+      }),
+    };
+    // Two docs in the scan; the second triggers a Firestore failure
+    // when its `auditLog` add is attempted.
+    mockSubmissionsGet.mockResolvedValue({ docs: [goodDoc, badDoc] });
+    mockTaggedAuditGet.mockResolvedValue({ empty: true, docs: [] });
+    mockOriginalAuditGet.mockResolvedValue({ docs: [] });
+    // First add succeeds, second throws.
+    mockAuditAdd.mockResolvedValueOnce().mockRejectedValueOnce(new Error('Firestore unavailable'));
+
+    const result = await ageVerificationAuditReconcile();
+
+    expect(result.scanned).toBe(2);
+    expect(result.reconciled).toBe(1);
+    expect(result.failed).toBe(1);
+    // The good doc was still written even though the bad one failed.
+    expect(mockAuditAdd).toHaveBeenCalledTimes(2);
+  });
+
+  test('a doc whose data() throws is counted as failed, not as a hard crash', async () => {
+    const exploding = {
+      id: 'sub-explode',
+      data: () => {
+        throw new Error('corrupted snapshot');
+      },
+    };
+    const good = submission({ id: 'sub-ok' });
+    mockSubmissionsGet.mockResolvedValue({ docs: [exploding, good] });
+    mockTaggedAuditGet.mockResolvedValue({ empty: true, docs: [] });
+    mockOriginalAuditGet.mockResolvedValue({ docs: [] });
+
+    const result = await ageVerificationAuditReconcile();
+
+    expect(result.failed).toBe(1);
+    expect(result.reconciled).toBe(1);
+  });
+});
+
+// ─── Firestore Timestamp coercion ─────────────────────────────────
+
+describe('ageVerificationAuditReconcile — Firestore Timestamp shapes', () => {
+  test('decisionAt as Firestore Timestamp ({ toMillis() }) is matched against the audit-row window', async () => {
+    const decisionMs = 1777896000000 - 60_000;
+    mockSubmissionsGet.mockResolvedValue({
+      docs: [
+        submission({
+          decisionAt: { toMillis: () => decisionMs },
+        }),
+      ],
+    });
+    mockTaggedAuditGet.mockResolvedValue({ empty: true, docs: [] });
+    // Original audit row 30s before the Timestamp-shaped decisionAt.
+    mockOriginalAuditGet.mockResolvedValue({
+      docs: [{ data: () => ({ timestamp: { toMillis: () => decisionMs - 30_000 } }) }],
+    });
+
+    const result = await ageVerificationAuditReconcile();
+
+    // Match found via the Timestamp coercion path.
+    expect(result.skippedAlreadyAudited).toBe(1);
+    expect(result.reconciled).toBe(0);
+  });
+
+  test('decisionAt as { seconds, nanoseconds } shape (plain-object Timestamp) is coerced', async () => {
+    const decisionMs = 1777896000000 - 60_000;
+    mockSubmissionsGet.mockResolvedValue({
+      docs: [
+        submission({
+          decisionAt: { seconds: Math.floor(decisionMs / 1000), nanoseconds: 0 },
+        }),
+      ],
+    });
+    mockTaggedAuditGet.mockResolvedValue({ empty: true, docs: [] });
+    mockOriginalAuditGet.mockResolvedValue({ docs: [] });
+
+    const result = await ageVerificationAuditReconcile();
+
+    // No matching audit row → back-fill happens, proving decisionAt
+    // was successfully coerced (otherwise it would have skipped as
+    // "no decisionAt").
+    expect(result.reconciled).toBe(1);
+  });
+
+  test('decisionAt as a string is treated as missing — submission is skipped, not back-filled', async () => {
+    mockSubmissionsGet.mockResolvedValue({
+      docs: [submission({ decisionAt: 'not-a-timestamp' })],
+    });
+
+    const result = await ageVerificationAuditReconcile();
+
+    expect(result.skippedPending).toBe(1);
+    expect(mockAuditAdd).not.toHaveBeenCalled();
+  });
+});
+
+// ─── toMillis helper ──────────────────────────────────────────────
+
+describe('toMillis', () => {
+  const { toMillis } = ageVerificationAuditReconcile;
+
+  test('returns numbers unchanged when finite', () => {
+    expect(toMillis(1777896000000)).toBe(1777896000000);
+    expect(toMillis(0)).toBe(0);
+  });
+
+  test('returns null for non-finite numbers', () => {
+    expect(toMillis(NaN)).toBeNull();
+    expect(toMillis(Infinity)).toBeNull();
+  });
+
+  test('calls .toMillis() on Firestore-Timestamp-like objects', () => {
+    expect(toMillis({ toMillis: () => 1234567890 })).toBe(1234567890);
+  });
+
+  test('returns null when .toMillis() returns a non-finite value', () => {
+    expect(toMillis({ toMillis: () => NaN })).toBeNull();
+  });
+
+  test('coerces { seconds, nanoseconds } to ms', () => {
+    expect(toMillis({ seconds: 1777896, nanoseconds: 500_000_000 })).toBe(1777896 * 1000 + 500);
+  });
+
+  test('returns null for unknown shapes', () => {
+    expect(toMillis(null)).toBeNull();
+    expect(toMillis(undefined)).toBeNull();
+    expect(toMillis('1777896000000')).toBeNull();
+    expect(toMillis({})).toBeNull();
+  });
+});
+
+// ─── Internal helper exports ──────────────────────────────────────
+
+describe('exports', () => {
+  test('exposes constants for the cron registration site to schedule a window-aware run', () => {
+    expect(ageVerificationAuditReconcile.SCAN_WINDOW_MS).toBe(7 * 86_400_000);
+    expect(ageVerificationAuditReconcile.STATUS_ACTION_MAP.approved).toBe(
+      'age_verification_approved',
+    );
+    expect(ageVerificationAuditReconcile.STATUS_ACTION_MAP.rejected).toBe(
+      'age_verification_rejected',
+    );
+    expect(ageVerificationAuditReconcile.STATUS_ACTION_MAP['modify-dob']).toBe(
+      'age_verification_dob_modified',
+    );
+    // The status string actually written by the route handler.
+    expect(ageVerificationAuditReconcile.STATUS_ACTION_MAP.dob_modified).toBe(
+      'age_verification_dob_modified',
+    );
+  });
+
+  test('exposes toMillis for callers that need to coerce timestamp shapes', () => {
+    expect(typeof ageVerificationAuditReconcile.toMillis).toBe('function');
+  });
+});

--- a/express-api/tests/cron/index.test.js
+++ b/express-api/tests/cron/index.test.js
@@ -11,9 +11,12 @@ jest.mock('../../src/utils/log', () => ({
   error: jest.fn(),
 }));
 
-// Mock alertManagerInstance
+// Mock alertManagerInstance — createAlert returns a Promise so the
+// catastrophic-failure path on the age-verif reconcile cron can
+// chain `.catch(...)` without blowing up.
 jest.mock('../../src/utils/alertManagerInstance', () => ({
   send: jest.fn(),
+  createAlert: jest.fn().mockResolvedValue(undefined),
 }));
 
 // Mock all cron job modules
@@ -31,6 +34,7 @@ jest.mock('../../src/cron/serverHealth', () => jest.fn());
 jest.mock('../../src/cron/accountDeletion', () => jest.fn());
 jest.mock('../../src/cron/expireDataExports', () => jest.fn());
 jest.mock('../../src/cron/notification-dispatch', () => jest.fn());
+jest.mock('../../src/cron/ageVerificationAuditReconcile', () => jest.fn());
 const { startCronJobs } = require('../../src/cron/index');
 const log = require('../../src/utils/log');
 
@@ -114,8 +118,11 @@ describe('startCronJobs', () => {
       // Should NOT have dev-only jobs
       expect(schedules).not.toContain('*/30 * * * *'); // testDataCleanup
 
-      // Total: 11 schedules in production (staleRooms + serverHealth share */5, + accountDeletion, + expireDataExports, + notification-dispatch)
-      expect(mockSchedule).toHaveBeenCalledTimes(11);
+      // ageVerificationAuditReconcile — daily 05:00 UTC
+      expect(schedules).toContain('0 5 * * *');
+
+      // Total: 12 schedules in production (staleRooms + serverHealth share */5, + accountDeletion, + expireDataExports, + notification-dispatch, + ageVerificationAuditReconcile)
+      expect(mockSchedule).toHaveBeenCalledTimes(12);
     });
 
     test('does not register testDataCleanup in production', () => {
@@ -276,6 +283,68 @@ describe('startCronJobs', () => {
 
       expect(log.error).toHaveBeenCalledWith('cron', 'staleRooms failed', {
         error: 'stale error',
+      });
+    });
+
+    test('ageVerificationAuditReconcile callback invokes the job', async () => {
+      const ageVerificationAuditReconcile = require('../../src/cron/ageVerificationAuditReconcile');
+      ageVerificationAuditReconcile.mockResolvedValue({ scanned: 0, reconciled: 0 });
+      startCronJobs();
+
+      const reconcileCall = mockSchedule.mock.calls.find((c) => c[0] === '0 5 * * *');
+      expect(reconcileCall).toBeDefined();
+
+      reconcileCall[1]();
+
+      expect(ageVerificationAuditReconcile).toHaveBeenCalled();
+    });
+
+    test('ageVerificationAuditReconcile catastrophic crash logs AND fires a critical alert', async () => {
+      const ageVerificationAuditReconcile = require('../../src/cron/ageVerificationAuditReconcile');
+      const alertManager = require('../../src/utils/alertManagerInstance');
+      const error = new Error('Firestore unavailable');
+      ageVerificationAuditReconcile.mockRejectedValue(error);
+      startCronJobs();
+
+      const reconcileCall = mockSchedule.mock.calls.find((c) => c[0] === '0 5 * * *');
+      expect(reconcileCall).toBeDefined();
+
+      reconcileCall[1]();
+
+      // Wait for the .catch chain to settle (log.error then createAlert).
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(log.error).toHaveBeenCalledWith('cron', 'ageVerificationAuditReconcile failed', {
+        error: 'Firestore unavailable',
+      });
+      // Critical alert MUST fire — compliance back-fill is OSA/GDPR
+      // remediation; a multi-day gap can't rely on log-grep.
+      expect(alertManager.createAlert).toHaveBeenCalledWith(
+        'compliance_cron_failed',
+        'critical',
+        expect.stringMatching(/age-verification audit reconcile/i),
+        expect.any(String),
+        expect.objectContaining({
+          error: 'Firestore unavailable',
+          cron: 'ageVerificationAuditReconcile',
+        }),
+      );
+    });
+
+    test('ageVerificationAuditReconcile alert failure is logged but does not crash the cron', async () => {
+      const ageVerificationAuditReconcile = require('../../src/cron/ageVerificationAuditReconcile');
+      const alertManager = require('../../src/utils/alertManagerInstance');
+      ageVerificationAuditReconcile.mockRejectedValue(new Error('Firestore unavailable'));
+      alertManager.createAlert.mockRejectedValueOnce(new Error('alert pipe down'));
+      startCronJobs();
+
+      const reconcileCall = mockSchedule.mock.calls.find((c) => c[0] === '0 5 * * *');
+      reconcileCall[1]();
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(log.error).toHaveBeenCalledWith('cron', 'alertManager.createAlert failed', {
+        error: 'alert pipe down',
       });
     });
   });


### PR DESCRIPTION
## Summary
- Daily 05:00 UTC cron back-fills missing `auditLog` entries for age-verification admin decisions whose post-commit audit write failed (UK OSA / GDPR traceability gap).
- Two-path idempotency (`details.fromSubmissionId` tag OR `actionType + targetId + timestamp ±10 min`) so re-runs are no-ops; 7-day scan window absorbs multi-day Firestore outages.
- Resilience: per-doc `try/catch` with a `failed` counter (one bad doc can't abort the rest), `toMillis()` coercion for Firestore Timestamp shapes, and `alertManager.createAlert('compliance_cron_failed', 'critical', ...)` on catastrophic crash so multi-day failures page someone instead of relying on log-grep.

## Files
- `express-api/src/cron/ageVerificationAuditReconcile.js` (new)
- `express-api/src/cron/index.js` — registers cron at `0 5 * * *`, wires alertManager
- `express-api/tests/cron/ageVerificationAuditReconcile.test.js` (new — 24 tests)
- `express-api/tests/cron/index.test.js` — schedule count 11→12, 4 new tests for the new cron

## Test plan
- [x] `npx jest tests/cron/ageVerificationAuditReconcile.test.js` — 24 tests pass
- [x] `npx jest tests/cron/index.test.js` — 19 tests pass
- [x] `npx jest --no-coverage` (full Express suite) — 4637 tests pass, 196 suites
- [x] `npx eslint` on the four files — clean
- [x] Prettier formatting applied
- [x] Silent-failure-hunter agent — round 2: "all three fixed, no regressions"
- [x] Pre-push hook: Gradle build + SonarCloud quality gate passed
- [ ] Production verification (after deploy): logs show `Scan complete` daily at 05:00 UTC with `scanned/reconciled/failed` counters

Closes task #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)