### PR TITLE
fix(shared): log asBool() type drift

### DIFF
--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/MapExt.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/MapExt.kt
@@ -1,9 +1,33 @@
 package com.shyden.shytalk.core.util
 
+private const val LOG_TAG = "MapExt"
+
+// Test-injectable type-drift sink. Production callers go through the
+// real `logW` so a Firestore field arriving as the wrong shape (e.g.
+// a String "true" landing in `isSuspended`) emits a Sentry-visible
+// warning instead of silently coercing to `default`. Several call
+// sites read security gates (`isSuspended`, `suspensionCanAppeal`,
+// `ageVerified`, `pmLocked`); silent type drift on those would let a
+// corrupted doc bypass a gate without anyone noticing.
+internal var asBoolTypeDriftLogger: (typeName: String, default: Boolean) -> Unit =
+    { typeName, default ->
+        logW(
+            LOG_TAG,
+            "asBool type drift: expected Boolean/Number, got $typeName, returning default=$default",
+        )
+    }
+
 /** Safely converts a value to Boolean, handling integer booleans (0/1). */
 fun Any?.asBool(default: Boolean = false): Boolean =
     when (this) {
         is Boolean -> this
+
         is Number -> toInt() != 0
-        else -> default
+
+        null -> default
+
+        else -> {
+            asBoolTypeDriftLogger(this::class.simpleName ?: "Unknown", default)
+            default
+        }
     }

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/MapExtTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/MapExtTest.kt
@@ -1,10 +1,31 @@
 package com.shyden.shytalk.core.util
 
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class MapExtTest {
+    // ── Type-drift logger swap (saved + restored per test) ──────────
+    private val capturedDrifts = mutableListOf<Pair<String, Boolean>>()
+    private var savedLogger: ((String, Boolean) -> Unit)? = null
+
+    @BeforeTest
+    fun installCapturingLogger() {
+        savedLogger = asBoolTypeDriftLogger
+        capturedDrifts.clear()
+        asBoolTypeDriftLogger = { typeName, default ->
+            capturedDrifts += typeName to default
+        }
+    }
+
+    @AfterTest
+    fun restoreLogger() {
+        savedLogger?.let { asBoolTypeDriftLogger = it }
+    }
+
     // ── Boolean values ──────────────────────────────────────────────
 
     @Test
@@ -148,5 +169,80 @@ class MapExtTest {
     fun `asBool ignores default when value is Number`() {
         val value: Any? = 0
         assertFalse(value.asBool(default = true))
+    }
+
+    // ── Type-drift logging (security-critical) ──────────────────────
+    //
+    // Many call sites read security-sensitive flags (`isSuspended`,
+    // `suspensionCanAppeal`, `ageVerified`, `pmLocked`) via this
+    // helper. Silent fallback to `default` when Firestore returns a
+    // String or other unexpected shape would let a corrupted/migrated
+    // doc bypass a gate without anyone noticing. The drift logger
+    // turns that into a visible signal so we can investigate.
+
+    @Test
+    fun `asBool with String value invokes type-drift logger`() {
+        val value: Any? = "true"
+        value.asBool()
+        assertEquals(1, capturedDrifts.size)
+        assertEquals("String", capturedDrifts[0].first)
+    }
+
+    @Test
+    fun `asBool with List value invokes type-drift logger`() {
+        val value: Any? = listOf(1, 2, 3)
+        value.asBool()
+        assertEquals(1, capturedDrifts.size)
+    }
+
+    @Test
+    fun `asBool with Map value invokes type-drift logger`() {
+        val value: Any? = mapOf("k" to "v")
+        value.asBool()
+        assertEquals(1, capturedDrifts.size)
+    }
+
+    @Test
+    fun `asBool with arbitrary object invokes type-drift logger`() {
+        val value: Any? = object {}
+        value.asBool()
+        assertEquals(1, capturedDrifts.size)
+    }
+
+    @Test
+    fun `asBool drift logger receives the default value passed by caller`() {
+        val value: Any? = "yes"
+        value.asBool(default = true)
+        assertEquals(1, capturedDrifts.size)
+        assertEquals(true, capturedDrifts[0].second)
+
+        capturedDrifts.clear()
+        value.asBool(default = false)
+        assertEquals(1, capturedDrifts.size)
+        assertEquals(false, capturedDrifts[0].second)
+    }
+
+    @Test
+    fun `asBool with Boolean does NOT invoke type-drift logger`() {
+        true.asBool()
+        false.asBool()
+        assertTrue(capturedDrifts.isEmpty())
+    }
+
+    @Test
+    fun `asBool with Number does NOT invoke type-drift logger`() {
+        (1).asBool()
+        (0L).asBool()
+        (1.0).asBool()
+        (0.0f).asBool()
+        assertTrue(capturedDrifts.isEmpty())
+    }
+
+    @Test
+    fun `asBool with null does NOT invoke type-drift logger`() {
+        // Null is field-absent, not type drift — common and benign.
+        val value: Any? = null
+        value.asBool()
+        assertTrue(capturedDrifts.isEmpty())
     }
 }


### PR DESCRIPTION
## Summary
- `Any?.asBool()` is read on security-sensitive Firestore fields (`isSuspended`, `suspensionCanAppeal`, `pmLocked`, `ageVerified`) — silent fallback to `default` on a `String` / wrong-shape value would let a corrupted or migrated doc bypass a gate without anyone noticing.
- Type-drift on the `else` branch now goes through `logW(\"MapExt\", …)` with the actual type name + the default that was returned, so Sentry/logcat surfaces the warning.
- `null` continues to skip logging — field-absent is benign and common.
- Drift sink is an `internal var` so tests can swap in a capturing logger and assert on the calls; no global stdout capture and no per-call overhead.

## Files
- `shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/MapExt.kt`
- `shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/MapExtTest.kt`

## Test plan
- [x] 8 new tests on `MapExtTest` — String/List/Map/object trigger drift; Boolean/Number/null do not; default forwarded
- [x] `:shared:jvmTest` full suite — green
- [x] `:shared:detekt` — clean
- [x] `:shared:compileKotlinIosArm64` — green
- [x] `ktlint --relative` — clean
- [x] No call-site changes — API identical (default kwarg)

Closes task #56 (MEDIUM finding from PR #443).

🤖 Generated with [Claude Code](https://claude.com/claude-code)