### PR TITLE
feat(ci): dev-smoke covers R2 image upload journey

### DIFF
--- a/tests/web/dev-smoke.spec.ts
+++ b/tests/web/dev-smoke.spec.ts
@@ -424,3 +424,102 @@ test.describe("Dev Smoke — voice-room token issuance", () => {
     expect(res.status(), `expected 400 for missing roomName, got ${res.status()}`).toBe(400);
   });
 });
+
+// Smallest valid PNG: 1x1 transparent. Used to exercise the upload
+// pipeline end-to-end without sending real image data. Sharp will
+// successfully compress this; the path-allowlist invariant test
+// reuses a truncated copy that never reaches the compression step.
+const ONE_PIXEL_PNG = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54,
+  0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05,
+  0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4,
+  0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44,
+  0xae, 0x42, 0x60, 0x82,
+]);
+
+test.describe("Dev Smoke — R2 image upload", () => {
+  // Catches: R2 credentials, R2 PUT path, multer multipart parsing,
+  // sharp/imageCompressor pipeline, public-read URL signing.
+  //
+  // Idempotency strategy: leave-clean at the side-effect level. Each
+  // upload creates a unique R2 object; the test DELETEs it before
+  // returning so we don't accumulate orphaned objects across runs.
+  // The 'evidence' upload-path is chosen because it does NOT update
+  // any user-doc field (vs 'profiles' which would mutate
+  // smoke.profilePhotoUrl).
+
+  test("POST /api/storage/upload accepts a PNG, URL is reachable, DELETE cleans up", async () => {
+    // Phase 1 — upload via multipart. NOTE: do NOT include
+    // Content-Type in headers; Playwright's `multipart` option sets
+    // the multipart/form-data boundary automatically.
+    const upload = await smoke.api.post(`${API_BASE}/api/storage/upload`, {
+      headers: { Authorization: `Bearer ${smoke.idToken}` },
+      multipart: {
+        path: "evidence",
+        file: {
+          name: "smoke.png",
+          mimeType: "image/png",
+          buffer: ONE_PIXEL_PNG,
+        },
+      },
+    });
+    expect(
+      upload.ok(),
+      `upload expected 200, got ${upload.status()}: ${await upload.text()}`,
+    ).toBe(true);
+
+    const body = await upload.json();
+    expect(typeof body.url, `body.url shape: ${JSON.stringify(body)}`).toBe("string");
+    expect(body.url, `URL must be https://`).toMatch(/^https:\/\//);
+
+    // Phase 2 — verify the object is publicly reachable. R2 has
+    // read-after-write consistency so no retry is needed.
+    const fetched = await smoke.api.get(body.url);
+    expect(
+      fetched.ok(),
+      `fetch-back expected 200, got ${fetched.status()} for ${body.url}`,
+    ).toBe(true);
+    const ct = fetched.headers()["content-type"] || "";
+    expect(ct, `fetched content-type must be image/*, got "${ct}"`).toMatch(/^image\//);
+
+    // Phase 3 — cleanup. Extract the R2 key from the public URL
+    // pathname (DELETE expects ?key=, NOT the full URL).
+    const key = new URL(body.url).pathname.replace(/^\//, "");
+    const del = await smoke.api.delete(
+      `${API_BASE}/api/storage/delete?key=${encodeURIComponent(key)}`,
+      { headers: authedHeaders() },
+    );
+    expect(
+      del.ok(),
+      `delete expected 200, got ${del.status()}: ${await del.text()} for key=${key}`,
+    ).toBe(true);
+  });
+
+  test("POST /api/storage/upload with disallowed path is rejected with 400", async () => {
+    // Invariant: the path-allowlist is the upload-target ACL. If
+    // someone adds a new path-handling code branch but forgets to
+    // update ALLOWED_UPLOAD_PATHS, the gate would silently fail open.
+    // Path check happens BEFORE compression (line 45-48 in storage.js)
+    // so the body content doesn't matter — 8 bytes of PNG signature
+    // is enough.
+    const res = await smoke.api.post(`${API_BASE}/api/storage/upload`, {
+      headers: { Authorization: `Bearer ${smoke.idToken}` },
+      multipart: {
+        path: "smoke-invalid-path",
+        file: {
+          name: "x.png",
+          mimeType: "image/png",
+          buffer: ONE_PIXEL_PNG.subarray(0, 8),
+        },
+      },
+    });
+    expect(
+      res.status(),
+      `expected 400 for disallowed path, got ${res.status()}: ${await res.text()}`,
+    ).toBe(400);
+  });
+});

--- a/tests/web/dev-smoke.spec.ts
+++ b/tests/web/dev-smoke.spec.ts
@@ -425,21 +425,23 @@ test.describe("Dev Smoke — voice-room token issuance", () => {
   });
 });
 
-// Smallest valid PNG: 1x1 transparent. Used to exercise the upload
-// pipeline end-to-end without sending real image data. Sharp will
-// successfully compress this; the path-allowlist invariant test
-// reuses a truncated copy that never reaches the compression step.
-const ONE_PIXEL_PNG = Buffer.from([
-  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
-  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
-  0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89,
-  0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54,
-  0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05,
-  0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4,
-  0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44,
-  0xae, 0x42, 0x60, 0x82,
-]);
+// 100x100 black PNG, ~130 bytes. Generated once via:
+//   sharp({create:{width:100,height:100,channels:3,background:'#000'}}).png()
+// Embedded as base64 to keep this spec self-contained — no fixture
+// file, no new dep. The dimensions matter: imageCompressor.js
+// enforces MIN_DIMENSION = 100 and rejects smaller images with
+// ImagePolicyError → 400. A 1x1 PNG would silently fail every run.
+//
+// Reused by the disallowed-path invariant too. Even though that test
+// targets a check that runs BEFORE compression, using the same valid
+// fixture means the assertion can only fail for the reason we're
+// testing — not because the PNG is malformed.
+const TEST_PNG_100X100 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAA" +
+    "NElEQVR4nO3BAQ0AAADCoPdPbQ43oAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAujF1lAAB" +
+    "e5jSrAAAAABJRU5ErkJggg==",
+  "base64",
+);
 
 test.describe("Dev Smoke — R2 image upload", () => {
   // Catches: R2 credentials, R2 PUT path, multer multipart parsing,
@@ -463,7 +465,7 @@ test.describe("Dev Smoke — R2 image upload", () => {
         file: {
           name: "smoke.png",
           mimeType: "image/png",
-          buffer: ONE_PIXEL_PNG,
+          buffer: TEST_PNG_100X100,
         },
       },
     });
@@ -503,9 +505,12 @@ test.describe("Dev Smoke — R2 image upload", () => {
     // Invariant: the path-allowlist is the upload-target ACL. If
     // someone adds a new path-handling code branch but forgets to
     // update ALLOWED_UPLOAD_PATHS, the gate would silently fail open.
-    // Path check happens BEFORE compression (line 45-48 in storage.js)
-    // so the body content doesn't matter — 8 bytes of PNG signature
-    // is enough.
+    //
+    // Reuses the same valid 100x100 PNG as the happy path — even
+    // though the path check runs BEFORE compression today, using a
+    // valid PNG means the assertion can ONLY fail for the reason
+    // we're testing. A future reorder of checks won't silently make
+    // this test pass for the wrong reason.
     const res = await smoke.api.post(`${API_BASE}/api/storage/upload`, {
       headers: { Authorization: `Bearer ${smoke.idToken}` },
       multipart: {
@@ -513,7 +518,7 @@ test.describe("Dev Smoke — R2 image upload", () => {
         file: {
           name: "x.png",
           mimeType: "image/png",
-          buffer: ONE_PIXEL_PNG.subarray(0, 8),
+          buffer: TEST_PNG_100X100,
         },
       },
     });


### PR DESCRIPTION
## Summary
Adds the R2 image-upload journey to `tests/web/dev-smoke.spec.ts` so a deploy-dev run goes RED if the storage path regresses (R2 credentials, multer multipart parsing, sharp compression, public-read URL signing, path-allowlist gate).

Two tests:
1. **Happy path** — POST multipart with a 1x1 PNG to `path: 'evidence'`, GET the returned URL back to verify R2 public-read works, DELETE to leave clean.
2. **Invariant** — POST with `path: 'smoke-invalid-path'` returns 400. Path-allowlist gate runs before compression (`storage.js:45-48`), so the gate is exercised independently of MIME/compression checks.

## Path choice rationale
`evidence` (not `profiles`) is deliberate: it does NOT mutate any user-doc field. The smoke account's `profilePhotoUrl` stays unchanged across runs.

## Idempotency
Leave-clean at the **side-effect level** (DELETE the R2 object after upload) rather than the Firestore-state level used by follow/unfollow. The pattern generalizes to any infrastructure that accumulates state on use — FCM topic subs, LiveKit ghost rooms, etc. — and is worth cataloguing for future smoke PRs.

## Read-after-write consistency
R2 has strong read-after-write consistency, so the GET-back step doesn't need retry logic. If this ever flakes, the actual cause is more interesting than just "eventual consistency" and we should investigate rather than paper over with retries.

## Roadmap
PRs #474+#475+#476+#477 shipped 7/14 Tier 1; this PR ships #8. Remaining 6: IAP, bean redeem, PM, push, admin→app, block, report.

## Test plan
- [ ] CI: deploy-dev.yml `smoke-tests` runs both new tests; both pass against deployed dev.
- [ ] Verify R2 env vars are set on dev Express (creds + bucket + public URL — upload would 500 otherwise, caught by `res.ok()`).
- [ ] Verify R2 bucket has public-read for the 'evidence' path prefix (GET would 403 otherwise, caught by phase 2 fetch-back assertion).
- [ ] Manual spot-check after merge: confirm no orphaned `evidence/10000007/*` objects accumulate in R2 dev bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)