### PR TITLE
feat(ci): dev-smoke covers IAP coin purchase journey (sandbox)

### DIFF
--- a/tests/web/dev-smoke.spec.ts
+++ b/tests/web/dev-smoke.spec.ts
@@ -559,6 +559,11 @@ test.describe("Dev Smoke — IAP coin purchase (sandbox)", () => {
     ).toBeGreaterThan(0);
     const pkg = packages[0];
     expect(typeof pkg.productId, "package productId").toBe("string");
+    // The route reads `pkg.coins`/`pkg.bonusCoins` as camelCase
+    // (economy.js:1387-1389). If a future migration moves the
+    // coinPackages schema to snake_case (the codebase does this
+    // elsewhere via userField), expectedTotal would compute 0 and
+    // the next guard would fail loud — that's the intended signal.
     const expectedTotal = (pkg.coins ?? 0) + (pkg.bonusCoins ?? 0);
     expect(
       expectedTotal,

--- a/tests/web/dev-smoke.spec.ts
+++ b/tests/web/dev-smoke.spec.ts
@@ -528,3 +528,108 @@ test.describe("Dev Smoke — R2 image upload", () => {
     ).toBe(400);
   });
 });
+
+test.describe("Dev Smoke — IAP coin purchase (sandbox)", () => {
+  // Catches: GET /api/coin-packages catalog shape, purchase
+  // verification bypass on non-prod (`economy.js:1300-1330`),
+  // atomic balance increment + purchaseReceipts write + transaction
+  // log, replay-protection on duplicate purchaseToken (409 path).
+  //
+  // Why a single test combines purchase + replay: putting the replay
+  // assertion at the end of the same flow lets us reuse the token
+  // we just minted (which we KNOW exists in purchaseReceipts).
+  // A standalone replay test would have to seed state first.
+  //
+  // State accumulation: each run grants `coins + bonusCoins` to the
+  // smoke account permanently (no refund endpoint exposed). Coins
+  // are virtual currency, JS number-safe up to 2^53 ≈ 9e15, smoke
+  // account is dev-only — accepted as a no-op trade-off.
+
+  test("GET catalog → POST purchase → balance reflects → replay rejected with 409", async () => {
+    // Phase 1 — discover the catalog. Public endpoint (no auth on
+    // coin-packages route per config.js:786). A regression here
+    // means the IAP UI in the app would be empty for every user.
+    const cat = await smoke.api.get(`${API_BASE}/api/coin-packages`);
+    expect(cat.ok(), `catalog: ${cat.status()}: ${await cat.text()}`).toBe(true);
+    const packages = await cat.json();
+    expect(Array.isArray(packages), "catalog must be an array").toBe(true);
+    expect(
+      packages.length,
+      "dev must expose at least one active coin package",
+    ).toBeGreaterThan(0);
+    const pkg = packages[0];
+    expect(typeof pkg.productId, "package productId").toBe("string");
+    const expectedTotal = (pkg.coins ?? 0) + (pkg.bonusCoins ?? 0);
+    expect(
+      expectedTotal,
+      `package must grant > 0 coins (got coins=${pkg.coins} bonus=${pkg.bonusCoins})`,
+    ).toBeGreaterThan(0);
+
+    // Phase 2 — snapshot balance.
+    const before = await smoke.api.get(`${API_BASE}/api/economy/balance`, {
+      headers: authedHeaders(),
+    });
+    expect(before.ok()).toBe(true);
+    const coinsBefore: number = (await before.json()).coins;
+    expect(typeof coinsBefore, "coins must be a number").toBe("number");
+
+    // Phase 3 — purchase. Ephemeral purchaseToken to avoid colliding
+    // with purchaseReceipts from previous smoke runs (replay-protected).
+    // platform: 'google' is the route default but we set it explicitly
+    // so the assertion contract is unambiguous.
+    const purchaseToken = `smoke-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const buy = await smoke.api.post(`${API_BASE}/api/economy/purchase`, {
+      headers: authedHeaders(),
+      data: { productId: pkg.productId, purchaseToken, platform: "google" },
+    });
+    expect(
+      buy.ok(),
+      `purchase expected 200, got ${buy.status()}: ${await buy.text()}`,
+    ).toBe(true);
+    const buyBody = await buy.json();
+    expect(buyBody.success, "purchase body.success").toBe(true);
+    expect(
+      buyBody.coinsAdded,
+      `coinsAdded must equal package total ${expectedTotal}`,
+    ).toBe(expectedTotal);
+
+    // Phase 4 — verify balance increment is exactly the granted amount.
+    // Catches a regression where the purchase succeeds but the increment
+    // races with a concurrent write (very unlikely on dev with one
+    // smoke runner, but the assertion costs one GET).
+    const after = await smoke.api.get(`${API_BASE}/api/economy/balance`, {
+      headers: authedHeaders(),
+    });
+    const coinsAfter: number = (await after.json()).coins;
+    expect(
+      coinsAfter,
+      `balance must increase by ${expectedTotal}: before=${coinsBefore}, after=${coinsAfter}`,
+    ).toBe(coinsBefore + expectedTotal);
+
+    // Phase 5 — replay protection. Same token must 409. Without this,
+    // a refund-then-replay attack would let users grant themselves
+    // unlimited coins by re-submitting old purchase tokens.
+    const replay = await smoke.api.post(`${API_BASE}/api/economy/purchase`, {
+      headers: authedHeaders(),
+      data: { productId: pkg.productId, purchaseToken },
+    });
+    expect(
+      replay.status(),
+      `replay must 409, got ${replay.status()}: ${await replay.text()}`,
+    ).toBe(409);
+  });
+
+  test("POST /api/economy/purchase without productId is rejected with 400", async () => {
+    // Invariant: both productId and purchaseToken are required. The
+    // route checks at line 1279-1280 before any DB query, so this
+    // 400 is fast and pre-authorized.
+    const res = await smoke.api.post(`${API_BASE}/api/economy/purchase`, {
+      headers: authedHeaders(),
+      data: { purchaseToken: `smoke-noprod-${Date.now()}` },
+    });
+    expect(
+      res.status(),
+      `expected 400 for missing productId, got ${res.status()}`,
+    ).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
Adds the IAP coin-purchase journey to `tests/web/dev-smoke.spec.ts`. Two tests:

1. **Combined happy-path-with-replay** — GET catalog → snapshot balance → POST purchase with ephemeral token → GET balance again to verify exact increment → retry same token to verify 409 replay-protection.
2. **Invariant** — missing `productId` rejected with 400.

## Why one combined test instead of separate happy-path + replay
The replay assertion at the end of the same flow can reuse the token we *just minted* (which we know exists in `purchaseReceipts`). A standalone replay test would have to seed state first. One combined test = fewer HTTP round-trips, fewer state mutations, same coverage.

## Non-prod verification bypass
On dev, `economy.js:1300` short-circuits real verification: `verification = { orderId: 'dev-unverified' }`. This means smoke can use any `purchaseToken` string — no Google Play / Apple sandbox tokens needed. Replay-protection still applies via the duplicate-token Firestore query (line 1287-1295), so the 409 assertion is a real contract check.

## Discovery via GET /api/coin-packages
Rather than hardcode a `productId`, the test discovers a valid one from the public catalog endpoint. Benefits: resilient to product renames, exercises the catalog endpoint as part of the journey (matches what real clients do), and surfaces a useful regression signal if the catalog is empty.

## State accumulation (acknowledged trade-off)
Each run grants `coins + bonusCoins` to the smoke account permanently — there's no public refund endpoint. Coins are virtual currency, JS numbers are safe up to 2^53 ≈ 9e15, smoke account is dev-only. Operationally a no-op even after years of runs. If we wanted to spend the coins back, that would be a separate journey (bean redeem / gift-direct).

## Roadmap
PRs #474..#478 shipped 8/14; this PR ships #9. Remaining 5: bean redeem, PM, push, admin→app, block, report.

## Test plan
- [ ] CI: `smoke-tests` runs both tests; both pass against deployed dev.
- [ ] Verify dev `coinPackages` Firestore collection has at least one `isActive: true` document.
- [ ] Confirm smoke account's coin balance grows by ~`pkg.coins + pkg.bonusCoins` per run (expected; non-issue on dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)