### PR TITLE
fix(test): gacha precondition is self-sufficient via beforeAll seed

### DIFF
--- a/tests/web/dev-smoke.spec.ts
+++ b/tests/web/dev-smoke.spec.ts
@@ -699,14 +699,18 @@ test.describe("Dev Smoke — gacha wheel spin (transactional coin deduction)", (
     // Read current balance. If we already have enough coins from
     // prior runs (the typical case), no top-up needed — keeps the
     // smoke gate fast and avoids unnecessary IAP infrastructure load.
-    const bal = await smoke.api.get(`${API_BASE}/api/economy/balance`, {
-      headers: authedHeaders(),
-    });
-    expect(
-      bal.ok(),
-      `gacha-seed balance check: ${bal.status()}: ${await bal.text()}`,
-    ).toBe(true);
-    const coins: number = (await bal.json()).coins;
+    async function fetchCoins(): Promise<number> {
+      const bal = await smoke.api.get(`${API_BASE}/api/economy/balance`, {
+        headers: authedHeaders(),
+      });
+      expect(
+        bal.ok(),
+        `gacha-seed balance check: ${bal.status()}: ${await bal.text()}`,
+      ).toBe(true);
+      return (await bal.json()).coins;
+    }
+
+    let coins = await fetchCoins();
     if (coins >= GACHA_MIN_COINS) return;
 
     // Top-up via IAP catalog. We deliberately reuse the IAP path
@@ -731,18 +735,39 @@ test.describe("Dev Smoke — gacha wheel spin (transactional coin deduction)", (
     ).toBe(true);
     const pkg = packages[0];
 
-    const buy = await smoke.api.post(`${API_BASE}/api/economy/purchase`, {
-      headers: authedHeaders(),
-      data: {
-        productId: pkg.productId,
-        purchaseToken: `gacha-seed-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        platform: "google",
-      },
-    });
+    // Loop top-ups until threshold reached, with a safety cap to
+    // avoid infinite loops on pathological config (e.g. package
+    // grants 0 coins). `packages[0]` is sorted by `order` not size,
+    // so a single buy may grant fewer coins than GACHA_MIN_COINS.
+    // Looping is correct under any package size; the cap protects
+    // against silent infinite loops.
+    const MAX_SEED_ITERATIONS = 10;
+    for (let i = 0; i < MAX_SEED_ITERATIONS && coins < GACHA_MIN_COINS; i++) {
+      const buy = await smoke.api.post(`${API_BASE}/api/economy/purchase`, {
+        headers: authedHeaders(),
+        data: {
+          productId: pkg.productId,
+          purchaseToken: `gacha-seed-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          platform: "google",
+        },
+      });
+      expect(
+        buy.ok(),
+        `gacha-seed top-up #${i + 1}/${MAX_SEED_ITERATIONS}: ${buy.status()}: ${await buy.text()}`,
+      ).toBe(true);
+      coins = await fetchCoins();
+    }
+
+    // Final assertion: even after MAX_SEED_ITERATIONS top-ups, did
+    // we reach the threshold? If not, the package config is
+    // pathological (e.g., grants 0 coins) and the operator needs to
+    // know explicitly rather than seeing the gacha 402 with no clue
+    // that the seed loop already gave up.
     expect(
-      buy.ok(),
-      `gacha-seed top-up purchase: ${buy.status()}: ${await buy.text()}`,
-    ).toBe(true);
+      coins,
+      `gacha-seed: after up to ${MAX_SEED_ITERATIONS} top-ups, coins=${coins} < required ${GACHA_MIN_COINS}. ` +
+        `Either packages[0] (productId=${pkg.productId}) grants too few coins per buy, or GACHA_MIN_COINS is misconfigured.`,
+    ).toBeGreaterThanOrEqual(GACHA_MIN_COINS);
   });
 
   test("POST /api/economy/gacha (1 pull) deducts coins, returns gift, balance reflects", async () => {

--- a/tests/web/dev-smoke.spec.ts
+++ b/tests/web/dev-smoke.spec.ts
@@ -665,6 +665,12 @@ test.describe("Dev Smoke — IAP coin purchase (sandbox)", () => {
   });
 });
 
+// Minimum coin balance the gacha 1-pull requires. Cost is a pure
+// function of pullCount per route (`pullCosts[1]` defaults to 10),
+// so 10 is the floor today. If economy config raises the cost, the
+// pull would 402 and the failure message would be unambiguous.
+const GACHA_MIN_COINS = 10;
+
 test.describe("Dev Smoke — gacha wheel spin (transactional coin deduction)", () => {
   // Catches: atomic coin decrement on user doc, gifts collection
   // read with showOnWheel=true filter, weighted gift selection,
@@ -676,12 +682,68 @@ test.describe("Dev Smoke — gacha wheel spin (transactional coin deduction)", (
   // gifted-to in voice rooms. The smoke account never participates
   // in voice rooms, so it has 0 beans and would always 402. Gacha
   // exercises the same Firestore-transactional-deduction
-  // infrastructure using coins, which the smoke account accumulates
-  // from the IAP smoke (which runs earlier in this spec).
+  // infrastructure using coins.
+  //
+  // Precondition seed: the gacha test is now SELF-SUFFICIENT — the
+  // beforeAll below tops up coins via IAP if the smoke account is
+  // below GACHA_MIN_COINS. Previously this test relied on implicit
+  // ordering (IAP describe block runs first in the source file).
+  // That coupling silently broke if anyone reordered the file or
+  // split the spec. Making the dependency explicit means the test
+  // is runnable in isolation and immune to spec restructuring.
   //
   // State accumulation: each run increments pity/luck on the smoke
-  // user doc and adds a gift to backpack. Same dev-only no-op
-  // trade-off as IAP: virtual state, no operational impact.
+  // user doc and adds a gift to backpack. Dev-only virtual state.
+
+  test.beforeAll(async () => {
+    // Read current balance. If we already have enough coins from
+    // prior runs (the typical case), no top-up needed — keeps the
+    // smoke gate fast and avoids unnecessary IAP infrastructure load.
+    const bal = await smoke.api.get(`${API_BASE}/api/economy/balance`, {
+      headers: authedHeaders(),
+    });
+    expect(
+      bal.ok(),
+      `gacha-seed balance check: ${bal.status()}: ${await bal.text()}`,
+    ).toBe(true);
+    const coins: number = (await bal.json()).coins;
+    if (coins >= GACHA_MIN_COINS) return;
+
+    // Top-up via IAP catalog. We deliberately reuse the IAP path
+    // rather than introducing a new admin-coins endpoint because
+    // admin endpoints would need the smoke account to be admin
+    // (which it isn't, deliberately — see spec header).
+    //
+    // Failure-mode note: if this seed step fails, the operator sees
+    // "gacha-seed: ..." in the assertion message and knows the
+    // failure is a precondition issue (likely IAP infrastructure
+    // regression), not a gacha-specific bug. The IAP describe block
+    // will surface the actual root cause separately.
+    const cat = await smoke.api.get(`${API_BASE}/api/coin-packages`);
+    expect(
+      cat.ok(),
+      `gacha-seed: coin-packages catalog ${cat.status()}`,
+    ).toBe(true);
+    const packages = await cat.json();
+    expect(
+      Array.isArray(packages) && packages.length > 0,
+      `gacha-seed: catalog must have ≥1 active package`,
+    ).toBe(true);
+    const pkg = packages[0];
+
+    const buy = await smoke.api.post(`${API_BASE}/api/economy/purchase`, {
+      headers: authedHeaders(),
+      data: {
+        productId: pkg.productId,
+        purchaseToken: `gacha-seed-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        platform: "google",
+      },
+    });
+    expect(
+      buy.ok(),
+      `gacha-seed top-up purchase: ${buy.status()}: ${await buy.text()}`,
+    ).toBe(true);
+  });
 
   test("POST /api/economy/gacha (1 pull) deducts coins, returns gift, balance reflects", async () => {
     // Phase 1 — snapshot balance.


### PR DESCRIPTION
## Audit-driven follow-up to PR #480
Per the new correctness/quality bar (`feedback-correctness-over-clarity`): the gacha test depended on the IAP describe block running first to seed coins on the smoke account. The coupling was implicit — relying on Playwright's `workers:1` config and source-order test execution. A future file split, describe reorder, or IAP test removal would silently break gacha.

## Fix
The gacha describe block now has its own `beforeAll` that:
1. GETs current balance
2. If `< GACHA_MIN_COINS` (10), tops up via the IAP catalog
3. Otherwise no-op (the typical case — smoke account already has thousands of coins from prior runs)

In practice the seed is dormant (smoke account already coin-rich), but the explicit dependency means the test is **runnable in isolation** and immune to spec restructuring.

## Failure-mode design
A seed failure surfaces with `"gacha-seed: ..."` prefix so the operator knows the failure is a *precondition* issue (likely IAP infra regression) rather than a gacha-specific bug. The IAP describe block separately confirms IAP root cause.

## Why not an admin grant
The smoke account is deliberately non-admin (per spec header). Reusing the IAP path keeps that boundary intact and exercises the same code real users do.

## Roadmap
Tier 1 hardening pass on PRs #476-#480 — this is fix #2 of 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)