### PR TITLE
fix(api): gift-direct coin deduction race (audit C1)

### DIFF
--- a/express-api/src/routes/economy.js
+++ b/express-api/src/routes/economy.js
@@ -837,17 +837,34 @@ router.post('/economy/gift-direct', async (req, res) => {
 
     const coinValue = gift.coinValue || gift.coin_value || 0;
     const totalCost = coinValue * quantity;
-    const senderCoins = userField(sender, 'shyCoins', 'shy_coins') || 0;
-    if (senderCoins < totalCost) return res.status(402).json({ error: 'Insufficient coins' });
 
     const config = await loadEconomyConfig();
     const beanReward = Math.floor(coinValue * config.beanConversionRate * quantity);
-    const newSenderCoins = senderCoins - totalCost;
     const recipientBeans = userField(recipient, 'shyBeans', 'shy_beans') || 0;
     const timestamp = now();
 
-    // Deduct coins (atomic)
-    await db.doc(`users/${uniqueId}`).update({ shyCoins: FieldValue.increment(-totalCost) });
+    // Atomic coin deduction. Without the transaction, two concurrent
+    // gift-direct requests at the sender's exact balance both pass the
+    // pre-check and both call FieldValue.increment(-totalCost), pushing
+    // the balance below 0. The transaction reads `shyCoins` fresh and
+    // aborts on insufficient funds before decrementing — matches the
+    // pattern at /economy/gift-batch (line 1006-1011).
+    const senderRef = db.doc(`users/${uniqueId}`);
+    let newSenderCoins;
+    try {
+      newSenderCoins = await db.runTransaction(async (t) => {
+        const snap = await t.get(senderRef);
+        const coins = snap.exists ? userField(snap.data(), 'shyCoins', 'shy_coins') || 0 : 0;
+        if (coins < totalCost) throw new Error('Insufficient coins');
+        t.update(senderRef, { shyCoins: FieldValue.increment(-totalCost) });
+        return coins - totalCost;
+      });
+    } catch (txErr) {
+      if (txErr.message === 'Insufficient coins') {
+        return res.status(402).json({ error: 'Insufficient coins' });
+      }
+      throw txErr;
+    }
 
     // Gift wall
     await updateGiftWall(recipientId, giftId, uniqueId, quantity);

--- a/express-api/tests/routes/economy-coverage-core.test.js
+++ b/express-api/tests/routes/economy-coverage-core.test.js
@@ -297,6 +297,14 @@ describe('addBroadcast old broadcast trimming (lines 109-116)', () => {
       .mockResolvedValueOnce({ exists: false })
       .mockResolvedValueOnce({ exists: false })
       .mockResolvedValue({ exists: false });
+    // PR #485: gift-direct uses Firestore transaction for coin deduction
+    mockRunTransaction.mockImplementationOnce(async (cb) => {
+      const tx = {
+        get: jest.fn().mockResolvedValue(makeUserDoc({ shyCoins: 500 })),
+        update: jest.fn(),
+      };
+      return cb(tx);
+    });
 
     const app = createApp('user-A');
     const res = await request(app)

--- a/express-api/tests/routes/economy-coverage-gifts-core.test.js
+++ b/express-api/tests/routes/economy-coverage-gifts-core.test.js
@@ -531,6 +531,15 @@ describe('updateGiftRankings error handling (line 222)', () => {
       if (callCount === 6) return Promise.reject(new Error('Rankings fetch failed')); // giftRankings
       return Promise.resolve({ exists: false });
     });
+    // PR #485: gift-direct now uses Firestore transaction for coin
+    // deduction. Mock the transaction to succeed with sufficient coins.
+    mockRunTransaction.mockImplementationOnce(async (cb) => {
+      const tx = {
+        get: jest.fn().mockResolvedValue(makeUserDoc({ shyCoins: 500 })),
+        update: jest.fn(),
+      };
+      return cb(tx);
+    });
 
     const app = createApp('user-A');
     const res = await request(app)

--- a/express-api/tests/routes/economy-coverage-gifts-send.test.js
+++ b/express-api/tests/routes/economy-coverage-gifts-send.test.js
@@ -325,6 +325,9 @@ describe('POST /api/economy/gift-direct — additional coverage', () => {
   });
 
   test('writes room message when sender is in a room (lines 825-828)', async () => {
+    // PR #485: gift-direct now wraps coin deduction in a Firestore
+    // transaction. Tests must mock mockRunTransaction to return a tx
+    // object with sufficient coins.
     mockDocGet
       .mockResolvedValueOnce(makeGiftDoc({ coinValue: 10 }))
       .mockResolvedValueOnce(
@@ -335,6 +338,13 @@ describe('POST /api/economy/gift-direct — additional coverage', () => {
       .mockResolvedValueOnce({ exists: false })
       .mockResolvedValueOnce({ exists: false })
       .mockResolvedValue({ exists: false });
+    mockRunTransaction.mockImplementationOnce(async (cb) => {
+      const tx = {
+        get: jest.fn().mockResolvedValue(makeUserDoc({ shyCoins: 500 })),
+        update: jest.fn(),
+      };
+      return cb(tx);
+    });
 
     const app = createApp('user-A');
     const res = await request(app)

--- a/express-api/tests/routes/economy-gifts.test.js
+++ b/express-api/tests/routes/economy-gifts.test.js
@@ -303,11 +303,22 @@ describe('POST /api/economy/gift-direct', () => {
   // ── Insufficient coins ────────────────────────────────────────────
 
   test('returns 402 when sender has insufficient coins', async () => {
-    // gift costs 100 coins, sender has only 50
+    // gift costs 100 coins, sender has only 50. The check now happens
+    // INSIDE a Firestore transaction (PR #485 race fix), so we mock the
+    // transaction to throw 'Insufficient coins' which the route maps to 402.
     mockDocGet
       .mockResolvedValueOnce(makeGiftDoc({ coinValue: 100 })) // gift
-      .mockResolvedValueOnce(makeUserDoc({ shyCoins: 50 })) // sender
-      .mockResolvedValueOnce(makeUserDoc({ displayName: 'Bob' })); // recipient
+      .mockResolvedValueOnce(makeUserDoc({ shyCoins: 50 })) // sender (outer read for displayName/block)
+      .mockResolvedValueOnce(makeUserDoc({ displayName: 'Bob' })) // recipient
+      .mockResolvedValueOnce(ECONOMY_CONFIG_DOC); // loadEconomyConfig
+    // Transaction reads sender's coins fresh; returns 50 < 100 cost → throws
+    mockRunTransaction.mockImplementationOnce(async (cb) => {
+      const tx = {
+        get: jest.fn().mockResolvedValue(makeUserDoc({ shyCoins: 50 })),
+        update: jest.fn(),
+      };
+      return cb(tx);
+    });
 
     const app = createApp('user-A');
     const res = await request(app)
@@ -321,10 +332,11 @@ describe('POST /api/economy/gift-direct', () => {
   // ── Happy path ────────────────────────────────────────────────────
 
   test('returns 200 and deducts coins on success', async () => {
-    // gift costs 10 coins, sender has 500 coins
+    // gift costs 10 coins, sender has 500 coins. Per PR #485, the
+    // deduction is now in a Firestore transaction.
     mockDocGet
       .mockResolvedValueOnce(makeGiftDoc({ coinValue: 10 })) // gift
-      .mockResolvedValueOnce(makeUserDoc({ shyCoins: 500 })) // sender
+      .mockResolvedValueOnce(makeUserDoc({ shyCoins: 500 })) // sender (outer read)
       .mockResolvedValueOnce(makeUserDoc({ displayName: 'Bob' })) // recipient
       // loadEconomyConfig
       .mockResolvedValueOnce(ECONOMY_CONFIG_DOC)
@@ -334,6 +346,14 @@ describe('POST /api/economy/gift-direct', () => {
       .mockResolvedValueOnce({ exists: false })
       // writeTransaction calls
       .mockResolvedValue({ exists: false });
+    // Transaction reads sender's coins fresh inside the tx; sufficient → updates
+    mockRunTransaction.mockImplementationOnce(async (cb) => {
+      const tx = {
+        get: jest.fn().mockResolvedValue(makeUserDoc({ shyCoins: 500 })),
+        update: jest.fn(),
+      };
+      return cb(tx);
+    });
 
     const app = createApp('user-A');
     const res = await request(app)
@@ -344,6 +364,38 @@ describe('POST /api/economy/gift-direct', () => {
     expect(res.body.success).toBe(true);
     expect(res.body.coinsSpent).toBe(10);
     expect(res.body.giftName).toBe('Rose');
+    // Verify the transaction was actually invoked (atomicity contract)
+    expect(mockRunTransaction).toHaveBeenCalled();
+  });
+
+  // ── Race condition coverage (PR #485) ─────────────────────────────
+
+  test('aborts when concurrent send empties balance between outer read and tx read', async () => {
+    // Outer read sees shyCoins=100 (sufficient for 100-coin gift).
+    // Inside the transaction, the FRESH read sees shyCoins=0 (a
+    // concurrent send has emptied the balance). Tx must throw, route
+    // must 402. This is the bug the audit caught: pre-fix, the route
+    // trusted the stale outer read and went negative.
+    mockDocGet
+      .mockResolvedValueOnce(makeGiftDoc({ coinValue: 100 })) // gift
+      .mockResolvedValueOnce(makeUserDoc({ shyCoins: 100 })) // sender (stale)
+      .mockResolvedValueOnce(makeUserDoc({ displayName: 'Bob' })) // recipient
+      .mockResolvedValueOnce(ECONOMY_CONFIG_DOC); // loadEconomyConfig
+    mockRunTransaction.mockImplementationOnce(async (cb) => {
+      const tx = {
+        get: jest.fn().mockResolvedValue(makeUserDoc({ shyCoins: 0 })), // FRESH read
+        update: jest.fn(),
+      };
+      return cb(tx);
+    });
+
+    const app = createApp('user-A');
+    const res = await request(app)
+      .post('/api/economy/gift-direct')
+      .send({ recipientId: 'user-B', giftId: 'gift-rose', quantity: 1 });
+
+    expect(res.status).toBe(402);
+    expect(res.body.error).toMatch(/insufficient coins/i);
   });
 });
 


### PR DESCRIPTION
## Audit-driven fix — Phase 2A finding C1
Per universal-quality-bar correctness audit on `express-api/src/`:

**Vulnerability:** `/economy/gift-direct` (line 850) read shyCoins from a Promise.all snapshot, checked sufficient balance, then called `FieldValue.increment(-totalCost)` — without a Firestore transaction. Two concurrent gift sends at the sender's exact balance both pass the check and both decrement, pushing the balance below 0.

**Real failure scenario:** User has 100 coins, sends two 100-coin gifts within ms (network retry, double-tap, race). Both reads see senderCoins=100. Both pass the `senderCoins < totalCost` guard. Both call `FieldValue.increment(-100)`. Final balance: -100 coins. No audit trail of the over-spend.

## Fix
Wrap the read+decrement in `db.runTransaction` matching the canonical pattern at `/economy/gift-batch:1006-1011`. The transaction reads shyCoins fresh inside the tx, aborts on insufficient funds, decrements atomically. The 'Insufficient coins' Error is caught and mapped to 402.

## Tests
- 18 existing economy-gifts tests: all pass after updating mocks
- 81 affected tests across 4 files: all pass
- New race-coverage test added: stale outer read passes, fresh tx read sees empty balance, tx aborts → 402
- Total: 4637 → 4638

## Roadmap
First of 18 fix PRs draining Phase 2A audit findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)