### PR TITLE
fix(api): purchase replay race + deterministic receipt ID (audit C4)

### DIFF
--- a/express-api/src/routes/economy.js
+++ b/express-api/src/routes/economy.js
@@ -21,6 +21,7 @@
  * GET  /api/users/:uniqueId/gift-wall/:giftId/senders → Get gift wall senders
  */
 
+const crypto = require('node:crypto');
 const router = require('express').Router();
 const { db, FieldValue } = require('../utils/firebase');
 const { generateId, now, todayStr, yesterdayStr } = require('../utils/helpers');
@@ -1324,14 +1325,29 @@ router.post('/economy/purchase', async (req, res) => {
     // historically omitted the field. iOS clients MUST send `platform: 'apple'`.
     const purchasePlatform = platform === 'apple' ? 'apple' : 'google';
 
-    // Check for duplicate purchase token to prevent replay attacks
-    const existingSnap = await db
-      .collection('purchaseReceipts')
-      .where('purchaseToken', '==', purchaseToken)
-      .limit(1)
-      .get();
-    if (!existingSnap.empty) {
-      log.warn('economy', 'Duplicate purchase token rejected', { userId: uniqueId, productId });
+    // Deterministic receipt doc ID derived from purchaseToken.
+    // SHA-256 collisions are infeasible; any two requests with the
+    // SAME token write to the SAME doc, making the receipt set
+    // idempotent at the storage layer. Combined with the inside-tx
+    // existence check below, this closes the replay race window
+    // that the previous where-query duplicate check could not.
+    //
+    // Audit C4 (Phase 2A): /economy/purchase replay race.
+    const receiptId = crypto.createHash('sha256').update(String(purchaseToken)).digest('hex');
+    const receiptRef = db.doc(`purchaseReceipts/${receiptId}`);
+
+    // Pre-flight (cheap fast-path on already-processed tokens).
+    // The authoritative duplicate check happens inside the
+    // transaction below — this just avoids paying the verification
+    // cost (network call to Google/Apple) for tokens we've already
+    // seen. A race between this check and the tx is fine: the tx
+    // will catch the duplicate and reject.
+    const existingSnap = await receiptRef.get();
+    if (existingSnap.exists) {
+      log.warn('economy', 'Duplicate purchase token rejected (pre-flight)', {
+        userId: uniqueId,
+        productId,
+      });
       return res.status(409).json({ error: 'Purchase already processed' });
     }
 
@@ -1372,36 +1388,63 @@ router.post('/economy/purchase', async (req, res) => {
 
     const orderId = verification.orderId || verification.latestOrderId || null;
     const timestamp = now();
-    const receiptId = generateId();
+    const userRef = db.doc(`users/${uniqueId}`);
+
+    // Sentinels for tx-internal aborts. Caught after the tx and
+    // mapped to the appropriate HTTP status.
+    const ERR_DUPLICATE = 'Purchase already processed';
+    const ERR_UNKNOWN_SUB = 'Unknown subscription product';
+    const ERR_USER_NOT_FOUND = 'User not found';
+    const ERR_UNKNOWN_PKG = 'Unknown coin package';
 
     if (isSubscription) {
       const sub = SUBSCRIPTION_TIERS[productId];
-      if (!sub) return res.status(400).json({ error: 'Unknown subscription product' });
+      if (!sub) return res.status(400).json({ error: ERR_UNKNOWN_SUB });
 
       const expiry = sub.days ? timestamp + sub.days * 86400000 : null;
 
-      // Store receipt AFTER tier resolution so we can persist the granted
-      // tier + days. The refund handler reads from the receipt instead of
-      // re-deriving from the (mutable) SUBSCRIPTION_TIERS map, so a future
-      // tier change cannot retroactively rewrite the refund's reversal.
-      await db.doc(`purchaseReceipts/${receiptId}`).set({
-        userId: uniqueId,
-        productId,
-        purchaseToken,
-        platform: purchasePlatform,
-        isSubscription: true,
-        createdAt: timestamp,
-        verified: true,
-        orderId,
-        tierGranted: sub.tier,
-        daysGranted: sub.days,
-      });
-
-      await db.doc(`users/${uniqueId}`).update({
-        isSuperShy: true,
-        superShyExpiry: expiry,
-        superShyTier: sub.tier,
-      });
+      // Atomic: re-check receipt + write receipt + grant subscription.
+      // Firestore transactions retry on contention; a concurrent
+      // request that wins the race will populate the receipt before
+      // this tx's t.get() sees it, causing this attempt to abort
+      // with ERR_DUPLICATE on retry.
+      try {
+        await db.runTransaction(async (t) => {
+          const rcptSnap = await t.get(receiptRef);
+          if (rcptSnap.exists) {
+            throw new Error(ERR_DUPLICATE);
+          }
+          // Persist tier + days for refund-time reversal (see
+          // pre-fix comment): refund reads from receipt rather
+          // than re-deriving from mutable SUBSCRIPTION_TIERS map.
+          t.set(receiptRef, {
+            userId: uniqueId,
+            productId,
+            purchaseToken,
+            platform: purchasePlatform,
+            isSubscription: true,
+            createdAt: timestamp,
+            verified: true,
+            orderId,
+            tierGranted: sub.tier,
+            daysGranted: sub.days,
+          });
+          t.update(userRef, {
+            isSuperShy: true,
+            superShyExpiry: expiry,
+            superShyTier: sub.tier,
+          });
+        });
+      } catch (txErr) {
+        if (txErr.message === ERR_DUPLICATE) {
+          log.warn('economy', 'Duplicate purchase rejected (tx)', {
+            userId: uniqueId,
+            productId,
+          });
+          return res.status(409).json({ error: ERR_DUPLICATE });
+        }
+        throw txErr;
+      }
 
       const subTxId = generateId();
       await writeTransaction(uniqueId, subTxId, {
@@ -1416,46 +1459,67 @@ router.post('/economy/purchase', async (req, res) => {
       return res.json({ success: true, tier: sub.tier });
     }
 
-    // Coin package
+    // Coin package — look up package OUTSIDE the tx (read-only,
+    // stable). Fail fast on unknown package before opening the tx.
     const pkgSnap = await db
       .collection('coinPackages')
       .where('productId', '==', productId)
       .limit(1)
       .get();
     const pkg = pkgSnap.empty ? null : { id: pkgSnap.docs[0].id, ...pkgSnap.docs[0].data() };
-    if (!pkg) return res.status(404).json({ error: 'Unknown coin package' });
+    if (!pkg) return res.status(404).json({ error: ERR_UNKNOWN_PKG });
 
     const coinsGranted = pkg.coins || 0;
     const bonusCoinsGranted = pkg.bonusCoins || 0;
     const totalCoins = coinsGranted + bonusCoinsGranted;
 
-    const userSnap = await db.doc(`users/${uniqueId}`).get();
-    if (!userSnap.exists) return res.status(404).json({ error: 'User not found' });
-    const user = userSnap.data();
+    // Atomic: re-check receipt + read user + write receipt + grant
+    // coins, all in one transaction. Reading the user inside the tx
+    // ensures `newBalance` reflects post-grant state consistently
+    // even under concurrent purchases.
+    let newBalance;
+    try {
+      newBalance = await db.runTransaction(async (t) => {
+        const rcptSnap = await t.get(receiptRef);
+        if (rcptSnap.exists) {
+          throw new Error(ERR_DUPLICATE);
+        }
+        const userSnap = await t.get(userRef);
+        if (!userSnap.exists) {
+          throw new Error(ERR_USER_NOT_FOUND);
+        }
+        const user = userSnap.data();
+        const shyCoins = userField(user, 'shyCoins', 'shy_coins') || 0;
+        // Persist actual granted amounts on the receipt so the refund
+        // handler can reverse the original entitlement even if
+        // `coinPackages` is later mutated (price changes, promotional
+        // bonus weekends, deprecated SKUs).
+        t.set(receiptRef, {
+          userId: uniqueId,
+          productId,
+          purchaseToken,
+          platform: purchasePlatform,
+          isSubscription: false,
+          createdAt: timestamp,
+          verified: true,
+          orderId,
+          coinsGranted,
+          bonusCoinsGranted,
+        });
+        t.update(userRef, { shyCoins: FieldValue.increment(totalCoins) });
+        return shyCoins + totalCoins;
+      });
+    } catch (txErr) {
+      if (txErr.message === ERR_DUPLICATE) {
+        log.warn('economy', 'Duplicate purchase rejected (tx)', { userId: uniqueId, productId });
+        return res.status(409).json({ error: ERR_DUPLICATE });
+      }
+      if (txErr.message === ERR_USER_NOT_FOUND) {
+        return res.status(404).json({ error: ERR_USER_NOT_FOUND });
+      }
+      throw txErr;
+    }
 
-    const shyCoins = userField(user, 'shyCoins', 'shy_coins') || 0;
-
-    // Persist the actual granted amounts on the receipt so the refund
-    // handler can reverse the original entitlement even if `coinPackages`
-    // is later mutated (price changes, promotional bonus weekends,
-    // deprecated SKUs). Without this the refund would reverse today's
-    // package config, not what the user originally received.
-    await db.doc(`purchaseReceipts/${receiptId}`).set({
-      userId: uniqueId,
-      productId,
-      purchaseToken,
-      platform: purchasePlatform,
-      isSubscription: false,
-      createdAt: timestamp,
-      verified: true,
-      orderId,
-      coinsGranted,
-      bonusCoinsGranted,
-    });
-
-    await db.doc(`users/${uniqueId}`).update({ shyCoins: FieldValue.increment(totalCoins) });
-
-    const newBalance = shyCoins + totalCoins;
     const purchaseTxId = generateId();
     await writeTransaction(uniqueId, purchaseTxId, {
       type: 'PURCHASE',

--- a/express-api/tests/routes/economy-coverage-core.test.js
+++ b/express-api/tests/routes/economy-coverage-core.test.js
@@ -405,9 +405,25 @@ describe('POST /api/economy/redeem-beans — additional coverage', () => {
 // ═══════════════════════════════════════════════════════════════════
 
 describe('POST /api/economy/purchase — additional coverage', () => {
+  // PR #488: purchase route now uses deterministic receipt doc ID +
+  // tx-wrapped grant. Override the default tx mock (which returns
+  // backpack-shaped data) to route tx.get → mockDocGet.
+  const setupTxMock = () => {
+    mockRunTransaction.mockImplementation(async (cb) => {
+      const tx = {
+        get: (ref) => mockDocGet(ref),
+        update: jest.fn(),
+        set: jest.fn(),
+        delete: jest.fn(),
+      };
+      return cb(tx);
+    });
+  };
+
   test('returns 400 for unknown subscription productId (line 1313)', async () => {
+    setupTxMock();
+    mockDocGet.mockResolvedValue({ exists: false }); // pre-flight passes
     mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-    mockDocGet.mockResolvedValue(makeUserDoc());
 
     const app = createApp('user-A');
     const res = await request(app).post('/api/economy/purchase').send({
@@ -421,11 +437,9 @@ describe('POST /api/economy/purchase — additional coverage', () => {
   });
 
   test('returns 404 when coin package not found (line 1343)', async () => {
-    mockCollectionGet = jest.fn().mockImplementation(() => {
-      return Promise.resolve({ empty: true, docs: [] });
-    });
-
-    mockDocGet.mockResolvedValue(makeUserDoc());
+    setupTxMock();
+    mockDocGet.mockResolvedValue({ exists: false }); // pre-flight passes
+    mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] }); // no package
 
     const app = createApp('user-A');
     const res = await request(app).post('/api/economy/purchase').send({
@@ -438,24 +452,13 @@ describe('POST /api/economy/purchase — additional coverage', () => {
   });
 
   test('returns 404 when user not found for coin package (line 1348)', async () => {
-    let collectionCallCount = 0;
-    mockCollectionGet = jest.fn().mockImplementation(() => {
-      collectionCallCount++;
-      if (collectionCallCount === 1) {
-        return Promise.resolve({ empty: true, docs: [] });
-      }
-      return Promise.resolve({
-        empty: false,
-        docs: [
-          {
-            id: 'pkg-1',
-            data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 10 }),
-          },
-        ],
-      });
-    });
-
+    setupTxMock();
+    // pre-flight + tx-receipt + tx-user — all return missing
     mockDocGet.mockResolvedValue({ exists: false });
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [{ id: 'pkg-1', data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 10 }) }],
+    });
 
     const app = createApp('user-A');
     const res = await request(app).post('/api/economy/purchase').send({
@@ -468,8 +471,8 @@ describe('POST /api/economy/purchase — additional coverage', () => {
   });
 
   test('handles yearly subscription', async () => {
-    mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-    mockDocGet.mockResolvedValue(makeUserDoc());
+    setupTxMock();
+    mockDocGet.mockResolvedValue({ exists: false }); // pre-flight + tx receipt
 
     const app = createApp('user-A');
     const res = await request(app).post('/api/economy/purchase').send({
@@ -484,8 +487,8 @@ describe('POST /api/economy/purchase — additional coverage', () => {
   });
 
   test('handles lifetime subscription', async () => {
-    mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-    mockDocGet.mockResolvedValue(makeUserDoc());
+    setupTxMock();
+    mockDocGet.mockResolvedValue({ exists: false });
 
     const app = createApp('user-A');
     const res = await request(app).post('/api/economy/purchase').send({
@@ -734,30 +737,35 @@ describe('POST /api/economy/purchase — production verification (lines 1272-128
     process.env.NODE_ENV = originalEnv;
   });
 
+  // PR #488: purchase route now uses deterministic receipt doc ID +
+  // tx-wrapped grant. Pre-flight check uses mockDocGet on the receipt.
+  const setupTxMock = () => {
+    mockRunTransaction.mockImplementation(async (cb) => {
+      const tx = {
+        get: (ref) => mockDocGet(ref),
+        update: jest.fn(),
+        set: jest.fn(),
+        delete: jest.fn(),
+      };
+      return cb(tx);
+    });
+  };
+
   test('calls verifyProductPurchase in production for non-subscription', async () => {
     process.env.NODE_ENV = 'production';
-
-    mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-    mockDocGet.mockResolvedValue(makeUserDoc());
-
-    verifyProductPurchase.mockResolvedValue({ orderId: 'prod-order-123' });
-
-    let collectionCallCount = 0;
-    mockCollectionGet = jest.fn().mockImplementation(() => {
-      collectionCallCount++;
-      if (collectionCallCount === 1) {
-        return Promise.resolve({ empty: true, docs: [] }); // No duplicate receipt
-      }
-      return Promise.resolve({
-        empty: false,
-        docs: [
-          {
-            id: 'pkg-1',
-            data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 10 }),
-          },
-        ],
-      });
+    setupTxMock();
+    // pre-flight + tx-receipt = no receipt; tx-user = user
+    let docCallCount = 0;
+    mockDocGet.mockImplementation(() => {
+      docCallCount++;
+      if (docCallCount <= 2) return Promise.resolve({ exists: false });
+      return Promise.resolve(makeUserDoc());
     });
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [{ id: 'pkg-1', data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 10 }) }],
+    });
+    verifyProductPurchase.mockResolvedValue({ orderId: 'prod-order-123' });
 
     const app = createApp('user-A');
     const res = await request(app).post('/api/economy/purchase').send({
@@ -775,10 +783,8 @@ describe('POST /api/economy/purchase — production verification (lines 1272-128
 
   test('calls verifySubscription in production for subscription', async () => {
     process.env.NODE_ENV = 'production';
-
-    mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-    mockDocGet.mockResolvedValue(makeUserDoc());
-
+    setupTxMock();
+    mockDocGet.mockResolvedValue({ exists: false });
     verifySubscription.mockResolvedValue({ orderId: 'sub-order-123' });
 
     const app = createApp('user-A');
@@ -798,10 +804,8 @@ describe('POST /api/economy/purchase — production verification (lines 1272-128
 
   test('returns 403 when production verification fails (lines 1278-1285)', async () => {
     process.env.NODE_ENV = 'production';
-
-    mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-    mockDocGet.mockResolvedValue(makeUserDoc());
-
+    setupTxMock();
+    mockDocGet.mockResolvedValue({ exists: false }); // pre-flight passes; verification will reject
     verifyProductPurchase.mockRejectedValue(new Error('Invalid purchase'));
 
     const app = createApp('user-A');
@@ -824,10 +828,8 @@ describe('POST /api/economy/purchase — production verification (lines 1272-128
 
   test('returns 403 when subscription verification fails', async () => {
     process.env.NODE_ENV = 'production';
-
-    mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-    mockDocGet.mockResolvedValue(makeUserDoc());
-
+    setupTxMock();
+    mockDocGet.mockResolvedValue({ exists: false });
     verifySubscription.mockRejectedValue(new Error('Invalid subscription'));
 
     const app = createApp('user-A');

--- a/express-api/tests/routes/economy-purchase.test.js
+++ b/express-api/tests/routes/economy-purchase.test.js
@@ -171,11 +171,16 @@ describe('POST /api/economy/purchase', () => {
     expect(res.body.error).toMatch(/purchaseToken/i);
   });
 
-  test('returns 409 when purchaseToken is duplicate', async () => {
-    // Collection query for purchaseReceipts returns an existing doc
-    mockCollectionGet = jest.fn().mockResolvedValue({
-      empty: false,
-      docs: [{ id: 'receipt-existing', data: () => ({ purchaseToken: 'token-dup' }) }],
+  // PR #488: purchase route now uses deterministic receipt doc ID
+  // (sha256(purchaseToken)) and wraps receipt-set + grant in a tx.
+  // Pre-flight check uses mockDocGet on the receipt; tx-internal
+  // re-check also uses mockDocGet via the default tx mock.
+
+  test('returns 409 when purchaseToken is duplicate (pre-flight catches)', async () => {
+    // Pre-flight receipt doc.get() → exists → 409 fast path
+    mockDocGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ purchaseToken: 'token-dup' }),
     });
 
     const app = createApp('user-A');
@@ -188,34 +193,25 @@ describe('POST /api/economy/purchase', () => {
   });
 
   test('returns 200 and increments coins for coin package', async () => {
-    // The purchase handler (non-subscription) does NOT call loadEconomyConfig.
-    // db.doc().get() is only called once: for the user lookup (step 5).
-    // Collection calls:
-    //   1. purchaseReceipts.where(...).limit(1).get() → empty (no duplicate)
-    //   2. coinPackages.where(...).limit(1).get() → package found
-    let collectionCallCount = 0;
-    mockCollectionGet = jest.fn().mockImplementation(() => {
-      collectionCallCount++;
-      if (collectionCallCount === 1) {
-        // purchaseReceipts check — no duplicate
-        return Promise.resolve({ empty: true, docs: [] });
-      }
-      // coinPackages — return the package
-      return Promise.resolve({
-        empty: false,
-        docs: [
-          {
-            id: 'pkg-coins-100',
-            data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 10 }),
-          },
-        ],
-      });
+    // mockDocGet sequence:
+    //   1. pre-flight receipt → {exists:false}
+    //   2. tx receipt re-check → {exists:false}
+    //   3. tx user lookup → user with shyCoins
+    let docCallCount = 0;
+    mockDocGet.mockImplementation(() => {
+      docCallCount++;
+      if (docCallCount <= 2) return Promise.resolve({ exists: false });
+      return Promise.resolve({ exists: true, data: () => ({ shyCoins: 500, shyBeans: 0 }) });
     });
-
-    // Only one doc.get() call: the user doc
-    mockDocGet.mockResolvedValue({
-      exists: true,
-      data: () => ({ shyCoins: 500, shyBeans: 0 }),
+    // coinPackages query (still uses mockCollectionGet)
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'pkg-coins-100',
+          data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 10 }),
+        },
+      ],
     });
 
     const app = createApp('user-A');
@@ -225,16 +221,12 @@ describe('POST /api/economy/purchase', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
-    expect(res.body.coinsAdded).toBe(110); // 100 + 10 bonus
-    expect(res.body.newBalance).toBe(610); // 500 + 110
+    expect(res.body.coinsAdded).toBe(110);
+    expect(res.body.newBalance).toBe(610);
   });
 
   test('returns 200 and sets isSuperShy for subscription', async () => {
-    // purchaseReceipts check — empty (no duplicate)
-    mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-
-    // Config doc for loadEconomyConfig
-    mockDocGet.mockResolvedValue(makeConfigDoc());
+    mockDocGet.mockResolvedValue({ exists: false }); // pre-flight + tx receipt re-check
 
     const app = createApp('user-A');
     const res = await request(app).post('/api/economy/purchase').send({
@@ -246,11 +238,6 @@ describe('POST /api/economy/purchase', () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.tier).toBe('monthly');
-
-    // db.doc().update() should have been called with isSuperShy: true
-    expect(mockDocUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ isSuperShy: true, superShyTier: 'monthly' }),
-    );
   });
 
   // ── All subscription tiers ──
@@ -260,8 +247,18 @@ describe('POST /api/economy/purchase', () => {
     ['super_shy_yearly', 'yearly', 365],
     ['super_shy_lifetime', 'lifetime', null],
   ])('subscription %s sets tier=%s with %s day expiry', async (productId, tier, days) => {
-    mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-    mockDocGet.mockResolvedValue(makeConfigDoc());
+    mockDocGet.mockResolvedValue({ exists: false });
+    // Capture tx.update to verify expiry math
+    const txUpdate = jest.fn();
+    mockRunTransaction.mockImplementationOnce(async (cb) => {
+      const tx = {
+        get: (ref) => mockDocGet(ref),
+        update: txUpdate,
+        set: jest.fn(),
+        delete: jest.fn(),
+      };
+      return cb(tx);
+    });
 
     const app = createApp('user-A');
     const res = await request(app)
@@ -277,7 +274,8 @@ describe('POST /api/economy/purchase', () => {
     expect(res.body.tier).toBe(tier);
 
     const expectedExpiry = days ? 1709913600000 + days * 86400000 : null;
-    expect(mockDocUpdate).toHaveBeenCalledWith(
+    expect(txUpdate).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
         isSuperShy: true,
         superShyTier: tier,
@@ -287,8 +285,7 @@ describe('POST /api/economy/purchase', () => {
   });
 
   test('returns 400 for unknown subscription productId', async () => {
-    mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-    mockDocGet.mockResolvedValue(makeConfigDoc());
+    mockDocGet.mockResolvedValue({ exists: false });
 
     const app = createApp('user-A');
     const res = await request(app).post('/api/economy/purchase').send({
@@ -313,21 +310,16 @@ describe('POST /api/economy/purchase', () => {
   ])(
     'purchases $productId ($coins + $bonusCoins bonus = $expectedTotal)',
     async ({ productId, coins, bonusCoins, expectedTotal }) => {
-      let collectionCallCount = 0;
-      mockCollectionGet = jest.fn().mockImplementation(() => {
-        collectionCallCount++;
-        if (collectionCallCount === 1) {
-          return Promise.resolve({ empty: true, docs: [] }); // no duplicate
-        }
-        return Promise.resolve({
-          empty: false,
-          docs: [{ id: `pkg-${productId}`, data: () => ({ productId, coins, bonusCoins }) }],
-        });
+      // mockDocGet: 1=pre-flight, 2=tx-receipt, 3=tx-user
+      let docCallCount = 0;
+      mockDocGet.mockImplementation(() => {
+        docCallCount++;
+        if (docCallCount <= 2) return Promise.resolve({ exists: false });
+        return Promise.resolve({ exists: true, data: () => ({ shyCoins: 0, shyBeans: 0 }) });
       });
-
-      mockDocGet.mockResolvedValue({
-        exists: true,
-        data: () => ({ shyCoins: 0, shyBeans: 0 }),
+      mockCollectionGet = jest.fn().mockResolvedValue({
+        empty: false,
+        docs: [{ id: `pkg-${productId}`, data: () => ({ productId, coins, bonusCoins }) }],
       });
 
       const app = createApp('user-A');
@@ -343,14 +335,8 @@ describe('POST /api/economy/purchase', () => {
   );
 
   test('returns 404 for unknown coin package productId', async () => {
-    let collectionCallCount = 0;
-    mockCollectionGet = jest.fn().mockImplementation(() => {
-      collectionCallCount++;
-      if (collectionCallCount === 1) {
-        return Promise.resolve({ empty: true, docs: [] }); // no duplicate
-      }
-      return Promise.resolve({ empty: true, docs: [] }); // no package found
-    });
+    mockDocGet.mockResolvedValue({ exists: false }); // pre-flight passes
+    mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] }); // no package
 
     const app = createApp('user-A');
     const res = await request(app)
@@ -361,24 +347,73 @@ describe('POST /api/economy/purchase', () => {
     expect(res.body.error).toMatch(/unknown coin package/i);
   });
 
-  test('stores purchase receipt with orderId', async () => {
-    let collectionCallCount = 0;
-    mockCollectionGet = jest.fn().mockImplementation(() => {
-      collectionCallCount++;
-      if (collectionCallCount === 1) {
-        return Promise.resolve({ empty: true, docs: [] });
-      }
-      return Promise.resolve({
-        empty: false,
-        docs: [
-          { id: 'pkg-100', data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 0 }) },
-        ],
-      });
+  // ── Race coverage (PR #488 audit C4) ─────────────────────────────
+
+  test('aborts when concurrent purchase wins between pre-flight and tx', async () => {
+    // Pre-flight sees no receipt; tx-internal re-check sees existing
+    // receipt (race winner). Tx must throw, route 409.
+    let docCallCount = 0;
+    mockDocGet.mockImplementation(() => {
+      docCallCount++;
+      if (docCallCount === 1) return Promise.resolve({ exists: false }); // pre-flight
+      return Promise.resolve({ exists: true }); // tx receipt re-check sees winner
+    });
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [{ id: 'pkg', data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 0 }) }],
     });
 
-    mockDocGet.mockResolvedValue({
-      exists: true,
-      data: () => ({ shyCoins: 0, shyBeans: 0 }),
+    const app = createApp('user-A');
+    const res = await request(app)
+      .post('/api/economy/purchase')
+      .send({ productId: 'coins_100', purchaseToken: 'token-race' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/already processed/i);
+  });
+
+  test('returns 404 if user disappears between pre-flight and tx', async () => {
+    // Pre-flight + tx receipt both see no receipt; tx user-lookup
+    // sees user-not-found. Tx throws, route 404.
+    mockDocGet.mockResolvedValue({ exists: false }); // all three reads return missing
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [{ id: 'pkg', data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 0 }) }],
+    });
+
+    const app = createApp('user-A');
+    const res = await request(app)
+      .post('/api/economy/purchase')
+      .send({ productId: 'coins_100', purchaseToken: 'token-no-user' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/user not found/i);
+  });
+
+  test('stores purchase receipt with orderId via tx.set', async () => {
+    // mockDocGet sequence: 1=pre-flight, 2=tx-receipt, 3=tx-user
+    let docCallCount = 0;
+    mockDocGet.mockImplementation(() => {
+      docCallCount++;
+      if (docCallCount <= 2) return Promise.resolve({ exists: false });
+      return Promise.resolve({ exists: true, data: () => ({ shyCoins: 0, shyBeans: 0 }) });
+    });
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [
+        { id: 'pkg-100', data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 0 }) },
+      ],
+    });
+    // Capture tx.set to verify receipt fields
+    const txSet = jest.fn();
+    mockRunTransaction.mockImplementationOnce(async (cb) => {
+      const tx = {
+        get: (ref) => mockDocGet(ref),
+        update: jest.fn(),
+        set: txSet,
+        delete: jest.fn(),
+      };
+      return cb(tx);
     });
 
     const app = createApp('user-A');
@@ -387,8 +422,8 @@ describe('POST /api/economy/purchase', () => {
       .send({ productId: 'coins_100', purchaseToken: 'receipt-token' })
       .expect(200);
 
-    // Verify receipt stored
-    expect(mockDocSet).toHaveBeenCalledWith(
+    expect(txSet).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
         userId: 'user-A',
         productId: 'coins_100',
@@ -406,23 +441,20 @@ describe('POST /api/economy/purchase', () => {
     const { verifyProductPurchase } = require('../../src/utils/playStore');
 
     test('routes consumable purchase through verifyApplePurchase, NOT playStore', async () => {
-      let collectionCallCount = 0;
-      mockCollectionGet = jest.fn().mockImplementation(() => {
-        collectionCallCount++;
-        if (collectionCallCount === 1) return Promise.resolve({ empty: true, docs: [] });
-        return Promise.resolve({
-          empty: false,
-          docs: [
-            {
-              id: 'pkg-100',
-              data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 0 }),
-            },
-          ],
-        });
+      // Doc sequence: 1=pre-flight, 2=tx-receipt, 3=tx-user
+      let docCallCount = 0;
+      mockDocGet.mockImplementation(() => {
+        docCallCount++;
+        if (docCallCount <= 2) return Promise.resolve({ exists: false });
+        return Promise.resolve({ exists: true, data: () => ({ shyCoins: 0, shyBeans: 0 }) });
       });
-      mockDocGet.mockResolvedValue({ exists: true, data: () => ({ shyCoins: 0, shyBeans: 0 }) });
+      mockCollectionGet = jest.fn().mockResolvedValue({
+        empty: false,
+        docs: [
+          { id: 'pkg-100', data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 0 }) },
+        ],
+      });
 
-      // Force production branch — non-prod skips verification entirely.
       const prevEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = 'production';
       verifyApplePurchase.mockResolvedValueOnce({
@@ -446,22 +478,29 @@ describe('POST /api/economy/purchase', () => {
       }
     });
 
-    test('records platform: apple on the purchaseReceipts doc', async () => {
-      let collectionCallCount = 0;
-      mockCollectionGet = jest.fn().mockImplementation(() => {
-        collectionCallCount++;
-        if (collectionCallCount === 1) return Promise.resolve({ empty: true, docs: [] });
-        return Promise.resolve({
-          empty: false,
-          docs: [
-            {
-              id: 'pkg-100',
-              data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 0 }),
-            },
-          ],
-        });
+    test('records platform: apple on the purchaseReceipts doc (via tx.set)', async () => {
+      let docCallCount = 0;
+      mockDocGet.mockImplementation(() => {
+        docCallCount++;
+        if (docCallCount <= 2) return Promise.resolve({ exists: false });
+        return Promise.resolve({ exists: true, data: () => ({ shyCoins: 0, shyBeans: 0 }) });
       });
-      mockDocGet.mockResolvedValue({ exists: true, data: () => ({ shyCoins: 0, shyBeans: 0 }) });
+      mockCollectionGet = jest.fn().mockResolvedValue({
+        empty: false,
+        docs: [
+          { id: 'pkg-100', data: () => ({ productId: 'coins_100', coins: 100, bonusCoins: 0 }) },
+        ],
+      });
+      const txSet = jest.fn();
+      mockRunTransaction.mockImplementationOnce(async (cb) => {
+        const tx = {
+          get: (ref) => mockDocGet(ref),
+          update: jest.fn(),
+          set: txSet,
+          delete: jest.fn(),
+        };
+        return cb(tx);
+      });
 
       const prevEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = 'production';
@@ -483,9 +522,10 @@ describe('POST /api/economy/purchase', () => {
           .expect(200);
 
         // Refund handler reads coinsGranted/bonusCoinsGranted from this
-        // receipt at refund time — assert they're persisted so a future
-        // economy.js refactor can't silently break the refund path.
-        expect(mockDocSet).toHaveBeenCalledWith(
+        // receipt at refund time — assert they're persisted via tx.set
+        // so a future economy.js refactor can't silently break refunds.
+        expect(txSet).toHaveBeenCalledWith(
+          expect.anything(),
           expect.objectContaining({
             platform: 'apple',
             orderId: '2000000abcdef',
@@ -499,9 +539,18 @@ describe('POST /api/economy/purchase', () => {
       }
     });
 
-    test('subscription receipt persists tierGranted + daysGranted for refund handler', async () => {
-      mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-      mockDocGet.mockResolvedValue({ exists: true, data: () => ({ shyCoins: 0, shyBeans: 0 }) });
+    test('subscription receipt persists tierGranted + daysGranted for refund handler (via tx.set)', async () => {
+      mockDocGet.mockResolvedValue({ exists: false }); // pre-flight + tx receipt
+      const txSet = jest.fn();
+      mockRunTransaction.mockImplementationOnce(async (cb) => {
+        const tx = {
+          get: (ref) => mockDocGet(ref),
+          update: jest.fn(),
+          set: txSet,
+          delete: jest.fn(),
+        };
+        return cb(tx);
+      });
 
       const prevEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = 'production';
@@ -523,7 +572,8 @@ describe('POST /api/economy/purchase', () => {
           })
           .expect(200);
 
-        expect(mockDocSet).toHaveBeenCalledWith(
+        expect(txSet).toHaveBeenCalledWith(
+          expect.anything(),
           expect.objectContaining({
             platform: 'apple',
             orderId: '2000000sub-monthly',
@@ -538,7 +588,7 @@ describe('POST /api/economy/purchase', () => {
     });
 
     test('returns 403 when verifyApplePurchase rejects (e.g. revoked transaction)', async () => {
-      mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
+      mockDocGet.mockResolvedValue({ exists: false }); // pre-flight passes
 
       const prevEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = 'production';
@@ -559,8 +609,7 @@ describe('POST /api/economy/purchase', () => {
     });
 
     test('routes subscription through verifyApplePurchase with isSubscription=true', async () => {
-      mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
-      mockDocGet.mockResolvedValue({ exists: true, data: () => ({}) });
+      mockDocGet.mockResolvedValue({ exists: false });
 
       const prevEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = 'production';


### PR DESCRIPTION
## Audit-driven fix — Phase 2A finding C4 (LAST critical race)
The purchase route had a real-money replay race: a token submitted twice nearly simultaneously could grant DOUBLE COINS for one purchase because the dedup check (where-query on purchaseReceipts) and the receipt write + balance grant were not atomic.

## Two-part fix
1. **Deterministic receipt ID** = `sha256(purchaseToken)`. Same token → same doc. Set is now idempotent at the storage layer. SHA-256 collisions are infeasible.
2. **Tx-wrapped receipt + grant**: receipt set + user update (subscription tier OR coin increment) are inside `db.runTransaction`. Tx reads the receipt doc first; if it exists, throws ERR_DUPLICATE → 409. Coin path also reads user inside tx for consistent `newBalance` under concurrent purchases.

A fast-path pre-flight check is kept BEFORE the store verification to skip paying network-cost on already-processed tokens. Authoritative duplicate check remains inside the tx.

## Tests
- 22 existing purchase tests updated (incl. apple branch + production verification). Receipt assertions now capture `tx.set` instead of `mockDocSet`.
- 2 new race-coverage tests: concurrent winner between pre-flight and tx → 409, user disappears between pre-flight and tx → 404
- Total: 4642 → 4644

## Roadmap
ALL 4 CRITICAL race conditions now fixed: C1 ✓ (gift-direct), C2 ✓ (redeem-beans), C3 ✓ (trial-claim), C4 ✓ (purchase). Moving to High-priority findings: H1 (age calc), H2 (appeal idempotency), H3 (follow validation), H4 (PIN bcrypt DoS), H5 (broadcast Spark burn), H6 (daily-reward race), H7 (warning revoke atomicity), H8 (backpack-send partial failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)