### PR TITLE
fix(api): daily-reward race condition (audit H6)

### DIFF
--- a/express-api/src/routes/economy.js
+++ b/express-api/src/routes/economy.js
@@ -274,48 +274,76 @@ router.post('/economy/daily-reward', async (req, res) => {
     const today = todayStr();
     const yesterday = yesterdayStr();
 
-    const userSnap = await db.doc(`users/${uniqueId}`).get();
-    if (!userSnap.exists) return res.status(404).json({ error: 'User not found' });
-    const user = userSnap.data();
+    // Atomic claim per audit H6 — wraps user-read + already-claimed
+    // check + user-update + backpack-merge in a Firestore transaction.
+    // Pattern matches PRs #485-#488. Sentinel errors caught after.
+    const userRef = db.doc(`users/${uniqueId}`);
+    const ERR_USER_NOT_FOUND = 'User not found';
+    const ERR_ALREADY_CLAIMED = 'Already claimed today';
+    let txResult;
+    try {
+      txResult = await db.runTransaction(async (t) => {
+        const userSnap = await t.get(userRef);
+        if (!userSnap.exists) {
+          throw new Error(ERR_USER_NOT_FOUND);
+        }
+        const user = userSnap.data();
+        const shyCoins = userField(user, 'shyCoins', 'shy_coins') || 0;
+        const isSuperShy = userField(user, 'isSuperShy', 'is_super_shy') || false;
+        const loginStreak = userField(user, 'loginStreak', 'login_streak') || 0;
+        const lastLoginDate = userField(user, 'lastLoginDate', 'last_login_date');
+        const lastLoginRewardDate = userField(
+          user,
+          'lastLoginRewardDate',
+          'last_login_reward_date',
+        );
 
-    const shyCoins = userField(user, 'shyCoins', 'shy_coins') || 0;
-    const isSuperShy = userField(user, 'isSuperShy', 'is_super_shy') || false;
-    const loginStreak = userField(user, 'loginStreak', 'login_streak') || 0;
-    const lastLoginDate = userField(user, 'lastLoginDate', 'last_login_date');
-    const lastLoginRewardDate = userField(user, 'lastLoginRewardDate', 'last_login_reward_date');
+        if (lastLoginRewardDate === today) {
+          throw new Error(ERR_ALREADY_CLAIMED);
+        }
 
-    if (lastLoginRewardDate === today) {
-      return res.status(409).json({ error: 'Already claimed today' });
-    }
+        const newStreak = lastLoginDate === yesterday ? loginStreak + 1 : 1;
+        const reward = computeDailyReward(config, newStreak, isSuperShy);
+        const newBalance = shyCoins + reward.coinReward;
 
-    const newStreak = lastLoginDate === yesterday ? loginStreak + 1 : 1;
-    const { coinReward, giftReward, isMilestone } = computeDailyReward(
-      config,
-      newStreak,
-      isSuperShy,
-    );
+        const userUpdates = {
+          loginStreak: newStreak,
+          lastLoginDate: today,
+          lastLoginRewardDate: today,
+        };
+        if (reward.coinReward > 0) userUpdates.shyCoins = newBalance;
+        t.update(userRef, userUpdates);
 
-    const newBalance = shyCoins + coinReward;
+        if (reward.giftReward) {
+          const bpRef = db.doc(`users/${uniqueId}/backpack/${reward.giftReward.giftId}`);
+          const bpSnap = await t.get(bpRef);
+          const currentQty = bpSnap.exists ? bpSnap.data().quantity || 0 : 0;
+          t.set(bpRef, {
+            giftId: reward.giftReward.giftId,
+            quantity: currentQty + reward.giftReward.quantity,
+            lastAcquired: now(),
+          });
+        }
 
-    // Update user doc
-    const userUpdates = {
-      loginStreak: newStreak,
-      lastLoginDate: today,
-      lastLoginRewardDate: today,
-    };
-    if (coinReward > 0) userUpdates.shyCoins = newBalance;
-    await db.doc(`users/${uniqueId}`).update(userUpdates);
-
-    // Add gift to backpack if gift reward
-    if (giftReward) {
-      const bpSnap = await db.doc(`users/${uniqueId}/backpack/${giftReward.giftId}`).get();
-      const currentQty = bpSnap.exists ? bpSnap.data().quantity || 0 : 0;
-      await db.doc(`users/${uniqueId}/backpack/${giftReward.giftId}`).set({
-        giftId: giftReward.giftId,
-        quantity: currentQty + giftReward.quantity,
-        lastAcquired: now(),
+        return {
+          coinReward: reward.coinReward,
+          giftReward: reward.giftReward,
+          isMilestone: reward.isMilestone,
+          newBalance,
+          newStreak,
+        };
       });
+    } catch (txErr) {
+      if (txErr.message === ERR_USER_NOT_FOUND) {
+        return res.status(404).json({ error: ERR_USER_NOT_FOUND });
+      }
+      if (txErr.message === ERR_ALREADY_CLAIMED) {
+        return res.status(409).json({ error: ERR_ALREADY_CLAIMED });
+      }
+      throw txErr;
     }
+
+    const { coinReward, giftReward, isMilestone, newBalance, newStreak } = txResult;
 
     // Transaction record
     const txId = generateId();

--- a/express-api/tests/contracts/api-contracts.test.js
+++ b/express-api/tests/contracts/api-contracts.test.js
@@ -14,6 +14,7 @@ const request = require('supertest');
 const mockDocGet = jest.fn();
 const mockDocUpdate = jest.fn().mockResolvedValue();
 const mockDocSet = jest.fn().mockResolvedValue();
+const mockRunTransaction = jest.fn();
 
 jest.mock('../../src/utils/firebase', () => ({
   db: {
@@ -39,7 +40,7 @@ jest.mock('../../src/utils/firebase', () => ({
       delete: jest.fn(),
       commit: jest.fn().mockResolvedValue(),
     })),
-    runTransaction: jest.fn(),
+    runTransaction: mockRunTransaction,
     getAll: jest.fn().mockResolvedValue([]),
   },
   auth: {
@@ -123,6 +124,20 @@ beforeEach(() => {
   mockDocSet.mockReset();
   mockDocUpdate.mockResolvedValue();
   mockDocSet.mockResolvedValue();
+  // Default tx mock — invokes the callback with a tx whose get/update
+  // route through the existing mockDocGet/mockDocUpdate/mockDocSet,
+  // so existing tests that mock those work unchanged with the new
+  // tx-based daily-reward / purchase / etc. routes (PR #485-#489).
+  mockRunTransaction.mockReset();
+  mockRunTransaction.mockImplementation(async (cb) => {
+    const tx = {
+      get: (ref) => mockDocGet(ref?._path),
+      update: (ref, data) => mockDocUpdate(ref?._path, data),
+      set: (ref, data) => mockDocSet(ref?._path, data),
+      delete: jest.fn(),
+    };
+    return cb(tx);
+  });
   // Reset the economy config cache between tests
   try {
     economyRouter._resetConfigCache();

--- a/express-api/tests/routes/economy-coverage-gifts-rewards.test.js
+++ b/express-api/tests/routes/economy-coverage-gifts-rewards.test.js
@@ -228,6 +228,22 @@ function makeBackpackDoc(quantity = 5) {
 // ═══════════════════════════════════════════════════════════════════
 
 describe('POST /api/economy/daily-reward — gift milestone rewards', () => {
+  // PR #489: daily-reward now wraps user-read + check + writes in
+  // a Firestore transaction. Override the default tx mock (which
+  // returns backpack-shaped {quantity:10}) so tx.get → mockDocGet
+  // and the existing call-count sequencing still works.
+  beforeEach(() => {
+    mockRunTransaction.mockImplementation(async (cb) => {
+      const tx = {
+        get: (ref) => mockDocGet(ref),
+        update: jest.fn(),
+        set: jest.fn(),
+        delete: jest.fn(),
+      };
+      return cb(tx);
+    });
+  });
+
   test('returns gift reward for milestone with type=gift (lines 258-260, 282-290, 307-310)', async () => {
     let callCount = 0;
     mockDocGet.mockImplementation(() => {

--- a/express-api/tests/routes/economy.test.js
+++ b/express-api/tests/routes/economy.test.js
@@ -6,6 +6,7 @@ const request = require('supertest');
 const mockDocGet = jest.fn();
 const mockDocUpdate = jest.fn().mockResolvedValue();
 const mockDocSet = jest.fn().mockResolvedValue();
+const mockRunTransaction = jest.fn();
 
 jest.mock('../../src/utils/firebase', () => ({
   db: {
@@ -34,6 +35,7 @@ jest.mock('../../src/utils/firebase', () => ({
       update: jest.fn(),
       commit: jest.fn().mockResolvedValue(),
     })),
+    runTransaction: mockRunTransaction,
   },
   FieldValue: {
     increment: jest.fn((n) => `increment(${n})`),
@@ -59,6 +61,17 @@ jest.mock('../../src/utils/helpers', () => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // Default tx mock: routes tx.get → mockDocGet so daily-reward
+  // tests work with the existing mockDocGet sequencing (PR #489).
+  mockRunTransaction.mockImplementation(async (cb) => {
+    const tx = {
+      get: (ref) => mockDocGet(ref),
+      update: jest.fn(),
+      set: jest.fn(),
+      delete: jest.fn(),
+    };
+    return cb(tx);
+  });
   // Reset the in-memory economy config cache between tests
   economyRouter._resetConfigCache();
 });


### PR DESCRIPTION
## Audit-driven fix — Phase 2A finding H6 (first High after all 4 critical race fixes)

**Vulnerability:** /economy/daily-reward read user state, checked lastLoginRewardDate, and wrote userUpdates + backpack-merge in separate awaits — no transaction. Two concurrent calls (common on app foreground/background race) both pass the 409 guard and both write — user gets DOUBLE reward for one calendar day.

## Fix
Wrap user-read + already-claimed check + user-update + backpack-merge in db.runTransaction. Pattern matches PRs #485-#488. Sentinel errors caught and mapped to 404/409. Backpack-merge inside the same tx so the quantity increment can't double-up.

## Test infrastructure improvement
- `economy.test.js` (2 tests): added module-level mockRunTransaction with default impl
- `economy-coverage-gifts-rewards.test.js` (5 tests): added beforeEach inside daily-reward describe to override the file-level backpack-shape tx mock
- **`api-contracts.test.js` (6 tests)**: added module-level mockRunTransaction with default impl that routes tx.get/update/set through the existing path-based proxies. **This single change supports ALL future tx-based route refactors** without per-test mock updates.

## Roadmap
PR 5 of 18 audit fixes. C1-C4 (all 4 critical races) ✓, H6 ✓. Remaining: H1 (age calc), H2 (appeal idempotency), H3 (follow validation), H4 (PIN bcrypt DoS), H5 (broadcast Spark burn), H7 (warning revoke atomicity), H8 (backpack-send partial failure), plus M1-M6 + L1+L2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)