### PR TITLE
fix(api): broadcast trim uses count() aggregate (audit H5)

### DIFF
--- a/express-api/src/routes/economy.js
+++ b/express-api/src/routes/economy.js
@@ -99,24 +99,42 @@ async function addBroadcast(data) {
     timestamp: now(),
   });
 
-  // Trim old broadcasts (keep last 50) — query oldest beyond 50
+  // Trim old broadcasts (keep last 50). Pre-fix used
+  // `offset(50).limit(100)` which charges Firestore reads for ALL
+  // 50 SKIPPED documents on every call — at high gift volume this
+  // burns the Spark free-tier 50K-reads/day quota fast (50 reads
+  // per broadcast × 1000 broadcasts/day = 50K reads just from
+  // trim alone).
+  //
+  // New strategy:
+  //   1. count() aggregate → ~1 billable read regardless of size
+  //   2. If count <= 50: skip the trim entirely (no extra cost)
+  //   3. If count > 50: read+delete only the OVERFLOW docs (typically 1)
+  //
+  // Steady-state cost per broadcast: 1 set + 1 count + 1 read + 1
+  // delete = 4 ops, down from 51+. Audit H5 (Phase 2A).
+  const countSnap = await db.collection('broadcasts').count().get();
+  const totalCount = countSnap.data().count;
+  const KEEP_LAST = 50;
+  if (totalCount <= KEEP_LAST) return;
+
+  const overflow = totalCount - KEEP_LAST;
   const oldSnap = await db
     .collection('broadcasts')
-    .orderBy('timestamp', 'desc')
-    .offset(50)
-    .limit(100)
+    .orderBy('timestamp', 'asc')
+    .limit(overflow)
     .get();
-  if (!oldSnap.empty) {
-    // Chunk deletes into batches of 500
-    const docs = oldSnap.docs;
-    for (let i = 0; i < docs.length; i += 500) {
-      const batch = db.batch();
-      const chunk = docs.slice(i, i + 500);
-      for (const doc of chunk) {
-        batch.delete(doc.ref);
-      }
-      await batch.commit();
+  if (oldSnap.empty) return;
+
+  // Chunk deletes into batches of 500 (Firestore batch limit).
+  const docs = oldSnap.docs;
+  for (let i = 0; i < docs.length; i += 500) {
+    const batch = db.batch();
+    const chunk = docs.slice(i, i + 500);
+    for (const doc of chunk) {
+      batch.delete(doc.ref);
     }
+    await batch.commit();
   }
 }
 

--- a/express-api/tests/routes/economy-coverage-core.test.js
+++ b/express-api/tests/routes/economy-coverage-core.test.js
@@ -39,6 +39,10 @@ jest.mock('../../src/utils/firebase', () => ({
     })),
     collection: jest.fn(() => ({
       get: mockCollectionGet,
+      // PR #492: addBroadcast uses count() aggregate (audit H5)
+      count: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue({ data: () => ({ count: 0 }) }),
+      })),
       where: jest.fn(() => ({
         limit: jest.fn(() => ({
           get: mockCollectionGet,
@@ -257,6 +261,9 @@ describe('loadEconomyConfig edge cases', () => {
 
 describe('addBroadcast old broadcast trimming (lines 109-116)', () => {
   test('trims old broadcasts when more than 50 exist', async () => {
+    // PR #492 (audit H5): addBroadcast now uses count() aggregate
+    // + orderBy(asc).limit(overflow) instead of offset(50).limit(100).
+    // Count returns 53 → overflow = 3 → fetch + delete 3 oldest.
     const { db } = require('../../src/utils/firebase');
 
     const oldBroadcastDocs = Array.from({ length: 3 }, (_, i) => ({
@@ -267,6 +274,10 @@ describe('addBroadcast old broadcast trimming (lines 109-116)', () => {
     db.collection.mockImplementation(() => {
       return {
         get: mockCollectionGet,
+        // count() aggregate: simulate 53 broadcasts → 3 overflow
+        count: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue({ data: () => ({ count: 53 }) }),
+        })),
         where: jest.fn(() => ({
           limit: jest.fn(() => ({ get: mockCollectionGet })),
           orderBy: jest.fn(() => ({
@@ -274,16 +285,18 @@ describe('addBroadcast old broadcast trimming (lines 109-116)', () => {
           })),
         })),
         orderBy: jest.fn(() => ({
+          // New trim path: orderBy(asc).limit(overflow) returns oldest
+          limit: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue({
+              empty: false,
+              docs: oldBroadcastDocs,
+            }),
+          })),
+          // Pre-fix path: keep offset() chain for any other callers
           offset: jest.fn(() => ({
             limit: jest.fn(() => ({
-              get: jest.fn().mockResolvedValue({
-                empty: false,
-                docs: oldBroadcastDocs,
-              }),
+              get: jest.fn().mockResolvedValue({ empty: true, docs: [] }),
             })),
-          })),
-          limit: jest.fn(() => ({
-            get: jest.fn().mockResolvedValue({ docs: [] }),
           })),
         })),
       };

--- a/express-api/tests/routes/economy-coverage-gifts-core.test.js
+++ b/express-api/tests/routes/economy-coverage-gifts-core.test.js
@@ -39,6 +39,10 @@ jest.mock('../../src/utils/firebase', () => ({
     })),
     collection: jest.fn(() => ({
       get: mockCollectionGet,
+      // PR #492: addBroadcast uses count() aggregate (audit H5)
+      count: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue({ data: () => ({ count: 0 }) }),
+      })),
       where: jest.fn(() => ({
         limit: jest.fn(() => ({
           get: mockCollectionGet,

--- a/express-api/tests/routes/economy-coverage-gifts-send.test.js
+++ b/express-api/tests/routes/economy-coverage-gifts-send.test.js
@@ -39,6 +39,10 @@ jest.mock('../../src/utils/firebase', () => ({
     })),
     collection: jest.fn(() => ({
       get: mockCollectionGet,
+      // PR #492: addBroadcast uses count() aggregate (audit H5)
+      count: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue({ data: () => ({ count: 0 }) }),
+      })),
       where: jest.fn(() => ({
         limit: jest.fn(() => ({
           get: mockCollectionGet,

--- a/express-api/tests/routes/economy-gifts.test.js
+++ b/express-api/tests/routes/economy-gifts.test.js
@@ -26,6 +26,10 @@ jest.mock('../../src/utils/firebase', () => ({
     })),
     collection: jest.fn(() => ({
       get: mockCollectionGet,
+      // PR #492: addBroadcast uses count() aggregate (audit H5)
+      count: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue({ data: () => ({ count: 0 }) }),
+      })),
       where: jest.fn(() => ({
         orderBy: jest.fn(() => ({
           limit: jest.fn(() => ({


### PR DESCRIPTION
## Audit-driven fix — Phase 2A finding H5 (Spark quota)

**Vulnerability:** `addBroadcast()` used `offset(50).limit(100)` which charges Firestore reads for ALL 50 SKIPPED docs on every call. At ~1000 broadcasts/day, that's 50K reads just from trim ops — eating the entire Spark free-tier daily quota.

**Failure scenario (real):** Heavy gift activity day → many broadcast trim ops → 50+ billable reads per trim → Spark tier exhausts at 50K reads → rest of day, ALL Firestore reads from the API fail. App goes effectively offline.

## Fix
Replace `offset()` with `count()` aggregate + targeted `orderBy(asc).limit(overflow)`:
1. `count()` = ~1 billable read regardless of collection size
2. If count ≤ 50: skip trim entirely
3. If count > 50: read+delete only overflow docs (typically 1)

**Steady-state cost:** 1 set + 1 count + ~1 read + ~1 delete = **4 ops**, down from **51+**. ~12x reduction.

## Tests
- Updated 4 economy test files: added `count()` mock to all `db.collection()` mock chains
- Updated trim-test in `economy-coverage-core.test.js` to use new `orderBy(asc).limit(overflow)` path with simulated count=53 → overflow=3
- Total: 4646 (unchanged; existing tests now exercise the new path)

## Roadmap
PR 8 of 18 audit fixes. C1-C4 ✓, H5 ✓, H6 ✓, H7 ✓, H8 ✓. Remaining 10: H1 (age calc), H2 (appeal idempotency), H3 (follow validation), H4 (PIN bcrypt DoS), M1-M6 + L1+L2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)