### PR TITLE
fix(api): follow target validation + NaN/404 guards (audit H3)

### DIFF
--- a/express-api/src/routes/users.js
+++ b/express-api/src/routes/users.js
@@ -700,19 +700,43 @@ router.post('/users/:uniqueId/lift-suspension', async (req, res) => {
 router.post('/users/:uniqueId/follow', async (req, res) => {
   try {
     const body = req.body;
-    const targetId = body?.targetUserId;
-    if (!targetId) return res.status(400).json({ error: 'targetUserId required' });
+    const rawTargetId = body?.targetUserId;
+    if (!rawTargetId) return res.status(400).json({ error: 'targetUserId required' });
     if (requireOwner(req, res)) return;
-    if (String(req.params.uniqueId) === String(targetId))
-      return res.status(400).json({ error: 'Cannot follow yourself' });
 
-    const uniqueId = req.params.uniqueId;
+    // Strict integer validation. Pre-fix used Number(targetId) which
+    // turns 'evil../path' into NaN and stuffs NaN into followingIds via
+    // arrayUnion(NaN). NaN poisoning corrupts every subsequent array
+    // operation against the field. Audit H3 (Phase 2A).
+    const targetId = Number.parseInt(String(rawTargetId), 10);
+    if (!Number.isInteger(targetId) || targetId <= 0) {
+      return res.status(400).json({ error: 'targetUserId must be a positive integer' });
+    }
+    if (String(targetId) !== String(rawTargetId).trim()) {
+      // Reject inputs like '123abc' that parseInt would silently
+      // truncate to 123 — strict round-trip equality.
+      return res.status(400).json({ error: 'targetUserId must be a positive integer' });
+    }
+
+    const uniqueId = Number(req.params.uniqueId);
+    if (uniqueId === targetId) {
+      return res.status(400).json({ error: 'Cannot follow yourself' });
+    }
+
+    // Verify target user exists. Pre-fix would let the batch write
+    // fail with a Firestore error and return 500; with the validation
+    // here, the API returns the correct 404 contract.
+    const targetSnap = await db.doc(`users/${targetId}`).get();
+    if (!targetSnap.exists) {
+      return res.status(404).json({ error: 'Target user not found' });
+    }
+
     const batch = db.batch();
     batch.update(db.doc(`users/${uniqueId}`), {
-      followingIds: FieldValue.arrayUnion(Number(targetId)),
+      followingIds: FieldValue.arrayUnion(targetId),
     });
     batch.update(db.doc(`users/${targetId}`), {
-      followerIds: FieldValue.arrayUnion(Number(uniqueId)),
+      followerIds: FieldValue.arrayUnion(uniqueId),
     });
     await batch.commit();
     log.info('users', 'User followed', { uniqueId, targetUserId: targetId });

--- a/express-api/tests/routes/identity-core.test.js
+++ b/express-api/tests/routes/identity-core.test.js
@@ -490,6 +490,9 @@ describe('Route parameter migration (:uid → :uniqueId)', () => {
 
   test('POST /api/users/:uniqueId/follow uses uniqueId for ownership check', async () => {
     const app = createApp('firebase-uid-1', 10000005);
+    // PR #494 (audit H3): the route now verifies the target user
+    // exists before writing. Mock target.exists = true.
+    mockDocGet.mockResolvedValue({ exists: true, data: () => ({}) });
 
     await request(app)
       .post('/api/users/10000005/follow')

--- a/express-api/tests/routes/users-missing.test.js
+++ b/express-api/tests/routes/users-missing.test.js
@@ -231,6 +231,57 @@ describe('POST /api/users/:uniqueId/lift-suspension', () => {
   });
 });
 
+// ─── POST /api/users/:uniqueId/follow (PR #494 — audit H3) ──────
+
+describe('POST /api/users/:uniqueId/follow', () => {
+  it('rejects targetUserId with path-traversal style string (NaN guard)', async () => {
+    // Pre-fix: Number('evil../path') = NaN; arrayUnion(NaN) corrupted
+    // followingIds. Strict-integer parse + round-trip equality rejects.
+    const app = createApp('uid-A', 10000001);
+    const res = await request(app)
+      .post('/api/users/10000001/follow')
+      .send({ targetUserId: 'evil../path' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive integer/i);
+  });
+
+  it('rejects targetUserId with mixed alphanumeric (parseInt truncation guard)', async () => {
+    // parseInt('123abc', 10) = 123 — silent truncation. Round-trip
+    // equality on String(parsed) vs String(input) catches this.
+    const app = createApp('uid-A', 10000001);
+    const res = await request(app)
+      .post('/api/users/10000001/follow')
+      .send({ targetUserId: '123abc' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive integer/i);
+  });
+
+  it('rejects negative targetUserId', async () => {
+    // Note: 0 is rejected by the existing falsy check; -1 is truthy
+    // but my integer check should still reject it.
+    const app = createApp('uid-A', 10000001);
+    const res = await request(app).post('/api/users/10000001/follow').send({ targetUserId: -1 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive integer/i);
+  });
+
+  it('returns 404 when target user does not exist', async () => {
+    // Pre-fix: target-doesnt-exist caused a 500 (Firestore batch
+    // update on non-existent doc). Now returns the correct 404.
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+    const app = createApp('uid-A', 10000001);
+    const res = await request(app)
+      .post('/api/users/10000001/follow')
+      .send({ targetUserId: 99999999 });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/target user not found/i);
+  });
+});
+
 // ─── POST /api/users/:uniqueId/unfollow ──────────────────────────
 
 describe('POST /api/users/:uniqueId/unfollow', () => {


### PR DESCRIPTION
## Audit-driven fix — Phase 2A finding H3 (input validation + 500→404)

**Two bugs:**

1. **NaN injection**: pre-fix used `Number(targetId)` which silently converts `'evil../path'` to `NaN`. `arrayUnion(NaN)` writes NaN into followingIds, corrupting every subsequent array operation against the field. `Number('123abc')` = NaN (silent truncation in `parseInt`), another bypass.

2. **500 instead of 404**: target-doesn't-exist caused a Firestore batch error (update on non-existent doc) returning 500. Caller's UI shows generic network error rather than "user not found".

## Fix
- `parseInt` + `Number.isInteger` + `> 0` check for the integer parse
- Round-trip equality on `String(parsed) !== String(input).trim()` to catch silent truncation
- Pre-flight `target.exists` check returns 404 cleanly

## Tests
- 4 new boundary tests in `users-missing.test.js`:
  - path-traversal string rejected (NaN guard)
  - alphanumeric `'123abc'` rejected (parseInt truncation guard)
  - negative target rejected
  - non-existent target → 404 (was 500)
- `identity-core.test.js` happy-path test updated to mock `target.exists`
- Total: 4648 → 4652

## Roadmap
PR 10 of 18. C1-C4 ✓, H1 ✓, H3 ✓, H5 ✓, H6 ✓, H7 ✓, H8 ✓. Remaining 8: H2 (appeal idempotency), H4 (PIN bcrypt DoS), M1-M6 + L1+L2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)