### PR TITLE
fix(api): suspension appeal idempotency (audit H2)

### DIFF
--- a/express-api/src/routes/users.js
+++ b/express-api/src/routes/users.js
@@ -623,6 +623,20 @@ router.post('/users/:uniqueId/appeal', async (req, res) => {
     }
 
     const uniqueId = req.params.uniqueId;
+
+    // Idempotency check: if a pending appeal already exists, reject
+    // with 409. Without this, a user could spam the endpoint, creating
+    // unbounded suspensionAppeals docs (Spark quota burn) and admin
+    // noise. Audit H2 (Phase 2A).
+    const userSnap = await db.doc(`users/${uniqueId}`).get();
+    if (userSnap.exists) {
+      const userData = userSnap.data();
+      const currentStatus = userData.suspensionAppealStatus;
+      if (currentStatus === 'pending') {
+        return res.status(409).json({ error: 'Appeal already pending' });
+      }
+    }
+
     log.info('users', 'Suspension appeal submitted', { uniqueId });
 
     await Promise.all([

--- a/express-api/tests/routes/users-missing.test.js
+++ b/express-api/tests/routes/users-missing.test.js
@@ -122,6 +122,13 @@ describe('POST /api/users/:uniqueId/appeal', () => {
   });
 
   it('returns 200 and creates appeal + updates user on success', async () => {
+    // PR #496 (audit H2): the route now reads the user doc to check
+    // for an existing pending appeal. Mock user.exists with no pending
+    // status so the new check passes through to the create path.
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ suspensionAppealStatus: null }),
+    });
     const app = createApp('uid-A', 10000001);
     const res = await request(app)
       .post('/api/users/10000001/appeal')
@@ -145,6 +152,27 @@ describe('POST /api/users/:uniqueId/appeal', () => {
       'users/10000001',
       expect.objectContaining({ suspensionAppealStatus: 'pending' }),
     );
+  });
+
+  // ── PR #496 (audit H2): idempotency — reject duplicate pending ──
+
+  it('rejects duplicate appeal with 409 when one is already pending', async () => {
+    // Pre-fix: user could spam the endpoint creating unbounded
+    // suspensionAppeals docs. Now the route reads suspensionAppealStatus
+    // and 409s if already pending.
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ suspensionAppealStatus: 'pending' }),
+    });
+    const app = createApp('uid-A', 10000001);
+    const res = await request(app)
+      .post('/api/users/10000001/appeal')
+      .send({ appealText: 'Spam attempt' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/already pending/i);
+    // No new appeal doc should have been created
+    expect(mockDocSet).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Audit-driven fix — Phase 2A finding H2 (LAST High-priority fix)

**Vulnerability:** /users/:uniqueId/appeal had no idempotency check. A suspended user could spam the endpoint creating unbounded `suspensionAppeals` docs (Spark quota burn) and admin noise. Each call wrote a new doc keyed by `generateId()`; the user-doc field `suspensionAppealStatus` was set to 'pending' each time, but no guard prevented duplicate creates.

## Fix
Read `user.suspensionAppealStatus` before writing. If already 'pending', return 409. The existing user-doc-update path remains unchanged for the create-new case.

## Tests
- Existing happy-path test updated to mock `user.exists` with `suspensionAppealStatus: null`
- New regression test: already-pending → 409 with 'already pending' error, `mockDocSet` NOT called (no new doc created)
- Total: 4659 → 4660

## 🎉 Milestone: All Critical + High-Priority Audit Fixes Complete
- C1 ✓ gift-direct race
- C2 ✓ redeem-beans race
- C3 ✓ trial-claim TOCTOU
- C4 ✓ purchase replay race
- H1 ✓ age calc calendar math
- H2 ✓ appeal idempotency (this PR)
- H3 ✓ follow validation + 404
- H4 ✓ PIN bcrypt DoS
- H5 ✓ broadcast Spark quota
- H6 ✓ daily-reward race
- H7 ✓ warning revoke atomicity
- H8 ✓ backpack-send atomicity

## Roadmap
PR 12 of 18. Remaining 6 Medium fixes: M1-M6 + L1+L2 batched. After Phase 2A drain → Phase 2B (Shared KMP audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)