### PR TITLE
fix(api): suggestions search caps collection scan at 500 (audit M1)

### DIFF
--- a/express-api/src/routes/suggestions.js
+++ b/express-api/src/routes/suggestions.js
@@ -154,9 +154,23 @@ router.get('/suggestions/search', async (req, res) => {
     }
 
     const page = parseInt(req.query.page, 10) || 1;
+    // Cap the collection scan at 500 docs. Pre-fix had no .limit() —
+    // every search read the ENTIRE eligible suggestions collection,
+    // burning 1 read per doc. On Spark free tier (50K reads/day) a
+    // 1000-doc collection would exhaust quota in 50 searches. Audit
+    // M1 (Phase 2A).
+    //
+    // Trade-off: at >500 matches we won't find newer-than-newest-500
+    // entries. Order is by Firestore insertion (no orderBy specified
+    // here — uses index order), so this caps practical search to the
+    // most-recently-indexed 500 candidates. Acceptable for v1; a
+    // future PR can add a normalized search index if we cross 500
+    // active suggestions.
+    const SEARCH_SCAN_LIMIT = 500;
     const snap = await db
       .collection('suggestions')
       .where('status', 'in', [...PUBLIC_STATUSES, 'pending'])
+      .limit(SEARCH_SCAN_LIMIT)
       .get();
 
     const query = q.toLowerCase().trim();

--- a/express-api/tests/routes/suggestions-read.test.js
+++ b/express-api/tests/routes/suggestions-read.test.js
@@ -404,6 +404,18 @@ describe('GET /api/suggestions/search — Search', () => {
     expect(res.body.results.length).toBeLessThanOrEqual(3);
     expect(res.body).toHaveProperty('hasMore');
   });
+
+  test('caps the collection scan at 500 docs (audit M1 — Spark quota)', async () => {
+    // PR #497 (audit M1): the search route now applies .limit(500)
+    // before the .get() to bound read-quota burn on Spark free tier.
+    // Without this, every search read the entire eligible collection.
+    mockCollectionGet.mockResolvedValueOnce({ empty: true, docs: [], size: 0 });
+    const app = createApp();
+    await request(app).get('/api/suggestions/search?q=test').expect(200);
+
+    // Verify .limit() was called with the 500 cap before the .get()
+    expect(mockLimit).toHaveBeenCalledWith(500);
+  });
 });
 
 describe('GET /api/suggestions/:id — Get single', () => {


### PR DESCRIPTION
## Audit-driven fix — Phase 2A finding M1 (Spark quota)

**Vulnerability:** `GET /suggestions/search` read the ENTIRE eligible suggestions collection on every search request — no `.limit()`. On Spark free tier (50K reads/day), a 1000-doc collection would exhaust the daily quota in 50 searches.

## Fix
Add `.limit(500)` before `.get()`. Trade-off: at >500 active suggestions the search would only see the most-recently-indexed 500. Acceptable for v1; future normalized search index PR can lift the cap if collection grows past that.

## Tests
- 6 existing search tests pass unchanged
- New regression: asserts `mockLimit` called with 500 — pins down the cap so a future regression that removed `.limit()` surfaces immediately
- Total: 4660 → 4661

## Roadmap
PR 13 of 18. C1-C4 ✓, all H1-H8 ✓, M1 ✓. Remaining 5: M2 (subscriptions cron truncation), M3 (gacha pullCosts key tolerance), M4 (auth fallback Spark quota documentation), M5 (sign-in suspension check), M6 (updateGiftWall race), L1+L2 batched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)