### PR TITLE
fix(api): subscriptions cron warns on truncation (audit M2)

### DIFF
--- a/express-api/src/cron/subscriptions.js
+++ b/express-api/src/cron/subscriptions.js
@@ -8,6 +8,14 @@
 const { db } = require('../utils/firebase');
 const log = require('../utils/log');
 
+// Cap matches Firestore batch limit (500) AND keeps Spark-tier read
+// budget bounded per cron run. If more than CRON_LIMIT subscriptions
+// expire on the same day, the cron loops on subsequent invocations
+// until cleared. This is correct for daily cron cadence: the worst-
+// case lag is 24h × ceil(N / CRON_LIMIT). At 1000 expirations / day
+// = 2-day clear time, well within tolerance.
+const CRON_LIMIT = 500;
+
 async function subscriptions() {
   const timestamp = Date.now();
 
@@ -15,7 +23,7 @@ async function subscriptions() {
     .collection('users')
     .where('isSuperShy', '==', true)
     .where('superShyExpiry', '<=', timestamp)
-    .limit(500)
+    .limit(CRON_LIMIT)
     .get();
 
   if (snapshot.empty) return;
@@ -41,6 +49,24 @@ async function subscriptions() {
     }
 
     await batch.commit();
+  }
+
+  // Truncation warning: when toExpire.length === CRON_LIMIT we may
+  // have missed expirations beyond the limit. Pre-fix the cron silently
+  // ran another day before catching them, leaving 501+ users with
+  // wrongly-active SuperShy status for an extra 24h. Audit M2
+  // (Phase 2A): operator now sees the warning and can investigate.
+  //
+  // Note: we compare against `snapshot.size` (the raw query result)
+  // rather than `toExpire.length` because the lifetime-tier filter is
+  // post-query. If 500 lifetime users expired on the same day, the
+  // query hit the limit but toExpire would be 0 — still worth warning.
+  if (snapshot.size === CRON_LIMIT) {
+    log.warn('cron', 'subscriptions: query hit CRON_LIMIT — possible truncation', {
+      limit: CRON_LIMIT,
+      processed: toExpire.length,
+      lifetimeFiltered: snapshot.size - toExpire.length,
+    });
   }
 
   log.info('cron', 'subscriptions: expired Super Shy subscriptions', { count: toExpire.length });

--- a/express-api/tests/cron/subscriptions.test.js
+++ b/express-api/tests/cron/subscriptions.test.js
@@ -252,4 +252,49 @@ describe('subscriptions cron', () => {
 
     await expect(subscriptions()).resolves.not.toThrow();
   });
+
+  // ── PR #498 (audit M2): truncation warning ──────────────────────
+
+  test('logs warning when query hits CRON_LIMIT (truncation suspected)', async () => {
+    const log = require('../../src/utils/log');
+    // Build 500 expired non-lifetime users to fill CRON_LIMIT exactly
+    const docs = Array.from({ length: 500 }, (_, i) => ({
+      id: `user-${i}`,
+      data: () => ({ isSuperShy: true, superShyExpiry: pastTimestamp(), superShyTier: 'monthly' }),
+    }));
+
+    mockUsersGet.mockResolvedValue({ empty: false, docs, size: 500 });
+
+    await subscriptions();
+
+    // Pre-fix: query hit limit, cron silently ran another day before
+    // catching 501+ users. Now: warn + audit fields visible.
+    expect(log.warn).toHaveBeenCalledWith(
+      'cron',
+      expect.stringMatching(/truncation/i),
+      expect.objectContaining({ limit: 500, processed: 500 }),
+    );
+  });
+
+  test('does NOT log truncation warning when query returns fewer than CRON_LIMIT', async () => {
+    const log = require('../../src/utils/log');
+    mockUsersGet.mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'user-1',
+          data: () => ({
+            isSuperShy: true,
+            superShyExpiry: pastTimestamp(),
+            superShyTier: 'monthly',
+          }),
+        },
+      ],
+      size: 1,
+    });
+
+    await subscriptions();
+
+    expect(log.warn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Audit-driven fix — Phase 2A finding M2

**Issue:** `subscriptions` cron had a hard `.limit(500)` with no warning when hit. If more than 500 subscriptions expired on the same day, the cron silently processed only the first 500 — the remaining 501+ users had wrongly-active SuperShy status for an extra 24h until the next cron run.

## Fix
- Extracted `CRON_LIMIT = 500` as a named constant
- Added `log.warn` when `snapshot.size === CRON_LIMIT` (query saturation indicates truncation)
- Warning includes audit fields (`limit`, `processed`, `lifetimeFiltered`) so operator can see whether 500 = real expirations or 500 lifetime users filtered out

Comparing against `snapshot.size` (raw query) rather than `toExpire.length` catches the case where 500 lifetime users hit the limit but `toExpire` is 0 — still worth warning about query saturation.

## Tests
2 new in `cron/subscriptions.test.js`:
- 500-doc result triggers `log.warn` with audit fields
- <500-doc result does NOT trigger warn

Total: 4661 → 4663.

## Roadmap
PR 14 of 18. Remaining 4: M3, M4, M5, M6 + L1+L2 batched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)