### PR TITLE
fix(api): sign-in checks suspension BEFORE granting claims (audit M5)

### DIFF
--- a/express-api/src/routes/users.js
+++ b/express-api/src/routes/users.js
@@ -223,6 +223,29 @@ router.post('/users/sign-in', async (req, res) => {
 
     const uniqueId = identity.uniqueId;
 
+    // Suspension check BEFORE updating firebaseUid + custom claims.
+    // Audit M5 (Phase 2A): pre-fix signed in suspended users (updated
+    // their UID and granted custom claims) before the auth-middleware
+    // suspension check ran. The suspension cache had a 5-min TTL —
+    // brief window where suspended users could perform writes.
+    //
+    // Now: read the user doc, check isSuspended, return found+suspended
+    // WITHOUT mutating Firebase state. Client surfaces the suspension
+    // to the user; no UID refresh, no custom claim grant.
+    const userSnap = await db.doc(`users/${uniqueId}`).get();
+    if (userSnap.exists) {
+      const userData = userSnap.data();
+      const isSuspended = userData.isSuspended ?? userData.is_suspended ?? false;
+      if (isSuspended) {
+        log.warn('users', 'Sign-in attempt by suspended user', { uniqueId, provider });
+        return res.json({
+          found: true,
+          suspended: true,
+          uniqueId,
+        });
+      }
+    }
+
     // Update firebaseUid to current project's UID + refresh lastSeenAt
     await db.doc(`users/${uniqueId}`).update({
       firebaseUid: req.auth.uid,

--- a/express-api/tests/routes/identity-core.test.js
+++ b/express-api/tests/routes/identity-core.test.js
@@ -411,6 +411,44 @@ describe('POST /api/users/sign-in', () => {
     expect(res.body.uniqueId).toBeUndefined();
   });
 
+  // ── PR #500 (audit M5): suspension check before claims grant ──
+
+  test('returns suspended=true WITHOUT updating firebaseUid or claims', async () => {
+    // Pre-fix: signed in suspended users (updated UID, granted custom
+    // claims) before the auth-middleware suspension check ran. The
+    // suspension cache had a 5-min TTL — brief window for writes.
+    // Now: suspension check happens BEFORE any state mutation.
+    getDoc.mockImplementation((path) => {
+      if (path === 'identityMap/email:suspended@example.com') {
+        return Promise.resolve({
+          uniqueId: 10000050,
+          unlinked: false,
+        });
+      }
+      return Promise.resolve(null);
+    });
+    // User doc returns isSuspended: true
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ isSuspended: true, displayName: 'Suspended User' }),
+    });
+
+    const app = createApp('firebase-uid-new', null);
+    const res = await request(app)
+      .post('/api/users/sign-in')
+      .send({ provider: 'email', identifier: 'suspended@example.com' })
+      .expect(200);
+
+    expect(res.body.found).toBe(true);
+    expect(res.body.suspended).toBe(true);
+    expect(res.body.uniqueId).toBe(10000050);
+
+    // Critical: NO state mutation — no firebaseUid update, no claims
+    // grant. This is the security contract the fix establishes.
+    expect(mockDocUpdate).not.toHaveBeenCalled();
+    expect(mockSetCustomUserClaims).not.toHaveBeenCalled();
+  });
+
   test('returns deactivated flag for unlinked identity', async () => {
     getDoc.mockImplementation((path) => {
       if (path === 'identityMap/email:old@work.com') {


### PR DESCRIPTION
## Audit-driven fix — Phase 2A finding M5 (security gap)

**Vulnerability:** /users/sign-in updated `firebaseUid` and granted Firebase custom claims BEFORE the auth-middleware suspension check ran. The middleware's suspension cache had a 5-min TTL — brief window where suspended users could perform writes that the rules would otherwise reject.

## Fix
Read the user doc upfront, check `isSuspended`, and return `{found: true, suspended: true, uniqueId}` WITHOUT mutating Firebase state. No `firebaseUid` update, no claims grant. The client surfaces the suspension to the user; the existing auth middleware handles write blocking afterward.

## Tests
- 6 existing sign-in tests pass unchanged (default mockDocGet returns `{exists:false}` which makes the new check a no-op for non-suspended paths)
- 1 new regression test: `isSuspended: true` → 200 + body.suspended: true, **mockDocUpdate NOT called, mockSetCustomUserClaims NOT called** — the not-called assertions pin down the security contract

Total: 4665 → 4666.

## 🎯 PR #500 milestone
This is PR #500 in the ShydenMcM/ShyTalk repository. Crossing this threshold while landing 16 of 18 audit-driven fixes is symbolic — the codebase is meaningfully harder to break than it was 24 PRs ago.

## Roadmap
PR 16 of 18. Remaining 2: M6 (updateGiftWall race), L1+L2 batched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)