### PR TITLE
fix(api): defensive auth checks — requireOwner NaN + requireAdmin chain (audit L1+L2)

### DIFF
--- a/express-api/src/middleware/auth.js
+++ b/express-api/src/middleware/auth.js
@@ -169,7 +169,14 @@ async function authMiddlewareStrict(req, res, next) {
  * Returns true if blocked (response already sent), false if admin.
  */
 function requireAdmin(req, res) {
-  if (!req.auth?.token.admin) {
+  // Audit L2 (Phase 2A): defensive optional-chaining all the way
+  // down. Pre-fix used `req.auth?.token.admin` which throws TypeError
+  // if `req.auth` is set but `token` is undefined. In practice the
+  // auth middleware always sets both, but a future refactor that
+  // changes the shape would crash the request rather than fail-closed.
+  // `req.auth?.token?.admin` returns undefined → falls into the 403
+  // branch — fail closed.
+  if (!req.auth?.token?.admin) {
     res.status(403).json({ error: 'Admin access required' });
     return true;
   }

--- a/express-api/src/routes/users.js
+++ b/express-api/src/routes/users.js
@@ -36,7 +36,18 @@ const MAX_IDENTIFIERS_PER_PROVIDER = 5;
 // ─── Helper: ownership check ────────────────────────────────────
 
 function requireOwner(req, res) {
+  // Audit L1 (Phase 2A): explicit NaN guard. Without this, a non-
+  // numeric :uniqueId param produces NaN from Number(), and the
+  // comparison `req.auth.uniqueId !== NaN` is always true (NaN
+  // is unequal to everything including itself), so the route fails
+  // closed (403) — safe but obscure. Returning a clearer 400 makes
+  // a malformed-route-param the visible failure mode rather than
+  // a misleading 'Cannot modify another user'.
   const paramId = Number(req.params.uniqueId);
+  if (!Number.isInteger(paramId)) {
+    res.status(400).json({ error: 'uniqueId must be a positive integer' });
+    return true; // blocked
+  }
   if (req.auth.uniqueId !== paramId) {
     res.status(403).json({ error: 'Cannot modify another user' });
     return true; // blocked

--- a/express-api/tests/middleware/auth.test.js
+++ b/express-api/tests/middleware/auth.test.js
@@ -785,3 +785,54 @@ describe('cache eviction', () => {
     expect(mockCollectionQuery).toHaveBeenCalledTimes(1);
   });
 });
+
+// ─── PR #502 (audit L2): requireAdmin defensive optional chaining ──
+
+describe('requireAdmin defensive checks', () => {
+  test('returns 403 when req.auth is undefined (defensive)', () => {
+    const req = {};
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const blocked = requireAdmin(req, res);
+    expect(blocked).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  test('returns 403 when req.auth.token is undefined (defensive)', () => {
+    // Pre-fix used `req.auth?.token.admin` — would throw TypeError
+    // here. Now `req.auth?.token?.admin` returns undefined → falsy →
+    // 403. Fail closed.
+    const req = { auth: { uid: 'some-uid' /* no token field */ } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const blocked = requireAdmin(req, res);
+    expect(blocked).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  test('returns 403 when admin claim is false', () => {
+    const req = { auth: { uid: 'some-uid', token: { admin: false } } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const blocked = requireAdmin(req, res);
+    expect(blocked).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  test('returns false (allows) when admin claim is true', () => {
+    const req = { auth: { uid: 'admin-uid', token: { admin: true } } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const blocked = requireAdmin(req, res);
+    expect(blocked).toBe(false);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/express-api/tests/routes/users-missing.test.js
+++ b/express-api/tests/routes/users-missing.test.js
@@ -92,6 +92,22 @@ beforeEach(() => {
 // ─── POST /api/users/:uniqueId/appeal ────────────────────────────
 
 describe('POST /api/users/:uniqueId/appeal', () => {
+  // ── PR #502 (audit L1): requireOwner NaN guard ────────────────────
+
+  it('returns 400 when :uniqueId is non-numeric (NaN guard)', async () => {
+    // Pre-fix: Number('not-a-number') → NaN, comparison NaN !== auth
+    // is always true → 403 'Cannot modify another user'. Confusing
+    // error message for a malformed-route-param. Now: explicit 400
+    // before the ownership check.
+    const app = createApp('uid-A', 10000001);
+    const res = await request(app)
+      .post('/api/users/not-a-number/appeal')
+      .send({ appealText: 'test' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive integer/i);
+  });
+
   it('returns 403 when caller does not own the account', async () => {
     // caller is 10000001, trying to appeal on behalf of 10000099
     const app = createApp('uid-A', 10000001);


### PR DESCRIPTION
## Audit-driven fix — Phase 2A findings L1 + L2 batched (FINAL)

Two low-priority defensive-code findings batched into one PR.

### L1: requireOwner NaN-blocks-owner
**Pre-fix:** `Number('not-a-number')` → `NaN`, comparison `NaN !== anything` is always true → 403 'Cannot modify another user'. Fail-closed (safe) but obscure error message for what's actually a malformed-route-param.
**Fix:** explicit `Number.isInteger` check returns 400 with clear 'positive integer' error.

### L2: requireAdmin optional-chain depth
**Pre-fix:** `req.auth?.token.admin` — guards against missing `req.auth` but throws TypeError if `req.auth` is set but `token` is undefined. In practice always set; future refactor that changes the shape would crash the request rather than fail-closed.
**Fix:** `req.auth?.token?.admin` — undefined → falsy → 403. Fail closed all the way down.

## Tests
5 new:
- 1 in `users-missing.test.js`: non-numeric `:uniqueId` → 400 (was 403)
- 4 in `middleware/auth.test.js`: requireAdmin returns 403 for undefined req.auth, undefined req.auth.token, admin: false; and false (allows) for admin: true

Total: 4666 → 4671.

## 🎉 Phase 2A — All 18 audit findings fixed
- **C1-C4** (critical race conditions): gift-direct, redeem-beans, trial-claim, purchase replay
- **H1-H8** (high-priority): age calc, appeal idempotency, follow validation, PIN bcrypt DoS, broadcast Spark quota, daily-reward race, warning revoke atomicity, backpack-send atomicity
- **M1, M2, M3, M5, M6** (medium): suggestions search cap, subscriptions cron warning, gacha pullCosts cleanup, sign-in suspension check, gift-wall increment (M4 was documentation-only)
- **L1, L2** (low — this PR): defensive checks

Total: 18 findings, 18 fix PRs (#485-#502), 34 new regression tests (4637 → 4671).

## Roadmap
PR 18 of 18. Phase 2A drain complete. Master plan transitions to Phase 3 (integration test framework — design already in `.project/plans/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)