### PR TITLE
feat(test): integration test framework foundation (Phase 3 PR A)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "test:web": "playwright test",
+    "test:integration": "playwright test --config=playwright.integration.config.ts",
     "seed:dev": "node scripts/seed-dev-fixtures.mjs",
     "prepare": "husky"
   },

--- a/playwright.integration.config.ts
+++ b/playwright.integration.config.ts
@@ -1,0 +1,63 @@
+import { defineConfig } from "@playwright/test";
+
+/**
+ * Integration test runner configuration.
+ *
+ * Distinct from `playwright.config.ts` (browser/web tests) because:
+ *   - testDir is `tests/integration` not `tests/web`
+ *   - globalSetup probes the local stack, not browser auth
+ *   - no browser binary is required (these tests are HTTP/RTC, no UI)
+ *   - reports go to a separate Allure folder so the dashboards don't
+ *     mix browser test runs with API integration runs
+ *
+ * Per `.project/plans/2026-05-05-integration-test-framework.md`.
+ *
+ * Run with:
+ *   npm run test:integration       # locally, requires `bash local/start.sh` first
+ *   npm run test:integration:ci    # CI wrapper that brings up the stack
+ */
+
+const reporters: any[] = [
+  ["list"],
+  ["html", { outputFolder: "playwright-report-integration" }],
+  ["junit", { outputFile: "playwright-results-integration.xml" }],
+];
+if (process.env.ALLURE_ENABLED === "true") {
+  reporters.push([
+    "allure-playwright",
+    {
+      outputFolder: `allure-results/${process.env.ALLURE_PROJECT || "integration"}`,
+      suiteTitle: true,
+      detail: false,
+    },
+  ]);
+}
+
+export default defineConfig({
+  testDir: "./tests/integration",
+  globalSetup: "./tests/integration/global-setup.ts",
+  // Integration tests must be deterministic — no retries.
+  // A flaky integration test masks a real cross-system regression.
+  retries: 0,
+  // Worker count: 1 to avoid Firebase Emulator + LiveKit Docker
+  // contention. Bump only after confirming the local stack handles
+  // parallelism without races.
+  workers: 1,
+  // 30s default. Per-test override available for cron-trigger tests.
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  reporter: reporters,
+  use: {
+    // Integration tests are API-driven (HTTP, RTC, RTDB). No browser.
+    // Setting browserName to undefined avoids launching a browser binary.
+    baseURL: process.env.API_BASE_URL || "http://localhost:3000",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "integration",
+      // No browserName means no browser is launched — the test runner
+      // executes Node-side code that talks to the local stack via HTTP.
+    },
+  ],
+});

--- a/tests/integration/01-express-firestore-roundtrip.spec.ts
+++ b/tests/integration/01-express-firestore-roundtrip.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Integration test #1 — Express → Firestore round-trip.
+ *
+ * Verifies the local stack's Express API can read from the Firebase
+ * Firestore emulator end-to-end. This is the foundational integration
+ * test — all other integration specs assume this round-trip works.
+ *
+ * Path exercised: client → Caddy gateway (or direct :3000) → Express
+ *   → Firebase Admin SDK → Firestore Emulator → response back to client.
+ *
+ * What this catches that no other test tier covers:
+ *   1. Firebase Admin SDK auth (service-account vs emulator detection)
+ *   2. Firestore emulator config (FIRESTORE_EMULATOR_HOST env var)
+ *   3. Express → Firestore connectivity through the actual stack
+ *      (not the mocked-Firestore Jest tests in `express-api/tests/`)
+ *
+ * Why /api/coin-packages: it's a public endpoint (no auth required) that
+ * does a Firestore .where().orderBy() query. If Express can't talk to
+ * Firestore, this returns 500 or hangs. If the seed data isn't loaded,
+ * it returns an empty array (still a valid round-trip).
+ */
+
+const API_BASE = process.env.API_BASE_URL || "http://localhost:3000";
+
+test.describe("Integration — Express ↔ Firestore", () => {
+  test("GET /api/health responds OK from a real Express instance", async ({ request }) => {
+    const res = await request.get(`${API_BASE}/api/health`);
+    expect(res.ok(), `${res.status()}: ${await res.text()}`).toBe(true);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  test("GET /api/coin-packages does a real Firestore round-trip", async ({ request }) => {
+    // Public endpoint, no auth. Hits Firestore emulator via Express.
+    // A 500 here means Express can't talk to Firestore. An empty
+    // array means Firestore is reachable but no data is seeded —
+    // still a valid round-trip, but the local seed should populate
+    // at least one coin package per local/seed.js.
+    const res = await request.get(`${API_BASE}/api/coin-packages`);
+    expect(res.ok(), `${res.status()}: ${await res.text()}`).toBe(true);
+    const body = await res.json();
+    expect(Array.isArray(body), `body must be array, got ${typeof body}`).toBe(true);
+    // Note: we don't assert length > 0 because the seed is best-effort.
+    // The point of this test is the round-trip works — payload contents
+    // are a separate concern handled by data-shape tests in PR B+.
+  });
+});

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,51 @@
+# Integration Tests
+
+Multi-service integration tests for the ShyTalk Express API + Firebase
+Emulators + LiveKit Docker + MinIO + Mailpit local stack.
+
+## What this tier covers
+
+| Tier | What it tests | What it mocks |
+|---|---|---|
+| **Unit** (`express-api/tests/`, `shared/src/jvmTest/`) | Business logic | All I/O |
+| **Integration** (this dir) | Cross-service contracts (Express ↔ Firestore ↔ RTDB ↔ R2 ↔ LiveKit) | Browser, app UI |
+| **E2E** (`app/src/androidTest/`, `tests/web/*.spec.ts`) | UI contracts via real user actions | Some Firebase fakes |
+| **Smoke** (`tests/web/dev-smoke.spec.ts`) | Real deployed dev infrastructure | Nothing |
+
+The integration tier sits between unit (mocked I/O) and E2E (UI-driven).
+Tests here exercise REAL services: Firebase Admin SDK against the
+emulator, Express API against Firestore/RTDB, R2 PUT/GET via MinIO.
+
+## Running locally
+
+```bash
+# 1. Start the local stack
+bash local/start.sh
+cd express-api && npm run local &
+
+# 2. Run integration tests (from repo root)
+npm run test:integration
+```
+
+The global-setup probes the stack before tests run and fails loud
+with a "run bash local/start.sh first" message if anything is down.
+
+## Running in CI
+
+`.github/workflows/integration-tests.yml` (separate PR) brings up
+the stack via the same composite actions used by `playwright-tests.yml`,
+then runs `npm run test:integration`.
+
+## Adding new tests
+
+1. Create `NN-name.spec.ts` (numbered for order)
+2. Use the helpers in `helpers/` for common assertions/fixtures
+3. Use `fixtures/scenarios.ts` (PR B+) for multi-account flows
+4. Each test must be deterministic — no retries on this tier (per
+   `playwright.integration.config.ts`). A flaky integration test
+   masks a real cross-system regression.
+
+## Reference
+
+Full implementation plan:
+[`.project/plans/2026-05-05-integration-test-framework.md`](../../.project/plans/2026-05-05-integration-test-framework.md)

--- a/tests/integration/global-setup.ts
+++ b/tests/integration/global-setup.ts
@@ -1,0 +1,102 @@
+import type { FullConfig } from "@playwright/test";
+import { request as pwRequest } from "@playwright/test";
+
+/**
+ * Integration test global-setup.
+ *
+ * Probes that the local stack is up and ready before tests run.
+ * The stack is brought up by `bash local/start.sh` (locally) or a
+ * CI-side step that calls the same composite actions used by
+ * `playwright-tests.yml` (Docker + Firebase emulators + Express).
+ *
+ * Strategy:
+ *   - Locally: assume the stack is already up. If any probe fails,
+ *     throw with a clear "run bash local/start.sh first" message.
+ *   - CI: same — but the workflow step ensures the stack is up
+ *     before this setup runs, so probes always succeed.
+ *
+ * We do NOT spin up the stack from inside this setup because:
+ *   1. start.sh has its own polling loops that would race with ours.
+ *   2. A failed start.sh should fail the workflow, not be hidden
+ *      behind a "trying to start" message in setup output.
+ *
+ * Per `.project/plans/2026-05-05-integration-test-framework.md`.
+ */
+
+const PROBE_TIMEOUT_MS = 5_000;
+
+interface ProbeTarget {
+  name: string;
+  url: string;
+  /** Optional check on the response — if it returns a string, that's a failure reason. */
+  check?: (status: number, body: string) => string | null;
+}
+
+const PROBES: ProbeTarget[] = [
+  {
+    name: "Express API",
+    url: "http://localhost:3000/api/health",
+    check: (status, body) => {
+      if (status !== 200) return `expected 200, got ${status}`;
+      try {
+        const json = JSON.parse(body);
+        if (json.ok !== true) return `body.ok must be true, got ${JSON.stringify(json)}`;
+      } catch {
+        return `body must be JSON, got: ${body.slice(0, 200)}`;
+      }
+      return null;
+    },
+  },
+  {
+    name: "Firebase Emulator UI",
+    url: "http://localhost:4000",
+    check: (status) => (status === 200 ? null : `expected 200, got ${status}`),
+  },
+  {
+    name: "MinIO (R2 mock)",
+    url: "http://localhost:9002/minio/health/live",
+    check: (status) => (status === 200 ? null : `expected 200, got ${status}`),
+  },
+];
+
+async function probe(api: ReturnType<typeof pwRequest.newContext> extends Promise<infer T> ? T : never, target: ProbeTarget): Promise<string | null> {
+  try {
+    const res = await api.get(target.url, { timeout: PROBE_TIMEOUT_MS });
+    const body = await res.text();
+    if (target.check) {
+      const err = target.check(res.status(), body);
+      if (err) return `${target.name}: ${err}`;
+    }
+    return null;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return `${target.name}: ${msg}`;
+  }
+}
+
+export default async function globalSetup(_config: FullConfig): Promise<void> {
+  const api = await pwRequest.newContext();
+  try {
+    const results = await Promise.all(PROBES.map((p) => probe(api, p)));
+    const failures = results.filter((r): r is string => r !== null);
+
+    if (failures.length > 0) {
+      const message = [
+        "",
+        "Integration test stack is not ready. Probes that failed:",
+        ...failures.map((f) => `  - ${f}`),
+        "",
+        "If running locally, start the stack with:",
+        "  bash local/start.sh",
+        "  cd express-api && npm run local",
+        "",
+        "If running in CI, the workflow step that brings up the stack",
+        "either failed or hadn't completed before tests started.",
+        "",
+      ].join("\n");
+      throw new Error(message);
+    }
+  } finally {
+    await api.dispose();
+  }
+}


### PR DESCRIPTION
## Phase 3 PR A — Integration test framework foundation

Per `.project/plans/2026-05-05-integration-test-framework.md`. Establishes the multi-service integration test tier between unit tests (mocked I/O) and E2E (UI-driven). Exercises real services: Firebase Admin SDK against the emulator, Express API against Firestore/RTDB, R2 PUT/GET via MinIO.

## Files added
1. **`tests/integration/global-setup.ts`** — probes the local stack (Express + Firebase Emulator UI + MinIO) with 5s/probe timeout. Parallel probe via `Promise.all`. Fails loud with "run bash local/start.sh first" message if anything is down.
2. **`tests/integration/01-express-firestore-roundtrip.spec.ts`** — foundational test. Verifies Express → Firestore Admin SDK → Firestore Emulator round-trip via `/api/health` and `/api/coin-packages` (no auth, public endpoints).
3. **`tests/integration/README.md`** — onboarding doc.
4. **`playwright.integration.config.ts`** — separate config (NOT a project entry in `playwright.config.ts`) to avoid `globalSetup` collision with web tests. `retries: 0` because flaky integration tests mask real cross-system regressions. `workers: 1` to avoid emulator + LiveKit Docker contention.
5. **`package.json`** — added `npm run test:integration` script.

## Design choice: separate config file
Playwright's `globalSetup` is config-level, not project-level. To probe the local stack only when running integration (not when running web tests), the configs must be separate.

## What this PR is NOT
- No CI wiring yet — runs on local stack only. CI workflow comes in PR G.
- No multi-account fixtures — those come in PR B.
- No LiveKit RTC tests — heavy native dep deferred to PR D.
- No FCM capture — comes in PR C.

## Roadmap
PR A of 8 (A-H per the plan). Express test count: 4671 (unchanged). Integration tier adds 2 tests in this PR; runs against local stack only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)