### PR TITLE
feat(test): /api/test/mint-id-token route (Phase 3 PR B)

### DIFF
--- a/express-api/src/routes/test-helpers.js
+++ b/express-api/src/routes/test-helpers.js
@@ -9,7 +9,7 @@
  */
 
 const router = require('express').Router();
-const { db } = require('../utils/firebase');
+const { db, auth } = require('../utils/firebase');
 const { generateId } = require('../utils/helpers');
 const log = require('../utils/log');
 
@@ -421,6 +421,86 @@ router.post('/test/write/:collection', async (req, res) => {
 
     res.json({ success: true, id: docId });
   } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /api/test/mint-id-token
+//
+// Mint a Firebase ID token for a test user, suitable for use as a
+// Bearer Authorization header against the auth-protected Express
+// routes. Used by the integration test framework
+// (Phase 3, PR C) to authenticate as multi-account scenarios
+// (sender, recipient, admin) without going through the real
+// Firebase Auth REST flow.
+//
+// Flow:
+//   1. Caller provides a Firebase UID (already created via
+//      /test/setup or /test/create-user).
+//   2. Server uses Firebase Admin to mint a *custom token* for that
+//      UID.
+//   3. Custom token is exchanged for a regular ID token via the
+//      Auth Emulator's signInWithCustomToken REST endpoint.
+//
+// Step 3 happens server-side rather than in the test runner because
+// the emulator host is reachable from inside the local stack
+// (`http://localhost:9099` from Express). This avoids exposing the
+// emulator host config to test code.
+//
+// Production safety: this route is gated by NODE_ENV !== 'production'
+// AND by TEST_API_KEY. Even if NODE_ENV was misconfigured, the
+// TEST_API_KEY check fails-closed.
+router.post('/test/mint-id-token', async (req, res) => {
+  try {
+    if (process.env.NODE_ENV === 'production') {
+      return res.status(403).json({ error: 'Not available in production' });
+    }
+    if (requireTestApiKey(req, res)) return;
+
+    const { uid } = req.body || {};
+    if (!uid || typeof uid !== 'string') {
+      return res.status(400).json({ error: 'uid (string) required' });
+    }
+
+    // Step 1: mint custom token via Admin SDK
+    const customToken = await auth.createCustomToken(uid);
+
+    // Step 2: exchange for ID token via Auth Emulator REST.
+    // FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099' in local mode.
+    // FIREBASE_WEB_API_KEY can be any non-empty string in emulator
+    // mode — the emulator doesn't validate it.
+    const emulatorHost = process.env.FIREBASE_AUTH_EMULATOR_HOST || 'localhost:9099';
+    const apiKey = process.env.FIREBASE_WEB_API_KEY || 'fake-api-key';
+    const exchangeUrl = `http://${emulatorHost}/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${apiKey}`;
+
+    const resp = await fetch(exchangeUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: customToken, returnSecureToken: true }),
+    });
+    if (!resp.ok) {
+      const errBody = await resp.text();
+      log.error('test-helpers', 'mint-id-token exchange failed', {
+        status: resp.status,
+        body: errBody.slice(0, 500),
+      });
+      return res.status(502).json({
+        error: 'Failed to exchange custom token for ID token',
+        details: `${resp.status}: ${errBody.slice(0, 200)}`,
+      });
+    }
+    const exchangeBody = await resp.json();
+    const idToken = exchangeBody.idToken;
+    if (!idToken) {
+      return res.status(502).json({
+        error: 'Auth Emulator did not return idToken',
+        details: JSON.stringify(exchangeBody).slice(0, 200),
+      });
+    }
+
+    res.json({ idToken });
+  } catch (err) {
+    log.error('test-helpers', 'mint-id-token failed', { error: err.message });
     res.status(500).json({ error: err.message });
   }
 });

--- a/express-api/tests/routes/test-helpers-mint-id-token.test.js
+++ b/express-api/tests/routes/test-helpers-mint-id-token.test.js
@@ -1,0 +1,222 @@
+/**
+ * Tests for POST /api/test/mint-id-token (Phase 3 PR B).
+ *
+ * Verifies the route correctly:
+ *   - Gates on production (403)
+ *   - Gates on TEST_API_KEY (403)
+ *   - Validates uid (400)
+ *   - Mints a custom token via Admin SDK
+ *   - Exchanges custom token for ID token via Auth Emulator REST
+ *   - Returns the ID token to the caller
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// ─── Firebase mock ───────────────────────────────────────────────
+
+const mockCreateCustomToken = jest.fn();
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    doc: jest.fn(),
+    collection: jest.fn(),
+    batch: jest.fn(),
+    runTransaction: jest.fn(),
+  },
+  auth: {
+    createCustomToken: (...args) => mockCreateCustomToken(...args),
+  },
+}));
+
+jest.mock('../../src/utils/helpers', () => ({
+  generateId: jest.fn(() => 'gen-id'),
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+// ─── App setup ───────────────────────────────────────────────────
+
+const testHelpersRouter = require('../../src/routes/test-helpers');
+
+const VALID_API_KEY = 'test-secret-key-123';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', testHelpersRouter);
+  return app;
+}
+
+// Stub global fetch (Node 18+ has native fetch). Each test overrides
+// per-call as needed.
+let mockFetchResponse;
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCreateCustomToken.mockReset();
+  process.env.TEST_API_KEY = VALID_API_KEY;
+  delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+  delete process.env.FIREBASE_WEB_API_KEY;
+  // Default fetch returns 200 with idToken
+  mockFetchResponse = {
+    ok: true,
+    status: 200,
+    json: jest.fn().mockResolvedValue({ idToken: 'test-id-token-abc' }),
+    text: jest.fn().mockResolvedValue(''),
+  };
+  global.fetch = jest.fn().mockImplementation(() => Promise.resolve(mockFetchResponse));
+});
+
+afterEach(() => {
+  delete global.fetch;
+});
+
+// ─── Tests ────────────────────────────────────────────────────────
+
+describe('POST /api/test/mint-id-token', () => {
+  test('returns 403 when NODE_ENV=production', async () => {
+    const prevEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      const app = createApp();
+      const res = await request(app)
+        .post('/api/test/mint-id-token')
+        .set('x-test-api-key', VALID_API_KEY)
+        .send({ uid: 'test-uid' });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toMatch(/Not available in production/i);
+      expect(mockCreateCustomToken).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = prevEnv;
+    }
+  });
+
+  test('returns 403 when TEST_API_KEY missing on server', async () => {
+    delete process.env.TEST_API_KEY;
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/test/mint-id-token')
+      .set('x-test-api-key', 'any')
+      .send({ uid: 'test-uid' });
+
+    // requireTestApiKey returns 500 if env var unset; 403 if mismatch
+    expect([403, 500]).toContain(res.status);
+  });
+
+  test('returns 403 when X-Test-API-Key header is wrong', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/test/mint-id-token')
+      .set('x-test-api-key', 'wrong-key')
+      .send({ uid: 'test-uid' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/Invalid test API key/i);
+  });
+
+  test('returns 400 when uid is missing', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/test/mint-id-token')
+      .set('x-test-api-key', VALID_API_KEY)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/uid.*required/i);
+  });
+
+  test('returns 400 when uid is not a string', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/test/mint-id-token')
+      .set('x-test-api-key', VALID_API_KEY)
+      .send({ uid: 12345 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/uid.*string/i);
+  });
+
+  test('returns 200 with idToken on happy path', async () => {
+    mockCreateCustomToken.mockResolvedValue('mock-custom-token');
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/test/mint-id-token')
+      .set('x-test-api-key', VALID_API_KEY)
+      .send({ uid: 'test-uid-happy' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.idToken).toBe('test-id-token-abc');
+    expect(mockCreateCustomToken).toHaveBeenCalledWith('test-uid-happy');
+    // Verify fetch was called with the emulator REST URL
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('localhost:9099'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  test('uses FIREBASE_AUTH_EMULATOR_HOST env override when set', async () => {
+    process.env.FIREBASE_AUTH_EMULATOR_HOST = 'custom-host:9999';
+    mockCreateCustomToken.mockResolvedValue('mock-custom-token');
+
+    const app = createApp();
+    await request(app)
+      .post('/api/test/mint-id-token')
+      .set('x-test-api-key', VALID_API_KEY)
+      .send({ uid: 'test-uid' });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('custom-host:9999'),
+      expect.any(Object),
+    );
+  });
+
+  test('returns 502 when emulator REST exchange fails', async () => {
+    mockCreateCustomToken.mockResolvedValue('mock-custom-token');
+    mockFetchResponse.ok = false;
+    mockFetchResponse.status = 400;
+    mockFetchResponse.text = jest.fn().mockResolvedValue('INVALID_CUSTOM_TOKEN');
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/test/mint-id-token')
+      .set('x-test-api-key', VALID_API_KEY)
+      .send({ uid: 'test-uid' });
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toMatch(/Failed to exchange/i);
+    expect(res.body.details).toMatch(/INVALID_CUSTOM_TOKEN/);
+  });
+
+  test('returns 502 when emulator returns no idToken', async () => {
+    mockCreateCustomToken.mockResolvedValue('mock-custom-token');
+    mockFetchResponse.json = jest.fn().mockResolvedValue({}); // missing idToken
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/test/mint-id-token')
+      .set('x-test-api-key', VALID_API_KEY)
+      .send({ uid: 'test-uid' });
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toMatch(/did not return idToken/i);
+  });
+
+  test('returns 500 when createCustomToken throws', async () => {
+    mockCreateCustomToken.mockRejectedValue(new Error('Admin SDK down'));
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/test/mint-id-token')
+      .set('x-test-api-key', VALID_API_KEY)
+      .send({ uid: 'test-uid' });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatch(/Admin SDK down/);
+  });
+});


### PR DESCRIPTION
## Phase 3 PR B — Test-helper route for ID token minting

Adds the test-helper route that mints Firebase ID tokens for test users. Used by the integration test framework (Phase 3, PR C+) to authenticate as multi-account scenarios (sender, recipient, admin) without going through the real Firebase Auth REST flow.

## Flow
1. Caller provides a Firebase UID (already created via `/test/setup` or `/test/create-user`)
2. Server uses Firebase Admin to mint a *custom token* for that UID
3. Custom token is exchanged for a regular ID token via the Auth Emulator's `signInWithCustomToken` REST endpoint

Step 3 happens server-side rather than in the test runner because the emulator host is reachable from inside the local stack. This avoids exposing emulator host config to test code.

## Production safety
Route is gated by `NODE_ENV !== 'production'` AND `TEST_API_KEY`. Even if `NODE_ENV` was misconfigured, the API-key check fails-closed.

## Tests
10 new in `test-helpers-mint-id-token.test.js`:
- production guard (403)
- API key missing/wrong (403)
- uid missing/non-string (400)
- happy path → 200 with idToken, fetch called with emulator URL
- `FIREBASE_AUTH_EMULATOR_HOST` override respected
- exchange-fail → 502
- no-idToken-returned → 502
- `createCustomToken` throws → 500

Total: 4671 → 4681.

## Roadmap
PR B of 8 (A-H per plan). PR C will add `tests/integration/fixtures/scenarios.ts` that uses this route, plus the first integration test that authenticates against `/api/livekit/token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)