### PR TITLE
feat(test): integration scenarios fixture + first authenticated test (Phase 3 PR C)

### DIFF
--- a/tests/integration/01-express-firestore-roundtrip.spec.ts
+++ b/tests/integration/01-express-firestore-roundtrip.spec.ts
@@ -16,34 +16,50 @@ import { test, expect } from "@playwright/test";
  *   3. Express → Firestore connectivity through the actual stack
  *      (not the mocked-Firestore Jest tests in `express-api/tests/`)
  *
- * Why /api/coin-packages: it's a public endpoint (no auth required) that
- * does a Firestore .where().orderBy() query. If Express can't talk to
- * Firestore, this returns 500 or hangs. If the seed data isn't loaded,
- * it returns an empty array (still a valid round-trip).
+ * Why /api/config/startingScreens: it's an explicitly auth-exempt
+ * endpoint (see express-api/src/index.js — `req.path === '/config/startingScreens'`
+ * in the unauthenticated allow-list) that performs a Firestore
+ * `db.doc('config/startingScreens').get()` read. If Express can't
+ * talk to Firestore, this returns 500. If the doc doesn't exist
+ * the route returns `{}` — still a valid round-trip. We previously
+ * tested /api/coin-packages, but that endpoint requires auth, which
+ * makes it inappropriate for a foundation/no-fixture test.
  */
 
 const API_BASE = process.env.API_BASE_URL || "http://localhost:3000";
 
 test.describe("Integration — Express ↔ Firestore", () => {
-  test("GET /api/health responds OK from a real Express instance", async ({ request }) => {
+  test("GET /api/health responds OK from a real Express instance", async ({
+    request,
+  }) => {
     const res = await request.get(`${API_BASE}/api/health`);
     expect(res.ok(), `${res.status()}: ${await res.text()}`).toBe(true);
     const body = await res.json();
-    expect(body.ok).toBe(true);
+    // health.js returns `{status: 'ok', timestamp, subsystems}` — see
+    // express-api/src/routes/health.js. There is no `ok` field.
+    expect(body.status).toBe("ok");
   });
 
-  test("GET /api/coin-packages does a real Firestore round-trip", async ({ request }) => {
-    // Public endpoint, no auth. Hits Firestore emulator via Express.
-    // A 500 here means Express can't talk to Firestore. An empty
-    // array means Firestore is reachable but no data is seeded —
-    // still a valid round-trip, but the local seed should populate
-    // at least one coin package per local/seed.js.
-    const res = await request.get(`${API_BASE}/api/coin-packages`);
+  test("GET /api/config/startingScreens does a real Firestore round-trip", async ({
+    request,
+  }) => {
+    // Public endpoint (allow-listed in src/index.js), so no fixture
+    // setup needed. Express performs `db.doc('config/startingScreens').get()`
+    // — a real Firestore round-trip. A 500 here means Express can't
+    // talk to Firestore. An empty `{}` means the doc doesn't exist
+    // but the round-trip succeeded, which is also valid for this tier.
+    const res = await request.get(`${API_BASE}/api/config/startingScreens`);
     expect(res.ok(), `${res.status()}: ${await res.text()}`).toBe(true);
     const body = await res.json();
-    expect(Array.isArray(body), `body must be array, got ${typeof body}`).toBe(true);
-    // Note: we don't assert length > 0 because the seed is best-effort.
-    // The point of this test is the round-trip works — payload contents
-    // are a separate concern handled by data-shape tests in PR B+.
+    // Body is an object (possibly empty if no config doc exists). We
+    // assert shape rather than contents — content tests belong to the
+    // route's unit tests, not the integration tier.
+    expect(typeof body, `body must be object, got ${typeof body}`).toBe(
+      "object",
+    );
+    expect(body, "body must not be null").not.toBeNull();
+    expect(Array.isArray(body), "body must be plain object, not array").toBe(
+      false,
+    );
   });
 });

--- a/tests/integration/02-livekit-token-issuance.spec.ts
+++ b/tests/integration/02-livekit-token-issuance.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from "./fixtures/scenarios";
+
+/**
+ * Integration test #2 — LiveKit token issuance for an authenticated user.
+ *
+ * Verifies the full Bearer-token → auth-middleware → uniqueId-resolution
+ * → LiveKit JWT signing chain works end-to-end against the real local
+ * stack. This is the FIRST authenticated integration test and exercises:
+ *
+ *   1. /api/test/setup creates a real user doc in the Firestore emulator
+ *   2. /api/test/mint-id-token mints a custom token via Admin SDK and
+ *      exchanges it via the Auth emulator REST API for an ID token
+ *   3. authMiddleware.verifyIdToken accepts the ID token (real Firebase
+ *      Auth emulator path)
+ *   4. resolveUniqueId queries `users` for `firebaseUid == decoded.uid`
+ *      and returns the real uniqueId
+ *   5. /api/livekit/token signs a JWT with that uniqueId as `sub`
+ *
+ * What this catches that no unit test can:
+ *   - Auth emulator returning ID tokens that the Admin SDK actually
+ *     accepts (cross-process emulator wiring)
+ *   - `resolveUniqueId` matching the user doc by `firebaseUid` field
+ *   - LIVEKIT_API_KEY / LIVEKIT_API_SECRET env vars actually loaded
+ *     into the running Express process (not just the .env file)
+ *   - The JWT shape that the Android/iOS clients depend on
+ *
+ * Per `.project/plans/2026-05-05-integration-test-framework.md` test #2.
+ * Per memory `feedback-quality-bar-universal.md` — covers golden path
+ * AND failure paths that exist at this tier (401 missing-token, 400
+ * missing-roomName both verify the auth + validation chain in one go).
+ */
+
+const API_BASE = process.env.API_BASE_URL || "http://localhost:3000";
+
+/**
+ * Decode the payload of a JWT (3-part dot-separated string) without
+ * verifying the signature. Signature verification belongs to the
+ * downstream LiveKit server; integration tier verifies the chain
+ * produced a structurally valid token with the correct claims.
+ */
+function decodeJwtPayload(jwt: string): Record<string, unknown> {
+  const parts = jwt.split(".");
+  if (parts.length !== 3) {
+    throw new Error(
+      `Expected 3-part JWT, got ${parts.length} parts: ${jwt.slice(0, 80)}…`,
+    );
+  }
+  const payloadB64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+  const padded = payloadB64 + "=".repeat((4 - (payloadB64.length % 4)) % 4);
+  const json = Buffer.from(padded, "base64").toString("utf-8");
+  return JSON.parse(json);
+}
+
+test.describe("Integration — LiveKit token issuance", () => {
+  test("POST /api/livekit/token returns a signed JWT for an authenticated user", async ({
+    api,
+    sender,
+  }) => {
+    const roomName = `int-test-room-${Date.now()}`;
+
+    const res = await api.post(`${API_BASE}/api/livekit/token`, {
+      headers: {
+        Authorization: `Bearer ${sender.idToken}`,
+        "Content-Type": "application/json",
+      },
+      data: { roomName },
+    });
+
+    expect(res.ok(), `${res.status()}: ${await res.text()}`).toBe(true);
+    const body = await res.json();
+    expect(typeof body.token, "response.token must be a string").toBe("string");
+
+    // Validate the JWT shape and content. The integration-tier guarantee
+    // is that the token was minted by THIS Express against THIS user —
+    // so `sub` must equal the user's uniqueId (number-as-string per
+    // livekit.js:20) and `video.room` must equal the requested room.
+    const payload = decodeJwtPayload(body.token);
+    expect(payload.sub, "JWT.sub must be the user's uniqueId").toBe(
+      String(sender.uniqueId),
+    );
+    expect((payload as { video: { room: string } }).video.room).toBe(roomName);
+    expect((payload as { video: { roomJoin: boolean } }).video.roomJoin).toBe(
+      true,
+    );
+    expect(
+      (payload as { video: { canPublish: boolean } }).video.canPublish,
+    ).toBe(true);
+    expect(
+      (payload as { video: { canSubscribe: boolean } }).video.canSubscribe,
+    ).toBe(true);
+    // 24h TTL per livekit.js:39 — exp is unix-seconds, so within (now, now+25h)
+    const nowSec = Math.floor(Date.now() / 1000);
+    expect(payload.exp).toBeGreaterThan(nowSec);
+    expect(payload.exp).toBeLessThan(nowSec + 25 * 3600);
+  });
+
+  test("POST /api/livekit/token returns 401 when Authorization header missing", async ({
+    api,
+  }) => {
+    // Negative path is integration-tier-relevant because the auth
+    // middleware lives BETWEEN the gateway (Caddy → Express) and the
+    // route handler. Unit tests can mock authMiddleware away; only
+    // integration proves the real middleware actually rejects the
+    // unauthenticated request before /api/livekit/token sees it.
+    const res = await api.post(`${API_BASE}/api/livekit/token`, {
+      headers: { "Content-Type": "application/json" },
+      data: { roomName: "no-auth" },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test("POST /api/livekit/token returns 400 when roomName missing", async ({
+    api,
+    sender,
+  }) => {
+    const res = await api.post(`${API_BASE}/api/livekit/token`, {
+      headers: {
+        Authorization: `Bearer ${sender.idToken}`,
+        "Content-Type": "application/json",
+      },
+      data: {},
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/roomName/i);
+  });
+});

--- a/tests/integration/fixtures/scenarios.ts
+++ b/tests/integration/fixtures/scenarios.ts
@@ -1,0 +1,169 @@
+import {
+  test as base,
+  request as pwRequest,
+  type APIRequestContext,
+} from "@playwright/test";
+
+/**
+ * Multi-account scenario fixtures for integration tests.
+ *
+ * Uses the local stack's `/api/test/setup` to create scoped test
+ * users and `/api/test/mint-id-token` to mint Firebase ID tokens
+ * usable as Bearer Authorization headers against the auth-protected
+ * Express routes.
+ *
+ * Per `.project/plans/2026-05-05-integration-test-framework.md`.
+ *
+ * Usage:
+ *   import { test, expect } from "./fixtures/scenarios";
+ *
+ *   test("my flow", async ({ api, sender }) => {
+ *     const res = await api.post(`${API_BASE}/api/some-endpoint`, {
+ *       headers: { Authorization: `Bearer ${sender.idToken}` },
+ *     });
+ *     expect(res.ok()).toBe(true);
+ *   });
+ *
+ * Currently exposes a single `sender` fixture. A multi-account
+ * `recipient` fixture (paired with sender via a shared testRunId)
+ * will be added when the first cross-account test is written —
+ * shipping it ahead of a real consumer would let an unverified
+ * lifecycle leak into green CI.
+ */
+
+const API_BASE = process.env.API_BASE_URL || "http://localhost:3000";
+const TEST_API_KEY = process.env.TEST_API_KEY || "local-test-key";
+
+export interface IntegrationUser {
+  /** Server-assigned numeric user ID. */
+  uniqueId: number;
+  /** Firebase UID for this user. */
+  uid: string;
+  /** Display name (used by routes that read user.displayName). */
+  displayName: string;
+  /** Long-lived Firebase ID token, suitable as Bearer token. */
+  idToken: string;
+}
+
+export interface IntegrationFixtures {
+  /** A request context shared across the test — disposed in fixture teardown. */
+  api: APIRequestContext;
+  /** A regular (non-admin) test user. Created on first access. */
+  sender: IntegrationUser;
+}
+
+/**
+ * Provision a new test user via /api/test/setup, then mint an ID
+ * token for it. Returns the full user record AND the testRunId so
+ * the caller can teardown the scenario.
+ */
+async function provisionUser(
+  api: APIRequestContext,
+  name: string,
+): Promise<{ testRunId: string; user: IntegrationUser }> {
+  const setupRes = await api.post(`${API_BASE}/api/test/setup`, {
+    headers: { "X-Test-API-Key": TEST_API_KEY },
+    data: {
+      users: [{ name, shyCoins: 1000, shyBeans: 0 }],
+    },
+  });
+  if (!setupRes.ok()) {
+    throw new Error(
+      `provisionUser /test/setup failed: ${setupRes.status()}: ${await setupRes.text()}. ` +
+        `Verify TEST_API_KEY is set on Express and matches.`,
+    );
+  }
+  const setupBody = await setupRes.json();
+  const testRunId: string = setupBody.testRunId;
+  const userRecord = setupBody.users?.[0];
+  // `uniqueId === 0` would be a bug, not a missing field — guard on
+  // type rather than truthiness so a future server-side change that
+  // ever yielded 0 surfaces as a clear shape error.
+  if (
+    !userRecord ||
+    typeof userRecord.uid !== "string" ||
+    typeof userRecord.uniqueId !== "number"
+  ) {
+    throw new Error(
+      `provisionUser: /test/setup returned unexpected shape: ${JSON.stringify(setupBody)}`,
+    );
+  }
+
+  const mintRes = await api.post(`${API_BASE}/api/test/mint-id-token`, {
+    headers: { "X-Test-API-Key": TEST_API_KEY },
+    data: { uid: userRecord.uid },
+  });
+  if (!mintRes.ok()) {
+    throw new Error(
+      `provisionUser /test/mint-id-token failed: ${mintRes.status()}: ${await mintRes.text()}`,
+    );
+  }
+  const { idToken } = await mintRes.json();
+  if (!idToken) {
+    throw new Error("provisionUser: /test/mint-id-token returned no idToken");
+  }
+
+  return {
+    testRunId,
+    user: {
+      uniqueId: userRecord.uniqueId,
+      uid: userRecord.uid,
+      displayName: userRecord.displayName || name,
+      idToken,
+    },
+  };
+}
+
+/**
+ * Tear down the test scenario by deleting all data tagged with the
+ * given testRunId. Best-effort: failures are logged but don't fail
+ * the test. We DO inspect the HTTP status — `api.post` only rejects
+ * on network failure, not 4xx/5xx, and a silently-failed teardown
+ * leaves emulator state for subsequent runs (which retries=0
+ * cannot tolerate without restarting the stack).
+ */
+async function teardown(
+  api: APIRequestContext,
+  testRunId: string,
+): Promise<void> {
+  try {
+    const res = await api.post(`${API_BASE}/api/test/teardown`, {
+      headers: { "X-Test-API-Key": TEST_API_KEY },
+      data: { testRunId },
+    });
+    if (!res.ok()) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `scenarios.teardown: /api/test/teardown returned ${res.status()}: ${await res
+          .text()
+          .catch(() => "<no body>")}. testRunId=${testRunId}`,
+      );
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `scenarios.teardown: ${(err as Error).message}. testRunId=${testRunId}`,
+    );
+  }
+}
+
+export const test = base.extend<IntegrationFixtures>({
+  api: async ({}, use) => {
+    const ctx = await pwRequest.newContext();
+    try {
+      await use(ctx);
+    } finally {
+      await ctx.dispose();
+    }
+  },
+  sender: async ({ api }, use) => {
+    const { testRunId, user } = await provisionUser(api, "sender");
+    try {
+      await use(user);
+    } finally {
+      await teardown(api, testRunId);
+    }
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/tests/integration/global-setup.ts
+++ b/tests/integration/global-setup.ts
@@ -40,7 +40,10 @@ const PROBES: ProbeTarget[] = [
       if (status !== 200) return `expected 200, got ${status}`;
       try {
         const json = JSON.parse(body);
-        if (json.ok !== true) return `body.ok must be true, got ${JSON.stringify(json)}`;
+        // health.js returns `{status: 'ok', timestamp, subsystems}` — see
+        // express-api/src/routes/health.js. The "ok" field does NOT exist.
+        if (json.status !== "ok")
+          return `body.status must be "ok", got ${JSON.stringify(json)}`;
       } catch {
         return `body must be JSON, got: ${body.slice(0, 200)}`;
       }
@@ -59,7 +62,12 @@ const PROBES: ProbeTarget[] = [
   },
 ];
 
-async function probe(api: ReturnType<typeof pwRequest.newContext> extends Promise<infer T> ? T : never, target: ProbeTarget): Promise<string | null> {
+async function probe(
+  api: ReturnType<typeof pwRequest.newContext> extends Promise<infer T>
+    ? T
+    : never,
+  target: ProbeTarget,
+): Promise<string | null> {
   try {
     const res = await api.get(target.url, { timeout: PROBE_TIMEOUT_MS });
     const body = await res.text();


### PR DESCRIPTION
## Summary
- Adds `tests/integration/fixtures/scenarios.ts` exposing `api` + `sender` fixtures (multi-account fixture composed via `/api/test/setup` + `/api/test/mint-id-token`).
- Adds `tests/integration/02-livekit-token-issuance.spec.ts` — first authenticated integration test, covering 200 (JWT claims verified), 401 (no auth), and 400 (missing roomName).
- Fixes two foundation bugs surfaced during local verification:
  - `global-setup.ts` health probe checked `body.ok` but the route returns `{status: 'ok', ...}`.
  - `01-express-firestore-roundtrip.spec.ts` used `/api/coin-packages` (now auth-required) — switched to `/api/config/startingScreens` (allow-listed).

## Why this matters
This is the first integration test that exercises the full `Bearer token → verifyIdToken → loadUserProfile → grant` chain against the real Firebase Auth Emulator + Firestore Emulator. Unit tests mock `verifyIdToken`; only this tier proves the cross-process emulator wiring (Auth Emulator REST exchange + Admin SDK acceptance) actually works.

## Reviewer fixes applied before push
- Removed orphan `testRunId` fixture that would have leaked separate testRunIds when composed with `sender` — will re-add when a real multi-account test needs it.
- `sender` teardown wrapped in try/finally so a thrown assertion cannot abandon the test user in the emulator.
- `teardown` now inspects `res.ok()` and warns on non-2xx (was previously silent on HTTP errors).
- `provisionUser` shape guard uses `typeof === 'number'` instead of truthiness so a future `uniqueId === 0` regression would surface clearly.

## Test plan
- [x] `bash local/start.sh` + `npx playwright test --config=playwright.integration.config.ts` — 5/5 pass locally
- [x] Determinism: two consecutive runs both pass (~600ms warm)
- [x] Prettier clean
- [x] No regression on existing integration tests (`01-express-firestore-roundtrip` re-pointed to a public endpoint that still round-trips through Firestore)

Per `.project/plans/2026-05-05-integration-test-framework.md` test #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)