### PR TITLE
feat(test): gift-direct state-cascade integration test (Phase 3 PR E)

### DIFF
--- a/tests/integration/04-gift-direct-cascade.spec.ts
+++ b/tests/integration/04-gift-direct-cascade.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect } from "./fixtures/scenarios";
+
+/**
+ * Integration test #6 — Gift-direct state cascade.
+ *
+ * Verifies the full sender→recipient gift flow exercises all the
+ * side effects that PR #485 (audit C1) made race-safe:
+ *
+ *   1. POST /api/economy/gift-direct with valid sender + recipient + gift
+ *   2. Sender's `shyCoins` decremented by `gift.coinValue * quantity`
+ *      (transactional — verified pre/post via /api/economy/balance)
+ *   3. Recipient's `shyBeans` incremented by `floor(coinValue *
+ *      beanConversionRate * quantity)` — at default config
+ *      (rate=0.6, qty=1, coinValue=100) that's 60 beans.
+ *   4. The route returns the actual `beanReward` and `coinsSpent`
+ *      values that were applied — not just success — so a future
+ *      regression that double-counted would be caught
+ *
+ * What this catches that no unit test can:
+ *   - The transaction in economy.js:951 actually commits to Firestore
+ *     (mocks let the test pass even when the transaction throws
+ *     mid-commit; emulator does not).
+ *   - The /api/economy/balance read sees the post-write state — i.e.
+ *     no Firestore-cache skew between transactional write and
+ *     subsequent read.
+ *   - The gift doc's coinValue is read at request time (not cached)
+ *     and the bean reward is computed against the live config doc.
+ *
+ * Per `.project/plans/2026-05-05-integration-test-framework.md` test #6.
+ */
+
+const API_BASE = process.env.API_BASE_URL || "http://localhost:3000";
+
+// /api/economy/balance defines the response shape: `{coins, beans}`.
+// The `shyCoins`/`shyBeans` aliases are server-internal — the public
+// API normalises to the lowercase form. Asserting against the wire
+// shape (not the doc-field shape) catches a future doc rename that
+// forgot to update the read path.
+async function readBalance(
+  api: import("@playwright/test").APIRequestContext,
+  idToken: string,
+): Promise<{ coins: number; beans: number }> {
+  const res = await api.get(`${API_BASE}/api/economy/balance`, {
+    headers: { Authorization: `Bearer ${idToken}` },
+  });
+  if (!res.ok()) {
+    throw new Error(`readBalance failed: ${res.status()}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+test.describe("Integration — gift-direct state cascade", () => {
+  test("sender→recipient gift decrements coins, credits beans, returns the canonical reward", async ({
+    api,
+    pair,
+  }) => {
+    // Pre-assert starting state. If these fail, the test setup is
+    // broken — surface that as a setup error (not a failure of the
+    // route under test).
+    const senderBefore = await readBalance(api, pair.sender.idToken);
+    const recipientBefore = await readBalance(api, pair.recipient.idToken);
+    expect(senderBefore).toEqual({ coins: 1000, beans: 0 });
+    expect(recipientBefore).toEqual({ coins: 0, beans: 0 });
+
+    const res = await api.post(`${API_BASE}/api/economy/gift-direct`, {
+      headers: {
+        Authorization: `Bearer ${pair.sender.idToken}`,
+        "Content-Type": "application/json",
+      },
+      data: {
+        recipientId: pair.recipient.uniqueId,
+        giftId: pair.gift.id,
+        quantity: 1,
+      },
+    });
+    expect(
+      res.ok(),
+      `gift-direct expected 200, got ${res.status()}: ${await res.text()}`,
+    ).toBe(true);
+
+    const body = await res.json();
+    // Default beanConversionRate is 0.6 (see test-helpers.js
+    // economyConfig fallback) — coinValue=100 × 0.6 × qty=1 = 60.
+    // Pinning to the exact value catches a future config drift or a
+    // rounding-mode regression (Math.floor → Math.round, etc.).
+    expect(body).toMatchObject({
+      success: true,
+      coinsSpent: 100,
+      beanReward: 60,
+      quantity: 1,
+    });
+
+    // Post-assert state. Reading via /api/economy/balance proves the
+    // writes actually committed to Firestore — not just that the
+    // route returned the right numbers from in-memory state.
+    const senderAfter = await readBalance(api, pair.sender.idToken);
+    const recipientAfter = await readBalance(api, pair.recipient.idToken);
+    expect(senderAfter).toEqual({ coins: 900, beans: 0 });
+    expect(recipientAfter).toEqual({ coins: 0, beans: 60 });
+  });
+
+  test("returns 402 when sender has insufficient coins", async ({
+    api,
+    pair,
+  }) => {
+    // Drain the sender first by gifting all 1000 coins (10 × 100).
+    // This proves the transactional check at economy.js:954 fires
+    // on a real-Firestore read, not just the pre-check.
+    const drain = await api.post(`${API_BASE}/api/economy/gift-direct`, {
+      headers: {
+        Authorization: `Bearer ${pair.sender.idToken}`,
+        "Content-Type": "application/json",
+      },
+      data: {
+        recipientId: pair.recipient.uniqueId,
+        giftId: pair.gift.id,
+        quantity: 10,
+      },
+    });
+    expect(drain.ok(), `drain expected 200, got ${drain.status()}`).toBe(true);
+
+    // Now sender is at 0 coins. Next attempt MUST 402.
+    const res = await api.post(`${API_BASE}/api/economy/gift-direct`, {
+      headers: {
+        Authorization: `Bearer ${pair.sender.idToken}`,
+        "Content-Type": "application/json",
+      },
+      data: {
+        recipientId: pair.recipient.uniqueId,
+        giftId: pair.gift.id,
+        quantity: 1,
+      },
+    });
+    expect(res.status()).toBe(402);
+    const body = await res.json();
+    expect(body.error).toMatch(/insufficient/i);
+
+    // CRITICAL — verify the failed attempt did NOT side-effect.
+    // Without the transaction, the recipient's bean balance would
+    // still tick up (from the failed parent), or the giftWall doc
+    // would record an extra send. Re-reading the recipient's beans
+    // is the simplest single assertion that catches both classes.
+    const recipientAfter = await readBalance(api, pair.recipient.idToken);
+    // 10 × 60 from the drain above; nothing extra from the 402.
+    expect(recipientAfter.beans).toBe(600);
+  });
+
+  test("returns 400 when sender tries to gift themselves", async ({
+    api,
+    pair,
+  }) => {
+    const res = await api.post(`${API_BASE}/api/economy/gift-direct`, {
+      headers: {
+        Authorization: `Bearer ${pair.sender.idToken}`,
+        "Content-Type": "application/json",
+      },
+      data: {
+        recipientId: pair.sender.uniqueId,
+        giftId: pair.gift.id,
+        quantity: 1,
+      },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/yourself/i);
+
+    // Self-gift validation happens BEFORE the doc reads at
+    // economy.js:912 — so sender.coins must remain 1000. If a future
+    // refactor ever moves the validation past the coin-debit
+    // transaction, this assertion is what catches it.
+    const senderAfter = await readBalance(api, pair.sender.idToken);
+    expect(senderAfter.coins).toBe(1000);
+  });
+
+  test("returns 404 when gift does not exist", async ({ api, pair }) => {
+    const res = await api.post(`${API_BASE}/api/economy/gift-direct`, {
+      headers: {
+        Authorization: `Bearer ${pair.sender.idToken}`,
+        "Content-Type": "application/json",
+      },
+      data: {
+        recipientId: pair.recipient.uniqueId,
+        giftId: "nonexistent-gift-id",
+        quantity: 1,
+      },
+    });
+    expect(res.status()).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/gift not found/i);
+
+    // Sender must not be debited.
+    const senderAfter = await readBalance(api, pair.sender.idToken);
+    expect(senderAfter.coins).toBe(1000);
+  });
+});

--- a/tests/integration/fixtures/scenarios.ts
+++ b/tests/integration/fixtures/scenarios.ts
@@ -24,11 +24,18 @@ import {
  *     expect(res.ok()).toBe(true);
  *   });
  *
- * Currently exposes a single `sender` fixture. A multi-account
- * `recipient` fixture (paired with sender via a shared testRunId)
- * will be added when the first cross-account test is written —
- * shipping it ahead of a real consumer would let an unverified
- * lifecycle leak into green CI.
+ * Two fixtures are exposed:
+ *   - `sender` — a single user with starter coins. Use for
+ *     single-account flows (token mint, photo upload, etc.).
+ *   - `pair`   — sender + recipient + a 100-coin gift, all created
+ *     by ONE /api/test/setup call so they share a testRunId and
+ *     tear down together. Use for cross-account flows
+ *     (gift-direct, follow, PM, etc.).
+ *
+ * Tests should pick exactly one of the two — composing both wastes
+ * provisioning calls and creates two unrelated testRunIds. The
+ * fixture mechanics don't enforce this, but the convention is
+ * deliberate.
  */
 
 const API_BASE = process.env.API_BASE_URL || "http://localhost:3000";
@@ -45,11 +52,34 @@ export interface IntegrationUser {
   idToken: string;
 }
 
+/**
+ * A fixed-cost gift created by /api/test/setup, used by gift-direct
+ * tests. The id matches the pattern `{testRunId}_gift_{generateId()}`
+ * — see test-helpers.js:130.
+ */
+export interface IntegrationGift {
+  id: string;
+  coinValue: number;
+}
+
+export interface IntegrationPair {
+  /** Sender — funded with enough coins to send the paired gift. */
+  sender: IntegrationUser;
+  /** Recipient — starts at 0 beans so bean-credit assertions are unambiguous. */
+  recipient: IntegrationUser;
+  /** A 100-coin gift created in the same /api/test/setup call. */
+  gift: IntegrationGift;
+  /** Shared testRunId — single teardown removes all paired entities. */
+  testRunId: string;
+}
+
 export interface IntegrationFixtures {
   /** A request context shared across the test — disposed in fixture teardown. */
   api: APIRequestContext;
-  /** A regular (non-admin) test user. Created on first access. */
+  /** A single (non-admin) test user. Created on first access. */
   sender: IntegrationUser;
+  /** Sender + recipient + gift in one scenario. Created on first access. */
+  pair: IntegrationPair;
 }
 
 /**
@@ -115,6 +145,100 @@ async function provisionUser(
 }
 
 /**
+ * Mint a Firebase ID token for the given Firebase UID via the local
+ * Auth emulator. Throws on any failure.
+ */
+async function mintIdToken(
+  api: APIRequestContext,
+  uid: string,
+): Promise<string> {
+  const mintRes = await api.post(`${API_BASE}/api/test/mint-id-token`, {
+    headers: { "X-Test-API-Key": TEST_API_KEY },
+    data: { uid },
+  });
+  if (!mintRes.ok()) {
+    throw new Error(
+      `mintIdToken failed: ${mintRes.status()}: ${await mintRes.text()}`,
+    );
+  }
+  const { idToken } = await mintRes.json();
+  if (!idToken) {
+    throw new Error("mintIdToken: emulator returned no idToken");
+  }
+  return idToken;
+}
+
+/**
+ * Provision a sender + recipient + 100-coin gift in a SINGLE
+ * /api/test/setup call so they share a testRunId. The recipient
+ * starts at 0 beans to keep bean-credit assertions unambiguous.
+ *
+ * Returns the full pair record. Caller is responsible for teardown.
+ */
+async function provisionPair(api: APIRequestContext): Promise<IntegrationPair> {
+  const setupRes = await api.post(`${API_BASE}/api/test/setup`, {
+    headers: { "X-Test-API-Key": TEST_API_KEY },
+    data: {
+      users: [
+        { name: "sender", shyCoins: 1000, shyBeans: 0 },
+        { name: "recipient", shyCoins: 0, shyBeans: 0 },
+      ],
+      gifts: [{ name: "Test gift", coinValue: 100 }],
+    },
+  });
+  if (!setupRes.ok()) {
+    throw new Error(
+      `provisionPair /test/setup failed: ${setupRes.status()}: ${await setupRes.text()}.`,
+    );
+  }
+  const setupBody = await setupRes.json();
+  const testRunId: string = setupBody.testRunId;
+  const userRecords = setupBody.users || [];
+  const giftRecords = setupBody.gifts || [];
+  // /test/setup creates users in the order specified, so [0] is
+  // sender and [1] is recipient. Asserting array length here is what
+  // catches a future server change that returns them in a map or
+  // re-orders them.
+  if (
+    userRecords.length !== 2 ||
+    giftRecords.length !== 1 ||
+    typeof userRecords[0].uniqueId !== "number" ||
+    typeof userRecords[1].uniqueId !== "number" ||
+    typeof giftRecords[0].id !== "string" ||
+    typeof giftRecords[0].coinValue !== "number"
+  ) {
+    throw new Error(
+      `provisionPair: /test/setup returned unexpected shape: ${JSON.stringify(setupBody)}`,
+    );
+  }
+
+  const [senderToken, recipientToken] = await Promise.all([
+    mintIdToken(api, userRecords[0].uid),
+    mintIdToken(api, userRecords[1].uid),
+  ]);
+
+  return {
+    testRunId,
+    sender: {
+      uniqueId: userRecords[0].uniqueId,
+      uid: userRecords[0].uid,
+      displayName: userRecords[0].displayName || "sender",
+      idToken: senderToken,
+    },
+    recipient: {
+      uniqueId: userRecords[1].uniqueId,
+      uid: userRecords[1].uid,
+      displayName: userRecords[1].displayName || "recipient",
+      idToken: recipientToken,
+    },
+    gift: {
+      id: giftRecords[0].id,
+      coinValue: giftRecords[0].coinValue,
+    },
+  };
+}
+
+/**
  * Tear down the test scenario by deleting all data tagged with the
  * given testRunId. Best-effort: failures are logged but don't fail
  * the test. We DO inspect the HTTP status — `api.post` only rejects
@@ -162,6 +286,14 @@ export const test = base.extend<IntegrationFixtures>({
       await use(user);
     } finally {
       await teardown(api, testRunId);
+    }
+  },
+  pair: async ({ api }, use) => {
+    const scenario = await provisionPair(api);
+    try {
+      await use(scenario);
+    } finally {
+      await teardown(api, scenario.testRunId);
     }
   },
 });


### PR DESCRIPTION
## Summary
First multi-account integration test, plus the supporting fixture infrastructure (`pair`).

### Fixture (scenarios.ts)
- New `pair` fixture provisions **sender + recipient + 100-coin gift** in ONE `/api/test/setup` call so all three share a `testRunId` and tear down in a single sweep.
- Extracted `mintIdToken` helper from `provisionUser` so it can be reused from `provisionPair` without copy-paste.
- Tightened shape guard: `provisionPair` validates array length and per-field types (`uniqueId` numeric, `gift.coinValue` numeric, `gift.id` string) — surfaces a future server-side reorder/rename as a clear shape error instead of a downstream NaN.

### Test #6 (04-gift-direct-cascade.spec.ts)
- **Happy path** — verifies the canonical reward AND the post-Firestore state via `/api/economy/balance` reads on both users. Proves the transaction at `economy.js:951` actually committed (mocks would let the assertion pass even if the txn threw mid-commit).
- **402 insufficient-coins** — drains the sender first, then asserts `recipient.beans === 600` (10×60 from the drain, nothing extra). Catches a regression that moved bean-credit before the transaction.
- **400 self-gift** — sender.coins must remain 1000 (early return path).
- **404 missing gift** — sender.coins must remain 1000 (early return path).

### Why this matters
Direct regression test for the C1 race-condition fix in PR #485. Mocks can't catch this class of bug because they let the test pass even when a transactional `t.update()` throws mid-commit. Only the real Firestore emulator forces the writes through and lets us verify post-state.

### Reviewer fixes applied before push
- **LOW** — Comment in self-gift test claimed validation happens AFTER doc reads; in reality `economy.js:909` validates self-gift BEFORE the parallel `Promise.all` reads at line 912. Fixed the comment so a future refactor guided by it would be correct.

## Test plan
- [x] `bash local/start.sh` + `npx playwright test --config=playwright.integration.config.ts` — 9/9 pass (5 pre-existing + 4 new)
- [x] Determinism: full suite re-runs cleanly (~1s warm)
- [x] Prettier clean

Per `.project/plans/2026-05-05-integration-test-framework.md` test #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)