### PR TITLE
ci: integration test framework wired into PR checks (Phase 3 PR G)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,127 @@
+name: Integration Tests
+
+# Reusable workflow that brings up the full local stack (Firebase
+# Emulators + LiveKit Docker + MinIO + Mailpit + Express API) and
+# runs the integration test suite at `tests/integration/`.
+#
+# Distinct from `playwright-tests.yml` (browser tests) and
+# `test-backend.yml` (Jest unit tests with mocked Firestore) —
+# integration sits between them and exercises real cross-service
+# contracts (Express ↔ Firestore ↔ RTDB ↔ R2).
+#
+# Per `.project/plans/2026-05-05-integration-test-framework.md` PR G.
+# Locally: `bash local/start.sh && cd express-api && npm run local`,
+# then `npm run test:integration` from repo root.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to test'
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to test (default: main)'
+        type: string
+        default: 'main'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: integration-tests-${{ inputs.ref }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: ./.github/actions/setup-jdk-gradle
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - uses: ./.github/actions/start-local-services
+
+      - uses: ./.github/actions/start-firebase-emulators
+
+      - name: Install Express API and seed data
+        run: |
+          cd express-api && npm ci
+          NODE_PATH=./node_modules NODE_ENV=local node ../local/seed.js
+
+      - name: Start Express API
+        run: |
+          cd express-api
+          # Match the playwright-tests.yml pattern verbatim: background
+          # the daemon, block on /api/health via `until`, let the step
+          # exit naturally. Using `exit 0` here would terminate the
+          # step's shell before the runner processes the backgrounded
+          # node — empirically the until-loop variant survives, the
+          # explicit-exit variant does not.
+          # LIVEKIT_API_KEY/SECRET added vs playwright-tests.yml so
+          # /api/livekit/token can sign — required by test #2.
+          NODE_ENV=local TEST_API_KEY=local-test-key FIREBASE_WEB_API_KEY=fake-ci-key FIREBASE_PROJECT_ID=demo-shytalk LIVEKIT_API_KEY=devkey LIVEKIT_API_SECRET=devsecret node src/index.js &
+          until curl -s http://localhost:3000/api/health > /dev/null 2>&1; do sleep 1; done
+
+      - name: Run integration tests
+        env:
+          API_BASE_URL: http://localhost:3000
+          TEST_API_KEY: local-test-key
+          ALLURE_ENABLED: 'true'
+          ALLURE_PROJECT: integration
+        run: npm run test:integration
+
+      - name: Cleanup Docker containers
+        if: always()
+        run: |
+          docker logs livekit 2>/dev/null || true
+          docker logs minio 2>/dev/null || true
+          docker logs mailpit 2>/dev/null || true
+          docker rm -f livekit minio mailpit 2>/dev/null || true
+
+      - name: Write environment.properties
+        if: always()
+        run: |
+          DIR="allure-results/integration"
+          mkdir -p "$DIR"
+          sed 's/^ *//' > "$DIR/environment.properties" <<'INTEOF'
+          tier=Integration
+          base_url=localhost:3000
+          stack=Local Emulators (Firestore, Auth, RTDB, MinIO, LiveKit)
+          INTEOF
+
+      - name: Upload Allure results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: allure-results-integration
+          path: allure-results/
+          retention-days: 14
+
+      - name: Upload failure traces
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: failure()
+        with:
+          name: integration-failures
+          path: |
+            test-results/
+            playwright-report-integration/
+            playwright-results-integration.xml
+          retention-days: 7

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -26,6 +26,7 @@ jobs:
       app_changed: ${{ steps.changes.outputs.app_changed }}
       backend_changed: ${{ steps.changes.outputs.backend_changed }}
       web_changed: ${{ steps.changes.outputs.web_changed }}
+      integration_changed: ${{ steps.changes.outputs.integration_changed }}
       workflow_only: ${{ steps.changes.outputs.workflow_only }}
       skip_android_e2e: ${{ steps.changes.outputs.skip_android_e2e }}
       skip_ios_e2e: ${{ steps.changes.outputs.skip_ios_e2e }}
@@ -44,20 +45,25 @@ jobs:
           # latest push only touches workflow files.
           MERGE_BASE=$(git merge-base "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
           CHANGED=$(git diff --name-only "$MERGE_BASE...${{ github.event.pull_request.head.sha }}")
-          APP=false BACKEND=false WEB=false OTHER=false
+          APP=false BACKEND=false WEB=false INTEGRATION=false OTHER=false
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             case "$file" in
               public/*.md) WEB=true ;;
               public/*) WEB=true ;;
               app/*|shared/*|iosApp/*|gradle/*|*.gradle.kts|gradle.properties|gradlew|gradlew.bat) APP=true ;;
+              # Integration test files match BEFORE express-api/* so a
+              # PR that changes ONLY tests/integration/ files runs the
+              # integration job without dragging in the heavier
+              # backend-changed gate (Sonar, full backend suite).
+              tests/integration/*|playwright.integration.config.ts) INTEGRATION=true ;;
               express-api/*|firestore.rules|database.rules.json) BACKEND=true ;;
               .github/*|.claude/*|.project/*|*.md|.gitignore|.gitattributes) ;;
               *) OTHER=true ;;
             esac
           done <<< "$CHANGED"
           WORKFLOW_ONLY=false
-          if [ "$APP" = "false" ] && [ "$BACKEND" = "false" ] && [ "$WEB" = "false" ] && [ "$OTHER" = "false" ]; then
+          if [ "$APP" = "false" ] && [ "$BACKEND" = "false" ] && [ "$WEB" = "false" ] && [ "$INTEGRATION" = "false" ] && [ "$OTHER" = "false" ]; then
             WORKFLOW_ONLY=true
           fi
           # Explicit per-platform E2E skip markers in the PR body. Use when the
@@ -79,10 +85,10 @@ jobs:
           if printf '%s' "$PR_BODY" | grep -qE '^[[:space:]]*\[skip-ios-e2e\][[:space:]]*$'; then
             SKIP_IOS_E2E=true
           fi
-          for v in app_changed=$APP backend_changed=$BACKEND web_changed=$WEB workflow_only=$WORKFLOW_ONLY skip_android_e2e=$SKIP_ANDROID_E2E skip_ios_e2e=$SKIP_IOS_E2E; do
+          for v in app_changed=$APP backend_changed=$BACKEND web_changed=$WEB integration_changed=$INTEGRATION workflow_only=$WORKFLOW_ONLY skip_android_e2e=$SKIP_ANDROID_E2E skip_ios_e2e=$SKIP_IOS_E2E; do
             echo "$v" >> "$GITHUB_OUTPUT"
           done
-          echo "Detection results: app=$APP backend=$BACKEND web=$WEB workflow_only=$WORKFLOW_ONLY skip_android_e2e=$SKIP_ANDROID_E2E skip_ios_e2e=$SKIP_IOS_E2E"
+          echo "Detection results: app=$APP backend=$BACKEND web=$WEB integration=$INTEGRATION workflow_only=$WORKFLOW_ONLY skip_android_e2e=$SKIP_ANDROID_E2E skip_ios_e2e=$SKIP_IOS_E2E"
 
   lint:
     needs: [detect-changes]
@@ -228,6 +234,26 @@ jobs:
       report_env: pr
     secrets: inherit
 
+  integration-tests:
+    # Cross-service contract tests (Express ↔ Firestore ↔ RTDB ↔ R2).
+    # Triggers on backend, integration-test, OR app/shared changes —
+    # the last because shared KMP-side contract changes (request
+    # shapes, response parsing) can break the integration tier even
+    # when no Express file moves. Runs after backend unit tests pass
+    # — no point lighting up the full local stack in CI if the
+    # backend's own jest suite is red.
+    needs: [detect-changes, test-backend]
+    if: |
+      always() &&
+      (needs.detect-changes.outputs.backend_changed == 'true' ||
+       needs.detect-changes.outputs.integration_changed == 'true' ||
+       needs.detect-changes.outputs.app_changed == 'true') &&
+      (needs.test-backend.result == 'success' || needs.test-backend.result == 'skipped')
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit
+
   ios-e2e:
     needs: [detect-changes, build-and-test, sonarcloud, test-backend]
     if: |
@@ -246,7 +272,7 @@ jobs:
 
   gate:
     name: PR Gate
-    needs: [detect-changes, lint, build-and-test, sonarcloud, test-backend, android-e2e, playwright-web, ios-e2e]
+    needs: [detect-changes, lint, build-and-test, sonarcloud, test-backend, android-e2e, playwright-web, integration-tests, ios-e2e]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -267,6 +293,7 @@ jobs:
             "${{ needs.test-backend.result }}" \
             "${{ needs.android-e2e.result }}" \
             "${{ needs.playwright-web.result }}" \
+            "${{ needs.integration-tests.result }}" \
             "${{ needs.ios-e2e.result }}"; do
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
               echo "Required check failed: $result"


### PR DESCRIPTION
## Summary
Adds the CI plumbing that lets the integration test suite gate PR merges.

### New workflow: `.github/workflows/integration-tests.yml`
Reusable workflow modeled after `playwright-tests.yml`, trimmed for the API tier (no browser install, no admin/portal serve, no matrix). Brings up the local stack via existing composite actions (`start-local-services` + `start-firebase-emulators`), starts Express with `LIVEKIT_API_KEY/SECRET` (so `/api/livekit/token` can sign — needed by test #2), then runs `npm run test:integration`.

### `pr-checks.yml` updates
- New `integration_changed` output, triggered by `tests/integration/*` or `playwright.integration.config.ts` changes. Case ordered **before** `express-api/*` so an integration-only PR doesn't drag in the heavier backend gates.
- New `integration-tests` job that calls `integration-tests.yml` when **backend**, **integration-test**, OR **app/shared** changes — the last because a shared KMP contract change (request shapes, response parsing) can break the API tier even when no Express file moves.
- Job added to the PR Gate's `needs` list and result-aggregation loop.

## Reviewer fixes applied before push
- **HIGH** — Express startup pattern now matches `playwright-tests.yml` exactly (`&`-then-until-loop, no explicit `exit 0`). An explicit `exit` terminates the step's shell prematurely and could kill the backgrounded daemon before the next step runs.
- **MED** — `integration-tests` now also triggers on `app_changed`.

## Test plan
- [x] YAML syntax verified (`js-yaml` loads both files cleanly).
- [x] Referenced scripts exist (`npm run test:integration` in package.json) and all composite actions present (`start-local-services`, `start-firebase-emulators`, `setup-jdk-gradle`).
- [ ] Live verification will come when this PR runs against itself in CI — the `integration_changed` detection should fire on the modified `pr-checks.yml`/`integration-tests.yml` paths and run the suite.

Per `.project/plans/2026-05-05-integration-test-framework.md` PR G.

🤖 Generated with [Claude Code](https://claude.com/claude-code)