### PR TITLE
fix(test): /api/test/setup conversations write participantIds field (Phase 2A miss)

### DIFF
--- a/express-api/src/routes/test-helpers.js
+++ b/express-api/src/routes/test-helpers.js
@@ -182,12 +182,13 @@ router.post('/test/setup', async (req, res) => {
 
     // Create test conversations with messages subcollection
     // (seeded BEFORE reports so reports can reference conversationIndex)
+    // Production reads `participantIds`; legacy `participants` accepted for backward compat.
     for (const convSpec of spec.conversations || []) {
       const convId = `${testRunId}_conv_${generateId()}`;
-      const participants = convSpec.participants || [];
+      const participantIds = convSpec.participantIds || convSpec.participants || [];
       const convData = {
         id: convId,
-        participants,
+        participantIds,
         createdAt: now,
         _testRun: testRunId,
       };

--- a/express-api/tests/routes/test-helpers-misc.test.js
+++ b/express-api/tests/routes/test-helpers-misc.test.js
@@ -781,7 +781,7 @@ describe('POST /api/test/setup', () => {
     expect(alert.status).toBe('new');
   });
 
-  test('creates test conversation with messages subcollection', async () => {
+  test('creates test conversation with messages subcollection (participantIds field)', async () => {
     const app = createApp();
     const res = await request(app)
       .post('/api/test/setup')
@@ -789,7 +789,7 @@ describe('POST /api/test/setup', () => {
       .send({
         conversations: [
           {
-            participants: ['uid1', 'uid2'],
+            participantIds: ['uid1', 'uid2'],
             messages: [
               { text: 'Hello!', senderId: 'uid1' },
               { text: 'Hi there!', senderId: 'uid2' },
@@ -801,7 +801,11 @@ describe('POST /api/test/setup', () => {
 
     expect(res.body.conversations).toHaveLength(1);
     const conv = res.body.conversations[0];
-    expect(conv.participants).toEqual(['uid1', 'uid2']);
+    // The doc field is `participantIds` (matches the production
+    // route at conversations.js:229). The legacy `participants` key
+    // remains accepted at the input level for backward compat with
+    // older test fixtures (verified in the next test).
+    expect(conv.participantIds).toEqual(['uid1', 'uid2']);
     expect(conv._testRun).toBe(res.body.testRunId);
     expect(conv.id).toContain(res.body.testRunId);
     expect(mockDoc).toHaveBeenCalledWith(`conversations/${conv.id}`);
@@ -816,13 +820,47 @@ describe('POST /api/test/setup', () => {
     );
   });
 
+  test('legacy `participants` input key still maps to participantIds', async () => {
+    // Backward compat: pre-rename fixtures pass `participants`. The
+    // route maps it to `participantIds` so the seeded doc still
+    // satisfies the production participant check.
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/test/setup')
+      .set('X-Test-Api-Key', VALID_API_KEY)
+      .send({
+        conversations: [{ participants: ['legacy-uid'] }],
+      })
+      .expect(200);
+
+    expect(res.body.conversations[0].participantIds).toEqual(['legacy-uid']);
+  });
+
+  test('conversation with neither key falls back to empty participantIds', async () => {
+    // Branch coverage for the `|| []` fallback when callers pass an
+    // empty spec. A test seeding a conversation with no participants
+    // is unrealistic for actual scenarios, but the route should not
+    // crash — it should yield a conversation doc with an empty array.
+    // SonarCloud's branch-coverage gate caught this missing case.
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/test/setup')
+      .set('X-Test-Api-Key', VALID_API_KEY)
+      .send({
+        conversations: [{}],
+      })
+      .expect(200);
+
+    expect(res.body.conversations[0].participantIds).toEqual([]);
+  });
+
   test('creates conversation without messages when none specified', async () => {
     const app = createApp();
     const res = await request(app)
       .post('/api/test/setup')
       .set('X-Test-Api-Key', VALID_API_KEY)
       .send({
-        conversations: [{ participants: ['uid1'] }],
+        conversations: [{ participantIds: ['uid1'] }],
       })
       .expect(200);
 


### PR DESCRIPTION
## Summary
Production routes consistently read `participantIds` (conversations.js:161, 229; admin-cleanup.js:132; translate.js:30; system-pm.js:38; data-export-builder.js:104; cron/accountDeletion.js:114). The test helper at `/api/test/setup` was writing the field as `participants` instead — so any seeded conversation would **403** the first message-send because the participant check at conversations.js:230 would never find the sender.

This is a Phase 2A audit miss; surfaced while building the integration test framework's PM real-time delivery test (PR coming next).

## Changes
- `/api/test/setup` now writes `participantIds` to seeded conversation docs (matches production).
- The input shape still accepts the legacy `participants` key for backward compat — the route normalises to `participantIds` before persisting.
- `test-helpers-misc.test.js`:
  - Primary test now asserts on the new field name.
  - New dedicated test pins the legacy-key backward-compat path so a future cleanup can't silently drop it.

## Test plan
- [x] `cd express-api && npx jest` — 197/197 suites + 4682/4682 tests pass.
- [x] Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)