### PR TITLE
feat(test): FCM payload-shape integration test (Phase 3 PR J)

### DIFF
--- a/express-api/src/routes/test-helpers.js
+++ b/express-api/src/routes/test-helpers.js
@@ -11,6 +11,7 @@
 const router = require('express').Router();
 const { db, auth } = require('../utils/firebase');
 const { generateId } = require('../utils/helpers');
+const { getFcmCaptures, clearFcmCaptures } = require('../utils/fcm');
 const log = require('../utils/log');
 
 const TEST_PREFIX = 'test_';
@@ -528,6 +529,25 @@ router.post('/test/teardown', async (req, res) => {
     log.error('test-helpers', 'Teardown failed', { error: err.message });
     res.status(500).json({ error: err.message });
   }
+});
+
+// GET /api/test/fcm-captures — read the in-process FCM capture buffer.
+// fcm.js stores `{tokens, data, ts}` entries here whenever sendFcmToTokens
+// runs in NODE_ENV=local. Used by integration test #9 to verify FCM
+// payload shape without contacting real FCM. Returns the captures in
+// order; clear via POST /api/test/fcm-captures/clear before each test.
+router.get('/test/fcm-captures', (req, res) => {
+  if (requireTestApiKey(req, res)) return;
+  res.json({ captures: getFcmCaptures() });
+});
+
+// POST /api/test/fcm-captures/clear — empty the FCM capture buffer.
+// Tests call this in beforeEach to isolate from prior runs in the
+// same Express process.
+router.post('/test/fcm-captures/clear', (req, res) => {
+  if (requireTestApiKey(req, res)) return;
+  clearFcmCaptures();
+  res.json({ success: true });
 });
 
 // POST /api/test/reset — wipe ALL test data

--- a/express-api/src/utils/fcm.js
+++ b/express-api/src/utils/fcm.js
@@ -7,6 +7,27 @@
 const { messaging, db, FieldValue } = require('./firebase');
 const log = require('./log');
 
+// Local-mode FCM capture buffer for integration tests.
+// In NODE_ENV=local the route never contacts real FCM — we record the
+// payload here so a Playwright test can verify the contract via
+// /api/test/fcm-captures (test-helpers.js). Cleared between tests
+// via /api/test/fcm-captures/clear. Production never touches this.
+const _fcmCaptures = [];
+const FCM_CAPTURE_LIMIT = 1000;
+
+function captureLocal(tokens, data) {
+  if (_fcmCaptures.length >= FCM_CAPTURE_LIMIT) {
+    // Bound the buffer so a long-lived dev process can't OOM.
+    // Drop the oldest — tests should clear before running anyway.
+    _fcmCaptures.shift();
+  }
+  _fcmCaptures.push({
+    tokens: [...tokens],
+    data: { ...data },
+    ts: Date.now(),
+  });
+}
+
 /**
  * Send a data-only FCM message to multiple tokens via Firebase Admin SDK.
  * All values are stringified (FCM data messages require string values).
@@ -16,6 +37,7 @@ async function sendFcmToTokens(tokens, data) {
   if (!tokens || tokens.length === 0) return [];
 
   if (process.env.NODE_ENV === 'local') {
+    captureLocal(tokens, data);
     log.info('fcm', `[FCM-LOCAL] Would send to ${tokens.length} tokens: ${data?.title}`);
     return [];
   }
@@ -65,4 +87,23 @@ async function cleanupInvalidTokens(invalidTokens, userId) {
   }
 }
 
-module.exports = { sendFcmToTokens, cleanupInvalidTokens };
+/**
+ * Test helpers — local-mode only. Used by the integration suite to
+ * verify FCM payload shape without hitting real Firebase Cloud
+ * Messaging. Returns a defensive copy so callers can't mutate the
+ * buffer in place.
+ */
+function getFcmCaptures() {
+  return _fcmCaptures.map((c) => ({ ...c, tokens: [...c.tokens], data: { ...c.data } }));
+}
+
+function clearFcmCaptures() {
+  _fcmCaptures.length = 0;
+}
+
+module.exports = {
+  sendFcmToTokens,
+  cleanupInvalidTokens,
+  getFcmCaptures,
+  clearFcmCaptures,
+};

--- a/express-api/tests/utils/fcm.test.js
+++ b/express-api/tests/utils/fcm.test.js
@@ -15,7 +15,12 @@ jest.mock('../../src/utils/firebase', () => ({
   },
 }));
 
-const { sendFcmToTokens, cleanupInvalidTokens } = require('../../src/utils/fcm');
+const {
+  sendFcmToTokens,
+  cleanupInvalidTokens,
+  getFcmCaptures,
+  clearFcmCaptures,
+} = require('../../src/utils/fcm');
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -98,5 +103,49 @@ describe('cleanupInvalidTokens', () => {
   test('removes invalid tokens from user doc', async () => {
     await cleanupInvalidTokens(['bad-token-1', 'bad-token-2'], 'user-1');
     expect(mockDocUpdate).toHaveBeenCalled();
+  });
+});
+
+describe('local-mode FCM capture buffer', () => {
+  const prevEnv = process.env.NODE_ENV;
+  beforeEach(() => {
+    process.env.NODE_ENV = 'local';
+    clearFcmCaptures();
+  });
+  afterEach(() => {
+    process.env.NODE_ENV = prevEnv;
+    clearFcmCaptures();
+  });
+
+  test('captures sends in local mode and returns empty invalid-tokens array', async () => {
+    const result = await sendFcmToTokens(['t1'], { type: 'PM', title: 'hi' });
+    expect(result).toEqual([]);
+    expect(mockSendEachForMulticast).not.toHaveBeenCalled();
+
+    const caps = getFcmCaptures();
+    expect(caps).toHaveLength(1);
+    expect(caps[0].tokens).toEqual(['t1']);
+    expect(caps[0].data).toEqual({ type: 'PM', title: 'hi' });
+    expect(typeof caps[0].ts).toBe('number');
+  });
+
+  test('getFcmCaptures returns a defensive copy (callers cannot mutate buffer)', async () => {
+    await sendFcmToTokens(['t1'], { type: 'PM' });
+    const caps = getFcmCaptures();
+    caps[0].tokens.push('mutated');
+    caps[0].data.injected = 'oops';
+    caps.push({ tokens: ['fake'], data: {}, ts: 0 });
+
+    const fresh = getFcmCaptures();
+    expect(fresh).toHaveLength(1);
+    expect(fresh[0].tokens).toEqual(['t1']);
+    expect(fresh[0].data).toEqual({ type: 'PM' });
+  });
+
+  test('clearFcmCaptures empties the buffer', async () => {
+    await sendFcmToTokens(['t1'], { type: 'PM' });
+    expect(getFcmCaptures()).toHaveLength(1);
+    clearFcmCaptures();
+    expect(getFcmCaptures()).toHaveLength(0);
   });
 });

--- a/tests/integration/08-fcm-message-shape.spec.ts
+++ b/tests/integration/08-fcm-message-shape.spec.ts
@@ -1,0 +1,209 @@
+import { test, expect } from "./fixtures/scenarios";
+
+/**
+ * Integration test #9 — FCM message-shape verification.
+ *
+ * Verifies that POST /api/conversations/:id/messages produces an
+ * FCM payload with the documented shape that the Android/iOS
+ * clients depend on.
+ *
+ * In NODE_ENV=local the route never contacts real FCM —
+ * `fcm.js:sendFcmToTokens` records the `{ tokens, data, ts }` triple
+ * to an in-process buffer accessible via /api/test/fcm-captures.
+ * The test clears the buffer, sends a PM, and reads back the
+ * captured payload.
+ *
+ * What this catches that no unit test can:
+ *   - The full Express → conversations → fcm.js call chain produces
+ *     a payload with the contract fields. A unit test mocks
+ *     sendFcmToTokens; only this integration tier proves the
+ *     production code path actually populates the data object.
+ *   - The shouldNotifyRecipient gate (conversations.js:64) does NOT
+ *     suppress sends for healthy users with FCM tokens.
+ *   - The recipient's `fcmTokens` array is read fresh from Firestore
+ *     every send (regression-coverage for a future refactor that
+ *     might cache tokens and miss revocations).
+ *
+ * Per `.project/plans/2026-05-05-integration-test-framework.md`
+ * test #9.
+ */
+
+const API_BASE = process.env.API_BASE_URL || "http://localhost:3000";
+const TEST_API_KEY = process.env.TEST_API_KEY || "local-test-key";
+
+interface FcmCapture {
+  tokens: string[];
+  data: Record<string, string>;
+  ts: number;
+}
+
+async function readCaptures(
+  api: import("@playwright/test").APIRequestContext,
+): Promise<FcmCapture[]> {
+  const res = await api.get(`${API_BASE}/api/test/fcm-captures`, {
+    headers: { "X-Test-API-Key": TEST_API_KEY },
+  });
+  if (!res.ok()) {
+    throw new Error(
+      `readCaptures failed: ${res.status()}: ${await res.text()}`,
+    );
+  }
+  const body = await res.json();
+  return body.captures;
+}
+
+async function clearCaptures(
+  api: import("@playwright/test").APIRequestContext,
+): Promise<void> {
+  // Express's body parser is strict about Content-Type even on
+  // bodyless POSTs in some setups — pass an empty JSON object so we
+  // don't depend on that being relaxed.
+  const res = await api.post(`${API_BASE}/api/test/fcm-captures/clear`, {
+    headers: {
+      "X-Test-API-Key": TEST_API_KEY,
+      "Content-Type": "application/json",
+    },
+    data: {},
+  });
+  if (!res.ok()) {
+    throw new Error(
+      `clearCaptures failed: ${res.status()}: ${await res.text()}`,
+    );
+  }
+}
+
+test.describe("Integration — FCM payload shape", () => {
+  test.beforeEach(async ({ api }) => {
+    // Buffer is process-global, so prior tests in the suite (or in
+    // the developer's local Express) can leave entries behind.
+    await clearCaptures(api);
+  });
+
+  test("PM send produces FCM payload with documented shape", async ({
+    api,
+    pair,
+  }) => {
+    // Recipient must have an FCM token registered for shouldNotifyRecipient
+    // to return true (see conversations.js:69). /api/test/write/users
+    // merges into the existing user doc.
+    await api.post(`${API_BASE}/api/test/write/users`, {
+      headers: { "X-Test-API-Key": TEST_API_KEY },
+      data: {
+        id: String(pair.recipient.uniqueId),
+        fcmTokens: ["fcm-test-token-1"],
+        _testRun: pair.testRunId,
+      },
+    });
+
+    const convId = `${pair.testRunId}_fcm_${Date.now()}`;
+    await api.post(`${API_BASE}/api/test/write/conversations`, {
+      headers: { "X-Test-API-Key": TEST_API_KEY },
+      data: {
+        id: convId,
+        participantIds: [pair.sender.uniqueId, pair.recipient.uniqueId],
+        createdAt: Date.now(),
+        _testRun: pair.testRunId,
+      },
+    });
+
+    const messageText = `fcm-shape-test-${Date.now()}`;
+    const post = await api.post(
+      `${API_BASE}/api/conversations/${convId}/messages`,
+      {
+        headers: {
+          Authorization: `Bearer ${pair.sender.idToken}`,
+          "Content-Type": "application/json",
+        },
+        data: {
+          text: messageText,
+          type: "TEXT",
+          senderName: pair.sender.displayName,
+        },
+      },
+    );
+    expect(
+      post.ok(),
+      `post expected 200, got ${post.status()}: ${await post.text()}`,
+    ).toBe(true);
+
+    // The notification call is fire-and-forget (conversations.js:301).
+    // Poll briefly for the capture to land — typically <100ms but
+    // emulator scheduling can stretch.
+    let captures: FcmCapture[] = [];
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      captures = await readCaptures(api);
+      if (captures.length > 0) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    expect(
+      captures.length,
+      "exactly one FCM capture must land",
+    ).toBeGreaterThanOrEqual(1);
+    const cap = captures[0];
+
+    expect(cap.tokens).toEqual(["fcm-test-token-1"]);
+
+    // Data payload contract — must match what conversations.js:117
+    // produces. Each value is a string (FCM data messages require
+    // string values per spec — fcm.js:23 stringifies before send,
+    // but the buffer captures the pre-stringified shape since the
+    // local-mode branch skips stringification).
+    expect(cap.data).toMatchObject({
+      type: "PM",
+      senderId: pair.sender.uniqueId,
+      messageText,
+      conversationId: convId,
+      isGroup: "false",
+      showPreview: "true",
+    });
+    expect(cap.data.senderName).toContain(pair.sender.displayName);
+    expect(typeof cap.ts).toBe("number");
+    expect(cap.ts).toBeGreaterThan(Date.now() - 10_000);
+  });
+
+  test("recipient with empty fcmTokens does NOT trigger an FCM capture", async ({
+    api,
+    pair,
+  }) => {
+    // The shouldNotifyRecipient gate at conversations.js:69 returns
+    // false when fcmTokens is empty/missing. /api/test/setup creates
+    // users without fcmTokens (default), so the recipient already
+    // has no tokens — we just verify nothing lands in the capture
+    // buffer.
+    const convId = `${pair.testRunId}_fcm_skip_${Date.now()}`;
+    await api.post(`${API_BASE}/api/test/write/conversations`, {
+      headers: { "X-Test-API-Key": TEST_API_KEY },
+      data: {
+        id: convId,
+        participantIds: [pair.sender.uniqueId, pair.recipient.uniqueId],
+        createdAt: Date.now(),
+        _testRun: pair.testRunId,
+      },
+    });
+
+    const post = await api.post(
+      `${API_BASE}/api/conversations/${convId}/messages`,
+      {
+        headers: {
+          Authorization: `Bearer ${pair.sender.idToken}`,
+          "Content-Type": "application/json",
+        },
+        data: { text: "no-fcm", type: "TEXT" },
+      },
+    );
+    expect(post.ok()).toBe(true);
+
+    // Wait the same window we'd wait for a real send to confirm
+    // nothing arrives. A regression that suppressed the gate would
+    // produce a capture inside this window.
+    await new Promise((r) => setTimeout(r, 1000));
+
+    const captures = await readCaptures(api);
+    expect(
+      captures.length,
+      "no FCM capture should land for a recipient with no fcmTokens",
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Integration test #9 — verifies POST `/api/conversations/:id/messages` produces an FCM payload with the documented shape that Android/iOS clients depend on.

## Code changes

### `fcm.js` — capture buffer
- In-process `_fcmCaptures` buffer that records `{tokens, data, ts}` whenever `sendFcmToTokens` runs in `NODE_ENV=local`.
- Bounded at 1000 entries with FIFO eviction so a long-lived dev process can't OOM.
- New exports `getFcmCaptures` (defensive copy) and `clearFcmCaptures`. Production never touches these.

### `test-helpers.js` — endpoints
- `GET /api/test/fcm-captures` — returns the buffer
- `POST /api/test/fcm-captures/clear` — empties the buffer
- Both gated on the existing X-Test-API-Key check.

## Tests

### Integration (`tests/integration/08-fcm-message-shape.spec.ts`)
- **Happy path**: seeds `recipient.fcmTokens`, sends a PM, polls captures, asserts payload shape matches what conversations.js:117 produces (`type=PM`, `senderId`, `conversationId`, `isGroup='false'`, `showPreview='true'`, etc.).
- **Negative path**: recipient with no fcmTokens MUST NOT trigger a capture (regression coverage for the `shouldNotifyRecipient` gate at conversations.js:69).

### Unit (`tests/utils/fcm.test.js`)
- 3 new test cases covering local-mode capture, defensive-copy semantics, and clear.

## Why this matters
Mocks let unit tests pass even when the route stops calling `sendFcmToTokens` entirely or when `data` is shaped wrong. Only this integration tier proves the production code path actually populates the data object that the Android FCM message handler decodes. A future regression that drops a field would surface here.

## Test plan
- [x] `npx jest tests/utils/fcm.test.js tests/routes/test-helpers` — 119 tests pass.
- [x] `bash local/start.sh` + `npx playwright test --config=playwright.integration.config.ts` — 26/26 pass (~4.2s warm).
- [x] Determinism re-run clean.
- [x] Prettier clean.

Per `.project/plans/2026-05-05-integration-test-framework.md` test #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)