### PR TITLE
feat(test): account-deletion cron cascade integration test (Phase 3 PR K)

### DIFF
--- a/express-api/src/routes/test-helpers.js
+++ b/express-api/src/routes/test-helpers.js
@@ -550,6 +550,37 @@ router.post('/test/fcm-captures/clear', (req, res) => {
   res.json({ success: true });
 });
 
+// POST /api/test/run-cron/:cronName — manually trigger a cron job once.
+// Used by the integration suite to verify cron-driven cascades
+// (account deletion, subscription expiry, etc.) without waiting for
+// the schedule. Whitelist enforced — only crons safe to invoke
+// directly from a test (no external network calls beyond the
+// emulator) are listed.
+const ALLOWED_CRONS = {
+  'account-deletion': require('../cron/accountDeletion'),
+};
+
+router.post('/test/run-cron/:cronName', async (req, res) => {
+  if (requireTestApiKey(req, res)) return;
+  if (process.env.NODE_ENV === 'production') {
+    return res.status(403).json({ error: 'Not available in production' });
+  }
+  const { cronName } = req.params;
+  const cronFn = ALLOWED_CRONS[cronName];
+  if (!cronFn) {
+    return res.status(400).json({
+      error: `Cron '${cronName}' not allowed. Available: ${Object.keys(ALLOWED_CRONS).join(', ')}`,
+    });
+  }
+  try {
+    await cronFn();
+    res.json({ success: true });
+  } catch (err) {
+    log.error('test-helpers', 'Cron trigger failed', { cronName, error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // POST /api/test/reset — wipe ALL test data
 router.post('/test/reset', async (req, res) => {
   try {

--- a/express-api/tests/routes/test-helpers-cron.test.js
+++ b/express-api/tests/routes/test-helpers-cron.test.js
@@ -1,0 +1,126 @@
+/**
+ * Tests for the test-helper cron-trigger endpoint (Phase 3 PR K).
+ *
+ * POST /api/test/run-cron/:cronName → manually invoke a whitelisted
+ *   cron job. Whitelist enforced; 400 on unknown name; 403 in
+ *   production; 500 on cron-internal error.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// ─── Mocks ────────────────────────────────────────────────────────
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    doc: jest.fn(),
+    collection: jest.fn(),
+    batch: jest.fn(),
+    runTransaction: jest.fn(),
+  },
+  auth: { createCustomToken: jest.fn() },
+}));
+
+jest.mock('../../src/utils/helpers', () => ({
+  generateId: jest.fn(() => 'gen-id'),
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+// Mock the cron module — the test-helpers route requires it via
+// `require('../cron/accountDeletion')` and the result is assigned
+// into the ALLOWED_CRONS map at module-load time.
+const mockAccountDeletion = jest.fn();
+jest.mock('../../src/cron/accountDeletion', () => mockAccountDeletion);
+
+const testHelpersRouter = require('../../src/routes/test-helpers');
+
+const VALID_API_KEY = 'test-secret-key-123';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', testHelpersRouter);
+  return app;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.TEST_API_KEY = VALID_API_KEY;
+  mockAccountDeletion.mockResolvedValue();
+});
+
+afterEach(() => {
+  delete process.env.TEST_API_KEY;
+});
+
+// ─── Tests ────────────────────────────────────────────────────────
+
+describe('POST /api/test/run-cron/:cronName', () => {
+  test('runs the whitelisted cron and returns success:true', async () => {
+    const res = await request(createApp())
+      .post('/api/test/run-cron/account-deletion')
+      .set('X-Test-Api-Key', VALID_API_KEY)
+      .send({})
+      .expect(200);
+
+    expect(res.body).toEqual({ success: true });
+    expect(mockAccountDeletion).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns 400 for an unknown cron name with available list', async () => {
+    const res = await request(createApp())
+      .post('/api/test/run-cron/totally-fake-cron')
+      .set('X-Test-Api-Key', VALID_API_KEY)
+      .send({})
+      .expect(400);
+
+    expect(res.body.error).toMatch(/not allowed/i);
+    expect(res.body.error).toMatch(/account-deletion/);
+    expect(mockAccountDeletion).not.toHaveBeenCalled();
+  });
+
+  test('returns 403 in production', async () => {
+    const prevEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      const res = await request(createApp())
+        .post('/api/test/run-cron/account-deletion')
+        .set('X-Test-Api-Key', VALID_API_KEY)
+        .send({})
+        .expect(403);
+
+      expect(res.body.error).toMatch(/Not available in production/i);
+      expect(mockAccountDeletion).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = prevEnv;
+    }
+  });
+
+  test('returns 403 without X-Test-Api-Key header', async () => {
+    const res = await request(createApp())
+      .post('/api/test/run-cron/account-deletion')
+      .send({})
+      .expect(403);
+
+    expect(res.body.error).toBe('Invalid test API key');
+    expect(mockAccountDeletion).not.toHaveBeenCalled();
+  });
+
+  test('returns 500 when the cron throws', async () => {
+    mockAccountDeletion.mockRejectedValue(new Error('Firestore down'));
+
+    const res = await request(createApp())
+      .post('/api/test/run-cron/account-deletion')
+      .set('X-Test-Api-Key', VALID_API_KEY)
+      .send({})
+      .expect(500);
+
+    expect(res.body.error).toBe('Firestore down');
+    expect(mockAccountDeletion).toHaveBeenCalledTimes(1);
+  });
+});

--- a/express-api/tests/routes/test-helpers-fcm.test.js
+++ b/express-api/tests/routes/test-helpers-fcm.test.js
@@ -1,0 +1,121 @@
+/**
+ * Tests for the FCM-capture test-helper endpoints (added alongside Phase 3 PR J).
+ *
+ * GET  /api/test/fcm-captures        → returns buffered captures
+ * POST /api/test/fcm-captures/clear  → empties the buffer
+ *
+ * Both gated on the X-Test-Api-Key header.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// ─── Firebase + fcm mocks ────────────────────────────────────────
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    doc: jest.fn(),
+    collection: jest.fn(),
+    batch: jest.fn(),
+    runTransaction: jest.fn(),
+  },
+  auth: { createCustomToken: jest.fn() },
+}));
+
+jest.mock('../../src/utils/helpers', () => ({
+  generateId: jest.fn(() => 'gen-id'),
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const mockGetFcmCaptures = jest.fn();
+const mockClearFcmCaptures = jest.fn();
+jest.mock('../../src/utils/fcm', () => ({
+  getFcmCaptures: (...args) => mockGetFcmCaptures(...args),
+  clearFcmCaptures: (...args) => mockClearFcmCaptures(...args),
+}));
+
+const testHelpersRouter = require('../../src/routes/test-helpers');
+
+const VALID_API_KEY = 'test-secret-key-123';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', testHelpersRouter);
+  return app;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.TEST_API_KEY = VALID_API_KEY;
+  mockGetFcmCaptures.mockReturnValue([]);
+});
+
+afterEach(() => {
+  delete process.env.TEST_API_KEY;
+});
+
+// ─── Tests ────────────────────────────────────────────────────────
+
+describe('GET /api/test/fcm-captures', () => {
+  test('returns the buffer wrapped in {captures: [...]}', async () => {
+    const fakeCaptures = [
+      { tokens: ['t1'], data: { type: 'PM' }, ts: 123 },
+      { tokens: ['t2', 't3'], data: { type: 'GIFT' }, ts: 456 },
+    ];
+    mockGetFcmCaptures.mockReturnValue(fakeCaptures);
+
+    const res = await request(createApp())
+      .get('/api/test/fcm-captures')
+      .set('X-Test-Api-Key', VALID_API_KEY)
+      .expect(200);
+
+    expect(res.body).toEqual({ captures: fakeCaptures });
+    expect(mockGetFcmCaptures).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns 403 without X-Test-Api-Key header', async () => {
+    const res = await request(createApp()).get('/api/test/fcm-captures').expect(403);
+
+    expect(res.body.error).toBe('Invalid test API key');
+    expect(mockGetFcmCaptures).not.toHaveBeenCalled();
+  });
+
+  test('returns 403 with wrong X-Test-Api-Key header', async () => {
+    const res = await request(createApp())
+      .get('/api/test/fcm-captures')
+      .set('X-Test-Api-Key', 'wrong-key')
+      .expect(403);
+
+    expect(res.body.error).toBe('Invalid test API key');
+    expect(mockGetFcmCaptures).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/test/fcm-captures/clear', () => {
+  test('calls clearFcmCaptures and returns success:true', async () => {
+    const res = await request(createApp())
+      .post('/api/test/fcm-captures/clear')
+      .set('X-Test-Api-Key', VALID_API_KEY)
+      .send({})
+      .expect(200);
+
+    expect(res.body).toEqual({ success: true });
+    expect(mockClearFcmCaptures).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns 403 without X-Test-Api-Key header', async () => {
+    const res = await request(createApp())
+      .post('/api/test/fcm-captures/clear')
+      .send({})
+      .expect(403);
+
+    expect(res.body.error).toBe('Invalid test API key');
+    expect(mockClearFcmCaptures).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/09-account-deletion-cron.spec.ts
+++ b/tests/integration/09-account-deletion-cron.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from "./fixtures/scenarios";
+
+/**
+ * Integration test #8 — Account-deletion cron cascade.
+ *
+ * Verifies that the `accountDeletion()` cron at
+ * express-api/src/cron/accountDeletion.js, when triggered after a
+ * user's grace period expires, actually deletes the user's primary
+ * doc (and its subcollections — verified indirectly via the
+ * fixture teardown's cascade probe).
+ *
+ * What this catches that no unit test can:
+ *   - The cron's Firestore query (`where('deletionExecuteAt', '>',
+ *     0).where('deletionExecuteAt', '<=', timestamp)`) actually
+ *     finds users tagged for deletion. A composite-index miss
+ *     would silently skip them in production.
+ *   - `hardDeleteAccount` runs to completion against a real user
+ *     with subcollections.
+ *   - The user doc IS actually removed (a regression that only
+ *     soft-deletes by setting a flag would surface here).
+ *
+ * Per `.project/plans/2026-05-05-integration-test-framework.md`
+ * test #8.
+ */
+
+const API_BASE = process.env.API_BASE_URL || "http://localhost:3000";
+const TEST_API_KEY = process.env.TEST_API_KEY || "local-test-key";
+
+test.describe("Integration — account-deletion cron cascade", () => {
+  test("cron deletes a user whose grace period has expired", async ({
+    api,
+    sender,
+  }) => {
+    // Mark the sender for deletion with `deletionExecuteAt` in the
+    // past so the cron's "<=now()" predicate matches on first run.
+    // /api/test/write/users does a merge:true into the existing doc.
+    const setDeletion = await api.post(`${API_BASE}/api/test/write/users`, {
+      headers: { "X-Test-API-Key": TEST_API_KEY },
+      data: {
+        id: String(sender.uniqueId),
+        deletionScheduledAt: Date.now() - 31 * 86400000,
+        deletionExecuteAt: 1, // any positive past timestamp matches
+        deletionReason: "user_request",
+      },
+    });
+    expect(
+      setDeletion.ok(),
+      `mark-for-deletion: ${await setDeletion.text()}`,
+    ).toBe(true);
+
+    // Confirm the user exists pre-cron via /api/test/verify so the
+    // post-cron 404 is meaningful (not "we never wrote the doc in
+    // the first place").
+    const pre = await api.get(
+      `${API_BASE}/api/test/verify/users/${sender.uniqueId}`,
+      { headers: { "X-Test-API-Key": TEST_API_KEY } },
+    );
+    expect(pre.status(), `pre-cron user must exist`).toBe(200);
+
+    // Trigger the cron. The endpoint loops over all users matching
+    // the deletion predicate; our test user is the only one in this
+    // emulator with `deletionExecuteAt` set (other test runs are
+    // teardown-isolated by `_testRun`).
+    const trigger = await api.post(
+      `${API_BASE}/api/test/run-cron/account-deletion`,
+      {
+        headers: {
+          "X-Test-API-Key": TEST_API_KEY,
+          "Content-Type": "application/json",
+        },
+        data: {},
+      },
+    );
+    expect(
+      trigger.ok(),
+      `cron trigger: ${trigger.status()}: ${await trigger.text()}`,
+    ).toBe(true);
+
+    // Verify the user doc is GONE. /api/test/verify returns 404
+    // when the doc doesn't exist. This is the integration-tier
+    // proof that the cron's cascade actually committed.
+    const post = await api.get(
+      `${API_BASE}/api/test/verify/users/${sender.uniqueId}`,
+      { headers: { "X-Test-API-Key": TEST_API_KEY } },
+    );
+    expect(
+      post.status(),
+      `post-cron user must be deleted, got status ${post.status()}`,
+    ).toBe(404);
+  });
+
+  test("cron is a no-op for users without deletionExecuteAt", async ({
+    api,
+    sender,
+  }) => {
+    // Sender doc exists but has NO deletionExecuteAt field. The
+    // cron's predicate `where('deletionExecuteAt', '>', 0)` must
+    // skip this user — verified by checking the doc still exists
+    // after a trigger.
+    const trigger = await api.post(
+      `${API_BASE}/api/test/run-cron/account-deletion`,
+      {
+        headers: {
+          "X-Test-API-Key": TEST_API_KEY,
+          "Content-Type": "application/json",
+        },
+        data: {},
+      },
+    );
+    expect(trigger.ok()).toBe(true);
+
+    const post = await api.get(
+      `${API_BASE}/api/test/verify/users/${sender.uniqueId}`,
+      { headers: { "X-Test-API-Key": TEST_API_KEY } },
+    );
+    expect(
+      post.status(),
+      "user without deletionExecuteAt must NOT be deleted by the cron",
+    ).toBe(200);
+  });
+
+  test("cron rejects unknown cron name with 400", async ({ api }) => {
+    const res = await api.post(
+      `${API_BASE}/api/test/run-cron/totally-fake-cron`,
+      {
+        headers: {
+          "X-Test-API-Key": TEST_API_KEY,
+          "Content-Type": "application/json",
+        },
+        data: {},
+      },
+    );
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/not allowed/i);
+  });
+});


### PR DESCRIPTION
## Summary
Integration test #8 — verifies the `accountDeletion()` cron at `express-api/src/cron/accountDeletion.js` actually finds users past their grace period and deletes them.

## Code changes
- **`test-helpers.js`** — adds `POST /api/test/run-cron/:cronName` endpoint with whitelist (currently `account-deletion`). Production-gated (403 in prod). Lets the integration suite drive cron-cascade tests without waiting for the schedule.

## Test cases (`tests/integration/09-account-deletion-cron.spec.ts`)
- **Happy path** — marks the sender for deletion (`deletionExecuteAt: 1`, in the past), triggers the cron, asserts the user doc is GONE via `/api/test/verify` (404).
- **Skip path** — a user with no `deletionExecuteAt` must NOT be deleted: predicate `where('deletionExecuteAt', '>', 0)` must hold.
- **Whitelist enforcement** — unknown cron name 400s with the available list.

## Why this matters
Catches the class of bug where a Firestore composite-index miss makes the cron silently skip pending deletions, or where a refactor accidentally soft-deletes (sets a flag) instead of hard-deleting. A unit test on the cron with mocked Firestore would let either pass.

## Test plan
- [x] `bash local/start.sh` + `npx playwright test --config=playwright.integration.config.ts` — 29/29 pass (~3.8s warm)
- [x] Determinism re-run clean
- [x] Prettier clean
- [x] `cd express-api && npx jest tests/routes/test-helpers` — 108/108 pass

Per `.project/plans/2026-05-05-integration-test-framework.md` test #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)