### PR TITLE
fix(shared): User default timestamps are 0L (Phase 2B finding)

### DIFF
--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
@@ -25,9 +25,16 @@ data class User(
     val email: String? = null,
     val currentRoomId: String? = null,
     val lastRoomName: String? = null,
-    val createdAt: Long = currentTimeMillis(),
+    // 0L sentinel so a default-constructed User() does NOT capture the
+    // current timestamp at construction time. Default-constructing a User
+    // and then writing it via UserRepository.createOrUpdateUser would
+    // overwrite the server's authoritative createdAt/lastSeenAt with
+    // wall-clock-at-construction. fromMap() populates these from the
+    // Firestore doc; client-built User instances should always set the
+    // field explicitly when the value matters.
+    val createdAt: Long = 0L,
     val userType: UserType = UserType.MEMBER,
-    val lastSeenAt: Long = currentTimeMillis(),
+    val lastSeenAt: Long = 0L,
     val stalkerCount: Long = 0,
     val newStalkerCount: Long = 0,
     val stalkersLastViewedAt: Long = 0,

--- a/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/model/UserTest.kt
+++ b/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/model/UserTest.kt
@@ -484,6 +484,20 @@ class UserTest {
     }
 
     @Test
+    fun `default createdAt and lastSeenAt are 0L (not capture-time)`() {
+        // Regression test: default-constructed User must NOT capture
+        // currentTimeMillis() at construction time. If it did, writing
+        // a default-constructed User via UserRepository.createOrUpdateUser
+        // would overwrite the server's authoritative createdAt with
+        // wall-clock-at-construction. fromMap() populates these fields
+        // from the Firestore doc; client-built User instances must
+        // explicitly set them when the value matters.
+        val user = User()
+        assertEquals(0L, user.createdAt)
+        assertEquals(0L, user.lastSeenAt)
+    }
+
+    @Test
     fun `isPendingDeletion is true when both timestamps are set`() {
         val user =
             User(


### PR DESCRIPTION
## Summary
Phase 2B audit caught: `User.createdAt` and `User.lastSeenAt` defaulted to `currentTimeMillis()`, which **evaluates at construction time**. A default-constructed `User` used as a placeholder, `MutableStateFlow` seed, or partially-initialised profile that ended up in `UserRepository.createOrUpdateUser` would overwrite the server's authoritative `createdAt` with wall-clock-at-construction.

No production code currently calls `User()` directly (verified via grep); all `User` instances come from `User.fromMap()` which populates these fields from the Firestore doc. The change is defensive against future regressions and makes the contract explicit: client-built `User` instances must explicitly set the field when the value matters.

## Verified safe for current consumers
- `ProfileViewModel`/`PrivateChatScreen` lastSeenAt arithmetic: `currentTimeMillis() - 0 < ONLINE_THRESHOLD_MS` evaluates false → "not online" → correct (default-constructed user hasn't been seen).
- No production code reads `user.createdAt` directly.

## Phase 2B audit context
Audited `shared/src/commonMain/kotlin/com/shyden/shytalk/data/` (32 files) plus adjacent consumers. Findings: 6 candidates → 4 false positives, 1 minor edge case deferred, 1 real-but-theoretical bug → this fix.

## Test plan
- [x] New regression test in `UserTest`: `default createdAt and lastSeenAt are 0L (not capture-time)`
- [x] `./gradlew :shared:jvmTest` — passes
- [x] `./gradlew :shared:compileKotlinIosArm64` — passes (KMP iOS contract intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)