### PR TITLE
fix(android): cancel RoomService.serviceScope in onDestroy (Phase 2C #1)

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/core/room/RoomService.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/room/RoomService.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -320,6 +321,12 @@ class RoomService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
+        // Cancel the parent scope so SupervisorJob and any in-flight or
+        // subsequently-launched child coroutines are torn down with the
+        // service. The individual job cancels below are now redundant
+        // (children are cancelled when the parent is) but kept for
+        // explicit readability around which observers existed.
+        serviceScope.cancel()
         observerJob?.cancel()
         chatHeadJob?.cancel()
         roomClosedJob?.cancel()


### PR DESCRIPTION
## Summary
Phase 2C audit found: `RoomService.onDestroy` cancelled the three observer Jobs individually (`observerJob`, `chatHeadJob`, `roomClosedJob`) but never cancelled the parent `serviceScope`. The `SupervisorJob` plus any coroutine launched into the scope after `onDestroy` would leak — the scope object remains reachable until GC and any subsequent `serviceScope.launch{}` would spin up work on a service that no longer exists.

## Fix
Add `serviceScope.cancel()` to `onDestroy`. Cancelling the parent scope tears down all children. Individual job cancels are now redundant but kept for explicit readability around which observers existed.

## Verification
- Reading `RoomService.kt:35-47` confirmed the scope declaration without parent cancellation.
- Reading `RoomService.kt:321-329` confirmed the missing `serviceScope.cancel()` in `onDestroy`.
- `./gradlew :app:compileDevDebugKotlin` passes.
- `./gradlew :app:testDevDebugUnitTest` passes (no regressions).

## Test plan
- [x] Compile clean
- [x] Unit tests pass
- [ ] Branch protection gates the merge automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)