### PR TITLE
fix(android): remove ProcessLifecycleOwner observer in onDestroy (Phase 2C #2)

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/MainActivity.kt
+++ b/app/src/main/java/com/shyden/shytalk/MainActivity.kt
@@ -94,6 +94,14 @@ class MainActivity : AppCompatActivity() {
     private val showLeaveConfirmationState = mutableStateOf(false)
     private var lastSeenJob: Job? = null
 
+    // Tracked so we can removeObserver in onDestroy. ProcessLifecycleOwner
+    // is process-scoped, so observers registered in Activity onCreate
+    // outlive the Activity. Without explicit removal, every config change
+    // (rotation, locale switch via attachBaseContext) accumulates a new
+    // observer, each independently calling appLockRepository on every
+    // background transition.
+    private var processLifecycleObserver: DefaultLifecycleObserver? = null
+
     override fun attachBaseContext(newBase: Context) {
         val language = LanguagePreference.get()
         val locale = java.util.Locale.forLanguageTag(language)
@@ -122,15 +130,19 @@ class MainActivity : AppCompatActivity() {
         biometricAuth.setActivity(this)
         enableEdgeToEdge()
 
-        // Track app background/foreground for lock timeout
-        ProcessLifecycleOwner.get().lifecycle.addObserver(
+        // Track app background/foreground for lock timeout. Save the
+        // observer so it can be removed in onDestroy — ProcessLifecycleOwner
+        // is process-scoped and would otherwise accumulate observers
+        // across config-change Activity recreations.
+        val observer =
             object : DefaultLifecycleObserver {
                 override fun onStop(owner: LifecycleOwner) {
                     // App went to background — record timestamp
                     appLockRepository.updateLastActiveTimestamp()
                 }
-            },
-        )
+            }
+        ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
+        processLifecycleObserver = observer
 
         setContent {
             ShyTalkTheme(darkTheme = true) {
@@ -619,5 +631,13 @@ class MainActivity : AppCompatActivity() {
                 showLeaveConfirmationState.value = true
             }
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        processLifecycleObserver?.let {
+            ProcessLifecycleOwner.get().lifecycle.removeObserver(it)
+        }
+        processLifecycleObserver = null
     }
 }


### PR DESCRIPTION
## Summary
Phase 2C audit found: `MainActivity.onCreate` registered a `DefaultLifecycleObserver` on `ProcessLifecycleOwner` unconditionally, but never removed it. `ProcessLifecycleOwner` is process-scoped, so the observer outlived the Activity. On every config-change Activity recreation (rotation, or locale switch via `attachBaseContext`), `onCreate` ran again and registered a SECOND observer on the same lifecycle. Over multiple recreations, observers accumulated, each independently calling `appLockRepository.updateLastActiveTimestamp()` on every background transition.

## Fix
- Store the observer in a `processLifecycleObserver` field.
- Add `onDestroy` override that calls `lifecycle.removeObserver(it)`.

## Verification
- Reading `MainActivity.kt:90-95` confirmed no field existed for the observer.
- Reading `MainActivity.kt:126-133` confirmed the anonymous `addObserver` with no removal.
- Reading `MainActivity.kt:615-633` confirmed no `onDestroy` override existed.
- `./gradlew :app:compileDevDebugKotlin` passes.
- `./gradlew :app:testDevDebugUnitTest` passes.

## Test plan
- [x] Compile clean
- [x] Unit tests pass
- [ ] Branch protection gates the merge automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)