### PR TITLE
fix(android): wrap room seat-clear paths in transactions (Phase 2C #3-4)

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
@@ -145,26 +145,38 @@ class RoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to leave room") {
-            // Get current room to find user's seat
-            val doc = firestore.document("rooms/$roomId").get().await()
-            val data = doc.data
-            val updates =
-                mutableMapOf<String, Any?>(
-                    "participantIds" to FieldValue.arrayRemove(userId),
-                )
-            // Clear any seat occupied by this user
-            if (data != null) {
-                val seatsRaw = data["seats"] as? Map<*, *>
-                seatsRaw?.forEach { (index, seatData) ->
-                    val seat = seatData as? Map<*, *>
-                    if (seat?.get("userId") == userId) {
-                        updates["seats.$index.userId"] = null
-                        updates["seats.$index.state"] = "EMPTY"
-                        updates["seats.$index.isMuted"] = false
+            // Atomic: read seats + clear-by-user in one transaction so a
+            // concurrent moveSeat (also transactional) can't swap the seat
+            // mid-flight, which would otherwise leave us writing the
+            // pre-move user's seat clear (stale data) or missing the
+            // target's actual seat. moveSeat at line 219 uses the same
+            // pattern; this brings leaveRoom's read-then-write to parity.
+            val roomRef = firestore.document("rooms/$roomId")
+            firestore
+                .runTransaction { transaction ->
+                    val doc = transaction.get(roomRef)
+                    val data = doc.data
+                    val updates =
+                        mutableMapOf<String, Any?>(
+                            "participantIds" to FieldValue.arrayRemove(userId),
+                        )
+                    if (data != null) {
+                        val seatsRaw = data["seats"] as? Map<*, *>
+                        seatsRaw?.forEach { (index, seatData) ->
+                            val seat = seatData as? Map<*, *>
+                            if (seat?.get("userId") == userId) {
+                                updates["seats.$index.userId"] = null
+                                updates["seats.$index.state"] = "EMPTY"
+                                updates["seats.$index.isMuted"] = false
+                            }
+                        }
                     }
-                }
-            }
-            firestore.document("rooms/$roomId").update(updates).await()
+                    transaction.update(roomRef, updates)
+                }.await()
+            // user-doc update is intentionally outside the transaction —
+            // Firestore transactions can't span unrelated docs without a
+            // multi-doc read; if the user-doc write fails, the user has a
+            // stale currentRoomId but the room is correctly cleared.
             firestore.document("users/$userId").update("currentRoomId", null).await()
         }
 
@@ -252,36 +264,42 @@ class RoomRepositoryImpl(
     ): Resource<Unit> =
         firebaseCall("Failed to kick user") {
             val effectiveReason = reason.ifBlank { "No reason given" }
-            val updates =
-                mutableMapOf<String, Any?>(
-                    "participantIds" to FieldValue.arrayRemove(userId),
-                    "bannedUserIds" to FieldValue.arrayUnion(userId),
-                    "kickInfo.$userId" to
-                        mapOf(
-                            "kickerName" to kickerName,
-                            "reason" to effectiveReason,
-                        ),
-                )
-            // Clear any seat occupied by this user
-            if (seatIndex != null) {
-                updates["seats.$seatIndex.userId"] = null
-                updates["seats.$seatIndex.state"] = "EMPTY"
-                updates["seats.$seatIndex.isMuted"] = false
-            } else {
-                // Find and clear seat by reading room data
-                val doc = firestore.document("rooms/$roomId").get().await()
-                val data = doc.data
-                val seatsRaw = data?.get("seats") as? Map<*, *>
-                seatsRaw?.forEach { (index, seatData) ->
-                    val seat = seatData as? Map<*, *>
-                    if (seat?.get("userId") == userId) {
-                        updates["seats.$index.userId"] = null
-                        updates["seats.$index.state"] = "EMPTY"
-                        updates["seats.$index.isMuted"] = false
+            val roomRef = firestore.document("rooms/$roomId")
+            // Atomic: when seatIndex is unknown we MUST read seats inside
+            // the same transaction as the clear, otherwise a concurrent
+            // moveSeat can shuffle the target's seat between our read and
+            // write, leaving us blanking the wrong seat.
+            firestore
+                .runTransaction { transaction ->
+                    val updates =
+                        mutableMapOf<String, Any?>(
+                            "participantIds" to FieldValue.arrayRemove(userId),
+                            "bannedUserIds" to FieldValue.arrayUnion(userId),
+                            "kickInfo.$userId" to
+                                mapOf(
+                                    "kickerName" to kickerName,
+                                    "reason" to effectiveReason,
+                                ),
+                        )
+                    if (seatIndex != null) {
+                        updates["seats.$seatIndex.userId"] = null
+                        updates["seats.$seatIndex.state"] = "EMPTY"
+                        updates["seats.$seatIndex.isMuted"] = false
+                    } else {
+                        val doc = transaction.get(roomRef)
+                        val data = doc.data
+                        val seatsRaw = data?.get("seats") as? Map<*, *>
+                        seatsRaw?.forEach { (index, seatData) ->
+                            val seat = seatData as? Map<*, *>
+                            if (seat?.get("userId") == userId) {
+                                updates["seats.$index.userId"] = null
+                                updates["seats.$index.state"] = "EMPTY"
+                                updates["seats.$index.isMuted"] = false
+                            }
+                        }
                     }
-                }
-            }
-            firestore.document("rooms/$roomId").update(updates).await()
+                    transaction.update(roomRef, updates)
+                }.await()
             firestore.document("users/$userId").update("currentRoomId", null).await()
         }
 
@@ -492,23 +510,31 @@ class RoomRepositoryImpl(
                     .await()
             for (doc in snapshot.documents) {
                 if (doc.id == exceptRoomId) continue
-                val data = doc.data ?: continue
-                val updates =
-                    mutableMapOf<String, Any?>(
-                        "participantIds" to FieldValue.arrayRemove(userId),
-                    )
-                // Clear any seat occupied by this user
-                val seatsRaw = data["seats"] as? Map<*, *>
-                seatsRaw?.forEach { (index, seatData) ->
-                    val seat = seatData as? Map<*, *>
-                    if (seat?.get("userId") == userId) {
-                        updates["seats.$index.userId"] = null
-                        updates["seats.$index.state"] = "EMPTY"
-                        updates["seats.$index.isMuted"] = false
-                    }
-                }
+                // Atomic per-room: read seats + clear under one transaction
+                // so a concurrent moveSeat can't shuffle this user's seat
+                // between our read and write. Each room is independent so
+                // a per-room transaction (not multi-doc) is sufficient.
+                val roomRef = firestore.document("rooms/${doc.id}")
                 try {
-                    firestore.document("rooms/${doc.id}").update(updates).await()
+                    firestore
+                        .runTransaction { transaction ->
+                            val freshDoc = transaction.get(roomRef)
+                            val data = freshDoc.data ?: return@runTransaction
+                            val updates =
+                                mutableMapOf<String, Any?>(
+                                    "participantIds" to FieldValue.arrayRemove(userId),
+                                )
+                            val seatsRaw = data["seats"] as? Map<*, *>
+                            seatsRaw?.forEach { (index, seatData) ->
+                                val seat = seatData as? Map<*, *>
+                                if (seat?.get("userId") == userId) {
+                                    updates["seats.$index.userId"] = null
+                                    updates["seats.$index.state"] = "EMPTY"
+                                    updates["seats.$index.isMuted"] = false
+                                }
+                            }
+                            transaction.update(roomRef, updates)
+                        }.await()
                 } catch (e: Exception) {
                     Log.w(TAG, "Room operation failed", e)
                 }
@@ -561,25 +587,29 @@ class RoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to remove disconnected user") {
-            // Same logic as leaveRoom
-            val doc = firestore.document("rooms/$roomId").get().await()
-            val data = doc.data
-            val updates =
-                mutableMapOf<String, Any?>(
-                    "participantIds" to FieldValue.arrayRemove(userId),
-                )
-            if (data != null) {
-                val seatsRaw = data["seats"] as? Map<*, *>
-                seatsRaw?.forEach { (index, seatData) ->
-                    val seat = seatData as? Map<*, *>
-                    if (seat?.get("userId") == userId) {
-                        updates["seats.$index.userId"] = null
-                        updates["seats.$index.state"] = "EMPTY"
-                        updates["seats.$index.isMuted"] = false
+            // Same race-safety logic as leaveRoom.
+            val roomRef = firestore.document("rooms/$roomId")
+            firestore
+                .runTransaction { transaction ->
+                    val doc = transaction.get(roomRef)
+                    val data = doc.data
+                    val updates =
+                        mutableMapOf<String, Any?>(
+                            "participantIds" to FieldValue.arrayRemove(userId),
+                        )
+                    if (data != null) {
+                        val seatsRaw = data["seats"] as? Map<*, *>
+                        seatsRaw?.forEach { (index, seatData) ->
+                            val seat = seatData as? Map<*, *>
+                            if (seat?.get("userId") == userId) {
+                                updates["seats.$index.userId"] = null
+                                updates["seats.$index.state"] = "EMPTY"
+                                updates["seats.$index.isMuted"] = false
+                            }
+                        }
                     }
-                }
-            }
-            firestore.document("rooms/$roomId").update(updates).await()
+                    transaction.update(roomRef, updates)
+                }.await()
             firestore.document("users/$userId").update("currentRoomId", null).await()
         }
 }

--- a/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
@@ -136,7 +136,10 @@ class RoomRepositoryImplTest {
     @Test
     fun `leaveRoom returns Error on exception`() =
         runTest {
-            every { mockDocRef.get() } returns Tasks.forException(RuntimeException("Fail"))
+            // leaveRoom now reads + writes inside a transaction (race-safety
+            // fix for the seat-clear path), so failures surface via
+            // runTransaction rather than the standalone get/update calls.
+            every { firestore.runTransaction<Unit>(any()) } returns Tasks.forException(RuntimeException("Fail"))
 
             val result = repo.leaveRoom("room-1", "user-1")
             assertTrue(result is Resource.Error)
@@ -218,7 +221,9 @@ class RoomRepositoryImplTest {
     @Test
     fun `kickUser returns Error on exception`() =
         runTest {
-            every { mockDocRef.update(any<Map<String, Any>>()) } returns Tasks.forException(RuntimeException("Fail"))
+            // kickUser now reads + writes inside a transaction; failure
+            // surfaces via runTransaction.
+            every { firestore.runTransaction<Unit>(any()) } returns Tasks.forException(RuntimeException("Fail"))
 
             val result = repo.kickUser("room-1", "bad-user", 2)
             assertTrue(result is Resource.Error)
@@ -448,7 +453,9 @@ class RoomRepositoryImplTest {
     @Test
     fun `removeDisconnectedUser returns Error on exception`() =
         runTest {
-            every { mockDocRef.get() } returns Tasks.forException(RuntimeException("Fail"))
+            // removeDisconnectedUser now reads + writes inside a transaction;
+            // failure surfaces via runTransaction.
+            every { firestore.runTransaction<Unit>(any()) } returns Tasks.forException(RuntimeException("Fail"))
 
             val result = repo.removeDisconnectedUser("room-1", "user-1")
             assertTrue(result is Resource.Error)


### PR DESCRIPTION
## Summary
Phase 2C audit caught 4 methods on `RoomRepositoryImpl` that read room data and then wrote seat-clear updates **outside any transaction**. `moveSeat` at line 219 already uses `runTransaction` — so a concurrent `moveSeat` could shuffle the target user's seat between our read and write, leaving us either blanking the wrong seat or missing the user's seat entirely.

This is the Android client mirror of the Express-side `gift-direct` race fix from Phase 2A (PR #485).

## Methods fixed (all now use `firestore.runTransaction { ... }`)
| Method | Risk |
|---|---|
| `leaveRoom` | Every-user exit path; high frequency |
| `kickUser` (seatIndex==null branch) | Moderator action; the read-then-write that races moveSeat |
| `removeDisconnectedUser` | Same logic as leaveRoom; runs on disconnect detection |
| `leaveAllRooms` | Sign-out path; per-room transaction (each room is independent so no cross-doc transaction needed) |

The user-doc `currentRoomId` update remains outside the transaction (Firestore can't span unrelated docs without a multi-doc read). Acceptable trade-off: if the user-doc write fails, the user has a stale `currentRoomId` but the room state is correctly cleared.

## Verification (per Phase 2B's "verify before fixing" rule)
- Read lines 143-169 (`leaveRoom`), 246-285 (`kickUser`), 559-584 (`removeDisconnectedUser`), 482-517 (`leaveAllRooms`).
- Confirmed `moveSeat` at 210-244 IS in a transaction → race surface confirmed.
- 3 existing "Error on exception" tests updated to mock `firestore.runTransaction` instead of the standalone `mockDocRef.get()`/`update()`. Success-path tests reuse the existing transaction mock at test setup line 64-72.

## Test plan
- [x] `./gradlew :app:compileDevDebugKotlin` passes
- [x] `./gradlew :app:testDevDebugUnitTest` passes (all 42 tasks)
- [ ] Branch protection gates the merge automatically (PR Gate + SonarCloud Code Analysis required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)