### PR TITLE
fix(ios): User repo correctness — observeUsers ghost docs + JSON list serialization (Phase 2D)

### DIFF
--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosUserRepositoryImpl.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosUserRepositoryImpl.kt
@@ -19,8 +19,12 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.boolean
@@ -193,6 +197,14 @@ class IosUserRepositoryImpl(
                     .collection("users")
                     .document(userId)
                     .snapshots
+                    // Skip non-existent docs (deletion or never-created):
+                    // dataMap() on a missing doc yields an empty map, and
+                    // User.fromMap of an empty map produces a zero-value
+                    // ghost User (uid="", uniqueId=0) that propagates into
+                    // seat rendering and follower-counts with no error
+                    // signal. Guard matches the observeUserFlags pattern
+                    // already in this file at line 178.
+                    .filter { it.exists }
                     .map { snapshot ->
                         docToUser(snapshot, userId)
                     }
@@ -203,20 +215,41 @@ class IosUserRepositoryImpl(
 
     override suspend fun createOrUpdateUser(user: User): Resource<Unit> =
         firebaseCall("Failed to create/update user") {
-            val body =
-                JsonObject(
-                    user.toMap().mapValues { (_, v) ->
-                        when (v) {
-                            null -> JsonPrimitive(null as String?)
-                            is String -> JsonPrimitive(v)
-                            is Number -> JsonPrimitive(v)
-                            is Boolean -> JsonPrimitive(v)
-                            else -> JsonPrimitive(v.toString())
-                        }
-                    },
-                )
+            val body = JsonObject(user.toMap().mapValues { (_, v) -> toJsonElement(v) })
             api.post("/api/users", body)
             _userUpdates.tryEmit(user)
+        }
+
+    /**
+     * Recursively convert a value to the matching kotlinx.serialization JsonElement.
+     * Critical: List/Map values must NOT fall through to JsonPrimitive(v.toString()),
+     * which yields strings like "[uid1, uid2]" or "{key=value}" instead of valid
+     * JSON arrays/objects. The Express API receives those as strings and either
+     * rejects the request or stores garbage. List<String> fields like blockedUserIds,
+     * followingIds, providers must round-trip as JSON arrays.
+     */
+    private fun toJsonElement(v: Any?): JsonElement =
+        when (v) {
+            null -> JsonNull
+
+            is String -> JsonPrimitive(v)
+
+            is Number -> JsonPrimitive(v)
+
+            is Boolean -> JsonPrimitive(v)
+
+            is Map<*, *> ->
+                JsonObject(
+                    v.entries.associate { (k, value) ->
+                        k.toString() to toJsonElement(value)
+                    },
+                )
+
+            is List<*> -> JsonArray(v.map { toJsonElement(it) })
+
+            is Set<*> -> JsonArray(v.map { toJsonElement(it) })
+
+            else -> JsonPrimitive(v.toString())
         }
 
     override suspend fun updateDisplayName(


### PR DESCRIPTION
## Summary
Phase 2D audit caught 2 real bugs in IosUserRepositoryImpl, both verified by reading the file:

### 1. observeUsers ghost-User on doc deletion (line 188)
`docToUser` called `dataMap()` unconditionally. When a Firestore listener fires with a deletion event (`snapshot.exists == false`), `dataMap()` returns an empty map; `User.fromMap` of empty produces a zero-value ghost User (`uid=""`, `uniqueId=0`) that propagates into seat rendering and follower-count UI with no error signal.
**Fix:** `filter { it.exists }` pre-map, matching the `observeUserFlags` guard at line 178.

### 2. createOrUpdateUser broke List/Map values (line 204)
The `else -> JsonPrimitive(v.toString())` branch caught List<String> fields like `blockedUserIds`, `followingIds`, `providers`, `fcmTokens` — producing strings like `"[uid1, uid2]"` instead of valid JSON arrays. Express received those as strings and either rejected requests or stored garbage.
**Fix:** extracted recursive `toJsonElement(v: Any?)` helper handling List/Set/Map plus the existing primitives. Brings iOS to parity with Android's JSONObject.put.

## Verification
- `:shared:compileKotlinIosArm64` passes.
- ktlint format applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)