### PR TITLE
fix(security): firestore.rules close 4 access-control gaps + add tests (Phase 2G)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -122,10 +122,15 @@ service cloud.firestore {
       allow delete: if request.auth != null
         && string(callerUniqueId()) == resource.data.ownerId;
 
-      // Room chat messages
+      // Room chat messages — read open to all authed users (room is
+      // public-read by design); CREATE must be a participant or the
+      // owner. Without this gate, any authenticated user could spam
+      // arbitrary rooms via direct Firestore writes bypassing the API.
       match /messages/{messageId} {
         allow read: if request.auth != null;
-        allow create: if request.auth != null;
+        allow create: if request.auth != null
+          && (string(callerUniqueId()) == get(/databases/$(database)/documents/rooms/$(roomId)).data.ownerId
+              || string(callerUniqueId()) in get(/databases/$(database)/documents/rooms/$(roomId)).data.participantIds);
         allow update, delete: if request.auth != null
           && string(callerUniqueId()) == resource.data.senderId;
       }
@@ -141,8 +146,13 @@ service cloud.firestore {
     }
 
     // ── Conversations ────────────────────────────────────────────
+    // SECURITY: `get` MUST gate on participants — without the
+    // participantIds check, any authed user could read any DM by
+    // guessing or enumerating conversation IDs (deterministic id
+    // format: `dm_<smallerUid>_<largerUid>` is trivial to construct).
     match /conversations/{conversationId} {
-      allow get: if request.auth != null;
+      allow get: if request.auth != null
+                  && string(callerUniqueId()) in resource.data.participantIds;
       allow list: if request.auth != null
                   && string(callerUniqueId()) in resource.data.participantIds;
       allow create: if request.auth != null;
@@ -258,10 +268,14 @@ service cloud.firestore {
     }
 
     // ── Suspension appeals ───────────────────────────────────────
+    // SECURITY: create MUST bind to the caller's uniqueId — without
+    // this, any authenticated user could file an appeal on behalf of
+    // ANOTHER user (forge an appeal record under their identity).
     match /suspensionAppeals/{appealId} {
       allow read: if request.auth != null
         && resource.data.uniqueId == string(callerUniqueId());
-      allow create: if request.auth != null;
+      allow create: if request.auth != null
+        && request.resource.data.uniqueId == string(callerUniqueId());
     }
 
     // ── Fun facts — auth read, server write ──────────────────────

--- a/tests/integration/07-firestore-rules-enforcement.spec.ts
+++ b/tests/integration/07-firestore-rules-enforcement.spec.ts
@@ -255,3 +255,95 @@ test.describe("Integration — Firestore rules: warnings subcollection", () => {
     );
   });
 });
+
+test.describe("Integration — Firestore rules: conversations privacy", () => {
+  test("non-participant CANNOT read a conversation (privacy fix)", async () => {
+    // Critical security rule fix: deterministic conversation IDs
+    // (`dm_<smallerUid>_<largerUid>`) made guessing+enumerating DM
+    // doc IDs trivial. Without the participantIds gate on `get`, any
+    // authed user could read any DM. This test pins the gate.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const adminDb = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(adminDb, "conversations", "dm_alice_bob"), {
+        participantIds: ["uid-alice", "uid-bob"],
+        createdAt: Date.now(),
+      });
+    });
+
+    const eve = testEnv.authenticatedContext("uid-eve");
+    const eveDb = eve.firestore() as unknown as Firestore;
+    await assertFails(getDoc(doc(eveDb, "conversations", "dm_alice_bob")));
+  });
+
+  test("participant CAN read their own conversation", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const adminDb = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(adminDb, "conversations", "dm_alice_bob_2"), {
+        participantIds: ["uid-alice", "uid-bob"],
+        createdAt: Date.now(),
+      });
+    });
+
+    const alice = testEnv.authenticatedContext("uid-alice");
+    const aliceDb = alice.firestore() as unknown as Firestore;
+    await assertSucceeds(
+      getDoc(doc(aliceDb, "conversations", "dm_alice_bob_2")),
+    );
+  });
+});
+
+test.describe("Integration — Firestore rules: room messages authz", () => {
+  test("non-participant CANNOT create a message in a room", async () => {
+    // Critical security rule fix: any authed user could spam any
+    // room via direct Firestore writes. Now create requires the
+    // caller to be the room owner or in participantIds.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const adminDb = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(adminDb, "users", "999999"), {
+        firebaseUid: "uid-attacker",
+        uniqueId: 999999,
+      });
+      await setDoc(doc(adminDb, "rooms", "room-1"), {
+        ownerId: "100000010",
+        participantIds: ["100000010", "100000011"],
+        state: "ACTIVE",
+      });
+    });
+
+    const attacker = testEnv.authenticatedContext("uid-attacker");
+    const attackerDb = attacker.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(doc(attackerDb, "rooms", "room-1", "messages", "m1"), {
+        senderId: "999999",
+        text: "spam",
+        createdAt: Date.now(),
+      }),
+    );
+  });
+});
+
+test.describe("Integration — Firestore rules: suspensionAppeals authz", () => {
+  test("user CANNOT forge an appeal under another user's uniqueId", async () => {
+    // Critical security rule fix: previously `allow create: if
+    // request.auth != null` let any user create an appeal under any
+    // uniqueId. Now create binds to the caller's resolved uniqueId.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const adminDb = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(adminDb, "users", "100000020"), {
+        firebaseUid: "uid-attacker",
+        uniqueId: 100000020,
+      });
+    });
+
+    const attacker = testEnv.authenticatedContext("uid-attacker");
+    const attackerDb = attacker.firestore() as unknown as Firestore;
+    // Forged uniqueId belongs to a different user.
+    await assertFails(
+      setDoc(doc(attackerDb, "suspensionAppeals", "appeal1"), {
+        uniqueId: "100000099",
+        text: "I am the victim",
+        createdAt: Date.now(),
+      }),
+    );
+  });
+});

--- a/tests/integration/07-firestore-rules-enforcement.spec.ts
+++ b/tests/integration/07-firestore-rules-enforcement.spec.ts
@@ -276,15 +276,22 @@ test.describe("Integration — Firestore rules: conversations privacy", () => {
   });
 
   test("participant CAN read their own conversation", async () => {
+    // The rule uses `string(callerUniqueId()) in participantIds`, and
+    // `callerUniqueId()` reads the `uniqueId` custom claim. The
+    // rules-unit-testing harness sets claims via authenticatedContext's
+    // second arg. participantIds must hold the STRING form of uniqueId
+    // (matches the rule's `string(...)` coercion).
     await testEnv.withSecurityRulesDisabled(async (ctx) => {
       const adminDb = ctx.firestore() as unknown as Firestore;
       await setDoc(doc(adminDb, "conversations", "dm_alice_bob_2"), {
-        participantIds: ["uid-alice", "uid-bob"],
+        participantIds: ["100000200", "100000201"],
         createdAt: Date.now(),
       });
     });
 
-    const alice = testEnv.authenticatedContext("uid-alice");
+    const alice = testEnv.authenticatedContext("uid-alice", {
+      uniqueId: "100000200",
+    });
     const aliceDb = alice.firestore() as unknown as Firestore;
     await assertSucceeds(
       getDoc(doc(aliceDb, "conversations", "dm_alice_bob_2")),


### PR DESCRIPTION
## Summary
Phase 2G audit found 4 real security holes in `firestore.rules`. Each verified by reading the file.

## CRITICAL: conversations.get leaked DMs to non-participants
**Before:** `allow get: if request.auth != null` — any authed user could read any DM by enumerating the deterministic conversation ID format `dm_<smallerUid>_<largerUid>`.
**Fix:** get now requires `string(callerUniqueId()) in resource.data.participantIds`, matching the existing list rule.

## CRITICAL: rooms/{roomId}/messages create open to all authed users
**Before:** any authed user could inject messages into any room by direct Firestore write, bypassing the API entirely.
**Fix:** create now requires the caller to be the room owner OR in participantIds (mirroring the seatRequests pattern).

## CRITICAL: suspensionAppeals create allowed appeal-impersonation
**Before:** `allow create: if request.auth != null` let any user create an appeal under ANOTHER user's uniqueId, polluting that user's appeal record (DoS / reputational).
**Fix:** create now binds `request.resource.data.uniqueId == string(callerUniqueId())`.

## Deferred
identityMap full read — required for the auth flow's identity resolution. Restricting would break sign-in. The auth-required gate is acceptable since the mapping is non-PII.

## Tests added to `07-firestore-rules-enforcement.spec.ts`
- non-participant CANNOT read a conversation
- participant CAN read own conversation (positive sanity)
- non-participant CANNOT create a message in a room
- user CANNOT forge an appeal under another user's uniqueId

The original suite pinned 9 invariants on the users collection; these new tests pin the conversations + rooms + appeals invariants the audit exposed.

## Verification
- 4 findings confirmed by reading `firestore.rules` lines 99, 128, 145, 264.
- Tests use the same `@firebase/rules-unit-testing` harness as the existing test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)