### PR TITLE
test: remove no-op assertions from suggestions integration tests (Phase 2F)

### DIFF
--- a/express-api/tests/routes/suggestions-integration-a-flows.test.js
+++ b/express-api/tests/routes/suggestions-integration-a-flows.test.js
@@ -618,65 +618,25 @@ describe('11.72 — GDPR Data Export & Account Deletion', () => {
       expect(res.body).toBeDefined();
     }
   });
-  test('data export includes user votes', async () => {
-    mockCollectionGet.mockResolvedValueOnce({
-      empty: false,
-      docs: [
-        makeVoteDoc('v1', { voterUid: 1001 }),
-        makeVoteDoc('v2', { voterUid: 1001, direction: 'down' }),
-      ],
-      size: 2,
-    });
-    expect(mockCollectionGet).toBeDefined();
-  });
-  test('data export includes user comments', async () => {
-    mockCollectionGet.mockResolvedValueOnce({
-      empty: false,
-      docs: [makeCommentDoc('c1', { authorUid: 1001 })],
-      size: 1,
-    });
-    expect(mockCollectionGet).toBeDefined();
-  });
-  test('account deletion cascade: user suggestions anonymized or deleted', async () => {
-    setupDocMocks({ 'users/1001': makeUserDoc(1001) });
-    mockCollectionGet.mockResolvedValueOnce({
-      empty: false,
-      docs: [
-        makeSuggestionDoc('s1', { submitterUid: 1001 }),
-        makeSuggestionDoc('s2', { submitterUid: 1001 }),
-      ],
-      size: 2,
-    });
-    expect(true).toBe(true);
-  });
-  test('account deletion cascade: user votes removed and counts decremented', async () => {
-    mockCollectionGet.mockResolvedValueOnce({
-      empty: false,
-      docs: [makeVoteDoc('v1', { voterUid: 1001, direction: 'up' })],
-      size: 1,
-    });
-    expect(true).toBe(true);
-  });
-  test('account deletion cascade: user comments anonymized', async () => {
-    mockCollectionGet.mockResolvedValueOnce({
-      empty: false,
-      docs: [makeCommentDoc('c1', { authorUid: 1001 })],
-      size: 1,
-    });
-    expect(true).toBe(true);
-  });
-  test('account deletion cascade: subscription preferences removed', async () => {
-    setupDocMocks({ 'subscriptions/1001': makeSubscriptionDoc(1001) });
-    expect(mockDocDelete).toBeDefined();
-  });
-  test('account deletion cascade: notification inbox cleared', async () => {
-    mockCollectionGet.mockResolvedValueOnce({
-      empty: false,
-      docs: [makeNotifDoc('n1'), makeNotifDoc('n2')],
-      size: 2,
-    });
-    expect(true).toBe(true);
-  });
+  // Both of these placeholder tests asserted only that the mock
+  // collection helper exists (always true), not that the data export
+  // actually included votes/comments. Honest TODO until the export
+  // path is integration-tested.
+  test.skip('TODO: data export includes user votes', async () => {});
+  test.skip('TODO: data export includes user comments', async () => {});
+  // ── Account-deletion cascade — TODO group ───────────────────────
+  // These tests currently set up mocks but assert nothing meaningful
+  // (`expect(true).toBe(true)` or `expect(mockX).toBeDefined()`).
+  // Marked test.skip to surface honestly that the cascade behaviour
+  // is NOT covered, rather than passing falsely. Implement properly
+  // when the suggestions cascade logic is hardened, OR migrate to
+  // the integration framework (cron #8 pattern in PR #514) which
+  // exercises real Firestore + the cron.
+  test.skip('TODO: account deletion cascade: user suggestions anonymized or deleted', async () => {});
+  test.skip('TODO: account deletion cascade: user votes removed and counts decremented', async () => {});
+  test.skip('TODO: account deletion cascade: user comments anonymized', async () => {});
+  test.skip('TODO: account deletion cascade: subscription preferences removed', async () => {});
+  test.skip('TODO: account deletion cascade: notification inbox cleared', async () => {});
   test('GDPR export: suspended user can still request data export', async () => {
     const res = await request(createApp({ uniqueId: 1001, isSuspended: true })).get(
       '/api/suggestions/mine',

--- a/express-api/tests/routes/suggestions-integration-a-submission.test.js
+++ b/express-api/tests/routes/suggestions-integration-a-submission.test.js
@@ -605,10 +605,11 @@ describe('11.31 — Integration Tests Full Flows', () => {
         .send(VALID_SUGGESTION);
       expect(res.status).toBe(403);
     });
-    test('ban cascade: user ban marks their suggestions for review', async () => {
-      setupDocMocks({ 'users/5555': makeUserDoc(5555, { isSuspended: true }) });
-      expect(mockDocGet).toBeDefined();
-    });
+    // The ban cascade behaviour (user-ban → existing-suggestions
+    // re-flagged for review) is not asserted here. Marked skip until
+    // implemented properly, rather than passing falsely on a check
+    // that the mock helper exists.
+    test.skip('TODO: ban cascade: user ban marks their suggestions for review', async () => {});
   });
 
   describe('Multi-account flow', () => {


### PR DESCRIPTION
Phase 2F audit found 8 placeholder tests asserting nothing meaningful (`expect(true).toBe(true)` / `expect(mockX).toBeDefined()`). Converted to `test.skip` with TODO labels — honest skip beats fake-pass.

Affected: 5 account-deletion cascade tests, 2 data-export tests, 1 ban-cascade test in suggestions-integration-a-*.test.js.

`cd express-api && npx jest` — 199 suites, 4696 tests (8 newly skipped, 4688 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)