### PR TITLE
fix(test): dev-smoke IAP catalog needs auth header

### DIFF
--- a/tests/web/dev-smoke.spec.ts
+++ b/tests/web/dev-smoke.spec.ts
@@ -697,10 +697,15 @@ test.describe("Dev Smoke — IAP coin purchase (sandbox)", () => {
   // behavior, not artificially-isolated state.
 
   test("GET catalog → POST purchase → balance reflects → replay rejected with 409", async () => {
-    // Phase 1 — discover the catalog. Public endpoint (no auth on
-    // coin-packages route per config.js:786). A regression here
-    // means the IAP UI in the app would be empty for every user.
-    const cat = await smoke.api.get(`${API_BASE}/api/coin-packages`);
+    // Phase 1 — discover the catalog. Despite the route handler not
+    // checking auth itself (config.js:786), the global auth
+    // middleware (index.js:82-113) gates every /api path NOT in the
+    // allow-list, and /coin-packages is NOT allow-listed. Pass the
+    // smoke runner's bearer token. A regression here means the IAP
+    // UI in the app would be empty for every user.
+    const cat = await smoke.api.get(`${API_BASE}/api/coin-packages`, {
+      headers: authedHeaders(),
+    });
     expect(cat.ok(), `catalog: ${cat.status()}: ${await cat.text()}`).toBe(true);
     const packages = await cat.json();
     expect(Array.isArray(packages), "catalog must be an array").toBe(true);


### PR DESCRIPTION
## Summary
The dev-deploy smoke test failed with `catalog: 401: Missing or invalid Authorization header`. Root cause: `/api/coin-packages` requires auth (gated by the global middleware in `index.js:82-113`, NOT in the allow-list), but the smoke test called it without `authedHeaders()`. The test comment incorrectly claimed it was public.

## Fix
Add `authedHeaders()` to the catalog request.

## Verification
Caught in dev-deploy run 25409573616 — see `gh run view --job=74528302568`. All deploys (backend, web, Android, iOS) succeeded; only the smoke test had the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)