### PR TITLE
fix(security): firestore.rules close 4 more access-control gaps + tests (Phase 2G batch 2)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -94,10 +94,15 @@ service cloud.firestore {
       }
     }
 
-    // ── Identity Map — auth read, server write only ──────────────
+    // ── Identity Map — server-only read/write ────────────────────
+    // SECURITY: previously open to any authed user. Combined with the
+    // deterministic DM conversation ID format (`dm_<smallerUid>_<largerUid>`),
+    // any user could enumerate the UID↔uniqueId mapping and forge
+    // private-conversation IDs. The Express API uses Admin SDK
+    // (bypasses rules); no client path references identityMap directly
+    // (verified by grep across shared/src, app/src/main, public/).
     match /identityMap/{docId} {
-      allow read: if request.auth != null;
-      allow write: if false;
+      allow read, write: if false;
     }
 
     // ── Counters — server only ───────────────────────────────────
@@ -135,10 +140,14 @@ service cloud.firestore {
           && string(callerUniqueId()) == resource.data.senderId;
       }
 
-      // Seat requests — owner can approve/deny, requester can cancel own
+      // Seat requests — owner can approve/deny, requester can cancel own.
+      // SECURITY: create MUST bind userId to the caller; otherwise any
+      // authed user could file a seat request attributed to ANOTHER
+      // user, causing the room owner to promote the wrong account.
       match /seatRequests/{requestId} {
         allow read: if request.auth != null;
-        allow create: if request.auth != null;
+        allow create: if request.auth != null
+          && request.resource.data.userId == string(callerUniqueId());
         allow update: if request.auth != null
           && (string(callerUniqueId()) == get(/databases/$(database)/documents/rooms/$(roomId)).data.ownerId
               || string(callerUniqueId()) == resource.data.userId);
@@ -218,10 +227,17 @@ service cloud.firestore {
       allow write: if false;
     }
 
-    // ── Device bindings — auth read own, API creates ─────────────
-    // Client writes "userId" field, API writes "uniqueId" — accept either
+    // ── Device bindings — auth read OWN, API creates ─────────────
+    // Client writes "userId" field, API writes "uniqueId" — accept either.
+    // SECURITY: previously `allow read: if request.auth != null`,
+    // exposing every device↔user binding to any authed user (useful
+    // for device-fingerprinting / ban-evasion correlation). Now
+    // gated to the device's owner OR an admin.
     match /deviceBindings/{deviceId} {
-      allow read: if request.auth != null;
+      allow read: if request.auth != null
+        && (resource.data.userId == string(callerUniqueId())
+            || resource.data.uniqueId == string(callerUniqueId())
+            || request.auth.token.admin == true);
       allow create: if request.auth != null
         && (request.resource.data.userId == string(callerUniqueId())
             || request.resource.data.uniqueId == string(callerUniqueId()));
@@ -410,9 +426,13 @@ service cloud.firestore {
     }
 
     // ── Suggestion disputes — submitter create, admin resolve ───
+    // SECURITY: create MUST bind submitterUid to the caller; otherwise
+    // any authed user could file a dispute attributed to ANOTHER user,
+    // spoofing the complainant identity.
     match /suggestionDisputes/{disputeId} {
       allow read: if request.auth != null;
-      allow create: if request.auth != null;
+      allow create: if request.auth != null
+        && request.resource.data.submitterUid == string(callerUniqueId());
       allow update: if request.auth != null && request.auth.token.admin == true;
     }
 

--- a/tests/integration/07-firestore-rules-enforcement.spec.ts
+++ b/tests/integration/07-firestore-rules-enforcement.spec.ts
@@ -354,3 +354,106 @@ test.describe("Integration — Firestore rules: suspensionAppeals authz", () => 
     );
   });
 });
+
+test.describe("Integration — Firestore rules: identityMap server-only", () => {
+  test("client CANNOT read identityMap (server-only)", async () => {
+    // Critical privacy fix: previously any authed user could enumerate
+    // the full UID↔uniqueId mapping. Combined with the deterministic
+    // DM conversation ID format, that let attackers forge valid
+    // conversation IDs for any user pair.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const adminDb = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(adminDb, "identityMap", "uid-target"), {
+        firebaseUid: "uid-target",
+        uniqueId: 100000300,
+      });
+    });
+
+    const reader = testEnv.authenticatedContext("uid-reader");
+    const readerDb = reader.firestore() as unknown as Firestore;
+    await assertFails(getDoc(doc(readerDb, "identityMap", "uid-target")));
+  });
+});
+
+test.describe("Integration — Firestore rules: seatRequests authz", () => {
+  test("user CANNOT forge a seat request under another user's uniqueId", async () => {
+    // Without the field binding, any authed user could file a seat
+    // request attributed to ANOTHER user — the room owner approving
+    // that request would promote the wrong account.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const adminDb = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(adminDb, "rooms", "room-seat-test"), {
+        ownerId: "100000400",
+        participantIds: ["100000400"],
+        state: "ACTIVE",
+      });
+    });
+
+    const attacker = testEnv.authenticatedContext("uid-attacker", {
+      uniqueId: "100000401",
+    });
+    const attackerDb = attacker.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(
+        doc(attackerDb, "rooms", "room-seat-test", "seatRequests", "req1"),
+        {
+          userId: "100000999", // forged — NOT the attacker's uniqueId
+          createdAt: Date.now(),
+        },
+      ),
+    );
+  });
+});
+
+test.describe("Integration — Firestore rules: suggestionDisputes authz", () => {
+  test("user CANNOT forge a dispute under another user's uniqueId", async () => {
+    const attacker = testEnv.authenticatedContext("uid-attacker", {
+      uniqueId: "100000500",
+    });
+    const attackerDb = attacker.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(doc(attackerDb, "suggestionDisputes", "dispute1"), {
+        submitterUid: "100000999", // forged
+        suggestionId: "s1",
+        text: "I dispute this — but as someone else",
+      }),
+    );
+  });
+});
+
+test.describe("Integration — Firestore rules: deviceBindings privacy", () => {
+  test("user CANNOT read another user's device binding", async () => {
+    // Critical privacy fix: previously any authed user could read all
+    // device↔user bindings, useful for device-fingerprinting and
+    // ban-evasion correlation. Now restricted to the device's owner.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const adminDb = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(adminDb, "deviceBindings", "device-victim"), {
+        userId: "100000600",
+        deviceId: "device-victim",
+      });
+    });
+
+    const attacker = testEnv.authenticatedContext("uid-attacker", {
+      uniqueId: "100000601",
+    });
+    const attackerDb = attacker.firestore() as unknown as Firestore;
+    await assertFails(getDoc(doc(attackerDb, "deviceBindings", "device-victim")));
+  });
+
+  test("user CAN read their own device binding", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const adminDb = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(adminDb, "deviceBindings", "device-owner"), {
+        userId: "100000700",
+        deviceId: "device-owner",
+      });
+    });
+
+    const owner = testEnv.authenticatedContext("uid-owner", {
+      uniqueId: "100000700",
+    });
+    const ownerDb = owner.firestore() as unknown as Firestore;
+    await assertSucceeds(getDoc(doc(ownerDb, "deviceBindings", "device-owner")));
+  });
+});


### PR DESCRIPTION
## Summary
Second deeper audit of firestore.rules found 4 more real security holes. Each verified by reading the file (and for identityMap, confirming no client code references it directly via grep).

### CRITICAL: identityMap full read leak
Previously `allow read: if request.auth != null` — combined with the deterministic DM conversation ID format (`dm_<smallerUid>_<largerUid>`), any authed user could enumerate the UID↔uniqueId mapping and **forge valid conversation IDs for any user pair**. Now: server-only (`allow read, write: if false`). Express uses Admin SDK so this is non-breaking.

### CRITICAL: seatRequests create no field binding
Any authed user could file a seat request under **another user's uniqueId**; the room owner approving would promote the wrong account. Now binds `request.resource.data.userId == callerUniqueId()`.

### CRITICAL: suggestionDisputes create no field binding
Same impersonation vector as suspensionAppeals (fixed in PR #522). Now binds `submitterUid` to caller.

### IMPORTANT: deviceBindings full read
Previously any authed user could read every device↔user binding — useful for device-fingerprinting and ban-evasion correlation. Now restricted to the device's owner OR an admin.

## Tests added (4 + 1 positive sanity)
- client CANNOT read identityMap
- user CANNOT forge a seat request under another user's uniqueId
- user CANNOT forge a dispute under another user's uniqueId
- user CANNOT read another user's device binding
- user CAN read their own device binding (positive)

Phase 2G batch 1 (PR #522) fixed conversations/rooms/appeals; batch 2 covers identityMap/seatRequests/disputes/deviceBindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)