### PR TITLE
fix(cron): cap unbounded queries on Spark tier — expireBans + expireDataExports

### DIFF
--- a/express-api/src/cron/expireBans.js
+++ b/express-api/src/cron/expireBans.js
@@ -10,19 +10,43 @@ const { db } = require('../utils/firebase');
 const { sendFcmToTokens, cleanupInvalidTokens } = require('../utils/fcm');
 const log = require('../utils/log');
 
+// Cap per-tick reads to keep Spark-tier quota bounded. The cron runs
+// every 15min; if there are >CRON_LIMIT non-null-expiresAt bans, the
+// remainder are processed on the next tick. We log a truncation warning
+// so operators see the backlog. Pattern matches subscriptions.js cron.
+const CRON_LIMIT = 500;
+
 async function expireBans() {
   const nowIso = new Date().toISOString();
 
-  // Query expired device bans
-  const deviceSnap = await db.collection('deviceBans').where('expiresAt', '!=', null).get();
+  // Query expired device bans (capped — see CRON_LIMIT comment)
+  const deviceSnap = await db
+    .collection('deviceBans')
+    .where('expiresAt', '!=', null)
+    .limit(CRON_LIMIT)
+    .get();
+  if (deviceSnap.size === CRON_LIMIT) {
+    log.warn('cron', 'expireBans: deviceBans hit CRON_LIMIT — possible truncation', {
+      limit: CRON_LIMIT,
+    });
+  }
 
   const expiredDeviceDocs = deviceSnap.docs.filter((d) => {
     const expiresAt = d.data().expiresAt;
     return expiresAt && expiresAt < nowIso;
   });
 
-  // Query expired network bans
-  const networkSnap = await db.collection('networkBans').where('expiresAt', '!=', null).get();
+  // Query expired network bans (capped — see CRON_LIMIT comment)
+  const networkSnap = await db
+    .collection('networkBans')
+    .where('expiresAt', '!=', null)
+    .limit(CRON_LIMIT)
+    .get();
+  if (networkSnap.size === CRON_LIMIT) {
+    log.warn('cron', 'expireBans: networkBans hit CRON_LIMIT — possible truncation', {
+      limit: CRON_LIMIT,
+    });
+  }
 
   const expiredNetworkDocs = networkSnap.docs.filter((d) => {
     const expiresAt = d.data().expiresAt;

--- a/express-api/src/cron/expireDataExports.js
+++ b/express-api/src/cron/expireDataExports.js
@@ -9,12 +9,23 @@ const { db } = require('../utils/firebase');
 const r2 = require('../utils/r2');
 const log = require('../utils/log');
 
+// Cap per-tick reads to keep Spark-tier quota bounded. Daily cron;
+// any backlog beyond CRON_LIMIT processes on the next day's tick.
+// Pattern matches subscriptions.js / expireBans.js cron caps.
+const CRON_LIMIT = 500;
+
 async function expireDataExports() {
   const expiredSnap = await db
     .collection('users')
     .where('dataExportStatus', '==', 'ready')
     .where('dataExportExpiresAt', '>', 0)
+    .limit(CRON_LIMIT)
     .get();
+  if (expiredSnap.size === CRON_LIMIT) {
+    log.warn('cron', 'expireDataExports: hit CRON_LIMIT — possible truncation', {
+      limit: CRON_LIMIT,
+    });
+  }
 
   let expired = 0;
   for (const doc of expiredSnap.docs) {

--- a/express-api/tests/cron/expireBans.test.js
+++ b/express-api/tests/cron/expireBans.test.js
@@ -420,4 +420,53 @@ describe('expireBans', () => {
 
     expect(mockCleanupInvalidTokens).toHaveBeenCalledWith(['invalid-token'], 'admin1');
   });
+
+  test('logs truncation warning when query hits CRON_LIMIT (500)', async () => {
+    const log = require('../../src/utils/log');
+    const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => {});
+
+    // 500 device bans (= CRON_LIMIT) — none expired so no batch work
+    const futureExpiry = new Date(Date.now() + 86400000).toISOString();
+    const fullPage = Array.from({ length: 500 }, (_, i) => ({
+      id: `dev${i}`,
+      data: () => ({ expiresAt: futureExpiry }),
+      ref: { path: `deviceBans/dev${i}` },
+    }));
+    mockCollectionGet.mockResolvedValueOnce({ docs: fullPage, size: 500 });
+    mockCollectionGet.mockResolvedValueOnce({ docs: [], size: 0 });
+
+    await expireBans();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'cron',
+      expect.stringContaining('deviceBans hit CRON_LIMIT'),
+      expect.objectContaining({ limit: 500 }),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  test('logs truncation warning on networkBans hitting CRON_LIMIT', async () => {
+    const log = require('../../src/utils/log');
+    const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => {});
+
+    const futureExpiry = new Date(Date.now() + 86400000).toISOString();
+    mockCollectionGet.mockResolvedValueOnce({ docs: [], size: 0 });
+    const fullPage = Array.from({ length: 500 }, (_, i) => ({
+      id: `net${i}`,
+      data: () => ({ expiresAt: futureExpiry }),
+      ref: { path: `networkBans/net${i}` },
+    }));
+    mockCollectionGet.mockResolvedValueOnce({ docs: fullPage, size: 500 });
+
+    await expireBans();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'cron',
+      expect.stringContaining('networkBans hit CRON_LIMIT'),
+      expect.objectContaining({ limit: 500 }),
+    );
+
+    warnSpy.mockRestore();
+  });
 });

--- a/express-api/tests/cron/expireBans.test.js
+++ b/express-api/tests/cron/expireBans.test.js
@@ -5,14 +5,20 @@ const mockCollectionGet = jest.fn();
 const mockBatchDelete = jest.fn();
 const mockBatchCommit = jest.fn().mockResolvedValue();
 
+// Query chain supports `.where(...).limit(N).get()` for the cron's
+// CRON_LIMIT cap. The chain returns the same `mockCollectionGet`
+// regardless of the limit value, so existing test expectations still
+// hold.
+const mockLimit = jest.fn(() => ({ get: mockCollectionGet }));
 const mockWhere = jest.fn(() => ({
   get: mockCollectionGet,
+  limit: mockLimit,
 }));
 
 const mockCollection = jest.fn(() => ({
   where: (...args) => {
     mockWhere(...args);
-    return { get: mockCollectionGet };
+    return { get: mockCollectionGet, limit: mockLimit };
   },
 }));
 

--- a/express-api/tests/cron/expireDataExports.test.js
+++ b/express-api/tests/cron/expireDataExports.test.js
@@ -134,4 +134,34 @@ describe('expireDataExports cron', () => {
     // Should not delete active exports
     expect(mockDeleteObjects).not.toHaveBeenCalled();
   });
+
+  test('logs truncation warning when query hits CRON_LIMIT (500)', async () => {
+    // All 500 docs are not-yet-expired (future expiresAt), so the loop hits
+    // `continue` for every one — keeps the test fast while still tripping
+    // the `size === CRON_LIMIT` truncation branch.
+    const futureExpiry = Date.now() + 24 * 3600000;
+    const fullPage = Array.from({ length: 500 }, (_, i) => ({
+      id: `1000${String(i).padStart(4, '0')}`,
+      data: () => ({
+        dataExportStatus: 'ready',
+        dataExportR2Key: `exports/1000${String(i).padStart(4, '0')}/gen.zip`,
+        dataExportExpiresAt: futureExpiry,
+      }),
+    }));
+    mockCollectionGet.mockResolvedValueOnce({
+      docs: fullPage,
+      size: 500,
+      empty: false,
+    });
+
+    await expireDataExports();
+
+    expect(log.warn).toHaveBeenCalledWith(
+      'cron',
+      expect.stringContaining('hit CRON_LIMIT'),
+      expect.objectContaining({ limit: 500 }),
+    );
+    // No deletions because all docs are not-yet-expired
+    expect(mockDeleteObjects).not.toHaveBeenCalled();
+  });
 });

--- a/express-api/tests/cron/expireDataExports.test.js
+++ b/express-api/tests/cron/expireDataExports.test.js
@@ -21,8 +21,12 @@ jest.mock('../../src/utils/firebase', () => ({
       update: (...args) => mockDocUpdate(path, ...args),
     })),
     collection: jest.fn(() => {
+      // Chain supports `.where().where().limit().get()` for the cron's
+      // CRON_LIMIT cap. limit returns the same chain so further calls
+      // (and .get()) work uniformly.
       const chain = {
         where: jest.fn().mockImplementation(() => chain),
+        limit: jest.fn().mockImplementation(() => chain),
         get: mockCollectionGet,
       };
       return chain;


### PR DESCRIPTION
## Summary
Two cron jobs ran unbounded `.where(...).get()` queries that scaled linearly with collection size, burning Spark-tier Firestore quota on every tick.

### expireBans (every 15min)
`deviceBans` and `networkBans` were fetched **entirely** (filtered server-side for `expiresAt != null`, then client-filtered to actually-expired). Every non-null-expiry ban read on every tick regardless of expiry. Fix: `.limit(500)` + truncation `log.warn` on each query.

### expireDataExports (daily)
`users.where(dataExportStatus=='ready').where(dataExportExpiresAt>0).get()` fetched all users with pending exports. A backlog of any size drained daily quota. Fix: `.limit(500)` + truncation log.warn.

Pattern matches the `subscriptions.js` cap added earlier in this session.

## Verification
- 199 express test suites, 4696 tests pass after adding `.limit()` to test mock chains.
- Phase 2-cron audit: 4 candidates, 2 real bugs (50% TP rate).
- Skipped: `backups.js` (full read by design); `ageVerificationAuditReconcile.js` (7-day window naturally bounded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)