### PR TITLE
fix(util): race-safe room writes in evictSuspendedUser (Phase 2A util audit)

### DIFF
--- a/express-api/src/utils/evict-suspended-user.js
+++ b/express-api/src/utils/evict-suspended-user.js
@@ -21,7 +21,7 @@
  * single participants-only query would miss them and leave the room running.
  */
 
-const { db, rtdb } = require('./firebase');
+const { db, rtdb, FieldValue } = require('./firebase');
 const { queryDocs } = require('./firestore-helpers');
 const { now } = require('./helpers');
 const log = require('./log');
@@ -80,7 +80,11 @@ async function evictSuspendedUser(uid) {
     const isOwner = room.ownerId === uid;
 
     if (isOwner) {
+      // Closure replaces room state wholesale — set+merge is intentional here
+      // because we're CLOSING (any concurrent participant/seat write should
+      // also be invalidated by the CLOSED state).
       batchOps.push({
+        method: 'set',
         path: `rooms/${room.id}`,
         data: {
           state: 'CLOSED',
@@ -94,28 +98,37 @@ async function evictSuspendedUser(uid) {
       continue;
     }
 
-    const participantIds = (room.participantIds || []).filter((id) => id !== uid);
-    const hostIds = (room.hostIds || []).filter((id) => id !== uid);
+    // Race-safe non-owner eviction: use `batch.update` with FieldValue.arrayRemove
+    // (atomic array removal, no full-array overwrite) and dot-path seat writes
+    // (atomic per-seat replacement, preserves sibling seats from concurrent
+    // client claims). The previous `set+merge` of {participantIds, hostIds, seats}
+    // overwrote the entire seats map and entire arrays, clobbering concurrent
+    // writes from clients (which use dot-paths like `seats.2.userId`).
+    const updates = {
+      participantIds: FieldValue.arrayRemove(uid),
+      hostIds: FieldValue.arrayRemove(uid),
+    };
 
-    // Clear any seat occupied by this user. Field shape matches the Seat data
-    // class (userId, state, isMuted) — the previous admin-users.js code wrote
-    // `status` and `index` keys which are not part of the data model.
-    const seats = room.seats ? { ...room.seats } : {};
-    for (const [index, seat] of Object.entries(seats)) {
-      if (seat && (seat.userId === uid || seat.user_id === uid)) {
-        seats[index] = { userId: null, state: 'EMPTY', isMuted: false };
+    // Clear any seat occupied by this user via dot-path writes. Field shape
+    // matches the Seat data class (userId, state, isMuted).
+    if (room.seats) {
+      for (const [index, seat] of Object.entries(room.seats)) {
+        if (seat && (seat.userId === uid || seat.user_id === uid)) {
+          updates[`seats.${index}`] = { userId: null, state: 'EMPTY', isMuted: false };
+        }
       }
     }
 
     batchOps.push({
+      method: 'update',
       path: `rooms/${room.id}`,
-      data: { participantIds, hostIds, seats },
+      data: updates,
     });
     rtdbEvents.push({ roomId: room.id, type: 'room_updated' });
     roomsUpdated += 1;
   }
 
-  batchOps.push({ path: `users/${uid}`, data: { currentRoomId: null } });
+  batchOps.push({ method: 'set', path: `users/${uid}`, data: { currentRoomId: null } });
 
   // Firestore batch (chunked at 500 to respect Firestore limits). Track which
   // room chunks AND the user-doc op failed so the caller can distinguish a
@@ -129,7 +142,11 @@ async function evictSuspendedUser(uid) {
     const chunk = batchOps.slice(i, i + 500);
     const batch = db.batch();
     for (const op of chunk) {
-      batch.set(db.doc(op.path), op.data, { merge: true });
+      if (op.method === 'update') {
+        batch.update(db.doc(op.path), op.data);
+      } else {
+        batch.set(db.doc(op.path), op.data, { merge: true });
+      }
     }
     try {
       await batch.commit();

--- a/express-api/tests/routes/admin-users-write.test.js
+++ b/express-api/tests/routes/admin-users-write.test.js
@@ -25,6 +25,7 @@ jest.mock('../../src/utils/firebase', () => ({
       return chain;
     }),
     batch: jest.fn(() => ({
+      set: jest.fn(),
       update: jest.fn(),
       commit: jest.fn().mockResolvedValue(),
     })),
@@ -35,6 +36,11 @@ jest.mock('../../src/utils/firebase', () => ({
       email: null,
       providerData: [],
     }),
+  },
+  FieldValue: {
+    arrayRemove: jest.fn((...args) => 'arrayRemove(' + args.join(',') + ')'),
+    arrayUnion: jest.fn((...args) => 'arrayUnion(' + args.join(',') + ')'),
+    increment: jest.fn((n) => 'increment(' + n + ')'),
   },
 }));
 
@@ -1010,23 +1016,27 @@ describe('POST /api/user/:uniqueId/suspend --- room eviction', () => {
     expect(res.status).toBe(200);
     await flushPromises();
 
-    // The shared evictSuspendedUser util in src/utils/evict-suspended-user.js
-    // uses `batch.set(ref, data, { merge: true })` (not `batch.update(...)`),
-    // and writes the canonical Seat shape `{ userId, state, isMuted }` (not the
-    // old `{ index, status, userId, isMuted }` form which never matched the
-    // commonMain Seat data class). Test mirrors the new behaviour.
-    expect(mockBatchSet).toHaveBeenCalled();
+    // Race-safe writes: non-owner room evictions go through batch.update with
+    // FieldValue.arrayRemove + dot-path 'seats.X' keys (so concurrent client
+    // dot-path writes for OTHER seats don't get clobbered). The user-doc
+    // currentRoomId clear still uses batch.set+merge.
+    expect(mockBatchUpdate).toHaveBeenCalled();
 
-    const roomUpdateCall = mockBatchSet.mock.calls.find(
-      (call) => call[1]?.participantIds && call[1]?.seats,
+    const roomUpdateCall = mockBatchUpdate.mock.calls.find(
+      (call) => call[1]?.participantIds !== undefined,
     );
     expect(roomUpdateCall).toBeDefined();
-    expect(roomUpdateCall[1].participantIds).not.toContain('user-evict');
-    expect(roomUpdateCall[1].seats[0].state).toBe('EMPTY');
-    expect(roomUpdateCall[1].seats[0].userId).toBeNull();
-    // The other seat is read-through unchanged from the source room (still
-    // shows OCCUPIED with its original userId).
-    expect(roomUpdateCall[1].seats[1].userId).toBe('other-user');
+    // arrayRemove sentinel from FieldValue mock — proves we're not building a
+    // literal filtered array (which would race with concurrent arrayUnion).
+    expect(roomUpdateCall[1].participantIds).toBe('arrayRemove(user-evict)');
+    // Cleared seat written via dot-path key.
+    expect(roomUpdateCall[1]['seats.0']).toEqual({
+      userId: null,
+      state: 'EMPTY',
+      isMuted: false,
+    });
+    // The other seat must NOT be in the write — server-side preserves it.
+    expect(roomUpdateCall[1]['seats.1']).toBeUndefined();
   });
 });
 

--- a/express-api/tests/routes/reports-coverage-admin.test.js
+++ b/express-api/tests/routes/reports-coverage-admin.test.js
@@ -11,6 +11,7 @@ const mockDocSet = jest.fn().mockResolvedValue();
 const mockDocDelete = jest.fn().mockResolvedValue();
 const mockBatchCommit = jest.fn().mockResolvedValue();
 const mockBatchSet = jest.fn();
+const mockBatchUpdate = jest.fn();
 const mockRtdbSet = jest.fn().mockResolvedValue();
 const mockRtdbRemove = jest.fn().mockResolvedValue();
 
@@ -31,11 +32,15 @@ jest.mock('../../src/utils/firebase', () => ({
       };
       return chain;
     }),
-    batch: jest.fn(() => ({ set: mockBatchSet, commit: mockBatchCommit })),
+    batch: jest.fn(() => ({
+      set: mockBatchSet,
+      update: mockBatchUpdate,
+      commit: mockBatchCommit,
+    })),
   },
   rtdb: { ref: jest.fn(() => ({ set: mockRtdbSet, remove: mockRtdbRemove })) },
   FieldValue: {
-    arrayRemove: jest.fn(),
+    arrayRemove: jest.fn((...args) => 'arrayRemove(' + args.join(',') + ')'),
     arrayUnion: jest.fn(),
     increment: jest.fn((n) => 'increment(' + n + ')'),
   },
@@ -384,7 +389,9 @@ describe('evictSuspendedUser - via suspend', () => {
       .send({ reason: 'Test', canAppeal: false });
     expect(res.status).toBe(200);
     await new Promise((r) => setTimeout(r, 100));
-    expect(mockBatchSet).toHaveBeenCalled();
+    // Non-owner eviction now writes via batch.update (race-safe arrayRemove +
+    // dot-path seat keys); user-doc currentRoomId clear still uses batch.set.
+    expect(mockBatchUpdate).toHaveBeenCalled();
     expect(mockBatchCommit).toHaveBeenCalled();
   });
 
@@ -426,6 +433,9 @@ describe('evictSuspendedUser - via suspend', () => {
     expect(res.status).toBe(200);
     await new Promise((r) => setTimeout(r, 100));
     expect(mockBatchCommit).toHaveBeenCalled();
+    // The room write happens even though seats is null — arrayRemove on
+    // participantIds still fires.
+    expect(mockBatchUpdate).toHaveBeenCalled();
   });
 
   it('handles RTDB event write failure', async () => {
@@ -484,8 +494,12 @@ describe('evictSuspendedUser - via suspend', () => {
       .send({ reason: 'Test', canAppeal: false });
     expect(res.status).toBe(200);
     await new Promise((r) => setTimeout(r, 100));
-    const call = mockBatchSet.mock.calls.find((c) => c[1]?.seats !== undefined);
-    expect(call[1].seats['0']).toEqual({ userId: null, state: 'EMPTY', isMuted: false });
+    // New shape: dot-path seat key on the batch.update payload, not a full
+    // `seats` map on a batch.set+merge call.
+    const call = mockBatchUpdate.mock.calls.find((c) => c[1]?.['seats.0'] !== undefined);
+    expect(call[1]['seats.0']).toEqual({ userId: null, state: 'EMPTY', isMuted: false });
+    // Seat 1 was occupied by 'other' — must NOT be touched in our write.
+    expect(call[1]['seats.1']).toBeUndefined();
   });
 
   it('handles multiple rooms', async () => {
@@ -499,7 +513,10 @@ describe('evictSuspendedUser - via suspend', () => {
       .send({ reason: 'Test', canAppeal: false });
     expect(res.status).toBe(200);
     await new Promise((r) => setTimeout(r, 100));
-    expect(mockBatchSet).toHaveBeenCalledTimes(3);
+    // 1 batch.set (owner closure of room-2) + 1 batch.set (user-doc currentRoomId)
+    // + 1 batch.update (non-owner room-1 eviction).
+    expect(mockBatchSet).toHaveBeenCalledTimes(2);
+    expect(mockBatchUpdate).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/express-api/tests/utils/evict-suspended-user.test.js
+++ b/express-api/tests/utils/evict-suspended-user.test.js
@@ -31,8 +31,13 @@
 const mockDocUpdate = jest.fn().mockResolvedValue();
 const mockDocSet = jest.fn().mockResolvedValue();
 const mockBatchSet = jest.fn();
+const mockBatchUpdate = jest.fn();
 const mockBatchCommit = jest.fn().mockResolvedValue();
-const mockBatch = jest.fn(() => ({ set: mockBatchSet, commit: mockBatchCommit }));
+const mockBatch = jest.fn(() => ({
+  set: mockBatchSet,
+  update: mockBatchUpdate,
+  commit: mockBatchCommit,
+}));
 const mockDoc = jest.fn(() => ({ update: mockDocUpdate, set: mockDocSet }));
 // Collection chain returns a self-referential proxy so .where().where().get() etc.
 // all resolve. queryDocs is mocked separately so the actual return is irrelevant.
@@ -57,6 +62,11 @@ jest.mock('../../src/utils/firebase', () => ({
   },
   rtdb: {
     ref: (...args) => mockRtdbRef(...args),
+  },
+  // Sentinel-string return so assertions can match the FieldValue without
+  // depending on a real admin SDK Sentinel instance.
+  FieldValue: {
+    arrayRemove: jest.fn((...args) => `arrayRemove(${args.join(',')})`),
   },
 }));
 
@@ -84,6 +94,7 @@ beforeEach(() => {
   mockDocSet.mockReset();
   mockDocSet.mockResolvedValue();
   mockBatchSet.mockReset();
+  mockBatchUpdate.mockReset();
   mockBatchCommit.mockReset();
   mockBatchCommit.mockResolvedValue();
   mockRtdbSet.mockReset();
@@ -133,10 +144,12 @@ function mockRoomsQueries({ participantRooms = [], ownerRooms = [] } = {}) {
   mockQueryDocs.mockResolvedValueOnce(ownerRooms);
 }
 
-/** Locate the data payload for a given doc path in batch.set() calls. */
+/**
+ * Locate the data payload for a given doc path in batch.set() OR batch.update()
+ * calls. Owner closures + user-doc go through batch.set(merge); non-owner room
+ * evictions go through batch.update with FieldValue + dot-path keys.
+ */
 function findWrittenData(path) {
-  // Each batch.set(ref, data, opts) call: ref is whatever db.doc(path) returned.
-  // Track which ref came from which path via mockDoc.mock.calls.
   const docCalls = mockDoc.mock.calls;
   const docResults = mockDoc.mock.results.map((r) => r.value);
   const targetIndices = docCalls.map((c, i) => (c[0] === path ? i : -1)).filter((i) => i >= 0);
@@ -144,6 +157,8 @@ function findWrittenData(path) {
     const ref = docResults[i];
     const setCall = mockBatchSet.mock.calls.find((c) => c[0] === ref);
     if (setCall) return setCall[1];
+    const updateCall = mockBatchUpdate.mock.calls.find((c) => c[0] === ref);
+    if (updateCall) return updateCall[1];
   }
   return null;
 }
@@ -228,16 +243,16 @@ describe('evictSuspendedUser — host role (seated)', () => {
 
     const written = findWrittenData('rooms/room-full');
     expect(written).toBeDefined();
-    expect(written.participantIds).not.toContain('host-1');
-    expect(written.participantIds).toContain('owner-1');
-    expect(written.participantIds).toContain('host-2');
-    expect(written.participantIds.length).toBe(7); // 8 - host-1
-    expect(written.hostIds).toEqual(['host-2']);
-    expect(written.seats[1]).toEqual({ userId: null, state: 'EMPTY', isMuted: false });
-    // Other seats untouched
-    expect(written.seats[0].userId).toBe('owner-1');
-    expect(written.seats[2].userId).toBe('host-2');
-    expect(written.seats[3].userId).toBe('att-1');
+    // Race-safe writes: arrayRemove sentinel for arrays, dot-path for the seat
+    // we cleared. Other seats are NOT in the write payload (preserved from
+    // concurrent client claims).
+    expect(written.participantIds).toBe('arrayRemove(host-1)');
+    expect(written.hostIds).toBe('arrayRemove(host-1)');
+    expect(written['seats.1']).toEqual({ userId: null, state: 'EMPTY', isMuted: false });
+    // Other seats not written → preserved on Firestore side
+    expect(written['seats.0']).toBeUndefined();
+    expect(written['seats.2']).toBeUndefined();
+    expect(written['seats.3']).toBeUndefined();
     expect(written.state).toBeUndefined(); // room not closed
   });
 
@@ -278,19 +293,20 @@ describe('evictSuspendedUser — host role (not seated)', () => {
     await evictSuspendedUser('walking-host');
 
     const written = findWrittenData('rooms/room-1');
-    expect(written.hostIds).toEqual([]);
-    expect(written.participantIds).not.toContain('walking-host');
-    // Seats unchanged — none were occupied by walking-host
-    expect(written.seats[0].userId).toBe('owner-1');
-    expect(written.seats[1].userId).toBe('someone-else');
-    expect(written.seats[2].state).toBe('EMPTY');
+    expect(written.hostIds).toBe('arrayRemove(walking-host)');
+    expect(written.participantIds).toBe('arrayRemove(walking-host)');
+    // No seat writes — walking-host wasn't in any seat. The other seats are
+    // preserved server-side because we didn't touch them in the update.
+    expect(written['seats.0']).toBeUndefined();
+    expect(written['seats.1']).toBeUndefined();
+    expect(written['seats.2']).toBeUndefined();
   });
 });
 
 // ── Seated non-host suspension ───────────────────────────────────
 
 describe('evictSuspendedUser — seated non-host role', () => {
-  it('clears seat + removes from participantIds; hostIds untouched', async () => {
+  it('clears seat + removes from participantIds; hostIds untouched (server-side)', async () => {
     const room = makeFullRoom({
       ownerId: 'owner-1',
       host1Id: 'host-1',
@@ -302,13 +318,16 @@ describe('evictSuspendedUser — seated non-host role', () => {
     await evictSuspendedUser('att-3');
 
     const written = findWrittenData('rooms/room-full');
-    expect(written.participantIds).not.toContain('att-3');
-    expect(written.hostIds).toEqual(['host-1', 'host-2']); // untouched
-    expect(written.seats[5]).toEqual({ userId: null, state: 'EMPTY', isMuted: false });
-    // Other seats untouched
-    expect(written.seats[0].userId).toBe('owner-1');
-    expect(written.seats[1].userId).toBe('host-1');
-    expect(written.seats[3].userId).toBe('att-1');
+    // arrayRemove(att-3) on hostIds is a no-op server-side since att-3 isn't
+    // a host — but we always issue the remove for shape-uniformity. This is
+    // safe: arrayRemove of a non-member is a no-op on Firestore.
+    expect(written.participantIds).toBe('arrayRemove(att-3)');
+    expect(written.hostIds).toBe('arrayRemove(att-3)');
+    expect(written['seats.5']).toEqual({ userId: null, state: 'EMPTY', isMuted: false });
+    // Other seats not written (preserved from concurrent claims)
+    expect(written['seats.0']).toBeUndefined();
+    expect(written['seats.1']).toBeUndefined();
+    expect(written['seats.3']).toBeUndefined();
     expect(written.state).toBeUndefined();
   });
 });
@@ -334,11 +353,12 @@ describe('evictSuspendedUser — visitor role (not seated)', () => {
     await evictSuspendedUser('visitor-1');
 
     const written = findWrittenData('rooms/room-1');
-    expect(written.participantIds).toEqual(['owner-1', 'host-1']);
-    expect(written.hostIds).toEqual(['host-1']);
-    expect(written.seats[0].userId).toBe('owner-1');
-    expect(written.seats[1].userId).toBe('host-1');
-    expect(written.seats[2].state).toBe('EMPTY');
+    expect(written.participantIds).toBe('arrayRemove(visitor-1)');
+    expect(written.hostIds).toBe('arrayRemove(visitor-1)');
+    // No seat writes (visitor wasn't in a seat)
+    expect(written['seats.0']).toBeUndefined();
+    expect(written['seats.1']).toBeUndefined();
+    expect(written['seats.2']).toBeUndefined();
     expect(written.state).toBeUndefined();
   });
 });
@@ -377,11 +397,15 @@ describe('evictSuspendedUser — multi-room cascade', () => {
 
     const owned = findWrittenData('rooms/room-owned');
     const hosted = findWrittenData('rooms/room-hosted');
+    // Owner closure → set+merge with full state replacement.
     expect(owned.state).toBe('CLOSED');
+    expect(owned.participantIds).toEqual([]);
+    expect(owned.hostIds).toEqual([]);
+    // Host eviction → batch.update with arrayRemove + dot-path seat.
     expect(hosted.state).toBeUndefined();
-    expect(hosted.hostIds).toEqual([]);
-    expect(hosted.participantIds).toEqual(['someone-else']);
-    expect(hosted.seats[2]).toEqual({ userId: null, state: 'EMPTY', isMuted: false });
+    expect(hosted.participantIds).toBe('arrayRemove(multi-1)');
+    expect(hosted.hostIds).toBe('arrayRemove(multi-1)');
+    expect(hosted['seats.2']).toEqual({ userId: null, state: 'EMPTY', isMuted: false });
   });
 
   it('clears currentRoomId on the user even when they are not in any rooms', async () => {
@@ -430,7 +454,7 @@ describe('evictSuspendedUser — legacy snake_case seat fields', () => {
     await evictSuspendedUser('snake-user');
 
     const written = findWrittenData('rooms/room-1');
-    expect(written.seats[0]).toEqual({ userId: null, state: 'EMPTY', isMuted: false });
+    expect(written['seats.0']).toEqual({ userId: null, state: 'EMPTY', isMuted: false });
   });
 });
 
@@ -690,6 +714,122 @@ describe('evictSuspendedUser — RTDB failure tolerance', () => {
       const result = await evictSuspendedUser('suspended-uid');
       expect(result.rtdbEventsFailed).toBe(1);
       expect(result.roomsClosed).toBe(1);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Race-safety contract: dot-path seat writes + arrayRemove for arrays
+  // ─────────────────────────────────────────────────────────────────
+  // Phase 2A util audit (PR after #526): the previous implementation did
+  //   batch.set(roomRef, { participantIds: [...], hostIds: [...], seats: {...} },
+  //             { merge: true })
+  // which replaces the entire seats map and entire arrays — clobbering any
+  // concurrent client write (clients use dot-paths like seats.2.userId and
+  // FieldValue.arrayUnion(uid) for participantIds). The current code uses
+  // batch.update with FieldValue.arrayRemove + dot-path 'seats.X' keys, so
+  // sibling seats and concurrent participant additions survive.
+  //
+  // These tests pin the wire-format so a regression to set+merge shows up
+  // immediately — not only as a race in production but as a unit-test failure.
+  describe('race-safety wire-format (Phase 2A util audit)', () => {
+    it('uses FieldValue.arrayRemove for participantIds (not literal-array overwrite)', async () => {
+      const room = {
+        id: 'roomA',
+        ownerId: 'someone',
+        participantIds: ['target', 'other-1', 'other-2'],
+        hostIds: [],
+        seats: {},
+      };
+      mockRoomsQueries({ participantRooms: [room], ownerRooms: [] });
+
+      await evictSuspendedUser('target');
+
+      const written = findWrittenData('rooms/roomA');
+      // Sentinel from FieldValue.arrayRemove mock; literal arrays would race.
+      expect(written.participantIds).toBe('arrayRemove(target)');
+      expect(Array.isArray(written.participantIds)).toBe(false);
+    });
+
+    it('uses FieldValue.arrayRemove for hostIds (not literal-array overwrite)', async () => {
+      const room = {
+        id: 'roomA',
+        ownerId: 'someone',
+        participantIds: ['target', 'other'],
+        hostIds: ['target'],
+        seats: {},
+      };
+      mockRoomsQueries({ participantRooms: [room], ownerRooms: [] });
+
+      await evictSuspendedUser('target');
+
+      const written = findWrittenData('rooms/roomA');
+      expect(written.hostIds).toBe('arrayRemove(target)');
+      expect(Array.isArray(written.hostIds)).toBe(false);
+    });
+
+    it('uses dot-path seat keys (never writes the full seats map)', async () => {
+      const room = makeFullRoom({
+        ownerId: 'owner',
+        host1Id: 'h1',
+        host2Id: 'h2',
+        attendees: ['target', 'a', 'b', 'c', 'd'],
+      });
+      mockRoomsQueries({ participantRooms: [room], ownerRooms: [] });
+
+      await evictSuspendedUser('target');
+
+      const written = findWrittenData('rooms/room-full');
+      // The cleared seat is keyed by dot-path; the full `seats` map is NEVER
+      // present in the write payload (which would race with concurrent
+      // dot-path claims on other seats from clients).
+      expect(written['seats.3']).toEqual({ userId: null, state: 'EMPTY', isMuted: false });
+      expect(written.seats).toBeUndefined();
+    });
+
+    it('uses batch.update (not batch.set) for non-owner room evictions', async () => {
+      const room = {
+        id: 'roomA',
+        ownerId: 'someone',
+        participantIds: ['target'],
+        hostIds: [],
+        seats: {},
+      };
+      mockRoomsQueries({ participantRooms: [room], ownerRooms: [] });
+
+      await evictSuspendedUser('target');
+
+      // The room write went through batch.update — not batch.set+merge.
+      expect(mockBatchUpdate).toHaveBeenCalled();
+      // Find the room update specifically (user-doc still uses set+merge).
+      const updateCalls = mockBatchUpdate.mock.calls;
+      const roomUpdate = updateCalls.find(([_, data]) => data.participantIds !== undefined);
+      expect(roomUpdate).toBeDefined();
+    });
+
+    it('owner closure still uses batch.set (full-state replacement is intentional)', async () => {
+      const room = {
+        id: 'roomA',
+        ownerId: 'target',
+        participantIds: ['target', 'other'],
+        hostIds: [],
+        seats: { 0: { userId: 'target', state: 'OCCUPIED', isMuted: false } },
+      };
+      mockRoomsQueries({ participantRooms: [room], ownerRooms: [room] });
+
+      await evictSuspendedUser('target');
+
+      const written = findWrittenData('rooms/roomA');
+      // Owner closure carries the full state-replacement payload.
+      expect(written.state).toBe('CLOSED');
+      expect(written.participantIds).toEqual([]);
+      expect(written.hostIds).toEqual([]);
+      // Closure goes via batch.set+merge, not batch.update.
+      expect(mockBatchSet).toHaveBeenCalled();
+      const setCallForRoom = mockBatchSet.mock.calls.find(([_, data]) => data.state === 'CLOSED');
+      expect(setCallForRoom).toBeDefined();
+      // The merge option must still be passed so we don't accidentally drop
+      // ownerId, createdAt, or other fields the route relies on for audit.
+      expect(setCallForRoom[2]).toEqual({ merge: true });
     });
   });
 });

--- a/public/roadmap-data.json
+++ b/public/roadmap-data.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-04",
+  "lastUpdated": "2026-05-06",
   "currentlyWorkingOn": [
     {
       "name": "`resolveReport` partial-failure flag surfacing",


### PR DESCRIPTION
## Summary

- `evictSuspendedUser` did `batch.set(roomRef, {participantIds, hostIds, seats}, { merge: true })` which replaces the entire `seats` map and entire arrays — clobbering concurrent client dot-path / `arrayUnion` writes
- Switched non-owner room evictions to `batch.update()` with `FieldValue.arrayRemove` for arrays + dot-path `seats.X` keys for the cleared seat (sibling seats preserved server-side)
- Owner closures still use `batch.set(merge)` — closing replaces state by design

Mirrors the fix pattern from PR #518 (Android) + #520 (iOS) seat-clear hardening, this time on the server eviction cascade.

Phase 2A utils-audit finding #3 of 6.

## Test plan

- [x] `tests/utils/evict-suspended-user.test.js` — all 24 existing tests updated for new write shape, all pass
- [x] 5 new race-safety contract tests pin: `arrayRemove(uid)` sentinel for participantIds/hostIds, dot-path `seats.X` keys never produce a full `seats` map, owner closure still uses set+merge
- [x] All 9 consumer test suites green (264 tests across `admin-users-write`, `reports-coverage-*`, `build-cascade-failure`)
- [x] Full express jest suite: 4691 passed, 8 skipped, 0 regressions
- [x] Playwright pre-push: 1124 passed, 29 skipped (chromium only, against local stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)