### PR TITLE
fix(util): cache ensureSystemUser across sendSystemPm calls (Phase 2A util audit)

### DIFF
--- a/express-api/src/utils/system-pm.js
+++ b/express-api/src/utils/system-pm.js
@@ -5,7 +5,15 @@ const log = require('./log');
 const SYSTEM_UID = 'SHYTALK_SYSTEM';
 const SYSTEM_DISPLAY_NAME = 'ShyTalk System';
 
+// Process-lifetime cache: the system-user doc is created at most once per
+// process lifetime. Without this, every `sendSystemPm` call (and there are
+// many — every age-verification decision, mod warning, admin device action)
+// burns one Firestore read for a no-op existence check on Spark-tier quota.
+// Reset on cold-start; first call after process restart re-validates.
+let systemUserEnsured = false;
+
 async function ensureSystemUser() {
+  if (systemUserEnsured) return;
   const snap = await db.doc(`users/${SYSTEM_UID}`).get();
   if (!snap.exists) {
     const timestamp = now();
@@ -17,6 +25,13 @@ async function ensureSystemUser() {
       lastSeenAt: timestamp,
     });
   }
+  systemUserEnsured = true;
+}
+
+// Test-only — reset the cache between unit-test runs so each test starts
+// with a clean slate. Production callers should never invoke this.
+function _resetSystemUserCache() {
+  systemUserEnsured = false;
 }
 
 function systemConversationId(recipientUid) {
@@ -80,4 +95,4 @@ async function sendSystemPm(recipientUid, text) {
   }
 }
 
-module.exports = { sendSystemPm, SYSTEM_UID, systemConversationId };
+module.exports = { sendSystemPm, SYSTEM_UID, systemConversationId, _resetSystemUserCache };

--- a/express-api/tests/utils/system-pm.test.js
+++ b/express-api/tests/utils/system-pm.test.js
@@ -52,13 +52,23 @@ jest.mock('../../src/utils/log', () => ({
   fatal: jest.fn(),
 }));
 
-const { sendSystemPm, SYSTEM_UID, systemConversationId } = require('../../src/utils/system-pm');
+const {
+  sendSystemPm,
+  SYSTEM_UID,
+  systemConversationId,
+  _resetSystemUserCache,
+} = require('../../src/utils/system-pm');
 const { db: _db, rtdb, FieldValue } = require('../../src/utils/firebase');
 
 // ─── Tests ────────────────────────────────────────────────────────
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // Reset the process-lifetime cache so each test starts with a clean
+  // ensureSystemUser state. Without this, the second test's mockResolvedValueOnce
+  // sequence is consumed by the conversation read instead of the system-user
+  // existence check, masking the system-user-write expectation.
+  _resetSystemUserCache();
   // Default: system user does not exist, conversation does not exist
   mockGet.mockResolvedValue({ exists: false });
 });
@@ -275,5 +285,64 @@ describe('sendSystemPm()', () => {
       'Failed to write RTDB event',
       expect.objectContaining({ error: 'RTDB down' }),
     );
+  });
+
+  // ─── ensureSystemUser cache (Phase 2A util audit, finding #5) ──────
+  // The system-user existence check used to fire on EVERY sendSystemPm
+  // invocation — burning one Firestore read per call on a no-op (the doc
+  // is created at most once per process). Cache short-circuits subsequent
+  // calls until the process restarts. Without this test, a regression that
+  // drops the cache would silently re-introduce the per-call read.
+  describe('ensureSystemUser process-lifetime cache', () => {
+    test('reads users/SHYTALK_SYSTEM only once across multiple sendSystemPm calls', async () => {
+      // Conversation reads need a `.data()` accessor since system-pm.js
+      // pulls participantIds off it. exists:true with empty data — fine.
+      mockGet.mockResolvedValue({ exists: true, data: () => ({}) });
+
+      await sendSystemPm('recipient1', 'msg1');
+      await sendSystemPm('recipient1', 'msg2');
+      await sendSystemPm('recipient2', 'msg3');
+
+      const systemUserGetCalls = mockDocFn.mock.calls.filter(
+        (call) => call[0] === `users/${SYSTEM_UID}`,
+      );
+      // db.doc(`users/${SYSTEM_UID}`) is referenced ONCE (the first call's
+      // existence check); subsequent calls short-circuit on the cache and
+      // never call .doc(...) for the system-user path again.
+      expect(systemUserGetCalls).toHaveLength(1);
+    });
+
+    test('skips system-user write on second call when cache says ensured', async () => {
+      // First call: system user doc missing → triggers a write
+      mockGet
+        .mockResolvedValueOnce({ exists: false }) // users/SYSTEM
+        .mockResolvedValueOnce({ exists: false }); // conv
+
+      await sendSystemPm('recipient1', 'first');
+
+      // Second call: cache says ensured, no system-user read at all
+      mockSet.mockClear();
+      mockGet.mockResolvedValueOnce({ exists: false }); // conv
+      await sendSystemPm('recipient1', 'second');
+
+      const systemUserSetCall = mockSet.mock.calls.find(
+        (call) => call[0] && call[0].id === SYSTEM_UID && call[0].userType === 'SYSTEM',
+      );
+      expect(systemUserSetCall).toBeUndefined();
+    });
+
+    test('cache reset (test helper) restores per-call existence check', async () => {
+      mockGet.mockResolvedValue({ exists: true, data: () => ({}) });
+
+      await sendSystemPm('recipient1', 'msg1');
+      _resetSystemUserCache();
+      await sendSystemPm('recipient1', 'msg2');
+
+      const systemUserGetCalls = mockDocFn.mock.calls.filter(
+        (call) => call[0] === `users/${SYSTEM_UID}`,
+      );
+      // Reset between calls means the second call re-checks existence.
+      expect(systemUserGetCalls.length).toBeGreaterThanOrEqual(2);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `ensureSystemUser()` reads `users/SHYTALK_SYSTEM` on every `sendSystemPm` invocation despite the doc being created exactly once per process
- Module-level `systemUserEnsured` boolean short-circuits subsequent calls; first call validates + writes (if missing); cache stays true until process restart
- Test helper `_resetSystemUserCache()` exported for unit-test isolation

Phase 2A utils-audit finding #5 of 6.

## Quota impact

On Spark-tier (50K reads/day), every age-verification decision, mod warning, and admin device action hits the system-pm path. Conservatively 100 system PMs/day = 100 wasted reads/day. Modest but pure waste — caching them away costs zero correctness.

## Test plan

- [x] system-pm.test.js: 16 tests pass (13 original + 3 new cache contract tests pinning the wire format)
- [x] 53 consumer suites green (1503 tests across age-verification-system-pm, admin-users-write, suggestions-*, reports-*, etc)
- [x] Playwright pre-push: green
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)