### PR TITLE
fix(cron): rotateLogs truncation warn when page hits CRON_LIMIT (Phase 2-cron batch 2)

### DIFF
--- a/express-api/src/cron/rotateLogs.js
+++ b/express-api/src/cron/rotateLogs.js
@@ -15,6 +15,12 @@ const log = require('../utils/log');
 const DEFAULT_RETENTION_HOURS = 48;
 const PRUNE_DAYS = 90;
 
+// Per-tick page size for the logs query. Pattern matches expireBans.js +
+// expireDataExports.js + subscriptions.js: a hard cap protects Spark-tier
+// quota, and we surface a truncation warning when the page is full so an
+// operator can see backlog growth before the next tick eats it.
+const CRON_LIMIT = 500;
+
 async function rotateLogs() {
   // 1. Read config
   let retentionHours = DEFAULT_RETENTION_HOURS;
@@ -39,8 +45,13 @@ async function rotateLogs() {
     .collection('logs')
     .where('timestamp', '<', cutoff)
     .orderBy('timestamp')
-    .limit(500)
+    .limit(CRON_LIMIT)
     .get();
+  if (snapshot.size === CRON_LIMIT) {
+    log.warn('cron', 'rotateLogs: hit CRON_LIMIT — possible truncation', {
+      limit: CRON_LIMIT,
+    });
+  }
 
   if (!snapshot.empty) {
     const docs = snapshot.docs;

--- a/express-api/tests/cron/rotateLogs.test.js
+++ b/express-api/tests/cron/rotateLogs.test.js
@@ -49,8 +49,17 @@ jest.mock('../../src/utils/r2', () => ({
   deleteObjects: jest.fn().mockResolvedValue(undefined),
 }));
 
+// Mock log so we can assert on truncation warnings without polluting stderr
+jest.mock('../../src/utils/log', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
 const rotateLogs = require('../../src/cron/rotateLogs');
 const r2 = require('../../src/utils/r2');
+const log = require('../../src/utils/log');
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -181,5 +190,52 @@ describe('rotateLogs', () => {
     expect(mockWhere).toHaveBeenCalledWith('timestamp', '<', expectedCutoff);
 
     Date.now.mockRestore();
+  });
+
+  // ─── CRON_LIMIT truncation warning (Phase 2-cron batch 2) ──────────
+  // rotateLogs always pulls a capped page (CRON_LIMIT=500) from `logs`. If
+  // the page is full, we're behind on rotation — the next tick will pick
+  // up the rest, but operators need a signal so they can lean in (raise
+  // retentionHours? add a sweep cron?) before backlog snowballs and ages
+  // past compliance thresholds. Without this warn, a stuck rotation cron
+  // is silent until R2 storage starts getting noisy.
+  test('logs truncation warning when query hits CRON_LIMIT (500)', async () => {
+    // Config: default retention OK
+    mockGet.mockResolvedValueOnce({ exists: true, data: () => ({ retentionHours: 48 }) });
+
+    // 500 log docs returned — fills the page exactly.
+    const fullPage = Array.from({ length: 500 }, (_, i) =>
+      makeLogDoc(`log${i}`, { timestamp: '2020-01-01T00:00:00Z', message: `msg ${i}` }),
+    );
+    mockGet.mockResolvedValueOnce({ empty: false, size: 500, docs: fullPage });
+
+    await rotateLogs();
+
+    expect(log.warn).toHaveBeenCalledWith(
+      'cron',
+      expect.stringContaining('hit CRON_LIMIT'),
+      expect.objectContaining({ limit: 500 }),
+    );
+    // Verify the limit was actually applied (so the cap is real, not just logged)
+    expect(mockLimit).toHaveBeenCalledWith(500);
+  });
+
+  test('does NOT log truncation warning when query returns < CRON_LIMIT', async () => {
+    mockGet.mockResolvedValueOnce({ exists: true, data: () => ({ retentionHours: 48 }) });
+    // Smaller page than the cap
+    const partialPage = Array.from({ length: 100 }, (_, i) =>
+      makeLogDoc(`log${i}`, { timestamp: '2020-01-01T00:00:00Z', message: `msg ${i}` }),
+    );
+    mockGet.mockResolvedValueOnce({ empty: false, size: 100, docs: partialPage });
+
+    await rotateLogs();
+
+    // The warn message must be specifically about CRON_LIMIT — other
+    // log.warn callers in this cron (none today, but defensively) won't
+    // mask a regression that drops the truncation check.
+    const truncationWarn = log.warn.mock.calls.find(
+      ([_, msg]) => typeof msg === 'string' && msg.includes('hit CRON_LIMIT'),
+    );
+    expect(truncationWarn).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- `rotateLogs` already capped the logs query at 500, but had no truncation signal when a tick fills the page
- Added `CRON_LIMIT = 500` constant + `if (snapshot.size === CRON_LIMIT) log.warn(...)` matching the pattern from PR #526 (expireBans, expireDataExports, subscriptions)

A stuck rotation cron (R2 outage, backlog from temporarily disabled cron) would silently fall behind indefinitely — operators only notice when R2 storage gets noisy or compliance windows lapse. This warn surfaces backlog before snowballing.

Phase 2-cron batch-2 follow-up after PR #526.

## Test plan

- [x] 8 rotateLogs tests pass: 6 existing + 2 new pinning warn-on-full and no-warn-on-partial branches
- [x] Full express suite: 4586 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)