### PR TITLE
fix(util): partial-failure contract on data-export builder (Phase 2A finding #4)

### DIFF
--- a/express-api/src/routes/data-export.js
+++ b/express-api/src/routes/data-export.js
@@ -100,10 +100,15 @@ router.post('/users/:uniqueId/data-export', async (req, res) => {
             : 'https://dev-api.shytalk.shyden.co.uk');
         const downloadUrl = `${apiBase}/api/users/${uniqueId}/data-export/download?token=${downloadToken}&expiresAt=${expiresAt}`;
 
+        // Persist partial-failure state on the user doc so the status
+        // endpoint can surface it without re-running the export. Per GDPR
+        // Article 20, the user has a right to know what data was retrieved.
         await db.doc(`users/${uniqueId}`).update({
           dataExportStatus: 'ready',
           dataExportR2Key: r2Key,
           dataExportExpiresAt: expiresAt,
+          dataExportPartial: result.partial,
+          dataExportFailedSections: result.failedSections,
         });
 
         // Send email with download link
@@ -112,6 +117,8 @@ router.post('/users/:uniqueId/data-export', async (req, res) => {
             const template = buildDataExportReadyEmail(
               downloadUrl,
               new Date(expiresAt).toISOString(),
+              result.partial,
+              result.failedSections,
             );
             await sendEmail(user.email, template.subject, template.html);
           } catch (emailErr) {
@@ -121,7 +128,12 @@ router.post('/users/:uniqueId/data-export', async (req, res) => {
           }
         }
 
-        log.info('data-export', 'Export ready', { uniqueId, r2Key });
+        log.info('data-export', 'Export ready', {
+          uniqueId,
+          r2Key,
+          partial: result.partial,
+          failedSectionCount: result.failedSections.length,
+        });
       } catch (err) {
         log.error('data-export', 'Export build failed', {
           uniqueId,
@@ -180,6 +192,13 @@ router.get('/users/:uniqueId/data-export/status', async (req, res) => {
       requestedAt: user.lastDataExportRequestedAt || null,
       readyAt: status === 'ready' ? user.lastDataExportRequestedAt : null,
       expiresAt: user.dataExportExpiresAt || null,
+      // Surface partial-failure state so clients can warn the user before
+      // they download. `partial` is only meaningful when status === 'ready'.
+      partial: status === 'ready' ? Boolean(user.dataExportPartial) : false,
+      failedSections:
+        status === 'ready' && Array.isArray(user.dataExportFailedSections)
+          ? user.dataExportFailedSections
+          : [],
     });
   } catch (err) {
     log.error('data-export', 'Failed to get export status', {

--- a/express-api/src/utils/data-export-builder.js
+++ b/express-api/src/utils/data-export-builder.js
@@ -4,8 +4,16 @@
  * Collects all personal data from Firestore, strips sensitive internal
  * fields, and assembles a ZIP buffer using archiver.
  *
+ * Partial-failure contract: each subcollection query is wrapped in a try
+ * block. On failure the section is omitted (or empty), the failure is
+ * recorded in `failedSections`, and the export still completes. The caller
+ * MUST surface partial state to the user (per GDPR Article 20 — exports
+ * claiming completeness while silently missing data are a compliance
+ * issue). The ZIP itself includes a `manifest.json` enumerating all
+ * sections + their status, so the user can see exactly what was retrieved.
+ *
  * @param {string} uniqueId - The user's uniqueId
- * @returns {Promise<{buffer: Buffer}>}
+ * @returns {Promise<{buffer: Buffer, partial: boolean, failedSections: string[]}>}
  */
 
 const archiver = require('archiver');
@@ -30,6 +38,20 @@ const STRIP_FIELDS = [
 ];
 
 async function buildDataExport(uniqueId) {
+  // Track every section's outcome so the manifest + caller can see exactly
+  // which subcollection queries succeeded. Insertion order matches the order
+  // of section reads below — useful for debugging which doc is failing on
+  // a given user.
+  const failedSections = [];
+  function recordFailure(section, err) {
+    failedSections.push(section);
+    log.error('data-export', `Failed to query ${section}`, {
+      uniqueId,
+      section,
+      error: err.message,
+    });
+  }
+
   // Read user doc
   const userSnap = await db.doc(`users/${uniqueId}`).get();
   if (!userSnap.exists) {
@@ -79,11 +101,33 @@ async function buildDataExport(uniqueId) {
     pityCounter: userData.pityCounter || 0,
   };
 
-  // Subcollections
-  const backpack = await queryDocs(db.collection(`users/${uniqueId}/backpack`));
-  const giftWall = await queryDocs(db.collection(`users/${uniqueId}/giftWall`));
-  const transactions = await queryDocs(db.collection(`users/${uniqueId}/transactions`));
-  const warnings = await queryDocs(db.collection(`users/${uniqueId}/warnings`));
+  // Subcollections — each individually try-catched so a transient failure
+  // on one (e.g., a bad rules deploy on `warnings`) doesn't abort the
+  // entire export and lose the rest of the user's data.
+  let backpack = [];
+  try {
+    backpack = await queryDocs(db.collection(`users/${uniqueId}/backpack`));
+  } catch (err) {
+    recordFailure('backpack', err);
+  }
+  let giftWall = [];
+  try {
+    giftWall = await queryDocs(db.collection(`users/${uniqueId}/giftWall`));
+  } catch (err) {
+    recordFailure('giftWall', err);
+  }
+  let transactions = [];
+  try {
+    transactions = await queryDocs(db.collection(`users/${uniqueId}/transactions`));
+  } catch (err) {
+    recordFailure('transactions', err);
+  }
+  let warnings = [];
+  try {
+    warnings = await queryDocs(db.collection(`users/${uniqueId}/warnings`));
+  } catch (err) {
+    recordFailure('warnings', err);
+  }
 
   // Conversations (only user's own messages)
   let conversations = [];
@@ -122,18 +166,14 @@ async function buildDataExport(uniqueId) {
           userMessages.push({ conversationId: conv.id, id: m.id, ...m.data() });
         }
       } catch (msgErr) {
-        log.error('data-export', 'Failed to query messages for conversation', {
-          uniqueId,
-          conversationId: conv.id,
-          error: msgErr.message,
-        });
+        // Per-conversation message failure: record the conversation id in
+        // the section name so operators can identify which conversation
+        // is poisoned without needing log correlation.
+        recordFailure(`conversations/${conv.id}/messages`, msgErr);
       }
     }
   } catch (err) {
-    log.error('data-export', 'Failed to query conversations', {
-      uniqueId,
-      error: err.message,
-    });
+    recordFailure('conversations', err);
   }
 
   // Rooms owned by user
@@ -142,10 +182,7 @@ async function buildDataExport(uniqueId) {
     const roomSnap = await db.collection('rooms').where('ownerId', '==', uniqueId).get();
     roomsOwned = roomSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
   } catch (err) {
-    log.error('data-export', 'Failed to query rooms', {
-      uniqueId,
-      error: err.message,
-    });
+    recordFailure('rooms', err);
   }
 
   // Reports filed by user
@@ -154,10 +191,7 @@ async function buildDataExport(uniqueId) {
     const reportSnap = await db.collection('reports').where('reporterId', '==', uniqueId).get();
     reportsFiled = reportSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
   } catch (err) {
-    log.error('data-export', 'Failed to query reports', {
-      uniqueId,
-      error: err.message,
-    });
+    recordFailure('reports', err);
   }
 
   // Appeals
@@ -169,10 +203,7 @@ async function buildDataExport(uniqueId) {
       .get();
     appeals = appealSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
   } catch (err) {
-    log.error('data-export', 'Failed to query appeals', {
-      uniqueId,
-      error: err.message,
-    });
+    recordFailure('appeals', err);
   }
 
   // Identity
@@ -184,10 +215,7 @@ async function buildDataExport(uniqueId) {
       .get();
     identity = idSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
   } catch (err) {
-    log.error('data-export', 'Failed to query identity', {
-      uniqueId,
-      error: err.message,
-    });
+    recordFailure('identity', err);
   }
 
   // Device bindings
@@ -199,10 +227,7 @@ async function buildDataExport(uniqueId) {
       .get();
     deviceBindings = bindSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
   } catch (err) {
-    log.error('data-export', 'Failed to query device bindings', {
-      uniqueId,
-      error: err.message,
-    });
+    recordFailure('deviceBindings', err);
   }
 
   // Suggestions (GDPR: include all user's suggestions)
@@ -214,7 +239,7 @@ async function buildDataExport(uniqueId) {
       .get();
     suggestions = sugSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
   } catch (err) {
-    log.error('data-export', 'Failed to query suggestions', { uniqueId, error: err.message });
+    recordFailure('suggestions', err);
   }
 
   // Suggestion votes by this user
@@ -229,7 +254,7 @@ async function buildDataExport(uniqueId) {
       }
     }
   } catch (err) {
-    log.error('data-export', 'Failed to query suggestion votes', { uniqueId, error: err.message });
+    recordFailure('suggestionVotes', err);
   }
 
   // Subscription preferences
@@ -238,7 +263,7 @@ async function buildDataExport(uniqueId) {
     const subSnap = await db.doc(`subscriptions/${uniqueId}`).get();
     if (subSnap.exists) subscriptionPrefs = subSnap.data();
   } catch (err) {
-    log.error('data-export', 'Failed to query subscriptions', { uniqueId, error: err.message });
+    recordFailure('subscriptionPrefs', err);
   }
 
   // Notification history
@@ -250,8 +275,42 @@ async function buildDataExport(uniqueId) {
       .get();
     notificationHistory = notifSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
   } catch (err) {
-    log.error('data-export', 'Failed to query notifications', { uniqueId, error: err.message });
+    recordFailure('notifications', err);
   }
+
+  const partial = failedSections.length > 0;
+
+  // Manifest enumerates every section in the export — its presence in the
+  // ZIP guarantees the user can reconstruct what was attempted vs. what
+  // succeeded, even years later when this code has changed. The `partial`
+  // flag drives caller-side notification ("we couldn't get all your data,
+  // please retry") and the entry in failedSections is what they retry on.
+  const manifest = {
+    uniqueId,
+    exportDate: new Date().toISOString(),
+    partial,
+    failedSections,
+    sections: {
+      profile: 'ok',
+      settings: 'ok',
+      identity: failedSections.includes('identity') ? 'failed' : 'ok',
+      followers: 'ok',
+      blocked: 'ok',
+      backpack: failedSections.includes('backpack') ? 'failed' : 'ok',
+      giftWall: failedSections.includes('giftWall') ? 'failed' : 'ok',
+      transactions: failedSections.includes('transactions') ? 'failed' : 'ok',
+      warnings: failedSections.includes('warnings') ? 'failed' : 'ok',
+      conversations: failedSections.includes('conversations') ? 'failed' : 'ok',
+      rooms: failedSections.includes('rooms') ? 'failed' : 'ok',
+      reports: failedSections.includes('reports') ? 'failed' : 'ok',
+      appeals: failedSections.includes('appeals') ? 'failed' : 'ok',
+      deviceBindings: failedSections.includes('deviceBindings') ? 'failed' : 'ok',
+      suggestions: failedSections.includes('suggestions') ? 'failed' : 'ok',
+      suggestionVotes: failedSections.includes('suggestionVotes') ? 'failed' : 'ok',
+      subscriptionPrefs: failedSections.includes('subscriptionPrefs') ? 'failed' : 'ok',
+      notifications: failedSections.includes('notifications') ? 'failed' : 'ok',
+    },
+  };
 
   // Build ZIP
   const buffer = await new Promise((resolve, reject) => {
@@ -262,16 +321,39 @@ async function buildDataExport(uniqueId) {
     archive.on('end', () => resolve(Buffer.concat(chunks)));
     archive.on('error', reject);
 
-    const readme = [
+    const readmeLines = [
       'ShyTalk Data Export',
       '===================',
       '',
       `User ID: ${uniqueId}`,
       `Export date: ${new Date().toISOString()}`,
       '',
-      'This ZIP contains all personal data associated with your ShyTalk account.',
-      '',
+    ];
+    if (partial) {
+      // Surface partial-export state explicitly in the README so the user
+      // sees it without parsing manifest.json. The list of failed sections
+      // tells them exactly what they're missing.
+      readmeLines.push(
+        '⚠️  PARTIAL EXPORT',
+        '',
+        'This export is incomplete. The following sections could not be',
+        'retrieved due to a transient backend failure:',
+        '',
+        ...failedSections.map((s) => `  - ${s}`),
+        '',
+        'You can request a fresh export in 24 hours. We apologise for the',
+        'inconvenience — this is a compliance issue we take seriously.',
+        '',
+      );
+    } else {
+      readmeLines.push(
+        'This ZIP contains all personal data associated with your ShyTalk account.',
+        '',
+      );
+    }
+    readmeLines.push(
       'Files:',
+      '  manifest.json     — Section-by-section status of this export',
       '  profile.json      — Your profile information',
       '  settings.json     — Your privacy and notification settings',
       '  identity.json     — Your linked sign-in providers',
@@ -284,9 +366,11 @@ async function buildDataExport(uniqueId) {
       '  reports/          — Reports you filed and appeals',
       '  devices/          — Your device bindings',
       '  moderation/       — Your warning history',
-    ].join('\n');
+    );
+    const readme = readmeLines.join('\n');
 
     archive.append(readme, { name: 'README.txt' });
+    archive.append(JSON.stringify(manifest, null, 2), { name: 'manifest.json' });
     archive.append(JSON.stringify(profile, null, 2), { name: 'profile.json' });
     archive.append(JSON.stringify(settings, null, 2), {
       name: 'settings.json',
@@ -349,7 +433,7 @@ async function buildDataExport(uniqueId) {
     archive.finalize();
   });
 
-  return { buffer };
+  return { buffer, partial, failedSections };
 }
 
 module.exports = buildDataExport;

--- a/express-api/src/utils/email-templates.js
+++ b/express-api/src/utils/email-templates.js
@@ -2,6 +2,19 @@ const CDN_URL = process.env.CDN_URL || 'https://images.shytalk.shyden.co.uk';
 
 const LOGO_URL = `${CDN_URL}/branding/logo.png`;
 
+// Minimal HTML-escape for user-influenced strings interpolated into email
+// templates (e.g., the failedSections list in the partial-export notice).
+// Section names are server-controlled today, but a future refactor that
+// includes user-supplied identifiers must not be an injection vector.
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function wrapTemplate(bodyHtml) {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -98,17 +111,36 @@ function buildDeletionCompleteEmail() {
   return { subject: 'Your ShyTalk account has been deleted', html };
 }
 
-function buildDataExportReadyEmail(downloadUrl, expiresAt) {
+function buildDataExportReadyEmail(downloadUrl, expiresAt, partial = false, failedSections = []) {
+  // Partial-export notice surfaces ABOVE the download CTA so the user
+  // sees it before they click. The list of failed sections lets them
+  // decide whether to use this export or wait 24h and re-request.
+  const partialNotice = partial
+    ? `
+    <div style="background:#3a2630;border-left:4px solid #ff8b8b;padding:12px 16px;margin:0 0 16px;border-radius:6px;">
+      <p style="margin:0 0 8px;color:#ffd0d0;font-weight:700;">⚠ Partial export</p>
+      <p style="margin:0 0 8px;color:#d0d0e0;font-size:13px;">We couldn't retrieve every section of your data due to a transient backend failure. The following sections are missing or incomplete:</p>
+      <ul style="margin:0;padding-left:20px;color:#d0d0e0;font-size:13px;">
+        ${failedSections.map((s) => `<li>${escapeHtml(s)}</li>`).join('')}
+      </ul>
+      <p style="margin:8px 0 0;color:#7a7a9e;font-size:12px;">You can request a fresh export in 24 hours. The ZIP also contains a <code>manifest.json</code> with the full section status.</p>
+    </div>
+  `
+    : '';
   const html = wrapTemplate(`
     <p style="margin:0 0 8px;color:#d0d0e0;">Hi there,</p>
     <p style="margin:0 0 12px;color:#d0d0e0;">Your ShyTalk data export is ready for download.</p>
+    ${partialNotice}
     <div style="text-align:center;margin:24px 0;">
       <a href="${downloadUrl}" style="display:inline-block;background:#8b7fff;color:#fff;padding:14px 28px;border-radius:10px;text-decoration:none;font-weight:700;font-size:15px;">Download Your Data</a>
     </div>
     <p style="margin:0 0 12px;color:#7a7a9e;font-size:13px;">This link expires on ${expiresAt}. After that, you can request a new export.</p>
     <p style="margin:0;color:#7a7a9e;font-size:13px;">If you have any questions, contact <a href="mailto:shytalk.help@gmail.com" style="color:#8b7fff;">shytalk.help@gmail.com</a></p>
   `);
-  return { subject: 'Your ShyTalk data export is ready', html };
+  const subject = partial
+    ? 'Your ShyTalk data export is ready (partial)'
+    : 'Your ShyTalk data export is ready';
+  return { subject, html };
 }
 
 module.exports = {

--- a/express-api/tests/utils/data-export-builder.test.js
+++ b/express-api/tests/utils/data-export-builder.test.js
@@ -49,6 +49,22 @@ const { queryDocs } = require('../../src/utils/firestore-helpers');
 beforeEach(() => {
   jest.clearAllMocks();
   mockCollectionGet.mockResolvedValue({ docs: [], empty: true });
+  // Reset the db.collection implementation between tests — `clearAllMocks`
+  // clears call history but not `.mockImplementation(...)` overrides, so
+  // a test that selectively rejects (e.g., `name === 'reports' ? throw`)
+  // would otherwise leak that override into subsequent tests and cause
+  // unexpected failures (failedSections contaminated, partial=true on a
+  // test expecting all-success). Per `[Test mock isolation]` memory rule.
+  const { db } = require('../../src/utils/firebase');
+  db.collection.mockImplementation(() => {
+    const chain = {
+      where: jest.fn().mockImplementation(() => chain),
+      orderBy: jest.fn().mockImplementation(() => chain),
+      limit: jest.fn().mockImplementation(() => chain),
+      get: mockCollectionGet,
+    };
+    return chain;
+  });
 });
 
 // ── Tests ───────────────────────────────────────────────────────
@@ -275,9 +291,15 @@ describe('buildDataExport', () => {
     const log = require('../../src/utils/log');
     expect(log.error).toHaveBeenCalledWith(
       'data-export',
-      'Failed to query messages for conversation',
-      expect.objectContaining({ conversationId: 'conv-err' }),
+      // recordFailure tags by section name; per-conversation message
+      // failures use `conversations/{convId}/messages` so operators can
+      // tell exactly which conversation poisoned the export.
+      'Failed to query conversations/conv-err/messages',
+      expect.objectContaining({ uniqueId: '10000001' }),
     );
+    // Partial-failure contract: this section is in failedSections.
+    expect(result.partial).toBe(true);
+    expect(result.failedSections).toContain('conversations/conv-err/messages');
   });
 
   // --- Error paths for each collection query --------------------------------
@@ -441,9 +463,11 @@ describe('buildDataExport', () => {
     const log = require('../../src/utils/log');
     expect(log.error).toHaveBeenCalledWith(
       'data-export',
-      'Failed to query device bindings',
+      'Failed to query deviceBindings',
       expect.objectContaining({ uniqueId: '10000001' }),
     );
+    expect(result.partial).toBe(true);
+    expect(result.failedSections).toContain('deviceBindings');
   });
 
   test('handles suggestions query error gracefully', async () => {
@@ -610,9 +634,11 @@ describe('buildDataExport', () => {
     const log = require('../../src/utils/log');
     expect(log.error).toHaveBeenCalledWith(
       'data-export',
-      'Failed to query subscriptions',
+      'Failed to query subscriptionPrefs',
       expect.objectContaining({ uniqueId: '10000001' }),
     );
+    expect(result.partial).toBe(true);
+    expect(result.failedSections).toContain('subscriptionPrefs');
   });
 
   // --- Suggestion votes error path ------------------------------------------
@@ -655,7 +681,7 @@ describe('buildDataExport', () => {
     const log = require('../../src/utils/log');
     expect(log.error).toHaveBeenCalledWith(
       'data-export',
-      'Failed to query suggestion votes',
+      'Failed to query suggestionVotes',
       expect.objectContaining({ uniqueId: '10000001' }),
     );
   });
@@ -738,5 +764,82 @@ describe('buildDataExport', () => {
       'Failed to query conversations',
       expect.objectContaining({ uniqueId: '10000001' }),
     );
+  });
+
+  // ─── Partial-failure contract (Phase 2A finding #4) ─────────────────
+  // GDPR Article 20 requires the user know what data was retrieved. Before
+  // this contract every transient query failure produced a ZIP that
+  // claimed completeness while silently missing sections. The new contract
+  // returns `{partial, failedSections}` and includes a manifest.json in the
+  // ZIP enumerating each section's status. These tests pin both halves of
+  // the contract so a regression that drops them fails CI immediately.
+  describe('partial-failure contract', () => {
+    test('returns partial=false + empty failedSections when all queries succeed', async () => {
+      mockDocGet.mockResolvedValue({ exists: true, data: () => testUser });
+      queryDocs.mockResolvedValue([]);
+      mockCollectionGet.mockResolvedValue({ docs: [], empty: true });
+
+      const result = await buildDataExport('10000001');
+
+      expect(result.partial).toBe(false);
+      expect(result.failedSections).toEqual([]);
+    });
+
+    test('returns partial=true with the failing section name when ONE query fails', async () => {
+      mockDocGet.mockResolvedValue({ exists: true, data: () => testUser });
+      queryDocs.mockResolvedValue([]);
+      const { db } = require('../../src/utils/firebase');
+      // Only `appeals` rejects; everything else uses the default empty mock
+      db.collection.mockImplementation((name) => {
+        const chain = {
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockReturnThis(),
+          get:
+            name === 'suspensionAppeals'
+              ? jest.fn().mockRejectedValue(new Error('appeals down'))
+              : mockCollectionGet,
+        };
+        return chain;
+      });
+      mockCollectionGet.mockResolvedValue({ docs: [], empty: true });
+
+      const result = await buildDataExport('10000001');
+
+      expect(result.partial).toBe(true);
+      expect(result.failedSections).toEqual(['appeals']);
+    });
+
+    test('failedSections lists every distinct section that errored', async () => {
+      mockDocGet.mockResolvedValue({ exists: true, data: () => testUser });
+      queryDocs.mockResolvedValue([]);
+      const { db } = require('../../src/utils/firebase');
+      // Both reports AND deviceBindings reject — both must surface in
+      // failedSections (no early-exit, no swallowing).
+      db.collection.mockImplementation((name) => {
+        const chain = {
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockReturnThis(),
+          get:
+            name === 'reports'
+              ? jest.fn().mockRejectedValue(new Error('reports down'))
+              : name === 'deviceBindings'
+                ? jest.fn().mockRejectedValue(new Error('deviceBindings down'))
+                : mockCollectionGet,
+        };
+        return chain;
+      });
+      mockCollectionGet.mockResolvedValue({ docs: [], empty: true });
+
+      const result = await buildDataExport('10000001');
+
+      expect(result.partial).toBe(true);
+      expect(result.failedSections).toEqual(expect.arrayContaining(['reports', 'deviceBindings']));
+      // Buffer is still produced even with multiple section failures (the
+      // user gets SOMETHING back, not an empty error response).
+      expect(result.buffer).toBeInstanceOf(Buffer);
+      expect(result.buffer.length).toBeGreaterThan(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary

GDPR Article 20 right of access requires the user know what data was retrieved. Previously every transient subcollection-query failure inside `buildDataExport` was caught and logged but the export silently continued with empty section data — producing a ZIP that *claimed* completeness while quietly missing data.

**New contract:**
- `buildDataExport` returns `{buffer, partial, failedSections[]}`
- Every subcollection read calls `recordFailure(section, err)` on failure
- ZIP includes a `manifest.json` enumerating each section status (ok/failed)
- README inside the ZIP carries a PARTIAL EXPORT warning + the failed-section list when `partial=true`
- Status endpoint surfaces `partial` + `failedSections` so clients can warn the user before download
- Email template adds a partial-export notice ABOVE the download CTA when `partial=true`; subject becomes "Your ShyTalk data export is ready (partial)"

Phase 2A util audit finding #4. Replaces the old "deferred for design" rationalisation per the new `[No deferring]` memory rule — verified-real findings get fixed in the current cycle.

## Test plan

- [x] 52 tests pass: 49 existing assertions updated for the new section-name strings (`recordFailure` uses tagged section names like `conversations/{convId}/messages` instead of free-text log strings) + 3 new contract tests pinning `{partial, failedSections}` return shape, multi-section failure aggregation, and clean-success default
- [x] Test isolation hardened — `db.collection.mockImplementation` now reset in `beforeEach` (per `[Test mock isolation]` rule) so tests with selective rejection don't leak state into siblings
- [x] Full express jest suite: 4555 passed, 0 regressions
- [x] Playwright pre-push: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)