### PR TITLE
fix(security): clear suspension cache at every suspend site (Phase 2H finding #1)

### DIFF
--- a/express-api/src/routes/admin-users.js
+++ b/express-api/src/routes/admin-users.js
@@ -917,6 +917,13 @@ router.post('/user/:uniqueId/suspend', async (req, res) => {
       }),
     ]);
 
+    // Phase 2H finding #1: invalidate the 5-min checkSuspension cache so
+    // the just-suspended user can't keep making API calls during the
+    // active-moderation window. See clearSuspensionCache JSDoc for full
+    // rationale; mirrored at every other suspend site (reports.js,
+    // identity-graph.js).
+    clearSuspensionCache(Number(req.params.uniqueId));
+
     // Create a suspension warning that sets GCS to 0
     const currentGcs = user.gcsScore ?? user.gcs_score ?? 100;
     if (currentGcs > 0) {

--- a/express-api/src/routes/identity-graph.js
+++ b/express-api/src/routes/identity-graph.js
@@ -12,6 +12,7 @@ const router = require('express').Router();
 const { db } = require('../utils/firebase');
 const { generateId, now } = require('../utils/helpers');
 const log = require('../utils/log');
+const { clearSuspensionCache } = require('../middleware/auth');
 
 function requireAdmin(req, res) {
   if (!req.auth?.token?.admin) {
@@ -173,6 +174,7 @@ router.post('/admin/identity-graph/:id/suspend-all', async (req, res) => {
         },
         { merge: true },
       );
+      clearSuspensionCache(Number(id)); // Phase 2H finding #1
     } catch (e) {
       log.warn('identity-graph', 'User suspend propagation failed', { error: e.message });
     }

--- a/express-api/src/routes/reports.js
+++ b/express-api/src/routes/reports.js
@@ -597,6 +597,7 @@ router.post('/reports/:id/resolve', async (req, res) => {
           description: null,
           currentRoomId: null,
         });
+        clearSuspensionCache(Number(reportedUniqueId)); // Phase 2H finding #1
 
         // Awaited (was fire-and-forget) so cascade partial-failure surfaces in
         // the response and the admin UI can warn about manual cleanup.
@@ -853,6 +854,7 @@ router.post('/reports/resolve-all/:userId', async (req, res) => {
           description: null,
           currentRoomId: null,
         });
+        clearSuspensionCache(Number(reportedUniqueId));
 
         try {
           cascade = await evictSuspendedUser(reportedUniqueId);
@@ -1272,6 +1274,7 @@ router.post('/admin/users/:uniqueId/suspend', async (req, res) => {
         { merge: true },
       ),
     ]);
+    clearSuspensionCache(Number(req.params.uniqueId));
 
     // Awaited (was fire-and-forget) so cascade partial-failure is visible to admin.
     // cascade is unconditionally assigned below (success: evictSuspendedUser

--- a/express-api/tests/routes/admin-users-write.test.js
+++ b/express-api/tests/routes/admin-users-write.test.js
@@ -1099,4 +1099,27 @@ describe('POST /api/user/:uniqueId/suspend --- timed ban duration', () => {
   });
 });
 
+// --- Suspend cache invalidation (Phase 2H finding #1) ----------------------
+describe('POST /api/user/:uniqueId/suspend --- cache invalidation', () => {
+  let app;
+  beforeEach(() => {
+    app = createApp();
+    jest.clearAllMocks();
+  });
+  it('calls clearSuspensionCache after suspend', async () => {
+    const { clearSuspensionCache } = require('../../src/middleware/auth');
+    const futureDate = new Date(Date.now() + 86400000).toISOString();
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      id: 'u',
+      data: () => ({ displayName: 'U', gcsScore: 100 }),
+    });
+    await request(app)
+      .post('/api/user/u/suspend')
+      .send({ reason: 'T', canAppeal: false, endDate: futureDate });
+    await flushPromises();
+    expect(clearSuspensionCache).toHaveBeenCalled();
+  });
+});
+
 // --- GET /api/conversations/:id/messages ------------------------------------


### PR DESCRIPTION
## Summary

5-min in-process suspension cache invalidated on every UNSUSPEND but on NONE of the SUSPEND paths — just-suspended user kept passing checkSuspension for up to 5 min, exactly when moderation is most needed.

5 sites fixed: admin-users.js:919, reports.js:600, reports.js:861, reports.js:1280, identity-graph.js:175. Each now calls clearSuspensionCache(Number(uniqueId)) after the Firestore write.

Phase 2H middleware audit finding #1.

## Test plan
- [x] 51 admin-users-write tests pass (50 existing + 1 new regression-proof contract)
- [x] Full express jest suite: 4720 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)