### PR TITLE
fix(security): recoveryLimiter trims email before bucketing (Phase 2H finding #3)

### DIFF
--- a/express-api/src/middleware/rateLimit.js
+++ b/express-api/src/middleware/rateLimit.js
@@ -89,7 +89,15 @@ const recoveryLimiter = rateLimit({
   max: 3,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
-  keyGenerator: (req) => req.body?.email?.toLowerCase() || req.ip,
+  // Trim AND lowercase to match the route-side normalisation (portal.js:524
+  // does `email.trim().toLowerCase()` before user lookup). Without `.trim()`
+  // an attacker could spam OTPs to `victim@x.com` by alternating
+  // ` victim@x.com`, `victim@x.com `, and `victim@x.com` — three distinct
+  // rate-limit buckets all targeting the same Firebase user (Phase 2H finding #3).
+  keyGenerator: (req) => {
+    const email = typeof req.body?.email === 'string' ? req.body.email.trim().toLowerCase() : null;
+    return email || req.ip;
+  },
   validate: false,
   skip: () => isNonProd(),
 });

--- a/express-api/tests/middleware/rateLimit.test.js
+++ b/express-api/tests/middleware/rateLimit.test.js
@@ -339,6 +339,52 @@ describe('keyGenerator', () => {
   });
 });
 
+// Phase 2H finding #3: recoveryLimiter must trim+lowercase the email so
+// `victim@x.com`, ` victim@x.com`, and `victim@x.com ` are ONE bucket, not
+// three. Without `.trim()` an attacker could spam OTPs to a victim's inbox
+// by cycling whitespace variants of the same email.
+describe('recoveryLimiter — email normalisation', () => {
+  function freshRecovery() {
+    jest.resetModules();
+    process.env.NODE_ENV = 'production';
+    return require('../../src/middleware/rateLimit').recoveryLimiter;
+  }
+
+  function appFor(limiter) {
+    const app = express();
+    app.use(express.json());
+    app.use('/recover', limiter);
+    app.post('/recover', (_req, res) => res.json({ ok: true }));
+    return app;
+  }
+
+  test('whitespace and case variants share one bucket', async () => {
+    const limiter = freshRecovery();
+    const app = appFor(limiter);
+
+    // 3-per-24h limit. Exhaust with the canonical form first.
+    for (let i = 0; i < 3; i++) {
+      await request(app).post('/recover').send({ email: 'victim@example.com' }).expect(200);
+    }
+    // Whitespace variant — must hit the SAME bucket and 429.
+    await request(app).post('/recover').send({ email: ' victim@example.com' }).expect(429);
+    // Case variant — same bucket.
+    await request(app).post('/recover').send({ email: 'VICTIM@example.com' }).expect(429);
+    // Trailing whitespace — same bucket.
+    await request(app).post('/recover').send({ email: 'victim@example.com ' }).expect(429);
+  });
+
+  test('non-string email body falls back to req.ip key (no crash)', async () => {
+    const limiter = freshRecovery();
+    const app = appFor(limiter);
+    // Object-shaped body should not throw — keyGenerator returns req.ip.
+    await request(app)
+      .post('/recover')
+      .send({ email: { not: 'a string' } })
+      .expect(200);
+  });
+});
+
 describe('non-production skip', () => {
   // Counter-test the suite-wide `process.env.NODE_ENV = 'production'` setup:
   // when NODE_ENV is anything other than 'production', ALL limiters become


### PR DESCRIPTION
## Summary

recoveryLimiter keyGenerator lower-cased email but did NOT trim. Route-side normalisation does trim+lowercase, so 'victim@x.com', ' victim@x.com', and 'victim@x.com ' were three distinct rate-limit buckets all targeting the same user. Attacker could spam OTPs to a victim's inbox by cycling whitespace variants.

Fix: email.trim().toLowerCase() before bucketing, with typeof-string fallback to req.ip for non-string bodies.

Phase 2H middleware audit finding #3.

## Test plan
- [x] 22 rateLimit tests pass (20 existing + 2 new pinning whitespace/case variants share one bucket + non-string body fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)