### PR TITLE
fix(quota): in-flight Promise dedup in auth caches (Phase 2H finding #5)

### DIFF
--- a/express-api/src/middleware/auth.js
+++ b/express-api/src/middleware/auth.js
@@ -19,6 +19,15 @@ const uniqueIdCache = new Map();
 // uniqueId → { isSuspended, expiresAt }
 const suspensionCache = new Map();
 
+// In-flight Promise dedup. Without these, N concurrent first-touch requests
+// for the same key issue N parallel Firestore reads — Spark-tier free quota
+// is 50K reads/day and a typical app cold-start fires 5-10 parallel API
+// calls per user, so 1000 users × 10 = 10K reads in the warmup minute alone
+// without dedup (vs ~1K with). Keys mirror their respective caches.
+// (Phase 2H finding #5)
+const uniqueIdInFlight = new Map(); // uid → Promise<uniqueId|null>
+const suspensionInFlight = new Map(); // uniqueId → Promise<boolean>
+
 function evictOldest(cache) {
   if (cache.size > MAX_CACHE_SIZE) {
     const firstKey = cache.keys().next().value;
@@ -39,14 +48,27 @@ async function resolveUniqueId(uid) {
     return cached.uniqueId;
   }
 
-  const snap = await db.collection('users').where('firebaseUid', '==', uid).limit(1).get();
+  // Inflight dedup: if another caller is already resolving this uid, await
+  // their Promise instead of issuing a parallel Firestore query.
+  const existing = uniqueIdInFlight.get(uid);
+  if (existing) return existing;
 
-  const uniqueId = snap.empty ? null : (snap.docs[0].data().uniqueId ?? null);
-
-  uniqueIdCache.set(uid, { uniqueId, expiresAt: Date.now() + CACHE_TTL });
-  evictOldest(uniqueIdCache);
-
-  return uniqueId;
+  const promise = (async () => {
+    try {
+      const snap = await db.collection('users').where('firebaseUid', '==', uid).limit(1).get();
+      const uniqueId = snap.empty ? null : (snap.docs[0].data().uniqueId ?? null);
+      uniqueIdCache.set(uid, { uniqueId, expiresAt: Date.now() + CACHE_TTL });
+      evictOldest(uniqueIdCache);
+      return uniqueId;
+    } finally {
+      // Always release the inflight slot — including on Firestore errors —
+      // so a transient outage doesn't pin a stuck Promise that subsequent
+      // callers keep awaiting forever.
+      uniqueIdInFlight.delete(uid);
+    }
+  })();
+  uniqueIdInFlight.set(uid, promise);
+  return promise;
 }
 
 // ─── Suspension check ────────────────────────────────────────────
@@ -63,14 +85,24 @@ async function checkSuspension(uniqueId) {
     return cached.isSuspended;
   }
 
-  const snap = await db.doc(`users/${uniqueId}`).get();
-  const user = snap.exists ? snap.data() : null;
-  const isSuspended = !!(user?.isSuspended || user?.is_suspended);
+  // Inflight dedup — see resolveUniqueId for rationale.
+  const existing = suspensionInFlight.get(uniqueId);
+  if (existing) return existing;
 
-  suspensionCache.set(uniqueId, { isSuspended, expiresAt: Date.now() + CACHE_TTL });
-  evictOldest(suspensionCache);
-
-  return isSuspended;
+  const promise = (async () => {
+    try {
+      const snap = await db.doc(`users/${uniqueId}`).get();
+      const user = snap.exists ? snap.data() : null;
+      const isSuspended = !!(user?.isSuspended || user?.is_suspended);
+      suspensionCache.set(uniqueId, { isSuspended, expiresAt: Date.now() + CACHE_TTL });
+      evictOldest(suspensionCache);
+      return isSuspended;
+    } finally {
+      suspensionInFlight.delete(uniqueId);
+    }
+  })();
+  suspensionInFlight.set(uniqueId, promise);
+  return promise;
 }
 
 // ─── Middleware ───────────────────────────────────────────────────
@@ -185,14 +217,19 @@ function requireAdmin(req, res) {
 
 function clearSuspensionCache(uniqueId) {
   suspensionCache.delete(uniqueId);
+  // Also drop any inflight Promise so the NEXT caller refetches from
+  // Firestore (the inflight Promise was about to resolve to the OLD value).
+  suspensionInFlight.delete(uniqueId);
 }
 
 /** Clear uniqueId cache entry — call after firebaseUid is updated. */
 function clearUniqueIdCache(uid) {
   if (uid) {
     uniqueIdCache.delete(uid);
+    uniqueIdInFlight.delete(uid);
   } else {
     uniqueIdCache.clear();
+    uniqueIdInFlight.clear();
   }
 }
 

--- a/express-api/tests/middleware/auth.test.js
+++ b/express-api/tests/middleware/auth.test.js
@@ -836,3 +836,67 @@ describe('requireAdmin defensive checks', () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 });
+
+// Phase 2H finding #5: in-flight Promise dedup. Without these, N concurrent
+// first-touch requests for the same key fire N parallel Firestore reads
+// — a quota grenade on cold-start where 5-10 parallel calls per user each
+// miss the cache. The fix caches the in-flight Promise itself so the
+// second+ caller awaits the first caller's lookup. These tests pin the
+// behaviour so a regression that drops the dedup fails CI.
+describe('in-flight Promise dedup (resolveUniqueId)', () => {
+  test('5 concurrent same-uid requests issue ONE Firestore query, not 5', async () => {
+    // Slow Firestore mock so all 5 requests land in the inflight window.
+    let resolveQuery;
+    const queryPromise = new Promise((r) => {
+      resolveQuery = r;
+    });
+    mockCollectionQuery.mockReturnValueOnce(queryPromise);
+    // verifyIdToken returns the same uid for all 5 requests.
+    mockVerifyIdToken.mockResolvedValue({ uid: 'concurrent-uid' });
+    // suspension check is uid-keyed; resolve immediately.
+    mockDocGet.mockResolvedValue({ exists: true, data: () => ({ isSuspended: false }) });
+
+    const app = createApp();
+    const fired = Array.from({ length: 5 }, () =>
+      request(app).get('/api/users/10000080').set('Authorization', 'Bearer t'),
+    );
+    // Let all 5 requests dispatch through middleware up to the inflight await.
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Resolve the slow Firestore query with a real result so the dedup'd
+    // callers all return the same uniqueId.
+    resolveQuery({
+      empty: false,
+      docs: [
+        { id: '10000080', data: () => ({ uniqueId: 10000080, firebaseUid: 'concurrent-uid' }) },
+      ],
+    });
+    await Promise.all(fired);
+
+    // Single Firestore call across the 5 concurrent requests — the dedup
+    // contract is real, not just a happy-path optimisation.
+    expect(mockCollectionQuery).toHaveBeenCalledTimes(1);
+  });
+
+  test('inflight slot released on Firestore error so retry refetches', async () => {
+    // First call: rejects.
+    mockCollectionQuery.mockRejectedValueOnce(new Error('Firestore down'));
+    // Second call: succeeds.
+    mockCollectionQuery.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: '10000081', data: () => ({ uniqueId: 10000081, firebaseUid: 'retry-uid' }) }],
+    });
+    mockVerifyIdToken.mockResolvedValue({ uid: 'retry-uid' });
+    mockDocGet.mockResolvedValue({ exists: true, data: () => ({ isSuspended: false }) });
+
+    const app = createApp();
+    // First request hits the rejecting query path. Middleware catches and
+    // returns 401 (auth boundary fails closed). The inflight slot must be
+    // released regardless — the next retry should re-issue the query.
+    await request(app).get('/api/users/10000081').set('Authorization', 'Bearer t');
+    await request(app).get('/api/users/10000081').set('Authorization', 'Bearer t');
+
+    // Both calls fired Firestore — second wasn't pinned to the rejected Promise.
+    expect(mockCollectionQuery).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

resolveUniqueId and checkSuspension were read-through caches with no inflight-Promise dedup. N concurrent first-touch requests for the same uid each fired their own Firestore read.

App cold-start fires 5-10 parallel API calls per user; on a fresh PM2 process those all miss the cache. 1000 users × 10 = 10K reads in the warmup minute (vs ~1K with dedup) — burning into the 50K/day Spark free-tier budget.

Fix: cache the inflight Promise in uniqueIdInFlight / suspensionInFlight Maps; release via finally so transient errors don't pin a rejected Promise. clearSuspensionCache / clearUniqueIdCache also drop inflight slot.

Phase 2H middleware audit finding #5.

## Test plan
- [x] 43 auth tests pass (41 existing + 2 new pinning dedup contract: 5 concurrent → 1 Firestore call; inflight slot released on error)
- [x] Full express jest suite: 201 suites, 4720 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)