### PR TITLE
fix(security): recursive body sanitiser + extended denylist (Phase 2H finding #6)

### DIFF
--- a/express-api/src/middleware/requestLogger.js
+++ b/express-api/src/middleware/requestLogger.js
@@ -9,27 +9,42 @@
 
 const crypto = require('node:crypto');
 
-const SENSITIVE_BODY_KEYS = new Set([
-  'password',
-  'token',
-  'idtoken',
-  'accesstoken',
-  'refreshtoken',
-  'secret',
-  'credential',
-  'pin',
-  'code',
-]);
+// Substring-match denylist. The previous shallow + exact-match list missed
+// nested credentials (`{ user: { password } }`, `{ data: { idToken } }`)
+// and credential field names not on the explicit list (`passcode`, `otp`,
+// `totp`, `verifier`, `clientSecret`, `apiKey`, `recoveryCode`,
+// `appleSignedPayload`, `firebaseIdToken`, etc.). Logs are searchable by
+// uid; an admin reviewing one user's logs could grab another user's
+// still-valid credentials. Phase 2H finding #6.
+//
+// Pattern matches whole-key substrings — `pin`, `pinHash`, `oldPin`,
+// `userPasscode`, `idToken`, `accessToken`, `apiKey`, `clientSecret`,
+// `recoveryCode`, `appleSignedPayload`, etc. all redact correctly.
+const SENSITIVE_KEY_PATTERN =
+  /token|secret|password|passcode|pin|otp|totp|code|credential|verifier|signature|recovery|apple.*payload|hash|apikey/i;
+
+// Cap recursion depth defensively. Express body-parser has its own
+// `parameterLimit` and `depth` defaults that bound the inbound payload,
+// but a custom express.raw() route could feed in a deeper structure.
+// 8 is plenty for any legitimate API DTO and is far below Node's stack
+// limit on a stock Mac/Linux build.
+const SANITIZE_DEPTH_LIMIT = 8;
 
 /**
- * Strip sensitive fields from request body (shallow clone, one level deep).
+ * Strip sensitive fields from request body. Recurses into nested objects
+ * and arrays so credentials nested under DTO wrappers (`{ user: { password } }`,
+ * `{ data: { idToken } }`) are also removed. Sensitive keys are deleted
+ * (not present in output) to match the existing log-consumer contract.
  */
-function sanitizeBody(body) {
-  if (!body || typeof body !== 'object') return body;
+function sanitizeBody(body, depth = 0) {
+  if (depth > SANITIZE_DEPTH_LIMIT) return null;
+  if (body === null || body === undefined) return body;
+  if (Array.isArray(body)) return body.map((v) => sanitizeBody(v, depth + 1));
+  if (typeof body !== 'object') return body;
   const clean = {};
   for (const [key, value] of Object.entries(body)) {
-    if (SENSITIVE_BODY_KEYS.has(key.toLowerCase())) continue;
-    clean[key] = value;
+    if (SENSITIVE_KEY_PATTERN.test(key)) continue;
+    clean[key] = sanitizeBody(value, depth + 1);
   }
   return clean;
 }

--- a/express-api/tests/middleware/requestLogger.test.js
+++ b/express-api/tests/middleware/requestLogger.test.js
@@ -309,3 +309,91 @@ describe('requestLogger middleware — pin/code redaction end-to-end', () => {
     expect(loggedBody.uniqueId).toBe('10000001');
   });
 });
+
+// Phase 2H finding #6: nested credentials + extended denylist.
+describe('sanitizeBody — recursion + extended denylist (Phase 2H finding #6)', () => {
+  const { sanitizeBody } = require('../../src/middleware/requestLogger');
+
+  test('strips nested password under a DTO wrapper', () => {
+    const out = sanitizeBody({ user: { password: 'p', email: 'a@b.c' } });
+    expect(out.user).not.toHaveProperty('password');
+    expect(out.user.email).toBe('a@b.c');
+  });
+
+  test('strips nested idToken inside an array element', () => {
+    const out = sanitizeBody({ batch: [{ idToken: 'eyJ', name: 'first' }] });
+    expect(out.batch[0]).not.toHaveProperty('idToken');
+    expect(out.batch[0].name).toBe('first');
+  });
+
+  test('strips passcode / otp / totp / verifier (previously missing)', () => {
+    const out = sanitizeBody({
+      passcode: '1234',
+      otp: '5678',
+      totp: '9012',
+      verifier: 'sig',
+      kept: 'ok',
+    });
+    expect(out).not.toHaveProperty('passcode');
+    expect(out).not.toHaveProperty('otp');
+    expect(out).not.toHaveProperty('totp');
+    expect(out).not.toHaveProperty('verifier');
+    expect(out.kept).toBe('ok');
+  });
+
+  test('strips clientSecret / apiKey / recoveryCode / appleSignedPayload', () => {
+    const out = sanitizeBody({
+      clientSecret: 'cs',
+      apiKey: 'ak',
+      recoveryCode: 'rc',
+      appleSignedPayload: 'asp',
+      keep: 1,
+    });
+    expect(out).not.toHaveProperty('clientSecret');
+    expect(out).not.toHaveProperty('apiKey');
+    expect(out).not.toHaveProperty('recoveryCode');
+    expect(out).not.toHaveProperty('appleSignedPayload');
+    expect(out.keep).toBe(1);
+  });
+
+  test('strips key with sensitive substring even when surrounded (idToken, refreshToken, oldPin, passwordHash)', () => {
+    const out = sanitizeBody({
+      idToken: 'a',
+      refreshToken: 'b',
+      oldPin: 'c',
+      passwordHash: 'd',
+      regular: 'e',
+    });
+    expect(out).not.toHaveProperty('idToken');
+    expect(out).not.toHaveProperty('refreshToken');
+    expect(out).not.toHaveProperty('oldPin');
+    expect(out).not.toHaveProperty('passwordHash');
+    expect(out.regular).toBe('e');
+  });
+
+  test('caps recursion at SANITIZE_DEPTH_LIMIT (DoS guard)', () => {
+    // Build a 20-deep nested object — well past the cap of 8.
+    let obj = { v: 'leaf' };
+    for (let i = 0; i < 20; i++) obj = { wrap: obj };
+    const out = sanitizeBody(obj);
+    // Walk down until we hit a non-object — the cap returns `null` so we
+    // can detect it. Anything deeper than the limit collapses to null.
+    let cur = out;
+    let depth = 0;
+    while (cur && typeof cur === 'object' && cur.wrap !== undefined) {
+      cur = cur.wrap;
+      depth++;
+      if (depth > 50) break; // safety against an infinite loop on regression
+    }
+    // Below the limit we keep returning objects; at the limit we get null.
+    expect(cur).toBeNull();
+    expect(depth).toBeLessThanOrEqual(20);
+  });
+
+  test('preserves non-object values (string/number/null) untouched', () => {
+    expect(sanitizeBody('hello')).toBe('hello');
+    expect(sanitizeBody(42)).toBe(42);
+    expect(sanitizeBody(null)).toBeNull();
+    expect(sanitizeBody(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

sanitizeBody walked only the top level and skipped a fixed 9-key list. Nested credentials (`{ user: { password } }`, `{ data: { idToken } }`) plus several common credential names not on the explicit list (passcode, otp, totp, verifier, clientSecret, apiKey, recoveryCode, appleSignedPayload, firebaseIdToken) got logged in clear text.

Logs are stored in Firestore and searchable by uid — an admin reviewing logs for one user could grab another user's still-valid credentials.

## Fix
- Substring-match SENSITIVE_KEY_PATTERN regex catches idToken, refreshToken, oldPin, passwordHash, etc.
- Recurse into nested objects + arrays
- Cap recursion at SANITIZE_DEPTH_LIMIT=8 (DoS guard)

Phase 2H middleware audit finding #6.

## Test plan
- [x] 27 requestLogger tests pass (20 existing + 7 new: nested redaction, extended denylist, recursion cap, primitive preservation)
- [x] Full express jest suite: 201 suites, 4725 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)