### PR TITLE
fix(quota): bounded-LRU store for recoveryLimiter (Phase 2H finding #4)

### DIFF
--- a/express-api/src/middleware/rateLimit.js
+++ b/express-api/src/middleware/rateLimit.js
@@ -83,8 +83,63 @@ const portalLimiter = rateLimit({
   skip: () => isNonProd(),
 });
 
+// Bounded LRU store for the recoveryLimiter. The default `MemoryStore` from
+// `express-rate-limit` uses an unbounded `Map` and only prunes expired keys
+// once per `windowMs` — at 24h with email-keyed buckets, a botnet of unique
+// emails can grow the Map to millions of entries before any pruning. The
+// Oracle free-tier API VM has 1 GB RAM; sustained attack → OOM-killed pm2
+// → restart loop that wipes legitimate-user counters too. Phase 2H finding #4.
+//
+// Caps the keyspace at MAX_KEYS (10_000 — sufficient for ~3K active users
+// at 3 attempts/24h each, far above realistic ShyTalk recovery volume) and
+// evicts the least-recently-used entry on overflow. Entries past `windowMs`
+// self-clear when accessed.
+class BoundedLruRateLimitStore {
+  constructor({ windowMs, maxKeys = 10_000 }) {
+    this.windowMs = windowMs;
+    this.maxKeys = maxKeys;
+    this.hits = new Map(); // insertion-ordered → cheap LRU via delete+set
+  }
+  init() {}
+  async increment(key) {
+    const now = Date.now();
+    let entry = this.hits.get(key);
+    if (entry && now >= entry.resetTime.getTime()) {
+      entry = undefined;
+    }
+    if (!entry) {
+      entry = { totalHits: 0, resetTime: new Date(now + this.windowMs) };
+    } else {
+      // LRU touch: re-insert to move to the most-recent end.
+      this.hits.delete(key);
+    }
+    entry.totalHits += 1;
+    this.hits.set(key, entry);
+    while (this.hits.size > this.maxKeys) {
+      const oldestKey = this.hits.keys().next().value;
+      this.hits.delete(oldestKey);
+    }
+    return { totalHits: entry.totalHits, resetTime: entry.resetTime };
+  }
+  async decrement(key) {
+    const entry = this.hits.get(key);
+    if (entry && entry.totalHits > 0) entry.totalHits -= 1;
+  }
+  async resetKey(key) {
+    this.hits.delete(key);
+  }
+  async resetAll() {
+    this.hits.clear();
+  }
+  // Test-only observability hook.
+  _size() {
+    return this.hits.size;
+  }
+}
+
 // Recovery endpoints (password reset, TOTP recovery): 3 per 24 hours per email
 const recoveryLimiter = rateLimit({
+  store: new BoundedLruRateLimitStore({ windowMs: 24 * 60 * 60 * 1000, maxKeys: 10_000 }),
   windowMs: 24 * 60 * 60 * 1000,
   max: 3,
   standardHeaders: 'draft-7',
@@ -102,4 +157,13 @@ const recoveryLimiter = rateLimit({
   skip: () => isNonProd(),
 });
 
-module.exports = { generalLimiter, writeLimiter, sensitiveLimiter, portalLimiter, recoveryLimiter };
+module.exports = {
+  generalLimiter,
+  writeLimiter,
+  sensitiveLimiter,
+  portalLimiter,
+  recoveryLimiter,
+  // Test-only export so suite can pin LRU eviction without standing up the
+  // full rate-limit middleware. Production callers use `recoveryLimiter` only.
+  BoundedLruRateLimitStore,
+};

--- a/express-api/src/middleware/rateLimit.js
+++ b/express-api/src/middleware/rateLimit.js
@@ -89,7 +89,15 @@ const recoveryLimiter = rateLimit({
   max: 3,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
-  keyGenerator: (req) => req.body?.email?.toLowerCase() || req.ip,
+  // Trim AND lowercase to match the route-side normalisation (portal.js:524
+  // does `email.trim().toLowerCase()` before user lookup). Without `.trim()`
+  // an attacker could spam OTPs to `victim@x.com` by alternating
+  // ` victim@x.com`, `victim@x.com `, and `victim@x.com` — three distinct
+  // rate-limit buckets all targeting the same Firebase user (Phase 2H finding #3).
+  keyGenerator: (req) => {
+    const email = typeof req.body?.email === 'string' ? req.body.email.trim().toLowerCase() : null;
+    return email || req.ip;
+  },
   validate: false,
   skip: () => isNonProd(),
 });

--- a/express-api/tests/middleware/rateLimit.test.js
+++ b/express-api/tests/middleware/rateLimit.test.js
@@ -339,6 +339,52 @@ describe('keyGenerator', () => {
   });
 });
 
+// Phase 2H finding #3: recoveryLimiter must trim+lowercase the email so
+// `victim@x.com`, ` victim@x.com`, and `victim@x.com ` are ONE bucket, not
+// three. Without `.trim()` an attacker could spam OTPs to a victim's inbox
+// by cycling whitespace variants of the same email.
+describe('recoveryLimiter — email normalisation', () => {
+  function freshRecovery() {
+    jest.resetModules();
+    process.env.NODE_ENV = 'production';
+    return require('../../src/middleware/rateLimit').recoveryLimiter;
+  }
+
+  function appFor(limiter) {
+    const app = express();
+    app.use(express.json());
+    app.use('/recover', limiter);
+    app.post('/recover', (_req, res) => res.json({ ok: true }));
+    return app;
+  }
+
+  test('whitespace and case variants share one bucket', async () => {
+    const limiter = freshRecovery();
+    const app = appFor(limiter);
+
+    // 3-per-24h limit. Exhaust with the canonical form first.
+    for (let i = 0; i < 3; i++) {
+      await request(app).post('/recover').send({ email: 'victim@example.com' }).expect(200);
+    }
+    // Whitespace variant — must hit the SAME bucket and 429.
+    await request(app).post('/recover').send({ email: ' victim@example.com' }).expect(429);
+    // Case variant — same bucket.
+    await request(app).post('/recover').send({ email: 'VICTIM@example.com' }).expect(429);
+    // Trailing whitespace — same bucket.
+    await request(app).post('/recover').send({ email: 'victim@example.com ' }).expect(429);
+  });
+
+  test('non-string email body falls back to req.ip key (no crash)', async () => {
+    const limiter = freshRecovery();
+    const app = appFor(limiter);
+    // Object-shaped body should not throw — keyGenerator returns req.ip.
+    await request(app)
+      .post('/recover')
+      .send({ email: { not: 'a string' } })
+      .expect(200);
+  });
+});
+
 describe('non-production skip', () => {
   // Counter-test the suite-wide `process.env.NODE_ENV = 'production'` setup:
   // when NODE_ENV is anything other than 'production', ALL limiters become

--- a/express-api/tests/middleware/rateLimit.test.js
+++ b/express-api/tests/middleware/rateLimit.test.js
@@ -454,3 +454,56 @@ describe('non-production skip', () => {
     }
   });
 });
+
+// Phase 2H finding #4: BoundedLruRateLimitStore.
+describe('BoundedLruRateLimitStore — keyspace cap', () => {
+  let store;
+  beforeEach(() => {
+    jest.isolateModules(() => {
+      const rateLimitMod = require('../../src/middleware/rateLimit');
+      const StoreClass = rateLimitMod.BoundedLruRateLimitStore;
+      store = new StoreClass({ windowMs: 1000, maxKeys: 3 });
+    });
+  });
+
+  test('evicts the oldest key when over the cap', async () => {
+    await store.increment('a');
+    await store.increment('b');
+    await store.increment('c');
+    expect(store._size()).toBe(3);
+    await store.increment('d');
+    expect(store._size()).toBe(3);
+    expect(store.hits.has('a')).toBe(false);
+    expect(store.hits.has('d')).toBe(true);
+  });
+
+  test('LRU touch keeps recently-accessed key alive', async () => {
+    await store.increment('a');
+    await store.increment('b');
+    await store.increment('c');
+    await store.increment('a');
+    await store.increment('d');
+    expect(store.hits.has('a')).toBe(true);
+    expect(store.hits.has('b')).toBe(false);
+    expect(store.hits.has('d')).toBe(true);
+  });
+
+  test('expired entry is replaced (not preserved across windowMs)', async () => {
+    const result1 = await store.increment('exp');
+    expect(result1.totalHits).toBe(1);
+    const expiredEntry = store.hits.get('exp');
+    expiredEntry.resetTime = new Date(Date.now() - 1);
+    const result2 = await store.increment('exp');
+    expect(result2.totalHits).toBe(1);
+  });
+
+  test('resetKey clears a single key; resetAll clears the whole store', async () => {
+    await store.increment('x');
+    await store.increment('y');
+    await store.resetKey('x');
+    expect(store.hits.has('x')).toBe(false);
+    expect(store.hits.has('y')).toBe(true);
+    await store.resetAll();
+    expect(store._size()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Default `MemoryStore` from express-rate-limit uses an unbounded `Map` and only prunes expired keys once per windowMs. With recoveryLimiter keyed by email and a 24h window, a botnet hitting unique emails grows the Map to millions of entries — Oracle 1GB VM → OOM-killed pm2 → restart loop that wipes legitimate-user counters too.

## Fix

`BoundedLruRateLimitStore` caps keyspace at 10_000 entries (sufficient for ~3K active users × 3 attempts/24h, far above realistic ShyTalk recovery volume). LRU eviction on overflow via Map's insertion-order iteration: increment does delete+set to touch the key.

Implements the 5-method express-rate-limit Store interface so production recoveryLimiter swaps in via the `store` option.

Phase 2H middleware audit finding #4. **Stacks on Finding #3 (PR #534)** — same file, sequential merge.

## Test plan
- [x] 26 rateLimit tests pass (22 existing + 4 new: eviction order, LRU touch, expired-entry replacement, resetKey/resetAll semantics)
- [x] Full express jest suite: 201 suites, 4724 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)