### PR TITLE
fix(admin): Phase 2I admin panel audit — XSS, partial-failure surfacing, stale-write guard

### DIFF
--- a/express-api/tests/admin-client/reports-xss-static.test.js
+++ b/express-api/tests/admin-client/reports-xss-static.test.js
@@ -1,0 +1,85 @@
+/**
+ * Static regression test for Phase 2I finding #1: numeric user-controlled
+ * fields landing in admin reports innerHTML must always be passed through
+ * escapeHtml(). reports.js is an ES module imported directly by the
+ * browser — no Jest/jsdom harness is set up for it — so this test does a
+ * source scan instead of an in-DOM render. It is intentionally narrow:
+ * the goal is to prevent the specific regression class where a developer
+ * adds a new innerHTML interpolation of a number from the API response
+ * and forgets escapeHtml because "numbers are safe".
+ *
+ * The threat model assumes a malicious or corrupted Firestore aggregation
+ * could land a string-with-HTML in a field the admin panel reads via
+ * /api/reports. Defense-in-depth: escape every user-controlled value
+ * regardless of its expected type.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const REPORTS_JS = fs.readFileSync(
+  path.resolve(__dirname, '../../../public/admin/js/tabs/reports.js'),
+  'utf8',
+);
+
+describe('reports.js — XSS prevention on user-controlled numeric fields', () => {
+  // Each entry: a substring the file must NOT contain. We assert each
+  // dangerous pattern is absent. If a future edit re-introduces one, the
+  // test fails with the line context.
+  const DANGEROUS_PATTERNS = [
+    // Bare ${user.reportCount} interpolation
+    '${user.reportCount}',
+    // Bare ${gcsScore} interpolation (line 416 — same XSS class via
+    // user.gcsDisplayScore from the API response)
+    '} ${gcsScore}',
+    // Bare ${user.warningCount} (was already escaped, but lock it in)
+    '${user.warningCount}',
+    // Defensive: don't allow raw user.uniqueId interpolation either —
+    // the file already escapes it via escapeHtml(String(...)).
+    'data-navigate-uid="${user.uniqueId',
+  ];
+
+  for (const pattern of DANGEROUS_PATTERNS) {
+    test(`reports.js does NOT contain dangerous pattern: ${pattern}`, () => {
+      const idx = REPORTS_JS.indexOf(pattern);
+      if (idx === -1) {
+        expect(idx).toBe(-1);
+        return;
+      }
+      // Show the offending line to make the failure actionable.
+      const line = REPORTS_JS.substring(0, idx).split('\n').length;
+      const offendingLine = REPORTS_JS.split('\n')[line - 1];
+      throw new Error(
+        `reports.js line ${line} contains unescaped pattern \`${pattern}\`:\n  ${offendingLine.trim()}\n` +
+          `Wrap the value in escapeHtml(String(...)) — the helper is imported from /js/core/ui.js.`,
+      );
+    });
+  }
+
+  test('every "reportCount" template substitution uses escapeHtml', () => {
+    // Find all `${...reportCount...}` substitutions and ensure each
+    // contains "escapeHtml" within the interpolation braces.
+    const substitutions = REPORTS_JS.match(/\$\{[^}]*reportCount[^}]*\}/g) || [];
+    expect(substitutions.length).toBeGreaterThan(0); // sanity — file does use reportCount
+    for (const sub of substitutions) {
+      // Comparisons (e.g. user.reportCount !== 1) are fine — they evaluate
+      // to a boolean that gets stringified, but the boolean cannot contain
+      // attacker-controlled HTML. The dangerous case is when the value
+      // itself reaches innerHTML directly.
+      const isComparison = /(?:!==|===|<|>|<=|>=)\s*\d/.test(sub);
+      if (isComparison) continue;
+      expect(sub).toMatch(/escapeHtml/);
+    }
+  });
+
+  test('every "gcsScore" template substitution uses escapeHtml or a helper function', () => {
+    const substitutions = REPORTS_JS.match(/\$\{[^}]*gcsScore[^}]*\}/g) || [];
+    expect(substitutions.length).toBeGreaterThan(0);
+    for (const sub of substitutions) {
+      // Helper-function wrappers (_gcsClass, _gcsEmoji) are safe — they
+      // map a number to a known class name or emoji, not raw input.
+      const isHelperCall = /_gcs(Class|Emoji)\s*\(/.test(sub);
+      if (isHelperCall) continue;
+      expect(sub).toMatch(/escapeHtml/);
+    }
+  });
+});

--- a/express-api/tests/admin-client/suggestions-bulk-partial-failure-static.test.js
+++ b/express-api/tests/admin-client/suggestions-bulk-partial-failure-static.test.js
@@ -1,0 +1,62 @@
+/**
+ * Static regression test for Phase 2I finding #3: bulk approve/reject in
+ * `public/admin/js/tabs/suggestions.js` previously used `Promise.all`,
+ * which masks per-id partial failures (the success toast fires even when
+ * some ids both-endpoints-fail). The fix uses `Promise.allSettled` and
+ * counts succeeded/failed per id.
+ *
+ * suggestions.js is an ES module imported directly by the browser — no
+ * Jest/jsdom harness is set up for it — so this test does a source scan
+ * for the dangerous patterns and the fix-marker patterns.
+ *
+ * Per memory `[Partial-failure response contracts]`: routes/handlers that
+ * silently aggregate per-id failures are themselves bugs, even when the
+ * comment in the code says "tracked as follow-up".
+ */
+const fs = require('fs');
+const path = require('path');
+
+const SUGGESTIONS_JS = fs.readFileSync(
+  path.resolve(__dirname, '../../../public/admin/js/tabs/suggestions.js'),
+  'utf8',
+);
+
+describe('suggestions.js — bulk approve/reject must surface partial failures', () => {
+  test('does NOT use Promise.all on bulk id arrays (use allSettled instead)', () => {
+    // Match `Promise.all(ids.map(` or any `Promise.all(<list of api calls>)`
+    // pattern that would reject on first failure. We allow Promise.all
+    // for unrelated parallel-fetches like the dashboard data load on
+    // line ~362, which intentionally short-circuits on any failure
+    // because it's read-only.
+    const dangerous = /Promise\.all\s*\(\s*ids\.map/;
+    expect(SUGGESTIONS_JS).not.toMatch(dangerous);
+  });
+
+  test('uses Promise.allSettled in the bulk action helper', () => {
+    expect(SUGGESTIONS_JS).toMatch(/Promise\.allSettled/);
+  });
+
+  test('counts failed ids and shows them in the toast', () => {
+    // The helper must distinguish all-success / partial / all-failed.
+    // Look for the three toast paths.
+    expect(SUGGESTIONS_JS).toMatch(/failed for all/i);
+    expect(SUGGESTIONS_JS).toMatch(/of \$\{ids\.length\}/);
+    expect(SUGGESTIONS_JS).toMatch(/r\.status === 'rejected'/);
+  });
+
+  test('drops the "tracked as follow-up" deferral comments', () => {
+    // The old code had inline comments saying the partial-failure
+    // aggregation was a deferred follow-up. Per memory `[No deferring]`
+    // those comments must not return.
+    expect(SUGGESTIONS_JS).not.toMatch(/Tracked as follow-up: align bulk/);
+    expect(SUGGESTIONS_JS).not.toMatch(/deferred per-id partial-failure/);
+  });
+
+  test('runBulkSuggestionAction helper is defined and used twice (approve + reject)', () => {
+    const defLoc = SUGGESTIONS_JS.indexOf('async function runBulkSuggestionAction');
+    expect(defLoc).toBeGreaterThan(-1);
+    const callMatches = SUGGESTIONS_JS.match(/runBulkSuggestionAction\s*\(/g) || [];
+    // 1 definition site + 2 call sites
+    expect(callMatches.length).toBe(3);
+  });
+});

--- a/express-api/tests/admin-client/users-stale-write-guard-static.test.js
+++ b/express-api/tests/admin-client/users-stale-write-guard-static.test.js
@@ -1,0 +1,82 @@
+/**
+ * Static regression test for Phase 2I finding #2: when the admin rapidly
+ * switches users (search A → search B before A's loaders finish), the
+ * older user's API responses landed AFTER the newer user's and overwrote
+ * the displayed DOM (last-write-wins on the same elements like
+ * #report-history-list, #warning-history-list, #backpack-grid, etc).
+ *
+ * Fix: each loader compares its `uid` parameter to the module-level
+ * `currentUid` immediately after the await resolves and BEFORE any DOM
+ * mutation. If they no longer match, the loader bails — its result is
+ * discarded.
+ *
+ * users.js is an ES module imported directly by the browser — no
+ * Jest/jsdom harness is set up for it — so this test does a source scan
+ * to assert each known loader has the guard.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const USERS_JS = fs.readFileSync(
+  path.resolve(__dirname, '../../../public/admin/js/tabs/users.js'),
+  'utf8',
+);
+
+// Each entry: [function name, the unique line within the function that
+// MUST be immediately followed by the uid !== currentUid guard].
+// We pick a unique substring from the function (its first await call)
+// and verify the next non-blank statement is the guard.
+const LOADERS = [
+  {
+    name: 'loadReportHistory',
+    awaitMarker: 'apiCall("GET", "/api/reports?status=resolved&userId=" + uid)',
+  },
+  { name: 'loadWarningHistory', awaitMarker: 'await apiCall("GET", url)' },
+  { name: 'loadBackpack', awaitMarker: 'apiCall("GET", "/api/users/" + uid + "/backpack")' },
+  { name: 'populateBansSection', awaitMarker: 'apiCall("GET", `/api/admin/devices/user/${uid}`)' },
+  {
+    name: 'populateDeviceBindingCard',
+    awaitMarker: 'apiCall("GET", `/api/admin/devices/user/${uid}`)',
+  },
+  { name: 'loadStalkers', awaitMarker: 'apiCall("GET", "/api/user/" + uid + "/stalkers")' },
+];
+
+describe('users.js — stale-write guard on rapid user switch', () => {
+  test('populateFormFull passes `uid` (not module currentUid) to loadStalkers', () => {
+    // Symmetry with the other loaders in the same Promise.all. Using
+    // currentUid here would be doubly racy because currentUid can be
+    // mutated by populateForm before this fan-out.
+    expect(USERS_JS).toMatch(/loadStalkers\(uid\)/);
+    expect(USERS_JS).not.toMatch(/loadStalkers\(currentUid\)/);
+  });
+
+  for (const { name, awaitMarker } of LOADERS) {
+    test(`${name} bails on stale uid before mutating DOM`, () => {
+      const idx = USERS_JS.indexOf(awaitMarker);
+      expect(idx).toBeGreaterThan(-1); // sanity — marker must exist
+      // Take the next ~200 chars after the marker; the guard must
+      // appear before any innerHTML / appendChild / textContent /
+      // _backpackItems = / loadedData. assignment.
+      const after = USERS_JS.substring(idx, idx + 400);
+      const guardIdx = after.indexOf('uid !== currentUid');
+      expect(guardIdx).toBeGreaterThan(-1);
+      // Ensure the guard appears BEFORE any DOM-mutation token
+      const mutationTokens = [
+        'innerHTML',
+        'appendChild',
+        '_backpackItems =',
+        '_warningLastTimestamp =',
+      ];
+      for (const tok of mutationTokens) {
+        const tokIdx = after.indexOf(tok);
+        if (tokIdx === -1) continue;
+        expect(guardIdx).toBeLessThan(tokIdx);
+      }
+    });
+  }
+
+  test('the guard message comment is present at every site (regression-friendly grep)', () => {
+    const matches = USERS_JS.match(/admin switched users mid-load — drop stale write/g) || [];
+    expect(matches.length).toBe(LOADERS.length);
+  });
+});

--- a/express-api/tests/admin-client/users-stale-write-guard-static.test.js
+++ b/express-api/tests/admin-client/users-stale-write-guard-static.test.js
@@ -22,10 +22,12 @@ const USERS_JS = fs.readFileSync(
   'utf8',
 );
 
-// Each entry: [function name, the unique line within the function that
-// MUST be immediately followed by the uid !== currentUid guard].
-// We pick a unique substring from the function (its first await call)
-// and verify the next non-blank statement is the guard.
+// Each entry: function name to anchor the search, plus the unique
+// substring within that function that marks its first await. We anchor
+// by function name first because two loaders share an identical await
+// (populateBansSection and populateDeviceBindingCard both fetch
+// /api/admin/devices/user/${uid}); a bare indexOf would inspect the
+// wrong function for the second loader.
 const LOADERS = [
   {
     name: 'loadReportHistory',
@@ -33,7 +35,7 @@ const LOADERS = [
   },
   { name: 'loadWarningHistory', awaitMarker: 'await apiCall("GET", url)' },
   { name: 'loadBackpack', awaitMarker: 'apiCall("GET", "/api/users/" + uid + "/backpack")' },
-  { name: 'populateBansSection', awaitMarker: 'apiCall("GET", `/api/admin/devices/user/${uid}`)' },
+  { name: 'populateBansSection', awaitMarker: 'apiCall("GET", `/api/admin/bans/user/${uid}`)' },
   {
     name: 'populateDeviceBindingCard',
     awaitMarker: 'apiCall("GET", `/api/admin/devices/user/${uid}`)',
@@ -52,20 +54,33 @@ describe('users.js — stale-write guard on rapid user switch', () => {
 
   for (const { name, awaitMarker } of LOADERS) {
     test(`${name} bails on stale uid before mutating DOM`, () => {
-      const idx = USERS_JS.indexOf(awaitMarker);
-      expect(idx).toBeGreaterThan(-1); // sanity — marker must exist
-      // Take the next ~200 chars after the marker; the guard must
-      // appear before any innerHTML / appendChild / textContent /
-      // _backpackItems = / loadedData. assignment.
+      // Anchor at the function declaration so the marker search is
+      // scoped to this loader's body. Without this anchor, two loaders
+      // that share an await string (populateBansSection +
+      // populateDeviceBindingCard both call /api/admin/devices/user)
+      // would both inspect the FIRST occurrence and the second
+      // function's test would silently no-op.
+      const fnStart = USERS_JS.indexOf(`function ${name}(`);
+      expect(fnStart).toBeGreaterThan(-1);
+      const idx = USERS_JS.indexOf(awaitMarker, fnStart);
+      expect(idx).toBeGreaterThan(-1); // sanity — marker must exist after fn start
+      // Take the next ~400 chars after the marker; the guard must
+      // appear before any DOM- or state-mutation token.
       const after = USERS_JS.substring(idx, idx + 400);
       const guardIdx = after.indexOf('uid !== currentUid');
       expect(guardIdx).toBeGreaterThan(-1);
-      // Ensure the guard appears BEFORE any DOM-mutation token
+      // Mutation tokens to guard against. Adding `loadedData.` and
+      // `_stalkerCount` covers loadStalkers' mutation of the shared
+      // `loadedData` object — without these the loadStalkers test
+      // would pass even if the guard were misplaced after the
+      // `loadedData._stalkerCount = data.count` write.
       const mutationTokens = [
         'innerHTML',
         'appendChild',
         '_backpackItems =',
         '_warningLastTimestamp =',
+        'loadedData.',
+        '_stalkerCount',
       ];
       for (const tok of mutationTokens) {
         const tokIdx = after.indexOf(tok);

--- a/public/admin/js/tabs/reports.js
+++ b/public/admin/js/tabs/reports.js
@@ -413,8 +413,8 @@ function renderMoreCards() {
       <div class="report-user-name" data-navigate-uid="${escapeHtml(String(user.uniqueId || user.uid))}">${escapeHtml(user.displayName || 'Unknown')}${user.isSuspended ? ' <span style="color:var(--danger);font-size:11px;font-weight:600;background:rgba(231,76,60,0.1);padding:1px 6px;border-radius:4px;">Suspended</span>' : ''}</div>
       <div class="report-user-id">ID: ${escapeHtml(String(user.uniqueId || '?'))} | Warnings: ${escapeHtml(String(user.warningCount || 0))}</div>
     </div>`;
-    headerHtml += `<span class="gcs-badge ${_gcsClass(gcsScore)}">${_gcsEmoji(gcsScore)} ${gcsScore}</span>`;
-    headerHtml += `<span class="report-count-badge">${user.reportCount} report${user.reportCount !== 1 ? 's' : ''}</span>`;
+    headerHtml += `<span class="gcs-badge ${_gcsClass(gcsScore)}">${_gcsEmoji(gcsScore)} ${escapeHtml(String(gcsScore))}</span>`;
+    headerHtml += `<span class="report-count-badge">${escapeHtml(String(user.reportCount || 0))} report${user.reportCount !== 1 ? 's' : ''}</span>`;
 
     // Review lock badge
     if (user.lock && user.lock.adminUid !== myUid) {
@@ -492,7 +492,7 @@ function renderMoreCards() {
         </div>
         <div class="resolve-buttons">
           <button class="btn-resolve" data-resolve-first="${safeUid}">Resolve Latest</button>
-          <button class="btn-resolve-all" data-resolve-all="${safeUid}">Resolve All (${user.reportCount})</button>
+          <button class="btn-resolve-all" data-resolve-all="${safeUid}">Resolve All (${escapeHtml(String(user.reportCount || 0))})</button>
         </div>
       </div>`;
     }

--- a/public/admin/js/tabs/suggestions.js
+++ b/public/admin/js/tabs/suggestions.js
@@ -115,26 +115,41 @@ export function init(deps) {
     dialog.dataset.ids = JSON.stringify(selected);
   });
 
+  // Bulk handler — runs each id's primary endpoint, falls back to the
+  // legacy PUT /status endpoint, and reports per-id success/failure.
+  // Uses Promise.allSettled so a single failure does not mask the
+  // outcome of the other ids (Promise.all would reject on the first
+  // failure and showToast(`Approved N`) on the success path was firing
+  // even when some/all ids individually failed both endpoints).
+  async function runBulkSuggestionAction({ ids, primary, fallback, verb }) {
+    const settled = await Promise.allSettled(ids.map(async (id) => {
+      try { return await primary(id); } catch (_) { return await fallback(id); }
+    }));
+    const failed = [];
+    settled.forEach((r, i) => { if (r.status === 'rejected') failed.push({ id: ids[i], error: r.reason?.message || String(r.reason) }); });
+    if (failed.length === 0) {
+      showToast(`${verb} ${ids.length} suggestion(s)`, 'success');
+    } else if (failed.length === ids.length) {
+      showToast(`${verb} failed for all ${ids.length} suggestion(s): ${failed[0].error}`, 'error');
+    } else {
+      const sample = failed.slice(0, 3).map((f) => f.id).join(', ');
+      const more = failed.length > 3 ? ` (+${failed.length - 3} more)` : '';
+      showToast(`${verb} ${ids.length - failed.length} of ${ids.length} — failed: ${sample}${more}`, 'error');
+    }
+    loadSuggestions();
+  }
+
   // ── Confirm bulk action ──
   document.querySelector('#suggestions-bulk-confirm-dialog .btn-confirm-bulk').addEventListener('click', async () => {
     const dialog = document.getElementById('suggestions-bulk-confirm-dialog');
     const ids = JSON.parse(dialog.dataset.ids || '[]');
     dialog.style.display = 'none';
-    try {
-      // Bulk approve uses two-tier endpoint chain (new POST /approve falls
-      // back to legacy PUT /status). We don't aggregate per-id
-      // pms: { failed, total } here because the .catch fallback masks per-call
-      // shape — single-suggestion handlers (~line 188, 605, 628) DO consume
-      // pms via PartialFailureToast. Tracked as follow-up: align bulk +
-      // single shapes once the legacy fallback is removed.
-      await Promise.all(ids.map((id) =>
-        apiCall('POST', `/api/admin/suggestions/${id}/approve`).catch(() =>
-          apiCall('PUT', `/api/admin/suggestions/${id}/status`, { status: 'accepted' }),
-        ),
-      ));
-      showToast(`Approved ${ids.length} suggestion(s)`, 'success');
-      loadSuggestions();
-    } catch (err) { showToast(err.message, 'error'); }
+    await runBulkSuggestionAction({
+      ids,
+      verb: 'Approved',
+      primary: (id) => apiCall('POST', `/api/admin/suggestions/${id}/approve`),
+      fallback: (id) => apiCall('PUT', `/api/admin/suggestions/${id}/status`, { status: 'accepted' }),
+    });
   });
   document.querySelector('#suggestions-bulk-confirm-dialog .btn-cancel-bulk').addEventListener('click', () => {
     document.getElementById('suggestions-bulk-confirm-dialog').style.display = 'none';
@@ -146,17 +161,12 @@ export function init(deps) {
     const ids = JSON.parse(dialog.dataset.ids || '[]');
     const reason = document.getElementById('bulk-reject-reason').value || '';
     dialog.style.display = 'none';
-    try {
-      // See bulk-approve comment above — same two-tier fallback shape, same
-      // deferred per-id partial-failure aggregation.
-      await Promise.all(ids.map((id) =>
-        apiCall('POST', `/api/admin/suggestions/${id}/reject`, { reason }).catch(() =>
-          apiCall('PUT', `/api/admin/suggestions/${id}/status`, { status: 'rejected', reason }),
-        ),
-      ));
-      showToast(`Rejected ${ids.length} suggestion(s)`, 'success');
-      loadSuggestions();
-    } catch (err) { showToast(err.message, 'error'); }
+    await runBulkSuggestionAction({
+      ids,
+      verb: 'Rejected',
+      primary: (id) => apiCall('POST', `/api/admin/suggestions/${id}/reject`, { reason }),
+      fallback: (id) => apiCall('PUT', `/api/admin/suggestions/${id}/status`, { status: 'rejected', reason }),
+    });
   });
   document.querySelector('#suggestions-bulk-reject-dialog .btn-cancel-bulk-reject').addEventListener('click', () => {
     document.getElementById('suggestions-bulk-reject-dialog').style.display = 'none';

--- a/public/admin/js/tabs/users.js
+++ b/public/admin/js/tabs/users.js
@@ -992,6 +992,7 @@ export async function loadReportHistory(uid) {
   reportHistoryList.innerHTML = '<div style="color:var(--text2);font-size:12px;">Loading...</div>';
   try {
     const result = await apiCall("GET", "/api/reports?status=resolved&userId=" + uid);
+    if (uid !== currentUid) return; // admin switched users mid-load — drop stale write
     const allReports = Array.isArray(result) ? result : (result.users ? result.users.flatMap((u) => u.reports) : []);
     if (allReports.length === 0) { reportHistoryList.innerHTML = '<div style="color:var(--text2);font-size:12px;font-style:italic;">No report history</div>'; return; }
     reportHistoryList.innerHTML = "";
@@ -1035,6 +1036,7 @@ export async function loadWarningHistory(uid, append) {
     let url = "/api/user/" + uid + "/warnings?limit=20";
     if (_warningLastTimestamp) url += "&startAfter=" + _warningLastTimestamp;
     const data = await apiCall("GET", url);
+    if (uid !== currentUid) return; // admin switched users mid-load — drop stale write
     const warnings = data.warnings || [];
     if (!append) warningHistoryList.textContent = "";
     if (warnings.length === 0 && !append) {
@@ -1114,7 +1116,7 @@ export async function populateFormFull(data) {
     loadBackpack(uid),
     populateBansSection(uid),
     populateDeviceBindingCard(uid),
-    loadStalkers(currentUid),
+    loadStalkers(uid),
   ]);
   const profilePreview = document.getElementById("profile-preview");
   if (profilePreview) profilePreview.style.display = "flex";
@@ -1394,6 +1396,7 @@ export async function loadBackpack(uid) {
   _backpackEdits = {};
   try {
     const data = await apiCall("GET", "/api/users/" + uid + "/backpack");
+    if (uid !== currentUid) return; // admin switched users mid-load — drop stale write
     _backpackItems = Array.isArray(data) ? data : (data.items || []);
     renderBackpack();
     populateCategoryFilter();
@@ -1645,6 +1648,7 @@ export async function populateBansSection(uid) {
       apiCall("GET", `/api/admin/bans/user/${uid}`),
       apiCall("GET", `/api/admin/devices/user/${uid}`),
     ]);
+    if (uid !== currentUid) return; // admin switched users mid-load — drop stale write
     // Device bans
     const deviceBans = bansData.deviceBans || [];
     if (bansDeviceList) {
@@ -1682,6 +1686,7 @@ export async function populateDeviceBindingCard(uid) {
   if (emptyEl) emptyEl.style.display = "none";
   try {
     const data = await apiCall("GET", `/api/admin/devices/user/${uid}`);
+    if (uid !== currentUid) return; // admin switched users mid-load — drop stale write
     const devices = data.devices || [];
     if (devices.length === 0) { if (emptyEl) emptyEl.style.display = "block"; if (cardsEl) cardsEl.innerHTML = ""; return; }
     if (cardsEl) cardsEl.innerHTML = devices.map(d => { const rows = [["Manufacturer", d.manufacturer || "Unknown"],["Model", d.model || "Unknown"],["OS Version", d.osVersion || "N/A"],["App Version", (d.appVersion || "N/A") + (d.buildNumber ? " (" + d.buildNumber + ")" : "")],["Screen", d.screenResolution || "N/A"],["Density", d.screenDensity || "N/A"],["Network Type", d.networkType || "N/A"],["Carrier", d.carrier || "N/A"],["Last IP", d.lastIp || "N/A"],["ISP", d.isp || "N/A"],["ASN", d.asn || "N/A"],["Country", d.country || "N/A"],["Region", d.region || "N/A"],["First Seen", d.firstSeen ? new Date(d.firstSeen).toLocaleString() : "N/A"],["Last Seen", d.lastSeen ? new Date(d.lastSeen).toLocaleString() : "N/A"]]; return '<div style="background:var(--surface2);border-radius:8px;padding:12px;margin-bottom:8px;"><div style="font-weight:600;font-size:14px;margin-bottom:8px;color:var(--text);">' + escapeHtml((d.manufacturer || "") + " " + (d.model || d.id)) + '</div><div style="display:grid;grid-template-columns:140px 1fr;gap:4px 12px;font-size:12px;">' + rows.map(([label, val]) => '<div style="color:var(--text2);font-weight:500;">' + label + '</div><div style="color:var(--text);">' + escapeHtml(String(val)) + '</div>').join("") + '</div><div style="margin-top:8px;font-size:11px;color:var(--text2);">Device ID: ' + escapeHtml(d.id) + '</div></div>'; }).join("");
@@ -1747,6 +1752,7 @@ function setPreviewCounts(id, data) { const el = document.getElementById(id); if
 export async function loadStalkers(uid) {
   try {
     const data = await apiCall("GET", "/api/user/" + uid + "/stalkers");
+    if (uid !== currentUid) return; // admin switched users mid-load — drop stale write
     loadedData._stalkerCount = data.count;
     const container = document.getElementById("stalkers-list"); if (!container) return;
     while (container.firstChild) container.removeChild(container.firstChild);


### PR DESCRIPTION
## Summary
Phase 2I admin-panel audit — three correctness fixes derived from the audit recorded in [project-phase-2i-admin-panel-audit](memory). 8 candidates reviewed, 3 verified real, 5 false positives. Each fix has a static regression test pinned in `express-api/tests/admin-client/`.

- **XSS hardening on `reports.js`** (`901e2ed`) — three numeric template substitutions (`gcsScore`, `user.reportCount` x2) landed in `card.innerHTML` without `escapeHtml`. Adjacent fields on lines 408/413/414 were already escaped — this brings the three outliers in line. Defense-in-depth against a malicious value reaching the admin via /api/reports.
- **Partial-failure surfacing on bulk suggestions** (`6b02f75`) — `Promise.all(ids.map(...))` masked per-id failures; success toast fired even when some/all ids failed both endpoints. Now uses `Promise.allSettled` and surfaces `all-success` / `partial` / `all-failed` via three distinct toasts. Drops the prior "tracked as follow-up" comment per memory `[No deferring]`.
- **Stale write-back guard on `populateFormFull` loaders** (`bc727a3`) — when admin rapidly switched users (search A → search B before A's six parallel loaders finished), A's API responses landed AFTER B's and overwrote B's display. Each loader now checks `uid !== currentUid` immediately after its await and bails before mutating DOM. Also normalised `loadStalkers(currentUid)` → `loadStalkers(uid)` for symmetry.
- **Test tightening from review** (`fb2fda6`) — folded in two findings from the code-reviewer agent: (1) `populateBansSection` and `populateDeviceBindingCard` shared an identical await marker so the test was inspecting the wrong function for the second loader; (2) mutation-token list missed `loadedData.` and `_stalkerCount`.

## Test plan
- [x] `npx jest tests/admin-client/reports-xss-static.test.js` — 6 passed
- [x] `npx jest tests/admin-client/suggestions-bulk-partial-failure-static.test.js` — 5 passed
- [x] `npx jest tests/admin-client/users-stale-write-guard-static.test.js` — 8 passed
- [x] Full express jest: 4764 passed / 8 skipped (was 4745 — +19 from this PR)
- [x] ESLint + Prettier clean
- [x] Local Playwright chromium full suite green (pre-push hook, 15+ min)
- [x] Code-reviewer agent — 2 actionable test improvements folded in

🤖 Generated with [Claude Code](https://claude.com/claude-code)