### PR TITLE
fix(ios): surface ban-check errors via Resource.Error for parity

### DIFF
--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosSmallRepositories.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosSmallRepositories.kt
@@ -73,8 +73,13 @@ class IosDeviceRepositoryImpl(
                 Resource.Success(BanStatus())
             }
         } catch (e: Exception) {
-            logW("DeviceRepository", "Ban check failed, allowing through: ${e.message}")
-            Resource.Success(BanStatus())
+            // Surface as Error so the caller can log/telemeter. AuthViewModel
+            // already treats Error leniently (see AuthViewModelBanTest.kt:144
+            // "ban check error is lenient") — same user-facing outcome as
+            // the prior Resource.Success(BanStatus()), but iOS no longer
+            // hides the error signal from anything else that might want it.
+            logW("DeviceRepository", "Ban check failed: ${e.message}")
+            Resource.Error("Ban check failed: ${e.message}")
         }
 }
 


### PR DESCRIPTION
## Summary

Phase 2J finding #3 — `IosDeviceRepositoryImpl.checkBanStatus` previously caught exceptions and returned `Resource.Success(BanStatus())`, silently hiding the error from any caller.

The user-facing outcome was already correct: `AuthViewModel` treats `Resource.Error` as lenient (per existing test `app/src/test/java/com/shyden/shytalk/feature/auth/AuthViewModelBanTest.kt:144` "ban check error is lenient" — sign-in proceeds when ban check fails). But iOS was masking the error signal from any caller that might want to log/telemeter it.

Fix: return `Resource.Error("Ban check failed: ${e.message}")` so the error surfaces. Same lenient sign-in flow downstream (the AuthViewModel's existing Error handling path is what makes this change non-breaking).

## Test plan

- [x] `./gradlew :shared:compileKotlinIosArm64` — passes (K/N still compiles)
- [x] `./gradlew detekt` — passes (no new lint issues)
- [x] `AuthViewModelBanTest.kt:144` already covers the Error-is-lenient path — no new test needed
- [x] Local SonarCloud quality gate passed (after a transient upload retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)