### PR TITLE
fix(ios): Apple Sign-In anchor must be foreground-active scene window (Phase 2J #7)

### DIFF
--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/feature/auth/IosAppleSignInHelper.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/feature/auth/IosAppleSignInHelper.kt
@@ -26,6 +26,7 @@ import platform.Security.SecRandomCopyBytes
 import platform.Security.errSecSuccess
 import platform.Security.kSecRandomDefault
 import platform.UIKit.UIApplication
+import platform.UIKit.UISceneActivationStateForegroundActive
 import platform.UIKit.UIWindow
 import platform.UIKit.UIWindowScene
 import platform.darwin.NSObject
@@ -51,6 +52,20 @@ data class AppleSignInResult(
  */
 suspend fun performAppleSignIn(): AppleSignInResult =
     suspendCancellableCoroutine { continuation ->
+        // Pre-flight: ASAuthorizationController on iOS 15+ requires a
+        // scene-attached UIWindow as presentation anchor. Returning a
+        // bare UIWindow() (no scene) is an Apple contract violation and
+        // results in silent presentation failure on iPad multi-scene
+        // state. Fail loudly here so the caller's existing snackbar path
+        // surfaces it, instead of waiting for a no-op auth controller.
+        val anchorWindow = activePresentationWindow()
+        if (anchorWindow == null) {
+            continuation.resumeWithException(
+                Exception("Apple Sign-In: no active UIWindow to anchor presentation"),
+            )
+            return@suspendCancellableCoroutine
+        }
+
         val rawNonce = generateNonce(32)
         val hashedNonce = sha256(rawNonce)
 
@@ -132,20 +147,8 @@ suspend fun performAppleSignIn(): AppleSignInResult =
 
         val contextProvider =
             object : NSObject(), ASAuthorizationControllerPresentationContextProvidingProtocol {
-                override fun presentationAnchorForAuthorizationController(controller: ASAuthorizationController): ASPresentationAnchor {
-                    // Use connectedScenes (iOS 13+) to find the active window scene
-                    val windowScene =
-                        UIApplication.sharedApplication.connectedScenes
-                            .filterIsInstance<UIWindowScene>()
-                            .firstOrNull()
-                    val window =
-                        windowScene
-                            ?.windows
-                            ?.filterIsInstance<UIWindow>()
-                            ?.firstOrNull { it.isKeyWindow() }
-                            ?: windowScene?.windows?.firstOrNull() as? UIWindow
-                    return window ?: UIWindow()
-                }
+                override fun presentationAnchorForAuthorizationController(controller: ASAuthorizationController): ASPresentationAnchor =
+                    anchorWindow
             }
 
         // Hold strong references
@@ -162,6 +165,28 @@ suspend fun performAppleSignIn(): AppleSignInResult =
             strongContextProvider = null
         }
     }
+
+/**
+ * Returns the active scene-attached UIWindow suitable as an
+ * `ASPresentationAnchor`, or null if the app is not in a foreground-
+ * active scene state. Apple requires the anchor to belong to a
+ * UIWindowScene whose `activationState == foregroundActive`; a window
+ * from a backgrounded or inactive scene is the same category of
+ * contract violation as a bare unattached `UIWindow()`. iPad multi-
+ * scene apps can have several connected scenes simultaneously where
+ * only one is foreground-active, so filter explicitly.
+ */
+private fun activePresentationWindow(): UIWindow? {
+    val windowScene =
+        UIApplication.sharedApplication.connectedScenes
+            .filterIsInstance<UIWindowScene>()
+            .firstOrNull { it.activationState == UISceneActivationStateForegroundActive }
+            ?: return null
+    return windowScene.windows
+        .filterIsInstance<UIWindow>()
+        .firstOrNull { it.isKeyWindow() }
+        ?: windowScene.windows.firstOrNull() as? UIWindow
+}
 
 private fun generateNonce(length: Int): String {
     val bytes = ByteArray(length)


### PR DESCRIPTION
## Summary

- Phase 2J audit finding #7: `presentationAnchorForAuthorizationController` returned a bare `UIWindow()` (no scene) as a final fallback. iOS 15+ requires the `ASPresentationAnchor` to belong to a foreground-active `UIWindowScene`, so the bare window silently fails to present the Apple Sign-In sheet.
- Pre-flight check now finds the foreground-active scene's window before constructing the auth request. If none exists, the continuation resumes with an exception so the caller's existing snackbar path surfaces a clear failure instead of a silently-non-presenting auth sheet.
- Reviewer caught and we applied the additional `activationState == foregroundActive` filter — `connectedScenes` includes inactive/background scenes on iPad multi-scene state, so picking the first connected scene wasn't strict enough.

## Test plan

- [x] `./gradlew :shared:compileKotlinIosArm64` → BUILD SUCCESSFUL
- [x] `./gradlew :shared:jvmTest detekt` → BUILD SUCCESSFUL
- [x] `ktlint --relative` → clean
- [x] code-reviewer agent — no remaining HIGH/MED findings after foreground-active fix
- [x] pre-push hooks (incl. SonarCloud quality gate) → passed
- [ ] iOS-simulator manual QA: tap Apple Sign-In on a normal foreground state — should still complete identically; tap from a contrived "no foreground scene" state (rare; difficult to reproduce) — should now show the localized "Apple Sign-In failed" snackbar instead of silent stall.

## Phase 2J context

This closes the most actionable iOS-only finding from the Phase 2J audit. After this PR:

| # | Status |
|---|---|
| 1 (`signOut runBlocking`) | Deferred — interface change |
| 2 (reactions cast) | Dismissed — false positive (matches Android) |
| 3 (ban-check parity) | Shipped #542 |
| 4 (gift sender ghost rows) | Dismissed — false positive (matches Android) |
| 5 (PM edits batch retry) | Dismissed — auto-ID is client-side; matches Android |
| 6 (HttpClient leak) | Dismissed — `try/finally` handles cancellation |
| 7 (Apple Sign-In anchor) | **This PR** |
| 8 (`uniqueId!!`) | Dismissed — caught by outer try/catch; observability only |

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)