### PR TITLE
test(ios): typed Apple Sign-In failure exceptions + contract tests (recovery for #543)

### DIFF
--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AppleSignInHelper.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AppleSignInHelper.kt
@@ -32,3 +32,26 @@ expect suspend fun performAppleSignInFlow(
  * Caller should treat as silent — no error toast.
  */
 class AppleSignInCancelledException : Exception("Apple Sign-In cancelled by user")
+
+/**
+ * Thrown by the iOS implementation when it cannot find a foreground-
+ * active `UIWindowScene` to use as the `ASPresentationAnchor` for
+ * `ASAuthorizationController`. Apple's contract requires the anchor
+ * to belong to such a scene; a bare `UIWindow()` (no scene) silently
+ * fails to present on iOS 15+. The caller should treat this as a real
+ * failure (snackbar), distinct from a user-initiated cancellation.
+ *
+ * Cross-platform type so consumers can match it without depending on
+ * iOS-specific exception classes.
+ */
+class AppleSignInPresentationException : Exception("Apple Sign-In: no active UIWindow to anchor presentation")
+
+/**
+ * Thrown by the iOS implementation when ASAuthorizationController
+ * reports success but the returned `ASAuthorizationAppleIDCredential`
+ * has no `identityToken`. Apple's contract guarantees the token on
+ * the success path, so encountering this is an SDK contract violation
+ * — typed so observability can distinguish it from generic auth
+ * failures (e.g. network, provider error).
+ */
+class AppleSignInMissingTokenException : Exception("Apple Sign-In: no identity token")

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/auth/AppleSignInHelperTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/auth/AppleSignInHelperTest.kt
@@ -64,4 +64,87 @@ class AppleSignInHelperTest {
         assertTrue(apple !is GoogleSignInCancelledException)
         assertTrue(google !is AppleSignInCancelledException)
     }
+
+    // ── AppleSignInPresentationException ──────────────────────────
+    // Locks the contract introduced by PR #543 (Phase 2J #7) for the
+    // iOS-only failure mode where ASAuthorizationController can't be
+    // anchored to a foreground-active UIWindowScene. Generic
+    // `Exception("Apple Sign-In: no active UIWindow…")` was the
+    // original throw — replaced with a typed class so SignInScreen
+    // (and future observability code) can match on it.
+
+    @Test
+    fun `presentation exception is throwable`() {
+        val e = AppleSignInPresentationException()
+        assertIs<Throwable>(e)
+    }
+
+    @Test
+    fun `presentation exception has stable message`() {
+        // Message is the surface a future log filter (Sentry breadcrumb,
+        // grep over diagnostic exports) keys off — pin the literal so
+        // accidental rewording doesn't break alerting.
+        val e = AppleSignInPresentationException()
+        assertEquals("Apple Sign-In: no active UIWindow to anchor presentation", e.message)
+    }
+
+    @Test
+    fun `presentation exception is distinct from cancellation so SignInScreen surfaces a snackbar`() {
+        // SignInScreen.kt (the AppleSignInButton catch chain) treats
+        // AppleSignInCancelledException as silent and any other
+        // Exception as a snackbar-worthy failure. Presentation failures
+        // MUST fall into the snackbar arm — silent failure on a
+        // genuinely-broken auth flow is the worst possible UX. Locking
+        // the type-disjointness here prevents a future refactor from
+        // collapsing the two into a parent class without intent.
+        val cancelled: Throwable = AppleSignInCancelledException()
+        val presentation: Throwable = AppleSignInPresentationException()
+        assertTrue(cancelled !is AppleSignInPresentationException)
+        assertTrue(presentation !is AppleSignInCancelledException)
+    }
+
+    @Test
+    fun `presentation exception is distinct from Google's cancel so providers don't cross-match`() {
+        // Same provider-isolation reasoning as the cancel exceptions:
+        // future provider-specific recovery hints depend on the type split.
+        val applePresentation: Throwable = AppleSignInPresentationException()
+        val googleCancel: Throwable = GoogleSignInCancelledException()
+        assertTrue(applePresentation !is GoogleSignInCancelledException)
+        assertTrue(googleCancel !is AppleSignInPresentationException)
+    }
+
+    // ── AppleSignInMissingTokenException ─────────────────────────
+    // Locks the contract for the iOS-only contract-violation path
+    // where ASAuthorizationController returns success but the
+    // ASAuthorizationAppleIDCredential has no identityToken. This is
+    // a documented Apple post-condition failure (the credential MUST
+    // include the token on success) — typed so observability code can
+    // distinguish "Apple SDK gave us garbage" from generic auth errors.
+
+    @Test
+    fun `missing token exception is throwable`() {
+        val e = AppleSignInMissingTokenException()
+        assertIs<Throwable>(e)
+    }
+
+    @Test
+    fun `missing token exception has stable message`() {
+        val e = AppleSignInMissingTokenException()
+        assertEquals("Apple Sign-In: no identity token", e.message)
+    }
+
+    @Test
+    fun `missing token exception is distinct from cancellation and presentation`() {
+        // All three Apple-side exceptions must be type-disjoint so the
+        // SignInScreen catch chain can branch correctly: cancel = silent,
+        // presentation + missing-token = snackbar-worthy.
+        val cancelled: Throwable = AppleSignInCancelledException()
+        val presentation: Throwable = AppleSignInPresentationException()
+        val missingToken: Throwable = AppleSignInMissingTokenException()
+
+        assertTrue(missingToken !is AppleSignInCancelledException)
+        assertTrue(missingToken !is AppleSignInPresentationException)
+        assertTrue(cancelled !is AppleSignInMissingTokenException)
+        assertTrue(presentation !is AppleSignInMissingTokenException)
+    }
 }

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/feature/auth/IosAppleSignInHelper.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/feature/auth/IosAppleSignInHelper.kt
@@ -56,13 +56,12 @@ suspend fun performAppleSignIn(): AppleSignInResult =
         // scene-attached UIWindow as presentation anchor. Returning a
         // bare UIWindow() (no scene) is an Apple contract violation and
         // results in silent presentation failure on iPad multi-scene
-        // state. Fail loudly here so the caller's existing snackbar path
-        // surfaces it, instead of waiting for a no-op auth controller.
+        // state. Fail loudly here via the typed
+        // [AppleSignInPresentationException] so the caller's snackbar
+        // path surfaces it, instead of waiting for a no-op auth controller.
         val anchorWindow = activePresentationWindow()
         if (anchorWindow == null) {
-            continuation.resumeWithException(
-                Exception("Apple Sign-In: no active UIWindow to anchor presentation"),
-            )
+            continuation.resumeWithException(AppleSignInPresentationException())
             return@suspendCancellableCoroutine
         }
 
@@ -107,7 +106,7 @@ suspend fun performAppleSignIn(): AppleSignInResult =
                         }
                     }
                     if (continuation.isActive) {
-                        continuation.resumeWithException(Exception("Apple Sign-In: no identity token"))
+                        continuation.resumeWithException(AppleSignInMissingTokenException())
                     }
                 }
 


### PR DESCRIPTION
## Summary

Recovery PR for a TDD violation on #543. That PR introduced two new failure paths in `IosAppleSignInHelper.kt` (no foreground-active `UIWindowScene`; ASAuthorizationController returns success without an identityToken) but threw generic `Exception("...")` and shipped without tests. Behaviour was already correct — `SignInScreen`'s catch-Exception arm shows the localised snackbar — but the contract was untested.

This PR replaces both generic throws with typed exception classes that mirror the existing `AppleSignInCancelledException` pattern, and adds 7 cross-platform contract tests in `AppleSignInHelperTest.kt`.

## Changes

- `AppleSignInPresentationException` — no foreground-active `UIWindowScene` to anchor `ASAuthorizationController`.
- `AppleSignInMissingTokenException` — Apple SDK contract violation (success without identityToken).
- 7 new tests covering: throwable, stable message, type-disjointness from sibling Apple/Google exceptions.
- TDD this time: tests written FIRST → watched RED → implementation added → watched GREEN.

## Why not type the third throw

`Exception("Apple Sign-In failed: ${didCompleteWithError.localizedDescription}")` at line 140 wraps arbitrary Apple SDK errors with localised descriptions. The variability comes from Apple's domain — typing would obscure rather than clarify.

## Test plan

- [x] TDD: RED → GREEN cycle confirmed for each typed exception
- [x] `./gradlew :shared:compileKotlinIosArm64` → BUILD SUCCESSFUL
- [x] `./gradlew :shared:jvmTest detekt` → BUILD SUCCESSFUL (7 new tests pass)
- [x] `ktlint --relative` → clean
- [x] code-reviewer agent: no HIGH/MED findings
- [x] pre-push (incl. SonarCloud) → passed

## Adjacent gap (separate PR)

`shared/src` has commonTest + jvmTest but **no `iosTest` source set** — every iosMain change today still ships without unit-test coverage on iOS itself. This PR closes the cross-platform contract surface; it does not close the iosMain implementation surface. Saved as a hard rule: **no new iosMain work until iosTest infra is built.** That setup will be its own PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)