### PR TITLE
test(commonTest): rename two tests for K/N name compatibility

### DIFF
--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/model/GroupPermissionsTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/model/GroupPermissionsTest.kt
@@ -144,7 +144,7 @@ class GroupPermissionsTest {
     }
 
     @Test
-    fun `OWNER_ONLY denies MEMBER, MOD, and ADMIN`() {
+    fun `OWNER_ONLY denies MEMBER MOD and ADMIN`() {
         val level = GroupPermissions.PermissionLevel.OWNER_ONLY
         assertFalse(level.isAllowed(GroupRole.MEMBER))
         assertFalse(level.isAllowed(GroupRole.MOD))

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/data/repository/ReportJsonParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/data/repository/ReportJsonParserTest.kt
@@ -31,7 +31,7 @@ class ReportJsonParserTest {
     }
 
     @Test
-    fun `timestamp is read from createdAt JSON key (not legacy timestamp)`() {
+    fun `timestamp is read from createdAt JSON key not legacy timestamp`() {
         val obj =
             json.parseToJsonElement(
                 """{"id":"r1","createdAt":1700000000,"timestamp":42}""",


### PR DESCRIPTION
## Summary

Two pre-existing `commonTest` test functions had backtick-quoted names containing characters (`,` and `()`) that the JVM compiler tolerates but Kotlin/Native rejects:

- `GroupPermissionsTest.kt:147` — `\`OWNER_ONLY denies MEMBER, MOD, and ADMIN\`` → `\`OWNER_ONLY denies MEMBER MOD and ADMIN\``
- `ReportJsonParserTest.kt:34` — `\`timestamp is read from createdAt JSON key (not legacy timestamp)\`` → `\`timestamp is read from createdAt JSON key not legacy timestamp\``

These tests were never actually typechecked for K/N because no `iosTest` source set exists, so the violation went undetected. JVM behaviour is unchanged — both tests still pass on `:shared:jvmTest`.

## Why this is independently valuable

This is a salvage from an investigation into K/N `iosTest` infrastructure (2026-05-07). The investigation concluded `iosTest` is **not viable** for this codebase because iosMain klibs reference Firebase pod transitive C++ static-library symbols (`re2::*`, `abseil::lts_*`) and system frameworks (`CoreAudioTypes`, `UIUtilities`, `SwiftUICore`) whose link cascade can't be replicated in a unit-test executable without becoming a full app build. Documented in the `[iosMain testing strategy]` memory.

But the K/N name violations are real correctness issues independent of that. Naming tests in a way that one platform tolerates and another rejects is a latent gap. Renaming defends against any future K/N compile path (cross-platform tests run via Compose Multiplatform UI test runner, etc.).

## Audit

Broader regex audit of `commonTest` for any remaining K/N-illegal characters in backtick-quoted names: `[(),\\:;<>?{}|/&~^!@*"=]` — no other matches found.

## Test plan

- [x] `:shared:jvmTest --tests "GroupPermissionsTest" --tests "ReportJsonParserTest"` — both renamed tests pass on JVM (confirmed locally)
- [x] Pre-push hook (ktlint, kmp-compat, SonarCloud) — green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)