### PR TITLE
refactor(auth): AuthRepository.signOut() → suspend (Phase 2J #1)

### DIFF
--- a/app/src/androidTest/java/com/shyden/shytalk/fake/FakeAuthRepository.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/fake/FakeAuthRepository.kt
@@ -64,7 +64,7 @@ class FakeAuthRepository : AuthRepository {
         return Resource.Success("test-user-1")
     }
 
-    override fun signOut() {
+    override suspend fun signOut() {
         resolvedUniqueId = null
         fakeAuthenticated = false
         fakeUserId = null

--- a/app/src/main/java/com/shyden/shytalk/MainActivity.kt
+++ b/app/src/main/java/com/shyden/shytalk/MainActivity.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.rememberNavController
 import com.google.firebase.auth.FirebaseAuth
 import com.shyden.shytalk.core.BuildVariant
@@ -461,7 +462,11 @@ class MainActivity : AppCompatActivity() {
                                 onEmailLinkConsumed = { pendingEmailLinkState.value = null },
                                 onSignOut = {
                                     workerApiClient.clearTokenCache()
-                                    authRepository.signOut()
+                                    // Process-scoped: sign-out must finish even if this
+                                    // Activity is destroyed by the navigation it triggers.
+                                    ProcessLifecycleOwner.get().lifecycleScope.launch {
+                                        authRepository.signOut()
+                                    }
                                 },
                             )
 

--- a/app/src/main/java/com/shyden/shytalk/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/AuthRepositoryImpl.kt
@@ -150,7 +150,7 @@ class AuthRepositoryImpl(
             result.user?.uid ?: throw Exception("Sign in failed: no user returned")
         }
 
-    override fun signOut() {
+    override suspend fun signOut() {
         resolvedUniqueId = null
         auth.signOut()
     }

--- a/app/src/test/java/com/shyden/shytalk/data/repository/AuthRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/AuthRepositoryImplTest.kt
@@ -157,17 +157,19 @@ class AuthRepositoryImplTest {
         }
 
     @Test
-    fun `signOut calls auth signOut`() {
-        repo.signOut()
-        verify { auth.signOut() }
-    }
+    fun `signOut calls auth signOut`() =
+        runTest {
+            repo.signOut()
+            verify { auth.signOut() }
+        }
 
     @Test
-    fun `signOut clears resolvedUniqueId`() {
-        repo.resolvedUniqueId = "10000005"
-        repo.signOut()
-        assertNull(repo.resolvedUniqueId)
-    }
+    fun `signOut clears resolvedUniqueId`() =
+        runTest {
+            repo.resolvedUniqueId = "10000005"
+            repo.signOut()
+            assertNull(repo.resolvedUniqueId)
+        }
 
     // ===== currentFirebaseUid =====
 

--- a/app/src/test/java/com/shyden/shytalk/feature/auth/AuthViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/auth/AuthViewModelTest.kt
@@ -446,7 +446,7 @@ class AuthViewModelTest {
             vm.signOut()
 
             assertFalse(vm.uiState.value.isAuthenticated)
-            verify { authRepository.signOut() }
+            coVerify { authRepository.signOut() }
         }
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/feature/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/home/HomeViewModelTest.kt
@@ -197,7 +197,7 @@ class HomeViewModelTest {
 
             vm.signOut()
 
-            verify { authRepository.signOut() }
+            coVerify { authRepository.signOut() }
         }
 
     @Test
@@ -541,7 +541,7 @@ class HomeViewModelTest {
 
             vm.signOut()
 
-            verify { authRepository.signOut() }
+            coVerify { authRepository.signOut() }
         }
 
     // ===== createRoom sets isLoading during operation =====

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/AuthRepository.kt
@@ -50,5 +50,5 @@ interface AuthRepository {
 
     suspend fun signInWithCustomToken(token: String): Resource<String>
 
-    fun signOut()
+    suspend fun signOut()
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeViewModel.kt
@@ -345,6 +345,6 @@ class HomeViewModel(
 
     fun signOut() {
         logI(TAG, "User signing out")
-        authRepository.signOut()
+        viewModelScope.launch { authRepository.signOut() }
     }
 }

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/data/repository/AuthRepositorySignOutContractTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/data/repository/AuthRepositorySignOutContractTest.kt
@@ -1,0 +1,86 @@
+package com.shyden.shytalk.data.repository
+
+import com.shyden.shytalk.core.util.Resource
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Locks down behaviour expected from any `AuthRepository.signOut()` impl:
+ *
+ *  1. It must be callable from a `suspend` context (the inline fake's
+ *     `override suspend fun signOut()` enforces this — if the interface ever
+ *     regresses to non-suspend without simultaneously reverting this fake,
+ *     compilation fails here).
+ *  2. `resolvedUniqueId` must be cleared on sign-out, so the next sign-in
+ *     starts from a clean slate.
+ *  3. Platform exceptions must propagate to the caller rather than be
+ *     swallowed (pre-Phase-2J the iOS impl wrapped GitLive's suspend
+ *     `auth.signOut()` in `runBlocking`, which silently surfaced any
+ *     CancellationException as the synchronous return — caller couldn't
+ *     distinguish success from failure).
+ */
+class AuthRepositorySignOutContractTest {
+    @Test
+    fun signOut_isCallableFromSuspendContext_clearsResolvedUniqueId() =
+        runTest {
+            val repo = FakeAuthRepository(initialResolvedUniqueId = "10000007")
+
+            repo.signOut()
+
+            assertTrue(repo.signOutCalled, "signOut should have run")
+            assertNull(repo.resolvedUniqueId, "resolvedUniqueId should be cleared on sign-out")
+        }
+
+    @Test
+    fun signOut_exceptionsPropagateToCaller() =
+        runTest {
+            val repo = FakeAuthRepository().apply { signOutShouldThrow = true }
+
+            val ex = assertFailsWith<IllegalStateException> { repo.signOut() }
+
+            assertEquals("simulated platform sign-out failure", ex.message)
+        }
+
+    private class FakeAuthRepository(
+        initialResolvedUniqueId: String? = null,
+    ) : AuthRepository {
+        var signOutCalled = false
+        var signOutShouldThrow = false
+
+        override val currentUserId: String? = null
+        override val isAuthenticated: Boolean = false
+        override val currentUserEmail: String? = null
+        override val currentFirebaseUid: String? = null
+        override var resolvedUniqueId: String? = initialResolvedUniqueId
+
+        override fun getProviderInfo(): Pair<String, String>? = null
+
+        override suspend fun signInWithGoogleIdToken(idToken: String): Resource<String> = Resource.Error("not used")
+
+        override suspend fun signInWithAppleIdToken(
+            idToken: String,
+            rawNonce: String,
+        ): Resource<String> = Resource.Error("not used")
+
+        override suspend fun signInWithAppleViaProvider(activity: Any): Resource<String> = Resource.Error("not used")
+
+        override suspend fun sendSignInLink(email: String): Resource<Unit> = Resource.Error("not used")
+
+        override suspend fun signInWithEmailLink(
+            email: String,
+            link: String,
+        ): Resource<String> = Resource.Error("not used")
+
+        override suspend fun signInWithCustomToken(token: String): Resource<String> = Resource.Error("not used")
+
+        override suspend fun signOut() {
+            if (signOutShouldThrow) throw IllegalStateException("simulated platform sign-out failure")
+            signOutCalled = true
+            resolvedUniqueId = null
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/auth/AuthViewModelIdentityTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/auth/AuthViewModelIdentityTest.kt
@@ -86,7 +86,7 @@ class AuthViewModelIdentityTest {
 
         var signOutShouldThrow = false
 
-        override fun signOut() {
+        override suspend fun signOut() {
             if (signOutShouldThrow) throw RuntimeException("signOut deliberately failing in test")
             signedOut = true
             resolvedUniqueId = null

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosAuthRepositoryImpl.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosAuthRepositoryImpl.kt
@@ -100,11 +100,8 @@ class IosAuthRepositoryImpl(
             result.user?.uid ?: throw Exception("Sign in failed: no user returned")
         }
 
-    override fun signOut() {
+    override suspend fun signOut() {
         resolvedUniqueId = null
-        // GitLive signOut is a suspend function, but our interface declares it as non-suspend.
-        // Firebase iOS SDK's signOut is synchronous underneath, so this is safe.
-        @Suppress("BlockingMethodInNonBlockingContext")
-        kotlinx.coroutines.runBlocking { auth.signOut() }
+        auth.signOut()
     }
 }


### PR DESCRIPTION
## Summary

- Promotes `AuthRepository.signOut()` from `fun` to `suspend fun` so `IosAuthRepositoryImpl` can drop the `runBlocking { auth.signOut() }` bridge that pinned the calling thread on Kotlin/Native and risked deadlock if GitLive's suspend Firebase Auth API ever dispatched back.
- Closes Phase 2J finding #1 — the only real bug from the iOS shared audit (other 7 candidates either shipped earlier or verified false-positive against Android).
- Includes a new `AuthRepositorySignOutContractTest` locking down: callable from suspend context, clears `resolvedUniqueId`, exceptions propagate.
- Catches a secondary cancellation race in `MainActivity.onSignOut` — switched from `lifecycleScope` to `ProcessLifecycleOwner.get().lifecycleScope` so sign-out completes even if the Activity is destroyed by the navigation it triggers.

## Trade-offs considered

- **Surgical vs. convention sweep**: chose surgical per `[Small PRs]`. Whether other repository interfaces should also become suspend-only is a separate design conversation, not bundled here.
- **`coVerify` migration**: `verify { authRepository.signOut() }` → `coVerify` in two test files; mockk requires the `co*` variants for suspend funs.

## Test plan

- [x] `:app:compileDevDebugKotlin :app:compileLocalDebugAndroidTestKotlin :app:testDevDebugUnitTest :shared:jvmTest` — BUILD SUCCESSFUL
- [x] `:shared:compileKotlinIosArm64` — BUILD SUCCESSFUL
- [x] `:shared:detekt` — clean
- [x] `ktlint --relative` on all changed Kotlin files — clean
- [x] SonarCloud quality gate (pre-push hook) — passed
- [x] Two-round local code review — second round green after fixing reviewer-caught compile-breakers in `MainActivity.kt` + `AuthRepositoryImplTest.kt` and the `lifecycleScope` cancellation race
- [ ] CI pipeline green
- [ ] Manual smoke after merge: sign in, sign out from settings, confirm session cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)