### PR TITLE
fix(auth): catch + log platform sign-out failures, rethrow cancellation

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/MainActivity.kt
+++ b/app/src/main/java/com/shyden/shytalk/MainActivity.kt
@@ -68,6 +68,7 @@ import com.shyden.shytalk.navigation.Screen
 import com.shyden.shytalk.resources.*
 import com.shyden.shytalk.resources.Res
 import com.shyden.shytalk.ui.theme.ShyTalkTheme
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -464,8 +465,16 @@ class MainActivity : AppCompatActivity() {
                                     workerApiClient.clearTokenCache()
                                     // Process-scoped: sign-out must finish even if this
                                     // Activity is destroyed by the navigation it triggers.
+                                    // Rethrow CancellationException to keep structured
+                                    // concurrency intact when the scope is cancelled.
                                     ProcessLifecycleOwner.get().lifecycleScope.launch {
-                                        authRepository.signOut()
+                                        try {
+                                            authRepository.signOut()
+                                        } catch (e: CancellationException) {
+                                            throw e
+                                        } catch (e: Exception) {
+                                            Log.e(TAG, "authRepository.signOut() failed: ${e.message}", e)
+                                        }
                                     }
                                 },
                             )

--- a/app/src/test/java/com/shyden/shytalk/feature/auth/AuthViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/auth/AuthViewModelTest.kt
@@ -15,6 +15,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.job
@@ -447,6 +448,81 @@ class AuthViewModelTest {
 
             assertFalse(vm.uiState.value.isAuthenticated)
             coVerify { authRepository.signOut() }
+        }
+
+    /**
+     * `AuthRepositorySignOutContractTest` proves platform sign-out can throw.
+     * If we don't catch here, the cleanup steps after `authRepository.signOut()`
+     * never run — `consumeChatDeepLink()` (cross-account leak risk) and
+     * `_uiState.value = AuthUiState()` (UI stays in authenticated state).
+     */
+    @Test
+    fun `signOut clears UI state even when authRepository throws`() =
+        runTest {
+            setupSignInIdentity()
+            coEvery { authRepository.signInWithGoogleIdToken("token") } returns Resource.Success("firebase-uid")
+            coEvery { deviceRepository.getDeviceBinding(deviceId) } returns Resource.Success(uniqueIdStr)
+            coEvery { userRepository.userExists(uniqueIdStr) } returns Resource.Success(true)
+            coEvery { userRepository.getUser(uniqueIdStr) } returns
+                Resource.Success(
+                    TestData.createTestUser(uid = uniqueIdStr, dateOfBirth = testDob),
+                )
+            coEvery { authRepository.signOut() } throws IllegalStateException("platform sign-out failure")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.signInWithGoogle("token")
+            advanceUntilIdle()
+            assertTrue(vm.uiState.value.isAuthenticated)
+
+            vm.signOut()
+            advanceUntilIdle()
+
+            assertFalse(
+                "UI must be reset to default even if platform sign-out failed — otherwise the user" +
+                    " stays on an authenticated screen with stale session state.",
+                vm.uiState.value.isAuthenticated,
+            )
+            assertNull(vm.uiState.value.error)
+            coVerify { authRepository.signOut() }
+        }
+
+    /**
+     * Catching `Exception` would swallow `CancellationException` (it extends
+     * `IllegalStateException`), breaking structured concurrency: a config-change
+     * cancelling the launch mid-`signOut()` would be silently absorbed and the
+     * post-try cleanup (UI reset) would run against a dead scope. The fix is a
+     * sibling `catch (e: CancellationException) { throw e }` BEFORE the broad
+     * catch. Observable signal: `_uiState.value = AuthUiState()` must NOT run
+     * after the rethrow, so `isAuthenticated` stays at its pre-signOut value.
+     */
+    @Test
+    fun `signOut propagates CancellationException — cleanup after rethrow must not run`() =
+        runTest {
+            setupSignInIdentity()
+            coEvery { authRepository.signInWithGoogleIdToken("token") } returns Resource.Success("firebase-uid")
+            coEvery { deviceRepository.getDeviceBinding(deviceId) } returns Resource.Success(uniqueIdStr)
+            coEvery { userRepository.userExists(uniqueIdStr) } returns Resource.Success(true)
+            coEvery { userRepository.getUser(uniqueIdStr) } returns
+                Resource.Success(
+                    TestData.createTestUser(uid = uniqueIdStr, dateOfBirth = testDob),
+                )
+            coEvery { authRepository.signOut() } throws CancellationException("scope cancelled mid-signOut")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.signInWithGoogle("token")
+            advanceUntilIdle()
+            assertTrue(vm.uiState.value.isAuthenticated)
+
+            vm.signOut()
+            advanceUntilIdle()
+
+            assertTrue(
+                "CancellationException must propagate — UI reset line must NOT execute, otherwise" +
+                    " a broad catch is silently swallowing structured cancellation.",
+                vm.uiState.value.isAuthenticated,
+            )
         }
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/feature/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/home/HomeViewModelTest.kt
@@ -200,6 +200,27 @@ class HomeViewModelTest {
             coVerify { authRepository.signOut() }
         }
 
+    /**
+     * `AuthRepositorySignOutContractTest` proves platform sign-out can throw.
+     * `HomeViewModel.signOut` is fire-and-forget — an uncaught exception would
+     * be swallowed by `viewModelScope`'s default handler and leak into
+     * `Thread.UncaughtExceptionHandler` on Android, surfacing as an error log
+     * with no diagnostic context. Catch + log explicitly here.
+     */
+    @Test
+    fun `signOut does not crash when authRepository throws`() =
+        runTest {
+            coEvery { authRepository.signOut() } throws IllegalStateException("platform sign-out failure")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.signOut()
+            advanceUntilIdle()
+
+            coVerify { authRepository.signOut() }
+        }
+
     @Test
     fun `isLoading becomes false after rooms emit`() =
         runTest {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AuthViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AuthViewModel.kt
@@ -21,6 +21,7 @@ import com.shyden.shytalk.data.repository.UserRepository
 import com.shyden.shytalk.feature.legal.CURRENT_LEGAL_VERSION
 import com.shyden.shytalk.resources.*
 import com.shyden.shytalk.resources.Res
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -769,7 +770,18 @@ class AuthViewModel(
             // Clear local credentials and Firebase session after revoke completes
             appLockRepository?.clearCredential()
             resolvedUniqueId = null
-            authRepository.signOut()
+            // Catch platform sign-out failure so the cleanup below (deep-link
+            // clear + UI reset) still runs — leaving the chat deep link or an
+            // authenticated UI behind on shared devices is the worse outcome.
+            // CancellationException must propagate so structured concurrency
+            // remains intact (e.g. config-change cancelling the launch).
+            try {
+                authRepository.signOut()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logE(TAG, "authRepository.signOut() failed: ${e.message}", e)
+            }
             // Allow migration path to run again on next sign-in
             migrationCompleted = false
             // Clear any pending push deep link so a notification tapped just

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeViewModel.kt
@@ -14,6 +14,7 @@ import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.BannerRepository
 import com.shyden.shytalk.data.repository.RoomRepository
 import com.shyden.shytalk.data.repository.UserRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -345,6 +346,17 @@ class HomeViewModel(
 
     fun signOut() {
         logI(TAG, "User signing out")
-        viewModelScope.launch { authRepository.signOut() }
+        // Catch + log so an exception isn't swallowed silently by viewModelScope's
+        // default handler. Rethrow CancellationException so structured concurrency
+        // remains intact when the scope is cancelled mid-flight.
+        viewModelScope.launch {
+            try {
+                authRepository.signOut()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logE(TAG, "authRepository.signOut() failed: ${e.message}", e)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #547 (Phase 2J #1) which made `AuthRepository.signOut()` suspend and shipped a contract test proving platform sign-out can throw. Three caller sites had no error handling — a real platform failure would have aborted local cleanup at each.

**Fix at all three sites:**
```kotlin
try {
    authRepository.signOut()
} catch (e: CancellationException) {
    throw e   // structured concurrency must remain intact
} catch (e: Exception) {
    logE(TAG, "authRepository.signOut() failed: ${e.message}", e)
}
```

## Why CancellationException is rethrown first

Reviewer caught (correctly) that `kotlinx.coroutines.CancellationException` extends `IllegalStateException` → `Exception`. A broad `catch (e: Exception)` would silently swallow structured cancellation, which would break coroutine framework guarantees. The sibling rethrow catch has to come BEFORE the broad catch since Kotlin matches the first catch.

## What the catch protects in each site

- **AuthViewModel.signOut()** — without the catch, exception abort skips `consumeChatDeepLink()` (cross-account leak risk on shared devices, exact concern called out in the existing comment) and `_uiState.value = AuthUiState()` (UI stuck on authenticated screen).
- **HomeViewModel.signOut()** — fire-and-forget; uncaught exception silently absorbed by `viewModelScope`'s default handler, surfacing as a stack trace with no diagnostic context.
- **MainActivity.onSignOut** — process-scoped launch with the same swallow risk.

## Test plan

- [x] New: `AuthViewModelTest.signOut clears UI state even when authRepository throws` — proves `_uiState` reset survives non-cancellation failure
- [x] New: `AuthViewModelTest.signOut propagates CancellationException — cleanup after rethrow must not run` — proves rethrow path leaves `isAuthenticated = true` (post-try cleanup doesn't run)
- [x] New: `HomeViewModelTest.signOut does not crash when authRepository throws`
- [x] `:app:compileDevDebugKotlin :app:compileLocalDebugAndroidTestKotlin :app:testDevDebugUnitTest :shared:jvmTest detekt :shared:compileKotlinIosArm64` — BUILD SUCCESSFUL
- [x] ktlint — clean
- [x] SonarCloud quality gate (pre-push hook) — passed
- [x] Two-round local code review — silent-failure-hunter caught the CancellationException issue, fix applied + regression test added
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)