### PR TITLE
fix(coroutines): rethrow CancellationException at 18 ViewModel catch sites

### DIFF
--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AuthViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/AuthViewModel.kt
@@ -170,6 +170,8 @@ class AuthViewModel(
                     var signedOut = true
                     try {
                         authRepository.signOut()
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         signedOut = false
                         logE(TAG, "signOut during migration abort failed: ${e.message}")
@@ -423,12 +425,16 @@ class AuthViewModel(
             var signedOut = true
             try {
                 appLockRepository?.clearCredential()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 credentialCleared = false
                 logE(TAG, "Failed to clear credential during auth-error recovery: ${e.message}")
             }
             try {
                 authRepository.signOut()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 signedOut = false
                 logE(TAG, "Sign-out during auth-error recovery failed: ${e.message}")
@@ -764,6 +770,8 @@ class AuthViewModel(
             // Revoke biometric key BEFORE clearing Firebase session (needs auth token)
             try {
                 biometricRepository?.revoke(deviceId)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 logW(TAG, "Failed to revoke biometric key: ${e.message}")
             }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeViewModel.kt
@@ -89,6 +89,8 @@ class HomeViewModel(
                 val banners = bannerRepository.getActiveBanners()
                 logI(TAG, "Loaded ${banners.size} active banners")
                 _uiState.update { it.copy(banners = banners) }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 logE(TAG, "Failed to load banners: ${e.message}")
             }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatViewModel.kt
@@ -39,6 +39,7 @@ import com.shyden.shytalk.feature.ageverification.AgeRestrictionService
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsBytes
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -386,6 +387,8 @@ class PrivateChatViewModel(
                         _uiState.update { it.copy(messages = combined) }
                         resolveRoomInvites(combined)
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     logE(TAG, "Messages observation failed: ${e.message}")
                     _uiState.update { it.copy(error = e.message ?: "Failed to load messages") }
@@ -858,6 +861,8 @@ class PrivateChatViewModel(
                 pendingMessages.remove(tempId)
                 updateMessagesWithPending()
                 sendImages(urls)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 pendingMessages[tempId] = pendingMsg.copy(sendStatus = SendStatus.FAILED)
                 updateMessagesWithPending()
@@ -978,6 +983,8 @@ class PrivateChatViewModel(
                 val bytes =
                     try {
                         stickerStorage?.readStickerBytes(sticker.id) ?: error("No sticker storage")
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         pendingMessages[tempId] = pendingMsg.copy(sendStatus = SendStatus.FAILED)
                         updateMessagesWithPending()
@@ -1090,6 +1097,8 @@ class PrivateChatViewModel(
 
                     else -> { /* Silently ignore — first send will upload as fallback */ }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 logW(TAG, "Sticker pre-upload failed (best-effort)", e)
             }
@@ -1120,6 +1129,8 @@ class PrivateChatViewModel(
                         error = "Sticker saved!",
                     )
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 logW(TAG, "Failed to save sticker from URL", e)
                 _uiState.update { it.copy(error = "Failed to save sticker") }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -32,6 +32,7 @@ import com.shyden.shytalk.data.repository.SeatRequestRepository
 import com.shyden.shytalk.data.repository.StorageRepository
 import com.shyden.shytalk.data.repository.TranslationRepository
 import com.shyden.shytalk.data.repository.UserRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
@@ -468,6 +469,8 @@ class RoomViewModel(
                             _uiState.update { it.copy(isLoading = false, shouldNavigateBack = true) }
                             return@launch
                         }
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         logE(TAG, "Failed to check suspension during auto-rejoin", e)
                     }
@@ -902,6 +905,8 @@ class RoomViewModel(
                     roomRepository.leaveAllRooms(userId, exceptRoomId = roomId)
                     roomRepository.joinRoom(roomId, userId)
                     roomRepository.recordFirstJoinTimestamp(roomId, userId)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     logE(TAG, "Failed to join room: ${e.message}")
                 }
@@ -1052,6 +1057,8 @@ class RoomViewModel(
 
                     is Resource.Loading -> Unit
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 logE(TAG, "Seat action failed", e)
                 _uiState.update { it.copy(seatActionStatus = SeatActionStatus.Idle, error = e.message ?: "Action failed") }
@@ -1457,6 +1464,8 @@ class RoomViewModel(
                     voiceService.setMicrophoneEnabled(shouldUnmute)
                     voiceService.setAudioMode(shouldUnmute)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 logE(TAG, "ownerReturn failed, will retry on next room update", e)
                 isOwnerReturnTriggered = false

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/splash/FunFactSplashViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/splash/FunFactSplashViewModel.kt
@@ -13,6 +13,7 @@ import com.shyden.shytalk.data.repository.FunFactRepository
 import com.shyden.shytalk.data.repository.PrivateMessageRepository
 import com.shyden.shytalk.data.repository.RoomRepository
 import com.shyden.shytalk.data.repository.UserRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -57,6 +58,8 @@ class FunFactSplashViewModel(
                                 launch {
                                     try {
                                         imagePreloader?.preload(banner.imageUrl)
+                                    } catch (e: CancellationException) {
+                                        throw e
                                     } catch (e: Exception) {
                                         logD(TAG, "Banner image preload failed: ${e.message}")
                                     }
@@ -66,12 +69,16 @@ class FunFactSplashViewModel(
                                     launch {
                                         try {
                                             webContentPreloader?.preload(actionValue)
+                                        } catch (e: CancellationException) {
+                                            throw e
                                         } catch (e: Exception) {
                                             logD(TAG, "Web content preload failed: ${e.message}")
                                         }
                                     }
                                 }
                             }
+                        } catch (e: CancellationException) {
+                            throw e
                         } catch (e: Exception) {
                             logE(TAG, "Banner preload failed: ${e.message}")
                         }
@@ -83,6 +90,8 @@ class FunFactSplashViewModel(
                                 logI(TAG, "Synced ${fresh.size} fresh fun facts")
                                 _funFacts.value = fresh.shuffled()
                             }
+                        } catch (e: CancellationException) {
+                            throw e
                         } catch (e: Exception) {
                             logE(TAG, "Fun fact sync failed: ${e.message}")
                         }


### PR DESCRIPTION
## Summary

Sweep follow-up to PRs #547 + #548. The pattern bug they exposed (`catch (Exception)` swallows `CancellationException` because it's a subclass) was found at 18 more ViewModel catch sites across 5 files. Each gains a sibling `catch (CancellationException) { throw e }` BEFORE the broad catch.

## Files touched (5)

| File | Sites | Why |
|---|---|---|
| RoomViewModel | 4 (471, 905, 1055, 1460) | Auto-rejoin, join-room writes, seat-action, owner-return — all in `viewModelScope.launch` blocks during high-traffic chat-room flows |
| PrivateChatViewModel | 5 (389, 861, 981, 1093, 1123) | Messages observation, send-images, sticker bytes, sticker pre-upload, save-sticker — all `viewModelScope.launch` |
| FunFactSplashViewModel | 4 (60, 69, 75, 86) | 4 nested preload `launch { ... }` blocks during splash warmup |
| HomeViewModel | 1 (92) | Banner load `viewModelScope.launch` |
| AuthViewModel | 4 (173, 426, 432, 767) | Migration abort + auth-error recovery + biometric-revoke |

## Why this matters

`kotlinx.coroutines.CancellationException` extends `IllegalStateException` → `Exception`. A broad `catch (Exception)` swallows structured cancellation, breaking coroutine framework guarantees. If the scope is cancelled mid-launch (config change, navigation, parent job cancel), the catch eats the cancellation, the rest of the launch body runs against a dead scope, and the framework's invariants are silently violated.

The codebase already has this idiom established (`FirebaseCall.kt` helper, `SignInScreen.kt` UI catches); this sweep brings the ViewModel layer in line.

## Test plan

- [x] `:app:compileDevDebugKotlin :app:compileLocalDebugAndroidTestKotlin :app:testDevDebugUnitTest :shared:jvmTest detekt :shared:compileKotlinIosArm64` — BUILD SUCCESSFUL
- [x] ktlint — clean
- [x] SonarCloud quality gate (pre-push hook) — passed
- [x] Sanity count: 20 `catch (Exception)` in changed files now have 20 matching `catch (CancellationException) { throw e }` siblings
- [x] Audit by Explore agent + manual verification of every site
- [ ] CI pipeline green

No new tests — change is mechanical, and PR #548's regression test (`signOut propagates CancellationException — cleanup after rethrow must not run`) covers the principle on a representative VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)