### PR TITLE
fix(smoke): clean up orphaned suggestions before submission test

### DIFF
--- a/tests/web/dev-smoke.spec.ts
+++ b/tests/web/dev-smoke.spec.ts
@@ -207,8 +207,40 @@ test.describe("Dev Smoke — critical user-facing API journeys", () => {
   test("POST /api/suggestions accepts a smoke submission (public-write path + sanitisation)", async () => {
     // Catches: input sanitisation, language detection, tag
     // validation, Firestore rule on the `suggestions` collection.
-    // The submission is tagged via title prefix so the smoke entries
-    // are filterable in Firestore for cleanup if needed.
+    //
+    // Pre-clean: withdraw any orphaned `[smoke]`-prefixed pending
+    // suggestions from prior runs. Without this, every deploy adds a
+    // pending entry that nobody reviews, and after 10 runs the route
+    // returns HTTP 429 (`MAX_PENDING_PER_USER` in
+    // express-api/src/utils/suggestion-constants.js — observed on the
+    // second back-to-back DEV deploy on 2026-05-08). Same idiom as the
+    // follow/unfollow journey's pre-clean: assert success because a
+    // pre-clean failure would let the rest of the test give misleading
+    // results.
+    const minePre = await smoke.api.get(`${API_BASE}/api/suggestions/mine`, {
+      headers: authedHeaders(),
+    });
+    expect(
+      minePre.ok(),
+      `pre-clean GET /suggestions/mine expected 200, got ${minePre.status()}: ${await minePre.text()}`,
+    ).toBe(true);
+    const minePreBody = (await minePre.json()) as { suggestions?: Array<Record<string, unknown>> };
+    const orphans = (minePreBody.suggestions ?? []).filter(
+      (s) =>
+        s.status === "pending" &&
+        typeof s.title === "string" &&
+        (s.title as string).startsWith("[smoke]"),
+    );
+    for (const s of orphans) {
+      const del = await smoke.api.delete(`${API_BASE}/api/suggestions/${s.id}`, {
+        headers: authedHeaders(),
+      });
+      expect(
+        del.ok(),
+        `pre-clean DELETE /suggestions/${s.id} expected 200, got ${del.status()}: ${await del.text()}`,
+      ).toBe(true);
+    }
+
     const stamp = new Date().toISOString();
     const res = await smoke.api.post(`${API_BASE}/api/suggestions`, {
       headers: authedHeaders(),
@@ -222,7 +254,16 @@ test.describe("Dev Smoke — critical user-facing API journeys", () => {
     });
     expect(res.ok(), `${res.status()}: ${await res.text()}`).toBe(true);
     const body = await res.json();
-    expect(body.id || body.suggestionId, "suggestion id returned").toBeTruthy();
+    const newId = (body.id || body.suggestionId) as string | undefined;
+    expect(newId, "suggestion id returned").toBeTruthy();
+
+    // Post-clean: withdraw the suggestion we just created. Best-effort
+    // — the next run's pre-clean catches anything we miss here.
+    if (newId) {
+      await smoke.api
+        .delete(`${API_BASE}/api/suggestions/${newId}`, { headers: authedHeaders() })
+        .catch(() => {});
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Restores the DEV deploy's smoke gate. The `POST /api/suggestions` smoke test creates a `[smoke]`-tagged suggestion every deploy but never withdraws it; after 10 runs without admin review, `MAX_PENDING_PER_USER` (10) fires HTTP 429 and the smoke gate goes red. Observed on the second back-to-back DEV deploy on 2026-05-08 (deploy run #25547458459).

**Not a regression from PRs #547/#548/#549** — those touch only Kotlin ViewModels; the suggestions API is Express/Node, separate runtime. The other 5 deploy jobs (Backend, Web, Android testers, TestFlight, Sanity Check) were green on that same deploy; the smoke gate's failure is the only red light, caused by accumulated test data.

## Fix

In `tests/web/dev-smoke.spec.ts`, in the suggestions test:
1. **Pre-clean**: GET `/api/suggestions/mine`, filter to `status === "pending"` + `title.startsWith("[smoke]")`, DELETE each. Asserts success (a silent pre-clean failure would make the test misleading) — same idiom as the follow/unfollow journey's pre-clean.
2. **Post-clean**: best-effort DELETE the just-created suggestion. The next run's pre-clean catches anything we miss.

Existing endpoints used:
- `GET /suggestions/mine` — auth → list submitter's own
- `DELETE /suggestions/:id` — auth → withdraw own pending (refuses non-pending or non-owned)

No server-side changes.

## Test plan

- [x] `npx playwright test --list tests/web/dev-smoke.spec.ts` — 105 tests parse + typecheck OK
- [x] Pre-push hook ran (no Kotlin/Java changed → SonarCloud scan skipped, lint-staged matched no tasks)
- [ ] CI green
- [ ] Trigger a third DEV deploy after merge — Dev Smoke Tests gate should now turn green (the first run's pre-clean clears the 10 orphans accumulated to date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)