### PR TITLE
fix(age-verif): non-prod simulation warning on submit screen

### DIFF
--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">الرجاء إضافة صورة قبل الإرسال.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">تعذر الإرسال — يرجى التحقق من الاتصال والمحاولة مرة أخرى.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">بيئة الاختبار</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">قم بتحميل أي صورة - هذه بيئة اختبار، ولا يلزم وجود معرفات حقيقية ولا يتم تخزينها على المدى الطويل.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -1686,4 +1686,8 @@
     <string name="age_verif_submit_error_no_image">Bitte fügen Sie vor dem Absenden ein Foto hinzu.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">Konnte nicht gesendet werden. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">Testumgebung</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">Laden Sie ein beliebiges Bild hoch – dies ist eine Testumgebung, echte IDs sind nicht erforderlich und werden nicht langfristig gespeichert.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">Por favor agregue una foto antes de enviarla.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">No se pudo enviar. Verifique su conexión e inténtelo nuevamente.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">Entorno de prueba</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">Cargue cualquier imagen: este es un entorno de prueba, no se requieren identificaciones reales y no se almacenan a largo plazo.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -1684,4 +1684,8 @@
     <string name="age_verif_submit_error_no_image">Veuillez ajouter une photo avant de soumettre.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">Impossible de soumettre. Veuillez vérifier votre connexion et réessayer.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">Environnement de test</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">Téléchargez n\'importe quelle image : il s\'agit d\'un environnement de test, les véritables identifiants ne sont pas requis et ne sont pas stockés à long terme.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">कृपया सबमिट करने से पहले एक फ़ोटो जोड़ें.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">सबमिट नहीं किया जा सका - कृपया अपना कनेक्शन जांचें और पुनः प्रयास करें।</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">परीक्षण वातावरण</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">कोई भी छवि अपलोड करें - यह एक परीक्षण वातावरण है, वास्तविक आईडी की आवश्यकता नहीं है और इसे लंबे समय तक संग्रहीत नहीं किया जाता है।</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-id/strings.xml
+++ b/shared/src/commonMain/composeResources/values-id/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">Silakan tambahkan foto sebelum mengirimkan.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">Tidak dapat mengirimkan — harap periksa koneksi Anda dan coba lagi.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">Lingkungan pengujian</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">Unggah gambar apa pun — ini adalah lingkungan pengujian, ID asli tidak diperlukan dan tidak disimpan dalam jangka panjang.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">Si prega di aggiungere una foto prima di inviare.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">Impossibile inviare: controlla la connessione e riprova.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">Ambiente di prova</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">Carica qualsiasi immagine: questo è un ambiente di test, gli ID reali non sono richiesti e non vengono archiviati a lungo termine.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">送信する前に写真を追加してください。</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">送信できませんでした — 接続を確認して、もう一度試してください。</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">テスト環境</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">任意の画像をアップロードします。これはテスト環境であり、実際の ID は必要なく、長期保存されません。</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-km/strings.xml
+++ b/shared/src/commonMain/composeResources/values-km/strings.xml
@@ -1773,4 +1773,8 @@
     <string name="age_verif_submit_error_no_image">សូមបន្ថែមរូបថតមុនពេលដាក់ស្នើ។</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">មិនអាចដាក់ស្នើបានទេ — សូមពិនិត្យមើលការតភ្ជាប់របស់អ្នក ហើយព្យាយាមម្តងទៀត។</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">បរិយាកាសសាកល្បង</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">បង្ហោះរូបភាពណាមួយ — នេះគឺជាបរិយាកាសសាកល្បង លេខសម្គាល់ពិតប្រាកដមិនត្រូវបានទាមទារ និងមិនត្រូវបានរក្សាទុករយៈពេលវែង។</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-ko/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ko/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">제출하기 전에 사진을 추가하세요.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">제출할 수 없습니다. 연결을 확인하고 다시 시도하십시오.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">테스트 환경</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">이미지 업로드 - 이는 테스트 환경이므로 실제 ID가 필요하지 않으며 장기간 저장되지 않습니다.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">Voeg een foto toe voordat u deze verzendt.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">Kan niet verzenden. Controleer uw verbinding en probeer het opnieuw.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">Testomgeving</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">Upload een afbeelding – dit is een testomgeving, echte ID’s zijn niet vereist en worden niet langdurig bewaard.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-pl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pl/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">Przed przesłaniem proszę dodać zdjęcie.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">Nie można przesłać — sprawdź połączenie i spróbuj ponownie.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">Środowisko testowe</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">Prześlij dowolny obraz — jest to środowisko testowe, prawdziwe identyfikatory nie są wymagane i nie są przechowywane długoterminowo.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">Adicione uma foto antes de enviar.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">Não foi possível enviar. Verifique sua conexão e tente novamente.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">Ambiente de teste</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">Faça upload de qualquer imagem – este é um ambiente de teste, IDs reais não são necessários e não são armazenados por longo prazo.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">Пожалуйста, добавьте фотографию перед отправкой.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">Не удалось отправить. Проверьте подключение и повторите попытку.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">Тестовая среда</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">Загрузите любое изображение — это тестовая среда, настоящие идентификаторы не требуются и долговременно не хранятся.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-sv/strings.xml
+++ b/shared/src/commonMain/composeResources/values-sv/strings.xml
@@ -1687,4 +1687,8 @@
     <string name="age_verif_submit_error_no_image">Lägg till ett foto innan du skickar in.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">Det gick inte att skicka – kontrollera din anslutning och försök igen.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">Testmiljö</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">Ladda upp vilken bild som helst – det här är en testmiljö, riktiga ID:n krävs inte och lagras inte på lång sikt.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-th/strings.xml
+++ b/shared/src/commonMain/composeResources/values-th/strings.xml
@@ -1686,4 +1686,8 @@
     <string name="age_verif_submit_error_no_image">กรุณาเพิ่มภาพถ่ายก่อนที่จะส่ง</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">ไม่สามารถส่งได้ — โปรดตรวจสอบการเชื่อมต่อของคุณแล้วลองอีกครั้ง</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">สภาพแวดล้อมการทดสอบ</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">อัปโหลดรูปภาพใดๆ — นี่เป็นสภาพแวดล้อมการทดสอบ ไม่จำเป็นต้องใช้ ID จริงและไม่ได้จัดเก็บไว้ในระยะยาว</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-tr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tr/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">Lütfen göndermeden önce bir fotoğraf ekleyin.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">Gönderilemedi; lütfen bağlantınızı kontrol edip tekrar deneyin.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">Test ortamı</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">Herhangi bir görsel yükleyin — bu bir test ortamıdır, gerçek kimlikler gerekli değildir ve uzun süre saklanmaz.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -1687,4 +1687,8 @@
     <string name="age_verif_submit_error_no_image">Перед надсиланням додайте фото.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">Не вдалося надіслати — перевірте з’єднання та повторіть спробу.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">Тестове середовище</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">Завантажте будь-яке зображення — це тестове середовище, справжні ідентифікатори не потрібні та не зберігаються довго.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-vi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-vi/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">Vui lòng thêm ảnh trước khi gửi.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">Không thể gửi - vui lòng kiểm tra kết nối của bạn và thử lại.</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">Môi trường thử nghiệm</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">Tải lên bất kỳ hình ảnh nào - đây là môi trường thử nghiệm, không yêu cầu ID thực và không được lưu trữ lâu dài.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -1688,4 +1688,8 @@
     <string name="age_verif_submit_error_no_image">提交前请添加照片。</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_generic">无法提交 - 请检查您的连接并重试。</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_label">测试环境</string>
+    <!-- google-translated 2026-05-08 -->
+    <string name="age_verif_test_env_warning">上传任何图像 - 这是一个测试环境，不需要真实 ID，也不会长期存储。</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -978,5 +978,7 @@
     <string name="age_verif_submit_error_no_method">Please pick an ID type before submitting.</string>
     <string name="age_verif_submit_error_no_image">Please add a photo before submitting.</string>
     <string name="age_verif_submit_error_generic">Could not submit — please check your connection and try again.</string>
+    <string name="age_verif_test_env_label">Test environment</string>
+    <string name="age_verif_test_env_warning">Upload any image — this is a test environment, real IDs are not required and not stored long-term.</string>
 
 </resources>

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitScreen.kt
@@ -60,6 +60,8 @@ import com.shyden.shytalk.resources.age_verif_step_submitted_body
 import com.shyden.shytalk.resources.age_verif_step_submitted_done
 import com.shyden.shytalk.resources.age_verif_step_submitted_title
 import com.shyden.shytalk.resources.age_verif_submit_title
+import com.shyden.shytalk.resources.age_verif_test_env_label
+import com.shyden.shytalk.resources.age_verif_test_env_warning
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -71,6 +73,7 @@ const val TAG_AGE_VERIF_PICK_IMAGE = "ageVerif_pickImage"
 const val TAG_AGE_VERIF_SUBMIT = "ageVerif_submit"
 const val TAG_AGE_VERIF_DONE = "ageVerif_done"
 const val TAG_AGE_VERIF_BACK = "ageVerif_back"
+const val TAG_AGE_VERIF_TEST_ENV_WARNING = "ageVerif_testEnvWarning"
 
 /**
  * 4-step user-facing verification flow (PR 9).
@@ -128,7 +131,10 @@ fun AgeVerificationSubmitScreen(
                 AgeVerificationSubmitStep.PickMethod -> PickMethodStep(viewModel::selectMethod)
 
                 AgeVerificationSubmitStep.PickImage ->
-                    PickImageStep(uiState.imageBytes != null) { bytes, ct ->
+                    PickImageStep(
+                        photoAlreadyAttached = uiState.imageBytes != null,
+                        showTestEnvWarning = uiState.isPreviewBuild,
+                    ) { bytes, ct ->
                         viewModel.setImage(bytes, ct)
                     }
 
@@ -206,6 +212,7 @@ private fun PickMethodStep(onMethodSelected: (IdMethod) -> Unit) {
 @Composable
 private fun PickImageStep(
     photoAlreadyAttached: Boolean,
+    showTestEnvWarning: Boolean,
     onImagePicked: (ByteArray, ContentType) -> Unit,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -218,6 +225,9 @@ private fun PickImageStep(
             stringResource(Res.string.age_verif_step_image_body),
             style = MaterialTheme.typography.bodyMedium,
         )
+        if (showTestEnvWarning) {
+            TestEnvironmentWarning()
+        }
         Spacer(Modifier.height(4.dp))
         // PlatformImagePicker emits JPEG bytes via the gallery picker.
         // Camera support is a follow-up — the existing
@@ -333,6 +343,41 @@ private fun SubmittedStep(onDone: () -> Unit) {
         ) {
             Text(stringResource(Res.string.age_verif_step_submitted_done))
         }
+    }
+}
+
+/**
+ * Prominent banner shown above the image picker on local + dev builds
+ * (driven by [AgeVerificationSubmitUiState.isPreviewBuild]). Reassures
+ * the tester not to upload a real ID — the spec rule is that non-prod
+ * environments simulate the flow without long-term retention of PII
+ * (`.project/plans/2026-05-03-age-verification.md` → "Non-prod
+ * simulation").
+ */
+@Composable
+private fun TestEnvironmentWarning() {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .testTag(TAG_AGE_VERIF_TEST_ENV_WARNING)
+                .background(
+                    MaterialTheme.colorScheme.tertiaryContainer,
+                    RoundedCornerShape(8.dp),
+                ).padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            stringResource(Res.string.age_verif_test_env_label),
+            color = MaterialTheme.colorScheme.onTertiaryContainer,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            stringResource(Res.string.age_verif_test_env_warning),
+            color = MaterialTheme.colorScheme.onTertiaryContainer,
+            style = MaterialTheme.typography.bodySmall,
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitViewModel.kt
@@ -2,6 +2,7 @@ package com.shyden.shytalk.feature.ageverification
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.shyden.shytalk.core.BuildVariant
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.core.util.UiText
 import com.shyden.shytalk.core.util.logE
@@ -51,6 +52,13 @@ data class AgeVerificationSubmitUiState(
     val imageContentType: ContentType? = null,
     val isSubmitting: Boolean = false,
     val error: UiText? = null,
+    /**
+     * `true` on local + dev builds — drives the prominent
+     * "test environment, do not upload a real ID" warning on the
+     * PickImage step (spec `.project/plans/2026-05-03-age-verification.md`
+     * Non-prod simulation).
+     */
+    val isPreviewBuild: Boolean = false,
 ) {
     /**
      * Custom equals to compare by reference / size for [imageBytes] —
@@ -65,7 +73,8 @@ data class AgeVerificationSubmitUiState(
             imageBytes === other.imageBytes &&
             imageContentType == other.imageContentType &&
             isSubmitting == other.isSubmitting &&
-            error == other.error
+            error == other.error &&
+            isPreviewBuild == other.isPreviewBuild
     }
 
     override fun hashCode(): Int {
@@ -75,18 +84,20 @@ data class AgeVerificationSubmitUiState(
         result = 31 * result + (imageContentType?.hashCode() ?: 0)
         result = 31 * result + isSubmitting.hashCode()
         result = 31 * result + (error?.hashCode() ?: 0)
+        result = 31 * result + isPreviewBuild.hashCode()
         return result
     }
 }
 
 class AgeVerificationSubmitViewModel(
     private val repository: AgeVerificationRepository,
+    isPreviewBuild: Boolean = BuildVariant.isPreviewBuild,
 ) : ViewModel() {
     companion object {
         private const val TAG = "AgeVerifSubmitVM"
     }
 
-    private val _uiState = MutableStateFlow(AgeVerificationSubmitUiState())
+    private val _uiState = MutableStateFlow(AgeVerificationSubmitUiState(isPreviewBuild = isPreviewBuild))
     val uiState: StateFlow<AgeVerificationSubmitUiState> = _uiState.asStateFlow()
 
     /**

--- a/shared/src/jvmTest/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitViewModelTest.kt
+++ b/shared/src/jvmTest/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitViewModelTest.kt
@@ -36,7 +36,7 @@ class AgeVerificationSubmitViewModelTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         repo = FakeAgeVerificationRepository()
-        viewModel = AgeVerificationSubmitViewModel(repo)
+        viewModel = AgeVerificationSubmitViewModel(repo, isPreviewBuild = false)
     }
 
     @AfterTest
@@ -53,6 +53,48 @@ class AgeVerificationSubmitViewModelTest {
         assertNull(viewModel.uiState.value.imageBytes)
         assertFalse(viewModel.uiState.value.isSubmitting)
         assertNull(viewModel.uiState.value.error)
+    }
+
+    // ─── Non-prod simulation warning flag ───────────────────────
+    //
+    // Spec (`.project/plans/2026-05-03-age-verification.md` Non-prod
+    // simulation): on local + dev builds the user must be prominently
+    // warned not to upload a real ID. Surfacing the flag through UI
+    // state so the screen renders the warning conditionally without
+    // each call site needing to know about BuildVariant.
+
+    @Test
+    fun `isPreviewBuild=true is exposed via uiState from initial state`() {
+        val previewVm = AgeVerificationSubmitViewModel(repo, isPreviewBuild = true)
+        assertTrue(previewVm.uiState.value.isPreviewBuild)
+    }
+
+    @Test
+    fun `isPreviewBuild=false is exposed via uiState from initial state`() {
+        val prodVm = AgeVerificationSubmitViewModel(repo, isPreviewBuild = false)
+        assertFalse(prodVm.uiState.value.isPreviewBuild)
+    }
+
+    @Test
+    fun `isPreviewBuild flag survives state transitions (copy preserves it)`() {
+        val previewVm = AgeVerificationSubmitViewModel(repo, isPreviewBuild = true)
+        previewVm.acknowledgeExplanation()
+        previewVm.selectMethod(IdMethod.Passport)
+        previewVm.setImage(byteArrayOf(0x01), ContentType.Jpeg)
+        // Now at Confirm; flag must still be true so the screen can
+        // re-display the warning if the user steps back to PickImage.
+        assertTrue(previewVm.uiState.value.isPreviewBuild)
+    }
+
+    @Test
+    fun `isPreviewBuild flag is still true when stepping back to PickImage from Confirm`() {
+        val previewVm = AgeVerificationSubmitViewModel(repo, isPreviewBuild = true)
+        previewVm.acknowledgeExplanation()
+        previewVm.selectMethod(IdMethod.Passport)
+        previewVm.setImage(byteArrayOf(0x01), ContentType.Jpeg)
+        previewVm.back() // Confirm → PickImage; warning is rendered here
+        assertEquals(AgeVerificationSubmitStep.PickImage, previewVm.uiState.value.step)
+        assertTrue(previewVm.uiState.value.isPreviewBuild)
     }
 
     // ─── Forward transitions ────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds the "test environment, do not upload a real ID" warning banner that the age-verification spec mandates for non-prod builds (`.project/plans/2026-05-03-age-verification.md` → "Non-prod simulation"). PR 9 (#466) shipped without it; verify-everything audit caught the gap.
- Plumbs `BuildVariant.isPreviewBuild` through `AgeVerificationSubmitUiState` so the screen renders a tertiary-container banner above the image picker on local + dev only. Production flow is unchanged.
- 2 new EN strings + Google-translated across all 19 non-EN locales via `scripts/translate-strings.js` (40/40 success, 0 fallback).

## Test plan

- [x] `:shared:compileKotlinIosArm64` — green (tri-platform sync)
- [x] `:shared:jvmTest detekt` — green; 0 code smells
- [x] `:app:compileDevDebugKotlin` — green
- [x] `ktlint --relative` — clean
- [x] 4 new VM tests pin: initial state with both flag values; flag survives forward state transitions; flag survives `back()` from Confirm → PickImage (the step that displays the warning)
- [x] Pre-commit hooks: ktlint + KMP-compat-check both passed
- [x] Pre-push: SonarCloud quality gate passed
- [x] Code review (feature-dev:code-reviewer): 2 important findings addressed inline (testTag placement, back() test gap); 0 critical
- [x] Silent-failure hunt (pr-review-toolkit:silent-failure-hunter): 0 silent failures introduced; pre-existing `Resource.Loading` branches at `submit()` lines 215/232/256 flagged for follow-up PR (out-of-scope here)
- [ ] Manual QA — covered by upcoming PR 14 (`/manual-qa` cycle, full age-verification end-to-end)

## Out-of-scope follow-up

`AgeVerificationSubmitViewModel.submit()` has 3 pre-existing `Resource.Loading` branches that silently leave `isSubmitting = true` if the repo contract is ever violated (lines 215/232/256). Worth a tiny follow-up PR; deliberately not bundled here to keep this scope-limited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)