### PR TITLE
fix(age-verif): recover from Resource.Loading contract violation in submit()

### DIFF
--- a/.project/plans/2026-03-29-feature-roadmap.md
+++ b/.project/plans/2026-03-29-feature-roadmap.md
@@ -19,7 +19,7 @@ The next batch to push toward DONE, in order:
 6. **W1 — Shared header on all web pages** (Phase 6) — bundles 4 latent web bugs (COOP, /api/firebase-config 503, watch-bell re-prompt, Google `select_account`).
 7. **C8 PR 14 — manual-QA cycle** (Phase 1) — final gate for the age-verification initiative; triggers DEV + PROD deploy. Multi-day work, defer until other Top Priority items are stacked up to bundle into one DEV deploy. See `.project/plans/2026-05-03-age-verification.md`.
 
-**Resource.Loading silent-failure follow-up** (out-of-scope of PR #553 but flagged): `AgeVerificationSubmitViewModel.submit()` lines 215/232/256 — pre-existing branches that silently leave `isSubmitting = true` if the repo contract is ever violated. Tiny follow-up PR worth doing alongside B6.12.
+**Resource.Loading silent-failure follow-up** — DONE (PR #556, 2026-05-08). `AgeVerificationSubmitViewModel.submit()` lines 215/232/256 now route through `handleUnexpectedLoading(stage)` (logE + reset state) instead of silent `return@launch`/`Unit`. Three RED→GREEN tests pin the recovery contract.
 
 Phase order (top-of-stack first): Phase 1 (Compliance) → Phase 2 (Platform/iOS finishing) → Phase 0 (Infra & test) → Phase 6 (Website) → Phase 3 (Revenue) → Phase 4 (Social) → Phase 5 (QoL) → Phase 7 (Entertainment) → Phase 8 (Support).
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitViewModel.kt
@@ -212,7 +212,10 @@ class AgeVerificationSubmitViewModel(
                         return@launch
                     }
 
-                    is Resource.Loading -> return@launch
+                    is Resource.Loading -> {
+                        handleUnexpectedLoading("requestUploadUrl")
+                        return@launch
+                    }
                 }
 
             when (val r = repository.uploadImage(handle.uploadUrl, contentType, bytes)) {
@@ -229,7 +232,10 @@ class AgeVerificationSubmitViewModel(
                     return@launch
                 }
 
-                is Resource.Loading -> return@launch
+                is Resource.Loading -> {
+                    handleUnexpectedLoading("uploadImage")
+                    return@launch
+                }
             }
 
             when (val r = repository.submit(method, handle.r2Key)) {
@@ -253,8 +259,39 @@ class AgeVerificationSubmitViewModel(
                     }
                 }
 
-                is Resource.Loading -> Unit
+                is Resource.Loading -> {
+                    handleUnexpectedLoading("submit")
+                    return@launch
+                }
             }
+        }
+    }
+
+    /**
+     * Defensive recovery for the contract violation where a
+     * `suspend fun` returning `Resource<T>` resolves to
+     * [Resource.Loading]. Loading is a Flow-emission state — suspend
+     * functions should resolve to Success or Error only. If a
+     * misbehaving / refactored repo impl ever leaks Loading, the
+     * three call sites in [submit] would otherwise strand the user
+     * with `isSubmitting = true` forever and no error to retry on.
+     *
+     * Strategy: **log + recover**. Emit a distinct error log so the
+     * violation is grep-able in dev / staging logs (it's a
+     * programming mistake, not a transient network error), then
+     * reset `isSubmitting` and surface the generic error UiText so
+     * the user can retry. Mirrors the logE-then-update pattern used
+     * by the Error branches at the three call sites.
+     *
+     * @param stage call-site name (for logs).
+     */
+    private fun handleUnexpectedLoading(stage: String) {
+        logE(TAG, "Repo contract violation: $stage returned Resource.Loading")
+        _uiState.update {
+            it.copy(
+                isSubmitting = false,
+                error = UiText.Res(Res.string.age_verif_submit_error_generic),
+            )
         }
     }
 

--- a/shared/src/jvmTest/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitViewModelTest.kt
+++ b/shared/src/jvmTest/kotlin/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitViewModelTest.kt
@@ -277,6 +277,76 @@ class AgeVerificationSubmitViewModelTest {
             assertFalse(viewModel.uiState.value.isSubmitting)
         }
 
+    // ─── Resource.Loading contract-violation paths ──────────────
+    //
+    // `requestUploadUrl`, `uploadImage`, and `submit` are suspend
+    // functions returning Resource<T>. By contract they should resolve
+    // to Success or Error — never Loading (Loading is a Flow-emission
+    // state). But `Resource<T>` is a 3-state sealed class, so a buggy
+    // or refactored repo impl could leak Loading. Without defensive
+    // handling the user is stranded with `isSubmitting = true` forever
+    // and no error to retry on. These tests pin the recovery contract:
+    // treat Loading as a generic submit error so the user can retry.
+
+    @Test
+    fun `submit Loading from requestUploadUrl recovers as error and stops spinner`() =
+        runTest(testDispatcher) {
+            repo.uploadUrlResult = Resource.Loading
+            viewModel.acknowledgeExplanation()
+            viewModel.selectMethod(IdMethod.Passport)
+            viewModel.setImage(byteArrayOf(0x01), ContentType.Jpeg)
+
+            viewModel.submit()
+            advanceUntilIdle()
+
+            assertEquals(AgeVerificationSubmitStep.Confirm, viewModel.uiState.value.step)
+            assertNotNull(viewModel.uiState.value.error)
+            assertFalse(viewModel.uiState.value.isSubmitting)
+            assertEquals(0, repo.uploadImageCalls)
+            assertEquals(0, repo.submitCalls)
+        }
+
+    @Test
+    fun `submit Loading from uploadImage recovers as error and stops spinner`() =
+        runTest(testDispatcher) {
+            repo.uploadUrlResult =
+                Resource.Success(UploadHandle("https://r2/sig", "age-verification/u1/k.jpg", 300))
+            repo.uploadImageResult = Resource.Loading
+            viewModel.acknowledgeExplanation()
+            viewModel.selectMethod(IdMethod.Passport)
+            viewModel.setImage(byteArrayOf(0x01), ContentType.Jpeg)
+
+            viewModel.submit()
+            advanceUntilIdle()
+
+            assertEquals(AgeVerificationSubmitStep.Confirm, viewModel.uiState.value.step)
+            assertNotNull(viewModel.uiState.value.error)
+            assertFalse(viewModel.uiState.value.isSubmitting)
+            // Crucially: submit() must NOT have been called — without
+            // bytes in R2, marking the submission pending would surface
+            // a broken record to the admin (mirrors the Error path).
+            assertEquals(0, repo.submitCalls)
+        }
+
+    @Test
+    fun `submit Loading from submit() recovers as error and stops spinner`() =
+        runTest(testDispatcher) {
+            repo.uploadUrlResult =
+                Resource.Success(UploadHandle("https://r2/sig", "age-verification/u1/k.jpg", 300))
+            repo.uploadImageResult = Resource.Success(Unit)
+            repo.submitResult = Resource.Loading
+            viewModel.acknowledgeExplanation()
+            viewModel.selectMethod(IdMethod.Passport)
+            viewModel.setImage(byteArrayOf(0x01), ContentType.Jpeg)
+
+            viewModel.submit()
+            advanceUntilIdle()
+
+            assertEquals(AgeVerificationSubmitStep.Confirm, viewModel.uiState.value.step)
+            assertNotNull(viewModel.uiState.value.error)
+            assertFalse(viewModel.uiState.value.isSubmitting)
+        }
+
     @Test
     fun `clearError nulls the error`() =
         runTest(testDispatcher) {


### PR DESCRIPTION
## Summary

- Three branches in `AgeVerificationSubmitViewModel.submit()` silently swallowed `Resource.Loading` from the suspend repo calls (`return@launch` / `Unit`), leaving `isSubmitting = true` forever and no error to retry on if the repo ever leaked Loading from a `suspend fun`. Loading is a Flow-emission state — suspend should resolve to Success/Error only — but `Resource<T>`'s 3-state sealed class can't enforce that at the type level.
- Replaced the three branches with a private `handleUnexpectedLoading(stage)` helper that logs `"Repo contract violation: $stage returned Resource.Loading"` (grep-distinct from existing `"X failed:"` transient-error logs) and updates state so the user can retry. Mirrors the `logE`-then-update pattern at the existing Error branches (`shared/.../AgeVerificationSubmitViewModel.kt:205/222/247`).
- TDD: 3 RED tests added first (one per call site — `requestUploadUrl`, `uploadImage`, `submit`), then helper implemented to make them GREEN. All 23 tests in `AgeVerificationSubmitViewModelTest` pass.

This is the **"Resource.Loading silent-failure follow-up"** flagged in the roadmap (Top Priorities, line 22, alongside B6.12) as out-of-scope of PR #553. Cleans the dead-code defensive shape so any future repo refactor that accidentally leaks Loading is loud-but-recoverable, not silent.

## Strategy chosen: log + recover

Trade-off considered:
- **(a) Defensive recovery only** — invisible to dev, hides a programming bug.
- **(b) Loud crash via `error()`** — visible in CI but catastrophic if it slips to prod for an ID-verification flow.
- **(c) Log + recover** ← chosen. Distinct log prefix surfaces the contract violation in dev/staging logs, but real users still get a retry path. Mirrors the existing `logE → update state` pattern for the Error branches.

## Reviewer findings (silent-failure-hunter)

**APPROVE — no required changes.**
- No new silent-failure paths introduced; helper is linear `logE` → `_uiState.update`.
- No other silent-failure branches present in the file.
- Test coverage pins the recovery contract for all three call sites.
- Two LOW-severity nice-to-haves (assert specific UiText identity, log-emission test infrastructure) explicitly marked out-of-scope; surrounding tests use `assertNotNull` only, so consistency wins.

## Test plan

- [x] 3 new RED tests for Loading at each call site fail as expected before the fix
- [x] All 23 jvmTest cases in `AgeVerificationSubmitViewModelTest` pass after the fix
- [x] `./gradlew :shared:compileKotlinIosArm64` — iOS link succeeds (commonMain change uses only `logE`, `UiText.Res`, `kotlinx.coroutines.flow.update` — all KMP-safe)
- [x] `ktlint --relative` — clean
- [x] `./gradlew detekt` — clean
- [ ] CI: PR Gate, Build & Test, SonarCloud, Android E2E, Playwright Web, iOS E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)