### PR TITLE
chore(roadmap): mark B7 Billing v7→v8 DONE — migration verified

### DIFF
--- a/.project/plans/2026-03-29-feature-roadmap.md
+++ b/.project/plans/2026-03-29-feature-roadmap.md
@@ -7,17 +7,20 @@ _Prioritised 2026-03-29 — last revised 2026-05-08 (status sweep: B6.9 deviceId
 
 ---
 
-## Top Priorities (next 7, revised 2026-05-08)
+## Top Priorities (next 6, revised 2026-05-09)
 
 The next batch to push toward DONE, in order:
 
-1. **B7 — Billing v7→v8** (Phase 2) — IN PROGRESS, Dependabot PR #270 build fails; needs investigation. Google Play deprecation deadline.
-2. **B6.12 — `resolveReport` partial-failure surfacing** (Phase 2) — IN PROGRESS, admin UI plumbing partly landed (PRs #385, #392, #393); resolveReport-specific outcome shape still pending.
-3. **B3 — Room message reporting** (Phase 1) — UK OSA, small effort, blocking nothing — quick compliance win.
-4. **C7 — Gift-blocked-but-profile-viewable gap** (Phase 1) — small block-list integrity bugfix; quick win.
-5. **17 — Age-based segregation** (Phase 1) — UK OSA, large; complementary to C8 (which is age-*gating* per-feature; this is age-*segregation*).
-6. **W1 — Shared header on all web pages** (Phase 6) — bundles 4 latent web bugs (COOP, /api/firebase-config 503, watch-bell re-prompt, Google `select_account`).
-7. **C8 PR 14 — manual-QA cycle** (Phase 1) — final gate for the age-verification initiative; triggers DEV + PROD deploy. Multi-day work, defer until other Top Priority items are stacked up to bundle into one DEV deploy. See `.project/plans/2026-05-03-age-verification.md`.
+1. **B6.12 — `resolveReport` partial-failure surfacing** (Phase 2) — IN PROGRESS, admin UI plumbing partly landed (PRs #385, #392, #393); resolveReport-specific outcome shape still pending.
+2. **B3 — Room message reporting** (Phase 1) — UK OSA, small effort, blocking nothing — quick compliance win.
+3. **C7 — Gift-blocked-but-profile-viewable gap** (Phase 1) — small block-list integrity bugfix; quick win.
+4. **17 — Age-based segregation** (Phase 1) — UK OSA, large; complementary to C8 (which is age-*gating* per-feature; this is age-*segregation*).
+5. **W1 — Shared header on all web pages** (Phase 6) — bundles 4 latent web bugs (COOP, /api/firebase-config 503, watch-bell re-prompt, Google `select_account`).
+6. **C8 PR 14 — manual-QA cycle** (Phase 1) — final gate for the age-verification initiative; triggers DEV + PROD deploy. Multi-day work, defer until other Top Priority items are stacked up to bundle into one DEV deploy. See `.project/plans/2026-05-03-age-verification.md`.
+
+> **Candidate adds (when re-promoting to 7+):** scan Phase 0 (test infra: #67 allure landing-page generator, #69 stable Kotlin upgrade off Beta2), Phase 0.5 (test-suite gaps), Phase 1 (other compliance items), and Phase 6 (W2+ web sub-tasks once W1 lands). **Skip** B6.10 (BLOCKED on Apple Dev account) and B6.15 (DEFERRED on UX decision) until their gates clear.
+
+**B7 — Billing v7→v8** — DONE (verified 2026-05-09). Dependabot PR #270 (commit `96f889ee1b0`, 2026-03-30) bumped `billing-ktx` 7.1.1 → 8.3.0 (`gradle/libs.versions.toml:29`). The Android app code already targeted Billing v8 APIs (`ProductDetails`, `QueryProductDetailsParams`, `PendingPurchasesParams`, plus v8-only `onPurchasesUpdatedSubResponseCode` / `unfetchedProductList` in `BillingService.kt:77-81,161-167`); no v7 surfaces (`SkuDetails`, `querySkuDetails`, `launchPriceChangeConfirmationFlow`) remain in the codebase. `./gradlew :app:assembleDevDebug` and `./gradlew :app:testDevDebugUnitTest` both BUILD SUCCESSFUL on 2026-05-09.
 
 **Resource.Loading silent-failure follow-up** — DONE (PR #556, 2026-05-08). `AgeVerificationSubmitViewModel.submit()` lines 215/232/256 now route through `handleUnexpectedLoading(stage)` (logE + reset state) instead of silent `return@launch`/`Unit`. Three RED→GREEN tests pin the recovery contract.
 
@@ -134,7 +137,7 @@ Keep Play Store billing current. Ship iOS alongside Android.
 
 | #     | Feature                                                                     | Effort | Status |
 |-------|-----------------------------------------------------------------------------|--------|--------|
-| B7    | **Billing v7→v8** — Google Play Billing major version, deprecation deadline | Medium | IN PROGRESS — Dependabot PR #270 build fails; needs investigation. **Top Priority #2.** |
+| B7    | **Billing v7→v8** — Google Play Billing major version, deprecation deadline | Medium | DONE (PR #270, 2026-03-30, verified 2026-05-09) — `billing-ktx` 7.1.1 → 8.3.0 in `gradle/libs.versions.toml:29`; `BillingService.kt` already on v8 APIs (`ProductDetails` / `QueryProductDetailsParams` / `PendingPurchasesParams`) plus v8-only surfaces (`onPurchasesUpdatedSubResponseCode`, `unfetchedProductList`). No v7 leftovers (`SkuDetails` / `querySkuDetails` / `launchPriceChangeConfirmationFlow`) anywhere. `assembleDevDebug` + `testDevDebugUnitTest` BUILD SUCCESSFUL on 2026-05-09. |
 | B6.12 | **`resolveReport` partial-failure flag surfacing** — admin UI must show per-sub-action failures (`warning.failed`, `suspension.failed`, `auditLog.failed`, `pms.failed`, `cascade`) currently swallowed by `Resource<Unit>`. Mostly DONE for admin-bans / economy / devices / warn / backpack PMs (PRs #385, #392, #393). Remaining: re-audit `resolveReport` itself + `reportMessage` / `reportUser` paths and any iOS admin surface when added. See `feedback-partial-failure-contracts.md` | Medium | IN PROGRESS — admin UI partial-failure plumbing landed PRs #385, #392, #393. resolveReport-specific outcome shape still pending. **Top Priority #3.** |
 | B6.10 | **iOS StoreKit billing integration** — mirrors Android Billing v8. Full 4-step plan at `.project/plans/2026-04-30-ios-storekit-blocker.md` | Large  | BLOCKED on Apple Developer account + App Store Connect product setup       |
 | B6.15 | **iOS dev sign-in multi-account picker** — Phase 4 simplified iOS to single-account dev sign-in (parity with Android). Restoring the picker on both platforms requires `BuildVariant.localDevEmails: List<String>`. Defer pending UX decision | Small  | DEFERRED — pending UX decision                                              |

--- a/public/roadmap-data.json
+++ b/public/roadmap-data.json
@@ -1,94 +1,11 @@
 {
-  "lastUpdated": "2026-05-08",
+  "lastUpdated": "2026-05-09",
   "currentlyWorkingOn": [
     {
       "name": "Age-gating per feature",
       "description": "separate age gates for voice rooms / gifting / DMs-with-strangers. Currently single 13+ gate at signup; needs per-feature age sensitivity",
       "phase": "Safety & Compliance",
       "i18n": {}
-    },
-    {
-      "name": "Billing v7→v8",
-      "description": "Google Play Billing major version, deprecation deadline",
-      "phase": "Platform & iOS",
-      "i18n": {
-        "ar": {
-          "n": "ترقية الفواتير",
-          "d": "عمليات شراء أكثر سلاسة"
-        },
-        "de": {
-          "n": "Billing-Upgrade",
-          "d": "Reibungslosere Käufe"
-        },
-        "es": {
-          "n": "Actualización de pagos",
-          "d": "Compras más fluidas"
-        },
-        "fr": {
-          "n": "Mise à jour paiements",
-          "d": "Achats plus fluides"
-        },
-        "hi": {
-          "n": "बिलिंग अपग्रेड",
-          "d": "आसान खरीदारी"
-        },
-        "id": {
-          "n": "Upgrade billing",
-          "d": "Pembelian lebih lancar"
-        },
-        "it": {
-          "n": "Aggiornamento billing",
-          "d": "Acquisti più fluidi"
-        },
-        "ja": {
-          "n": "課金アップグレード",
-          "d": "よりスムーズな購入"
-        },
-        "ko": {
-          "n": "결제 업그레이드",
-          "d": "더 원활한 구매"
-        },
-        "nl": {
-          "n": "Billing-upgrade",
-          "d": "Soepelere aankopen"
-        },
-        "pl": {
-          "n": "Aktualizacja płatności",
-          "d": "Płynniejsze zakupy"
-        },
-        "pt": {
-          "n": "Atualização de pagamento",
-          "d": "Compras mais suaves"
-        },
-        "ru": {
-          "n": "Обновление оплаты",
-          "d": "Более плавные покупки"
-        },
-        "sv": {
-          "n": "Betalningsuppgradering",
-          "d": "Smidigare köp"
-        },
-        "th": {
-          "n": "อัปเกรดการชำระเงิน",
-          "d": "การซื้อที่ราบรื่นขึ้น"
-        },
-        "tr": {
-          "n": "Ödeme yükseltme",
-          "d": "Daha akıcı satın alma"
-        },
-        "uk": {
-          "n": "Оновлення оплати",
-          "d": "Зручніші покупки"
-        },
-        "vi": {
-          "n": "Nâng cấp thanh toán",
-          "d": "Mua hàng mượt mà hơn"
-        },
-        "zh": {
-          "n": "支付升级",
-          "d": "更流畅的购买体验"
-        }
-      }
     },
     {
       "name": "`resolveReport` partial-failure flag surfacing",
@@ -730,14 +647,14 @@
       },
       "status": "in-progress",
       "progress": {
-        "done": 13,
+        "done": 14,
         "total": 17
       },
       "features": [
         {
           "name": "Billing v7→v8",
           "description": "Google Play Billing major version, deprecation deadline",
-          "status": "in-progress",
+          "status": "done",
           "i18n": {
             "ar": {
               "n": "ترقية الفواتير",


### PR DESCRIPTION
## Summary
- Verified B7 (Billing v7→v8) is functionally complete and updated the roadmap to reflect reality. PR #270 (`96f889ee1b0`, 2026-03-30) bumped `billing-ktx` 7.1.1 → 8.3.0; the app code was already targeting Billing v8 APIs (including v8-only surfaces `onPurchasesUpdatedSubResponseCode` and `unfetchedProductList`).
- Top Priorities list shrunk from 7 to 6 (B7 removed), with a new candidate-adds stub so future sessions can re-promote without rescanning the whole roadmap.
- Phase 2 detail row updated with full evidence (file:line references + build/test results).

## Verification (2026-05-09)
- `gradle/libs.versions.toml:29` → `billing = "8.3.0"` ✓
- `BillingService.kt:6-16` imports — `ProductDetails`, `QueryProductDetailsParams`, `PendingPurchasesParams`, etc. (all v8). No `SkuDetails` / `querySkuDetails` / `launchPriceChangeConfirmationFlow` anywhere in the codebase.
- `./gradlew :app:assembleDevDebug` → **BUILD SUCCESSFUL** in 2m 28s
- `./gradlew :app:testDevDebugUnitTest` → **BUILD SUCCESSFUL** in 56s

## Why this PR exists
The roadmap claimed PR #270 build was failing; the `verify, never assume` rule surfaced that the actual state is dep merged + v8 code shipped + clean build. Stale roadmap entries waste future-session effort, so updating the source-of-truth IS the work.

## Test plan
- [x] Local build passes (`assembleDevDebug`)
- [x] Local unit tests pass (`testDevDebugUnitTest`)
- [x] Roadmap generator regenerated `public/roadmap-data.json` cleanly (B7 removed from `currentlyWorkingOn`, `lastUpdated` bumped to 2026-05-09)
- [ ] CI green on PR
- [ ] Markdown-only deploy: no DEV/PROD app deploy needed (per `feedback-roadmap-dev-only-when-main-dirty.md`; main is clean post-#556)

🤖 Generated with [Claude Code](https://claude.com/claude-code)