### PR TITLE
feat(reports): surface resolveReport partial-failure flags to Kotlin admin client (B6.12)

### DIFF
--- a/app/src/androidTest/java/com/shyden/shytalk/fake/FakeReportRepository.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/fake/FakeReportRepository.kt
@@ -2,6 +2,7 @@ package com.shyden.shytalk.fake
 
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.data.repository.ReportRepository
+import com.shyden.shytalk.data.repository.ResolveReportOutcome
 import com.shyden.shytalk.feature.messaging.Report
 
 class FakeReportRepository : ReportRepository {
@@ -39,5 +40,5 @@ class FakeReportRepository : ReportRepository {
     override suspend fun resolveReport(
         reportId: String,
         action: String,
-    ): Resource<Unit> = Resource.Success(Unit)
+    ): Resource<ResolveReportOutcome> = Resource.Success(ResolveReportOutcome())
 }

--- a/app/src/main/java/com/shyden/shytalk/data/repository/ReportRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/ReportRepositoryImpl.kt
@@ -5,7 +5,7 @@ import com.shyden.shytalk.core.util.firebaseCall
 import com.shyden.shytalk.data.remote.WorkerApiClient
 import com.shyden.shytalk.feature.messaging.Report
 import org.json.JSONArray
-import org.json.JSONObject
+import org.json.JSONObject as OrgJsonObject
 
 class ReportRepositoryImpl(
     private val api: WorkerApiClient,
@@ -26,7 +26,7 @@ class ReportRepositoryImpl(
         firebaseCall<Unit>("Failed to submit report") {
             api.post(
                 "/api/reports",
-                JSONObject().apply {
+                OrgJsonObject().apply {
                     put("reportedUserId", reportedUserId)
                     put("reportedUserName", reportedUserName)
                     put("reportedUserUniqueId", reportedUserUniqueId)
@@ -54,7 +54,7 @@ class ReportRepositoryImpl(
         firebaseCall<Unit>("Failed to submit report") {
             api.post(
                 "/api/reports",
-                JSONObject().apply {
+                OrgJsonObject().apply {
                     put("reportedUserId", reportedUserId)
                     put("reportedUserName", reportedUserName)
                     put("reportedUserUniqueId", reportedUserUniqueId)
@@ -96,13 +96,17 @@ class ReportRepositoryImpl(
     override suspend fun resolveReport(
         reportId: String,
         action: String,
-    ): Resource<Unit> =
-        firebaseCall<Unit>("Failed to resolve report") {
-            api.post(
-                "/api/reports/$reportId/resolve",
-                JSONObject().apply {
-                    put("action", action)
-                },
-            )
+    ): Resource<ResolveReportOutcome> =
+        firebaseCall("Failed to resolve report") {
+            val response =
+                api.post(
+                    "/api/reports/$reportId/resolve",
+                    OrgJsonObject().apply {
+                        put("action", action)
+                    },
+                )
+            // String overload keeps kotlinx.serialization a shared-internal
+            // dep — :app stays on org.json. Hop is paid only on resolveReport.
+            parseResolveReportOutcome(response.toString())
         }
 }

--- a/app/src/test/java/com/shyden/shytalk/data/repository/ReportRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/ReportRepositoryImplTest.kt
@@ -192,7 +192,7 @@ class ReportRepositoryImplTest {
     // --- resolveReport ---
 
     @Test
-    fun `resolveReport posts to correct endpoint with action`() =
+    fun `resolveReport posts to correct endpoint with action and returns empty outcome on plain success`() =
         runTest {
             val bodySlot = slot<JSONObject>()
             coEvery { api.post("/api/reports/report-1/resolve", capture(bodySlot)) } returns
@@ -204,6 +204,8 @@ class ReportRepositoryImplTest {
 
             assertTrue(result is Resource.Success)
             assertEquals("warn", bodySlot.captured.getString("action"))
+            val outcome = (result as Resource.Success).data
+            assertTrue(!outcome.hasAnyFailure)
         }
 
     @Test
@@ -214,6 +216,123 @@ class ReportRepositoryImplTest {
             val result = repo.resolveReport("report-1", "dismiss")
 
             assertTrue(result is Resource.Error)
+        }
+
+    // ─── partial-failure response surfacing (B6.12) ─────────────────
+    //
+    // The Express handler emits per-sub-action failure flags
+    // (warning|suspension|auditLog|lockRelease + cascade + pms). The
+    // Kotlin client previously dropped the body and shipped a green
+    // toast. These tests pin the parsing wire so a future refactor of
+    // the response body keys can't silently regress to Resource<Unit>.
+
+    @Test
+    fun `resolveReport surfaces warning failure flag`() =
+        runTest {
+            coEvery { api.post(any(), any()) } returns
+                JSONObject().apply {
+                    put("success", true)
+                    put(
+                        "warning",
+                        JSONObject().apply {
+                            put("failed", true)
+                            put("error", "warning_create_failed")
+                        },
+                    )
+                }
+
+            val result = repo.resolveReport("report-1", "warn")
+
+            assertTrue(result is Resource.Success)
+            val outcome = (result as Resource.Success).data
+            assertTrue(outcome.hasAnyFailure)
+            assertEquals("warning_create_failed", outcome.warning?.error)
+        }
+
+    @Test
+    fun `resolveReport surfaces suspension and cascade partial-failure flags`() =
+        runTest {
+            coEvery { api.post(any(), any()) } returns
+                JSONObject().apply {
+                    put("success", true)
+                    put(
+                        "suspension",
+                        JSONObject().apply {
+                            put("failed", true)
+                            put("error", "suspension_update_failed")
+                        },
+                    )
+                    put(
+                        "cascade",
+                        JSONObject().apply {
+                            put("roomsClosed", 1)
+                            put("roomsUpdated", 0)
+                            put("partial", true)
+                            put("failedRoomIds", JSONArray(listOf("room-x")))
+                            put("userDocFailed", true)
+                            put("rtdbEventsFailed", 1)
+                            put("error", "cascade_failed")
+                        },
+                    )
+                }
+
+            val result = repo.resolveReport("report-1", "suspended")
+
+            assertTrue(result is Resource.Success)
+            val outcome = (result as Resource.Success).data
+            assertTrue(outcome.hasAnyFailure)
+            assertEquals("suspension_update_failed", outcome.suspension?.error)
+            assertEquals(true, outcome.cascade?.partial)
+            assertEquals("cascade_failed", outcome.cascade?.error)
+            assertEquals(listOf("room-x"), outcome.cascade?.failedRoomIds)
+        }
+
+    @Test
+    fun `resolveReport surfaces pms failure counters`() =
+        runTest {
+            coEvery { api.post(any(), any()) } returns
+                JSONObject().apply {
+                    put("success", true)
+                    put(
+                        "pms",
+                        JSONObject().apply {
+                            put("failed", 2)
+                            put("total", 3)
+                        },
+                    )
+                }
+
+            val result = repo.resolveReport("report-1", "warn")
+
+            assertTrue(result is Resource.Success)
+            val outcome = (result as Resource.Success).data
+            assertTrue(outcome.hasAnyFailure)
+            assertEquals(2, outcome.pms?.failed)
+            assertEquals(3, outcome.pms?.total)
+        }
+
+    @Test
+    fun `resolveReport ignores unknown extra keys on response body`() =
+        runTest {
+            // Forward compatibility: a future flag (e.g. cooldown) must not
+            // break older clients. Parser tolerates and ignores.
+            coEvery { api.post(any(), any()) } returns
+                JSONObject().apply {
+                    put("success", true)
+                    put(
+                        "cooldown",
+                        JSONObject().apply {
+                            put("failed", true)
+                            put("error", "cooldown_failed")
+                        },
+                    )
+                }
+
+            val result = repo.resolveReport("report-1", "warn")
+
+            assertTrue(result is Resource.Success)
+            val outcome = (result as Resource.Success).data
+            assertTrue(!outcome.hasAnyFailure)
         }
 
     // --- getPendingReports ---

--- a/app/src/test/java/com/shyden/shytalk/feature/messaging/ReportReviewViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/messaging/ReportReviewViewModelTest.kt
@@ -3,7 +3,10 @@ package com.shyden.shytalk.feature.messaging
 import androidx.lifecycle.viewModelScope
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.core.util.UiText
+import com.shyden.shytalk.data.repository.PmFailure
 import com.shyden.shytalk.data.repository.ReportRepository
+import com.shyden.shytalk.data.repository.ResolveReportOutcome
+import com.shyden.shytalk.data.repository.SubFailure
 import com.shyden.shytalk.data.repository.UserRepository
 import com.shyden.shytalk.testutil.MainDispatcherRule
 import com.shyden.shytalk.testutil.TestData
@@ -13,6 +16,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -85,7 +89,7 @@ class ReportReviewViewModelTest {
     fun `resolveReport success removes report from list`() =
         runTest {
             coEvery { reportRepository.getPendingReports() } returns Resource.Success(sampleReports)
-            coEvery { reportRepository.resolveReport("r2", "dismiss") } returns Resource.Success(Unit)
+            coEvery { reportRepository.resolveReport("r2", "dismiss") } returns Resource.Success(ResolveReportOutcome())
 
             val vm = createViewModel()
             advanceUntilIdle()
@@ -102,7 +106,7 @@ class ReportReviewViewModelTest {
     fun `resolveReport success sets Report resolved message`() =
         runTest {
             coEvery { reportRepository.getPendingReports() } returns Resource.Success(sampleReports)
-            coEvery { reportRepository.resolveReport("r1", "warn") } returns Resource.Success(Unit)
+            coEvery { reportRepository.resolveReport("r1", "warn") } returns Resource.Success(ResolveReportOutcome())
 
             val vm = createViewModel()
             advanceUntilIdle()
@@ -134,7 +138,7 @@ class ReportReviewViewModelTest {
     fun `clearMessage clears message`() =
         runTest {
             coEvery { reportRepository.getPendingReports() } returns Resource.Success(sampleReports)
-            coEvery { reportRepository.resolveReport("r1", "warn") } returns Resource.Success(Unit)
+            coEvery { reportRepository.resolveReport("r1", "warn") } returns Resource.Success(ResolveReportOutcome())
 
             val vm = createViewModel()
             advanceUntilIdle()
@@ -164,7 +168,7 @@ class ReportReviewViewModelTest {
     fun `resolveReport dismiss removes report from list`() =
         runTest {
             coEvery { reportRepository.getPendingReports() } returns Resource.Success(sampleReports)
-            coEvery { reportRepository.resolveReport("r1", "dismiss") } returns Resource.Success(Unit)
+            coEvery { reportRepository.resolveReport("r1", "dismiss") } returns Resource.Success(ResolveReportOutcome())
 
             val vm = createViewModel()
             advanceUntilIdle()
@@ -183,7 +187,7 @@ class ReportReviewViewModelTest {
     fun `resolveReport warn removes report and shows confirmation`() =
         runTest {
             coEvery { reportRepository.getPendingReports() } returns Resource.Success(sampleReports)
-            coEvery { reportRepository.resolveReport("r3", "warn") } returns Resource.Success(Unit)
+            coEvery { reportRepository.resolveReport("r3", "warn") } returns Resource.Success(ResolveReportOutcome())
 
             val vm = createViewModel()
             advanceUntilIdle()
@@ -202,7 +206,7 @@ class ReportReviewViewModelTest {
     fun `resolveReport multiple reports sequentially reduces list correctly`() =
         runTest {
             coEvery { reportRepository.getPendingReports() } returns Resource.Success(sampleReports)
-            coEvery { reportRepository.resolveReport(any(), any()) } returns Resource.Success(Unit)
+            coEvery { reportRepository.resolveReport(any(), any()) } returns Resource.Success(ResolveReportOutcome())
 
             val vm = createViewModel()
             advanceUntilIdle()
@@ -227,7 +231,7 @@ class ReportReviewViewModelTest {
         runTest {
             val singleReport = listOf(TestData.createTestReport(reportId = "r1", reason = "Spam"))
             coEvery { reportRepository.getPendingReports() } returns Resource.Success(singleReport)
-            coEvery { reportRepository.resolveReport("r1", "dismiss") } returns Resource.Success(Unit)
+            coEvery { reportRepository.resolveReport("r1", "dismiss") } returns Resource.Success(ResolveReportOutcome())
 
             val vm = createViewModel()
             advanceUntilIdle()
@@ -255,5 +259,124 @@ class ReportReviewViewModelTest {
             assertEquals(UiText.Plain("Connection timeout"), state.message)
             assertFalse(state.isLoading)
             assertTrue(state.reports.isEmpty())
+        }
+
+    // ─── Partial-failure surfacing (B6.12) ──────────────────────────
+    //
+    // When the backend resolveReport handler partially fails (warn write
+    // threw / suspension update threw / cascade partial / lock-release
+    // failed / PMs failed), the ViewModel must show a DIFFERENT toast so
+    // the admin doesn't get the misleading green "Report resolved" toast.
+    // Pre-B6.12 the VM collapsed every Resource.Success → green toast; the
+    // Web admin client (PR #355 Pass-9..12) already consumed the flags but
+    // the Kotlin admin UI did not. These tests pin the wiring.
+    //
+    // Note: assertions compare the UiText.Res *resource identity* across
+    // outcomes — JVM-test classpath does not expose `Res.string.xxx` (the
+    // Compose Multiplatform resource accessors are generated for the
+    // shared module, not :app), so we prove "different message per path"
+    // rather than naming the specific StringResource.
+
+    private suspend fun TestScope.resolveAndGetMessage(outcome: ResolveReportOutcome): UiText {
+        coEvery { reportRepository.getPendingReports() } returns Resource.Success(sampleReports)
+        coEvery { reportRepository.resolveReport(any(), any()) } returns Resource.Success(outcome)
+        val vm = createViewModel()
+        advanceUntilIdle()
+        vm.resolveReport("r1", "warn")
+        advanceUntilIdle()
+        return vm.uiState.value.message ?: error("expected message")
+    }
+
+    @Test
+    fun `resolveReport happy path emits a UiText_Res success message`() =
+        runTest {
+            val message = resolveAndGetMessage(ResolveReportOutcome())
+            assertTrue(message is UiText.Res)
+        }
+
+    @Test
+    fun `resolveReport with warning failure emits a different UiText_Res than happy path`() =
+        runTest {
+            val happy = resolveAndGetMessage(ResolveReportOutcome())
+            val partial =
+                resolveAndGetMessage(
+                    ResolveReportOutcome(warning = SubFailure("warning_create_failed")),
+                )
+            assertTrue(happy is UiText.Res)
+            assertTrue(partial is UiText.Res)
+            // Different StringResource ⇒ different UiText.Res ⇒ data class
+            // equality differs. Pre-B6.12 both paths shipped the same toast.
+            assertTrue(
+                "happy and partial messages must differ — got $happy on both",
+                happy != partial,
+            )
+        }
+
+    @Test
+    fun `resolveReport with suspension failure emits partial-failure message`() =
+        runTest {
+            val happy = resolveAndGetMessage(ResolveReportOutcome())
+            val partial =
+                resolveAndGetMessage(
+                    ResolveReportOutcome(suspension = SubFailure("suspension_update_failed")),
+                )
+            assertTrue(happy != partial)
+        }
+
+    @Test
+    fun `resolveReport with auditLog failure emits partial-failure message`() =
+        runTest {
+            val happy = resolveAndGetMessage(ResolveReportOutcome())
+            val partial =
+                resolveAndGetMessage(
+                    ResolveReportOutcome(auditLog = SubFailure("audit_write_failed")),
+                )
+            assertTrue(happy != partial)
+        }
+
+    @Test
+    fun `resolveReport with lockRelease failure emits partial-failure message`() =
+        runTest {
+            val happy = resolveAndGetMessage(ResolveReportOutcome())
+            val partial =
+                resolveAndGetMessage(
+                    ResolveReportOutcome(lockRelease = SubFailure(error = null)),
+                )
+            assertTrue(happy != partial)
+        }
+
+    @Test
+    fun `resolveReport with PM failure emits partial-failure message`() =
+        runTest {
+            val happy = resolveAndGetMessage(ResolveReportOutcome())
+            val partial =
+                resolveAndGetMessage(
+                    ResolveReportOutcome(pms = PmFailure(failed = 1, total = 2)),
+                )
+            assertTrue(happy != partial)
+        }
+
+    @Test
+    fun `resolveReport with partial failure still drops the report from the list`() =
+        runTest {
+            // Backend marks status='resolved' BEFORE running side-effects, so
+            // even a partial failure means the next pending-reports query
+            // won't return this report. The local-list filter must mirror.
+            coEvery { reportRepository.getPendingReports() } returns Resource.Success(sampleReports)
+            coEvery { reportRepository.resolveReport("r2", "warn") } returns
+                Resource.Success(
+                    ResolveReportOutcome(warning = SubFailure("warning_create_failed")),
+                )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            vm.resolveReport("r2", "warn")
+            advanceUntilIdle()
+
+            assertFalse(
+                vm.uiState.value.reports
+                    .any { it.reportId == "r2" },
+            )
+            assertEquals(2, vm.uiState.value.reports.size)
         }
 }

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">بيئة الاختبار</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">قم بتحميل أي صورة - هذه بيئة اختبار، ولا يلزم وجود معرفات حقيقية ولا يتم تخزينها على المدى الطويل.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">تم حل التقرير، ولكن لم تكتمل بعض الإجراءات. تحقق من لوحة الويب الخاصة بالمسؤول وأعد المحاولة حسب الحاجة.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -1690,4 +1690,6 @@
     <string name="age_verif_test_env_label">Testumgebung</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">Laden Sie ein beliebiges Bild hoch – dies ist eine Testumgebung, echte IDs sind nicht erforderlich und werden nicht langfristig gespeichert.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">Der Bericht wurde gelöst, aber einige Aktionen wurden nicht abgeschlossen. Überprüfen Sie das Admin-Webpanel und versuchen Sie es bei Bedarf erneut.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">Entorno de prueba</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">Cargue cualquier imagen: este es un entorno de prueba, no se requieren identificaciones reales y no se almacenan a largo plazo.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">Informe resuelto, pero algunas acciones no se completaron. Consulte el panel web de administración y vuelva a intentarlo según sea necesario.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -1688,4 +1688,6 @@
     <string name="age_verif_test_env_label">Environnement de test</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">Téléchargez n\'importe quelle image : il s\'agit d\'un environnement de test, les véritables identifiants ne sont pas requis et ne sont pas stockés à long terme.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">Rapport résolu, mais certaines actions n\'ont pas abouti. Vérifiez le panneau Web d\'administration et réessayez si nécessaire.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">परीक्षण वातावरण</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">कोई भी छवि अपलोड करें - यह एक परीक्षण वातावरण है, वास्तविक आईडी की आवश्यकता नहीं है और इसे लंबे समय तक संग्रहीत नहीं किया जाता है।</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">रिपोर्ट का समाधान हो गया, लेकिन कुछ कार्रवाइयां पूरी नहीं हुईं. व्यवस्थापक वेब पैनल की जाँच करें और आवश्यकतानुसार पुनः प्रयास करें।</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-id/strings.xml
+++ b/shared/src/commonMain/composeResources/values-id/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">Lingkungan pengujian</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">Unggah gambar apa pun — ini adalah lingkungan pengujian, ID asli tidak diperlukan dan tidak disimpan dalam jangka panjang.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">Laporan terselesaikan, namun beberapa tindakan tidak selesai. Periksa panel web admin dan coba lagi sesuai kebutuhan.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">Ambiente di prova</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">Carica qualsiasi immagine: questo è un ambiente di test, gli ID reali non sono richiesti e non vengono archiviati a lungo termine.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">Il report è stato risolto, ma alcune azioni non sono state completate. Controlla il pannello web di amministrazione e riprova se necessario.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">テスト環境</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">任意の画像をアップロードします。これはテスト環境であり、実際の ID は必要なく、長期保存されません。</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">レポートは解決されましたが、一部のアクションは完了しませんでした。管理 Web パネルを確認し、必要に応じて再試行してください。</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-km/strings.xml
+++ b/shared/src/commonMain/composeResources/values-km/strings.xml
@@ -1777,4 +1777,6 @@
     <string name="age_verif_test_env_label">បរិយាកាសសាកល្បង</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">បង្ហោះរូបភាពណាមួយ — នេះគឺជាបរិយាកាសសាកល្បង លេខសម្គាល់ពិតប្រាកដមិនត្រូវបានទាមទារ និងមិនត្រូវបានរក្សាទុករយៈពេលវែង។</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">របាយការណ៍ត្រូវបានដោះស្រាយ ប៉ុន្តែសកម្មភាពមួយចំនួនមិនបានបញ្ចប់ទេ។ ពិនិត្យផ្ទាំងគ្រប់គ្រងគេហទំព័រ ហើយព្យាយាមម្តងទៀតតាមតម្រូវការ។</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-ko/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ko/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">테스트 환경</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">이미지 업로드 - 이는 테스트 환경이므로 실제 ID가 필요하지 않으며 장기간 저장되지 않습니다.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">보고서가 해결되었지만 일부 작업이 완료되지 않았습니다. 관리자 웹 패널을 확인하고 필요에 따라 다시 시도하세요.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">Testomgeving</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">Upload een afbeelding – dit is een testomgeving, echte ID’s zijn niet vereist en worden niet langdurig bewaard.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">Rapport opgelost, maar sommige acties zijn niet voltooid. Controleer het beheerderswebpaneel en probeer het indien nodig opnieuw.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-pl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pl/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">Środowisko testowe</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">Prześlij dowolny obraz — jest to środowisko testowe, prawdziwe identyfikatory nie są wymagane i nie są przechowywane długoterminowo.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">Raport został rozwiązany, ale niektóre działania nie zostały ukończone. Sprawdź panel administracyjny i spróbuj ponownie, jeśli zajdzie taka potrzeba.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">Ambiente de teste</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">Faça upload de qualquer imagem – este é um ambiente de teste, IDs reais não são necessários e não são armazenados por longo prazo.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">Relatório resolvido, mas algumas ações não foram concluídas. Verifique o painel de administração da web e tente novamente conforme necessário.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">Тестовая среда</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">Загрузите любое изображение — это тестовая среда, настоящие идентификаторы не требуются и долговременно не хранятся.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">Отчет решен, но некоторые действия не выполнены. Проверьте веб-панель администратора и повторите попытку при необходимости.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-sv/strings.xml
+++ b/shared/src/commonMain/composeResources/values-sv/strings.xml
@@ -1691,4 +1691,6 @@
     <string name="age_verif_test_env_label">Testmiljö</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">Ladda upp vilken bild som helst – det här är en testmiljö, riktiga ID:n krävs inte och lagras inte på lång sikt.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">Rapporten löstes, men vissa åtgärder slutfördes inte. Kontrollera adminwebbpanelen och försök igen vid behov.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-th/strings.xml
+++ b/shared/src/commonMain/composeResources/values-th/strings.xml
@@ -1690,4 +1690,6 @@
     <string name="age_verif_test_env_label">สภาพแวดล้อมการทดสอบ</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">อัปโหลดรูปภาพใดๆ — นี่เป็นสภาพแวดล้อมการทดสอบ ไม่จำเป็นต้องใช้ ID จริงและไม่ได้จัดเก็บไว้ในระยะยาว</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">รายงานได้รับการแก้ไขแล้ว แต่การดำเนินการบางอย่างไม่เสร็จสมบูรณ์ ตรวจสอบแผงเว็บของผู้ดูแลระบบแล้วลองอีกครั้งตามความจำเป็น</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-tr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tr/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">Test ortamı</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">Herhangi bir görsel yükleyin — bu bir test ortamıdır, gerçek kimlikler gerekli değildir ve uzun süre saklanmaz.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">Rapor çözümlendi ancak bazı işlemler tamamlanmadı. Yönetici web panelini kontrol edin ve gerektiğinde yeniden deneyin.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -1691,4 +1691,6 @@
     <string name="age_verif_test_env_label">Тестове середовище</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">Завантажте будь-яке зображення — це тестове середовище, справжні ідентифікатори не потрібні та не зберігаються довго.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">Звіт вирішено, але деякі дії не виконано. Перевірте веб-панель адміністратора та за потреби повторіть спробу.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-vi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-vi/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">Môi trường thử nghiệm</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">Tải lên bất kỳ hình ảnh nào - đây là môi trường thử nghiệm, không yêu cầu ID thực và không được lưu trữ lâu dài.</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">Báo cáo đã được giải quyết nhưng một số hành động chưa hoàn tất. Kiểm tra bảng quản trị web và thử lại nếu cần.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -1692,4 +1692,6 @@
     <string name="age_verif_test_env_label">测试环境</string>
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_warning">上传任何图像 - 这是一个测试环境，不需要真实 ID，也不会长期存储。</string>
+    <!-- google-translated 2026-05-09 -->
+    <string name="success_report_resolved_with_issues">报告已解决，但某些操作未完成。检查管理 Web 面板并根据需要重试。</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -751,6 +751,7 @@
     <string name="success_redeemed_beans_bonus">Redeemed %1$s beans (10%% bonus!)</string>
     <string name="success_coins_added">+%1$s coins added!</string>
     <string name="success_report_resolved">Report resolved</string>
+    <string name="success_report_resolved_with_issues">Report resolved, but some actions did not complete. Check the admin web panel and retry as needed.</string>
     <string name="success_super_shy_activated">Super Shy activated! +30 days</string>
     <string name="success_sent_backpack">entire backpack (%1$d items)</string>
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/ReportJsonParser.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/ReportJsonParser.kt
@@ -1,10 +1,16 @@
 package com.shyden.shytalk.data.repository
 
 import com.shyden.shytalk.feature.messaging.Report
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
+
+private val resolveReportJson = Json { ignoreUnknownKeys = true }
 
 /**
  * Parses a single report JSON object as emitted by `GET /api/reports`
@@ -32,3 +38,141 @@ internal fun parseReportFromApi(obj: JsonObject): Report =
         timestamp = obj["createdAt"]?.jsonPrimitive?.longOrNull ?: 0L,
         status = obj["status"]?.jsonPrimitive?.contentOrNull ?: "pending",
     )
+
+/**
+ * Per-sub-action failure surfaced from the moderation partial-failure
+ * contract (see `express-api/src/routes/reports.js` MOD_ERROR + memory
+ * `feedback-partial-failure-contracts.md`). A non-null instance ALWAYS
+ * means the sub-action did NOT land server-side. `error` carries the
+ * stable token (`warning_create_failed`, `suspension_update_failed`,
+ * `audit_write_failed`) so the admin client can branch on the cause;
+ * `lockRelease` emits no token because the only retry strategy is
+ * "send the resolve again".
+ */
+data class SubFailure(
+    val error: String?,
+)
+
+/**
+ * Cascade outcome from `evictSuspendedUser` — surfaced ONLY when the
+ * resolve action is "suspended" and the cascade ran. `partial=true`
+ * means at least one room or the user-doc update failed and the admin
+ * UI should warn about manual cleanup; `partial=false` is the success
+ * shape and is informational only (`hasAnyFailure` ignores it).
+ */
+data class CascadeOutcome(
+    val roomsClosed: Int = 0,
+    val roomsUpdated: Int = 0,
+    val partial: Boolean = false,
+    val failedRoomIds: List<String> = emptyList(),
+    val userDocFailed: Boolean = false,
+    val rtdbEventsFailed: Int = 0,
+    val error: String? = null,
+)
+
+/**
+ * PM partial-failure counter. `failed` and `total` are summed across
+ * the warn-PM, suspend-PM, and reporter-PM dispatch; the admin sees
+ * "2 of 3 PMs failed" rather than three separate flags. Surfaced only
+ * when at least one PM fails (matches the server's
+ * `if (failedSinglePms > 0)` gate).
+ */
+data class PmFailure(
+    val failed: Int,
+    val total: Int,
+)
+
+/**
+ * Outcome of `POST /api/reports/:id/resolve`. ANY non-null sub-failure
+ * indicates a partial-success that the admin must see — the moderation
+ * applied SOME side-effects but not all. Replaces the `Resource<Unit>`
+ * shape that previously discarded the response body and silently green-
+ * toasted partial failures (the very bug PR #355 Pass-9 surfaced for
+ * the web client; this fix wires the same contract to the Kotlin
+ * admin client).
+ */
+data class ResolveReportOutcome(
+    val warning: SubFailure? = null,
+    val suspension: SubFailure? = null,
+    val auditLog: SubFailure? = null,
+    val lockRelease: SubFailure? = null,
+    val cascade: CascadeOutcome? = null,
+    val pms: PmFailure? = null,
+) {
+    /**
+     * True iff at least one sub-action failed. Cascade is folded in only
+     * when `partial=true` — a clean cascade carries informational counters
+     * but is NOT a failure.
+     */
+    val hasAnyFailure: Boolean
+        get() =
+            warning != null ||
+                suspension != null ||
+                auditLog != null ||
+                lockRelease != null ||
+                pms != null ||
+                (cascade?.partial == true)
+}
+
+private fun parseSubFailure(obj: JsonObject?): SubFailure? {
+    if (obj == null) return null
+    val failed = obj["failed"]?.jsonPrimitive?.booleanOrNull ?: false
+    if (!failed) return null
+    return SubFailure(error = obj["error"]?.jsonPrimitive?.contentOrNull)
+}
+
+private fun parseCascade(obj: JsonObject?): CascadeOutcome? {
+    if (obj == null) return null
+    val failedRoomIds: List<String> =
+        (obj["failedRoomIds"] as? JsonArray)?.mapNotNull {
+            it.jsonPrimitive.contentOrNull
+        } ?: emptyList()
+    return CascadeOutcome(
+        roomsClosed = obj["roomsClosed"]?.jsonPrimitive?.intOrNull ?: 0,
+        roomsUpdated = obj["roomsUpdated"]?.jsonPrimitive?.intOrNull ?: 0,
+        partial = obj["partial"]?.jsonPrimitive?.booleanOrNull ?: false,
+        failedRoomIds = failedRoomIds,
+        userDocFailed = obj["userDocFailed"]?.jsonPrimitive?.booleanOrNull ?: false,
+        rtdbEventsFailed = obj["rtdbEventsFailed"]?.jsonPrimitive?.intOrNull ?: 0,
+        error = obj["error"]?.jsonPrimitive?.contentOrNull,
+    )
+}
+
+private fun parsePms(obj: JsonObject?): PmFailure? {
+    if (obj == null) return null
+    val failed = obj["failed"]?.jsonPrimitive?.intOrNull ?: 0
+    val total = obj["total"]?.jsonPrimitive?.intOrNull ?: 0
+    if (failed <= 0) return null
+    return PmFailure(failed = failed, total = total)
+}
+
+/**
+ * Parse a `POST /api/reports/:id/resolve` response body into the typed
+ * partial-failure outcome. Forward-compatible: unknown top-level keys
+ * are ignored. Symmetric with the server-side MOD_ERROR contract.
+ */
+fun parseResolveReportOutcome(obj: JsonObject): ResolveReportOutcome =
+    ResolveReportOutcome(
+        warning = parseSubFailure(obj["warning"] as? JsonObject),
+        suspension = parseSubFailure(obj["suspension"] as? JsonObject),
+        auditLog = parseSubFailure(obj["auditLog"] as? JsonObject),
+        lockRelease = parseSubFailure(obj["lockRelease"] as? JsonObject),
+        cascade = parseCascade(obj["cascade"] as? JsonObject),
+        pms = parsePms(obj["pms"] as? JsonObject),
+    )
+
+/**
+ * String overload for callers (notably the Android `:app` module) that
+ * speak `org.json.JSONObject` and don't have kotlinx.serialization on
+ * their classpath. The hop is `JSONObject.toString()` → parse here →
+ * structured outcome — paid only on resolveReport, never on hot loops.
+ * Returns an empty outcome on malformed JSON rather than throwing,
+ * because the caller already wraps the call site in `firebaseCall` and
+ * a parse failure on the success path should still surface as
+ * "moderation applied" — the lost flags become visible in the next
+ * pending-reports query (status=resolved + admin sees the wrong state).
+ */
+fun parseResolveReportOutcome(rawJson: String): ResolveReportOutcome =
+    runCatching {
+        resolveReportJson.parseToJsonElement(rawJson) as? JsonObject
+    }.getOrNull()?.let(::parseResolveReportOutcome) ?: ResolveReportOutcome()

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/ReportRepository.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/ReportRepository.kt
@@ -37,5 +37,5 @@ interface ReportRepository {
     suspend fun resolveReport(
         reportId: String,
         action: String,
-    ): Resource<Unit>
+    ): Resource<ResolveReportOutcome>
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ReportReviewViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ReportReviewViewModel.kt
@@ -81,12 +81,40 @@ class ReportReviewViewModel(
         action: String,
     ) {
         viewModelScope.launch {
-            when (reportRepository.resolveReport(reportId, action)) {
+            when (val result = reportRepository.resolveReport(reportId, action)) {
                 is Resource.Success -> {
+                    // Always drop the report from the local list — even on
+                    // partial-failure the backend marks `status:'resolved'`
+                    // before any sub-action runs, so the report won't return
+                    // on the next pending-reports query. Keeping it in the
+                    // list would mislead the admin into thinking the resolve
+                    // can be retried in-place; the retry path is per-sub-
+                    // action through the targeted admin tabs (warn, suspend).
+                    val outcome = result.data
+                    val message =
+                        if (outcome.hasAnyFailure) {
+                            // Log the structured outcome so an admin reading
+                            // logcat can see WHICH sub-action failed (the toast
+                            // is intentionally generic — full detail belongs in
+                            // the admin web panel, not a phone toast).
+                            logI(
+                                TAG,
+                                "Report $reportId resolved with partial failure: " +
+                                    "warning=${outcome.warning?.error} " +
+                                    "suspension=${outcome.suspension?.error} " +
+                                    "auditLog=${outcome.auditLog?.error} " +
+                                    "lockRelease=${outcome.lockRelease != null} " +
+                                    "cascade.partial=${outcome.cascade?.partial} " +
+                                    "pms=${outcome.pms?.failed}/${outcome.pms?.total}",
+                            )
+                            UiText.res(Res.string.success_report_resolved_with_issues)
+                        } else {
+                            UiText.res(Res.string.success_report_resolved)
+                        }
                     _uiState.update {
                         it.copy(
                             reports = it.reports.filter { r -> r.reportId != reportId },
-                            message = UiText.res(Res.string.success_report_resolved),
+                            message = message,
                         )
                     }
                 }

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/data/repository/ReportJsonParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/data/repository/ReportJsonParserTest.kt
@@ -4,6 +4,10 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Lock down the `GET /api/reports` JSON contract on the iOS-shared parser.
@@ -70,5 +74,217 @@ class ReportJsonParserTest {
         assertEquals(0L, report.reporterUniqueId)
         assertEquals(0L, report.reportedUserUniqueId)
         assertEquals(0L, report.timestamp)
+    }
+
+    // ─── parseResolveReportOutcome — partial-failure contract ───
+    //
+    // The Express POST /reports/:id/resolve handler emits per-sub-action failure
+    // flags so the admin client can distinguish "everything applied" from
+    // "warning failed, the user was NOT warned, please retry" (see
+    // express-api/src/routes/reports.js MOD_ERROR + memory
+    // feedback-partial-failure-contracts.md). These tests pin the on-wire
+    // shape so the Kotlin client never silently regresses to a green-toast
+    // for a partial-failure response.
+
+    @Test
+    fun `resolve outcome — happy path has no failure flags`() {
+        val obj = json.parseToJsonElement("""{"success":true}""") as JsonObject
+        val outcome = parseResolveReportOutcome(obj)
+        assertNull(outcome.warning)
+        assertNull(outcome.suspension)
+        assertNull(outcome.auditLog)
+        assertNull(outcome.lockRelease)
+        assertNull(outcome.cascade)
+        assertNull(outcome.pms)
+        assertFalse(outcome.hasAnyFailure)
+    }
+
+    @Test
+    fun `resolve outcome — warning failure carries server error token`() {
+        val obj =
+            json.parseToJsonElement(
+                """{"success":true,"warning":{"failed":true,"error":"warning_create_failed"}}""",
+            ) as JsonObject
+        val outcome = parseResolveReportOutcome(obj)
+        val warning = outcome.warning
+        assertNotNull(warning)
+        assertEquals("warning_create_failed", warning.error)
+        assertTrue(outcome.hasAnyFailure)
+    }
+
+    @Test
+    fun `resolve outcome — suspension failure carries server error token`() {
+        val obj =
+            json.parseToJsonElement(
+                """{"success":true,"suspension":{"failed":true,"error":"suspension_update_failed"}}""",
+            ) as JsonObject
+        val outcome = parseResolveReportOutcome(obj)
+        val suspension = outcome.suspension
+        assertNotNull(suspension)
+        assertEquals("suspension_update_failed", suspension.error)
+        assertTrue(outcome.hasAnyFailure)
+    }
+
+    @Test
+    fun `resolve outcome — auditLog failure carries server error token`() {
+        val obj =
+            json.parseToJsonElement(
+                """{"success":true,"auditLog":{"failed":true,"error":"audit_write_failed"}}""",
+            ) as JsonObject
+        val outcome = parseResolveReportOutcome(obj)
+        val auditLog = outcome.auditLog
+        assertNotNull(auditLog)
+        assertEquals("audit_write_failed", auditLog.error)
+        assertTrue(outcome.hasAnyFailure)
+    }
+
+    @Test
+    fun `resolve outcome — lockRelease failure has no error token but is surfaced`() {
+        // The server emits {failed:true} only — lockRelease has no MOD_ERROR
+        // token because the admin doesn't need to distinguish lock-write
+        // causes; just retrying clears it.
+        val obj =
+            json.parseToJsonElement(
+                """{"success":true,"lockRelease":{"failed":true}}""",
+            ) as JsonObject
+        val outcome = parseResolveReportOutcome(obj)
+        val lockRelease = outcome.lockRelease
+        assertNotNull(lockRelease)
+        assertNull(lockRelease.error)
+        assertTrue(outcome.hasAnyFailure)
+    }
+
+    @Test
+    fun `resolve outcome — cascade success surfaces counts but no failure`() {
+        val obj =
+            json.parseToJsonElement(
+                """{"success":true,"cascade":{"roomsClosed":2,"roomsUpdated":3,"partial":false,"failedRoomIds":[],"userDocFailed":false,"rtdbEventsFailed":0,"error":null}}""",
+            ) as JsonObject
+        val outcome = parseResolveReportOutcome(obj)
+        val cascade = outcome.cascade
+        assertNotNull(cascade)
+        assertEquals(2, cascade.roomsClosed)
+        assertEquals(3, cascade.roomsUpdated)
+        assertFalse(cascade.partial)
+        assertNull(cascade.error)
+        // cascade.partial=false ⇒ cascade does NOT count as a failure.
+        assertFalse(outcome.hasAnyFailure)
+    }
+
+    @Test
+    fun `resolve outcome — cascade partial surfaces failed room ids`() {
+        val obj =
+            json.parseToJsonElement(
+                """{"success":true,"cascade":{"roomsClosed":1,"roomsUpdated":0,"partial":true,"failedRoomIds":["room-a","room-b"],"userDocFailed":true,"rtdbEventsFailed":2,"error":"cascade_failed"}}""",
+            ) as JsonObject
+        val outcome = parseResolveReportOutcome(obj)
+        val cascade = outcome.cascade
+        assertNotNull(cascade)
+        assertTrue(cascade.partial)
+        assertEquals(listOf("room-a", "room-b"), cascade.failedRoomIds)
+        assertTrue(cascade.userDocFailed)
+        assertEquals(2, cascade.rtdbEventsFailed)
+        assertEquals("cascade_failed", cascade.error)
+        assertTrue(outcome.hasAnyFailure)
+    }
+
+    @Test
+    fun `resolve outcome — pms surfaces failed-of-total counters`() {
+        val obj =
+            json.parseToJsonElement(
+                """{"success":true,"pms":{"failed":2,"total":3}}""",
+            ) as JsonObject
+        val outcome = parseResolveReportOutcome(obj)
+        val pms = outcome.pms
+        assertNotNull(pms)
+        assertEquals(2, pms.failed)
+        assertEquals(3, pms.total)
+        assertTrue(outcome.hasAnyFailure)
+    }
+
+    @Test
+    fun `resolve outcome — multiple failures surface independently`() {
+        // Pathological worst case: warn + suspend both threw, audit failed,
+        // lock-release failed, cascade is partial, both user-target and
+        // reporter PMs failed. The admin needs to see every flag so they
+        // can decide which sub-action to retry first.
+        val obj =
+            json.parseToJsonElement(
+                """{"success":true,
+                  "warning":{"failed":true,"error":"warning_create_failed"},
+                  "suspension":{"failed":true,"error":"suspension_update_failed"},
+                  "auditLog":{"failed":true,"error":"audit_write_failed"},
+                  "lockRelease":{"failed":true},
+                  "cascade":{"roomsClosed":0,"roomsUpdated":0,"partial":true,"failedRoomIds":["x"],"userDocFailed":true,"rtdbEventsFailed":1,"error":"cascade_failed"},
+                  "pms":{"failed":2,"total":2}}""",
+            ) as JsonObject
+        val outcome = parseResolveReportOutcome(obj)
+        assertNotNull(outcome.warning)
+        assertNotNull(outcome.suspension)
+        assertNotNull(outcome.auditLog)
+        assertNotNull(outcome.lockRelease)
+        assertNotNull(outcome.cascade)
+        assertNotNull(outcome.pms)
+        assertTrue(outcome.hasAnyFailure)
+    }
+
+    @Test
+    fun `resolve outcome — failed flag false is treated as no failure`() {
+        // Defensive: the server should never emit `{failed:false}` (a missing
+        // sub-key signals success), but if a future regression starts emitting
+        // an explicit false, the parser must NOT mis-flag it as a failure.
+        val obj =
+            json.parseToJsonElement(
+                """{"success":true,"warning":{"failed":false}}""",
+            ) as JsonObject
+        val outcome = parseResolveReportOutcome(obj)
+        assertNull(outcome.warning)
+        assertFalse(outcome.hasAnyFailure)
+    }
+
+    @Test
+    fun `resolve outcome — string overload parses JSON body identically`() {
+        // The Android :app module passes JSONObject.toString(); the string
+        // overload must yield the same outcome as parsing the JsonObject
+        // directly so platform-divergent regressions are impossible.
+        val raw = """{"success":true,"warning":{"failed":true,"error":"warning_create_failed"}}"""
+        val outcome = parseResolveReportOutcome(raw)
+        val warning = outcome.warning
+        assertNotNull(warning)
+        assertEquals("warning_create_failed", warning.error)
+    }
+
+    @Test
+    fun `resolve outcome — string overload swallows malformed JSON`() {
+        // Malformed JSON must NOT throw — the caller already wraps the
+        // resolveReport call in firebaseCall, and turning a parse miss into
+        // a Resource.Error would tell the admin the moderation didn't
+        // apply (it did, the report row was already updated server-side).
+        val outcome = parseResolveReportOutcome("not valid json {")
+        assertFalse(outcome.hasAnyFailure)
+        assertNull(outcome.warning)
+    }
+
+    @Test
+    fun `resolve outcome — string overload of non-object JSON returns empty outcome`() {
+        // Defensive: if the server ever returns a JSON array or scalar
+        // (it shouldn't — but a future bug could), don't crash the admin.
+        val outcome = parseResolveReportOutcome("[1, 2, 3]")
+        assertFalse(outcome.hasAnyFailure)
+    }
+
+    @Test
+    fun `resolve outcome — unknown extra keys on body are ignored`() {
+        // Forward compatibility: a future server-side flag (e.g. `cooldown`)
+        // must not crash older clients. Parser must read only known keys.
+        val obj =
+            json.parseToJsonElement(
+                """{"success":true,"cooldown":{"failed":true,"error":"cooldown_failed"},"warning":{"failed":true,"error":"warning_create_failed"}}""",
+            ) as JsonObject
+        val outcome = parseResolveReportOutcome(obj)
+        assertNotNull(outcome.warning)
+        // No surprise mapping of unknown keys onto known fields.
+        assertNull(outcome.suspension)
+        assertNull(outcome.auditLog)
     }
 }

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosSmallRepositories.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosSmallRepositories.kt
@@ -203,12 +203,14 @@ class IosReportRepositoryImpl(
     override suspend fun resolveReport(
         reportId: String,
         action: String,
-    ): Resource<Unit> =
+    ): Resource<ResolveReportOutcome> =
         firebaseCall("Failed to resolve report") {
-            api.post(
-                "/api/reports/$reportId/resolve",
-                JsonObject(mapOf("action" to JsonPrimitive(action))),
-            )
+            val response =
+                api.post(
+                    "/api/reports/$reportId/resolve",
+                    JsonObject(mapOf("action" to JsonPrimitive(action))),
+                )
+            parseResolveReportOutcome(response)
         }
 }
 


### PR DESCRIPTION
## Summary

Roadmap top priority **B6.12**. The Express \`POST /api/reports/:id/resolve\` handler emits per-sub-action failure flags (\`warning\`, \`suspension\`, \`auditLog\`, \`lockRelease\`, \`cascade\`, \`pms\`) so the admin can distinguish *"everything applied"* from *"warning failed, the user was NOT warned, please retry"*. The web admin client consumed these flags since PR #355 Pass-9..12, but the **Kotlin admin client** discarded the response body and shipped a misleading green "Report resolved" toast on every \`Resource.Success\` — exactly the silent-failure shape the partial-failure contract was designed to prevent.

This PR wires the contract end-to-end on the Kotlin side (Android + iOS + commonMain).

### Wire diagram

\`\`\`
Express  →  {success, warning?, suspension?, auditLog?, lockRelease?, cascade?, pms?}
              │
              ▼
Kotlin    →  parseResolveReportOutcome(JsonObject | String)  ← commonMain
              │
              ▼
Repo      →  Resource<ResolveReportOutcome>                  ← Android + iOS impls
              │
              ▼
ViewModel →  outcome.hasAnyFailure ? partial-failure toast
                                   : success toast
\`\`\`

### TDD harvest — 25 new tests

| Suite | Existing | Added | Total | Status |
|---|---|---|---|---|
| \`ReportJsonParserTest\` (commonTest) | 5 | 14 | 19 | ✅ all pass |
| \`ReportRepositoryImplTest\` (jvmTest) | 11 | 4 | 15 | ✅ all pass |
| \`ReportReviewViewModelTest\` (jvmTest) | 12 | 7 | 19 | ✅ all pass |

Coverage: every failure flag (warning/suspension/auditLog/lockRelease/cascade.partial/pms), all-flags-combined worst case, unknown-keys forward-compat, malformed-JSON resilience, non-object JSON, success-path (\`hasAnyFailure == false\`), partial-success-still-drops-from-list invariant.

### Implementation notes

- \`parseResolveReportOutcome\` exposed as both \`(JsonObject)\` (iOS native) and \`(String)\` overloads. The string overload keeps \`kotlinx.serialization\` a shared-internal dep — \`:app\` stays on \`org.json\` with no new transitive classpath weight.
- The string overload swallows malformed JSON returning an empty outcome — the moderation already applied server-side; turning a parse miss into \`Resource.Error\` would mislead the admin into thinking the resolve didn't apply.
- ViewModel still drops the report from the local list on partial-failure: backend marks \`status: 'resolved'\` BEFORE running side-effects, so the report won't return on the next pending-reports query. Retry path is per-sub-action through the targeted admin tabs (warn, suspend) — exactly what the surfaced flags tell the admin.
- New string \`success_report_resolved_with_issues\` translated via Google to all 19 non-EN locales (\`scripts/translate-strings.js\`).

Symmetric with PR #355 (web admin) and PR #385/#392/#393 (admin-bans / economy / devices / warn / backpack PMs).

## Test plan

- [x] \`./gradlew :shared:jvmTest :app:testDevDebugUnitTest :shared:compileKotlinIosArm64 detekt\` — BUILD SUCCESSFUL
- [x] \`ktlint --relative\` — 0 violations
- [x] 25 new tests, 0 failures, 0 skipped
- [x] iOS arm64 compile — green (no JVM-only APIs leaked into commonMain)
- [x] All 20 locales updated (Google-translated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)