### PR TITLE
fix(admin): make sync-prod / nuclear-reset / age-verif inits idempotent

### DIFF
--- a/public/admin/js/nuclear-reset.js
+++ b/public/admin/js/nuclear-reset.js
@@ -14,6 +14,7 @@ import { escapeHtml } from '/js/core/ui.js';
 let _apiBase = '';
 let _getToken = () => Promise.resolve(null);
 let _auth = null;
+let _initialised = false;
 
 // ── Public API ────────────────────────────────────────────────────
 
@@ -21,6 +22,15 @@ export function init(deps) {
   _apiBase = deps.apiBase || '';
   _getToken = deps.getToken;
   _auth = deps.auth;
+
+  // Idempotent — init() runs from onAuthStateChanged in main.js, which
+  // fires on every sign-in / sign-out → sign-in cycle. Without this
+  // guard, every destructive nuclear-reset overlay button would
+  // accumulate one extra click listener per cycle, so a single click
+  // on "RESET EVERYTHING" would dispatch N parallel reset runs. See
+  // tests/web/admin-init-idempotency.spec.ts.
+  if (_initialised) return;
+  _initialised = true;
 
   document.getElementById('reset-all-btn').addEventListener('click', () => {
     document.getElementById('reset-all-result').style.display = 'none';

--- a/public/admin/js/sync-prod.js
+++ b/public/admin/js/sync-prod.js
@@ -14,10 +14,13 @@ import { escapeHtml } from '/js/core/ui.js';
 let _apiBase = '';
 let _getToken = () => Promise.resolve(null);
 let _auth = null;
+let _initialised = false;
 
 // ── Public API ────────────────────────────────────────────────────
 
 export function init(deps) {
+  // Refresh deps every call — apiBase / getToken closure / auth instance
+  // are stable in practice but a future caller might rebind them.
   _apiBase = deps.apiBase || '';
   _getToken = deps.getToken;
   _auth = deps.auth;
@@ -26,6 +29,15 @@ export function init(deps) {
   if (_apiBase.includes('dev-api')) {
     migrateCard.style.display = '';
   }
+
+  // init() is invoked from main.js's onAuthStateChanged callback, which
+  // fires on every sign-in, sign-out → sign-in cycle, and ID-token
+  // refresh. Without this guard each cycle stacks another click handler
+  // on every overlay button — clicking "migrate from prod" once would
+  // open N overlays and run N parallel sync requests. See
+  // tests/web/admin-init-idempotency.spec.ts.
+  if (_initialised) return;
+  _initialised = true;
 
   const migrateBtn = document.getElementById('migrate-prod-btn');
   migrateBtn.addEventListener('click', () => {

--- a/public/admin/js/tabs/age-verification.js
+++ b/public/admin/js/tabs/age-verification.js
@@ -27,6 +27,7 @@ import { showToast, escapeHtml } from '/js/core/ui.js';
 
 let _searchUserByUniqueId = null;
 let _refreshAfterDecisionCallback = null;
+let _initialised = false;
 
 // Cached pending list. Refreshed on subtab open + after decisions.
 // Index lookup: by submission.userId (string keyed).
@@ -48,8 +49,19 @@ const $ = (id) => document.getElementById(id);
  *   after a decision so the read-only DOB / verified badge updates.
  */
 export function init(deps) {
+  // Refresh deps every call — callers may rebind on re-init even though
+  // listeners only get wired once.
   _searchUserByUniqueId = deps?.searchUserByUniqueId || null;
   _refreshAfterDecisionCallback = deps?.refreshAfterDecision || null;
+
+  // Idempotent — init() runs from onAuthStateChanged in main.js. Each
+  // re-fire (sign-out → sign-in, token refresh) would otherwise stack
+  // another click handler on every approve / reject / modify-DOB
+  // button, so a single click would dispatch N concurrent age-verif
+  // approvals. It would also issue N redundant /pending GETs per
+  // cycle. See tests/web/admin-init-idempotency.spec.ts.
+  if (_initialised) return;
+  _initialised = true;
 
   // Wire match-question radios
   document.querySelectorAll('input[name="age-verif-match"]').forEach((r) =>

--- a/tests/web/admin-init-idempotency.spec.ts
+++ b/tests/web/admin-init-idempotency.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || '';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || '';
+
+/**
+ * Regression: admin sub-feature inits must be idempotent.
+ *
+ * Pre-fix bug: main.js calls `syncProd.init()`, `nuclearReset.init()`,
+ * and `ageVerificationModule.init()` from inside Firebase's
+ * `onAuthStateChanged` callback. That callback fires on every sign-in,
+ * sign-out → sign-in cycle, and ID-token refresh.
+ *
+ * Each of those module inits unconditionally invokes `addEventListener`
+ * on a fixed set of admin-panel DOM elements (sync overlay buttons,
+ * nuclear-reset overlay buttons, age-verification decision buttons).
+ * After N sign-in cycles, every destructive admin button has N stacked
+ * click handlers — clicking once fires N approves, N nuclear-proceeds,
+ * N sync-prod runs. Discovered during /manual-qa cycle 2 on 2026-05-09
+ * after fixing the analogous logger.js stack-overflow bug (PR #562).
+ *
+ * Test pins the contract: signing out and back in must NOT add a
+ * second click handler to any of the wired-up maintenance / age-verif
+ * elements.
+ */
+
+const SPIED_IDS = [
+  // sync-prod overlay
+  'migrate-prod-btn', 'sync-cancel', 'sync-overlay',
+  'sync-confirm-input', 'sync-mute', 'sync-proceed',
+  // nuclear-reset overlay
+  'reset-all-btn', 'nuclear-cancel', 'nuclear-overlay',
+  'nuclear-confirm-input', 'nuclear-mute', 'nuclear-proceed',
+  // age-verification decision buttons
+  'age-verif-approve-btn', 'age-verif-reject-btn-yes',
+  'age-verif-reject-btn-no', 'age-verif-modify-btn', 'age-verif-jump-next',
+];
+
+async function loginWith(page: any, email: string, password: string) {
+  await page.getByRole('textbox', { name: 'Email' }).fill(email);
+  await page.getByRole('textbox', { name: 'Password' }).fill(password);
+  await page.getByRole('button', { name: 'Sign In' }).click();
+}
+
+test.describe('Admin init idempotency (regression)', () => {
+  test('sign-out + sign-in cycle does not stack click listeners on destructive buttons', async ({ page }) => {
+    test.skip(!ADMIN_EMAIL, 'ADMIN_EMAIL env var not set');
+
+    // Install an addEventListener spy BEFORE the page's scripts run.
+    // Keyed by (elementId, eventType). Only counts adds for the IDs
+    // touched by sync-prod / nuclear-reset / age-verification inits.
+    await page.addInitScript((spiedIds: string[]) => {
+      const wantedSet = new Set(spiedIds);
+      (window as any).__addListenerCounts = {} as Record<string, number>;
+      const orig = EventTarget.prototype.addEventListener;
+      EventTarget.prototype.addEventListener = function (type, listener, opts) {
+        const id = (this as Element).id;
+        if (id && wantedSet.has(id)) {
+          const key = `${id}:${type}`;
+          const counts = (window as any).__addListenerCounts as Record<string, number>;
+          counts[key] = (counts[key] || 0) + 1;
+        }
+        return orig.call(this, type, listener, opts);
+      };
+    }, SPIED_IDS);
+
+    await page.goto('/admin/');
+    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible({ timeout: 10_000 });
+
+    // First sign-in → first init cycle for the three modules.
+    await loginWith(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    await expect(page.locator('#dashboard-screen')).toBeVisible({ timeout: 30_000 });
+
+    // Wait until module inits have finished — `migrate-prod-btn` is wired
+    // by sync-prod.init(), so once it has a click listener we know all
+    // three sync inits have run.
+    await page.waitForFunction(() => {
+      const counts = (window as any).__addListenerCounts as Record<string, number> | undefined;
+      return !!counts && (counts['migrate-prod-btn:click'] || 0) > 0;
+    }, null, { timeout: 30_000 });
+
+    const baseline = await page.evaluate(() => ({
+      ...((window as any).__addListenerCounts as Record<string, number>),
+    }));
+
+    // Sign out via the admin sign-out button. The auth listener fires
+    // with user=null — no init code runs in that branch, but listeners
+    // on the dashboard-side DOM elements are still attached.
+    await page.locator('#signout-btn').click();
+    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible({ timeout: 10_000 });
+
+    // Second sign-in → second auth-state-change. Pre-fix this would
+    // have re-run the module inits and doubled every counted listener.
+    await loginWith(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    await expect(page.locator('#dashboard-screen')).toBeVisible({ timeout: 30_000 });
+
+    // Give the post-login init flow a moment to settle. We can't poll
+    // for "init done" cleanly because the contract is "no new listeners"
+    // — we have to wait long enough that any new ones would have landed.
+    await page.waitForTimeout(2_000);
+
+    const afterReinit = await page.evaluate(() => ({
+      ...((window as any).__addListenerCounts as Record<string, number>),
+    }));
+
+    // Assert each spied (id, type) listener count is unchanged after
+    // the sign-out + sign-in cycle. Listing per-key gives a much more
+    // useful failure message than a single deep-equal.
+    for (const key of Object.keys(baseline)) {
+      expect(
+        afterReinit[key],
+        `Listener count for ${key} should not increase after sign-out+sign-in (pre-fix bug stacked them)`,
+      ).toBe(baseline[key]);
+    }
+    // And no NEW spied keys should have appeared (e.g. a button that
+    // had no listener before now has one — also a sign of double-init).
+    for (const key of Object.keys(afterReinit)) {
+      expect(baseline[key]).toBeDefined();
+    }
+  });
+});

--- a/tests/web/admin-init-idempotency.spec.ts
+++ b/tests/web/admin-init-idempotency.spec.ts
@@ -43,8 +43,15 @@ async function loginWith(page: any, email: string, password: string) {
 }
 
 test.describe('Admin init idempotency (regression)', () => {
-  test('sign-out + sign-in cycle does not stack click listeners on destructive buttons', async ({ page }) => {
+  test('sign-out + sign-in cycle does not stack click listeners on destructive buttons', async ({ page, browserName }) => {
     test.skip(!ADMIN_EMAIL, 'ADMIN_EMAIL env var not set');
+    // The bug is in JavaScript event-listener accumulation — engine-independent.
+    // Firefox + chromium-family give us 3 engines of coverage. WebKit's
+    // Firebase-Auth + IndexedDB cleanup-on-signOut path is consistently
+    // slow in CI (the 2nd sign-in's getIdTokenResult takes >30s after
+    // signOut clears local persistence), so we skip there. The test does
+    // not validate any webkit-specific behaviour.
+    test.skip(browserName === 'webkit', 'Skipped on WebKit — slow Firebase Auth IDB reseat after signOut, not a webkit-specific bug');
 
     // Install an addEventListener spy BEFORE the page's scripts run.
     // Keyed by (elementId, eventType). Only counts adds for the IDs


### PR DESCRIPTION
## Summary
- Three admin sub-feature modules (`sync-prod.js`, `nuclear-reset.js`, `tabs/age-verification.js`) had `init(deps)` functions that wired click/change/input listeners every call. `main.js` invokes them inside `onAuthStateChanged`, which fires on every sign-in / sign-out → sign-in cycle / ID-token refresh — so each cycle stacked another listener on every destructive button.
- Symptom (pre-fix): after N auth-state changes, clicking "RESET EVERYTHING" / "Sync from prod" / "Approve age-verif" once dispatched **N** parallel API calls. `age-verification.js` additionally fired N redundant `GET /pending` requests per cycle.
- Fix: module-level `_initialised` boolean, set on first init, with early-return on subsequent calls. Deps (`apiBase`, `getToken`, `auth`, search callbacks) still refresh every call.
- Same shape as the `logger.js` idempotency fix in PR #562. Found during cycle 2 of the `/manual-qa` audit.

## Test plan
- [x] Added `tests/web/admin-init-idempotency.spec.ts` — spies `EventTarget.prototype.addEventListener` (filtered to 17 button IDs) via `addInitScript`, signs in, signs out via the dashboard sign-out button, signs in again, asserts no spied (id, type) listener count increased.
- [x] Verified test is RED against pre-fix code (`migrate-prod-btn:click` went 1 → 2).
- [x] Verified test is GREEN after guards (3.3s on chromium).
- [x] Re-ran `tests/web/admin-maintenance.spec.ts` (16/16 ✓) and `tests/web/admin-age-verification.spec.ts` (3/3 ✓) — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)