### PR TITLE
fix(api): log FCM stale-token cleanup errors + correct stale comment

### DIFF
--- a/express-api/src/routes/data-export.js
+++ b/express-api/src/routes/data-export.js
@@ -140,18 +140,19 @@ router.post('/users/:uniqueId/data-export', async (req, res) => {
           error: err.message,
         });
         // Don't swallow the status update failure silently — if this fails,
-        // the user's `dataExportStatus` stays at `building` forever, the
-        // polling endpoint reports "in progress", and the user sits waiting
+        // the user's `dataExportStatus` stays at `pending` forever, the
+        // polling endpoint reports "pending", and the user sits waiting
         // for an export that will never complete. This is a GDPR
         // data-export endpoint — silent stuck-in-progress states are a
-        // compliance issue.
+        // compliance issue. (Earlier wording said "building"; the actual
+        // state name set on the user doc is `pending` — see line 76.)
         await db
           .doc(`users/${uniqueId}`)
           .update({ dataExportStatus: 'failed' })
           .catch((statusErr) => {
             log.error(
               'data-export',
-              'Failed to mark dataExportStatus=failed — user may be stuck in building state',
+              'Failed to mark dataExportStatus=failed — user may be stuck in pending state',
               {
                 uniqueId,
                 error: statusErr.message,

--- a/express-api/src/utils/age-verification-fcm.js
+++ b/express-api/src/utils/age-verification-fcm.js
@@ -50,8 +50,17 @@ async function sendOutcomePush(targetUserId, data) {
     const invalid = await sendFcmToTokens(tokens, data);
     if (invalid.length > 0) {
       // Best-effort cleanup of stale tokens — pruning failures here
-      // shouldn't block the decision flow.
-      cleanupInvalidTokens(invalid, targetUserId).catch(() => {});
+      // shouldn't block the decision flow, but they MUST surface in
+      // logs so ops can spot a Firestore-permission regression that
+      // would otherwise let stale tokens accumulate forever.
+      cleanupInvalidTokens(invalid, targetUserId).catch((cleanupErr) => {
+        log.warn('age-verification-fcm', 'Stale-token cleanup failed', {
+          targetUserId,
+          invalidCount: invalid.length,
+          error: cleanupErr?.message,
+          code: cleanupErr?.code,
+        });
+      });
     }
     return true;
   } catch (err) {

--- a/express-api/tests/utils/age-verification-fcm.test.js
+++ b/express-api/tests/utils/age-verification-fcm.test.js
@@ -20,6 +20,14 @@ jest.mock('../../src/utils/firebase', () => ({
   },
 }));
 
+const mockLogWarn = jest.fn();
+const mockLogError = jest.fn();
+jest.mock('../../src/utils/log', () => ({
+  warn: (...args) => mockLogWarn(...args),
+  error: (...args) => mockLogError(...args),
+  info: jest.fn(),
+}));
+
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -74,6 +82,30 @@ describe('sendAgeVerificationApprovedPush', () => {
     await sendAgeVerificationApprovedPush(10000050);
 
     expect(mockCleanupInvalidTokens).toHaveBeenCalledWith(['tok-bad'], 10000050);
+  });
+
+  test('cleanup failure is logged (not silently swallowed) but does not fail the push', async () => {
+    mockDocGet.mockResolvedValue(userWithTokens(['tok-good', 'tok-bad']));
+    mockSendFcmToTokens.mockResolvedValue(['tok-bad']);
+    const cleanupErr = new Error('PERMISSION_DENIED');
+    cleanupErr.code = 'permission-denied';
+    mockCleanupInvalidTokens.mockRejectedValueOnce(cleanupErr);
+
+    const ok = await sendAgeVerificationApprovedPush(10000050);
+    // Yield once so the .catch handler attached to cleanup runs.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(ok).toBe(true); // push itself succeeded — only the cleanup failed
+    expect(mockLogWarn).toHaveBeenCalledWith(
+      'age-verification-fcm',
+      'Stale-token cleanup failed',
+      expect.objectContaining({
+        targetUserId: 10000050,
+        invalidCount: 1,
+        error: 'PERMISSION_DENIED',
+        code: 'permission-denied',
+      }),
+    );
   });
 
   test('swallows send errors and returns false (admin decision must not fail on push)', async () => {


### PR DESCRIPTION
## Summary
Two small observability fixes from manual-QA cycle 4 audit.

**1. `age-verification-fcm.js` silent .catch (real silent-failure violation)**
`cleanupInvalidTokens(invalid, targetUserId).catch(() => {})` swallowed every cleanup failure. The intent — don't fail the admin decision because pruning failed — is correct, but the silence means a Firestore-permission regression that broke cleanup would leave stale tokens accumulating forever with no log signal. Replaced with `log.warn` capturing `targetUserId`, `invalidCount`, `error.message`, `error.code` while preserving the don't-throw contract.

**2. `data-export.js` stale "building" comment**
The catch block protecting `dataExportStatus=failed` referenced a `building` state that does not exist — the actual in-progress state name set on the user doc is `pending` (see line 76). Anyone grepping logs for "stuck in building state" would never find hits even when the failure mode happens. Updated comment + log message to use the real state name.

## Test plan
- [x] Added new regression test `cleanup failure is logged (not silently swallowed) but does not fail the push` in `tests/utils/age-verification-fcm.test.js`. Mocks a rejecting `cleanupInvalidTokens` and asserts both that `log.warn` was called with the expected payload AND that the push itself returned `true`.
- [x] All 11 tests in `age-verification-fcm.test.js` pass locally (was 10, +1 new).
- [x] No behaviour change for `data-export.js` — comment + log-message text only.
- [x] SonarCloud pre-push quality gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)