### PR TITLE
fix(api): suggestion-email-templates env-aware URL fallbacks

### DIFF
--- a/express-api/src/utils/suggestion-email-templates.js
+++ b/express-api/src/utils/suggestion-email-templates.js
@@ -76,8 +76,20 @@ function getSubject(type, language, title) {
   return base;
 }
 
-const SITE_BASE = process.env.SITE_BASE_URL || 'https://shytalk.shyden.co.uk';
-const API_BASE = process.env.API_BASE_URL || 'https://api.shytalk.shyden.co.uk';
+// Env-aware fallbacks. The previous unconditional `|| 'https://shytalk...'`
+// + `|| 'https://api.shytalk...'` would silently emit prod URLs in
+// roadmap-suggestion emails sent from dev / local if SITE_BASE_URL /
+// API_BASE_URL were unset — so a developer clicking the unsubscribe link
+// from a dev test email would unsubscribe their PROD account from
+// suggestion notifications. See feedback-environment-isolation memory.
+// Kept on one line each (prettier-ignore) so the pre-commit URL-
+// isolation guard sees the localhost fallback alongside the prod URL.
+/* eslint-disable no-nested-ternary, max-len */
+// prettier-ignore
+const SITE_BASE = process.env.SITE_BASE_URL || (process.env.NODE_ENV === 'production' ? 'https://shytalk.shyden.co.uk' : process.env.NODE_ENV === 'local' ? 'http://localhost:8888' : 'https://dev.shytalk.shyden.co.uk');
+// prettier-ignore
+const API_BASE = process.env.API_BASE_URL || (process.env.NODE_ENV === 'production' ? 'https://api.shytalk.shyden.co.uk' : process.env.NODE_ENV === 'local' ? 'http://localhost:3000' : 'https://dev-api.shytalk.shyden.co.uk');
+/* eslint-enable no-nested-ternary, max-len */
 
 function buildHeaders(uid) {
   const unsubUrl = `${API_BASE}/api/subscriptions/unsubscribe?token=${uid}`;

--- a/express-api/tests/utils/suggestion-email-templates.test.js
+++ b/express-api/tests/utils/suggestion-email-templates.test.js
@@ -784,3 +784,90 @@ describe('unknown language falls back to English subject', () => {
     expect(unknownResult.subject).toBe(enResult.subject);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════
+// Environment-aware URL fallbacks
+//
+// Pre-fix: SITE_BASE / API_BASE fell back to PROD URLs unconditionally
+// when SITE_BASE_URL / API_BASE_URL env vars were unset, so a developer
+// clicking the unsubscribe link in a dev test email would unsubscribe
+// their PROD account.
+// ═══════════════════════════════════════════════════════════════
+
+describe('environment-aware fallbacks (env-isolation regression)', () => {
+  const SAVED_ENV = {
+    SITE_BASE_URL: process.env.SITE_BASE_URL,
+    API_BASE_URL: process.env.API_BASE_URL,
+    NODE_ENV: process.env.NODE_ENV,
+  };
+
+  afterEach(() => {
+    process.env.SITE_BASE_URL = SAVED_ENV.SITE_BASE_URL;
+    process.env.API_BASE_URL = SAVED_ENV.API_BASE_URL;
+    process.env.NODE_ENV = SAVED_ENV.NODE_ENV;
+    delete process.env.SITE_BASE_URL;
+    delete process.env.API_BASE_URL;
+    if (SAVED_ENV.SITE_BASE_URL !== undefined) process.env.SITE_BASE_URL = SAVED_ENV.SITE_BASE_URL;
+    if (SAVED_ENV.API_BASE_URL !== undefined) process.env.API_BASE_URL = SAVED_ENV.API_BASE_URL;
+    if (SAVED_ENV.NODE_ENV !== undefined) process.env.NODE_ENV = SAVED_ENV.NODE_ENV;
+  });
+
+  function loadFresh() {
+    let mod;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      mod = require('../../src/utils/suggestion-email-templates');
+    });
+    return mod;
+  }
+
+  test('NODE_ENV=production with no overrides → prod URLs', () => {
+    delete process.env.SITE_BASE_URL;
+    delete process.env.API_BASE_URL;
+    process.env.NODE_ENV = 'production';
+
+    const { buildAcceptedEmail } = loadFresh();
+    const email = buildAcceptedEmail('sug-1', 'Title', 'en');
+
+    expect(email.html).toContain('https://shytalk.shyden.co.uk/roadmap.html#suggestion-sug-1');
+    expect(email.headers['List-Unsubscribe']).toContain('https://api.shytalk.shyden.co.uk');
+  });
+
+  test('NODE_ENV=local with no overrides → localhost URLs (NOT prod, NOT dev)', () => {
+    delete process.env.SITE_BASE_URL;
+    delete process.env.API_BASE_URL;
+    process.env.NODE_ENV = 'local';
+
+    const { buildAcceptedEmail } = loadFresh();
+    const email = buildAcceptedEmail('sug-1', 'Title', 'en');
+
+    expect(email.html).toContain('http://localhost:8888/roadmap.html#suggestion-sug-1');
+    expect(email.html).not.toContain('shytalk.shyden.co.uk');
+    expect(email.headers['List-Unsubscribe']).toContain('http://localhost:3000');
+    expect(email.headers['List-Unsubscribe']).not.toContain('shytalk.shyden.co.uk');
+  });
+
+  test('NODE_ENV undefined (defaults to non-prod) with no overrides → DEV URLs (NOT prod)', () => {
+    delete process.env.SITE_BASE_URL;
+    delete process.env.API_BASE_URL;
+    delete process.env.NODE_ENV;
+
+    const { buildAcceptedEmail } = loadFresh();
+    const email = buildAcceptedEmail('sug-1', 'Title', 'en');
+
+    expect(email.html).toContain('https://dev.shytalk.shyden.co.uk');
+    expect(email.html).not.toContain('https://shytalk.shyden.co.uk/');
+  });
+
+  test('explicit overrides win over NODE_ENV-based defaults', () => {
+    process.env.SITE_BASE_URL = 'https://staging.example.test';
+    process.env.API_BASE_URL = 'https://api.staging.example.test';
+    process.env.NODE_ENV = 'production'; // would otherwise pick prod URLs
+
+    const { buildAcceptedEmail } = loadFresh();
+    const email = buildAcceptedEmail('sug-1', 'Title', 'en');
+
+    expect(email.html).toContain('https://staging.example.test/roadmap.html#suggestion-sug-1');
+    expect(email.headers['List-Unsubscribe']).toContain('https://api.staging.example.test');
+  });
+});


### PR DESCRIPTION
## Summary
`SITE_BASE` and `API_BASE` used unconditional `|| 'https://shytalk...'` and `|| 'https://api.shytalk...'` fallbacks. If either env var was unset on dev / local (env-loading glitch, missing `.env`, fresh shell), every roadmap-suggestion email would emit **PROD URLs** in:
- `List-Unsubscribe` header (one-click unsubscribe per RFC 8058)
- "View suggestion" CTAs (5+ template variants)

A developer clicking unsubscribe in a dev test email would unsubscribe their **PROD account** from suggestion notifications — silent cross-environment data flow violating the strict env-isolation rule.

## Fix
Replaced unconditional prod fallbacks with env-aware single-line ternaries:
- `NODE_ENV=production` → prod URLs
- `NODE_ENV=local` → localhost URLs (matches Mailpit-captured emails the dev actually clicks)
- otherwise → dev URLs

Explicit `SITE_BASE_URL` / `API_BASE_URL` overrides still win. Kept on one line each (`prettier-ignore`) so the pre-commit URL-isolation guard sees the localhost fallback alongside the prod URL.

Mirrors the env-aware ladder already in `routes/data-export.js`.

## Test plan
- [x] 4 new regression tests in `tests/utils/suggestion-email-templates.test.js` — `jest.isolateModules` reloads the module under each NODE_ENV scenario, asserts: (1) prod fallback when `NODE_ENV=production`, (2) **localhost** fallback when `NODE_ENV=local` (NOT prod), (3) dev fallback when `NODE_ENV` undefined (NOT prod), (4) explicit overrides beat NODE_ENV.
- [x] All 194 tests pass (190 prior + 4 new).
- [x] Prettier formatting clean.
- [x] SonarCloud pre-push quality gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)