### PR TITLE
fix(api): env-aware CDN_URL fallbacks in email-templates.js + r2.js

### DIFF
--- a/express-api/src/utils/email-templates.js
+++ b/express-api/src/utils/email-templates.js
@@ -1,4 +1,15 @@
-const CDN_URL = process.env.CDN_URL || 'https://images.shytalk.shyden.co.uk';
+// Env-aware fallback. Without this, dev/local would emit prod CDN URLs
+// in email logos when CDN_URL is unset (env-loading glitch, missing
+// .env). The prod CDN is publicly readable so this isn't a credential
+// leak, but a dev test email pointing at the prod logo asset crosses
+// environments — see feedback-environment-isolation memory. Mirrors
+// the pattern shipped in PR #565 for suggestion-email-templates.js.
+// Single-line ternary kept (prettier-ignore) so the pre-commit URL-
+// isolation guard sees the localhost fallback alongside the prod URL.
+/* eslint-disable no-nested-ternary, max-len */
+// prettier-ignore
+const CDN_URL = process.env.CDN_URL || (process.env.NODE_ENV === 'production' ? 'https://images.shytalk.shyden.co.uk' : process.env.NODE_ENV === 'local' ? 'http://localhost:9002/shytalk-media' : 'https://dev-images.shytalk.shyden.co.uk');
+/* eslint-enable no-nested-ternary, max-len */
 
 const LOGO_URL = `${CDN_URL}/branding/logo.png`;
 

--- a/express-api/src/utils/r2.js
+++ b/express-api/src/utils/r2.js
@@ -42,11 +42,20 @@ if (isLocal) {
   });
 }
 
-const CDN_URL =
-  process.env.CDN_URL ||
-  (isLocal
-    ? `${process.env.MINIO_ENDPOINT || 'http://localhost:9002'}/${bucketName}`
-    : 'https://images.shytalk.shyden.co.uk');
+// Env-aware fallback. The previous shape was `isLocal ? local : prod`,
+// which leaked the prod CDN URL on the dev environment (NODE_ENV !=
+// local). The prod CDN host is publicly readable so this isn't a
+// credential leak, but URLs returned by routes that consume
+// `CDN_URL` (image responses, etc.) would silently point dev clients
+// at prod-hosted media. Now: prod → prod CDN, local → MinIO,
+// otherwise (dev / staging) → dev CDN. See feedback-environment-
+// isolation memory.
+// Single-line ternary kept (prettier-ignore) so the pre-commit URL-
+// isolation guard sees the localhost fallback alongside the prod URL.
+/* eslint-disable no-nested-ternary, max-len */
+// prettier-ignore
+const CDN_URL = process.env.CDN_URL || (isLocal ? `${process.env.MINIO_ENDPOINT || 'http://localhost:9002'}/${bucketName}` : process.env.NODE_ENV === 'production' ? 'https://images.shytalk.shyden.co.uk' : 'https://dev-images.shytalk.shyden.co.uk');
+/* eslint-enable no-nested-ternary, max-len */
 
 async function putObject(key, body, contentType, metadata = {}, options = {}) {
   await s3.send(

--- a/express-api/tests/utils/email-templates.test.js
+++ b/express-api/tests/utils/email-templates.test.js
@@ -211,3 +211,68 @@ describe('Email Templates', () => {
     });
   });
 });
+
+// ═══════════════════════════════════════════════════════════════
+// Environment-aware CDN_URL fallback (env-isolation regression)
+//
+// Pre-fix: CDN_URL fell back to PROD images domain unconditionally.
+// Now: prod → prod CDN, local → MinIO, otherwise → dev CDN.
+// ═══════════════════════════════════════════════════════════════
+
+describe('CDN_URL env-isolation fallback', () => {
+  const SAVED = {
+    CDN_URL: process.env.CDN_URL,
+    NODE_ENV: process.env.NODE_ENV,
+  };
+
+  afterEach(() => {
+    delete process.env.CDN_URL;
+    delete process.env.NODE_ENV;
+    if (SAVED.CDN_URL !== undefined) process.env.CDN_URL = SAVED.CDN_URL;
+    if (SAVED.NODE_ENV !== undefined) process.env.NODE_ENV = SAVED.NODE_ENV;
+  });
+
+  function loadFresh() {
+    let mod;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      mod = require('../../src/utils/email-templates');
+    });
+    return mod;
+  }
+
+  it('NODE_ENV=production with no override → prod CDN', () => {
+    delete process.env.CDN_URL;
+    process.env.NODE_ENV = 'production';
+    const { buildOtpEmail } = loadFresh();
+    const email = buildOtpEmail('123456');
+    expect(email.html).toContain('https://images.shytalk.shyden.co.uk/');
+    expect(email.html).not.toContain('dev-images.shytalk.shyden.co.uk');
+  });
+
+  it('NODE_ENV=local with no override → localhost MinIO (NOT prod, NOT dev)', () => {
+    delete process.env.CDN_URL;
+    process.env.NODE_ENV = 'local';
+    const { buildOtpEmail } = loadFresh();
+    const email = buildOtpEmail('123456');
+    expect(email.html).toContain('http://localhost:9002/shytalk-media/');
+    expect(email.html).not.toContain('shytalk.shyden.co.uk');
+  });
+
+  it('NODE_ENV=development with no override → dev CDN (NOT prod)', () => {
+    delete process.env.CDN_URL;
+    process.env.NODE_ENV = 'development';
+    const { buildOtpEmail } = loadFresh();
+    const email = buildOtpEmail('123456');
+    expect(email.html).toContain('https://dev-images.shytalk.shyden.co.uk/');
+  });
+
+  it('explicit CDN_URL override beats NODE_ENV', () => {
+    process.env.CDN_URL = 'https://cdn.staging.example.test';
+    process.env.NODE_ENV = 'production';
+    const { buildOtpEmail } = loadFresh();
+    const email = buildOtpEmail('123456');
+    expect(email.html).toContain('https://cdn.staging.example.test/');
+    expect(email.html).not.toContain('shytalk.shyden.co.uk');
+  });
+});

--- a/express-api/tests/utils/r2.test.js
+++ b/express-api/tests/utils/r2.test.js
@@ -414,3 +414,78 @@ describe('exported constants', () => {
     expect(CDN_URL).toMatch(/^https?:\/\//);
   });
 });
+
+// ─── Environment-aware CDN_URL fallback (env-isolation regression) ──
+//
+// Pre-fix: r2.js used `isLocal ? local-minio : prod-CDN` — so dev
+// (NODE_ENV=development) leaked through to the prod images domain.
+// Now: prod → prod CDN, local → MinIO, otherwise → dev CDN.
+// ────────────────────────────────────────────────────────────────────
+
+describe('CDN_URL env-isolation fallback', () => {
+  const SAVED = {
+    CDN_URL: process.env.CDN_URL,
+    NODE_ENV: process.env.NODE_ENV,
+    MINIO_ENDPOINT: process.env.MINIO_ENDPOINT,
+  };
+
+  afterEach(() => {
+    delete process.env.CDN_URL;
+    delete process.env.NODE_ENV;
+    delete process.env.MINIO_ENDPOINT;
+    if (SAVED.CDN_URL !== undefined) process.env.CDN_URL = SAVED.CDN_URL;
+    if (SAVED.NODE_ENV !== undefined) process.env.NODE_ENV = SAVED.NODE_ENV;
+    if (SAVED.MINIO_ENDPOINT !== undefined) process.env.MINIO_ENDPOINT = SAVED.MINIO_ENDPOINT;
+  });
+
+  function loadFresh() {
+    let mod;
+    jest.isolateModules(() => {
+      // Re-mock in the isolated context — top-level jest.mock doesn't
+      // carry across isolateModules boundaries.
+      jest.doMock('@aws-sdk/client-s3', () => ({
+        S3Client: jest.fn(() => ({ send: jest.fn() })),
+        PutObjectCommand: jest.fn(),
+        GetObjectCommand: jest.fn(),
+        DeleteObjectCommand: jest.fn(),
+        DeleteObjectsCommand: jest.fn(),
+        ListObjectsV2Command: jest.fn(),
+      }));
+      jest.doMock('@aws-sdk/s3-request-presigner', () => ({
+        getSignedUrl: jest.fn(),
+      }));
+      // eslint-disable-next-line global-require
+      mod = require('../../src/utils/r2');
+    });
+    return mod;
+  }
+
+  it('NODE_ENV=production with no override → prod CDN', () => {
+    delete process.env.CDN_URL;
+    process.env.NODE_ENV = 'production';
+    const { CDN_URL: url } = loadFresh();
+    expect(url).toBe('https://images.shytalk.shyden.co.uk');
+  });
+
+  it('NODE_ENV=local with no override → MinIO localhost (NOT prod, NOT dev)', () => {
+    delete process.env.CDN_URL;
+    process.env.NODE_ENV = 'local';
+    const { CDN_URL: url } = loadFresh();
+    expect(url).toMatch(/^http:\/\/localhost:9002\//);
+    expect(url).not.toContain('shytalk.shyden.co.uk');
+  });
+
+  it('NODE_ENV=development with no override → dev CDN (NOT prod)', () => {
+    delete process.env.CDN_URL;
+    process.env.NODE_ENV = 'development';
+    const { CDN_URL: url } = loadFresh();
+    expect(url).toBe('https://dev-images.shytalk.shyden.co.uk');
+  });
+
+  it('explicit CDN_URL override beats NODE_ENV', () => {
+    process.env.CDN_URL = 'https://cdn.staging.example.test';
+    process.env.NODE_ENV = 'production';
+    const { CDN_URL: url } = loadFresh();
+    expect(url).toBe('https://cdn.staging.example.test');
+  });
+});


### PR DESCRIPTION
## Summary
Both `email-templates.js` and `r2.js` defaulted `CDN_URL` to the **prod** images domain when no explicit override was set:

- `r2.js`: `isLocal ? local-minio : 'https://images.shytalk.shyden.co.uk'` — the entire dev environment (`NODE_ENV=development`) fell through to the prod CDN.
- `email-templates.js`: `|| 'https://images.shytalk.shyden.co.uk'` — same unconditional prod fallback as the suggestion-email-templates.js bug fixed in #565.

The prod images host is publicly readable so neither leak is a credential exposure, but URLs returned by routes that consume `CDN_URL` (image responses, email logos, etc.) would silently point **dev clients at prod-hosted media** — cross-environment data flow violating the env-isolation contract.

## Fix
Both files now use the env-aware ladder shipped in #565:
- `NODE_ENV=production` → `https://images.shytalk.shyden.co.uk`
- `NODE_ENV=local` → `http://localhost:9002/shytalk-media` (MinIO)
- otherwise (dev / staging) → `https://dev-images.shytalk.shyden.co.uk`

Explicit `CDN_URL` env var still wins. Single-line ternaries kept (`prettier-ignore`) so the pre-commit URL-isolation guard sees the localhost fallback alongside the prod URL.

## Test plan
- [x] 4 new regression tests in `tests/utils/email-templates.test.js` (61 total, was 57): prod fallback, localhost fallback, dev fallback, explicit-override-wins.
- [x] 4 new regression tests in `tests/utils/r2.test.js` (35 total, was 31): same 4 scenarios.
- [x] All existing tests still pass.
- [x] Prettier formatting clean.
- [x] SonarCloud pre-push quality gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)