### PR TITLE
fix(web): language picker sets dir=rtl for Arabic

### DIFF
--- a/public/js/language-selector.js
+++ b/public/js/language-selector.js
@@ -46,9 +46,19 @@
     return 'en';
   }
 
+  // Languages whose script is read right-to-left. Only one in our
+  // current 20-locale set, but listed as a Set so adding Hebrew /
+  // Persian / Urdu later is a single-line change. Without this, the
+  // page keeps `dir` empty (browser-default LTR) even after switching
+  // to Arabic, so the layout never mirrors and Arabic users see a
+  // backwards UX. Found 2026-05-09 via /manual-qa: language picker
+  // set lang=ar but kept dir=""/ltr.
+  var RTL_LANGS = ['ar'];
+
   function setLanguage(lang) {
     localStorage.setItem(STORAGE_KEY, lang);
     document.documentElement.lang = lang;
+    document.documentElement.dir = RTL_LANGS.indexOf(lang) !== -1 ? 'rtl' : 'ltr';
     if (typeof window.applyLanguage === 'function') {
       window.applyLanguage(lang);
     }
@@ -207,9 +217,12 @@
     }
   });
 
-  // Apply saved language on load
+  // Apply saved language on load. Mirrors setLanguage() — keep both
+  // sites in sync so a refresh-into-Arabic shows RTL just like a
+  // mid-session switch does.
   var savedLang = getLanguage();
   document.documentElement.lang = savedLang;
+  document.documentElement.dir = RTL_LANGS.indexOf(savedLang) !== -1 ? 'rtl' : 'ltr';
   if (typeof window.applyLanguage === 'function') {
     window.applyLanguage(savedLang);
   }

--- a/tests/web/language-selector-rtl.spec.ts
+++ b/tests/web/language-selector-rtl.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEB_BASE_URL || 'http://localhost:8888';
+
+/**
+ * Regression: language picker MUST set `dir="rtl"` on Arabic and
+ * `dir="ltr"` on every other supported language.
+ *
+ * Pre-fix: `setLanguage()` only set `document.documentElement.lang`,
+ * leaving `dir` as whatever HTML default (`""` → browser-default LTR).
+ * Switching to Arabic kept the page LTR, so Arabic readers saw a
+ * backwards-mirrored UX (logo on left, Sign In on right is wrong for
+ * RTL). Found 2026-05-09 during /manual-qa.
+ */
+
+const SUPPORTED_LANGS = [
+  'en', 'de', 'es', 'fr', 'hi', 'id', 'it', 'km', 'ja', 'ko',
+  'nl', 'pl', 'pt', 'ru', 'sv', 'th', 'tr', 'uk', 'vi', 'zh',
+];
+
+test.describe('Language selector — RTL direction (regression)', () => {
+  test('switching to Arabic sets dir=rtl', async ({ page }) => {
+    await page.goto(`${BASE}/`);
+    await page.waitForFunction(() => typeof (window as any).ShyTalkLanguage !== 'undefined');
+
+    const result = await page.evaluate(() => {
+      (window as any).ShyTalkLanguage.set('ar');
+      return {
+        lang: document.documentElement.lang,
+        dir: document.documentElement.dir,
+      };
+    });
+
+    expect(result.lang).toBe('ar');
+    expect(result.dir).toBe('rtl');
+  });
+
+  test('switching from Arabic back to English resets dir=ltr', async ({ page }) => {
+    await page.goto(`${BASE}/`);
+    await page.waitForFunction(() => typeof (window as any).ShyTalkLanguage !== 'undefined');
+
+    const result = await page.evaluate(() => {
+      // Go to Arabic first
+      (window as any).ShyTalkLanguage.set('ar');
+      // Then back to English — must explicitly reset dir, otherwise
+      // a page-load-with-Arabic-saved-then-switch-to-English session
+      // would keep RTL.
+      (window as any).ShyTalkLanguage.set('en');
+      return {
+        lang: document.documentElement.lang,
+        dir: document.documentElement.dir,
+      };
+    });
+
+    expect(result.lang).toBe('en');
+    expect(result.dir).toBe('ltr');
+  });
+
+  test('all 19 non-RTL supported languages set dir=ltr', async ({ page }) => {
+    await page.goto(`${BASE}/`);
+    await page.waitForFunction(() => typeof (window as any).ShyTalkLanguage !== 'undefined');
+
+    const results = await page.evaluate((langs: string[]) => {
+      return langs.map((lang) => {
+        (window as any).ShyTalkLanguage.set(lang);
+        return { lang, dir: document.documentElement.dir };
+      });
+    }, SUPPORTED_LANGS);
+
+    for (const r of results) {
+      expect(r.dir, `${r.lang} should be LTR`).toBe('ltr');
+    }
+  });
+
+  test('saved Arabic preference applies dir=rtl on page load', async ({ page }) => {
+    // Set the localStorage marker BEFORE the page loads so the IIFE
+    // init path picks it up — exercises the line 220+ block, not the
+    // setLanguage() path.
+    await page.addInitScript(() => {
+      localStorage.setItem('shytalk_language', 'ar');
+    });
+
+    await page.goto(`${BASE}/`);
+    await page.waitForFunction(() => document.documentElement.lang === 'ar');
+
+    const dir = await page.evaluate(() => document.documentElement.dir);
+    expect(dir).toBe('rtl');
+  });
+});


### PR DESCRIPTION
## Summary
`setLanguage()` set `document.documentElement.lang` but never set `dir`. Switching to Arabic (the only RTL locale in our 20-language set) left `dir=""` (browser-default LTR), so Arabic readers saw a backwards-mirrored UX:
- Logo on the left, Sign In on the right
- Text flow left-to-right inside Arabic paragraphs
- Layout never mirrored

Same bug applied at page-load if a saved Arabic preference was restored from localStorage.

**Found 2026-05-09 during /manual-qa**: clicked language picker in real Playwright Chromium, selected Arabic, observed `dir=""` in the DOM despite `lang="ar"`.

## Fix
Declare an `RTL_LANGS` array (currently `['ar']`; trivial single-line addition for Hebrew / Persian / Urdu later) and set `document.documentElement.dir` in BOTH the runtime `setLanguage()` path and the IIFE init-from-saved-preference path.

## /manual-qa evidence (per the merge-gate rule established 2026-05-09)
Real-browser test via `tests/web/language-selector-rtl.spec.ts` (chromium):
- ✓ Arabic switch sets `dir=rtl`
- ✓ Switch back to English resets `dir=ltr`
- ✓ All 19 non-RTL languages set `dir=ltr`
- ✓ Saved Arabic preference applies `dir=rtl` on page-load init

All 4 pass against local stack. Tests run in fresh Chromium browser contexts (cache-isolated from session profiles).

## Out of scope
Separate bug: the homepage doesn't register a `window.applyLanguage` handler, so visible text never translates on locale switch. Will ship in a follow-up PR — this one stays scoped to the RTL direction fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)