### PR TITLE
fix(web): shared-header Sign In falls back to /portal/ when no modal hook

### DIFF
--- a/public/js/shared-header.js
+++ b/public/js/shared-header.js
@@ -110,8 +110,17 @@
       var signInBtn = header.querySelector('[data-testid="header-signin-btn"]');
       if (signInBtn) {
         signInBtn.addEventListener('click', function () {
+          // Roadmap registers `window.shytalkShowLoginModal` (via
+          // suggestions-board.js) for an in-page modal. The static
+          // legal pages, homepage, and event landing pages do NOT
+          // load suggestions-board.js, so the modal hook is undefined
+          // there — leaving the Sign In button silently broken.
+          // Fall back to the unified portal at /portal/, which is the
+          // canonical web auth UI per roadmap item #47.
           if (window.shytalkShowLoginModal) {
             window.shytalkShowLoginModal('access your account');
+          } else {
+            window.location.href = '/portal/';
           }
         });
       }

--- a/tests/web/shared-header-signin-fallback.spec.ts
+++ b/tests/web/shared-header-signin-fallback.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEB_BASE_URL || 'http://localhost:8888';
+
+/**
+ * Regression: shared-header's Sign In button MUST work on every page
+ * that loads shared-header.js, not just on the roadmap.
+ *
+ * Pre-fix: clicking Sign In on the homepage / legal pages / event
+ * pages was a no-op because shared-header.js called
+ * `window.shytalkShowLoginModal()` — a function only registered by
+ * `suggestions-board.js`, which only loads on `/roadmap.html`.
+ * Six static pages (index, privacy, terms, community-guidelines,
+ * cyber-bullying, do-not-sell) shipped with a non-functional Sign
+ * In button until the fallback was added. Found 2026-05-09 via
+ * /manual-qa.
+ *
+ * Post-fix: pages with the modal hook keep the in-page modal flow;
+ * pages without it navigate to /portal/, the canonical web auth UI.
+ */
+
+test.describe('Shared header Sign In — modal hook + portal fallback', () => {
+  test('homepage Sign In navigates to /portal/ (no modal hook registered)', async ({ page }) => {
+    await page.goto(`${BASE}/`);
+    await page.waitForFunction(() => !!document.querySelector('[data-testid="shared-header"]'));
+
+    // Confirm the modal hook is NOT registered on the homepage
+    const beforeClick = await page.evaluate(() => ({
+      modalHookExists: typeof (window as any).shytalkShowLoginModal === 'function',
+    }));
+    expect(beforeClick.modalHookExists).toBe(false);
+
+    // Click Sign In and assert navigation to /portal/
+    await Promise.all([
+      page.waitForURL((url) => url.pathname.startsWith('/portal/'), { timeout: 5_000 }),
+      page.locator('[data-testid="header-signin-btn"]').click(),
+    ]);
+    expect(page.url()).toContain('/portal/');
+  });
+
+  test('roadmap Sign In opens the in-page modal (modal hook registered)', async ({ page }) => {
+    await page.goto(`${BASE}/roadmap.html?qa=signin-modal`);
+    await page.waitForFunction(() => typeof (window as any).shytalkShowLoginModal === 'function');
+
+    // Spy on the modal hook + the navigation, prove modal is invoked
+    // and we do NOT navigate to /portal/.
+    const startUrl = page.url();
+    const result = await page.evaluate(async () => {
+      let calledWith: string | null = null;
+      const orig = (window as any).shytalkShowLoginModal;
+      (window as any).shytalkShowLoginModal = (action: string) => {
+        calledWith = action;
+        return orig?.(action);
+      };
+      const btn = document.querySelector('[data-testid="header-signin-btn"]') as HTMLElement | null;
+      if (!btn) return { invoked: false, calledWith };
+      btn.click();
+      // Brief settle so any deferred navigation / state change runs
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      return { invoked: !!calledWith, calledWith };
+    });
+
+    expect(result.invoked).toBe(true);
+    expect(result.calledWith).toBeTruthy();
+    // Confirm we did NOT navigate (modal flow keeps user on roadmap)
+    expect(page.url()).toBe(startUrl);
+  });
+});


### PR DESCRIPTION
## Summary
`shared-header.js`'s Sign In click handler called `window.shytalkShowLoginModal()` — a function only registered by `suggestions-board.js`, which only loads on `/roadmap.html`. **Six static pages** shipped with a non-functional Sign In button:

- `/` (homepage)
- `/privacy.html`
- `/terms.html`
- `/community-guidelines.html`
- `/cyber-bullying.html`
- `/do-not-sell.html`

The button rendered fine, but clicking it was a silent no-op — no modal, no navigation, no console error.

**Found 2026-05-09 via /manual-qa**: clicked Sign In on the homepage in real Playwright Chromium; nothing happened. Confirmed the same handler is silently broken across all 5 other static pages by greping for `suggestions-board.js` script tags.

## Fix
Extend the click handler to fall back to navigating to `/portal/` when the modal hook is absent. Pages with the modal keep the in-page modal UX (roadmap); pages without it route users to the canonical web auth UI per roadmap item #47 (\"Unified web portal — single login page\").

## /manual-qa evidence
`tests/web/shared-header-signin-fallback.spec.ts` (2 cases) in real chromium:
- ✓ Homepage Sign In navigates to `/portal/` (no modal hook registered)
- ✓ Roadmap Sign In invokes the modal hook (NOT navigation; URL unchanged)

Both pass against running local stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)