### PR TITLE
fix(ci): scope playwright-tests concurrency per ref

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,3 +85,6 @@ jobs:
 
       - name: No paid GitHub-hosted runner specs
         run: bash scripts/check-no-paid-runners.sh
+
+      - name: Workflow concurrency groups are scoped or intentionally global
+        run: bash scripts/check-workflow-concurrency-scoping.sh

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -43,7 +43,13 @@ permissions:
   contents: write
 
 concurrency:
-  group: playwright-tests
+  # Per-ref scoping: each PR / branch has its own queue, so independent PRs
+  # don't serialize through one slot. Without this, three concurrent PRs
+  # cause queue-cancellation: GitHub Actions allows at most ONE pending run
+  # per group, so the 3rd arrival cancels the 2nd's pending run, surfacing as
+  # `playwright-web / Resolve Inputs: CANCELLED → PR Gate: FAILURE` on PRs
+  # that did nothing wrong. (Observed 2026-05-09 against PR #568, #570.)
+  group: playwright-tests-${{ inputs.ref || github.ref }}
   cancel-in-progress: false
 
 env:

--- a/scripts/check-workflow-concurrency-scoping.sh
+++ b/scripts/check-workflow-concurrency-scoping.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Reject unscoped concurrency groups on workflows that accept cross-PR
+# triggers (workflow_call, pull_request, push) but don't intentionally
+# serialize on a shared physical resource.
+#
+# Background: 2026-05-09 — `playwright-tests.yml` had `group: playwright-tests`
+# (no `${{ github.ref }}` interpolation), serializing every PR through one
+# slot. GitHub Actions allows at most ONE pending run per group, so a 3rd
+# PR's arrival cancelled the 2nd's queued run, surfacing as
+# `playwright-web / Resolve Inputs: CANCELLED → PR Gate: FAILURE` on PRs
+# that did nothing wrong (#568, #570). Fix was to scope the group per ref.
+#
+# Some workflows INTENTIONALLY use a global group because they contend on
+# shared infrastructure (gh-pages, single deploy env, release pipeline,
+# emulator/simulator runner). Those are listed in INTENTIONAL_GLOBALS below.
+# Any new global group must either join that allowlist (with a comment in
+# the workflow explaining why) or use ref interpolation.
+#
+# Run from project root.
+
+set -euo pipefail
+
+INTENTIONAL_GLOBALS=(
+  "e2e-tests"           # Android emulator resource contention on gh-hosted runner
+  "ios-tests"           # iOS simulator resource contention on gh-hosted runner
+  "gh-pages-deploy"     # only one gh-pages deploy can land at a time
+  "deploy-prod"         # single prod environment, no parallel deploys
+  "release-main"        # single release pipeline owns version bump + tag
+)
+
+violations=0
+
+for wf in .github/workflows/*.yml .github/workflows/*.yaml; do
+  [ -f "$wf" ] || continue
+
+  # Find every `group:` value under a `concurrency:` block (one-pass awk;
+  # naive but workflow files are small and concurrency blocks are flat).
+  group_value=$(awk '
+    /^concurrency:/ { in_block = 1; next }
+    in_block && /^[^[:space:]]/ { in_block = 0 }
+    in_block && /^[[:space:]]+group:/ {
+      sub(/^[[:space:]]+group:[[:space:]]*/, "")
+      sub(/[[:space:]]*#.*$/, "")
+      print
+      exit
+    }
+  ' "$wf")
+
+  # No concurrency block? OK.
+  [ -z "$group_value" ] && continue
+
+  # Has `${{` interpolation? Per-ref scoped (or some other dynamic key) — OK.
+  if echo "$group_value" | grep -q '\${{'; then
+    continue
+  fi
+
+  # Static group value. Strip quotes for allowlist comparison.
+  bare=$(echo "$group_value" | sed -e "s/^['\"]//; s/['\"]$//")
+
+  intentional=false
+  for allowed in "${INTENTIONAL_GLOBALS[@]}"; do
+    if [ "$bare" = "$allowed" ]; then
+      intentional=true
+      break
+    fi
+  done
+
+  if [ "$intentional" = false ]; then
+    echo "::error file=$wf::Unscoped concurrency group '$bare'. Use \`group: ${bare}-\${{ github.ref }}\` (or \`inputs.ref\` for workflow_call), or add '$bare' to INTENTIONAL_GLOBALS in scripts/check-workflow-concurrency-scoping.sh with a comment explaining the shared resource."
+    violations=$((violations + 1))
+  fi
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo ""
+  echo "Found $violations unscoped concurrency group(s)."
+  echo "Why this matters: GitHub Actions only queues ONE pending run per group."
+  echo "A 3rd PR arrival cancels the 2nd's pending run — PRs fail for no reason."
+  exit 1
+fi
+
+echo "✓ All workflow concurrency groups are either ref-scoped or intentionally global."


### PR DESCRIPTION
## Summary

- `playwright-tests.yml` had `group: playwright-tests` (no `${{ github.ref }}` interpolation). GitHub Actions queues at most ONE pending run per concurrency group, so a 3rd PR arrival cancelled the 2nd's queued run.
- Surfaced as `playwright-web / Resolve Inputs: CANCELLED → PR Gate: FAILURE` on PRs #568 + #570 today (2026-05-09) — neither PR did anything wrong, but both got blocked.
- Fix: scope per ref so each branch has its own queue. `e2e-tests.yml` + `ios-tests.yml` keep their global groups (intentional — emulator/simulator resource contention, documented in their existing comments).
- New regression guard `scripts/check-workflow-concurrency-scoping.sh` runs in `lint.yml`: rejects future unscoped concurrency groups unless added to `INTENTIONAL_GLOBALS` with a comment.

## Why this matters

The two PRs blocked today (#568 cache-control fix, #570 sign-in fallback) both passed all real tests but failed `PR Gate` because GitHub cancelled their queued playwright runs to make room for #569's playwright run. The PRs were green in every meaningful sense — the gate failure was infrastructure-only.

## Test plan

- [x] Guard script passes against current workflow tree (`bash scripts/check-workflow-concurrency-scoping.sh`)
- [x] Guard script catches the bad form (verified with synthetic `group: bad-group` workflow — returns exit 1 with clear error)
- [x] `actionlint` passes (pre-push hook)
- [ ] CI runs cleanly on this PR (will verify post-push)
- [ ] After merge, rebase #568/#569/#570 onto main and verify they pass

## Manual QA

This is a CI-only YAML/script change with no user-facing surface. Manual QA equivalent is observing that:
1. This PR's own playwright run completes (sanity check)
2. After merge, the previously-blocked PRs (#568/#570) pass cleanly when rebased

🤖 Generated with [Claude Code](https://claude.com/claude-code)