### PR TITLE
fix(web): footer i18n gaps across legal pages

### DIFF
--- a/public/admin/translations.js
+++ b/public/admin/translations.js
@@ -1,5 +1,5 @@
 /**
- * Admin panel translations — all 19 locales.
+ * Admin panel translations — all 20 locales.
  *
  * Loaded by admin/index.html. Works with the shared language-selector.js.
  * Each key maps to a data-i18n attribute in the HTML.

--- a/public/community-guidelines.html
+++ b/public/community-guidelines.html
@@ -227,7 +227,7 @@
       <a href="/privacy.html" data-i18n="footer_privacy">Privacy Policy</a> &nbsp;&middot;&nbsp;
       <a href="/terms.html" data-i18n="footer_terms">Terms of Service</a> &nbsp;&middot;&nbsp;
       <a href="/cyber-bullying.html" data-i18n="footer_cyber">Cyber Bullying Policy</a> &nbsp;&middot;&nbsp;
-      <a href="/do-not-sell.html">Do Not Sell or Share My Personal Information</a>
+      <a href="/do-not-sell.html" data-i18n="footer_do_not_sell">Do Not Sell or Share My Personal Information</a>
       <p class="copyright" data-i18n="footer_copy">&copy; 2026 Shyden Ltd. All rights reserved.</p>
     </footer>
   </div>

--- a/public/cyber-bullying.html
+++ b/public/cyber-bullying.html
@@ -189,10 +189,10 @@
     </main>
 
     <footer>
-      <a href="/privacy.html">Privacy Policy</a> &nbsp;&middot;&nbsp;
-      <a href="/terms.html">Terms of Service</a> &nbsp;&middot;&nbsp;
-      <a href="/community-guidelines.html">Community Guidelines</a> &nbsp;&middot;&nbsp;
-      <a href="/do-not-sell.html">Do Not Sell or Share My Personal Information</a>
+      <a href="/privacy.html" data-i18n="footer_privacy">Privacy Policy</a> &nbsp;&middot;&nbsp;
+      <a href="/terms.html" data-i18n="footer_terms">Terms of Service</a> &nbsp;&middot;&nbsp;
+      <a href="/community-guidelines.html" data-i18n="footer_guidelines">Community Guidelines</a> &nbsp;&middot;&nbsp;
+      <a href="/do-not-sell.html" data-i18n="footer_do_not_sell">Do Not Sell or Share My Personal Information</a>
       <p class="copyright" data-i18n="footer_copy">&copy; 2026 Shyden Ltd. All rights reserved.</p>
     </footer>
   </div>

--- a/public/do-not-sell.html
+++ b/public/do-not-sell.html
@@ -125,15 +125,21 @@
     </main>
 
     <footer>
-      <a href="/privacy.html">Privacy Policy</a> &nbsp;&middot;&nbsp;
-      <a href="/terms.html">Terms of Service</a> &nbsp;&middot;&nbsp;
-      <a href="/community-guidelines.html">Community Guidelines</a> &nbsp;&middot;&nbsp;
-      <a href="/cyber-bullying.html">Cyber Bullying Policy</a>
-      <p class="copyright">&copy; 2026 Shyden Ltd. All rights reserved.</p>
+      <a href="/privacy.html" data-i18n="footer_privacy">Privacy Policy</a> &nbsp;&middot;&nbsp;
+      <a href="/terms.html" data-i18n="footer_terms">Terms of Service</a> &nbsp;&middot;&nbsp;
+      <a href="/community-guidelines.html" data-i18n="footer_guidelines">Community Guidelines</a> &nbsp;&middot;&nbsp;
+      <a href="/cyber-bullying.html" data-i18n="footer_cyber">Cyber Bullying Policy</a>
+      <p class="copyright" data-i18n="footer_copy">&copy; 2026 Shyden Ltd. All rights reserved.</p>
     </footer>
   </div>
+<script>window.LEGAL_PAGE_TYPE = 'donotsell';</script>
 <script src="/js/shared-header.js"></script>
 <script src="/js/language-selector.js"></script>
+<script src="/js/legal-translations.js"></script>
+<script>
+  var lang = (window.ShyTalkLanguage && window.ShyTalkLanguage.get()) || 'en';
+  applyLegalTranslations(window.LEGAL_PAGE_TYPE, lang);
+</script>
 <script src="/js/preview-watermark.js" defer></script>
 </body>
 </html>

--- a/public/js/legal-translations.js
+++ b/public/js/legal-translations.js
@@ -1,32 +1,32 @@
 /**
  * Shared translations for legal pages (privacy, terms, community guidelines).
- * All 19 locales. Loaded by each legal page alongside language-selector.js.
+ * All 20 locales. Loaded by each legal page alongside language-selector.js.
  */
 
 /* eslint-disable */
 var LEGAL_T = {
   // ─── Footer (shared across all legal pages) ───
   footer: {
-    ar: { footer_terms: 'شروط الخدمة', footer_guidelines: 'إرشادات المجتمع', footer_cyber: 'سياسة التنمر', footer_copy: '© 2026 Shyden Ltd. جميع الحقوق محفوظة.' },
-    de: { footer_terms: 'Nutzungsbedingungen', footer_guidelines: 'Community-Richtlinien', footer_cyber: 'Cybermobbing-Richtlinie', footer_copy: '© 2026 Shyden Ltd. Alle Rechte vorbehalten.' },
-    es: { footer_terms: 'Términos de servicio', footer_guidelines: 'Normas de la comunidad', footer_cyber: 'Política contra el ciberacoso', footer_copy: '© 2026 Shyden Ltd. Todos los derechos reservados.' },
-    fr: { footer_terms: 'Conditions d’utilisation', footer_guidelines: 'Règles de la communauté', footer_cyber: 'Politique anti-harcèlement', footer_copy: '© 2026 Shyden Ltd. Tous droits réservés.' },
-    hi: { footer_terms: 'सेवा की शर्तें', footer_guidelines: 'सामुदायिक दिशानिर्देश', footer_cyber: 'साइबर बुलिंग नीति', footer_copy: '© 2026 Shyden Ltd. सर्वाधिकार सुरक्षित.' },
-    id: { footer_terms: 'Ketentuan Layanan', footer_guidelines: 'Pedoman Komunitas', footer_cyber: 'Kebijakan Perundungan Siber', footer_copy: '© 2026 Shyden Ltd. Semua hak dilindungi.' },
-    it: { footer_terms: 'Termini di servizio', footer_guidelines: 'Linee guida della comunità', footer_cyber: 'Politica sul cyberbullismo', footer_copy: '© 2026 Shyden Ltd. Tutti i diritti riservati.' },
-    ja: { footer_terms: '利用規約', footer_guidelines: 'コミュニティガイドライン', footer_cyber: 'ネットいじめポリシー', footer_copy: '© 2026 Shyden Ltd. 無断複製禁止.' },
-    km: { footer_terms: 'លក្ខខណ្ឌនៃសេវាកម្ម', footer_guidelines: 'គោលការណ៍សហគមន៍', footer_cyber: 'គោលនយោបាយប្រឆាំងការសម្លុតតាមអ៊ីនធឺណិត', footer_copy: '© 2026 Shyden Ltd. រក្សាសិទ្ធិគ្រប់យ៉ាង។' },
-    ko: { footer_terms: '이용 약관', footer_guidelines: '커뮤니티 가이드라인', footer_cyber: '사이버 불링 정책', footer_copy: '© 2026 Shyden Ltd. 모든 권리 보유.' },
-    nl: { footer_terms: 'Servicevoorwaarden', footer_guidelines: 'Communityrichtlijnen', footer_cyber: 'Cyberpestbeleid', footer_copy: '© 2026 Shyden Ltd. Alle rechten voorbehouden.' },
-    pl: { footer_terms: 'Regulamin', footer_guidelines: 'Zasady społeczności', footer_cyber: 'Polityka cyberprzemocy', footer_copy: '© 2026 Shyden Ltd. Wszelkie prawa zastrzeżone.' },
-    pt: { footer_terms: 'Termos de Serviço', footer_guidelines: 'Diretrizes da Comunidade', footer_cyber: 'Política de Cyberbullying', footer_copy: '© 2026 Shyden Ltd. Todos os direitos reservados.' },
-    ru: { footer_terms: 'Условия использования', footer_guidelines: 'Правила сообщества', footer_cyber: 'Политика против кибербуллинга', footer_copy: '© 2026 Shyden Ltd. Все права защищены.' },
-    sv: { footer_terms: 'Användarvillkor', footer_guidelines: 'Gemenskapsriktlinjer', footer_cyber: 'Policy mot nätmobbning', footer_copy: '© 2026 Shyden Ltd. Alla rättigheter förbehållna.' },
-    th: { footer_terms: 'ข้อกำหนดการใช้งาน', footer_guidelines: 'หลักเกณฑ์ชุมชน', footer_cyber: 'นโยบายต่อต้านการกลั่นแกล้ง', footer_copy: '© 2026 Shyden Ltd. สงวนลิขสิทธิ์.' },
-    tr: { footer_terms: 'Hizmet Şartları', footer_guidelines: 'Topluluk Kuralları', footer_cyber: 'Siber Zorbalık Politikası', footer_copy: '© 2026 Shyden Ltd. Tüm hakları saklıdır.' },
-    uk: { footer_terms: 'Умови використання', footer_guidelines: 'Правила спільноти', footer_cyber: 'Політика проти кібербулінгу', footer_copy: '© 2026 Shyden Ltd. Всі права захищені.' },
-    vi: { footer_terms: 'Điều khoản dịch vụ', footer_guidelines: 'Nguyên tắc cộng đồng', footer_cyber: 'Chính sách chống bắt nạt trực tuyến', footer_copy: '© 2026 Shyden Ltd. Mọi quyền được bảo lưu.' },
-    zh: { footer_terms: '服务条款', footer_guidelines: '社区准则', footer_cyber: '网络欺凌政策', footer_copy: '© 2026 Shyden Ltd. 版权所有.' },
+    ar: { footer_privacy: 'سياسة الخصوصية', footer_terms: 'شروط الخدمة', footer_guidelines: 'إرشادات المجتمع', footer_cyber: 'سياسة التنمر', footer_do_not_sell: 'عدم بيع أو مشاركة معلوماتي الشخصية', footer_copy: '© 2026 Shyden Ltd. جميع الحقوق محفوظة.' },
+    de: { footer_privacy: 'Datenschutzerklärung', footer_terms: 'Nutzungsbedingungen', footer_guidelines: 'Community-Richtlinien', footer_cyber: 'Cybermobbing-Richtlinie', footer_do_not_sell: 'Meine personenbezogenen Daten nicht verkaufen oder teilen', footer_copy: '© 2026 Shyden Ltd. Alle Rechte vorbehalten.' },
+    es: { footer_privacy: 'Política de privacidad', footer_terms: 'Términos de servicio', footer_guidelines: 'Normas de la comunidad', footer_cyber: 'Política contra el ciberacoso', footer_do_not_sell: 'No vender ni compartir mi información personal', footer_copy: '© 2026 Shyden Ltd. Todos los derechos reservados.' },
+    fr: { footer_privacy: 'Politique de confidentialité', footer_terms: 'Conditions d’utilisation', footer_guidelines: 'Règles de la communauté', footer_cyber: 'Politique anti-harcèlement', footer_do_not_sell: 'Ne pas vendre ni partager mes informations personnelles', footer_copy: '© 2026 Shyden Ltd. Tous droits réservés.' },
+    hi: { footer_privacy: 'गोपनीयता नीति', footer_terms: 'सेवा की शर्तें', footer_guidelines: 'सामुदायिक दिशानिर्देश', footer_cyber: 'साइबर बुलिंग नीति', footer_do_not_sell: 'मेरी व्यक्तिगत जानकारी न बेचें या साझा करें', footer_copy: '© 2026 Shyden Ltd. सर्वाधिकार सुरक्षित.' },
+    id: { footer_privacy: 'Kebijakan Privasi', footer_terms: 'Ketentuan Layanan', footer_guidelines: 'Pedoman Komunitas', footer_cyber: 'Kebijakan Perundungan Siber', footer_do_not_sell: 'Jangan Jual atau Bagikan Informasi Pribadi Saya', footer_copy: '© 2026 Shyden Ltd. Semua hak dilindungi.' },
+    it: { footer_privacy: 'Informativa sulla privacy', footer_terms: 'Termini di servizio', footer_guidelines: 'Linee guida della comunità', footer_cyber: 'Politica sul cyberbullismo', footer_do_not_sell: 'Non vendere né condividere le mie informazioni personali', footer_copy: '© 2026 Shyden Ltd. Tutti i diritti riservati.' },
+    ja: { footer_privacy: 'プライバシーポリシー', footer_terms: '利用規約', footer_guidelines: 'コミュニティガイドライン', footer_cyber: 'ネットいじめポリシー', footer_do_not_sell: '個人情報を販売または共有しない', footer_copy: '© 2026 Shyden Ltd. 無断複製禁止.' },
+    km: { footer_privacy: 'គោលការណ៍ឯកជនភាព', footer_terms: 'លក្ខខណ្ឌនៃសេវាកម្ម', footer_guidelines: 'គោលការណ៍សហគមន៍', footer_cyber: 'គោលនយោបាយប្រឆាំងការសម្លុតតាមអ៊ីនធឺណិត', footer_do_not_sell: 'កុំលក់ឬចែករំលែកព័ត៌មានផ្ទាល់ខ្លួនរបស់ខ្ញុំ', footer_copy: '© 2026 Shyden Ltd. រក្សាសិទ្ធិគ្រប់យ៉ាង។' },
+    ko: { footer_privacy: '개인정보처리방침', footer_terms: '이용 약관', footer_guidelines: '커뮤니티 가이드라인', footer_cyber: '사이버 불링 정책', footer_do_not_sell: '개인정보 판매 또는 공유 거부', footer_copy: '© 2026 Shyden Ltd. 모든 권리 보유.' },
+    nl: { footer_privacy: 'Privacybeleid', footer_terms: 'Servicevoorwaarden', footer_guidelines: 'Communityrichtlijnen', footer_cyber: 'Cyberpestbeleid', footer_do_not_sell: 'Mijn persoonlijke gegevens niet verkopen of delen', footer_copy: '© 2026 Shyden Ltd. Alle rechten voorbehouden.' },
+    pl: { footer_privacy: 'Polityka prywatności', footer_terms: 'Regulamin', footer_guidelines: 'Zasady społeczności', footer_cyber: 'Polityka cyberprzemocy', footer_do_not_sell: 'Nie sprzedawaj ani nie udostępniaj moich danych osobowych', footer_copy: '© 2026 Shyden Ltd. Wszelkie prawa zastrzeżone.' },
+    pt: { footer_privacy: 'Política de Privacidade', footer_terms: 'Termos de Serviço', footer_guidelines: 'Diretrizes da Comunidade', footer_cyber: 'Política de Cyberbullying', footer_do_not_sell: 'Não vender ou compartilhar minhas informações pessoais', footer_copy: '© 2026 Shyden Ltd. Todos os direitos reservados.' },
+    ru: { footer_privacy: 'Политика конфиденциальности', footer_terms: 'Условия использования', footer_guidelines: 'Правила сообщества', footer_cyber: 'Политика против кибербуллинга', footer_do_not_sell: 'Не продавать и не передавать мои личные данные', footer_copy: '© 2026 Shyden Ltd. Все права защищены.' },
+    sv: { footer_privacy: 'Integritetspolicy', footer_terms: 'Användarvillkor', footer_guidelines: 'Gemenskapsriktlinjer', footer_cyber: 'Policy mot nätmobbning', footer_do_not_sell: 'Sälj eller dela inte min personliga information', footer_copy: '© 2026 Shyden Ltd. Alla rättigheter förbehållna.' },
+    th: { footer_privacy: 'นโยบายความเป็นส่วนตัว', footer_terms: 'ข้อกำหนดการใช้งาน', footer_guidelines: 'หลักเกณฑ์ชุมชน', footer_cyber: 'นโยบายต่อต้านการกลั่นแกล้ง', footer_do_not_sell: 'ห้ามขายหรือแชร์ข้อมูลส่วนบุคคลของฉัน', footer_copy: '© 2026 Shyden Ltd. สงวนลิขสิทธิ์.' },
+    tr: { footer_privacy: 'Gizlilik Politikası', footer_terms: 'Hizmet Şartları', footer_guidelines: 'Topluluk Kuralları', footer_cyber: 'Siber Zorbalık Politikası', footer_do_not_sell: 'Kişisel bilgilerimi satma veya paylaşma', footer_copy: '© 2026 Shyden Ltd. Tüm hakları saklıdır.' },
+    uk: { footer_privacy: 'Політика конфіденційності', footer_terms: 'Умови використання', footer_guidelines: 'Правила спільноти', footer_cyber: 'Політика проти кібербулінгу', footer_do_not_sell: 'Не продавати та не передавати мої особисті дані', footer_copy: '© 2026 Shyden Ltd. Всі права захищені.' },
+    vi: { footer_privacy: 'Chính sách bảo mật', footer_terms: 'Điều khoản dịch vụ', footer_guidelines: 'Nguyên tắc cộng đồng', footer_cyber: 'Chính sách chống bắt nạt trực tuyến', footer_do_not_sell: 'Không bán hoặc chia sẻ thông tin cá nhân của tôi', footer_copy: '© 2026 Shyden Ltd. Mọi quyền được bảo lưu.' },
+    zh: { footer_privacy: '隐私政策', footer_terms: '服务条款', footer_guidelines: '社区准则', footer_cyber: '网络欺凌政策', footer_do_not_sell: '不要出售或共享我的个人信息', footer_copy: '© 2026 Shyden Ltd. 版权所有.' },
   },
   // ─── Privacy Policy ───
   privacy: {

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -247,7 +247,7 @@
       <a href="/terms.html" data-i18n="footer_terms">Terms of Service</a> &nbsp;&middot;&nbsp;
       <a href="/community-guidelines.html" data-i18n="footer_guidelines">Community Guidelines</a> &nbsp;&middot;&nbsp;
       <a href="/cyber-bullying.html" data-i18n="footer_cyber">Cyber Bullying Policy</a> &nbsp;&middot;&nbsp;
-      <a href="/do-not-sell.html">Do Not Sell or Share My Personal Information</a>
+      <a href="/do-not-sell.html" data-i18n="footer_do_not_sell">Do Not Sell or Share My Personal Information</a>
       <p class="copyright" data-i18n="footer_copy">&copy; 2026 Shyden Ltd. All rights reserved.</p>
     </footer>
   </div>

--- a/public/terms.html
+++ b/public/terms.html
@@ -223,7 +223,7 @@
       <a href="/privacy.html" data-i18n="footer_privacy">Privacy Policy</a> &nbsp;&middot;&nbsp;
       <a href="/community-guidelines.html" data-i18n="footer_guidelines">Community Guidelines</a> &nbsp;&middot;&nbsp;
       <a href="/cyber-bullying.html" data-i18n="footer_cyber">Cyber Bullying Policy</a> &nbsp;&middot;&nbsp;
-      <a href="/do-not-sell.html">Do Not Sell or Share My Personal Information</a>
+      <a href="/do-not-sell.html" data-i18n="footer_do_not_sell">Do Not Sell or Share My Personal Information</a>
       <p class="copyright" data-i18n="footer_copy">&copy; 2026 Shyden Ltd. All rights reserved.</p>
     </footer>
   </div>

--- a/tests/web/legal-footer-i18n.spec.ts
+++ b/tests/web/legal-footer-i18n.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEB_BASE_URL || 'http://localhost:8888';
+
+/**
+ * Regression: footer i18n was silently broken across the legal pages.
+ *
+ * Two distinct gaps surfaced 2026-05-09 via /manual-qa:
+ *
+ * 1. `footer_privacy` was REFERENCED in HTML (terms / community-guidelines /
+ *    privacy / cyber-bullying / do-not-sell) but UNDEFINED in
+ *    legal-translations.js for all 20 locales — so "Privacy Policy" stayed
+ *    in English even after switching to e.g. Arabic. The
+ *    `applyLegalTranslations` pattern (`if (t[key]) el.innerHTML = t[key]`)
+ *    silently no-ops on undefined keys, hiding the gap from visual scan.
+ *
+ * 2. `footer_do_not_sell` was MISSING entirely — neither the HTML referenced
+ *    it nor the JS defined it. The "Do Not Sell or Share My Personal
+ *    Information" link stayed English regardless of locale.
+ *
+ * Plus cyber-bullying.html and do-not-sell.html footer links had NO
+ * `data-i18n` attributes at all (whole footer untranslated), and
+ * do-not-sell.html wasn't loading legal-translations.js OR setting
+ * window.LEGAL_PAGE_TYPE — so even adding data-i18n there required wiring
+ * the i18n bridge first.
+ *
+ * The test suite hits Arabic (RTL + non-Latin script — easiest to detect
+ * remaining English) on all 5 legal pages and asserts every footer link's
+ * text changed away from English defaults.
+ */
+
+const ENGLISH_FOOTER_TEXTS = {
+  privacy: 'Privacy Policy',
+  terms: 'Terms of Service',
+  guidelines: 'Community Guidelines',
+  cyber: 'Cyber Bullying Policy',
+  do_not_sell: 'Do Not Sell or Share My Personal Information',
+};
+
+const PAGES = [
+  { path: '/terms.html', selfKey: 'terms' },
+  { path: '/privacy.html', selfKey: 'privacy' },
+  { path: '/community-guidelines.html', selfKey: 'guidelines' },
+  { path: '/cyber-bullying.html', selfKey: 'cyber' },
+  { path: '/do-not-sell.html', selfKey: 'do_not_sell' },
+];
+
+test.describe('Legal footer i18n — every page, every locale-switch', () => {
+  for (const { path, selfKey } of PAGES) {
+    test(`${path} translates every footer link to Arabic`, async ({ page }) => {
+      // Pre-set the saved language so applyLanguage fires on init via the
+      // legal-translations.js inline bridge, not via the language-selector
+      // modal click flow (faster + more deterministic).
+      await page.addInitScript(() => {
+        localStorage.setItem('shytalk_language', 'ar');
+      });
+      await page.goto(`${BASE}${path}`);
+      // Wait for the inline init script to apply translations.
+      await page.waitForFunction(
+        () => document.documentElement.lang === 'ar',
+        null,
+        { timeout: 5_000 },
+      );
+
+      // Every footer link visible on this page must NOT contain its English
+      // default text after the locale switch. (The page's self-link isn't
+      // rendered in its own footer — skip it.)
+      for (const [key, englishText] of Object.entries(ENGLISH_FOOTER_TEXTS)) {
+        if (key === selfKey) continue;
+        const link = page.locator(`footer a[data-i18n="footer_${key}"]`);
+        const count = await link.count();
+        if (count === 0) continue; // page doesn't link to this policy
+        const text = await link.first().textContent();
+        expect(
+          text?.trim(),
+          `${path} footer link footer_${key} stayed in English ("${text?.trim()}") after Arabic switch — likely missing translation key in legal-translations.js or missing data-i18n attribute`,
+        ).not.toBe(englishText);
+        // Sanity: should contain non-Latin Arabic characters (؀-ۿ block).
+        expect(text).toMatch(/[؀-ۿ]/);
+      }
+    });
+  }
+
+  test('legal-translations.js defines footer_privacy + footer_do_not_sell for all 20 locales', async ({ request }) => {
+    const res = await request.get(`${BASE}/js/legal-translations.js`);
+    expect(res.status()).toBe(200);
+    const text = await res.text();
+    const locales = ['ar', 'de', 'es', 'fr', 'hi', 'id', 'it', 'ja', 'km', 'ko', 'nl', 'pl', 'pt', 'ru', 'sv', 'th', 'tr', 'uk', 'vi', 'zh'];
+    for (const locale of locales) {
+      // Find this locale's line in the footer object (locale: { ... })
+      const localeLineMatch = new RegExp(`\\s${locale}: \\{ [^\\n]*footer_copy:`, 'g').exec(text);
+      expect(localeLineMatch, `${locale} footer line not found`).not.toBeNull();
+      const localeLine = localeLineMatch![0];
+      expect(localeLine, `${locale} missing footer_privacy`).toContain('footer_privacy:');
+      expect(localeLine, `${locale} missing footer_do_not_sell`).toContain('footer_do_not_sell:');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two silent-failure i18n bugs across the 5 legal pages, found 2026-05-09 via /manual-qa:

1. **`footer_privacy` was referenced but undefined** for all 20 locales. The `applyLegalTranslations` pattern silently no-ops on undefined keys (`if (t[key]) el.innerHTML = t[key]`), so "Privacy Policy" stayed in English forever — undetectable without active language-switch testing.

2. **`footer_do_not_sell` was missing entirely** — the CCPA-mandated link stayed in English regardless of locale.

3. **cyber-bullying.html and do-not-sell.html footer links had no `data-i18n` attributes at all** (whole footers untranslated), and do-not-sell.html wasn't even loading legal-translations.js — required wiring the i18n bridge before retrofit could matter.

## Changes

- `public/js/legal-translations.js` — add `footer_privacy` + `footer_do_not_sell` to all 20 locales' footer object; comment fix (19 → 20).
- `public/admin/translations.js` — comment fix (19 → 20). [bundles task #20]
- `public/terms.html`, `public/privacy.html`, `public/community-guidelines.html` — add `data-i18n="footer_do_not_sell"` on existing link.
- `public/cyber-bullying.html` — retrofit data-i18n on all 4 footer links.
- `public/do-not-sell.html` — retrofit data-i18n on all 4 footer links + copyright; wire `LEGAL_PAGE_TYPE='donotsell'` + `legal-translations.js` + inline init bridge mirroring terms.html.

## Test plan

- [x] `WEB_BASE_URL=http://localhost:8888 npx playwright test tests/web/legal-footer-i18n.spec.ts --project=chromium` (6/6 passed in 2.0s)
- New test file: 5 page-by-page Arabic translation checks + 1 structural check across all 20 locales.

## Manual QA

Pure web/i18n change. Cross-platform mapping → real browser via chromium Playwright. All 6 tests pass; verified Arabic renders correctly on all 5 legal pages with the new keys.

## Why the silent-failure pattern is the real lesson

This bug existed since the original i18n wiring. It surfaced now because /manual-qa actively switched languages and visually inspected. A grep-paired CI check (data-i18n in HTML must have a matching key in JS) would prevent this class of bug — worth tracking as a follow-up CI guard task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)