### PR TITLE
feat(ci): orphan data-i18n key guard — prevents silent-failure i18n pattern

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,3 +88,6 @@ jobs:
 
       - name: Workflow concurrency groups are scoped or intentionally global
         run: bash scripts/check-workflow-concurrency-scoping.sh
+
+      - name: HTML data-i18n keys all have JS translation definitions
+        run: bash scripts/check-orphan-i18n-keys.sh

--- a/scripts/check-orphan-i18n-keys.sh
+++ b/scripts/check-orphan-i18n-keys.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Reject any HTML data-i18n key that isn't defined in at least one JS
+# translation file.
+#
+# Background: applyLegalTranslations / applyPortalTranslations etc. all
+# follow the pattern `if (t[key]) el.innerHTML = t[key];` — silently
+# no-opping on undefined keys. That means a `data-i18n="foo"` attribute
+# in HTML with no matching `foo:` definition in a JS translation file
+# renders as the inline HTML default forever, indistinguishable from
+# the intended translation. Three instances bit us 2026-05-09:
+#   1. footer_privacy referenced in 5 legal pages, undefined for all
+#      20 locales (PR #573 fixed)
+#   2. footer_do_not_sell never defined (PR #573 added)
+#   3. PORTAL_T.en drifted from HTML defaults in 18 places (PR #576
+#      first attempt broke 5 portal-dashboard tests)
+#
+# This guard greps every public/**/*.html for data-i18n attributes,
+# greps every public/**/*.js for `keyname:` object-property syntax in
+# files that look like translation modules (contain LEGAL_T / PORTAL_T
+# / a translations object), and reports any HTML key with no JS match.
+#
+# False-negative scope: if an HTML page loads JS file A but the only
+# definition of its key is in JS file B, the guard reports OK. For
+# ShyTalk this is fine — the namespaces (footer_*, portal_*,
+# dashboard_*, security_*, not_found_*, etc.) are distinct enough that
+# cross-file matches are practically all valid.
+#
+# Run from project root.
+
+set -euo pipefail
+
+# Translation files to scan for key definitions. Restricting the JS
+# scope avoids false positives from random object literals in app code.
+TRANSLATION_FILES=(
+  "public/js/legal-translations.js"
+  "public/portal/portal-translations.js"
+  "public/admin/translations.js"
+  "public/js/suggestions-i18n.js"
+  "public/js/roadmap-app.js"
+)
+
+# Aggregate every `keyname:` definition from translation files. Match
+# only lower_snake_case keys (ShyTalk's i18n key convention) to filter
+# out noise like `width:` or `color:` from inline style strings.
+defined_keys=$(
+  for f in "${TRANSLATION_FILES[@]}"; do
+    [ -f "$f" ] && grep -hoE '\b[a-z][a-z0-9_]+:' "$f" || true
+  done | sed 's/:$//' | sort -u
+)
+
+# Aggregate every `data-i18n="key"` attribute from public HTML files.
+referenced_keys=$(
+  grep -rhoE 'data-i18n="[a-z][a-z0-9_]+"' public --include='*.html' \
+    | sed -E 's/data-i18n="([^"]+)"/\1/' \
+    | sort -u
+)
+
+# Diff — any HTML key not present in JS keys is an orphan.
+all_orphans=$(comm -23 <(echo "$referenced_keys") <(echo "$defined_keys"))
+
+# Filter against the legacy allowlist (pre-existing orphans we haven't
+# yet retired — see scripts/i18n-orphan-allowlist.txt for context).
+ALLOWLIST="scripts/i18n-orphan-allowlist.txt"
+if [ -f "$ALLOWLIST" ]; then
+  allowlist_keys=$(grep -vE '^\s*(#|$)' "$ALLOWLIST" | sort -u)
+  orphans=$(comm -23 <(echo "$all_orphans") <(echo "$allowlist_keys"))
+else
+  orphans=$all_orphans
+fi
+
+if [ -n "$orphans" ]; then
+  echo "::error::Orphan data-i18n keys found in HTML — referenced but not defined in any JS translation file:"
+  echo ""
+  while IFS= read -r key; do
+    [ -z "$key" ] && continue
+    echo "  $key"
+    # Show which HTML files reference the orphan, to help the dev fix.
+    grep -rlE "data-i18n=\"${key}\"" public --include='*.html' 2>/dev/null \
+      | head -3 \
+      | while read -r match_file; do echo "    referenced by: $match_file"; done
+  done <<< "$orphans"
+  echo ""
+  echo "Why this matters: applyLegalTranslations / applyPortalTranslations"
+  echo "etc. silently no-op on undefined keys (\`if (t[key]) ...\`), so the"
+  echo "HTML inline default renders forever — undetectable without active"
+  echo "language-switch testing. Add the missing keys to the appropriate"
+  echo "translation file (legal-translations.js / portal-translations.js /"
+  echo "admin/translations.js etc.) for ALL 20 locales."
+  exit 1
+fi
+
+# Also report referenced-key count for visibility (helpful for tracking
+# the project's i18n surface area over time).
+ref_count=$(echo "$referenced_keys" | grep -c . || echo 0)
+def_count=$(echo "$defined_keys" | grep -c . || echo 0)
+echo "✓ All $ref_count HTML data-i18n keys have JS definitions ($def_count keys defined across translation files)."

--- a/scripts/i18n-orphan-allowlist.txt
+++ b/scripts/i18n-orphan-allowlist.txt
@@ -1,0 +1,117 @@
+# Allowlisted "legacy" orphan data-i18n keys — known to be undefined in
+# any JS translation file as of 2026-05-09 when scripts/check-orphan-i18n-keys.sh
+# was first wired into CI. The guard only fails on NEW additions; this
+# list is the baseline of pre-existing orphans we haven't yet retired.
+#
+# Each entry should eventually be either:
+#   (a) added to the appropriate JS translation file with translations
+#       for all 20 locales, then removed from this list, OR
+#   (b) confirmed as dormant markup (the page doesn't load any
+#       translation infrastructure) and removed from the HTML, OR
+#   (c) the page wired up with translation infrastructure and (a) applied.
+#
+# When adding a new entry: include a comment with the source page so a
+# future maintainer knows where to look. When removing: just delete the
+# line.
+
+# ── Admin age-verification panel — sub-tab never translated ──
+# (admin/translations.js doesn't define age_verif_* keys; sub-tab is
+#  English-only across all admin locales)
+age_verif_approve_button
+age_verif_approve_help
+age_verif_field_method
+age_verif_field_recorded_dob
+age_verif_field_submission_id
+age_verif_field_submitted_at
+age_verif_image_disclaimer
+age_verif_jump_next
+age_verif_match_no
+age_verif_match_question
+age_verif_match_yes
+age_verif_modify_button
+age_verif_modify_help
+age_verif_new_dob_label
+age_verif_no_pending_for_user
+age_verif_other_pending_label
+age_verif_panel_subtitle
+age_verif_panel_title
+age_verif_reject_button
+age_verif_reject_summary
+subtab_age_verification
+subtab_identity
+tab_audit_log
+tab_suggestions
+
+# ── Khmer New Year event page — fully untranslated ──
+# (events/khmer-new-year.html has no applyLanguage handler; data-i18n
+#  attributes are dormant markup. Either translate the page or remove
+#  the attributes.)
+kny_day1_date
+kny_day1_label
+kny_day1_p
+kny_day2_date
+kny_day2_label
+kny_day2_p
+kny_day3_date
+kny_day3_label
+kny_day3_p
+kny_days_h
+kny_days_intro
+kny_footer
+kny_greetings_h
+kny_greetings_p
+kny_hero_subtitle
+kny_trad1_h
+kny_trad1_p
+kny_trad2_h
+kny_trad2_p
+kny_trad3_h
+kny_trad3_p
+kny_trad4_h
+kny_trad4_p
+kny_trad5_h
+kny_trad5_p
+kny_trad6_h
+kny_trad6_p
+kny_traditions_h
+kny_what_h
+kny_what_p1
+kny_what_p2
+kny_what_p3
+kny_zodiac_col_animal
+kny_zodiac_col_khmer
+kny_zodiac_col_years
+kny_zodiac_fact_label
+kny_zodiac_fact_p
+kny_zodiac_h
+kny_zodiac_p
+
+# ── Privacy policy section 10 + a few inline keys — missing in legal-translations.js ──
+# (pp_s10_* are footer/contact section, pp_s1_p7 / pp_s2_li7 / pp_s3_li5
+#  are inline points added later. legal-translations.js has pp_s9_h as
+#  the last section; section 10 was added without backfilling translations.)
+pp_s1_p7
+pp_s2_li7
+pp_s3_li5
+pp_s10_h
+pp_s10_p1
+pp_s10_p2
+pp_s10_p3
+pp_s10_p4
+pp_s10_p5
+pp_s10_p6
+pp_s10_p7
+
+# ── Homepage data-i18n with no applyLanguage handler ──
+# (index.html doesn't load any translations script; data-i18n is
+#  dormant. The "Coming Soon" hero copy is English-only by design but
+#  marked-up for future i18n.)
+app_store
+coming_soon
+roadmap_cta
+roadmap_label
+roadmap_sparkle
+tagline
+
+# ── Roadmap footer copyright — needs key in roadmap-app.js translations ──
+copyright


### PR DESCRIPTION
## Summary

Three i18n bugs this session shared the same root cause: `applyLegalTranslations` / `applyPortalTranslations` silently no-op on undefined keys (`if (t[key]) el.innerHTML = t[key]`), so a `data-i18n="foo"` in HTML with no `foo:` definition in JS renders as inline default forever — undetectable without active language-switch testing.

This guard catches the pattern at PR time.

- **scripts/check-orphan-i18n-keys.sh** — greps every `public/**/*.html` for `data-i18n` attributes, greps 5 known translation modules for `keyname:` syntax, reports any HTML key without a JS match.
- **scripts/i18n-orphan-allowlist.txt** — snapshots the **80+ pre-existing orphans** found on first run (admin age-verif panel, Khmer New Year event, privacy section 10, homepage dormant markup, roadmap copyright) so legacy debt doesn't block the guard's adoption. Tracked as task #24.
- **.github/workflows/lint.yml** — invokes the guard alongside `check-workflow-concurrency-scoping.sh`.

## Why this matters

Three concrete instances bit us 2026-05-09:
1. `footer_privacy` referenced in 5 legal pages, undefined for all 20 locales → "Privacy Policy" stayed English regardless of locale (PR #573 fixed)
2. `footer_do_not_sell` never defined at all (PR #573 added)
3. `PORTAL_T.en` drifted from HTML defaults in 18 places → PR #576's first attempt broke 5 portal-dashboard tests when the new init-on-load IIFE activated previously-dormant en translations

Each took manual debugging to surface. The guard catches them at lint time.

## Test plan

- [x] Clean state: `bash scripts/check-orphan-i18n-keys.sh` exit 0, "320 HTML keys all defined; 418 JS keys defined"
- [x] Synthetic orphan injection (`data-i18n="this_key_does_not_exist_xyz"` in terms.html): exits 1 with clear error message including source file pointer
- [x] Allowlist test: removed allowlist file → guard reports all 80+ legacy orphans → restored allowlist → guard passes

## Manual QA

CI-only YAML/script change. Cross-platform mapping → static-config validation. Local guard + allowlist round-trip verified.

## Follow-up

Task #24: retire the 80+ legacy orphans by category. Each retired orphan = (a) translations added to JS translation file for all 20 locales, OR (b) data-i18n attribute removed if page has no translation infrastructure. Allowlist entries deleted as retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)