### PR TITLE
fix(roadmap): retire copyright i18n orphan

### DIFF
--- a/public/js/roadmap-app.js
+++ b/public/js/roadmap-app.js
@@ -32,6 +32,7 @@
       tryAgain: "Try again",
       notifyPrompt: "Sign in to the app to get notified about this feature.",
       disclaimer: "Features and priorities may change as development progresses and user feedback is received.",
+      copyright: "© Shyden Ltd",
     },
     ar: {
       inProgress:
@@ -697,6 +698,12 @@
     var disclaimerEl = document.querySelector("[data-i18n='disclaimer']");
     if (disclaimerEl) {
       disclaimerEl.textContent = t("disclaimer");
+    }
+
+    // Update footer copyright translation
+    var copyrightEl = document.querySelector("[data-i18n='copyright']");
+    if (copyrightEl) {
+      copyrightEl.textContent = t("copyright");
     }
 
     // Attach collapse/expand handlers

--- a/scripts/i18n-orphan-allowlist.txt
+++ b/scripts/i18n-orphan-allowlist.txt
@@ -113,5 +113,3 @@ roadmap_label
 roadmap_sparkle
 tagline
 
-# ── Roadmap footer copyright — needs key in roadmap-app.js translations ──
-copyright

--- a/tests/web/roadmap-footer-i18n.spec.ts
+++ b/tests/web/roadmap-footer-i18n.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEB_BASE_URL || 'http://localhost:8888';
+
+/**
+ * Regression test for the roadmap footer copyright orphan retired in
+ * the i18n-orphan cleanup work.
+ *
+ * Background: roadmap.html ships `<span data-i18n="copyright">© Shyden
+ * Ltd</span>`, but `copyright` was undefined in roadmap-app.js. The
+ * applyLanguage handler silently no-ops on missing keys, so the inline
+ * default rendered as an English string in every locale — invisibly
+ * "broken" because the value happens to be visually neutral.
+ *
+ * This test pins:
+ *  1. The DOM update path runs (textContent populated by JS, not just
+ *     inline default).
+ *  2. The English fallback works for languages that don't define
+ *     `copyright` explicitly (relies on `LABELS.en[key]` fallback in
+ *     `t()` at roadmap-app.js).
+ */
+
+test.describe('Roadmap footer i18n', () => {
+  test('copyright element is populated via t() — not left as raw HTML default', async ({ page }) => {
+    await page.goto(`${BASE}/roadmap.html`);
+
+    // Wait for roadmap-app.js to finish rendering (footer disclaimer
+    // gets populated in the same code path as copyright).
+    await page.waitForFunction(
+      () => {
+        const el = document.querySelector('[data-i18n="disclaimer"]');
+        return !!(el && el.textContent && el.textContent.trim().length > 0);
+      },
+      null,
+      { timeout: 10_000 },
+    );
+
+    const copyright = page.locator('[data-i18n="copyright"]');
+    await expect(copyright).toBeVisible();
+    const text = (await copyright.textContent())?.trim() || '';
+    expect(text, 'copyright must contain Shyden Ltd brand').toContain('Shyden Ltd');
+    expect(text, 'copyright must contain copyright symbol').toMatch(/©/);
+  });
+
+  test('copyright falls back to English when locale lacks the key', async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('shytalk_language', 'ar');
+      } catch {
+        /* localStorage may be unavailable on some webkit configs; ignore */
+      }
+    });
+    await page.goto(`${BASE}/roadmap.html`);
+
+    await page.waitForFunction(
+      () => {
+        const el = document.querySelector('[data-i18n="copyright"]');
+        return !!(el && el.textContent && el.textContent.includes('Shyden Ltd'));
+      },
+      null,
+      { timeout: 10_000 },
+    );
+
+    const copyright = await page.locator('[data-i18n="copyright"]').textContent();
+    expect(copyright, 'copyright must contain Shyden Ltd brand even in Arabic locale').toContain('Shyden Ltd');
+  });
+
+  test('roadmap-app.js defines copyright key (orphan-checker contract)', async ({ request }) => {
+    const res = await request.get(`${BASE}/js/roadmap-app.js`);
+    expect(res.ok()).toBe(true);
+    const src = await res.text();
+    expect(src, 'copyright key must be defined to satisfy orphan-i18n-keys check').toMatch(
+      /copyright:\s*"[^"]*Shyden Ltd[^"]*"/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Wires up the `copyright` data-i18n key on roadmap.html footer so it renders via JS instead of relying on the silently-no-op'd HTML default
- Defines `copyright: \"© Shyden Ltd\"` in `LABELS.en` (other locales fall through via `LABELS.en[key]` fallback in `t()` since the brand name is universal)
- Removes `copyright` from `scripts/i18n-orphan-allowlist.txt` so the orphan-i18n-keys CI guard enforces the contract going forward
- New Playwright spec (`tests/web/roadmap-footer-i18n.spec.ts`) pins three regression contracts: DOM-populated-by-JS, Arabic-locale fallback, orphan-checker key definition

## Why

`<span data-i18n=\"copyright\">© Shyden Ltd</span>` was an orphan since the roadmap-app.js LABELS struct never defined it. `applyLanguage` no-ops silently on missing keys (`if (t[key]) ...`), so the inline default rendered in every locale — invisibly broken because the brand name happens to be visually neutral. This pattern bit the project three times in 2026-05-09 (footer_privacy, footer_do_not_sell, PORTAL_T.en drift). PR #577 added the orphan-keys CI guard but allowlisted 80+ pre-existing entries; this is the first of those entries to be retired.

## Test plan

- [x] `bash scripts/check-orphan-i18n-keys.sh` → passes (320 keys all defined)
- [x] `WEB_BASE_URL=http://localhost:8888 npx playwright test tests/web/roadmap-footer-i18n.spec.ts --project=chromium` → 3/3 passed
- [x] `WEB_BASE_URL=http://localhost:8888 npx playwright test tests/web/roadmap-redesign.spec.ts --project=chromium` → 44/44 passed (no regressions on existing roadmap tests)
- [ ] Cross-browser CI (chromium/firefox/webkit/mobile-chrome/mobile-safari)
- [ ] Manual QA: load /roadmap.html in Arabic locale, confirm footer copyright still reads \"© Shyden Ltd\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)