### PR TITLE
fix(roadmap): translate footer links via legal-translations.js

### DIFF
--- a/public/js/roadmap-app.js
+++ b/public/js/roadmap-app.js
@@ -863,14 +863,21 @@
     return (navigator.language || "en").split("-")[0];
   }
 
-  // Called by language-selector.js when user changes language
-  window.applyLanguage = function (lang) {
-    currentLang = lang;
-    if (roadmapData) {
-      renderPhases(roadmapData);
-      setupScrollSpy();
-    }
-  };
+  // Called by language-selector.js when user changes language.
+  // Chains with any prior applyLanguage handler (e.g. legal-translations.js
+  // for footer link i18n) so multiple translation modules can co-exist
+  // without overwriting each other.
+  (function () {
+    var _prev = window.applyLanguage;
+    window.applyLanguage = function (lang) {
+      currentLang = lang;
+      if (roadmapData) {
+        renderPhases(roadmapData);
+        setupScrollSpy();
+      }
+      if (typeof _prev === "function") _prev(lang);
+    };
+  })();
 
   // ── Fetch and init ──
 

--- a/public/roadmap.html
+++ b/public/roadmap.html
@@ -1794,10 +1794,10 @@
       >
       <span class="footer-updated last-updated" id="footer-updated" data-testid="last-updated"></span>
       <nav class="footer-links" aria-label="Legal" style="display:flex;gap:16px;margin-top:8px;font-size:0.75rem;flex-wrap:wrap;">
-        <a href="/privacy.html" style="color:var(--text-secondary);text-decoration:none;">Privacy Policy</a>
-        <a href="/terms.html" style="color:var(--text-secondary);text-decoration:none;">Terms</a>
-        <a href="/community-guidelines.html" style="color:var(--text-secondary);text-decoration:none;">Community Guidelines</a>
-        <a href="/do-not-sell.html" style="color:var(--text-secondary);text-decoration:none;">Do Not Sell or Share My Personal Information</a>
+        <a href="/privacy.html" data-i18n="footer_privacy" style="color:var(--text-secondary);text-decoration:none;">Privacy Policy</a>
+        <a href="/terms.html" data-i18n="footer_terms" style="color:var(--text-secondary);text-decoration:none;">Terms</a>
+        <a href="/community-guidelines.html" data-i18n="footer_guidelines" style="color:var(--text-secondary);text-decoration:none;">Community Guidelines</a>
+        <a href="/do-not-sell.html" data-i18n="footer_do_not_sell" style="color:var(--text-secondary);text-decoration:none;">Do Not Sell or Share My Personal Information</a>
       </nav>
     </footer>
 
@@ -1863,6 +1863,13 @@
       })();
     </script>
     <script src="/js/roadmap-auth.js"></script>
+    <!-- legal-translations.js + LEGAL_PAGE_TYPE='roadmap' (no LEGAL_T.roadmap
+         section exists, so only LEGAL_T.footer applies — translates the
+         footer-link text alongside the existing copyright/disclaimer i18n). -->
+    <script>
+      window.LEGAL_PAGE_TYPE = "roadmap";
+    </script>
+    <script src="/js/legal-translations.js"></script>
     <script src="/js/roadmap-app.js" defer></script>
     <script src="/js/suggestions-i18n.js" defer></script>
     <script src="/js/suggestions-board.js" defer></script>

--- a/tests/web/roadmap-footer-links-i18n.spec.ts
+++ b/tests/web/roadmap-footer-links-i18n.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEB_BASE_URL || 'http://localhost:8888';
+
+/**
+ * Regression test for the roadmap footer LINK i18n gap surfaced during
+ * PR #579 manual-QA.
+ *
+ * Background: roadmap.html shipped four hardcoded English footer links
+ * — Privacy Policy, Terms, Community Guidelines, Do Not Sell or Share
+ * My Personal Information. The translations for these (footer_privacy,
+ * footer_terms, footer_guidelines, footer_do_not_sell) had been added
+ * to legal-translations.js in PR #573 for legal pages, but roadmap.html
+ * never loaded that script — so its footer links rendered English in
+ * every locale even though the rest of the page (disclaimer, copyright)
+ * translated correctly.
+ *
+ * Fix: load legal-translations.js (with `LEGAL_PAGE_TYPE='roadmap'` —
+ * no LEGAL_T.roadmap section so only LEGAL_T.footer applies), refactor
+ * roadmap-app.js applyLanguage to chain (not replace) the prior
+ * handler, and add `data-i18n` attributes to the four link texts.
+ *
+ * Test design: Spanish locale (Latin script, easiest to detect drift),
+ * with a structural check that all four data-i18n attrs exist in HTML.
+ */
+
+test.describe('Roadmap footer links i18n', () => {
+  test('Spanish locale translates all four footer links', async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('shytalk_language', 'es');
+      } catch {
+        /* ignore */
+      }
+    });
+    await page.goto(`${BASE}/roadmap.html`);
+
+    // Wait for the legal-translations chain to apply via language-selector init.
+    await page.waitForFunction(
+      () => {
+        const el = document.querySelector('[data-i18n="footer_privacy"]');
+        return !!(el && el.textContent && el.textContent.includes('Política'));
+      },
+      null,
+      { timeout: 10_000 },
+    );
+
+    const privacy = (await page.locator('[data-i18n="footer_privacy"]').textContent())?.trim();
+    const terms = (await page.locator('[data-i18n="footer_terms"]').textContent())?.trim();
+    const guidelines = (await page.locator('[data-i18n="footer_guidelines"]').textContent())?.trim();
+    const dns = (await page.locator('[data-i18n="footer_do_not_sell"]').textContent())?.trim();
+
+    expect(privacy, 'footer_privacy should not be English').not.toBe('Privacy Policy');
+    expect(privacy, 'footer_privacy in es').toContain('Política');
+    expect(terms, 'footer_terms should not be English').not.toBe('Terms');
+    expect(guidelines, 'footer_guidelines should not be English').not.toBe('Community Guidelines');
+    expect(dns, 'footer_do_not_sell should not be English').not.toBe(
+      'Do Not Sell or Share My Personal Information',
+    );
+  });
+
+  test('English (default) renders the inline HTML defaults', async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('shytalk_language', 'en');
+      } catch {
+        /* ignore */
+      }
+    });
+    await page.goto(`${BASE}/roadmap.html`);
+
+    await expect(page.locator('[data-i18n="footer_privacy"]')).toContainText('Privacy Policy');
+    await expect(page.locator('[data-i18n="footer_terms"]')).toContainText('Terms');
+    await expect(page.locator('[data-i18n="footer_guidelines"]')).toContainText(
+      'Community Guidelines',
+    );
+    await expect(page.locator('[data-i18n="footer_do_not_sell"]')).toContainText(
+      'Do Not Sell or Share My Personal Information',
+    );
+  });
+
+  test('roadmap-app.js applyLanguage chains rather than replaces (preserves prior handlers)', async ({
+    request,
+  }) => {
+    const res = await request.get(`${BASE}/js/roadmap-app.js`);
+    expect(res.ok()).toBe(true);
+    const src = await res.text();
+    // Look for the chain pattern: capture _prev, call it after own work.
+    expect(src, 'roadmap-app.js must capture prior applyLanguage in _prev').toMatch(
+      /var\s+_prev\s*=\s*window\.applyLanguage/,
+    );
+    expect(src, 'roadmap-app.js must call _prev to preserve chain').toMatch(
+      /_prev\s*\(\s*lang\s*\)/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The four footer link texts on roadmap.html — Privacy Policy, Terms, Community Guidelines, Do Not Sell or Share My Personal Information — were hardcoded English with no \`data-i18n\` attribute. They rendered in English in every locale even though the rest of the footer (copyright, disclaimer) translated correctly. Surfaced during PR #579 manual-QA.

Translations already existed in \`legal-translations.js\` (LEGAL_T.footer) from PR #573 — they just weren't wired into roadmap.html.

## Changes

1. **Load legal-translations.js on roadmap.html**, with \`LEGAL_PAGE_TYPE='roadmap'\` set first. No LEGAL_T.roadmap section exists, so applyLegalTranslations only iterates LEGAL_T.footer[lang] (the four needed keys × 20 locales). Avoids pulling in legal-page-specific translations.
2. **Refactor roadmap-app.js applyLanguage** from a hard \`window.applyLanguage = ...\` replacement into a chain wrapper that captures \`_prev\` and calls it after roadmap-specific work. Without this, legal-translations.js's window.applyLanguage assignment gets clobbered. Mirrors the chain pattern already used by suggestions-i18n.js and event-translations.js.
3. **Add \`data-i18n\` attributes** to the four \`<a>\` link texts in roadmap.html matching the existing footer_* keys.

## Why

This was discovered during manual-QA on PR #579 — the screenshot of the Arabic-locale roadmap footer showed copyright + disclaimer in Arabic but the four legal links still in English. Same silent-no-op pattern that bit us 5+ times in 2026-05-09.

## Test plan

- [x] \`bash scripts/check-orphan-i18n-keys.sh\` → passes (320 keys all defined, 467 keys defined across 6 translation files)
- [x] \`WEB_BASE_URL=http://localhost:8888 npx playwright test tests/web/roadmap-footer-links-i18n.spec.ts tests/web/roadmap-footer-i18n.spec.ts tests/web/roadmap-redesign.spec.ts --project=chromium\` → 50/50 passed (3 new + 3 existing footer + 44 redesign regressions)
- [ ] Cross-browser CI (chromium/firefox/webkit/mobile-chrome/mobile-safari)
- [ ] Manual QA: load /roadmap.html in Spanish, scroll to footer, verify all four links read in Spanish

🤖 Generated with [Claude Code](https://claude.com/claude-code)