### PR TITLE
fix(homepage): translate footer links + copyright via legal-translations.js

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -191,14 +191,19 @@
       <span class="coming-soon-link" data-i18n="app_store" title="Coming soon to iOS">App Store (Coming Soon)</span>
     </div>
     <div class="links" style="margin-top: 1.5rem;">
-      <a href="/privacy.html">Privacy Policy</a>
-      <a href="/terms.html">Terms of Service</a>
-      <a href="/community-guidelines.html">Community Guidelines</a>
-      <a href="/cyber-bullying.html">Cyber Bullying Policy</a>
-      <a href="/do-not-sell.html">Do Not Sell or Share My Personal Information</a>
+      <a href="/privacy.html" data-i18n="footer_privacy">Privacy Policy</a>
+      <a href="/terms.html" data-i18n="footer_terms">Terms of Service</a>
+      <a href="/community-guidelines.html" data-i18n="footer_guidelines">Community Guidelines</a>
+      <a href="/cyber-bullying.html" data-i18n="footer_cyber">Cyber Bullying Policy</a>
+      <a href="/do-not-sell.html" data-i18n="footer_do_not_sell">Do Not Sell or Share My Personal Information</a>
     </div>
-    <p class="copyright" style="color: var(--text2); font-size: 0.8rem; margin-top: 1.5rem; opacity: 0.6;">&copy; 2026 Shyden Ltd. All rights reserved.</p>
+    <p class="copyright" data-i18n="footer_copy" style="color: var(--text2); font-size: 0.8rem; margin-top: 1.5rem; opacity: 0.6;">&copy; 2026 Shyden Ltd. All rights reserved.</p>
   </main>
+<!-- legal-translations.js + LEGAL_PAGE_TYPE='home' (no LEGAL_T.home section
+     exists, so only LEGAL_T.footer applies — translates the footer-link text
+     and copyright across all 20 locales). -->
+<script>window.LEGAL_PAGE_TYPE = "home";</script>
+<script src="/js/legal-translations.js"></script>
 <script>
 (function() {
   var t = {
@@ -222,6 +227,10 @@
     nl: { tagline: "Spraakchatrooms, opnieuw uitgevonden.", coming_soon: "Binnenkort", app_store: "App Store (Binnenkort)", app_store_title: "Binnenkort op iOS" },
     sv: { tagline: "R\u00f6stchattrum, nyt\u00e4nkt.", coming_soon: "Kommer snart", app_store: "App Store (Kommer snart)", app_store_title: "Kommer snart till iOS" }
   };
+  // Chain with any prior applyLanguage handler (e.g. legal-translations.js
+  // for footer link i18n) so the inline tagline/coming_soon/roadmap_cta
+  // translations co-exist with the shared legal footer translations.
+  var _prevApplyLanguage = window.applyLanguage;
   window.applyLanguage = function(lang) {
     var strings = t[lang];
     if (strings) {
@@ -237,6 +246,7 @@
         if (el.dataset.defaultText) el.textContent = el.dataset.defaultText;
       });
     }
+    if (typeof _prevApplyLanguage === "function") _prevApplyLanguage(lang);
   };
   // Save default English text for reset
   document.querySelectorAll("[data-i18n]").forEach(function(el) {

--- a/tests/web/homepage-footer-links-i18n.spec.ts
+++ b/tests/web/homepage-footer-links-i18n.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEB_BASE_URL || 'http://localhost:8888';
+
+/**
+ * Regression test for the homepage footer LINK i18n gap.
+ *
+ * Background: index.html shipped six hardcoded English footer strings
+ * — Privacy Policy, Terms of Service, Community Guidelines, Cyber
+ * Bullying Policy, Do Not Sell or Share My Personal Information, and
+ * the © Shyden Ltd copyright line. None had `data-i18n` attributes,
+ * so they rendered English in every locale even though the rest of
+ * the homepage (tagline, Coming Soon, App Store, roadmap CTA)
+ * translated correctly.
+ *
+ * Fix: load legal-translations.js (with `LEGAL_PAGE_TYPE='home'` —
+ * no LEGAL_T.home section so only LEGAL_T.footer applies), refactor
+ * the inline applyLanguage to chain with the prior handler, and add
+ * `data-i18n` attributes to the six footer texts.
+ */
+
+test.describe('Homepage footer links + copyright i18n', () => {
+  test('Spanish locale translates all five footer links + copyright', async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('shytalk_language', 'es');
+      } catch {
+        /* ignore */
+      }
+    });
+    await page.goto(`${BASE}/index.html`);
+
+    // Wait for legal-translations chain to fire via the inline IIFE init.
+    await page.waitForFunction(
+      () => {
+        const el = document.querySelector('[data-i18n="footer_privacy"]');
+        return !!(el && el.textContent && el.textContent.includes('Política'));
+      },
+      null,
+      { timeout: 10_000 },
+    );
+
+    const privacy = (await page.locator('[data-i18n="footer_privacy"]').textContent())?.trim();
+    const terms = (await page.locator('[data-i18n="footer_terms"]').textContent())?.trim();
+    const guidelines = (await page.locator('[data-i18n="footer_guidelines"]').textContent())?.trim();
+    const cyber = (await page.locator('[data-i18n="footer_cyber"]').textContent())?.trim();
+    const dns = (await page.locator('[data-i18n="footer_do_not_sell"]').textContent())?.trim();
+    const copyright = (await page.locator('[data-i18n="footer_copy"]').textContent())?.trim();
+
+    expect(privacy, 'footer_privacy').not.toBe('Privacy Policy');
+    expect(privacy).toContain('Política');
+    expect(terms, 'footer_terms').not.toBe('Terms of Service');
+    expect(guidelines, 'footer_guidelines').not.toBe('Community Guidelines');
+    expect(cyber, 'footer_cyber').not.toBe('Cyber Bullying Policy');
+    expect(dns, 'footer_do_not_sell').not.toBe('Do Not Sell or Share My Personal Information');
+    expect(copyright, 'footer_copy').not.toBe('© 2026 Shyden Ltd. All rights reserved.');
+    expect(copyright, 'footer_copy in Spanish should mention "derechos"').toContain('derechos');
+  });
+
+  test('English (default) renders the inline HTML defaults', async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('shytalk_language', 'en');
+      } catch {
+        /* ignore */
+      }
+    });
+    await page.goto(`${BASE}/index.html`);
+
+    await expect(page.locator('[data-i18n="footer_privacy"]')).toContainText('Privacy Policy');
+    await expect(page.locator('[data-i18n="footer_terms"]')).toContainText('Terms of Service');
+    await expect(page.locator('[data-i18n="footer_guidelines"]')).toContainText(
+      'Community Guidelines',
+    );
+    await expect(page.locator('[data-i18n="footer_cyber"]')).toContainText('Cyber Bullying Policy');
+    await expect(page.locator('[data-i18n="footer_do_not_sell"]')).toContainText(
+      'Do Not Sell or Share My Personal Information',
+    );
+    await expect(page.locator('[data-i18n="footer_copy"]')).toContainText('Shyden Ltd');
+  });
+
+  test('Homepage-specific keys (tagline, app_store) still translate after the chain refactor', async ({
+    page,
+  }) => {
+    // Regression: ensure the chain refactor didn't break the inline
+    // homepage translations. Spanish has tagline + app_store defined
+    // in the inline `t` dict.
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('shytalk_language', 'es');
+      } catch {
+        /* ignore */
+      }
+    });
+    await page.goto(`${BASE}/index.html`);
+
+    await page.waitForFunction(
+      () => {
+        const el = document.querySelector('[data-i18n="tagline"]');
+        return !!(el && el.textContent && el.textContent.includes('Salas'));
+      },
+      null,
+      { timeout: 10_000 },
+    );
+
+    const tagline = (await page.locator('[data-i18n="tagline"]').textContent())?.trim();
+    expect(tagline, 'tagline in es').toContain('Salas');
+  });
+});


### PR DESCRIPTION
## Summary

Same silent-no-op pattern that bit roadmap.html (PR #582) — index.html shipped six hardcoded English footer strings (Privacy Policy, Terms of Service, Community Guidelines, Cyber Bullying Policy, Do Not Sell or Share My Personal Information, and the © Shyden Ltd copyright line) without \`data-i18n\` attributes. They rendered English in every locale even though the rest of the homepage (tagline, Coming Soon, App Store, roadmap CTA) translated correctly.

This is the **homepage** — every visitor in any non-English locale saw a partially-English landing page footer.

## Changes

1. **Load legal-translations.js on index.html** with \`LEGAL_PAGE_TYPE='home'\` set first. No LEGAL_T.home section exists, so applyLegalTranslations only iterates LEGAL_T.footer[lang] (the six needed keys × 20 locales — translations already in legal-translations.js from PR #573).
2. **Refactor the inline IIFE's applyLanguage** from a hard \`window.applyLanguage = ...\` replacement into a chain wrapper that captures \`_prevApplyLanguage\` and calls it after the inline work. Without this, legal-translations.js's handler gets clobbered.
3. **Add \`data-i18n\` attributes** to the six footer texts (5 links + copyright paragraph) matching the existing footer_* keys.

## Why

This is now the 5th page in the project to need this fix (already done on terms, privacy, community-guidelines, cyber-bullying, do-not-sell, and roadmap.html via PR #573 + PR #582). The homepage is the highest-traffic surface so this has the largest user-facing impact.

## Test plan

- [x] \`bash scripts/check-orphan-i18n-keys.sh\` → passes (320 keys all defined)
- [x] \`WEB_BASE_URL=http://localhost:8888 npx playwright test tests/web/homepage-footer-links-i18n.spec.ts --project=chromium\` → 3/3 passed
- [ ] Cross-browser CI (chromium/firefox/webkit/mobile-chrome/mobile-safari)
- [ ] Manual QA: load /index.html in Spanish, scroll to footer, verify all five links + copyright read in Spanish; tagline still in Spanish (regression check on chain refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)