### PR TITLE
fix(ci): treat tests/web/ + playwright.config.* as web changes

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -51,6 +51,13 @@ jobs:
             case "$file" in
               public/*.md) WEB=true ;;
               public/*) WEB=true ;;
+              # Tests under tests/web/ exercise the public/ surface via
+              # Playwright; treat them as web changes so the playwright-web
+              # job runs against the source they're testing. Without this
+              # branch, a PR that ADDS a Playwright test would silently
+              # skip the entire playwright-web pipeline (the test would
+              # only run locally before push, never in CI).
+              tests/web/*|playwright.config.ts|playwright.config.js) WEB=true ;;
               app/*|shared/*|iosApp/*|gradle/*|*.gradle.kts|gradle.properties|gradlew|gradlew.bat) APP=true ;;
               # Integration test files match BEFORE express-api/* so a
               # PR that changes ONLY tests/integration/ files runs the


### PR DESCRIPTION
## Summary

PRs that add or modify ONLY files under \`tests/web/\` (e.g. PR #583's XSS regression spec) silently **skipped** the entire \`playwright-web\` pipeline. The detect-changes case statement matched \`public/*\` for \`web_changed=true\` but had no branch for \`tests/web/\` — those files fell through to the catch-all \`*) OTHER=true\` clause, which doesn't gate any job.

Result: a PR that ADDED a Playwright test was the one PR where the new test never actually ran in CI. The merge gate aggregated 'skipped' as effectively pass, so we shipped untested-in-CI test additions.

## Fix

Add \`tests/web/*\` and \`playwright.config.{ts,js}\` to the \`WEB=true\` case so the \`playwright-web\` pipeline runs whenever the test surface or its configuration changes — even without a corresponding source change in \`public/\`.

The same pattern is already used for \`tests/integration/*\` (which gates the \`integration-tests\` job).

## Test plan

- [x] \`actionlint -shellcheck='-e SC2086' .github/workflows/pr-checks.yml\` → passes
- [ ] CI: this PR itself touches only the workflow, so the bug it fixes wouldn't apply here. Verify via the next tests-only PR (no immediate test surface).
- [ ] Manual verification path: after this merges, the next PR that adds only a Playwright spec should kick off the playwright-web matrix instead of skipping it.

## Why now

Discovered while merging #583 (XSS regression test for #578). The job rollup showed \`playwright-web: skipping\` even though the PR added a new \`tests/web/admin-appeals-xss.spec.ts\` file. Tracking task #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)