### PR TITLE
fix(ci): extend orphan-i18n checker to scan data-i18n-placeholder

### DIFF
--- a/scripts/check-orphan-i18n-keys.sh
+++ b/scripts/check-orphan-i18n-keys.sh
@@ -50,17 +50,20 @@ defined_keys=$(
   done | sed 's/:$//' | sort -u
 )
 
-# Aggregate every `data-i18n="key"` AND `data-i18n-aria-label="key"`
-# attribute from public HTML files. Both forms route through the same
-# silent-no-op pattern in applyLegalTranslations + applyPortalTranslations
-# etc., so an undefined aria-label key has the same screen-reader-visible
-# regression class as an undefined visual key.
+# Aggregate every `data-i18n="key"`, `data-i18n-aria-label="key"`, AND
+# `data-i18n-placeholder="key"` attribute from public HTML files. All three
+# forms route through the same silent-no-op pattern in apply*Translations
+# functions — an undefined placeholder key on a form input is just as
+# silently broken as an undefined visual or aria-label key, just less
+# visible because the inline `placeholder="..."` HTML default holds.
 referenced_keys=$(
   {
     grep -rhoE 'data-i18n="[a-z][a-z0-9_]+"' public --include='*.html' \
       | sed -E 's/data-i18n="([^"]+)"/\1/'
     grep -rhoE 'data-i18n-aria-label="[a-z][a-z0-9_]+"' public --include='*.html' \
       | sed -E 's/data-i18n-aria-label="([^"]+)"/\1/'
+    grep -rhoE 'data-i18n-placeholder="[a-z][a-z0-9_]+"' public --include='*.html' \
+      | sed -E 's/data-i18n-placeholder="([^"]+)"/\1/'
   } | sort -u
 )
 
@@ -85,7 +88,7 @@ if [ -n "$orphans" ]; then
     echo "  $key"
     # Show which HTML files reference the orphan, to help the dev fix.
     # Match both `data-i18n="key"` and `data-i18n-aria-label="key"`.
-    grep -rlE "data-i18n(-aria-label)?=\"${key}\"" public --include='*.html' 2>/dev/null \
+    grep -rlE "data-i18n(-aria-label|-placeholder)?=\"${key}\"" public --include='*.html' 2>/dev/null \
       | head -3 \
       | while read -r match_file; do echo "    referenced by: $match_file"; done
   done <<< "$orphans"


### PR DESCRIPTION
## Summary
The CI orphan guard scanned \`data-i18n=\` and (since PR #592) \`data-i18n-aria-label=\` but NOT \`data-i18n-placeholder=\`. All three attribute forms route through the same silent-no-op pattern in apply*Translations functions — an undefined placeholder key is just as silently broken, just less visible because the inline HTML default holds.

## Why
This is the third leg of the CI guard generalisation. PR #573 added the original guard, PR #592 generalised it to aria-label, this PR generalises it to placeholder. After this, all attribute-driven i18n key references are policed.

## Test plan
- [x] \`bash scripts/check-orphan-i18n-keys.sh\` passes (331 HTML keys / 517 JS keys; +4 from previous baseline = 3 placeholder keys verified defined in PORTAL_T + 1 alignment)
- [x] Negative test: introduced fake \`data-i18n-placeholder=\"foo_unknown_orphan_test\"\` on portal/index.html, checker correctly failed with the orphan name and source-file pointer. Reverted, checker green.
- [x] Existing 3 placeholder keys (login_email_placeholder, login_password_placeholder, recovery_email_placeholder) verified defined in PORTAL_T

## Notes
- Pure CI guard improvement, no production behaviour change.
- Future placeholder additions get the same regression protection as data-i18n + aria-label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)