### PR TITLE
fix(suggestions): translate STATUS_OPTIONS labels via sgT()

### DIFF
--- a/public/js/suggestions-board.js
+++ b/public/js/suggestions-board.js
@@ -32,11 +32,11 @@
 
   var STATUS_OPTIONS = [
     { value: "", label: sgT("allStatuses") },
-    { value: "pending", label: "Pending" },
-    { value: "accepted", label: "Accepted" },
-    { value: "planned", label: "Planned" },
-    { value: "completed", label: "Completed" },
-    { value: "rejected", label: "Rejected" },
+    { value: "pending", label: sgT("pending") },
+    { value: "accepted", label: sgT("accepted") },
+    { value: "planned", label: sgT("planned") },
+    { value: "completed", label: sgT("completed") },
+    { value: "rejected", label: sgT("rejected") },
   ];
 
   var TAG_OPTIONS = [

--- a/tests/web/suggestions-status-options-i18n.spec.ts
+++ b/tests/web/suggestions-status-options-i18n.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEB_BASE_URL || 'http://localhost:8888';
+
+/**
+ * Regression test for hardcoded English STATUS_OPTIONS labels in
+ * suggestions-board.js.
+ *
+ * Pre-fix, the status-filter dropdown rendered:
+ *   "Pending", "Accepted", "Planned", "Completed", "Rejected"
+ * — hardcoded English, even though SG_LABELS already had localised
+ * pending/accepted/planned/completed/rejected keys for ALL 21 locales
+ * (used elsewhere on the suggestion-card status badge). The constants
+ * were captured at IIFE-load time and never updated.
+ *
+ * Fix: replace each hardcoded label with sgT(key). Because sgLang is
+ * initialised from `window.ShyTalkLanguage.get()` in suggestions-i18n.js
+ * BEFORE suggestions-board.js's IIFE executes, the saved language wins
+ * at module load — exactly what we want.
+ *
+ * Limitation (out of scope): if the user switches language AFTER page
+ * load, the dropdown values stay frozen at the initial-load language.
+ * The page-load-language-wins property is a known limitation of the
+ * eval-once constants pattern across the project and is consistent
+ * with other similar constants (TAG_OPTIONS, LANG_OPTIONS, etc.). A
+ * subsequent PR could refactor to compute options at render time.
+ */
+
+const STATUS_KEYS = ['pending', 'accepted', 'planned', 'completed', 'rejected'];
+
+test.describe('Suggestions-board STATUS_OPTIONS i18n', () => {
+  test('STATUS_OPTIONS labels are sgT()-driven, not hardcoded', async ({ request }) => {
+    const res = await request.get(`${BASE}/js/suggestions-board.js`);
+    expect(res.ok()).toBe(true);
+    const src = await res.text();
+
+    // Extract the STATUS_OPTIONS array literal — first 200 chars from
+    // the const declaration suffice (5 entries on 7 lines).
+    const statusBlock = src.match(/var STATUS_OPTIONS = \[([\s\S]*?)\];/);
+    expect(statusBlock, 'STATUS_OPTIONS array not found').not.toBeNull();
+    const arrSrc = statusBlock![1];
+
+    // Hardcoded fail-cases: any of the 5 status names appearing as a
+    // bare quoted string label.
+    const hardcodedNames = ['Pending', 'Accepted', 'Planned', 'Completed', 'Rejected'];
+    for (const name of hardcodedNames) {
+      expect(arrSrc, `STATUS_OPTIONS should not hardcode "${name}"`).not.toMatch(
+        new RegExp(`label:\\s*"${name}"`),
+      );
+    }
+
+    // Sanity: verify the new sgT()-driven form is present for each key.
+    for (const key of STATUS_KEYS) {
+      expect(arrSrc, `STATUS_OPTIONS should use sgT("${key}")`).toMatch(
+        new RegExp(`label:\\s*sgT\\("${key}"\\)`),
+      );
+    }
+  });
+
+  test('Korean locale: sgT() returns Hangul for all 5 status keys', async ({ page }) => {
+    await page.addInitScript(() => {
+      try { localStorage.setItem('shytalk_language', 'ko'); } catch { /* ignore */ }
+    });
+    await page.goto(`${BASE}/roadmap.html`);
+    await page.waitForFunction(
+      () => typeof (window as Window & { sgT?: (k: string) => string }).sgT === 'function',
+      undefined,
+      { timeout: 10_000 },
+    );
+    const t = await page.evaluate((keys) => {
+      const w = window as Window & { sgT?: (k: string) => string };
+      const out: Record<string, string | null> = {};
+      for (const k of keys) out[k] = w.sgT ? w.sgT(k) : null;
+      return out;
+    }, STATUS_KEYS);
+
+    const englishValues = new Set(['Pending', 'Accepted', 'Planned', 'Completed', 'Rejected']);
+    for (const key of STATUS_KEYS) {
+      const value = t[key];
+      expect(value, `sgT(${key}) should not be English`).not.toBeNull();
+      expect(englishValues.has(value!), `sgT(${key}) should not be English: got ${value}`).toBe(false);
+      expect(value, `sgT(${key}) in ko should contain Hangul`).toMatch(/[가-힯]/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
The status filter dropdown on the suggestions board rendered hardcoded English labels (\`Pending\`, \`Accepted\`, \`Planned\`, \`Completed\`, \`Rejected\`) even though SG_LABELS already had localised \`pending\`/\`accepted\`/\`planned\`/\`completed\`/\`rejected\` keys for ALL 21 locales (used elsewhere on the suggestion-card status badge).

Replace hardcoded labels with \`sgT(key)\`. Non-English users now get localised filter options.

## Why this is bounded
SG_LABELS already has these 5 keys × 21 locales — zero new translations needed. The fix is purely a 5-line constant rewrite.

## Known limitation (out of scope)
If user switches language AFTER page load, dropdown stays frozen at the initial-load language. Same eval-once pattern as TAG_OPTIONS/LANG_OPTIONS/PHASE_OPTIONS/SUBSCRIBE_EVENTS/CHANNEL_LABELS. Future PR could refactor all six to compute on each \`render*()\` call.

## Test plan
- [x] \`bash scripts/check-orphan-i18n-keys.sh\` passes (no new HTML keys)
- [x] \`npx playwright test tests/web/suggestions-status-options-i18n.spec.ts --project=chromium\` — 2/2 pass (2.1s):
  - Source contract: STATUS_OPTIONS uses sgT(key) for all 5 keys, no hardcoded English
  - Runtime Korean: sgT() returns Hangul for all 5 keys
- [ ] Manual-QA: load \`localhost:8888/roadmap.html\` in Korean, scroll to suggestions board, verify status filter dropdown shows Hangul not English

🤖 Generated with [Claude Code](https://claude.com/claude-code)