### PR TITLE
fix(suggestions): localise relativeTime() via Intl.RelativeTimeFormat

### DIFF
--- a/public/js/suggestions-board.js
+++ b/public/js/suggestions-board.js
@@ -200,20 +200,36 @@
 
   function relativeTime(dateStr) {
     if (!dateStr) return "";
+    // Use Intl.RelativeTimeFormat for locale-aware compact relative times
+    // ("5m ago" / "5분 전" / "il y a 5 min"). All 20 supported locales have
+    // browser-native formatting — no project-side translations needed.
+    // Read the current language fresh on each call so the timestamp updates
+    // when the user switches locale post-load.
+    var lang = (window.ShyTalkLanguage && window.ShyTalkLanguage.get())
+      || (navigator.language || "en").slice(0, 2);
+    var rtf;
+    try {
+      rtf = new Intl.RelativeTimeFormat(lang, { style: "narrow", numeric: "auto" });
+    } catch (e) {
+      // Fallback for unsupported locales — RFT spec-compliant browsers
+      // accept any BCP-47 tag, but be defensive.
+      rtf = new Intl.RelativeTimeFormat("en", { style: "narrow", numeric: "auto" });
+    }
     var now = Date.now();
     var then = new Date(dateStr).getTime();
     var diffSec = Math.floor((now - then) / 1000);
-    if (diffSec < 60) return "just now";
+    // numeric:"auto" returns the locale's "now" / "지금" / etc. for 0-unit deltas.
+    if (diffSec < 60) return rtf.format(0, "second");
     var diffMin = Math.floor(diffSec / 60);
-    if (diffMin < 60) return diffMin + "m ago";
+    if (diffMin < 60) return rtf.format(-diffMin, "minute");
     var diffHr = Math.floor(diffMin / 60);
-    if (diffHr < 24) return diffHr + "h ago";
+    if (diffHr < 24) return rtf.format(-diffHr, "hour");
     var diffDay = Math.floor(diffHr / 24);
-    if (diffDay < 30) return diffDay + "d ago";
+    if (diffDay < 30) return rtf.format(-diffDay, "day");
     var diffMon = Math.floor(diffDay / 30);
-    if (diffMon < 12) return diffMon + "mo ago";
+    if (diffMon < 12) return rtf.format(-diffMon, "month");
     var diffYr = Math.floor(diffMon / 12);
-    return diffYr + "y ago";
+    return rtf.format(-diffYr, "year");
   }
 
   function statusBadgeClass(status) {

--- a/tests/web/suggestions-relative-time-i18n.spec.ts
+++ b/tests/web/suggestions-relative-time-i18n.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEB_BASE_URL || 'http://localhost:8888';
+
+/**
+ * Regression test for relativeTime() i18n in suggestions-board.js.
+ *
+ * Pre-fix, the function returned hardcoded English: "just now", "5m ago",
+ * "3h ago", "5d ago", "2mo ago", "1y ago". These display on EVERY
+ * suggestion card and comment.
+ *
+ * Fix: replaced the hardcoded strings with Intl.RelativeTimeFormat —
+ * browser-native, supports all 20 ShyTalk locales, returns localized
+ * compact relative times like "5분 전" / "il y a 5 min" / "5 منذ" with
+ * zero project-side translations needed.
+ *
+ * Test approach: open the suggestions board in Korean, evaluate
+ * relativeTime() in-page (it's not exported but Intl.RelativeTimeFormat
+ * is), and verify the formatter's output for several time deltas.
+ *
+ * The function is private to the IIFE so we can't call it directly. We
+ * test the underlying contract via a portable replication that uses the
+ * SAME Intl pattern. This pins the locale-aware behaviour while leaving
+ * the IIFE-internal function private.
+ */
+
+test.describe('Suggestions-board relativeTime() locale-aware', () => {
+  test('relativeTime no longer hardcodes English "ago" / "just now"', async ({ request }) => {
+    const res = await request.get(`${BASE}/js/suggestions-board.js`);
+    expect(res.ok()).toBe(true);
+    const src = await res.text();
+    // The old format strings should be gone.
+    expect(src, 'should not return hardcoded "just now"').not.toContain('"just now"');
+    expect(src, 'should not return hardcoded "m ago"').not.toMatch(/return\s+\w+\s*\+\s*"m ago"/);
+    expect(src, 'should not return hardcoded "h ago"').not.toMatch(/return\s+\w+\s*\+\s*"h ago"/);
+    expect(src, 'should not return hardcoded "d ago"').not.toMatch(/return\s+\w+\s*\+\s*"d ago"/);
+    // Sanity: the new Intl.RelativeTimeFormat is in use.
+    expect(src, 'should use Intl.RelativeTimeFormat').toContain('Intl.RelativeTimeFormat');
+  });
+
+  test('Korean locale: Intl.RelativeTimeFormat produces Hangul output', async ({ page }) => {
+    await page.addInitScript(() => {
+      try { localStorage.setItem('shytalk_language', 'ko'); } catch { /* ignore */ }
+    });
+    await page.goto(`${BASE}/roadmap.html`);
+    await page.waitForFunction(
+      () => typeof (window as Window & { ShyTalkLanguage?: { get: () => string } }).ShyTalkLanguage !== 'undefined',
+      undefined,
+      { timeout: 10_000 },
+    );
+    // Replicate the new relativeTime logic in-page and verify the output.
+    const samples = await page.evaluate(() => {
+      const w = window as Window & { ShyTalkLanguage?: { get: () => string } };
+      const lang = (w.ShyTalkLanguage && w.ShyTalkLanguage.get()) || 'en';
+      const rtf = new Intl.RelativeTimeFormat(lang, { style: 'narrow', numeric: 'auto' });
+      return {
+        lang,
+        zero: rtf.format(0, 'second'),
+        fiveMinAgo: rtf.format(-5, 'minute'),
+        threeDaysAgo: rtf.format(-3, 'day'),
+        oneYearAgo: rtf.format(-1, 'year'),
+      };
+    });
+    expect(samples.lang, 'should be Korean').toBe('ko');
+    expect(samples.zero, 'rtf.format(0, "second") in ko').toMatch(/[가-힯]/);
+    expect(samples.fiveMinAgo, '5 min ago in ko').toMatch(/[가-힯]/);
+    expect(samples.fiveMinAgo, '5 min ago in ko should not be English').not.toContain('ago');
+    expect(samples.threeDaysAgo, '3 days ago in ko').toMatch(/[가-힯]/);
+    expect(samples.oneYearAgo, '1 year ago in ko').toMatch(/[가-힯]/);
+  });
+
+  test('Arabic locale: Intl.RelativeTimeFormat produces Arabic script output', async ({ page }) => {
+    await page.addInitScript(() => {
+      try { localStorage.setItem('shytalk_language', 'ar'); } catch { /* ignore */ }
+    });
+    await page.goto(`${BASE}/roadmap.html`);
+    await page.waitForFunction(
+      () => typeof (window as Window & { ShyTalkLanguage?: { get: () => string } }).ShyTalkLanguage !== 'undefined',
+      undefined,
+      { timeout: 10_000 },
+    );
+    const samples = await page.evaluate(() => {
+      const w = window as Window & { ShyTalkLanguage?: { get: () => string } };
+      const lang = (w.ShyTalkLanguage && w.ShyTalkLanguage.get()) || 'en';
+      const rtf = new Intl.RelativeTimeFormat(lang, { style: 'narrow', numeric: 'auto' });
+      return {
+        lang,
+        fiveMinAgo: rtf.format(-5, 'minute'),
+      };
+    });
+    expect(samples.lang).toBe('ar');
+    expect(samples.fiveMinAgo, '5 min ago in ar should contain Arabic').toMatch(/[؀-ۿ]/);
+  });
+});


### PR DESCRIPTION
## Summary
Replace 6 hardcoded English relative-time strings in \`relativeTime()\` (\"just now\", \"5m ago\", \"3h ago\", \"5d ago\", \"2mo ago\", \"1y ago\") with browser-native \`Intl.RelativeTimeFormat\`. Localised on every suggestion card and comment timestamp.

**Zero new translations needed** — Intl.RelativeTimeFormat ships in every browser and supports all 20 ShyTalk locales natively.

## Output samples (verified for all 20 locales)
| Locale | 5 min ago | now | 3 days ago |
|---|---|---|---|
| ko | 5분 전 | 지금 | 3일 전 |
| ar | قبل 5 دقائق | الآن | قبل 3 أيام |
| ja | 5分前 | 今 | 3日前 |
| fr | -5 min | maintenant | -3 j |
| de | vor 5 m | jetzt | vor 3 Tagen |

## Test plan
- [x] Verified Intl.RelativeTimeFormat works for all 20 locales via Node REPL
- [x] \`npx playwright test tests/web/suggestions-relative-time-i18n.spec.ts --project=chromium\` — 3/3 pass (1.9s)
- [x] Source contract: no hardcoded English "just now" / "Nm ago" etc.
- [x] Korean runtime: rtf.format(-5, "minute") contains Hangul, no "ago"
- [x] Arabic runtime: rtf.format(-5, "minute") contains Arabic script
- [ ] Manual-QA: open \`localhost:8888/roadmap.html\` in Korean → suggestions board → verify card timestamps render in Hangul

## Why narrow style
\`style: "narrow"\` matches the existing compact format (\"5m\" not \"5 minutes\"). \`numeric: \"auto\"\` returns the locale's natural \"now\" / \"yesterday\" / \"tomorrow\" for 0/-1/+1 deltas instead of \"0 seconds ago\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)