### PR TITLE
fix(suggestions): use native language names in LANG_OPTIONS dropdown

### DIFF
--- a/public/js/suggestions-board.js
+++ b/public/js/suggestions-board.js
@@ -52,29 +52,34 @@
     { value: "other", label: "Other" },
   ];
 
+  // Language names rendered in their NATIVE form so a user filtering by
+  // a language always sees that language in its own script — convention
+  // mirrors language-selector.js's LANGUAGES.native list and is the
+  // standard pattern for language pickers (cf. Wikipedia language nav,
+  // YouTube language selector, etc.).
   var LANG_OPTIONS = [
     { value: "", label: sgT("allLanguages") },
     { value: "en", label: "English" },
-    { value: "ar", label: "Arabic" },
-    { value: "de", label: "German" },
-    { value: "es", label: "Spanish" },
-    { value: "fr", label: "French" },
-    { value: "hi", label: "Hindi" },
-    { value: "id", label: "Indonesian" },
-    { value: "it", label: "Italian" },
-    { value: "ja", label: "Japanese" },
-    { value: "km", label: "Khmer" },
-    { value: "ko", label: "Korean" },
-    { value: "nl", label: "Dutch" },
-    { value: "pl", label: "Polish" },
-    { value: "pt", label: "Portuguese" },
-    { value: "ru", label: "Russian" },
-    { value: "sv", label: "Swedish" },
-    { value: "th", label: "Thai" },
-    { value: "tr", label: "Turkish" },
-    { value: "uk", label: "Ukrainian" },
-    { value: "vi", label: "Vietnamese" },
-    { value: "zh", label: "Chinese" },
+    { value: "ar", label: "العربية" },
+    { value: "de", label: "Deutsch" },
+    { value: "es", label: "Español" },
+    { value: "fr", label: "Français" },
+    { value: "hi", label: "हिन्दी" },
+    { value: "id", label: "Bahasa Indonesia" },
+    { value: "it", label: "Italiano" },
+    { value: "ja", label: "日本語" },
+    { value: "km", label: "ភាសាខ្មែរ" },
+    { value: "ko", label: "한국어" },
+    { value: "nl", label: "Nederlands" },
+    { value: "pl", label: "Polski" },
+    { value: "pt", label: "Português" },
+    { value: "ru", label: "Русский" },
+    { value: "sv", label: "Svenska" },
+    { value: "th", label: "ไทย" },
+    { value: "tr", label: "Türkçe" },
+    { value: "uk", label: "Українська" },
+    { value: "vi", label: "Tiếng Việt" },
+    { value: "zh", label: "中文" },
   ];
 
   var SUBSCRIBE_EVENTS = [

--- a/tests/web/suggestions-lang-options-native-names.spec.ts
+++ b/tests/web/suggestions-lang-options-native-names.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEB_BASE_URL || 'http://localhost:8888';
+
+/**
+ * Regression test for LANG_OPTIONS native-name labels in suggestions-board.js.
+ *
+ * Pre-fix, the language filter dropdown rendered English language NAMES
+ * ("Arabic", "German", "Korean") for every locale option. A French user
+ * filtering by Arabic suggestions would see the option as "Arabic"
+ * instead of "العربية". This breaks the standard convention of
+ * displaying language names in their NATIVE script (cf. Wikipedia's
+ * language sidebar, YouTube's language picker).
+ *
+ * Fix: replace English names with native names. Reference:
+ * `language-selector.js`'s `LANGUAGES` array, where each entry has
+ * a `native` field that this PR copies into LANG_OPTIONS.
+ *
+ * No new translations needed — native names are language-property
+ * data, not user-facing translation strings.
+ */
+
+const NATIVE_NAMES = {
+  en: 'English',
+  ar: 'العربية',
+  de: 'Deutsch',
+  es: 'Español',
+  fr: 'Français',
+  hi: 'हिन्दी',
+  id: 'Bahasa Indonesia',
+  it: 'Italiano',
+  ja: '日本語',
+  km: 'ភាសាខ្មែរ',
+  ko: '한국어',
+  nl: 'Nederlands',
+  pl: 'Polski',
+  pt: 'Português',
+  ru: 'Русский',
+  sv: 'Svenska',
+  th: 'ไทย',
+  tr: 'Türkçe',
+  uk: 'Українська',
+  vi: 'Tiếng Việt',
+  zh: '中文',
+};
+
+test.describe('Suggestions-board LANG_OPTIONS native names', () => {
+  test('LANG_OPTIONS labels use native script for each language', async ({ request }) => {
+    const res = await request.get(`${BASE}/js/suggestions-board.js`);
+    expect(res.ok()).toBe(true);
+    const src = await res.text();
+
+    // Extract just the LANG_OPTIONS array literal.
+    const langBlock = src.match(/var LANG_OPTIONS = \[([\s\S]*?)\];/);
+    expect(langBlock, 'LANG_OPTIONS array not found').not.toBeNull();
+    const arrSrc = langBlock![1];
+
+    for (const [code, native] of Object.entries(NATIVE_NAMES)) {
+      const re = new RegExp(`value:\\s*"${code}",\\s*label:\\s*"${native.replace(/[.*+?^${}()|[\]\\]/g, '\\\\$&')}"`);
+      expect(arrSrc, `${code} label should be native "${native}"`).toMatch(re);
+    }
+  });
+
+  test('LANG_OPTIONS no longer hardcodes English language names', async ({ request }) => {
+    const res = await request.get(`${BASE}/js/suggestions-board.js`);
+    const src = await res.text();
+    const langBlock = src.match(/var LANG_OPTIONS = \[([\s\S]*?)\];/);
+    const arrSrc = langBlock![1];
+    // English language NAMES that should NOT appear (en is intentional).
+    const englishNames = [
+      'Arabic', 'German', 'Spanish', 'French', 'Hindi', 'Indonesian',
+      'Italian', 'Japanese', 'Khmer', 'Korean', 'Dutch', 'Polish',
+      'Portuguese', 'Russian', 'Swedish', 'Thai', 'Turkish', 'Ukrainian',
+      'Vietnamese', 'Chinese',
+    ];
+    for (const name of englishNames) {
+      expect(arrSrc, `English name "${name}" should not be in LANG_OPTIONS`).not.toMatch(
+        new RegExp(`label:\\s*"${name}"`),
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
The language filter dropdown rendered English language NAMES (\"Arabic\", \"German\", \"Korean\", etc.) for every option, regardless of UI locale. A French user filtering by Arabic-language suggestions saw \"Arabic\" instead of \"العربية\" — breaks the standard language-picker convention (Wikipedia, YouTube, etc. all use native names).

Replace each label with the language's native name. Reference list copied from \`language-selector.js\`'s \`LANGUAGES.native\` field — canonical project source.

## Why this is bounded
**Zero new translations needed**. Native names are language-property data, not translation keys. 21-line edit, no per-locale fan-out.

## Test plan
- [x] \`bash scripts/check-orphan-i18n-keys.sh\` passes (no new HTML keys)
- [x] \`npx playwright test tests/web/suggestions-lang-options-native-names.spec.ts --project=chromium\` — 2/2 pass (496ms):
  - Each value:code paired with the correct native label
  - No English language names linger in LANG_OPTIONS
- [ ] Manual-QA: load \`localhost:8888/roadmap.html\` in any locale, scroll to suggestions board, check the language filter dropdown — all 21 entries should display in their native script (العربية, 한국어, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)