### PR TITLE
fix(release): PR-based flow to satisfy branch protection (CRITICAL)

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,239 @@
+name: Release Tag
+
+# Fires when a release-bump PR (opened by release.yml) auto-merges to
+# main. Creates the git tag and GitHub Release in response. Splits the
+# work from release.yml because branch protection requires PRs for all
+# changes to main — release.yml can't push to main directly, so the
+# tag-and-release work has to happen AFTER the PR merges.
+#
+# Trigger: any push to main. The first step short-circuits unless the
+# pushed commit's subject matches `chore: release vX.Y.Z`. This makes
+# the workflow resilient to manual operations: if someone hand-rolls a
+# release commit (e.g. an emergency hotfix without going through
+# release.yml), this workflow will still tag + release it.
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+# Share concurrency with release.yml. release.yml exits ~3min after
+# starting (it just opens the PR; auto-merge handles the rest), and
+# release-tag.yml only fires once the PR's squashed commit hits main —
+# typically 30+min later. So queueing is rare but the slot is reserved
+# correctly when it does happen.
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  tag-and-release:
+    name: Tag and Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Inspect commit subject
+        id: inspect
+        env:
+          # Pass head_commit.message through an env var rather than
+          # interpolating into the shell directly. github.event values
+          # are attacker-controlled (anyone with merge access can craft
+          # a commit message with shell-metachar payloads); inline
+          # interpolation would let `chore: release v$(rm -rf /)` run
+          # arbitrary code on the runner.
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+          # Take only the first line — head_commit.message is the
+          # FULL commit message including body, not just the subject.
+          # Quoting the env var protects against word-splitting if a
+          # commit subject contains shell metachars (it doesn't run as
+          # code thanks to the env-var indirection above, but we still
+          # want to handle weird subjects gracefully).
+          SUBJECT_FIRST_LINE=$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | head -1)
+          echo "Latest commit subject: '$SUBJECT_FIRST_LINE'"
+
+          if echo "$SUBJECT_FIRST_LINE" | grep -qE '^chore: release v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            VERSION=$(echo "$SUBJECT_FIRST_LINE" | sed -E 's/^chore: release v([0-9]+\.[0-9]+\.[0-9]+)$/\1/')
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "Detected release commit for v${VERSION}"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "Not a release commit — exiting early."
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: steps.inspect.outputs.is_release == 'true'
+        with:
+          # Need full history to walk back to the previous release tag
+          # for the changelog aggregation step below.
+          fetch-depth: 0
+
+      - name: Verify tag does not already exist
+        if: steps.inspect.outputs.is_release == 'true'
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.inspect.outputs.version }}"
+          # If a tag already exists for this version, something is
+          # wrong — either release.yml's double-fired guard let a
+          # duplicate through, or someone tagged manually. Refuse to
+          # silently overwrite.
+          if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+            EXISTING_SHA=$(git rev-parse "v${VERSION}")
+            echo "::error::Tag v${VERSION} already exists at ${EXISTING_SHA}. Refusing to retag. Investigate: this commit's subject indicated a fresh release, but a tag for this version is already present."
+            exit 1
+          fi
+          echo "Tag v${VERSION} does not yet exist — safe to create."
+
+      - name: Verify HEAD versionName matches commit subject
+        if: steps.inspect.outputs.is_release == 'true'
+        run: |
+          set -euo pipefail
+          EXPECTED="${{ steps.inspect.outputs.version }}"
+          ACTUAL=$(awk -F'"' '/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"/ {print $2; exit}' app/build.gradle.kts || true)
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::HEAD versionName is '$ACTUAL' but commit subject promises '$EXPECTED'. Refusing to tag a mismatched commit. Investigate: did someone amend the version-bump commit, or land a non-release commit between the release PR opening and merging?"
+            exit 1
+          fi
+          echo "Verified: HEAD versionName '$ACTUAL' matches commit subject 'v${EXPECTED}'"
+
+      - name: Generate release notes from PRs since last tag
+        id: notes
+        if: steps.inspect.outputs.is_release == 'true'
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.inspect.outputs.version }}"
+          NOTES_FILE=$(mktemp)
+
+          # Walk back to the previous release tag. Mirror the logic in
+          # release.yml so behaviour is consistent — release.yml's PR
+          # body and this workflow's release notes use the same source.
+          # Subtle difference: release.yml computed notes BEFORE the
+          # release-bump commit existed, while this workflow runs AFTER.
+          # That means the changelog from this workflow may include
+          # additional PRs that merged between the release PR opening
+          # and merging. That's correct — the release notes reflect
+          # what's actually in the released code.
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            RANGE="${LAST_TAG}..HEAD"
+            echo "Aggregating commits since ${LAST_TAG}"
+          else
+            if [ -n "$(git tag -l)" ]; then
+              echo "::error::Tags exist but none match 'v*' — refusing to generate full-history changelog. Verify your tag naming or pass an explicit base."
+              git tag -l | head -10
+              exit 1
+            fi
+            RANGE=""
+            echo "No prior release tag found — aggregating all commits"
+          fi
+
+          # First-parent walk on main; allowlist of feat/fix/perf
+          # Conventional-Commits prefixes; reverts summarised separately.
+          # See release.yml for the rationale on each filter choice.
+          # shellcheck disable=SC2086
+          ALL_LINES=$(git log $RANGE --first-parent --pretty=format:'%s')
+          USER_FACING=$(echo "$ALL_LINES" \
+            | { grep -E '^(feat|fix|perf)(\(.+\))?:' || [ $? -eq 1 ]; } \
+            | sed -E 's/^[a-z]+(\([^)]*\))?: //')
+          REVERTS=$(echo "$ALL_LINES" \
+            | { grep -E '^revert(\(.+\))?:' || [ $? -eq 1 ]; } \
+            | sed -E 's/^revert(\([^)]*\))?: //')
+          if [ -z "$LAST_TAG" ]; then
+            USER_FACING=$(echo "$USER_FACING" | head -50)
+            REVERTS=$(echo "$REVERTS" | head -10)
+          fi
+
+          {
+            echo "## v${VERSION}"
+            echo ""
+            if [ -n "$USER_FACING" ]; then
+              echo "### What's new"
+              echo ""
+              echo "$USER_FACING" | while IFS= read -r line; do
+                cleaned=$(echo "$line" | sed -E 's/[[:space:]]*\(#[0-9]+\)[[:space:]]*$//')
+                echo "- ${cleaned}"
+              done
+            elif [ -z "$REVERTS" ]; then
+              echo "Internal release with no user-facing changes."
+            fi
+            if [ -n "$REVERTS" ]; then
+              echo ""
+              echo "### Reverted"
+              echo ""
+              echo "$REVERTS" | while IFS= read -r line; do
+                cleaned=$(echo "$line" | sed -E 's/[[:space:]]*\(#[0-9]+\)[[:space:]]*$//')
+                echo "- ${cleaned}"
+              done
+            fi
+          } > "$NOTES_FILE"
+
+          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+
+          echo "----- Generated release notes -----"
+          cat "$NOTES_FILE"
+          echo "-----------------------------------"
+
+      - name: Create GitHub release
+        if: steps.inspect.outputs.is_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.inspect.outputs.version }}"
+          COMMIT_SHA=$(git rev-parse HEAD)
+          NOTES_FILE="${{ steps.notes.outputs.notes_file }}"
+
+          # gh release create both creates the tag (via --target) AND
+          # publishes the GitHub Release in one atomic operation. If
+          # this fails (rate limit, 5xx, token scope issue, transient
+          # blip), no auto-retry — the merged release commit is on
+          # main but no tag/release exists. Surface a single-line
+          # ::error:: (multi-line annotations don't render) plus full
+          # recovery instructions in the step output and job summary so
+          # the operator can manually complete the release.
+          if ! gh release create "v${VERSION}" \
+            --target "$COMMIT_SHA" \
+            --title "v${VERSION}" \
+            --notes-file "$NOTES_FILE"; then
+            echo "::error::gh release create failed for v${VERSION}. The release commit is on main at ${COMMIT_SHA} but no tag/release exists. See step output + job summary for manual-recovery command."
+            {
+              echo ""
+              echo "============================================================"
+              echo "MANUAL RECOVERY REQUIRED"
+              echo "============================================================"
+              echo "The release commit for v${VERSION} is at ${COMMIT_SHA}"
+              echo "on origin/main, but the GitHub Release was not created."
+              echo "Re-running this workflow on the same SHA will succeed if"
+              echo "the underlying issue (rate limit, scope) is resolved."
+              echo "Otherwise run locally on a fresh clone of main:"
+              echo ""
+              echo "  gh release create v${VERSION} \\"
+              echo "    --target ${COMMIT_SHA} \\"
+              echo "    --title v${VERSION} \\"
+              echo "    --notes-file -<<'NOTES'"
+              cat "$NOTES_FILE"
+              echo "NOTES"
+              echo ""
+              echo "============================================================"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "Created release v${VERSION} at ${COMMIT_SHA}"
+
+          {
+            echo "## Release v${VERSION}"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Version** | \`v${VERSION}\` |"
+            echo "| **Commit** | \`${COMMIT_SHA:0:10}\` |"
+            echo "| **Release** | [v${VERSION}](${{ github.server_url }}/${{ github.repository }}/releases/tag/v${VERSION}) |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: release-main
@@ -26,8 +26,17 @@ env:
 
 # Releases are now manual: merge small PRs to main freely; cut a Release
 # only when a stable batch is ready by triggering this workflow from the
-# Actions tab. Each release aggregates ALL merged-PR titles since the
-# previous tag into the release notes (no per-merge release commits).
+# Actions tab.
+#
+# This workflow used to push the version-bump commit DIRECTLY to main.
+# That broke 2026-05-10 once classic branch protection started requiring
+# the PR Gate aggregator (`Detect Changes`, `Analyze JavaScript`,
+# `PR Gate`) on every commit landing on main — direct pushes can never
+# satisfy `PR Gate` because that's a `pull_request`-only aggregator. Now
+# we open a release PR with auto-merge enabled instead. The PR runs the
+# full required-check pipeline, auto-merges when green, and the
+# release-tag.yml workflow then creates the tag + GitHub Release in
+# response to the merged commit on main.
 #
 # Dev-build distribution stays automatic — deploy-dev.yml injects a
 # unique iOS CFBundleVersion from GITHUB_RUN_NUMBER so TestFlight uploads
@@ -35,8 +44,8 @@ env:
 # from the same run number for the same reason.
 
 jobs:
-  prepare-release:
-    name: Prepare Release
+  open-release-pr:
+    name: Open Release PR
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -51,7 +60,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           # Need full history to walk back to the previous release tag
-          # for the changelog aggregation step below.
+          # for the release-notes generation step below.
           fetch-depth: 0
 
       - name: Guard against double-fired releases
@@ -71,6 +80,16 @@ jobs:
             echo "::error::HEAD is already a release commit ('$LATEST_SUBJECT'). Refusing to bump on top of an existing release. If this was intentional (e.g. publishing a same-content re-tag), do it manually."
             exit 1
           fi
+          # Also guard against an open release PR. Two open release PRs
+          # would race each other through CI; whichever auto-merges
+          # second would carry an outdated version bump.
+          OPEN_RELEASE_PRS=$(gh pr list --state open --search 'in:title chore: release v' --json number --jq 'length')
+          if [ "${OPEN_RELEASE_PRS:-0}" -gt 0 ]; then
+            echo "::error::An open release PR already exists. Wait for it to merge (or close it) before opening another. Run 'gh pr list --state open --search \"in:title chore: release v\"' to find it."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Resolve bump type from input
         id: bump
@@ -272,109 +291,101 @@ jobs:
           cat "$NOTES_FILE"
           echo "-----------------------------------"
 
-      - name: Commit version bump
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Capture the SHA we expect HEAD~1 to point at after the bump.
-          # `git pull --rebase` updates the local `origin/main` ref to
-          # the freshly-fetched tip, so `git rev-parse origin/main`
-          # AFTER the pull would always equal HEAD~1 — making any post-
-          # pull comparison against origin/main vacuous. The only
-          # reliable witness of "did rebase pull in unrelated commits"
-          # is the origin/main SHA captured BEFORE the pull. If post-
-          # rebase HEAD~1 doesn't match it, the rebase replayed our
-          # bump on top of someone else's commits — and the changelog
-          # (computed from LAST_TAG..PRE_BUMP_HEAD earlier) won't
-          # mention them.
-          PRE_PULL_ORIGIN=$(git rev-parse origin/main)
-          git add app/build.gradle.kts app/src/main/play/release-notes/en-US/internal.txt app/src/main/play/release-notes/en-US/default.txt
-          git commit -m "chore: release v${{ steps.version.outputs.version }}"
-          # `set -euo pipefail` would abort on a rebase conflict with a
-          # generic "Process completed with exit code 1" annotation that
-          # gives the operator no indication WHY. Wrap the pull so we
-          # can surface a clear, action-oriented error if it fails.
-          if ! git pull --rebase origin main; then
-            echo "::error::git pull --rebase origin main failed — likely a conflict with concurrent commits on main. The release notes / version bump touched the same lines as another merge. Re-trigger the Release workflow once main has stabilised; the regenerated changelog will pick up the new commits cleanly."
-            exit 1
-          fi
-          POST_REBASE_BASE=$(git rev-parse HEAD~1)
-          if [ "$POST_REBASE_BASE" != "$PRE_PULL_ORIGIN" ]; then
-            echo "::error::Rebase pulled in unrelated commits (HEAD~1=$POST_REBASE_BASE, expected $PRE_PULL_ORIGIN — the origin/main tip captured BEFORE the pull). The release tag would attach to commits the changelog doesn't describe. Re-run the workflow to regenerate the changelog against the new main tip."
-            exit 1
-          fi
-          # Wrap push so a remote rejection (branch protection rule, force-
-          # push needed, network blip) emits a clear ::error:: annotation
-          # instead of the generic "Process completed with exit code 1".
-          if ! git push; then
-            echo "::error::git push failed — could be branch protection rule rejection, the remote moved between the rebase and the push, or a transient network issue. The version bump commit IS local; re-trigger the Release workflow once the cause is clear."
-            exit 1
-          fi
-          # Verify the bump landed at HEAD. `git pull --rebase` can race with
-          # other commits on main and silently produce a HEAD whose
-          # versionName doesn't match what we just bumped — leading to a tag
-          # that points at code with the wrong version. `|| true` lets the
-          # is-empty guard fire with a clear error if rebase ate the
-          # versionName line entirely (vs. set -e aborting on the grep).
-          PUSHED_VERSION=$(awk -F'"' '/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"/ {print $2; exit}' app/build.gradle.kts || true)
-          if [ "$PUSHED_VERSION" != "${{ steps.version.outputs.version }}" ]; then
-            echo "::error::HEAD versionName is '$PUSHED_VERSION' but expected '${{ steps.version.outputs.version }}' — rebase likely lost the bump commit"
-            exit 1
-          fi
-
-      - name: Create GitHub release
+      - name: Create release branch and open PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
-          COMMIT_SHA=$(git rev-parse HEAD)
+          BRANCH="release/v${VERSION}"
           NOTES_FILE="${{ steps.notes.outputs.notes_file }}"
-          # The version-bump commit is ALREADY on origin/main from the
-          # previous step. If `gh release create` fails (rate limit, 5xx,
-          # token scope issue, transient blip), we don't auto-retry —
-          # re-running this workflow would be blocked by the double-
-          # fired-release guard. Surface a single-line ::error::
-          # (multi-line annotations don't render) plus full recovery
-          # instructions in the step output and job summary so the
-          # operator can manually complete the release.
-          if ! gh release create "v${VERSION}" \
-            --target "$COMMIT_SHA" \
-            --title "v${VERSION}" \
-            --notes-file "$NOTES_FILE"; then
-            echo "::error::gh release create failed for v${VERSION}. The version bump is on main but no tag/release exists. See step output + job summary for manual-recovery command."
-            {
-              echo ""
-              echo "============================================================"
-              echo "MANUAL RECOVERY REQUIRED"
-              echo "============================================================"
-              echo "The version bump for v${VERSION} is at commit ${COMMIT_SHA}"
-              echo "on origin/main, but the GitHub Release was not created."
-              echo "Re-running this workflow will fail the double-fired-release"
-              echo "guard. Run locally on a fresh clone of main:"
-              echo ""
-              echo "  gh release create v${VERSION} \\"
-              echo "    --target ${COMMIT_SHA} \\"
-              echo "    --title v${VERSION} \\"
-              echo "    --notes-file -<<'NOTES'"
-              cat "$NOTES_FILE"
-              echo "NOTES"
-              echo ""
-              echo "============================================================"
-            } >> "$GITHUB_STEP_SUMMARY"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Create branch from current main and commit the bump + Play
+          # Store release notes. The branch name embeds the version so
+          # concurrent releases (should they ever happen despite the
+          # double-fired guard) wouldn't collide.
+          git checkout -b "$BRANCH"
+          git add app/build.gradle.kts \
+                  app/src/main/play/release-notes/en-US/internal.txt \
+                  app/src/main/play/release-notes/en-US/default.txt
+          git commit -m "chore: release v${VERSION}"
+
+          # Push to origin. Branch protection on main does NOT apply to
+          # release/* branches, so this push is unconditional. The push
+          # uses the release app token, which lets the resulting PR
+          # trigger downstream workflows (pr-checks.yml etc) — using
+          # GITHUB_TOKEN here would suppress those triggers per
+          # GitHub's loop-prevention design.
+          if ! git push --set-upstream origin "$BRANCH"; then
+            echo "::error::git push to release branch '$BRANCH' failed. The version bump is local only — re-run this workflow once the issue is resolved."
             exit 1
           fi
-          echo "Created release v${VERSION} at ${COMMIT_SHA}"
 
-          # Job summary for easy copy-paste
+          # PR body uses the same release notes that will eventually go
+          # to the GitHub Release. release-tag.yml will REGENERATE notes
+          # against the post-merge HEAD (which may include other PRs
+          # that landed between this PR opening and merging), so the
+          # body here is informational rather than authoritative — but
+          # it lets reviewers see what's expected.
+          PR_BODY_FILE=$(mktemp)
           {
             echo "## Release v${VERSION}"
+            echo ""
+            echo "**Bump type**: ${{ steps.bump.outputs.type }}"
+            echo ""
+            echo "Auto-generated release PR. CI will run the full required-check pipeline; once green, this PR auto-merges and \`release-tag.yml\` creates the GitHub Release + tag in response."
+            echo ""
+            echo "---"
+            echo ""
+            cat "$NOTES_FILE"
+            echo ""
+            echo "---"
+            echo ""
+            echo "_If this PR fails CI: investigate the failure, push fixes to \`${BRANCH}\` (NOT \`main\`), and re-trigger auto-merge. To abandon this release entirely, close the PR and delete the branch._"
+          } > "$PR_BODY_FILE"
+
+          # Create PR. We use --label release-bump so a follow-up
+          # workflow could choose to skip heavy non-required jobs for
+          # release bumps (future optimisation; not implemented yet).
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: release v${VERSION}" \
+            --body-file "$PR_BODY_FILE" \
+            --label release-bump 2>&1) || PR_CREATE_FAILED=$?
+          if [ "${PR_CREATE_FAILED:-0}" -ne 0 ]; then
+            # Some failure modes (e.g. label doesn't exist yet) leave
+            # the branch pushed but no PR. Surface a clear instruction.
+            echo "::error::gh pr create failed for ${BRANCH}. The branch is pushed; create the PR manually: gh pr create --base main --head ${BRANCH} --title 'chore: release v${VERSION}' --body-file <notes>"
+            exit 1
+          fi
+          PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          echo "Opened PR #${PR_NUMBER}: ${PR_URL}"
+
+          # Enable auto-merge with squash strategy. The squashed commit
+          # message defaults to the PR title (`chore: release vX.Y.Z`),
+          # which is exactly what release-tag.yml's trigger pattern
+          # matches. Auto-merge fires once all required checks pass.
+          if ! gh pr merge "$PR_NUMBER" --auto --squash; then
+            echo "::error::gh pr merge --auto --squash failed for PR #${PR_NUMBER}. The PR is open but auto-merge is not enabled — enable it manually via the PR UI."
+            exit 1
+          fi
+          echo "Auto-merge (squash) enabled on PR #${PR_NUMBER}"
+
+          # Job summary for easy copy-paste / status visibility.
+          {
+            echo "## Release PR Opened: v${VERSION}"
             echo ""
             echo "| | |"
             echo "|---|---|"
             echo "| **Version** | \`v${VERSION}\` |"
             echo "| **Bump** | ${{ steps.bump.outputs.type }} |"
-            echo "| **Commit** | \`${COMMIT_SHA:0:10}\` |"
-            echo "| **Release** | [v${VERSION}](${{ github.server_url }}/${{ github.repository }}/releases/tag/v${VERSION}) |"
+            echo "| **Branch** | \`${BRANCH}\` |"
+            echo "| **PR** | [#${PR_NUMBER}](${PR_URL}) |"
+            echo "| **Auto-merge** | enabled (squash) |"
+            echo ""
+            echo "Once CI passes, the PR will auto-merge and \`release-tag.yml\` will create the GitHub Release + tag."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/check-release-trigger.sh
+++ b/scripts/check-release-trigger.sh
@@ -121,4 +121,63 @@ if [ -f "$DEPLOY_DEV_YML" ]; then
   fi
 fi
 
-echo "✓ release.yml is workflow_dispatch-only; deploy-dev.yml injects unique iOS build number."
+# Verify the PR-based release shape (Option A from 2026-05-10's
+# release-bug fix). Direct push from CI to main is blocked by classic
+# branch protection's `PR Gate` required check (a `pull_request`-only
+# aggregator that no direct push can ever satisfy). release.yml must
+# instead:
+#   1. Open a PR with the version-bump commit on a release/* branch
+#   2. Enable auto-merge so the PR squashes into main once CI passes
+#   3. release-tag.yml then reacts to the squashed commit and creates
+#      the tag + GitHub Release
+#
+# Without these, the next manual Release dispatch would rediscover the
+# 2026-05-10 GH013 failure.
+
+# Reject any `git push` line in release.yml that pushes to main. We
+# match `git push` followed by anything that includes `main` either as
+# a direct refspec or `HEAD:main`. Pushes to `release/v*` branches are
+# the only allowed shape — those don't trip branch protection.
+# `grep -P` for a Perl-compatible negative-match pattern would be
+# cleaner but isn't portable; use a two-step grep instead.
+if grep -nE 'git push' "$RELEASE_YML" | grep -qE '\bmain\b|HEAD:main'; then
+  echo "::error::release.yml contains a 'git push' targeting main. Direct pushes to main from CI are blocked by branch protection's PR Gate aggregator. Push to release/* branches only and let auto-merge handle the merge."
+  grep -nE 'git push' "$RELEASE_YML"
+  exit 1
+fi
+
+# Verify release.yml uses the PR-based flow.
+if ! grep -qE 'gh pr create' "$RELEASE_YML"; then
+  echo "::error::release.yml does not contain 'gh pr create' — it should open a release PR rather than push directly."
+  exit 1
+fi
+if ! grep -qE 'gh pr merge.*--auto' "$RELEASE_YML"; then
+  echo "::error::release.yml does not enable auto-merge ('gh pr merge --auto'). Without auto-merge the release PR would sit indefinitely waiting for human action."
+  exit 1
+fi
+
+# Verify the companion workflow exists and is wired correctly.
+RELEASE_TAG_YML=".github/workflows/release-tag.yml"
+if [ ! -f "$RELEASE_TAG_YML" ]; then
+  echo "::error::$RELEASE_TAG_YML not found. The PR-based release flow needs a separate workflow that fires AFTER the release PR merges to create the tag + GitHub Release. Without it, releases would land on main but no tag/release would ever be created."
+  exit 1
+fi
+# release-tag.yml must trigger on push to main.
+if ! grep -qE '^[[:space:]]+- main$' "$RELEASE_TAG_YML"; then
+  echo "::error::$RELEASE_TAG_YML must trigger on push to main (look for 'branches: [main]' or '- main')."
+  exit 1
+fi
+# It must short-circuit on non-release commits — match the release-
+# commit subject pattern. Without this guard it would try to tag every
+# commit on main.
+if ! grep -qE 'chore: release v' "$RELEASE_TAG_YML"; then
+  echo "::error::$RELEASE_TAG_YML does not look for the 'chore: release v' commit subject pattern. Without that guard it would attempt to tag every push to main."
+  exit 1
+fi
+# It must call gh release create.
+if ! grep -qE 'gh release create' "$RELEASE_TAG_YML"; then
+  echo "::error::$RELEASE_TAG_YML does not call 'gh release create' — the workflow would never publish a GitHub Release."
+  exit 1
+fi
+
+echo "✓ release.yml is workflow_dispatch-only and uses PR-based flow; release-tag.yml fires on release commits; deploy-dev.yml injects unique iOS build number."


### PR DESCRIPTION
## Critical bug

The Release workflow has been **broken since around 2026-05-07** (last successful run: 2026-05-03). Today's attempted Release (run [25628586463](https://github.com/ShydenMcM/ShyTalk/actions/runs/25628586463) at 12:21Z) failed with:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - 3 of 3 required status checks are expected.
```

## Root cause

Two-layer enforcement collision between **classic branch protection** (which still exists on `main`) and the modern Repository Rulesets:

1. Classic protection requires 3 status checks (`Detect Changes`, `Analyze JavaScript`, `PR Gate`) with `enforce_admins: True`
2. **`PR Gate`** is a `pull_request`-only aggregator (`pr-checks.yml:281`). Any direct push to `main` is structurally impossible to make satisfy that requirement
3. The release app's bypass actor entry on the new ruleset (`12613584`) has **zero effect on classic protection** — the two enforcement layers are independent

The release workflow's `Commit version bump` step does `git push` directly to `main` from CI, so it now always fails.

## Fix — Option A: PR-based flow

Refactor into two workflows that work WITH branch protection rather than against it:

### `release.yml` (workflow_dispatch) — Open Release PR

- Bumps version on a `release/v<X.Y.Z>` branch (NOT main)
- Generates Play Store + release notes
- Opens PR with **auto-merge (squash) enabled** + `release-bump` label
- New guard: rejects dispatch if an open release PR already exists (prevents racing)

### `release-tag.yml` (push to main) — Tag and Release

- Short-circuits unless the pushed commit subject matches `^chore: release v\d+\.\d+\.\d+$` (the squash-merge commit message)
- Verifies tag doesn't exist and HEAD `versionName` matches the commit subject
- Regenerates release notes from PRs since last tag (post-merge content is authoritative — handles other PRs that merge between release.yml and auto-merge)
- Creates the git tag + GitHub Release

### Other notes

- **Security**: `head_commit.message` is passed via env var (avoids script-injection class flagged by actionlint)
- **Concurrency**: both workflows share `release-main`
- **No settings change needed**: repo already has `allow_auto_merge: true`, `allow_squash_merge: true`, `delete_branch_on_merge: true`

## Manual-QA verified

- [x] `actionlint` passes for both workflows (no warnings, no errors)
- [x] `bash scripts/check-release-trigger.sh` passes on new shape — exit 0
- [x] **Regression test**: simulated revert to old shape, validator correctly rejects with exit 1 + clear error message ("release.yml does not contain 'gh pr create'")
- [x] `bash scripts/check-workflow-concurrency-scoping.sh` passes
- [x] Pre-push `actionlint (workflow + embedded shellcheck)` hook passes
- [x] CI: Detect Changes ✓, Analyze JavaScript ✓, PR Gate ✓, lint ✓, SonarCloud ✓ (heavy jobs correctly SKIPPED — workflow-only PR)

## Post-merge verification (operator task)

The end-to-end test requires actually firing the new release flow:

1. Trigger Release workflow with `bump=patch` from Actions tab
2. Verify it opens a `release/v<NEW>` PR with the version bump
3. Verify auto-merge is enabled on the PR
4. Wait for PR Gate + playwright matrix to pass and PR to auto-merge
5. Verify `release-tag.yml` fires on the merged commit and produces tag + GitHub Release
6. Verify `roadmap-deploy.yml` (which fires on tag pushes) still works

## Why now

Without this fix, **no new release can be cut**. The user explicitly flagged this as CRITICAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)