### PR TITLE
fix(release): remove non-existent --label flag + improve diagnostics (CRITICAL)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,21 @@ jobs:
             echo "::error::An open release PR already exists. Wait for it to merge (or close it) before opening another. Run 'gh pr list --state open --search \"in:title chore: release v\"' to find it."
             exit 1
           fi
+          # Guard against orphan release branches left by a failed
+          # previous run. The "no-force-push-anywhere" ruleset blocks
+          # branch deletion, so an aborted run can leave release/vX.Y.Z
+          # behind — and the next dispatch would try to push to the
+          # same branch, hit branch-already-exists, and fail. Refuse
+          # to proceed; the operator must manually delete the orphan
+          # via the GitHub UI (or temporarily lift the deletion rule).
+          ORPHAN_RELEASE_BRANCHES=$(gh api repos/${{ github.repository }}/branches --paginate --jq '.[].name | select(startswith("release/v"))')
+          if [ -n "$ORPHAN_RELEASE_BRANCHES" ]; then
+            echo "::error::Orphan release branch(es) detected on origin — likely from a previous failed run."
+            echo "Branches: $ORPHAN_RELEASE_BRANCHES"
+            echo "Action: Delete via the GitHub UI (Settings > Branches > <branch> > Delete) and re-trigger this workflow."
+            echo "If branch protection blocks the UI delete, lift the no-force-push-anywhere ruleset's 'deletion' rule briefly, then re-enable."
+            exit 1
+          fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
@@ -347,19 +362,30 @@ jobs:
             echo "_If this PR fails CI: investigate the failure, push fixes to \`${BRANCH}\` (NOT \`main\`), and re-trigger auto-merge. To abandon this release entirely, close the PR and delete the branch._"
           } > "$PR_BODY_FILE"
 
-          # Create PR. We use --label release-bump so a follow-up
-          # workflow could choose to skip heavy non-required jobs for
-          # release bumps (future optimisation; not implemented yet).
+          # Create PR. We deliberately do NOT pass --label here:
+          # gh pr create requires the label to pre-exist in the repo
+          # and aborts with "could not add label" on miss, which would
+          # leave us with a pushed branch but no PR (the failure mode
+          # we hit on 2026-05-10 with a `release-bump` label that had
+          # never been created). Plain unlabelled PRs are robust and
+          # the release-tag.yml trigger keys off the commit subject,
+          # not a label.
+          # Capture combined stdout+stderr so on failure we can echo
+          # the actual gh error (the tail typically contains the GH
+          # API's reason: branch protection, permissions, label miss,
+          # etc.) — without this echo the operator sees only the
+          # generic "::error::gh pr create failed" annotation.
           PR_URL=$(gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "chore: release v${VERSION}" \
-            --body-file "$PR_BODY_FILE" \
-            --label release-bump 2>&1) || PR_CREATE_FAILED=$?
+            --body-file "$PR_BODY_FILE" 2>&1) || PR_CREATE_FAILED=$?
           if [ "${PR_CREATE_FAILED:-0}" -ne 0 ]; then
-            # Some failure modes (e.g. label doesn't exist yet) leave
-            # the branch pushed but no PR. Surface a clear instruction.
-            echo "::error::gh pr create failed for ${BRANCH}. The branch is pushed; create the PR manually: gh pr create --base main --head ${BRANCH} --title 'chore: release v${VERSION}' --body-file <notes>"
+            echo "::error::gh pr create failed for ${BRANCH}. See gh output below + manual recovery command."
+            echo "----- gh pr create output -----"
+            echo "$PR_URL"
+            echo "-------------------------------"
+            echo "Manual recovery: gh pr create --base main --head ${BRANCH} --title 'chore: release v${VERSION}' --body-file <notes>"
             exit 1
           fi
           PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')


### PR DESCRIPTION
## Critical bug — release still broken after #605

The 16:27Z Release dispatch on 2026-05-10 (run [25633834206](https://github.com/ShydenMcM/ShyTalk/actions/runs/25633834206)) failed with:
\`\`\`
::error::gh pr create failed for release/v0.97.6. The branch is pushed; create the PR manually...
\`\`\`

The branch was pushed successfully but **no PR was opened**, leaving an orphan \`release/v0.97.6\` branch on origin.

## Root cause — two compounding bugs

### Bug 1: \`--label release-bump\` references a non-existent label

PR #605's release.yml calls:
\`\`\`yaml
gh pr create --base main --head "$BRANCH" --label release-bump ...
\`\`\`

But \`release-bump\` was never created as a label in the repo (\`gh label list | grep release-bump\` returns empty). \`gh pr create\` aborts with "could not add label: 'release-bump' not found" and exits non-zero.

The label was originally added as a placeholder for a "skip heavy CI on release bumps" optimisation that was never implemented. \`release-tag.yml\` keys off the **commit subject** pattern, not the label, so the label is structurally unused.

### Bug 2: Error path swallows the actual failure reason

The workflow captures \`gh pr create\`'s combined output into \`PR_URL\` but **never echoes it** on the failure path:
\`\`\`bash
PR_URL=\$(gh pr create ... 2>&1) || PR_CREATE_FAILED=\$?
if [ "\${PR_CREATE_FAILED:-0}" -ne 0 ]; then
  echo "::error::gh pr create failed..."  # ← generic message, real reason discarded
  exit 1
fi
\`\`\`

The operator sees only "gh pr create failed" with no diagnostic detail. Made debugging Bug 1 unnecessarily slow.

## Fix

1. **Drop \`--label release-bump\` entirely**. Was unused; plain unlabelled PRs are robust.
2. **Echo \`PR_URL\` on failure**. Future failures will surface the GH API's actual reason directly in the workflow log between explicit \`-----\` markers.
3. **New guard for orphan release branches**. The \`no-force-push-anywhere\` ruleset (16058327) blocks branch deletion, so an aborted run can leave \`release/v<X.Y.Z>\` behind. The next dispatch would collide on push. New guard fails fast with cleanup instructions.

## Manual recovery for the current orphan

The orphan \`release/v0.97.6\` branch already has a valid \`chore: release v0.97.6\` commit. Quickest path to unblock the release:

\`\`\`
gh pr create --base main --head release/v0.97.6 \\
  --title 'chore: release v0.97.6' \\
  --body 'Manual recovery from run 25633834206'
\`\`\`

Then enable auto-merge on the resulting PR. \`release-tag.yml\` will fire on the squash-merge as designed.

After **this** PR merges, future Release dispatches will detect orphans via the new guard and refuse to proceed until cleanup, instead of failing silently.

## Manual-QA

- [x] \`actionlint\` passes for both workflows
- [x] \`bash scripts/check-release-trigger.sh\` passes
- [x] Confirmed the bug via \`gh label list | grep release-bump\` returning empty (label doesn't exist)
- [x] Confirmed orphan branch via \`gh api repos/.../branches | jq '.[].name | select(startswith("release/v"))'\` returning \`release/v0.97.6\`
- [ ] **After merge**: trigger Release with \`bump=patch\`. Expected: orphan-branch guard fires (release/v0.97.6 still exists). Operator manually cleans it up via UI, re-triggers; PR opens cleanly without the label flag.

## Why now

Without this fix, **the next Release dispatch will fail again** with the same silent error pattern. User explicitly flagged this as critical infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)