### PR TITLE
fix(release): regex must accept squash-merge ' (#NNN)' suffix (CRITICAL)

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -59,8 +59,13 @@ jobs:
           SUBJECT_FIRST_LINE=$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | head -1)
           echo "Latest commit subject: '$SUBJECT_FIRST_LINE'"
 
-          if echo "$SUBJECT_FIRST_LINE" | grep -qE '^chore: release v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            VERSION=$(echo "$SUBJECT_FIRST_LINE" | sed -E 's/^chore: release v([0-9]+\.[0-9]+\.[0-9]+)$/\1/')
+          # GitHub's squash-merge auto-appends a ` (#NNN)` PR-number
+          # suffix to the squashed commit's first line. The regex
+          # accepts that suffix as optional so this workflow fires
+          # for both squash-merged release PRs (the normal path) and
+          # hand-rolled `chore: release v...` commits without a PR.
+          if echo "$SUBJECT_FIRST_LINE" | grep -qE '^chore: release v[0-9]+\.[0-9]+\.[0-9]+( \(#[0-9]+\))?$'; then
+            VERSION=$(echo "$SUBJECT_FIRST_LINE" | sed -E 's/^chore: release v([0-9]+\.[0-9]+\.[0-9]+)( \(#[0-9]+\))?$/\1/')
             echo "is_release=true" >> "$GITHUB_OUTPUT"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Detected release commit for v${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,12 @@ jobs:
           # another release commit — the operator must explicitly choose
           # whether the second click was intentional.
           LATEST_SUBJECT=$(git log -1 --format='%s')
-          if echo "$LATEST_SUBJECT" | grep -qE '^chore: release v[0-9]+\.[0-9]+\.[0-9]+$'; then
+          # Accept optional ` (#NNN)` suffix because squash-merged
+          # release PRs land on main with that PR-number suffix
+          # appended by GitHub. Without the optional group, this guard
+          # would FAIL to detect a just-merged release as a release
+          # commit and would happily double-bump on top of it.
+          if echo "$LATEST_SUBJECT" | grep -qE '^chore: release v[0-9]+\.[0-9]+\.[0-9]+( \(#[0-9]+\))?$'; then
             echo "::error::HEAD is already a release commit ('$LATEST_SUBJECT'). Refusing to bump on top of an existing release. If this was intentional (e.g. publishing a same-content re-tag), do it manually."
             exit 1
           fi


### PR DESCRIPTION
## Critical: third bug in the release flow

Found while inspecting #608 (the user's manual-recovery PR for v0.97.6).

GitHub's squash-merge auto-appends \` (#NNN)\` to the squashed commit's first line. \`gh\`'s autoMergeRequest payload confirms the squashed commit will be:

\`\`\`
chore: release v0.97.6 (#608)
\`\`\`

Both regex anchors in the release workflows used \`$\` at end of version:

\`\`\`bash
'^chore: release v[0-9]+\\.[0-9]+\\.[0-9]+$'
\`\`\`

This **does not match** \`chore: release v0.97.6 (#608)\`, so:

1. **release-tag.yml:Inspect commit subject** would short-circuit on every push — no tag, no GitHub Release ever created
2. **release.yml:Guard against double-fired releases** would fail to detect a just-merged release commit, allowing a double-bump on the next dispatch

## Fix

Both regexes now accept an optional \` (#NNN)\` PR-number suffix:

\`\`\`bash
'^chore: release v[0-9]+\\.[0-9]+\\.[0-9]+( \\(#[0-9]+\\))?$'
\`\`\`

Verified locally:
- \`echo "chore: release v0.97.6 (#608)" | grep -qE '...'\` → matches
- \`sed\` extracts version cleanly: \`0.97.6\`

## Race condition

**This needs to merge BEFORE #608 auto-merges.** Otherwise #608's squashed commit will hit main, release-tag.yml will short-circuit on the version-extraction regex, and the user will have to manually create the v0.97.6 tag + GitHub Release.

If this lands first, #608's auto-merge → release-tag.yml → tag created → GitHub Release published, all hands-off.

## Manual-QA

- [x] \`actionlint\` passes both workflows
- [x] \`bash scripts/check-release-trigger.sh\` passes
- [x] Tested regex against the exact squashed-commit form: matches + extracts version correctly
- [x] Tested regex against legacy hand-rolled form (no suffix): still matches (backward-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)