### PR TITLE
fix(release): signed commits via GraphQL createCommitOnBranch (CRITICAL — 4th bug)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,7 +311,86 @@ jobs:
           cat "$NOTES_FILE"
           echo "-----------------------------------"
 
-      - name: Create release branch and open PR
+      - name: Create release branch and signed commit via GraphQL
+        id: create_commit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="release/v${VERSION}"
+          PARENT_SHA=$(git rev-parse HEAD)
+
+          # We deliberately do NOT use `git commit` + `git push` here.
+          # That path produces UNSIGNED commits regardless of the App
+          # token used to push, because git's commit-signing depends on
+          # local GPG/SSH key configuration that doesn't exist in CI.
+          # Branch protection ruleset 12613584 has `required_signatures`
+          # enabled, so unsigned release commits get blocked from being
+          # squash-merged into main — exactly the failure mode we hit
+          # with PR #608 (the v0.97.6 release). The PR appears as
+          # MERGEABLE/BLOCKED with all checks green and no clear reason
+          # in the GitHub UI; only `gh api repos/X/pulls/N/commits`
+          # reveals `verified: false, reason: "unsigned"`.
+          #
+          # GitHub's GraphQL `createCommitOnBranch` mutation creates
+          # commits server-side that are automatically signed as the
+          # authenticated GitHub App identity. That's the only path
+          # to signed commits from a workflow without a configured
+          # GPG/SSH key in CI.
+
+          # Step 1: Create the release branch (empty, points at main's
+          # current HEAD). createCommitOnBranch requires the branch to
+          # exist before adding commits to it.
+          if ! gh api -X POST "repos/${{ github.repository }}/git/refs" \
+                -f "ref=refs/heads/${BRANCH}" \
+                -f "sha=${PARENT_SHA}" > /tmp/refs-response.json 2>&1; then
+            echo "::error::Failed to create branch ${BRANCH} via REST API."
+            cat /tmp/refs-response.json
+            exit 1
+          fi
+          echo "Created branch ${BRANCH} at ${PARENT_SHA}"
+
+          # Step 2: Build the GraphQL mutation payload. Use jq to
+          # safely encode file contents (base64) and construct the
+          # JSON. --rawfile reads the file verbatim; @base64 in jq
+          # produces RFC-4648-compliant output that GraphQL accepts
+          # without padding/newline issues.
+          ADDITIONS=$(jq -n \
+            --rawfile c1 app/build.gradle.kts \
+            --rawfile c2 app/src/main/play/release-notes/en-US/internal.txt \
+            --rawfile c3 app/src/main/play/release-notes/en-US/default.txt \
+            '[
+              {path: "app/build.gradle.kts", contents: ($c1|@base64)},
+              {path: "app/src/main/play/release-notes/en-US/internal.txt", contents: ($c2|@base64)},
+              {path: "app/src/main/play/release-notes/en-US/default.txt", contents: ($c3|@base64)}
+            ]')
+
+          PAYLOAD=$(jq -n \
+            --arg repo "${{ github.repository }}" \
+            --arg branch "${BRANCH}" \
+            --arg oid "${PARENT_SHA}" \
+            --arg msg "chore: release v${VERSION}" \
+            --argjson additions "$ADDITIONS" \
+            '{
+              query: "mutation($repo: String!, $branch: String!, $oid: GitObjectID!, $msg: String!, $additions: [FileAddition!]!) { createCommitOnBranch(input: { branch: { repositoryNameWithOwner: $repo, branchName: $branch }, expectedHeadOid: $oid, fileChanges: { additions: $additions }, message: { headline: $msg } }) { commit { oid url } } }",
+              variables: {repo: $repo, branch: $branch, oid: $oid, msg: $msg, additions: $additions}
+            }')
+
+          # Step 3: Submit the mutation. gh api graphql --input - reads
+          # the full request body from stdin (query + variables), which
+          # handles complex variable types (FileAddition[]) cleanly.
+          RESPONSE=$(echo "$PAYLOAD" | gh api graphql --input -)
+          COMMIT_OID=$(echo "$RESPONSE" | jq -r '.data.createCommitOnBranch.commit.oid // empty')
+          if [ -z "$COMMIT_OID" ]; then
+            echo "::error::createCommitOnBranch mutation failed — response below."
+            echo "$RESPONSE" | jq .
+            exit 1
+          fi
+          echo "Created signed commit ${COMMIT_OID} on ${BRANCH}"
+          echo "commit_oid=${COMMIT_OID}" >> "$GITHUB_OUTPUT"
+
+      - name: Open release PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -319,30 +398,6 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           BRANCH="release/v${VERSION}"
           NOTES_FILE="${{ steps.notes.outputs.notes_file }}"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          # Create branch from current main and commit the bump + Play
-          # Store release notes. The branch name embeds the version so
-          # concurrent releases (should they ever happen despite the
-          # double-fired guard) wouldn't collide.
-          git checkout -b "$BRANCH"
-          git add app/build.gradle.kts \
-                  app/src/main/play/release-notes/en-US/internal.txt \
-                  app/src/main/play/release-notes/en-US/default.txt
-          git commit -m "chore: release v${VERSION}"
-
-          # Push to origin. Branch protection on main does NOT apply to
-          # release/* branches, so this push is unconditional. The push
-          # uses the release app token, which lets the resulting PR
-          # trigger downstream workflows (pr-checks.yml etc) — using
-          # GITHUB_TOKEN here would suppress those triggers per
-          # GitHub's loop-prevention design.
-          if ! git push --set-upstream origin "$BRANCH"; then
-            echo "::error::git push to release branch '$BRANCH' failed. The version bump is local only — re-run this workflow once the issue is resolved."
-            exit 1
-          fi
 
           # PR body uses the same release notes that will eventually go
           # to the GitHub Release. release-tag.yml will REGENERATE notes

--- a/scripts/check-release-trigger.sh
+++ b/scripts/check-release-trigger.sh
@@ -156,6 +156,25 @@ if ! grep -qE 'gh pr merge.*--auto' "$RELEASE_YML"; then
   exit 1
 fi
 
+# The release commit MUST be created server-side via GraphQL
+# `createCommitOnBranch`, NOT via `git commit` + `git push`. The latter
+# produces UNSIGNED commits regardless of token, which the
+# `required_signatures` rule on ruleset 12613584 blocks from being
+# squash-merged into main. We hit this exact failure mode on 2026-05-10
+# with PR #608 (release/v0.97.6 stuck MERGEABLE/BLOCKED with all
+# checks green; gh api revealed `verified: false, reason: "unsigned"`).
+if ! grep -qE 'createCommitOnBranch' "$RELEASE_YML"; then
+  echo "::error::release.yml does not use GraphQL 'createCommitOnBranch' — release commits would be unsigned and blocked by branch protection's required_signatures rule. Use the GraphQL mutation, not 'git commit' + 'git push'."
+  exit 1
+fi
+# Confirm we're NOT also doing a plain `git commit` of the release
+# bump — that would either be dead code OR produce a parallel unsigned
+# commit that races the signed one.
+if grep -qE '^[[:space:]]+git commit -m "chore: release v' "$RELEASE_YML"; then
+  echo "::error::release.yml still contains 'git commit -m \"chore: release v...\"' — that produces an unsigned commit. Remove it; createCommitOnBranch is the source of truth."
+  exit 1
+fi
+
 # Verify the companion workflow exists and is wired correctly.
 RELEASE_TAG_YML=".github/workflows/release-tag.yml"
 if [ ! -f "$RELEASE_TAG_YML" ]; then


### PR DESCRIPTION
## Critical: 4th bug in the release flow

Found while investigating why PR #608 (chore: release v0.97.6) is stuck \`MERGEABLE/BLOCKED\` with all checks green. \`gh api\` reveals:

\`\`\`json
{"sha":"74f06d4bc2","verified":false,"reason":"unsigned"}
\`\`\`

Branch protection ruleset 12613584 has the **\`required_signatures\`** rule enabled, so unsigned commits cannot be squash-merged into main. The release.yml workflow has been creating unsigned commits since #605:

- \`actions/create-github-app-token\` produces a token that **authorises pushes** as the App, but that token does NOT sign commits
- \`git commit\` produces a commit object that's only signed if a local GPG/SSH key is configured (which CI runners don't have)
- The push succeeds but the underlying commit object remains unsigned
- Branch protection refuses to merge it into main

## Fix

Replace \`git commit\` + \`git push\` with GraphQL's \`createCommitOnBranch\` mutation. That mutation creates commits **server-side** with the App's identity, and GitHub auto-signs commits created via the API as the authenticated GitHub App.

**Implementation:**
1. Create the empty release branch via REST \`POST /git/refs\`
2. Build the GraphQL payload with \`jq\` (`--rawfile` + `@base64` for safe file encoding; `--arg/--argjson` for all scalars to avoid shell-quoting hazards)
3. Submit via \`gh api graphql --input -\` (stdin handles array-of-object variables cleanly)
4. Verify response contains a non-empty commit oid

**Regression guard**: extends \`scripts/check-release-trigger.sh\` (pre-push hook) with positive + negative assertions:
- MUST contain \`createCommitOnBranch\`
- MUST NOT contain literal \`git commit -m "chore: release v...\`

## Manual recovery for the stuck #608

This fix does NOT directly resolve #608 — its commit is already unsigned, on remote, and force-push is blocked. To unblock:

1. Briefly disable \`required_signatures\` rule on ruleset 12613584 (Settings > Rules > main)
2. Squash-merge #608
3. Re-enable \`required_signatures\`
4. \`release-tag.yml\` fires automatically and creates v0.97.6 tag + GitHub Release (regex fix from #610 already on main)

After this PR merges, future Release dispatches will produce signed commits server-side and pass cleanly.

## Why this is the 4th bug

Each fix has revealed the next layer:
1. **#605**: direct push to main blocked by PR Gate required check → moved to PR-based flow
2. **#609**: \`--label release-bump\` references non-existent label + error suppression → removed flag, added diagnostic echo
3. **#610**: regex didn't accept \`(#NNN)\` squash-merge suffix → added optional group
4. **#611 (this)**: commits not signed → GraphQL createCommitOnBranch

Each bug was structurally invisible until the prior layer was fixed. Apologies for the death-by-a-thousand-cuts cadence.

## Manual-QA

- [x] \`actionlint\` passes
- [x] \`bash scripts/check-release-trigger.sh\` passes (with new positive + negative regex assertions)
- [x] Verified the bug via \`gh api repos/X/pulls/608/commits\` returning \`verified: false\`
- [x] Pre-push \`actionlint (workflow + embedded shellcheck)\` hook passes
- [ ] **After merge**: trigger Release with \`bump=patch\`. Verify (a) the resulting PR's commit shows \`verified: true\` in \`gh api repos/X/pulls/N/commits\` and (b) the PR auto-merges cleanly without the BLOCKED state #608 hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)