### PR TITLE
feat(deploy): require owner approval per deployable on prod deploys

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -121,6 +121,12 @@ jobs:
     name: Deploy Backend to Prod
     needs: [validate-release]
     if: inputs.backend
+    # Repo-owner approval gate (configured via GitHub Environments).
+    # The `prod-backend` environment must exist with the repo owner
+    # listed as a required reviewer — see PR description for one-time
+    # setup. Without the environment + reviewers, the job would run
+    # un-gated (environments default to empty reviewers when auto-created).
+    environment: prod-backend
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -202,6 +208,7 @@ jobs:
       always() &&
       inputs.web &&
       (needs.deploy-backend-prod.result == 'success' || needs.deploy-backend-prod.result == 'skipped')
+    environment: prod-web
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -237,6 +244,7 @@ jobs:
       always() &&
       inputs.android &&
       (needs.deploy-backend-prod.result == 'success' || needs.deploy-backend-prod.result == 'skipped')
+    environment: prod-android
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -282,6 +290,7 @@ jobs:
       always() &&
       inputs.ios &&
       (needs.deploy-backend-prod.result == 'success' || needs.deploy-backend-prod.result == 'skipped')
+    environment: prod-ios
     runs-on: [self-hosted, macOS, ARM64, shytalk-mac]
     # Bumped from 45 -> 90 on 2026-04-28: K/Native linkReleaseFrameworkIosArm64
     # plus xcodebuild archive plus App Store upload total ~50 min worst case


### PR DESCRIPTION
## Summary

Each of the four deploy jobs in \`deploy-prod.yml\` now declares an \`environment:\` (prod-backend / prod-web / prod-android / prod-ios). The matching GitHub Environments have been configured with **@ShydenMcM** as the required reviewer on each — so every prod deploy pauses at the start of its job and waits for explicit owner approval before running.

## What this changes in operator flow

1. You dispatch \`Deploy to Prod\` from the Actions tab as before.
2. The workflow validates the ref, builds Android, then **stops at each deploy job** waiting for approval.
3. In the run's UI, you'll see a yellow "Review deployments" prompt — you choose per-surface to approve, reject, or comment.
4. Approving a surface lets that job run. Rejecting it marks the job as \`failure\`, and any downstream surface (e.g. web/android/ios that gates on \`deploy-backend-prod.result == 'success'\`) is automatically blocked from shipping with a not-approved backend.

## Why per-surface (not workflow-wide)

A single workflow-wide approval forces an all-or-nothing decision. With four environments you can:
- Approve the backend, then watch its health check before approving web.
- Reject Android while approving iOS (or vice versa) if you spot a Play vs App Store issue.
- Approve everything except web if you want backend-only re-deploy during incident response.

\`build-android\` is intentionally un-gated — it's a prerequisite, and failing the build means nothing reaches Play regardless of approval. Smoke tests are also un-gated (verification, not deployment).

## Environment setup (already done)

This PR's branch was opened after the environments were configured via API:

\`\`\`bash
for env in prod-backend prod-web prod-android prod-ios; do
  gh api -X PUT \"repos/ShydenMcM/ShyTalk/environments/\$env\" \\
    --input - <<JSON
{\"reviewers\": [{\"type\": \"User\", \"id\": 152036300}], \"deployment_branch_policy\": null}
JSON
done
\`\`\`

All four environments now show 'Required reviewers: 1 (ShydenMcM)' in **Settings → Environments**.

## Audit trail

Every approval/rejection is recorded on the workflow run with reviewer identity, timestamp, and optional comment. Visible from the Actions tab and queryable via \`gh api repos/ShydenMcM/ShyTalk/actions/runs/<id>/approvals\`.

## Interaction with PR #624

PR #624 (\`feat: accept tag/branch/commit hash as deploy ref\`) is independent — both PRs modify deploy-prod.yml but at different lines (#624 = inputs + validate-release; this PR = \`environment:\` lines on deploy jobs). Either order of merge works without conflict.

## Test plan

- [x] All 4 environments created with required reviewer = @ShydenMcM (verified via \`gh api .../environments/<name>\`)
- [x] \`actionlint\` clean on changes
- [ ] CI: required checks green on this PR
- [ ] Post-merge smoke test: dispatch deploy-prod with all 4 surfaces enabled, confirm each pauses for approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)