### PR TITLE
fix(ci): skip gh-pages publish steps on dependabot PRs

### DIFF
--- a/.github/workflows/allure-report.yml
+++ b/.github/workflows/allure-report.yml
@@ -169,7 +169,8 @@ jobs:
           echo "Report size: $(du -sh allure-report | cut -f1)"
 
       - name: Deploy report to GitHub Pages
-        if: steps.check-existing.outputs.skip != 'true'
+        # See test-backend.yml for dependabot read-only GITHUB_TOKEN rationale.
+        if: steps.check-existing.outputs.skip != 'true' && github.actor != 'dependabot[bot]'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -175,7 +175,8 @@ jobs:
           echo "{\"passed\":0,\"failed\":0,\"total\":0,\"date\":\"${DATE}\",\"runUrl\":\"${RUN_URL}\",\"suite\":\"kotlin\",\"env\":\"pr\"}" > kotlin-report/metadata.json
 
       - name: Deploy Kotlin report to GitHub Pages
-        if: always()
+        # See test-backend.yml for dependabot read-only GITHUB_TOKEN rationale.
+        if: always() && github.actor != 'dependabot[bot]'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -60,7 +60,13 @@ jobs:
           echo "{\"passed\":${PASSED},\"failed\":${FAILED},\"total\":${TOTAL},\"date\":\"${DATE}\",\"runUrl\":\"${RUN_URL}\",\"suite\":\"express\",\"env\":\"${REPORT_ENV}\"}" > express-api/coverage/metadata.json
 
       - name: Deploy Express report to GitHub Pages
-        if: always()
+        # Skip for dependabot PRs: GitHub enforces a read-only
+        # GITHUB_TOKEN on dependabot-authored workflow runs (security
+        # tightening from 2021), so peaceiris/actions-gh-pages can't
+        # push to gh-pages and fails the whole job. Test reports for
+        # dependency bumps aren't load-bearing — the test results
+        # themselves are still visible in the run logs.
+        if: always() && github.actor != 'dependabot[bot]'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Unblock the dependabot PR backlog (9 of 10 PRs currently failing CI). All share the same root cause: peaceiris/actions-gh-pages publish steps can't push because GitHub enforces a read-only \`GITHUB_TOKEN\` on dependabot-authored workflow runs (security tightening from the 2021 supply-chain incidents).

## Three steps fixed

| File | Step | Affects |
|------|------|---------|
| \`test-backend.yml:62\` | Deploy Express report to GitHub Pages | 5 express-api dep PRs |
| \`pr-checks.yml:177\` | Deploy Kotlin report to GitHub Pages | 4 gradle dep PRs |
| \`allure-report.yml:171\` | Deploy report to GitHub Pages | Playwright + Android E2E reports |

Each gets \`github.actor != 'dependabot[bot]'\` added to its existing \`if:\` condition. Reports for dep-bump PRs aren't load-bearing — test results are still visible in the run logs; the report view exists primarily for feature PRs and main-branch runs.

## Post-merge: unblock the existing dependabot PRs

The 9 blocked PRs need to re-run against the updated workflow. Options per PR:
- **Rebase**: comment \`@dependabot rebase\` on each, dependabot will rebase + retrigger CI.
- **Recreate**: comment \`@dependabot recreate\` to get a fresh PR with regenerated lock files.

## Out of scope — separate issues

- **PR #626** (archiver 7→8): real ESM incompatibility — archiver 8.0 dropped CommonJS, breaking the data-export-builder test. Either pin to \`^7.x\` in \`package.json\` or add archiver to Jest's \`transformIgnorePatterns\`. Won't be fixed by this PR.
- **PR #630** (firebase 12.12→12.13): merge conflict (DIRTY/CONFLICTING). Just needs a rebase via \`@dependabot rebase\`.
- **PR #636** (coroutines 1.10→1.11): fails on a different step (\`decode-keystore\` can't access secrets from dependabot context). Needs a separate fix.

## Test plan

- [x] \`actionlint\` clean on all 3 modified workflows
- [x] Existing \`if:\` conditions preserved (we add to them, not replace)
- [ ] CI: required checks green on this PR (not a dependabot PR, so it should publish as normal)
- [ ] Post-merge: trigger \`@dependabot rebase\` on PRs #626, #628, #629, #631, #632, #633, #635, #637, #638, #639 and verify they go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)