### PR TITLE
fix(ci): guard gh-pages publish on github.head_ref (catches human-rebased PRs)

### DIFF
--- a/.github/workflows/allure-report.yml
+++ b/.github/workflows/allure-report.yml
@@ -169,8 +169,11 @@ jobs:
           echo "Report size: $(du -sh allure-report | cut -f1)"
 
       - name: Deploy report to GitHub Pages
-        # See test-backend.yml for dependabot read-only GITHUB_TOKEN rationale.
-        if: steps.check-existing.outputs.skip != 'true' && github.actor != 'dependabot[bot]'
+        # See test-backend.yml for full rationale: skip on dependabot
+        # PRs (read-only token + gh-pages race condition). Guard on
+        # github.head_ref so a merge commit added by a human doesn't
+        # bypass the skip (github.actor would resolve to the human).
+        if: steps.check-existing.outputs.skip != 'true' && !startsWith(github.head_ref, 'dependabot/')
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -175,8 +175,11 @@ jobs:
           echo "{\"passed\":0,\"failed\":0,\"total\":0,\"date\":\"${DATE}\",\"runUrl\":\"${RUN_URL}\",\"suite\":\"kotlin\",\"env\":\"pr\"}" > kotlin-report/metadata.json
 
       - name: Deploy Kotlin report to GitHub Pages
-        # See test-backend.yml for dependabot read-only GITHUB_TOKEN rationale.
-        if: always() && github.actor != 'dependabot[bot]'
+        # See test-backend.yml for full rationale: skip on dependabot
+        # PRs (read-only token + gh-pages race condition). Guard on
+        # github.head_ref so a merge commit added by a human doesn't
+        # bypass the skip (github.actor would resolve to the human).
+        if: always() && !startsWith(github.head_ref, 'dependabot/')
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -60,13 +60,22 @@ jobs:
           echo "{\"passed\":${PASSED},\"failed\":${FAILED},\"total\":${TOTAL},\"date\":\"${DATE}\",\"runUrl\":\"${RUN_URL}\",\"suite\":\"express\",\"env\":\"${REPORT_ENV}\"}" > express-api/coverage/metadata.json
 
       - name: Deploy Express report to GitHub Pages
-        # Skip for dependabot PRs: GitHub enforces a read-only
-        # GITHUB_TOKEN on dependabot-authored workflow runs (security
-        # tightening from 2021), so peaceiris/actions-gh-pages can't
-        # push to gh-pages and fails the whole job. Test reports for
-        # dependency bumps aren't load-bearing — the test results
-        # themselves are still visible in the run logs.
-        if: always() && github.actor != 'dependabot[bot]'
+        # Skip for dependabot PRs. Two layers of motivation:
+        #   1) Read-only GITHUB_TOKEN: on dependabot-authored runs
+        #      GitHub enforces a read-only token (2021 supply-chain
+        #      tightening), so peaceiris/actions-gh-pages can't push.
+        #   2) gh-pages race condition: when N dependabot PRs all
+        #      re-run CI in the same minute (e.g. after a batch
+        #      `merge main into` to pick up workflow fixes), each
+        #      peaceiris invocation does `git clone gh-pages --depth=1`,
+        #      commits its report, then `git push` — and N-1 of those
+        #      pushes are rejected as non-fast-forward because the
+        #      first push got there first. peaceiris doesn't retry.
+        # We guard on `github.head_ref` (PR's source branch) instead
+        # of `github.actor` so the skip applies even when the run is
+        # triggered by a non-dependabot user adding a merge commit to
+        # the PR (which makes github.actor that user, not dependabot).
+        if: always() && !startsWith(github.head_ref, 'dependabot/')
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Follow-up to #640. The guard added there used \`github.actor != 'dependabot[bot]'\`, which only skips when dependabot itself triggers the workflow. When a human adds a merge commit to a dependabot PR (e.g. to pull in workflow fixes — exactly what unblocking the 8 stuck dependabot PRs required), \`github.actor\` resolves to the human and the guard fails-open. The step then runs and hits a **new** failure mode: a non-fast-forward push to gh-pages.

## What actually fails (post-#640, post-merge-into-dependabot-branches)

8 dependabot PRs all re-ran CI in the same minute (08:52 UTC) after I merged main into each. Each peaceiris/actions-gh-pages step:

1. \`git clone --depth=1 gh-pages\`
2. commit its report
3. \`git push origin gh-pages\` → \`! [rejected] (fetch first)\`

7 of the 8 PRs got rejected. peaceiris doesn't retry.

## Fix

Swap the guard to \`!startsWith(github.head_ref, 'dependabot/')\`. This keys off the PR's source branch name, which is invariant under human merge commits — independent of who triggered the workflow run.

For push events (not pull_request), \`github.head_ref\` is empty so \`startsWith\` returns \`false\`, the guard is \`true\`, and the step runs — which is the correct behavior for main-branch publishes.

## Layered explanation now in the file

Added a longer comment in \`test-backend.yml\` documenting both motivations:
1. Read-only \`GITHUB_TOKEN\` on dependabot-authored runs
2. gh-pages race condition under concurrent CI

\`pr-checks.yml\` + \`allure-report.yml\` reference that explanation.

## Test plan

- [x] \`actionlint\` clean on all 3 modified workflows
- [x] Existing \`if:\` conditions preserved (we replaced the actor check, kept everything else)
- [ ] CI: required checks green on this PR (non-dependabot, should publish normally)
- [ ] Post-merge: 8 stuck dependabot PRs should go CLEAN on their next CI run (the existing merge commits are still on their branches, so \`gh workflow run\` won't help; need another \`merge main into\` to re-pick up CI — or just let dependabot's next weekly run bring fresh PRs that already have this guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)