### PR TITLE
ci(e2e): opt into keystore fallback so dependabot E2E unblocks

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -124,6 +124,12 @@ jobs:
       - uses: ./.github/actions/decode-keystore
         with:
           keystore-base64: ${{ secrets.KEYSTORE_BASE64 }}
+          # Dependabot PRs run with a read-only token and zero secret access,
+          # so KEYSTORE_BASE64 is empty. The localDebug variant we test uses
+          # Android's auto-generated debug keystore, not this one — but the
+          # action errors out when both secret and fallback are absent.
+          # Mirrors the same opt-in already present in pr-checks.yml.
+          fallback-debug: 'true'
 
       - name: Enable KVM
         run: |


### PR DESCRIPTION
## Summary
- `pr-checks.yml` already passes `fallback-debug: 'true'` to `./.github/actions/decode-keystore`. `e2e-tests.yml` did not. On dependabot PRs the secret is stripped, so the action errored out and cascaded a PR Gate failure.
- The `localDebug` variant under test uses Android's auto-generated debug keystore — the decoded `keystore.jks` is a Gradle configuration prerequisite only, never consumed by `connectedLocalDebugAndroidTest`. A throwaway debug keystore satisfies the configuration phase.
- This is the natural follow-up to PRs #640/#641 which fixed the gh-pages publish steps. Same pattern: discover that one workflow already handles dependabot correctly and bring the sibling into line.

## Test plan
- [x] yamllint / actionlint pass (pre-push hook)
- [ ] After merge, re-merge `main` into the 5 still-open dependabot branches (#626, #630, #631, #633, #636) and confirm the android-e2e step now runs through decode-keystore for #636
- [ ] Confirm #631 (lint-staged, CLEAN) auto-merges via its `merge` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)