### PR TITLE
chore(deps): bump @aws-sdk/client-s3 3.1041.0→3.1045.0 (supersedes #633)

### DIFF
--- a/express-api/package-lock.json
+++ b/express-api/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "dependencies": {
         "@apple/app-store-server-library": "^3.1.0",
-        "@aws-sdk/client-s3": "^3.1041.0",
+        "@aws-sdk/client-s3": "^3.1045.0",
         "@aws-sdk/s3-request-presigner": "^3.1041.0",
         "archiver": "^7.0.1",
         "bcrypt": "^6.0.0",
@@ -256,9 +256,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1041.0.tgz",
-      "integrity": "sha512-sQV14bIqslnBHuSlLMD+fc3pH+ajop6vnrFlJ4wM4JDqcYwVik4O+9srnZUrkesFw5y+CN0GfOQ06CAgtC4mjQ==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1045.0.tgz",
+      "integrity": "sha512-fsuO3Y6t+3Ro9Bsg41DKj4Sfy53CGSrhnMldNplWmG8Tx0UbYk+YDa4RD1hVlJpERw4JBmPkl0+J9qlxMh1pcA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",

--- a/express-api/package.json
+++ b/express-api/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@apple/app-store-server-library": "^3.1.0",
-    "@aws-sdk/client-s3": "^3.1041.0",
+    "@aws-sdk/client-s3": "^3.1045.0",
     "@aws-sdk/s3-request-presigner": "^3.1041.0",
     "archiver": "^7.0.1",
     "bcrypt": "^6.0.0",


### PR DESCRIPTION
## Summary
Supersedes Dependabot PR #633 — that branch went DIRTY/CONFLICTING after the dependabot batch-merge cascade earlier today, with no path forward via rebase under the repo's no-force-push ruleset.

Recreated cleanly off the latest `main` with the same target version.

## Test plan
- [x] `npm test` — 4,777 tests pass
- [x] AWS SDK patch bump within same minor range — no API changes expected

## Supersedes
- #633 (will close once this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)