### PR TITLE
fix(c7): enforce block list on profile view + gift-wall + record-visit

### DIFF
--- a/express-api/src/routes/economy.js
+++ b/express-api/src/routes/economy.js
@@ -288,6 +288,21 @@ async function updateGiftRankings(recipientId, giftId, quantity) {
 // ─── Shared gift helpers ─────────────────────────────────────────
 // (block-check helpers live in ../utils/block-check — imported above)
 
+/**
+ * Load the target user doc and refuse with 403 if they have blocked
+ * the caller (C7). Returns false when 403 was sent — caller must
+ * `return` immediately to avoid double-send. Returns true to continue.
+ */
+async function refuseIfTargetBlocksViewer(req, res) {
+  const snap = await db.doc(`users/${req.params.uniqueId}`).get();
+  const target = snap.exists ? snap.data() : null;
+  if (viewerIsBlocked(req.auth.uniqueId, target)) {
+    res.status(403).json({ error: 'Cannot view content of users who have blocked you' });
+    return false;
+  }
+  return true;
+}
+
 /** Compute daily reward from config and streak. */
 function computeDailyReward(config, newStreak, isSuperShy) {
   const milestoneRewards = config.milestoneRewards || {};
@@ -1879,15 +1894,8 @@ router.get('/users/:uniqueId/backpack', async (req, res) => {
 router.get('/users/:uniqueId/gift-wall', async (req, res) => {
   try {
     // C7 (block-list integrity): a user who has been blocked by the
-    // target must not be able to see the target's gift wall. We load
-    // the target user doc to consult blockedUserIds — one extra read
-    // per gift-wall view, which is acceptable since these are profile-
-    // page interactions, not feed reads.
-    const targetSnap = await db.doc(`users/${req.params.uniqueId}`).get();
-    const targetUser = targetSnap.exists ? targetSnap.data() : null;
-    if (viewerIsBlocked(req.auth.uniqueId, targetUser)) {
-      return res.status(403).json({ error: 'Cannot view content of users who have blocked you' });
-    }
+    // target must not be able to see the target's gift wall.
+    if (!(await refuseIfTargetBlocksViewer(req, res))) return;
 
     const snap = await db.collection(`users/${req.params.uniqueId}/giftWall`).get();
     const results = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
@@ -1903,11 +1911,7 @@ router.get('/users/:uniqueId/gift-wall/:giftId/senders', async (req, res) => {
   try {
     // C7: same block check as the parent gift-wall list — the sender
     // list is a strict subset of gift-wall data.
-    const targetSnap = await db.doc(`users/${req.params.uniqueId}`).get();
-    const targetUser = targetSnap.exists ? targetSnap.data() : null;
-    if (viewerIsBlocked(req.auth.uniqueId, targetUser)) {
-      return res.status(403).json({ error: 'Cannot view content of users who have blocked you' });
-    }
+    if (!(await refuseIfTargetBlocksViewer(req, res))) return;
 
     const docSnap = await db
       .doc(`users/${req.params.uniqueId}/giftWall/${req.params.giftId}`)

--- a/express-api/src/routes/economy.js
+++ b/express-api/src/routes/economy.js
@@ -30,6 +30,7 @@ const log = require('../utils/log');
 const { verifyProductPurchase, verifySubscription } = require('../utils/playStore');
 const { verifyApplePurchase } = require('../utils/appleStore');
 const { SUBSCRIPTION_TIERS } = require('../utils/subscriptionTiers');
+const { viewerIsBlocked, checkBlockRelationship } = require('../utils/block-check');
 
 // ─── Constants ────────────────────────────────────────────────────
 
@@ -285,16 +286,7 @@ async function updateGiftRankings(recipientId, giftId, quantity) {
 }
 
 // ─── Shared gift helpers ─────────────────────────────────────────
-
-/** Check block relationship between sender and recipient. Returns error string or null. */
-function checkBlockRelationship(sender, recipient, senderId, recipientId) {
-  const senderBlocked = (sender?.blockedUserIds || []).map(String);
-  const recipientBlocked = (recipient?.blockedUserIds || []).map(String);
-  if (senderBlocked.includes(String(recipientId)) || recipientBlocked.includes(String(senderId))) {
-    return 'Cannot send gifts to or from blocked users';
-  }
-  return null;
-}
+// (block-check helpers live in ../utils/block-check — imported above)
 
 /** Compute daily reward from config and streak. */
 function computeDailyReward(config, newStreak, isSuperShy) {
@@ -1886,6 +1878,17 @@ router.get('/users/:uniqueId/backpack', async (req, res) => {
 // ── Gift wall ──
 router.get('/users/:uniqueId/gift-wall', async (req, res) => {
   try {
+    // C7 (block-list integrity): a user who has been blocked by the
+    // target must not be able to see the target's gift wall. We load
+    // the target user doc to consult blockedUserIds — one extra read
+    // per gift-wall view, which is acceptable since these are profile-
+    // page interactions, not feed reads.
+    const targetSnap = await db.doc(`users/${req.params.uniqueId}`).get();
+    const targetUser = targetSnap.exists ? targetSnap.data() : null;
+    if (viewerIsBlocked(req.auth.uniqueId, targetUser)) {
+      return res.status(403).json({ error: 'Cannot view content of users who have blocked you' });
+    }
+
     const snap = await db.collection(`users/${req.params.uniqueId}/giftWall`).get();
     const results = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
     res.json(results);
@@ -1898,6 +1901,14 @@ router.get('/users/:uniqueId/gift-wall', async (req, res) => {
 // ── Gift wall senders ──
 router.get('/users/:uniqueId/gift-wall/:giftId/senders', async (req, res) => {
   try {
+    // C7: same block check as the parent gift-wall list — the sender
+    // list is a strict subset of gift-wall data.
+    const targetSnap = await db.doc(`users/${req.params.uniqueId}`).get();
+    const targetUser = targetSnap.exists ? targetSnap.data() : null;
+    if (viewerIsBlocked(req.auth.uniqueId, targetUser)) {
+      return res.status(403).json({ error: 'Cannot view content of users who have blocked you' });
+    }
+
     const docSnap = await db
       .doc(`users/${req.params.uniqueId}/giftWall/${req.params.giftId}`)
       .get();

--- a/express-api/src/routes/users.js
+++ b/express-api/src/routes/users.js
@@ -28,6 +28,7 @@ const { clearSuspensionCache, updateUniqueIdCache } = require('../middleware/aut
 const { sendEmail } = require('../utils/email');
 const { buildDeletionScheduledEmail } = require('../utils/email-templates');
 const { sendFcmToTokens } = require('../utils/fcm');
+const { viewerIsBlocked } = require('../utils/block-check');
 
 const VALID_PROVIDERS = ['google', 'apple', 'email'];
 const MIN_UNIQUE_ID = 10000000;
@@ -285,6 +286,17 @@ router.get('/users/:uniqueId', async (req, res) => {
   try {
     const user = await getDoc(`users/${req.params.uniqueId}`);
     if (!user) return res.status(404).json({ error: 'User not found' });
+
+    // C7 (block-list integrity): the target user must not be visible
+    // to a viewer they have blocked. Returns 403 — the client already
+    // handles 403 from interaction endpoints (gift-send) the same way.
+    // Allowed exception: the user looking at their own profile.
+    if (
+      String(req.auth.uniqueId) !== String(req.params.uniqueId) &&
+      viewerIsBlocked(req.auth.uniqueId, user)
+    ) {
+      return res.status(403).json({ error: 'Cannot view content of users who have blocked you' });
+    }
 
     user.blockedUserIds = user.blockedUserIds || [];
     user.followingIds = user.followingIds || [];
@@ -882,6 +894,18 @@ router.post('/users/:uniqueId/record-visit', async (req, res) => {
     if (req.params.uniqueId === visitorId) return res.json({ success: true }); // don't stalk yourself
 
     const profileUniqueId = req.params.uniqueId;
+
+    // C7: blocked viewers must not tick the stalker counter on the
+    // target's profile (otherwise blocking is observably useless —
+    // the blocker keeps getting "X new visitors" notifications driven
+    // by a user they've already chosen to disengage from). Return 200
+    // with success:true so the client treats the call as completed,
+    // avoiding a retry loop or a UI signal that reveals block state.
+    const targetUser = await getDoc(`users/${profileUniqueId}`);
+    if (viewerIsBlocked(visitorId, targetUser)) {
+      return res.json({ success: true, recorded: false });
+    }
+
     const stalkerPath = `users/${profileUniqueId}/stalkers/${visitorId}`;
     const existing = await getDoc(stalkerPath);
     const timestamp = now();

--- a/express-api/src/utils/block-check.js
+++ b/express-api/src/utils/block-check.js
@@ -1,0 +1,61 @@
+/**
+ * Block-list helpers — predicates for enforcing user-level block rules.
+ *
+ * ShyTalk stores blocks as a `blockedUserIds: number[]` field on the
+ * `users/{uniqueId}` Firestore doc. Block/unblock operations are written
+ * directly to Firestore by the iOS/Android clients (no Express endpoint),
+ * so the source of truth is always the user doc this module is handed.
+ *
+ * Two predicates live here:
+ *
+ *   - `viewerIsBlocked(viewerId, targetUser)` — one-direction, used by
+ *     read endpoints (profile-view, gift-wall) where only the target's
+ *     doc is already loaded. Returns true if the target has blocked the
+ *     viewer, so the read should be refused.
+ *
+ *   - `checkBlockRelationship(sender, recipient, senderId, recipientId)`
+ *     — symmetric, used by interaction endpoints (gift-send, backpack-send)
+ *     where both docs are already loaded for other reasons (balance read
+ *     + recipient existence). Returns an error string or null. The
+ *     symmetric form is correct for interactions: if either side has
+ *     blocked the other, the interaction must fail; a one-way block
+ *     would otherwise let the blocker continue to push gifts.
+ */
+
+/**
+ * One-direction block check for read endpoints.
+ *
+ * @param {number|string} viewerId  The caller's uniqueId (from req.auth.uniqueId)
+ * @param {object|null} targetUser  The target user doc (or null/undefined)
+ * @returns {boolean}                True if the target has blocked the viewer
+ */
+function viewerIsBlocked(viewerId, targetUser) {
+  if (!targetUser) return false;
+  const blocked = (targetUser.blockedUserIds || []).map(String);
+  return blocked.includes(String(viewerId));
+}
+
+/**
+ * Symmetric block check for interaction endpoints. Returns an error
+ * string suitable for `res.status(403).json({ error })`, or null when
+ * neither side blocks the other.
+ *
+ * Kept compatible with the original gift-route helper so existing
+ * call sites do not need to change.
+ *
+ * @param {object} sender         Sender's user doc
+ * @param {object} recipient      Recipient's user doc
+ * @param {number|string} senderId
+ * @param {number|string} recipientId
+ * @returns {string|null}         Error string, or null if OK
+ */
+function checkBlockRelationship(sender, recipient, senderId, recipientId) {
+  const senderBlocked = (sender?.blockedUserIds || []).map(String);
+  const recipientBlocked = (recipient?.blockedUserIds || []).map(String);
+  if (senderBlocked.includes(String(recipientId)) || recipientBlocked.includes(String(senderId))) {
+    return 'Cannot send gifts to or from blocked users';
+  }
+  return null;
+}
+
+module.exports = { viewerIsBlocked, checkBlockRelationship };

--- a/express-api/tests/routes/economy-queries.test.js
+++ b/express-api/tests/routes/economy-queries.test.js
@@ -83,6 +83,12 @@ beforeEach(() => {
   jest.clearAllMocks();
   economyRouter._resetConfigCache();
   mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
+  // C7: gift-wall + gift-wall/senders now load the target user doc to
+  // check `blockedUserIds` before returning data. Default the doc mock
+  // to "user exists, has not blocked anyone" so tests that don't care
+  // about block state still pass. Tests that explicitly mock mockDocGet
+  // (e.g. gift-wall senders) override this.
+  mockDocGet.mockResolvedValue({ exists: true, data: () => ({ blockedUserIds: [] }) });
 });
 
 function createApp(uniqueId = 'user-A') {
@@ -198,6 +204,29 @@ describe('GET /api/users/:uniqueId/gift-wall', () => {
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body).toHaveLength(0);
   });
+
+  // C7: gift-wall view must refuse to serve content when the target has
+  // blocked the caller. Critical for block-list integrity — without
+  // this, blocked users keep seeing their blocker's gifts indefinitely.
+  test('C7: returns 403 when target has blocked the viewer', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ blockedUserIds: ['user-A'] }),
+    });
+    // Even if the gift wall has data, the route must short-circuit
+    // before reading the subcollection — assert it does so by ensuring
+    // mockCollectionGet (the gift-wall fetcher) is never called.
+    mockCollectionGet = jest.fn().mockResolvedValue({
+      empty: false,
+      docs: [{ id: 'gift-1', data: () => ({ giftId: 'gift-rose' }) }],
+    });
+
+    const app = createApp('user-A');
+    const res = await request(app).get('/api/users/user-B/gift-wall').expect(403);
+
+    expect(res.body.error).toMatch(/blocked/i);
+    expect(mockCollectionGet).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /api/users/:uniqueId/gift-wall/:giftId/senders', () => {
@@ -247,5 +276,25 @@ describe('GET /api/users/:uniqueId/gift-wall/:giftId/senders', () => {
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body).toHaveLength(0);
+  });
+
+  // C7: senders list is a strict subset of gift-wall data, so the same
+  // block guard applies. Without this, a blocked user could enumerate
+  // who sent gifts to the blocker even though the parent gift-wall
+  // list is hidden.
+  test('C7: returns 403 when target has blocked the viewer', async () => {
+    // First mockDocGet call is for the user doc (block check); the
+    // second would be for the gift-wall doc but we expect the route to
+    // short-circuit. mockResolvedValueOnce is used for the user doc so
+    // any follow-up call falls back to the beforeEach default.
+    mockDocGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ blockedUserIds: ['user-A'] }),
+    });
+
+    const app = createApp('user-A');
+    const res = await request(app).get('/api/users/user-B/gift-wall/gift-rose/senders').expect(403);
+
+    expect(res.body.error).toMatch(/blocked/i);
   });
 });

--- a/express-api/tests/routes/users.test.js
+++ b/express-api/tests/routes/users.test.js
@@ -405,6 +405,40 @@ describe('POST /api/users/:uniqueId/record-visit', () => {
       .send({ visitorId: '10000999' })
       .expect(403);
   });
+
+  // C7: a blocked visitor must not silently tick the target's stalker
+  // counter — otherwise blocking is observably useless. Returns 200 to
+  // avoid leaking block state to the client, but `recorded: false` lets
+  // tests assert the no-op.
+  test('C7: silent no-op when target has blocked the visitor', async () => {
+    getDoc.mockResolvedValueOnce({ blockedUserIds: [10000002] });
+    const app = createApp('firebase-uid-visitor', 10000002);
+
+    const res = await request(app)
+      .post('/api/users/10000099/record-visit')
+      .send({ visitorId: '10000002' })
+      .expect(200);
+
+    expect(res.body).toEqual({ success: true, recorded: false });
+    expect(mockBatchSet).not.toHaveBeenCalled();
+    expect(mockBatchUpdate).not.toHaveBeenCalled();
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  test('C7: handles string/numeric id mismatch in blockedUserIds', async () => {
+    // Firestore may store blocked IDs as strings depending on which
+    // client wrote them; the helper coerces both sides to strings.
+    getDoc.mockResolvedValueOnce({ blockedUserIds: ['10000002'] });
+    const app = createApp('firebase-uid-visitor', 10000002);
+
+    const res = await request(app)
+      .post('/api/users/10000099/record-visit')
+      .send({ visitorId: '10000002' })
+      .expect(200);
+
+    expect(res.body.recorded).toBe(false);
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
 });
 
 // ─── GET /api/users/:uniqueId — PII stripping ──────────────────
@@ -566,5 +600,50 @@ describe('GET /api/users/:uniqueId', () => {
 
     const app = createApp('firebase-uid-A', 10000001);
     await request(app).get('/api/users/99999999').expect(404);
+  });
+
+  // C7: a user who has been blocked by the target must not see their
+  // profile. Returns 403 (matches gift-send semantics for blocked
+  // interactions); the client renders the blocked-state UI on this.
+  test('C7: returns 403 when target has blocked the viewer', async () => {
+    getDoc.mockResolvedValueOnce({
+      uniqueId: 10000099,
+      displayName: 'Target',
+      blockedUserIds: [10000001],
+    });
+
+    const app = createApp('firebase-uid-A', 10000001);
+    const res = await request(app).get('/api/users/10000099').expect(403);
+
+    expect(res.body.error).toMatch(/blocked/i);
+  });
+
+  test('C7: allows viewing own profile even if own id is in own blockedUserIds', async () => {
+    // Defensive edge case: blocking yourself is impossible via the
+    // client UI, but if the doc is ever corrupted in this way the user
+    // must still be able to see their own profile to recover.
+    getDoc.mockResolvedValueOnce({
+      uniqueId: 10000001,
+      displayName: 'Self',
+      blockedUserIds: [10000001],
+    });
+
+    const app = createApp('firebase-uid-A', 10000001);
+    const res = await request(app).get('/api/users/10000001').expect(200);
+
+    expect(res.body.displayName).toBe('Self');
+  });
+
+  test('C7: allows viewing when target has not blocked the viewer', async () => {
+    getDoc.mockResolvedValueOnce({
+      uniqueId: 10000099,
+      displayName: 'Target',
+      blockedUserIds: [99999999],
+    });
+
+    const app = createApp('firebase-uid-A', 10000001);
+    const res = await request(app).get('/api/users/10000099').expect(200);
+
+    expect(res.body.displayName).toBe('Target');
   });
 });

--- a/express-api/tests/utils/block-check.test.js
+++ b/express-api/tests/utils/block-check.test.js
@@ -1,0 +1,73 @@
+const { viewerIsBlocked, checkBlockRelationship } = require('../../src/utils/block-check');
+
+describe('viewerIsBlocked', () => {
+  test('returns true when target has blocked viewer', () => {
+    expect(viewerIsBlocked(10000001, { blockedUserIds: [10000001, 10000002] })).toBe(true);
+  });
+
+  test('returns false when target has not blocked viewer', () => {
+    expect(viewerIsBlocked(10000001, { blockedUserIds: [10000002] })).toBe(false);
+  });
+
+  test('returns false when target has no blockedUserIds field', () => {
+    expect(viewerIsBlocked(10000001, {})).toBe(false);
+  });
+
+  test('returns false when target is null', () => {
+    expect(viewerIsBlocked(10000001, null)).toBe(false);
+  });
+
+  test('returns false when target is undefined', () => {
+    expect(viewerIsBlocked(10000001, undefined)).toBe(false);
+  });
+
+  test('handles string viewer id against numeric blocked ids', () => {
+    expect(viewerIsBlocked('10000001', { blockedUserIds: [10000001] })).toBe(true);
+  });
+
+  test('handles numeric viewer id against string blocked ids', () => {
+    expect(viewerIsBlocked(10000001, { blockedUserIds: ['10000001'] })).toBe(true);
+  });
+
+  test('returns false on empty blockedUserIds array', () => {
+    expect(viewerIsBlocked(10000001, { blockedUserIds: [] })).toBe(false);
+  });
+});
+
+describe('checkBlockRelationship', () => {
+  test('returns null when neither side has blocked the other', () => {
+    const sender = { blockedUserIds: [] };
+    const recipient = { blockedUserIds: [] };
+    expect(checkBlockRelationship(sender, recipient, 10000001, 10000002)).toBeNull();
+  });
+
+  test('returns error string when sender has blocked recipient', () => {
+    const sender = { blockedUserIds: [10000002] };
+    const recipient = { blockedUserIds: [] };
+    expect(checkBlockRelationship(sender, recipient, 10000001, 10000002)).toMatch(/blocked/i);
+  });
+
+  test('returns error string when recipient has blocked sender', () => {
+    const sender = { blockedUserIds: [] };
+    const recipient = { blockedUserIds: [10000001] };
+    expect(checkBlockRelationship(sender, recipient, 10000001, 10000002)).toMatch(/blocked/i);
+  });
+
+  test('handles mixed string/numeric id storage', () => {
+    const sender = { blockedUserIds: ['10000002'] };
+    const recipient = { blockedUserIds: [] };
+    expect(checkBlockRelationship(sender, recipient, 10000001, 10000002)).toMatch(/blocked/i);
+  });
+
+  test('returns null when sender doc is null/undefined', () => {
+    // Defensive: the gift-send path validates existence separately; this
+    // predicate should not throw on a missing doc.
+    expect(checkBlockRelationship(null, { blockedUserIds: [] }, 1, 2)).toBeNull();
+    expect(checkBlockRelationship(undefined, { blockedUserIds: [] }, 1, 2)).toBeNull();
+  });
+
+  test('returns null when recipient doc is null/undefined', () => {
+    expect(checkBlockRelationship({ blockedUserIds: [] }, null, 1, 2)).toBeNull();
+    expect(checkBlockRelationship({ blockedUserIds: [] }, undefined, 1, 2)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Roadmap **C7 (Top Priority #5)** — a user blocked by the target could still view their profile, gift wall, and tick the target's stalker counter. Block-list integrity is now enforced server-side on all four read/visit endpoints.

## Design
**One-direction enforcement** (target-blocks-viewer → 403). Chosen over symmetric to:
1. Match the roadmap bug description exactly (the *blocked* user could view).
2. Avoid doubling Firestore reads on profile-page interactions (gift-send already reads both docs for balance + recipient existence; reads don't).

Symmetric (viewer-blocks-target also fails) is a strict improvement but belongs in a follow-up if the UX team wants it — a real cost-vs-correctness call, not a free lunch.

## Changes
- **New `src/utils/block-check.js`** with two predicates:
  - `viewerIsBlocked(viewerId, targetUser)` — one-direction, for reads
  - `checkBlockRelationship(s, r, sId, rId)` — symmetric, for sends (moved from inside `economy.js`; existing gift call sites re-import with zero behavioural change)
- **`GET /api/users/:uniqueId`** → 403 when target has blocked viewer. Owner viewing own profile is allowed even if their own id is in their own blockedUserIds (defensive recovery).
- **`GET /api/users/:uniqueId/gift-wall`** → 403; subcollection read is short-circuited.
- **`GET /api/users/:uniqueId/gift-wall/:giftId/senders`** → same.
- **`POST /api/users/:uniqueId/record-visit`** → silent 200 with `recorded:false`. Returning 200 (not 403) avoids leaking block state to the client.

## Tests
- **14 unit tests** for `block-check.js` — mixed id types, missing fields, null/undefined inputs.
- **4 integration tests** in `users.test.js` — record-visit silent no-op + string/numeric id coercion + profile 403 + self-view exception + no-block pass-through.
- **2 integration tests** in `economy-queries.test.js` — gift-wall 403 + short-circuit verification, senders 403.
- Full express-api suite: **4,799 tests / 206 suites pass** (zero regressions).
- SonarCloud quality gate passed on pre-push.

## Test plan
- [x] Unit tests for helper cover edge cases (string↔number, missing fields, null docs)
- [x] Integration tests verify each endpoint returns 403 / silent no-op as expected
- [x] Integration tests verify the route short-circuits before the data-read Firestore call when blocked
- [ ] Manual-QA: with real seeded users, verify (1) blocked viewer sees 403 on profile, (2) gift-wall returns 403, (3) stalker counter doesn't tick — covered by the next /manual-qa cycle once #636 clears the queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)