### PR TITLE
refactor(admin-gifts): inline requireAdmin guards, drop prefix-scoped mount

### DIFF
--- a/express-api/src/routes/admin-gifts.js
+++ b/express-api/src/routes/admin-gifts.js
@@ -10,18 +10,22 @@ const router = require('express').Router();
 const { db } = require('../utils/firebase');
 const { requireAdmin } = require('../middleware/auth');
 
-// Phase 2H finding #2 dedup: scope admin guard by path prefix.
-const _adminGuardWrapper = async (req, res, next) => {
-  if (await requireAdmin(req, res)) return;
-  next();
-};
-router.use('/gifts', _adminGuardWrapper);
+// Admin enforcement: per-handler `requireAdmin` instead of the earlier
+// `router.use('/gifts', adminGuard)` prefix mount. The prefix form matched
+// every `/gifts...` URL — including any future public GET handlers a sibling
+// file (suggestions.js, subscriptions.js, etc.) might add. config.js owns
+// the public GET /gifts handlers today and is registered first in index.js,
+// so route order saves us — but order is a fragile guarantee. Moving the
+// guard inline narrows it to exactly these 3 handlers. Matches the in-handler
+// pattern used across the rest of the admin route surface
+// (see project-cross-router-guard-followups.md).
 
 const { generateId, now } = require('../utils/helpers');
 const log = require('../utils/log');
 
 // ── Create gift ──
 router.post('/gifts', async (req, res) => {
+  if (await requireAdmin(req, res)) return;
   try {
     const body = req.body;
     if (!body?.name || body.coinValue === null || body.coinValue === undefined) {
@@ -64,6 +68,7 @@ router.post('/gifts', async (req, res) => {
 
 // ── Update gift ──
 router.put('/gifts/:id', async (req, res) => {
+  if (await requireAdmin(req, res)) return;
   try {
     const body = req.body;
     if (!body) return res.status(400).json({ error: 'Invalid JSON body' });
@@ -109,6 +114,7 @@ router.put('/gifts/:id', async (req, res) => {
 
 // ── Delete gift ──
 router.delete('/gifts/:id', async (req, res) => {
+  if (await requireAdmin(req, res)) return;
   try {
     await Promise.all([
       db.doc(`gifts/${req.params.id}`).delete(),


### PR DESCRIPTION
## Summary
Replaces the over-broad `router.use('/gifts', adminGuard)` prefix-scoped mount with inline `if (await requireAdmin(req, res)) return;` guards on each of the 3 handlers (POST, PUT, DELETE).

### Why this matters
The prefix form matched every `/gifts...` URL. config.js owns the public GET `/gifts` handlers; admin-gifts.js owns the admin-only POST/PUT/DELETE. Today the public GETs work only because config.js is registered before admin-gifts in `src/index.js` (line 179 vs line 196) — so the public route matches first and the admin guard never fires.

Any future public GET `/gifts/<anything>` added to a sibling router file registered AFTER admin-gifts would be silently 403'd by this guard, with no compile-time or test-time signal. Documented in `project-cross-router-guard-followups.md`.

### Why inline (not middleware)
A per-route middleware form (`router.post('/gifts', adminGuard, handler)`) was attempted first but rejected by the project's route-convention guard, which expects the inline `if (await requireAdmin(req, res)) return;` pattern used across the rest of the admin surface. Following convention rather than fighting it.

### No behaviour change
- Same 3 admin operations remain admin-only.
- Same 403 returned to non-admin requests.
- All 20 existing admin-gifts tests pass unmodified.
- Full express-api suite green (206 suites / 4,799 tests).
- SonarCloud quality gate green on pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)