### PR TITLE
feat(b3): room message reporting (UK OSA)

### DIFF
--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -3406,6 +3406,155 @@ class RoomViewModelTest {
             assertFalse(viewModel.uiState.value.isSubmittingReport)
         }
 
+    // ===== reportMessage Tests =====
+    //
+    // B3 (Room message reporting, UK OSA). Mirrors PrivateChatViewModel.reportMessage
+    // but adapted to the room's conversationId = roomId convention and the room's
+    // Message type. Server-side contract is identical (POST /api/reports).
+    //
+    // The four tests below cover: happy path field passing, missing target user
+    // (corrupted message), repository failure surfaces in uiState, and the
+    // server-trusted "no evidence on message reports" invariant (storage
+    // repository must NOT be called — different from reportUser).
+
+    @Test
+    fun `reportMessage - success passes roomId as conversationId and message fields`() =
+        roomTest {
+            val targetUid = "sender-7"
+            val targetUser = TestData.createTestUser(uid = targetUid, displayName = "Bad Actor")
+            coEvery { userRepository.getUser(targetUid) } returns Resource.Success(targetUser)
+            coEvery {
+                reportRepository.reportMessage(
+                    reporterId = any(),
+                    reporterName = any(),
+                    reporterUniqueId = any(),
+                    reportedUserId = any(),
+                    reportedUserName = any(),
+                    reportedUserUniqueId = any(),
+                    conversationId = any(),
+                    messageId = any(),
+                    messageText = any(),
+                    reason = any(),
+                    description = any(),
+                )
+            } returns Resource.Success(Unit)
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            val message =
+                Message(
+                    messageId = "msg-42",
+                    senderId = targetUid,
+                    senderName = "Bad Actor",
+                    text = "offensive content",
+                    type = MessageType.TEXT,
+                )
+
+            viewModel.reportMessage(message, "Harassment", "context")
+            advanceUntilIdle()
+
+            // conversationId MUST be the roomId, not "" (the reportUser convention).
+            // Server uses conversationId to scope per-room moderation queries — a
+            // blank value silently drops room reports out of the per-room admin view.
+            coVerify {
+                reportRepository.reportMessage(
+                    reporterId = currentUserId,
+                    reporterName = "Current User",
+                    reporterUniqueId = any(),
+                    reportedUserId = targetUid,
+                    reportedUserName = "Bad Actor",
+                    reportedUserUniqueId = any(),
+                    conversationId = "room-1",
+                    messageId = "msg-42",
+                    messageText = "offensive content",
+                    reason = "Harassment",
+                    description = "context",
+                )
+            }
+            // Same uiState flag as reportUser — RoomScreen's LaunchedEffect already
+            // surfaces report_thank_you on this transition, so reusing the flag
+            // avoids a second snackbar wire-up.
+            assertTrue(viewModel.uiState.value.reportSubmitted)
+            assertFalse(viewModel.uiState.value.isSubmittingReport)
+        }
+
+    @Test
+    fun `reportMessage - never calls storageRepository (no evidence on message reports)`() =
+        roomTest {
+            val targetUid = "sender-8"
+            val targetUser = TestData.createTestUser(uid = targetUid, displayName = "Sender")
+            coEvery { userRepository.getUser(targetUid) } returns Resource.Success(targetUser)
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Success(Unit)
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-1", senderId = targetUid, senderName = "Sender", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            // Message reports do not upload evidence (unlike reportUser). If a future
+            // refactor accidentally couples them, this regression test catches the
+            // resulting wasted R2 PUT on every room report.
+            coVerify(exactly = 0) { storageRepository.uploadImage(any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun `reportMessage - error when sender resolution fails sets reportError`() =
+        roomTest {
+            val targetUid = "ghost-sender"
+            coEvery { userRepository.getUser(targetUid) } returns Resource.Error("Not found")
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-2", senderId = targetUid, senderName = "Ghost", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            assertEquals("Could not submit report", viewModel.uiState.value.reportError)
+            assertFalse(viewModel.uiState.value.reportSubmitted)
+            assertFalse(viewModel.uiState.value.isSubmittingReport)
+        }
+
+    @Test
+    fun `reportMessage - repository failure surfaces reportError`() =
+        roomTest {
+            val targetUid = "sender-9"
+            val targetUser = TestData.createTestUser(uid = targetUid, displayName = "Sender")
+            coEvery { userRepository.getUser(targetUid) } returns Resource.Success(targetUser)
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Error("backend down")
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-3", senderId = targetUid, senderName = "Sender", text = "bad", type = MessageType.TEXT),
+                "Other",
+                "long context that exceeds nothing",
+            )
+            advanceUntilIdle()
+
+            assertEquals("Failed to submit report", viewModel.uiState.value.reportError)
+            assertFalse(viewModel.uiState.value.reportSubmitted)
+            assertFalse(viewModel.uiState.value.isSubmittingReport)
+        }
+
     // ===== editMessage Tests =====
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -3555,6 +3555,360 @@ class RoomViewModelTest {
             assertFalse(viewModel.uiState.value.isSubmittingReport)
         }
 
+    // ── reportMessage branch enumeration (added 2026-05-11, per the
+    // strengthened TDD rule). Every branch in the function body gets at least
+    // one test:
+    //   1a/1b/1c — currentUser via cache hit / repo Success / repo Error→null
+    //   2a/2b/2c — targetUser via cache hit / repo Success / repo Error→null
+    //   3a/3b/3c — null short-circuit: current-null, target-null, both-null
+    //   4a/4b/4c — Resource Success / Error / Loading from reportRepository
+    //   5      — isSubmittingReport flips on entry and clears on each exit
+    //   6      — reportError is reset to null on a fresh submission
+    //   7      — reportSubmitted does NOT flip on the Error path
+    //   8      — every value in reportMessageReasons is forwarded verbatim
+    //   9      — Resource.Loading from repository leaves state untouched
+    //
+    // The earlier 4 tests covered 1b/2b/4a, 2c/3-pure, 4b, and a no-evidence
+    // invariant. The 9 tests below close the remaining gaps.
+
+    @Test
+    fun `reportMessage - current user resolution failure also blocks submission`() =
+        roomTest {
+            // Branch 1c + 3a: currentUser repo lookup fails, target lookup succeeds —
+            // the null short-circuit must still fire (covers the LEFT operand of
+            // the `||` independently from the right).
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Error("auth down")
+            val targetUid = "sender-c1"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-c1", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            assertEquals("Could not submit report", viewModel.uiState.value.reportError)
+            assertFalse(viewModel.uiState.value.reportSubmitted)
+            assertFalse(viewModel.uiState.value.isSubmittingReport)
+            // Defence-in-depth: the report endpoint must NOT be called when either
+            // side of the user pair is null. Without this assertion the VM could
+            // silently send `Resource.Error.data!!` and 500 the server.
+            coVerify(exactly = 0) {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `reportMessage - both users null short-circuits without crashing`() =
+        roomTest {
+            // Branch 3c — both `currentUser == null` AND `targetUser == null` together.
+            // The if uses `||`, so if Kotlin ever changed short-circuit semantics
+            // (or someone refactors to `&&` by mistake), this row would still pass
+            // the guard wrongly. Pin the AND-of-nulls path.
+            val targetUid = "sender-c2"
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Error("auth down")
+            coEvery { userRepository.getUser(targetUid) } returns Resource.Error("not found")
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-c2", senderId = targetUid, senderName = "Z", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            assertEquals("Could not submit report", viewModel.uiState.value.reportError)
+            assertFalse(viewModel.uiState.value.reportSubmitted)
+        }
+
+    @Test
+    fun `reportMessage - reportError is reset to null at the start of each submission`() =
+        roomTest {
+            // Branch 6 — stale error from a previous failed submission must NOT
+            // persist after the user retries. Without this reset the UI shows
+            // "Failed to submit report" red text even though the in-flight call
+            // is succeeding.
+            val targetUid = "sender-r"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+            // First call: server fails so reportError gets set.
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Error("transient")
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            val message =
+                Message(messageId = "m-r", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT)
+            viewModel.reportMessage(message, "Spam", "")
+            advanceUntilIdle()
+            assertEquals("Failed to submit report", viewModel.uiState.value.reportError)
+
+            // Second call: server succeeds. The stale error from call 1 must be
+            // cleared during the initial state-update of call 2 — otherwise the
+            // success path would render with the old error still visible.
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Success(Unit)
+
+            viewModel.reportMessage(message, "Spam", "")
+            advanceUntilIdle()
+
+            assertEquals(null, viewModel.uiState.value.reportError)
+            assertTrue(viewModel.uiState.value.reportSubmitted)
+        }
+
+    @Test
+    fun `reportMessage - Resource Loading from repository does not mutate uiState`() =
+        roomTest {
+            // Branch 4c — the `is Resource.Loading -> Unit` arm. If a refactor
+            // accidentally drops the arm or treats Loading as Error/Success, the
+            // VM would either green-toast or red-toast on a still-pending request.
+            // Lock the no-op contract.
+            val targetUid = "sender-l"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Loading
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-l", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            // Loading is treated as "no terminal yet" — neither flag flips.
+            assertFalse(viewModel.uiState.value.reportSubmitted)
+            assertEquals(null, viewModel.uiState.value.reportError)
+            // isSubmittingReport remains true because no terminal arrived.
+            assertTrue(viewModel.uiState.value.isSubmittingReport)
+        }
+
+    @Test
+    fun `reportMessage - all four canonical reasons are forwarded verbatim`() =
+        roomTest {
+            // Branch 8 — the four `reportMessageReasons` values must pass through
+            // unchanged. A typo or accidental lowercase() somewhere in the chain
+            // would silently drift the admin-side reason list out of sync.
+            val targetUid = "sender-reason"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Success(Unit)
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            val message =
+                Message(messageId = "m-reason", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT)
+            for (reason in listOf("Spam", "Harassment", "Inappropriate Content", "Other")) {
+                viewModel.reportMessage(message, reason, "")
+                advanceUntilIdle()
+                coVerify {
+                    reportRepository.reportMessage(
+                        reporterId = any(),
+                        reporterName = any(),
+                        reporterUniqueId = any(),
+                        reportedUserId = any(),
+                        reportedUserName = any(),
+                        reportedUserUniqueId = any(),
+                        conversationId = any(),
+                        messageId = any(),
+                        messageText = any(),
+                        reason = reason,
+                        description = any(),
+                    )
+                }
+            }
+        }
+
+    @Test
+    fun `reportMessage - blank description still forwards correctly (server side stores empty)`() =
+        roomTest {
+            // Edge input: blank description must be passed through as "" — the
+            // server expects an empty string, not null, for the optional field.
+            // Without this regression test, a future refactor that coerces blank
+            // to null would change the on-wire shape silently.
+            val targetUid = "sender-b"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Success(Unit)
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-b", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            coVerify {
+                reportRepository.reportMessage(
+                    reporterId = any(),
+                    reporterName = any(),
+                    reporterUniqueId = any(),
+                    reportedUserId = any(),
+                    reportedUserName = any(),
+                    reportedUserUniqueId = any(),
+                    conversationId = any(),
+                    messageId = any(),
+                    messageText = any(),
+                    reason = any(),
+                    description = "",
+                )
+            }
+        }
+
+    @Test
+    fun `reportMessage - empty messageText still passes through (e g deleted-text edge)`() =
+        roomTest {
+            // Edge input: `message.text` may be empty (deleted message, gift-only
+            // message rendered as TEXT, etc.). The endpoint accepts empty text;
+            // the client must not pre-filter or 400-block.
+            val targetUid = "sender-e"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Success(Unit)
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-e", senderId = targetUid, senderName = "T", text = "", type = MessageType.TEXT),
+                "Other",
+                "",
+            )
+            advanceUntilIdle()
+
+            coVerify {
+                reportRepository.reportMessage(
+                    reporterId = any(),
+                    reporterName = any(),
+                    reporterUniqueId = any(),
+                    reportedUserId = any(),
+                    reportedUserName = any(),
+                    reportedUserUniqueId = any(),
+                    conversationId = any(),
+                    messageId = "m-e",
+                    messageText = "",
+                    reason = any(),
+                    description = any(),
+                )
+            }
+            assertTrue(viewModel.uiState.value.reportSubmitted)
+        }
+
+    @Test
+    fun `reportMessage - reporter and reported uniqueIds are placed in the correct field slots`() =
+        roomTest {
+            // Field-order sanity test. Without this, a future refactor that
+            // swapped `reporterUniqueId` and `reportedUserUniqueId` would compile
+            // (both Long) and pass any test that uses `any()` for those slots.
+            // Lock the exact uniqueId-to-field assignment.
+            val targetUid = "sender-id"
+            val targetUniqueId = 9999L
+            val targetUser =
+                TestData.createTestUser(uid = targetUid, displayName = "T").copy(uniqueId = targetUniqueId)
+            val reporterUniqueId = 1234L
+            coEvery { userRepository.getUser(currentUserId) } returns
+                Resource.Success(
+                    TestData
+                        .createTestUser(uid = currentUserId, displayName = "Current User")
+                        .copy(uniqueId = reporterUniqueId),
+                )
+            coEvery { userRepository.getUser(targetUid) } returns Resource.Success(targetUser)
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Success(Unit)
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-id", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            coVerify {
+                reportRepository.reportMessage(
+                    reporterId = currentUserId,
+                    reporterName = any(),
+                    reporterUniqueId = reporterUniqueId,
+                    reportedUserId = targetUid,
+                    reportedUserName = any(),
+                    reportedUserUniqueId = targetUniqueId,
+                    conversationId = any(),
+                    messageId = any(),
+                    messageText = any(),
+                    reason = any(),
+                    description = any(),
+                )
+            }
+        }
+
+    @Test
+    fun `reportMessage - isSubmittingReport remains true while a previous attempt is in flight`() =
+        roomTest {
+            // State machine assertion: while the suspension is awaiting the repo
+            // result, `isSubmittingReport` must be `true` (UI shows spinner).
+            // This isolates branch 5's "on" half from its "off" half.
+            val targetUid = "sender-flight"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+            // Suspend-forever repository call so we can observe the in-flight state.
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } coAnswers {
+                kotlinx.coroutines.awaitCancellation()
+            }
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-flight", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            // Let the launch reach the suspending repo call but NOT past it.
+            advanceTimeBy(1)
+
+            assertTrue(viewModel.uiState.value.isSubmittingReport)
+            assertFalse(viewModel.uiState.value.reportSubmitted)
+            assertEquals(null, viewModel.uiState.value.reportError)
+        }
+
     // ===== editMessage Tests =====
 
     @Test

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/ReportMessageDialog.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/ReportMessageDialog.kt
@@ -1,0 +1,108 @@
+package com.shyden.shytalk.core.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.shyden.shytalk.resources.Res
+import com.shyden.shytalk.resources.additional_details_optional
+import com.shyden.shytalk.resources.cancel
+import com.shyden.shytalk.resources.report_message
+import com.shyden.shytalk.resources.report_message_prompt
+import com.shyden.shytalk.resources.submit_report
+import org.jetbrains.compose.resources.stringResource
+
+internal val reportMessageReasons = listOf("Spam", "Harassment", "Inappropriate Content", "Other")
+
+/**
+ * Shared per-message report dialog. Used by both DM (PrivateChatScreen) and
+ * room (RoomScreen) surfaces — keep behaviour symmetric so a reporter who
+ * uses one path and then the other doesn't see a different reason list.
+ *
+ * Lives in `core/ui` rather than `feature/messaging` so the `feature/room`
+ * import isn't a sibling-feature dependency.
+ */
+@Composable
+fun ReportMessageDialog(
+    onDismiss: () -> Unit,
+    onSubmit: (reason: String, description: String) -> Unit,
+) {
+    var selectedReason by remember { mutableStateOf(reportMessageReasons[0]) }
+    var description by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.report_message)) },
+        text = {
+            Column {
+                Text(
+                    text = stringResource(Res.string.report_message_prompt),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                reportMessageReasons.forEach { reason ->
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable { selectedReason = reason }
+                                .padding(vertical = 4.dp)
+                                .testTag("reportReasonRow_$reason"),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = selectedReason == reason,
+                            onClick = { selectedReason = reason },
+                            modifier = Modifier.testTag("reportReasonRadio_$reason"),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(text = reason, style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    placeholder = { Text(stringResource(Res.string.additional_details_optional)) },
+                    modifier = Modifier.fillMaxWidth().testTag("reportDescription"),
+                    maxLines = 3,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onSubmit(selectedReason, description) },
+                modifier = Modifier.testTag("reportSubmit"),
+            ) {
+                Text(stringResource(Res.string.submit_report))
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.testTag("reportDismiss"),
+            ) {
+                Text(stringResource(Res.string.cancel))
+            }
+        },
+    )
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -41,12 +40,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
@@ -70,6 +67,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.shyden.shytalk.core.model.MessageEdit
 import com.shyden.shytalk.core.model.PrivateMessage
+import com.shyden.shytalk.core.ui.ReportMessageDialog
 import com.shyden.shytalk.core.ui.StyledDisplayName
 import com.shyden.shytalk.core.ui.StyledSnackbarHost
 import com.shyden.shytalk.core.util.Constants
@@ -994,66 +992,6 @@ fun PrivateChatScreen(
         onDismiss = { viewModel.dismissAgeRestrictionDialog() },
         onVerifyNow = onNavigateToAgeVerification,
         onContactSupport = { viewModel.dismissAgeRestrictionDialog() },
-    )
-}
-
-private val reportReasons = listOf("Spam", "Harassment", "Inappropriate Content", "Other")
-
-@Composable
-private fun ReportMessageDialog(
-    onDismiss: () -> Unit,
-    onSubmit: (reason: String, description: String) -> Unit,
-) {
-    var selectedReason by remember { mutableStateOf(reportReasons[0]) }
-    var description by remember { mutableStateOf("") }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(Res.string.report_message)) },
-        text = {
-            Column {
-                Text(
-                    text = stringResource(Res.string.report_message_prompt),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                reportReasons.forEach { reason ->
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable { selectedReason = reason }
-                                .padding(vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        RadioButton(
-                            selected = selectedReason == reason,
-                            onClick = { selectedReason = reason },
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = reason, style = MaterialTheme.typography.bodyMedium)
-                    }
-                }
-                Spacer(modifier = Modifier.height(8.dp))
-                OutlinedTextField(
-                    value = description,
-                    onValueChange = { description = it },
-                    placeholder = { Text(stringResource(Res.string.additional_details_optional)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    maxLines = 3,
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = { onSubmit(selectedReason, description) }) {
-                Text(stringResource(Res.string.submit_report))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(Res.string.cancel))
-            }
-        },
     )
 }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -53,6 +53,7 @@ import com.shyden.shytalk.core.model.Broadcast
 import com.shyden.shytalk.core.model.BroadcastType
 import com.shyden.shytalk.core.model.Gift
 import com.shyden.shytalk.core.model.GiftEvent
+import com.shyden.shytalk.core.model.Message
 import com.shyden.shytalk.core.model.RoomRole
 import com.shyden.shytalk.core.model.RoomState
 import com.shyden.shytalk.core.model.SeatState
@@ -201,6 +202,11 @@ fun RoomScreen(
     var pmStickerResultHandler by remember { mutableStateOf<((ByteArray) -> Unit)?>(null) }
     val reportEvidenceList = remember { mutableListOf<Pair<ByteArray, String>>() }
     var reportEvidenceVersion by remember { mutableStateOf(0) }
+    // B3 — room message reporting: holds the message the user long-pressed,
+    // null while no dialog open. Distinct state from reportEvidenceList (user
+    // reports) because room MESSAGE reports do not collect evidence — the
+    // message text + messageId IS the evidence.
+    var reportingRoomMessage by remember { mutableStateOf<Message?>(null) }
     var isCompressingEvidence by remember { mutableStateOf(false) }
 
     val evidenceScope = rememberCoroutineScope()
@@ -750,6 +756,7 @@ fun RoomScreen(
                                 aliases = uiState.aliases,
                                 translations = uiState.translations,
                                 onTranslateMessage = { viewModel.translateMessage(it) },
+                                onReportMessage = { msg -> reportingRoomMessage = msg },
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
@@ -1250,4 +1257,18 @@ fun RoomScreen(
         onVerifyNow = onNavigateToAgeVerification,
         onContactSupport = { gachaViewModel.dismissAgeRestrictionDialog() },
     )
+
+    // B3 — room message report dialog (UK OSA per-message reporting).
+    // Shown when a non-self TEXT message is long-pressed. The dialog itself
+    // lives in core/ui so DM and room use one identical surface; only the
+    // VM hop differs (RoomViewModel.reportMessage vs PrivateChatViewModel).
+    reportingRoomMessage?.let { msg ->
+        com.shyden.shytalk.core.ui.ReportMessageDialog(
+            onDismiss = { reportingRoomMessage = null },
+            onSubmit = { reason, description ->
+                viewModel.reportMessage(msg, reason, description)
+                reportingRoomMessage = null
+            },
+        )
+    }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -1804,6 +1804,67 @@ class RoomViewModel(
         _uiState.update { it.copy(reportSubmitted = false, reportError = null) }
     }
 
+    /**
+     * Report a specific room chat message (B3 — UK OSA per-message reporting).
+     *
+     * Differs from [reportUser] in three deliberate ways: (a) no evidence upload
+     * (the message text + messageId are the evidence), (b) conversationId is the
+     * roomId so per-room admin filters scope correctly, (c) the sender is resolved
+     * from `message.senderId` rather than a tap target.
+     */
+    fun reportMessage(
+        message: Message,
+        reason: String,
+        description: String,
+    ) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSubmittingReport = true, reportError = null) }
+
+            val currentUser =
+                userCache[_uiState.value.currentUserId]
+                    ?: when (val result = userRepository.getUser(_uiState.value.currentUserId)) {
+                        is Resource.Success -> result.data
+                        else -> null
+                    }
+            val targetUser =
+                userCache[message.senderId]
+                    ?: when (val result = userRepository.getUser(message.senderId)) {
+                        is Resource.Success -> result.data
+                        else -> null
+                    }
+            if (currentUser == null || targetUser == null) {
+                _uiState.update { it.copy(isSubmittingReport = false, reportError = "Could not submit report") }
+                return@launch
+            }
+
+            when (
+                reportRepository.reportMessage(
+                    reporterId = currentUser.uid,
+                    reporterName = currentUser.displayName,
+                    reporterUniqueId = currentUser.uniqueId,
+                    reportedUserId = targetUser.uid,
+                    reportedUserName = targetUser.displayName,
+                    reportedUserUniqueId = targetUser.uniqueId,
+                    conversationId = roomId,
+                    messageId = message.messageId,
+                    messageText = message.text,
+                    reason = reason,
+                    description = description,
+                )
+            ) {
+                is Resource.Success -> {
+                    _uiState.update { it.copy(isSubmittingReport = false, reportSubmitted = true) }
+                }
+
+                is Resource.Error -> {
+                    _uiState.update { it.copy(isSubmittingReport = false, reportError = "Failed to submit report") }
+                }
+
+                is Resource.Loading -> Unit
+            }
+        }
+    }
+
     // --- Notification Queue ---
 
     private fun enqueueNotification(notification: RoomNotification) {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ChatPanel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ChatPanel.kt
@@ -89,6 +89,7 @@ fun ChatPanel(
     aliases: Map<String, String> = emptyMap(),
     translations: Map<String, String> = emptyMap(),
     onTranslateMessage: (String) -> Unit = {},
+    onReportMessage: (Message) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
@@ -185,6 +186,12 @@ fun ChatPanel(
                         onEditMessage =
                             if (isSelf && message.type == com.shyden.shytalk.core.model.MessageType.TEXT) {
                                 { onStartEditMessage(message.messageId, message.text) }
+                            } else {
+                                null
+                            },
+                        onReportMessage =
+                            if (!isSelf && message.type == com.shyden.shytalk.core.model.MessageType.TEXT && message.senderId != "system") {
+                                { onReportMessage(message) }
                             } else {
                                 null
                             },

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ChatPanel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ChatPanel.kt
@@ -190,7 +190,7 @@ fun ChatPanel(
                                 null
                             },
                         onReportMessage =
-                            if (!isSelf && message.type == com.shyden.shytalk.core.model.MessageType.TEXT && message.senderId != "system") {
+                            if (isRoomMessageReportable(isSelf = isSelf, type = message.type, senderId = message.senderId)) {
                                 { onReportMessage(message) }
                             } else {
                                 null

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/MessageBubble.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/MessageBubble.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -112,6 +113,7 @@ fun MessageBubble(
     onTapUser: () -> Unit,
     onInvite: () -> Unit,
     onEditMessage: (() -> Unit)? = null,
+    onReportMessage: (() -> Unit)? = null,
     onTranslate: (() -> Unit)? = null,
     translatedText: String? = null,
     aliases: Map<String, String> = emptyMap(),
@@ -230,13 +232,22 @@ fun MessageBubble(
                                 MaterialTheme.colorScheme.surfaceVariant
                             },
                         modifier =
-                            if (isSelf && onEditMessage != null) {
-                                Modifier.combinedClickable(
-                                    onClick = {},
-                                    onLongClick = onEditMessage,
-                                )
-                            } else {
-                                Modifier
+                            when {
+                                isSelf && onEditMessage != null ->
+                                    Modifier
+                                        .combinedClickable(
+                                            onClick = {},
+                                            onLongClick = onEditMessage,
+                                        ).testTag("room_msg_editTarget_${message.messageId}")
+
+                                !isSelf && onReportMessage != null ->
+                                    Modifier
+                                        .combinedClickable(
+                                            onClick = {},
+                                            onLongClick = onReportMessage,
+                                        ).testTag("room_msg_reportTarget_${message.messageId}")
+
+                                else -> Modifier
                             },
                     ) {
                         Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/RoomMessageReportability.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/RoomMessageReportability.kt
@@ -1,0 +1,19 @@
+package com.shyden.shytalk.feature.room.components
+
+import com.shyden.shytalk.core.model.MessageType
+
+/**
+ * Decide whether a room message exposes the "report" long-press affordance.
+ *
+ * Pure function so the policy (UK OSA B3 — non-self TEXT messages from real
+ * users) is testable without spinning up Compose. ChatPanel uses this to gate
+ * the `onReportMessage` callback that MessageBubble's combinedClickable hooks
+ * into. Server-side never blocks based on these — defence is admin-side — so
+ * the gate exists purely for UX hygiene (don't show "report" on your own
+ * messages, on JOIN/GIFT events, or on system announcements).
+ */
+internal fun isRoomMessageReportable(
+    isSelf: Boolean,
+    type: MessageType,
+    senderId: String,
+): Boolean = !isSelf && type == MessageType.TEXT && senderId != "system"

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/ui/ReportMessageDialogTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/ui/ReportMessageDialogTest.kt
@@ -1,0 +1,46 @@
+package com.shyden.shytalk.core.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Lock the user-visible reason list. Both DM (PrivateChatScreen) and room
+ * (RoomScreen) surfaces pull from this constant, so a drift here changes
+ * both products' reporting taxonomy AND silently changes what the
+ * `reason` field carries on the wire to `POST /api/reports`.
+ *
+ * The admin moderation UI clusters reports by reason string for triage —
+ * adding a reason that the admin tab doesn't know about means those
+ * reports show up in "Other" rather than their own filter bucket. Pin
+ * the contents + order so future additions are a conscious, cross-cutting
+ * change.
+ */
+class ReportMessageDialogTest {
+    @Test
+    fun `reason list has exactly four entries in the canonical order`() {
+        assertEquals(
+            listOf("Spam", "Harassment", "Inappropriate Content", "Other"),
+            reportMessageReasons,
+        )
+    }
+
+    @Test
+    fun `all entries are non-blank`() {
+        // Defence against a stray empty string sneaking in via a translation
+        // refactor — the on-wire `reason` becomes "" which the admin filter
+        // treats as missing and the moderation queue loses the row.
+        for (reason in reportMessageReasons) {
+            assertTrue(reason.isNotBlank(), "Reason must be non-blank: '$reason'")
+        }
+    }
+
+    @Test
+    fun `Other is the last entry by convention`() {
+        // The "fallback" reason is always last in the radio list so it's not
+        // the default selection. A reorder that bubbled "Other" to the top
+        // would silently change which reason gets pre-selected, biasing
+        // every report whose author didn't explicitly tap a radio.
+        assertEquals("Other", reportMessageReasons.last())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/room/components/RoomMessageReportabilityTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/room/components/RoomMessageReportabilityTest.kt
@@ -1,0 +1,64 @@
+package com.shyden.shytalk.feature.room.components
+
+import com.shyden.shytalk.core.model.MessageType
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the B3 (UK OSA per-message reporting) UI gate. The 4 boolean predicates
+ * combine into 16 truth-table rows; this covers the happy path plus each
+ * predicate flipped independently so a future regression that drops one of
+ * the gates (e.g. accidentally allowing self-message reports) fails loudly.
+ */
+class RoomMessageReportabilityTest {
+    @Test
+    fun `happy path - non-self TEXT message from a real user is reportable`() {
+        assertTrue(isRoomMessageReportable(isSelf = false, type = MessageType.TEXT, senderId = "user-1"))
+    }
+
+    @Test
+    fun `self-flip - self TEXT message is NOT reportable`() {
+        assertFalse(isRoomMessageReportable(isSelf = true, type = MessageType.TEXT, senderId = "user-1"))
+    }
+
+    @Test
+    fun `type-flip SYSTEM - non-self SYSTEM message is NOT reportable`() {
+        assertFalse(isRoomMessageReportable(isSelf = false, type = MessageType.SYSTEM, senderId = "user-1"))
+    }
+
+    @Test
+    fun `type-flip JOIN - non-self JOIN message is NOT reportable`() {
+        assertFalse(isRoomMessageReportable(isSelf = false, type = MessageType.JOIN, senderId = "user-1"))
+    }
+
+    @Test
+    fun `type-flip GIFT - non-self GIFT message is NOT reportable`() {
+        assertFalse(isRoomMessageReportable(isSelf = false, type = MessageType.GIFT, senderId = "user-1"))
+    }
+
+    @Test
+    fun `sender-flip - system-sender TEXT message is NOT reportable even though type is TEXT`() {
+        // System announcements sometimes ship as TEXT with senderId="system" (admin
+        // broadcasts, room close warnings). The gate must catch this — otherwise
+        // a regular user could "report" a system message, which the server treats
+        // as a self-inflicted infraction since there is no real reportee.
+        assertFalse(isRoomMessageReportable(isSelf = false, type = MessageType.TEXT, senderId = "system"))
+    }
+
+    @Test
+    fun `compound - self AND system-type AND system-sender is NOT reportable`() {
+        // Multiple disqualifying conditions still produce false; no exotic AND/OR
+        // bug that would let one predicate accidentally override the others.
+        assertFalse(isRoomMessageReportable(isSelf = true, type = MessageType.SYSTEM, senderId = "system"))
+    }
+
+    @Test
+    fun `empty senderId - empty string is reportable per current policy`() {
+        // Lock the current behaviour: empty senderId passes the != "system" check
+        // and the gate evaluates true. If a future fix decides empty IDs should
+        // be filtered out, this test will fail loudly and force the policy change
+        // to be a conscious update (not a silent regression).
+        assertTrue(isRoomMessageReportable(isSelf = false, type = MessageType.TEXT, senderId = ""))
+    }
+}


### PR DESCRIPTION
## Summary

- B3 (Top Priority #2) — UK OSA per-message reporting on the voice room chat surface.
- Long-pressing a non-self TEXT message opens the same report dialog used by DMs.
- `RoomViewModel.reportMessage` uses `roomId` as `conversationId` so admin per-room filters scope correctly.
- Extracted `ReportMessageDialog` from `PrivateChatScreen.kt` into shared `core/ui/` — single source of truth for the reason list across DM + room.

## Why this matters

UK OSA compliance gap: previously the room screen had `reportUser` (whole-account) but no per-message report. Each user-generated message must have a "report" affordance under the Online Safety Act. This closes that gap symmetric with the DM surface.

## Changes

| File | Change |
|---|---|
| `shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/ReportMessageDialog.kt` | NEW — extracted shared dialog with testTags |
| `shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt` | New `reportMessage(message, reason, description)` |
| `shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/MessageBubble.kt` | New `onReportMessage` callback + long-press branch for non-self TEXT |
| `shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ChatPanel.kt` | Plumb `onReportMessage` through (gated on `!isSelf && type==TEXT && senderId!="system"`) |
| `shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomScreen.kt` | `reportingRoomMessage` state + dialog render |
| `shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatScreen.kt` | Drop private dialog, import shared one |
| `app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt` | 4 new `reportMessage` tests |

## Tests

4 new RoomViewModel tests (TDD red→green):
- `reportMessage - success passes roomId as conversationId and message fields`
- `reportMessage - never calls storageRepository (no evidence on message reports)`
- `reportMessage - error when sender resolution fails sets reportError`
- `reportMessage - repository failure surfaces reportError`

## Verification

- [x] `:shared:jvmTest + :app:testDevDebugUnitTest + detekt` — BUILD SUCCESSFUL
- [x] `:shared:compileKotlinIosArm64` — BUILD SUCCESSFUL (tri-platform)
- [x] `ktlint --relative` on touched files — clean
- [x] SonarCloud quality gate (pre-push hook) — passed
- [ ] **Manual-QA on emulator/device** — pending (hard merge gate per project rule)

## Test plan

- [ ] Local emulator: join a voice room, long-press a non-self message, verify dialog opens
- [ ] Submit with "Spam" reason — verify "Thank you for reporting" toast + report visible in admin queue at conversationId=roomId
- [ ] Long-press a SELF message — verify edit flow still works (no report dialog)
- [ ] Long-press a SYSTEM/JOIN message — verify no dialog appears
- [ ] iOS simulator: same scenarios (KMP parity)
- [ ] Admin web: confirm new room reports show with `conversationId` set to the room id

🤖 Generated with [Claude Code](https://claude.com/claude-code)