### PR TITLE
fix(reports): use Firebase UID for reportedUserId + seed DOB for local QA

### DIFF
--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -3406,6 +3406,155 @@ class RoomViewModelTest {
             assertFalse(viewModel.uiState.value.isSubmittingReport)
         }
 
+    // ===== reportMessage Tests =====
+    //
+    // B3 (Room message reporting, UK OSA). Mirrors PrivateChatViewModel.reportMessage
+    // but adapted to the room's conversationId = roomId convention and the room's
+    // Message type. Server-side contract is identical (POST /api/reports).
+    //
+    // The four tests below cover: happy path field passing, missing target user
+    // (corrupted message), repository failure surfaces in uiState, and the
+    // server-trusted "no evidence on message reports" invariant (storage
+    // repository must NOT be called — different from reportUser).
+
+    @Test
+    fun `reportMessage - success passes roomId as conversationId and message fields`() =
+        roomTest {
+            val targetUid = "sender-7"
+            val targetUser = TestData.createTestUser(uid = targetUid, displayName = "Bad Actor")
+            coEvery { userRepository.getUser(targetUid) } returns Resource.Success(targetUser)
+            coEvery {
+                reportRepository.reportMessage(
+                    reporterId = any(),
+                    reporterName = any(),
+                    reporterUniqueId = any(),
+                    reportedUserId = any(),
+                    reportedUserName = any(),
+                    reportedUserUniqueId = any(),
+                    conversationId = any(),
+                    messageId = any(),
+                    messageText = any(),
+                    reason = any(),
+                    description = any(),
+                )
+            } returns Resource.Success(Unit)
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            val message =
+                Message(
+                    messageId = "msg-42",
+                    senderId = targetUid,
+                    senderName = "Bad Actor",
+                    text = "offensive content",
+                    type = MessageType.TEXT,
+                )
+
+            viewModel.reportMessage(message, "Harassment", "context")
+            advanceUntilIdle()
+
+            // conversationId MUST be the roomId, not "" (the reportUser convention).
+            // Server uses conversationId to scope per-room moderation queries — a
+            // blank value silently drops room reports out of the per-room admin view.
+            coVerify {
+                reportRepository.reportMessage(
+                    reporterId = currentUserId,
+                    reporterName = "Current User",
+                    reporterUniqueId = any(),
+                    reportedUserId = targetUid,
+                    reportedUserName = "Bad Actor",
+                    reportedUserUniqueId = any(),
+                    conversationId = "room-1",
+                    messageId = "msg-42",
+                    messageText = "offensive content",
+                    reason = "Harassment",
+                    description = "context",
+                )
+            }
+            // Same uiState flag as reportUser — RoomScreen's LaunchedEffect already
+            // surfaces report_thank_you on this transition, so reusing the flag
+            // avoids a second snackbar wire-up.
+            assertTrue(viewModel.uiState.value.reportSubmitted)
+            assertFalse(viewModel.uiState.value.isSubmittingReport)
+        }
+
+    @Test
+    fun `reportMessage - never calls storageRepository (no evidence on message reports)`() =
+        roomTest {
+            val targetUid = "sender-8"
+            val targetUser = TestData.createTestUser(uid = targetUid, displayName = "Sender")
+            coEvery { userRepository.getUser(targetUid) } returns Resource.Success(targetUser)
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Success(Unit)
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-1", senderId = targetUid, senderName = "Sender", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            // Message reports do not upload evidence (unlike reportUser). If a future
+            // refactor accidentally couples them, this regression test catches the
+            // resulting wasted R2 PUT on every room report.
+            coVerify(exactly = 0) { storageRepository.uploadImage(any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun `reportMessage - error when sender resolution fails sets reportError`() =
+        roomTest {
+            val targetUid = "ghost-sender"
+            coEvery { userRepository.getUser(targetUid) } returns Resource.Error("Not found")
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-2", senderId = targetUid, senderName = "Ghost", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            assertEquals("Could not submit report", viewModel.uiState.value.reportError)
+            assertFalse(viewModel.uiState.value.reportSubmitted)
+            assertFalse(viewModel.uiState.value.isSubmittingReport)
+        }
+
+    @Test
+    fun `reportMessage - repository failure surfaces reportError`() =
+        roomTest {
+            val targetUid = "sender-9"
+            val targetUser = TestData.createTestUser(uid = targetUid, displayName = "Sender")
+            coEvery { userRepository.getUser(targetUid) } returns Resource.Success(targetUser)
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Error("backend down")
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-3", senderId = targetUid, senderName = "Sender", text = "bad", type = MessageType.TEXT),
+                "Other",
+                "long context that exceeds nothing",
+            )
+            advanceUntilIdle()
+
+            assertEquals("Failed to submit report", viewModel.uiState.value.reportError)
+            assertFalse(viewModel.uiState.value.reportSubmitted)
+            assertFalse(viewModel.uiState.value.isSubmittingReport)
+        }
+
     // ===== editMessage Tests =====
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -3555,6 +3555,360 @@ class RoomViewModelTest {
             assertFalse(viewModel.uiState.value.isSubmittingReport)
         }
 
+    // ── reportMessage branch enumeration (added 2026-05-11, per the
+    // strengthened TDD rule). Every branch in the function body gets at least
+    // one test:
+    //   1a/1b/1c — currentUser via cache hit / repo Success / repo Error→null
+    //   2a/2b/2c — targetUser via cache hit / repo Success / repo Error→null
+    //   3a/3b/3c — null short-circuit: current-null, target-null, both-null
+    //   4a/4b/4c — Resource Success / Error / Loading from reportRepository
+    //   5      — isSubmittingReport flips on entry and clears on each exit
+    //   6      — reportError is reset to null on a fresh submission
+    //   7      — reportSubmitted does NOT flip on the Error path
+    //   8      — every value in reportMessageReasons is forwarded verbatim
+    //   9      — Resource.Loading from repository leaves state untouched
+    //
+    // The earlier 4 tests covered 1b/2b/4a, 2c/3-pure, 4b, and a no-evidence
+    // invariant. The 9 tests below close the remaining gaps.
+
+    @Test
+    fun `reportMessage - current user resolution failure also blocks submission`() =
+        roomTest {
+            // Branch 1c + 3a: currentUser repo lookup fails, target lookup succeeds —
+            // the null short-circuit must still fire (covers the LEFT operand of
+            // the `||` independently from the right).
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Error("auth down")
+            val targetUid = "sender-c1"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-c1", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            assertEquals("Could not submit report", viewModel.uiState.value.reportError)
+            assertFalse(viewModel.uiState.value.reportSubmitted)
+            assertFalse(viewModel.uiState.value.isSubmittingReport)
+            // Defence-in-depth: the report endpoint must NOT be called when either
+            // side of the user pair is null. Without this assertion the VM could
+            // silently send `Resource.Error.data!!` and 500 the server.
+            coVerify(exactly = 0) {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `reportMessage - both users null short-circuits without crashing`() =
+        roomTest {
+            // Branch 3c — both `currentUser == null` AND `targetUser == null` together.
+            // The if uses `||`, so if Kotlin ever changed short-circuit semantics
+            // (or someone refactors to `&&` by mistake), this row would still pass
+            // the guard wrongly. Pin the AND-of-nulls path.
+            val targetUid = "sender-c2"
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Error("auth down")
+            coEvery { userRepository.getUser(targetUid) } returns Resource.Error("not found")
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-c2", senderId = targetUid, senderName = "Z", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            assertEquals("Could not submit report", viewModel.uiState.value.reportError)
+            assertFalse(viewModel.uiState.value.reportSubmitted)
+        }
+
+    @Test
+    fun `reportMessage - reportError is reset to null at the start of each submission`() =
+        roomTest {
+            // Branch 6 — stale error from a previous failed submission must NOT
+            // persist after the user retries. Without this reset the UI shows
+            // "Failed to submit report" red text even though the in-flight call
+            // is succeeding.
+            val targetUid = "sender-r"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+            // First call: server fails so reportError gets set.
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Error("transient")
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            val message =
+                Message(messageId = "m-r", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT)
+            viewModel.reportMessage(message, "Spam", "")
+            advanceUntilIdle()
+            assertEquals("Failed to submit report", viewModel.uiState.value.reportError)
+
+            // Second call: server succeeds. The stale error from call 1 must be
+            // cleared during the initial state-update of call 2 — otherwise the
+            // success path would render with the old error still visible.
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Success(Unit)
+
+            viewModel.reportMessage(message, "Spam", "")
+            advanceUntilIdle()
+
+            assertEquals(null, viewModel.uiState.value.reportError)
+            assertTrue(viewModel.uiState.value.reportSubmitted)
+        }
+
+    @Test
+    fun `reportMessage - Resource Loading from repository does not mutate uiState`() =
+        roomTest {
+            // Branch 4c — the `is Resource.Loading -> Unit` arm. If a refactor
+            // accidentally drops the arm or treats Loading as Error/Success, the
+            // VM would either green-toast or red-toast on a still-pending request.
+            // Lock the no-op contract.
+            val targetUid = "sender-l"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Loading
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-l", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            // Loading is treated as "no terminal yet" — neither flag flips.
+            assertFalse(viewModel.uiState.value.reportSubmitted)
+            assertEquals(null, viewModel.uiState.value.reportError)
+            // isSubmittingReport remains true because no terminal arrived.
+            assertTrue(viewModel.uiState.value.isSubmittingReport)
+        }
+
+    @Test
+    fun `reportMessage - all four canonical reasons are forwarded verbatim`() =
+        roomTest {
+            // Branch 8 — the four `reportMessageReasons` values must pass through
+            // unchanged. A typo or accidental lowercase() somewhere in the chain
+            // would silently drift the admin-side reason list out of sync.
+            val targetUid = "sender-reason"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Success(Unit)
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            val message =
+                Message(messageId = "m-reason", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT)
+            for (reason in listOf("Spam", "Harassment", "Inappropriate Content", "Other")) {
+                viewModel.reportMessage(message, reason, "")
+                advanceUntilIdle()
+                coVerify {
+                    reportRepository.reportMessage(
+                        reporterId = any(),
+                        reporterName = any(),
+                        reporterUniqueId = any(),
+                        reportedUserId = any(),
+                        reportedUserName = any(),
+                        reportedUserUniqueId = any(),
+                        conversationId = any(),
+                        messageId = any(),
+                        messageText = any(),
+                        reason = reason,
+                        description = any(),
+                    )
+                }
+            }
+        }
+
+    @Test
+    fun `reportMessage - blank description still forwards correctly (server side stores empty)`() =
+        roomTest {
+            // Edge input: blank description must be passed through as "" — the
+            // server expects an empty string, not null, for the optional field.
+            // Without this regression test, a future refactor that coerces blank
+            // to null would change the on-wire shape silently.
+            val targetUid = "sender-b"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Success(Unit)
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-b", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            coVerify {
+                reportRepository.reportMessage(
+                    reporterId = any(),
+                    reporterName = any(),
+                    reporterUniqueId = any(),
+                    reportedUserId = any(),
+                    reportedUserName = any(),
+                    reportedUserUniqueId = any(),
+                    conversationId = any(),
+                    messageId = any(),
+                    messageText = any(),
+                    reason = any(),
+                    description = "",
+                )
+            }
+        }
+
+    @Test
+    fun `reportMessage - empty messageText still passes through (e g deleted-text edge)`() =
+        roomTest {
+            // Edge input: `message.text` may be empty (deleted message, gift-only
+            // message rendered as TEXT, etc.). The endpoint accepts empty text;
+            // the client must not pre-filter or 400-block.
+            val targetUid = "sender-e"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Success(Unit)
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-e", senderId = targetUid, senderName = "T", text = "", type = MessageType.TEXT),
+                "Other",
+                "",
+            )
+            advanceUntilIdle()
+
+            coVerify {
+                reportRepository.reportMessage(
+                    reporterId = any(),
+                    reporterName = any(),
+                    reporterUniqueId = any(),
+                    reportedUserId = any(),
+                    reportedUserName = any(),
+                    reportedUserUniqueId = any(),
+                    conversationId = any(),
+                    messageId = "m-e",
+                    messageText = "",
+                    reason = any(),
+                    description = any(),
+                )
+            }
+            assertTrue(viewModel.uiState.value.reportSubmitted)
+        }
+
+    @Test
+    fun `reportMessage - reporter and reported uniqueIds are placed in the correct field slots`() =
+        roomTest {
+            // Field-order sanity test. Without this, a future refactor that
+            // swapped `reporterUniqueId` and `reportedUserUniqueId` would compile
+            // (both Long) and pass any test that uses `any()` for those slots.
+            // Lock the exact uniqueId-to-field assignment.
+            val targetUid = "sender-id"
+            val targetUniqueId = 9999L
+            val targetUser =
+                TestData.createTestUser(uid = targetUid, displayName = "T").copy(uniqueId = targetUniqueId)
+            val reporterUniqueId = 1234L
+            coEvery { userRepository.getUser(currentUserId) } returns
+                Resource.Success(
+                    TestData
+                        .createTestUser(uid = currentUserId, displayName = "Current User")
+                        .copy(uniqueId = reporterUniqueId),
+                )
+            coEvery { userRepository.getUser(targetUid) } returns Resource.Success(targetUser)
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Success(Unit)
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-id", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            coVerify {
+                reportRepository.reportMessage(
+                    reporterId = currentUserId,
+                    reporterName = any(),
+                    reporterUniqueId = reporterUniqueId,
+                    reportedUserId = targetUid,
+                    reportedUserName = any(),
+                    reportedUserUniqueId = targetUniqueId,
+                    conversationId = any(),
+                    messageId = any(),
+                    messageText = any(),
+                    reason = any(),
+                    description = any(),
+                )
+            }
+        }
+
+    @Test
+    fun `reportMessage - isSubmittingReport remains true while a previous attempt is in flight`() =
+        roomTest {
+            // State machine assertion: while the suspension is awaiting the repo
+            // result, `isSubmittingReport` must be `true` (UI shows spinner).
+            // This isolates branch 5's "on" half from its "off" half.
+            val targetUid = "sender-flight"
+            coEvery { userRepository.getUser(targetUid) } returns
+                Resource.Success(TestData.createTestUser(uid = targetUid, displayName = "T"))
+            // Suspend-forever repository call so we can observe the in-flight state.
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } coAnswers {
+                kotlinx.coroutines.awaitCancellation()
+            }
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-flight", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            // Let the launch reach the suspending repo call but NOT past it.
+            advanceTimeBy(1)
+
+            assertTrue(viewModel.uiState.value.isSubmittingReport)
+            assertFalse(viewModel.uiState.value.reportSubmitted)
+            assertEquals(null, viewModel.uiState.value.reportError)
+        }
+
     // ===== editMessage Tests =====
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -3877,6 +3877,65 @@ class RoomViewModelTest {
         }
 
     @Test
+    fun `reportMessage - reportedUserId is targetUser firebaseUid not User uid`() =
+        roomTest {
+            // Pins the server-contract fix from PR #651: `resolveUniqueId`
+            // middleware queries `users.where('firebaseUid','==',value)` so the
+            // client MUST send firebaseUid, NOT `User.uid` (which is the
+            // Firestore doc key = numeric uniqueId in this app). Without this
+            // test, a regression that swaps `targetUser.firebaseUid` back to
+            // `targetUser.uid` slips through because the default TestData
+            // fixture has uid == firebaseUid. Construct a user where they
+            // differ to detect the regression unambiguously.
+            val targetUid = "sender-id-test"
+            val targetFirebaseUid = "fb-uid-xyz-789"
+            val targetUser =
+                TestData
+                    .createTestUser(uid = targetUid, displayName = "T")
+                    .copy(firebaseUid = targetFirebaseUid)
+            coEvery { userRepository.getUser(targetUid) } returns Resource.Success(targetUser)
+            coEvery {
+                reportRepository.reportMessage(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Resource.Success(Unit)
+
+            // Same trick for the reporter (current user).
+            val reporterFirebaseUid = "fb-uid-current-456"
+            coEvery { userRepository.getUser(currentUserId) } returns
+                Resource.Success(
+                    TestData
+                        .createTestUser(uid = currentUserId, displayName = "Current User")
+                        .copy(firebaseUid = reporterFirebaseUid),
+                )
+
+            viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.reportMessage(
+                Message(messageId = "m-fb", senderId = targetUid, senderName = "T", text = "x", type = MessageType.TEXT),
+                "Spam",
+                "",
+            )
+            advanceUntilIdle()
+
+            coVerify {
+                reportRepository.reportMessage(
+                    reporterId = reporterFirebaseUid,
+                    reporterName = any(),
+                    reporterUniqueId = any(),
+                    reportedUserId = targetFirebaseUid,
+                    reportedUserName = any(),
+                    reportedUserUniqueId = any(),
+                    conversationId = any(),
+                    messageId = any(),
+                    messageText = any(),
+                    reason = any(),
+                    description = any(),
+                )
+            }
+        }
+
+    @Test
     fun `reportMessage - isSubmittingReport remains true while a previous attempt is in flight`() =
         roomTest {
             // State machine assertion: while the suspension is awaiting the repo

--- a/app/src/test/java/com/shyden/shytalk/testutil/TestData.kt
+++ b/app/src/test/java/com/shyden/shytalk/testutil/TestData.kt
@@ -56,6 +56,13 @@ object TestData {
         language: String = "en",
     ) = User(
         uid = uid,
+        // Default firebaseUid to uid so the existing wave of tests (which only
+        // pass `uid = "..."`) gets a populated firebaseUid for free. Production
+        // code paths that now send `User.firebaseUid` for report endpoints
+        // (PR #651 fix) would otherwise see empty strings and the tests would
+        // need every fixture rewritten. Tests that specifically care about the
+        // uid != firebaseUid distinction can `.copy(firebaseUid = "...")` it.
+        firebaseUid = uid,
         displayName = displayName,
         blockedUserIds = blockedUserIds,
         profilePhotoUrl = profilePhotoUrl,

--- a/express-api/tests/utils/seed-user-invariants.test.js
+++ b/express-api/tests/utils/seed-user-invariants.test.js
@@ -16,73 +16,55 @@ const path = require('path');
 const seedPath = path.resolve(__dirname, '../../../local/seed.js');
 const seedSrc = fs.readFileSync(seedPath, 'utf8');
 
-describe('local/seed.js — user doc invariants', () => {
-  describe('admin user (100000001)', () => {
-    const adminBlock = seedSrc.match(
-      /seedIfMissing\("users\/100000001",\s*\{([\s\S]*?)\}\s*\)\s*;/,
+/**
+ * Run the user-invariant battery against a seeded user block. Sharing the
+ * assertions through one helper keeps the admin / regular-user coverage
+ * symmetric and stops duplicated-test-block growth (3% SonarCloud gate).
+ */
+function describeSeededUserInvariants(label, uniqueId, firebaseVar) {
+  describe(`${label} (${uniqueId})`, () => {
+    const block = seedSrc.match(
+      new RegExp(`seedIfMissing\\("users\\/${uniqueId}",\\s*\\{([\\s\\S]*?)\\}\\s*\\)\\s*;`),
     );
 
-    it('admin user block is present', () => {
-      expect(adminBlock).not.toBeNull();
+    it('user block is present', () => {
+      expect(block).not.toBeNull();
     });
 
-    it('admin user does NOT carry a uid field (mirrors production users.js which never writes uid)', () => {
+    it('does NOT carry a uid field (mirrors production users.js which never writes uid)', () => {
       // Production user creation in express-api/src/routes/users.js writes
       // `uniqueId` + `firebaseUid` to `users/<uniqueId>` and never writes a
       // `uid` field. The seed should match — adding `uid: ...` here would
       // diverge from prod and risk masking field-handling bugs.
-      expect(adminBlock[1]).not.toMatch(/\buid:\s*/);
+      expect(block[1]).not.toMatch(/\buid:\s*/);
     });
 
-    it('admin firebaseUid is set to adminFirebaseUid (sanity)', () => {
-      expect(adminBlock[1]).toMatch(/\bfirebaseUid:\s*adminFirebaseUid\b/);
+    it(`firebaseUid is set to ${firebaseVar} (sanity)`, () => {
+      expect(block[1]).toMatch(new RegExp(`\\bfirebaseUid:\\s*${firebaseVar}\\b`));
     });
 
-    it('admin has dateOfBirth + age + ageVerified to bypass the C8 gate', () => {
+    it('has dateOfBirth + age + ageVerified to bypass the C8 gate', () => {
       // Without these the first sign-in hits "One More Step — Select Date
       // of Birth" and blocks every downstream QA flow.
-      expect(adminBlock[1]).toMatch(/\bdateOfBirth:\s*"\d{4}-\d{2}-\d{2}"/);
-      expect(adminBlock[1]).toMatch(/\bage:\s*\d+/);
-      expect(adminBlock[1]).toMatch(/\bageVerified:\s*true/);
+      expect(block[1]).toMatch(/\bdateOfBirth:\s*"\d{4}-\d{2}-\d{2}"/);
+      expect(block[1]).toMatch(/\bage:\s*\d+/);
+      expect(block[1]).toMatch(/\bageVerified:\s*true/);
     });
 
-    it('admin age is high enough to clear every per-feature gate', () => {
-      // C8 max gate is 18 (adults-only DMs / voice rooms). Seeded
-      // age must be >= 18 so the seeded admin can join every feature
-      // surface without bumping into age restrictions mid-QA.
-      const ageMatch = adminBlock[1].match(/\bage:\s*(\d+)/);
+    it('age is high enough to clear every per-feature gate', () => {
+      // C8 max gate is 18 (adults-only DMs / voice rooms). Seeded age must
+      // be >= 18 so the seeded user can reach every feature surface without
+      // bumping into age restrictions mid-QA.
+      const ageMatch = block[1].match(/\bage:\s*(\d+)/);
       expect(ageMatch).not.toBeNull();
       expect(Number(ageMatch[1])).toBeGreaterThanOrEqual(18);
     });
   });
+}
 
-  describe('regular user (100000002)', () => {
-    const userBlock = seedSrc.match(/seedIfMissing\("users\/100000002",\s*\{([\s\S]*?)\}\s*\)\s*;/);
-
-    it('regular-user block is present', () => {
-      expect(userBlock).not.toBeNull();
-    });
-
-    it('regular user does NOT carry a uid field (matches production users.js)', () => {
-      expect(userBlock[1]).not.toMatch(/\buid:\s*/);
-    });
-
-    it('regular-user firebaseUid is userFirebaseUid (sanity)', () => {
-      expect(userBlock[1]).toMatch(/\bfirebaseUid:\s*userFirebaseUid\b/);
-    });
-
-    it('regular-user has dateOfBirth + age + ageVerified', () => {
-      expect(userBlock[1]).toMatch(/\bdateOfBirth:\s*"\d{4}-\d{2}-\d{2}"/);
-      expect(userBlock[1]).toMatch(/\bage:\s*\d+/);
-      expect(userBlock[1]).toMatch(/\bageVerified:\s*true/);
-    });
-
-    it('regular-user age is high enough to clear every per-feature gate', () => {
-      const ageMatch = userBlock[1].match(/\bage:\s*(\d+)/);
-      expect(ageMatch).not.toBeNull();
-      expect(Number(ageMatch[1])).toBeGreaterThanOrEqual(18);
-    });
-  });
+describe('local/seed.js — user doc invariants', () => {
+  describeSeededUserInvariants('admin user', '100000001', 'adminFirebaseUid');
+  describeSeededUserInvariants('regular user', '100000002', 'userFirebaseUid');
 
   describe('identityMap entries (cross-check)', () => {
     it('identityMap entry for claude-test@shytalk.dev maps to uniqueId 100000001', () => {

--- a/express-api/tests/utils/seed-user-invariants.test.js
+++ b/express-api/tests/utils/seed-user-invariants.test.js
@@ -1,0 +1,100 @@
+/**
+ * Locks the contract for seeded test users in `local/seed.js`.
+ *
+ * Backstory: during the 2026-05-12 manual-QA cycle on PR #651, B3 room-message
+ * reporting failed end-to-end on local because every seeded test user was
+ * missing `dateOfBirth` + `age`, which forced the C8 age-verification flow on
+ * first sign-in and blocked downstream QA. These tests pin the DOB shape so a
+ * future refactor that drops the fields gets caught before manual-QA does.
+ *
+ * Static-source assertions because the seed module is a Firebase-Admin-coupled
+ * side-effect script that's awkward to exec under Jest.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const seedPath = path.resolve(__dirname, '../../../local/seed.js');
+const seedSrc = fs.readFileSync(seedPath, 'utf8');
+
+describe('local/seed.js — user doc invariants', () => {
+  describe('admin user (100000001)', () => {
+    const adminBlock = seedSrc.match(
+      /seedIfMissing\("users\/100000001",\s*\{([\s\S]*?)\}\s*\)\s*;/,
+    );
+
+    it('admin user block is present', () => {
+      expect(adminBlock).not.toBeNull();
+    });
+
+    it('admin user does NOT carry a uid field (mirrors production users.js which never writes uid)', () => {
+      // Production user creation in express-api/src/routes/users.js writes
+      // `uniqueId` + `firebaseUid` to `users/<uniqueId>` and never writes a
+      // `uid` field. The seed should match — adding `uid: ...` here would
+      // diverge from prod and risk masking field-handling bugs.
+      expect(adminBlock[1]).not.toMatch(/\buid:\s*/);
+    });
+
+    it('admin firebaseUid is set to adminFirebaseUid (sanity)', () => {
+      expect(adminBlock[1]).toMatch(/\bfirebaseUid:\s*adminFirebaseUid\b/);
+    });
+
+    it('admin has dateOfBirth + age + ageVerified to bypass the C8 gate', () => {
+      // Without these the first sign-in hits "One More Step — Select Date
+      // of Birth" and blocks every downstream QA flow.
+      expect(adminBlock[1]).toMatch(/\bdateOfBirth:\s*"\d{4}-\d{2}-\d{2}"/);
+      expect(adminBlock[1]).toMatch(/\bage:\s*\d+/);
+      expect(adminBlock[1]).toMatch(/\bageVerified:\s*true/);
+    });
+
+    it('admin age is high enough to clear every per-feature gate', () => {
+      // C8 max gate is 18 (adults-only DMs / voice rooms). Seeded
+      // age must be >= 18 so the seeded admin can join every feature
+      // surface without bumping into age restrictions mid-QA.
+      const ageMatch = adminBlock[1].match(/\bage:\s*(\d+)/);
+      expect(ageMatch).not.toBeNull();
+      expect(Number(ageMatch[1])).toBeGreaterThanOrEqual(18);
+    });
+  });
+
+  describe('regular user (100000002)', () => {
+    const userBlock = seedSrc.match(/seedIfMissing\("users\/100000002",\s*\{([\s\S]*?)\}\s*\)\s*;/);
+
+    it('regular-user block is present', () => {
+      expect(userBlock).not.toBeNull();
+    });
+
+    it('regular user does NOT carry a uid field (matches production users.js)', () => {
+      expect(userBlock[1]).not.toMatch(/\buid:\s*/);
+    });
+
+    it('regular-user firebaseUid is userFirebaseUid (sanity)', () => {
+      expect(userBlock[1]).toMatch(/\bfirebaseUid:\s*userFirebaseUid\b/);
+    });
+
+    it('regular-user has dateOfBirth + age + ageVerified', () => {
+      expect(userBlock[1]).toMatch(/\bdateOfBirth:\s*"\d{4}-\d{2}-\d{2}"/);
+      expect(userBlock[1]).toMatch(/\bage:\s*\d+/);
+      expect(userBlock[1]).toMatch(/\bageVerified:\s*true/);
+    });
+
+    it('regular-user age is high enough to clear every per-feature gate', () => {
+      const ageMatch = userBlock[1].match(/\bage:\s*(\d+)/);
+      expect(ageMatch).not.toBeNull();
+      expect(Number(ageMatch[1])).toBeGreaterThanOrEqual(18);
+    });
+  });
+
+  describe('identityMap entries (cross-check)', () => {
+    it('identityMap entry for claude-test@shytalk.dev maps to uniqueId 100000001', () => {
+      expect(seedSrc).toMatch(
+        /seedIfMissing\("identityMap\/email:claude-test@shytalk\.dev"[\s\S]{0,400}uniqueId:\s*100000001/,
+      );
+    });
+
+    it('identityMap entry for user@test.com maps to uniqueId 100000002', () => {
+      expect(seedSrc).toMatch(
+        /seedIfMissing\("identityMap\/email:user@test\.com"[\s\S]{0,400}uniqueId:\s*100000002/,
+      );
+    });
+  });
+});

--- a/local/seed.js
+++ b/local/seed.js
@@ -127,7 +127,6 @@ async function seed() {
     { admin: true },
   );
   await seedIfMissing("users/100000001", {
-    uid: "claude-test@shytalk.dev",
     firebaseUid: adminFirebaseUid,
     uniqueId: 100000001,
     displayName: "Local Admin",
@@ -144,6 +143,14 @@ async function seed() {
     blockedUserIds: [],
     followingIds: [],
     followerIds: [],
+    // C8 age-verification fields. Without these, the first sign-in on a
+    // fresh install hits the "One More Step — Select Date of Birth" gate
+    // and blocks every downstream QA flow. 1995-06-15 / age 30 keeps the
+    // user safely above every per-feature age gate (gifting / DMs /
+    // voice rooms) so seeded accounts are immediately usable.
+    dateOfBirth: "1995-06-15",
+    age: 30,
+    ageVerified: true,
     createdAt: now,
     lastSeenAt: now,
   });
@@ -164,7 +171,6 @@ async function seed() {
     "Test User",
   );
   await seedIfMissing("users/100000002", {
-    uid: "user@test.com",
     firebaseUid: userFirebaseUid,
     uniqueId: 100000002,
     displayName: "Test User",
@@ -181,6 +187,9 @@ async function seed() {
     blockedUserIds: [],
     followingIds: [],
     followerIds: [],
+    dateOfBirth: "1995-06-15",
+    age: 30,
+    ageVerified: true,
     createdAt: now,
     lastSeenAt: now,
   });

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/ReportMessageDialog.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/ui/ReportMessageDialog.kt
@@ -1,0 +1,108 @@
+package com.shyden.shytalk.core.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.shyden.shytalk.resources.Res
+import com.shyden.shytalk.resources.additional_details_optional
+import com.shyden.shytalk.resources.cancel
+import com.shyden.shytalk.resources.report_message
+import com.shyden.shytalk.resources.report_message_prompt
+import com.shyden.shytalk.resources.submit_report
+import org.jetbrains.compose.resources.stringResource
+
+internal val reportMessageReasons = listOf("Spam", "Harassment", "Inappropriate Content", "Other")
+
+/**
+ * Shared per-message report dialog. Used by both DM (PrivateChatScreen) and
+ * room (RoomScreen) surfaces — keep behaviour symmetric so a reporter who
+ * uses one path and then the other doesn't see a different reason list.
+ *
+ * Lives in `core/ui` rather than `feature/messaging` so the `feature/room`
+ * import isn't a sibling-feature dependency.
+ */
+@Composable
+fun ReportMessageDialog(
+    onDismiss: () -> Unit,
+    onSubmit: (reason: String, description: String) -> Unit,
+) {
+    var selectedReason by remember { mutableStateOf(reportMessageReasons[0]) }
+    var description by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.report_message)) },
+        text = {
+            Column {
+                Text(
+                    text = stringResource(Res.string.report_message_prompt),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                reportMessageReasons.forEach { reason ->
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable { selectedReason = reason }
+                                .padding(vertical = 4.dp)
+                                .testTag("reportReasonRow_$reason"),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = selectedReason == reason,
+                            onClick = { selectedReason = reason },
+                            modifier = Modifier.testTag("reportReasonRadio_$reason"),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(text = reason, style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    placeholder = { Text(stringResource(Res.string.additional_details_optional)) },
+                    modifier = Modifier.fillMaxWidth().testTag("reportDescription"),
+                    maxLines = 3,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onSubmit(selectedReason, description) },
+                modifier = Modifier.testTag("reportSubmit"),
+            ) {
+                Text(stringResource(Res.string.submit_report))
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.testTag("reportDismiss"),
+            ) {
+                Text(stringResource(Res.string.cancel))
+            }
+        },
+    )
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -41,12 +40,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
@@ -70,6 +67,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.shyden.shytalk.core.model.MessageEdit
 import com.shyden.shytalk.core.model.PrivateMessage
+import com.shyden.shytalk.core.ui.ReportMessageDialog
 import com.shyden.shytalk.core.ui.StyledDisplayName
 import com.shyden.shytalk.core.ui.StyledSnackbarHost
 import com.shyden.shytalk.core.util.Constants
@@ -994,66 +992,6 @@ fun PrivateChatScreen(
         onDismiss = { viewModel.dismissAgeRestrictionDialog() },
         onVerifyNow = onNavigateToAgeVerification,
         onContactSupport = { viewModel.dismissAgeRestrictionDialog() },
-    )
-}
-
-private val reportReasons = listOf("Spam", "Harassment", "Inappropriate Content", "Other")
-
-@Composable
-private fun ReportMessageDialog(
-    onDismiss: () -> Unit,
-    onSubmit: (reason: String, description: String) -> Unit,
-) {
-    var selectedReason by remember { mutableStateOf(reportReasons[0]) }
-    var description by remember { mutableStateOf("") }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(Res.string.report_message)) },
-        text = {
-            Column {
-                Text(
-                    text = stringResource(Res.string.report_message_prompt),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                reportReasons.forEach { reason ->
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable { selectedReason = reason }
-                                .padding(vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        RadioButton(
-                            selected = selectedReason == reason,
-                            onClick = { selectedReason = reason },
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = reason, style = MaterialTheme.typography.bodyMedium)
-                    }
-                }
-                Spacer(modifier = Modifier.height(8.dp))
-                OutlinedTextField(
-                    value = description,
-                    onValueChange = { description = it },
-                    placeholder = { Text(stringResource(Res.string.additional_details_optional)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    maxLines = 3,
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = { onSubmit(selectedReason, description) }) {
-                Text(stringResource(Res.string.submit_report))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(Res.string.cancel))
-            }
-        },
     )
 }
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatViewModel.kt
@@ -752,11 +752,18 @@ class PrivateChatViewModel(
             }
         viewModelScope.launch {
             when (
+                // reporterId / reportedUserId MUST be Firebase Auth UIDs — the
+                // server's resolveUniqueId queries `users.where('firebaseUid',
+                // '==', uid).limit(1)`. Using `currentUserId` (which is
+                // `resolvedUniqueId ?: firebaseUid`, almost always the uniqueId)
+                // or `message.senderId` (which is the sender's uniqueId)
+                // silently fails server resolution. Pre-existing bug fixed in
+                // the B3 wire-up cycle (PR #651).
                 reportRepository.reportMessage(
-                    reporterId = currentUserId,
+                    reporterId = currentUser?.firebaseUid ?: authRepository.currentFirebaseUid ?: "",
                     reporterName = currentUser?.displayName ?: "",
                     reporterUniqueId = currentUser?.uniqueId ?: 0L,
-                    reportedUserId = message.senderId,
+                    reportedUserId = reportedUser?.firebaseUid ?: "",
                     reportedUserName = reportedUser?.displayName ?: message.senderName,
                     reportedUserUniqueId = reportedUser?.uniqueId ?: 0L,
                     conversationId = conversationId,

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
@@ -577,11 +577,15 @@ class ProfileViewModel(
             }
 
             when (
+                // reporterId / reportedUserId MUST be Firebase Auth UIDs — the
+                // server's resolveUniqueId middleware queries
+                // `users.where('firebaseUid','==',uid).limit(1)`. Pre-existing
+                // bug fixed alongside the B3 room-report wire-up.
                 reportRepository.reportUser(
-                    reporterId = currentUser.uid,
+                    reporterId = currentUser.firebaseUid,
                     reporterName = currentUser.displayName,
                     reporterUniqueId = currentUser.uniqueId,
-                    reportedUserId = targetUser.uid,
+                    reportedUserId = targetUser.firebaseUid,
                     reportedUserName = targetUser.displayName,
                     reportedUserUniqueId = targetUser.uniqueId,
                     conversationId = "",

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/ProfileViewModel.kt
@@ -19,6 +19,8 @@ import com.shyden.shytalk.data.repository.ReportRepository
 import com.shyden.shytalk.data.repository.RoomRepository
 import com.shyden.shytalk.data.repository.StorageRepository
 import com.shyden.shytalk.data.repository.UserRepository
+import com.shyden.shytalk.feature.report.UserReportOutcome
+import com.shyden.shytalk.feature.report.submitUserReport
 import com.shyden.shytalk.resources.*
 import com.shyden.shytalk.resources.Res
 import kotlinx.coroutines.async
@@ -553,56 +555,35 @@ class ProfileViewModel(
                     }
                 }
 
-            // Upload evidence
-            val evidenceUrls = mutableListOf<String>()
-            for ((bytes, mimeType) in evidenceImages) {
-                when (
-                    val result =
-                        storageRepository.uploadImage(
-                            currentUser.uid,
-                            "report_evidence",
-                            bytes,
-                            mimeType,
-                        )
-                ) {
-                    is Resource.Success -> evidenceUrls.add(result.data)
-
-                    is Resource.Error -> {
-                        _uiState.update { it.copy(isSubmittingReport = false, reportError = UiText.res(Res.string.error_upload_evidence)) }
-                        return@launch
-                    }
-
-                    is Resource.Loading -> Unit
-                }
-            }
-
             when (
-                // reporterId / reportedUserId MUST be Firebase Auth UIDs — the
-                // server's resolveUniqueId middleware queries
-                // `users.where('firebaseUid','==',uid).limit(1)`. Pre-existing
-                // bug fixed alongside the B3 room-report wire-up.
-                reportRepository.reportUser(
-                    reporterId = currentUser.firebaseUid,
-                    reporterName = currentUser.displayName,
-                    reporterUniqueId = currentUser.uniqueId,
-                    reportedUserId = targetUser.firebaseUid,
-                    reportedUserName = targetUser.displayName,
-                    reportedUserUniqueId = targetUser.uniqueId,
-                    conversationId = "",
+                submitUserReport(
+                    reportRepository = reportRepository,
+                    storageRepository = storageRepository,
+                    currentUser = currentUser,
+                    targetUser = targetUser,
                     reason = reason,
                     description = description,
-                    evidenceUrls = evidenceUrls,
+                    evidenceImages = evidenceImages,
                 )
             ) {
-                is Resource.Success -> {
+                UserReportOutcome.Success ->
                     _uiState.update { it.copy(isSubmittingReport = false, reportSubmitted = true) }
-                }
 
-                is Resource.Error -> {
-                    _uiState.update { it.copy(isSubmittingReport = false, reportError = UiText.res(Res.string.error_submit_report)) }
-                }
+                UserReportOutcome.EvidenceUploadFailed ->
+                    _uiState.update {
+                        it.copy(
+                            isSubmittingReport = false,
+                            reportError = UiText.res(Res.string.error_upload_evidence),
+                        )
+                    }
 
-                is Resource.Loading -> Unit
+                UserReportOutcome.ReportSubmitFailed ->
+                    _uiState.update {
+                        it.copy(
+                            isSubmittingReport = false,
+                            reportError = UiText.res(Res.string.error_submit_report),
+                        )
+                    }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/report/UserReportOutcome.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/report/UserReportOutcome.kt
@@ -1,0 +1,80 @@
+package com.shyden.shytalk.feature.report
+
+import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.data.repository.ReportRepository
+import com.shyden.shytalk.data.repository.StorageRepository
+
+/**
+ * Outcome of [submitUserReport]. Callers map each case to their own UI state
+ * shape — VMs that use plain-String errors translate the same way VMs that
+ * use UiText do. The shared helper just collapses the evidence-upload +
+ * reportRepository.reportUser call sequence that was previously duplicated
+ * across RoomViewModel.reportUser and ProfileViewModel.reportUser (caught
+ * by the SonarCloud 3% new-duplicated-lines gate on PR #652).
+ */
+internal sealed class UserReportOutcome {
+    object Success : UserReportOutcome()
+
+    object EvidenceUploadFailed : UserReportOutcome()
+
+    object ReportSubmitFailed : UserReportOutcome()
+}
+
+/**
+ * Shared submit-user-report pipeline used by [com.shyden.shytalk.feature.room.RoomViewModel.reportUser]
+ * and [com.shyden.shytalk.feature.profile.ProfileViewModel.reportUser].
+ *
+ * `reporterId` / `reportedUserId` MUST be Firebase Auth UIDs — the Express
+ * server's `resolveUniqueId` middleware queries
+ * `users.where('firebaseUid','==',uid).limit(1)`. Passing `User.uid`
+ * (= Firestore doc key = numeric uniqueId) silently fails resolution and
+ * returns "reportedUserId does not match any known user" — pre-existing bug
+ * surfaced during the B3 manual-QA cycle (PR #651).
+ */
+@Suppress("LongParameterList")
+internal suspend fun submitUserReport(
+    reportRepository: ReportRepository,
+    storageRepository: StorageRepository,
+    currentUser: User,
+    targetUser: User,
+    reason: String,
+    description: String,
+    evidenceImages: List<Pair<ByteArray, String>>,
+    conversationId: String = "",
+): UserReportOutcome {
+    val evidenceUrls = mutableListOf<String>()
+    for ((bytes, mimeType) in evidenceImages) {
+        when (
+            val result =
+                storageRepository.uploadImage(
+                    userId = currentUser.uid,
+                    path = "report_evidence",
+                    imageData = bytes,
+                    contentType = mimeType,
+                )
+        ) {
+            is Resource.Success -> evidenceUrls.add(result.data)
+            is Resource.Error -> return UserReportOutcome.EvidenceUploadFailed
+            is Resource.Loading -> Unit
+        }
+    }
+    return when (
+        reportRepository.reportUser(
+            reporterId = currentUser.firebaseUid,
+            reporterName = currentUser.displayName,
+            reporterUniqueId = currentUser.uniqueId,
+            reportedUserId = targetUser.firebaseUid,
+            reportedUserName = targetUser.displayName,
+            reportedUserUniqueId = targetUser.uniqueId,
+            conversationId = conversationId,
+            reason = reason,
+            description = description,
+            evidenceUrls = evidenceUrls,
+        )
+    ) {
+        is Resource.Success -> UserReportOutcome.Success
+        is Resource.Error -> UserReportOutcome.ReportSubmitFailed
+        is Resource.Loading -> UserReportOutcome.ReportSubmitFailed
+    }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomScreen.kt
@@ -53,6 +53,7 @@ import com.shyden.shytalk.core.model.Broadcast
 import com.shyden.shytalk.core.model.BroadcastType
 import com.shyden.shytalk.core.model.Gift
 import com.shyden.shytalk.core.model.GiftEvent
+import com.shyden.shytalk.core.model.Message
 import com.shyden.shytalk.core.model.RoomRole
 import com.shyden.shytalk.core.model.RoomState
 import com.shyden.shytalk.core.model.SeatState
@@ -201,6 +202,11 @@ fun RoomScreen(
     var pmStickerResultHandler by remember { mutableStateOf<((ByteArray) -> Unit)?>(null) }
     val reportEvidenceList = remember { mutableListOf<Pair<ByteArray, String>>() }
     var reportEvidenceVersion by remember { mutableStateOf(0) }
+    // B3 — room message reporting: holds the message the user long-pressed,
+    // null while no dialog open. Distinct state from reportEvidenceList (user
+    // reports) because room MESSAGE reports do not collect evidence — the
+    // message text + messageId IS the evidence.
+    var reportingRoomMessage by remember { mutableStateOf<Message?>(null) }
     var isCompressingEvidence by remember { mutableStateOf(false) }
 
     val evidenceScope = rememberCoroutineScope()
@@ -750,6 +756,7 @@ fun RoomScreen(
                                 aliases = uiState.aliases,
                                 translations = uiState.translations,
                                 onTranslateMessage = { viewModel.translateMessage(it) },
+                                onReportMessage = { msg -> reportingRoomMessage = msg },
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
@@ -1250,4 +1257,18 @@ fun RoomScreen(
         onVerifyNow = onNavigateToAgeVerification,
         onContactSupport = { gachaViewModel.dismissAgeRestrictionDialog() },
     )
+
+    // B3 — room message report dialog (UK OSA per-message reporting).
+    // Shown when a non-self TEXT message is long-pressed. The dialog itself
+    // lives in core/ui so DM and room use one identical surface; only the
+    // VM hop differs (RoomViewModel.reportMessage vs PrivateChatViewModel).
+    reportingRoomMessage?.let { msg ->
+        com.shyden.shytalk.core.ui.ReportMessageDialog(
+            onDismiss = { reportingRoomMessage = null },
+            onSubmit = { reason, description ->
+                viewModel.reportMessage(msg, reason, description)
+                reportingRoomMessage = null
+            },
+        )
+    }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -32,6 +32,8 @@ import com.shyden.shytalk.data.repository.SeatRequestRepository
 import com.shyden.shytalk.data.repository.StorageRepository
 import com.shyden.shytalk.data.repository.TranslationRepository
 import com.shyden.shytalk.data.repository.UserRepository
+import com.shyden.shytalk.feature.report.UserReportOutcome
+import com.shyden.shytalk.feature.report.submitUserReport
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -1750,59 +1752,25 @@ class RoomViewModel(
                 return@launch
             }
 
-            // Upload evidence
-            val evidenceUrls = mutableListOf<String>()
-            for ((bytes, mimeType) in evidenceImages) {
-                when (
-                    val result =
-                        storageRepository.uploadImage(
-                            currentUser.uid,
-                            "report_evidence",
-                            bytes,
-                            mimeType,
-                        )
-                ) {
-                    is Resource.Success -> evidenceUrls.add(result.data)
-
-                    is Resource.Error -> {
-                        _uiState.update { it.copy(isSubmittingReport = false, reportError = "Failed to upload evidence") }
-                        return@launch
-                    }
-
-                    is Resource.Loading -> Unit
-                }
-            }
-
             when (
-                reportRepository.reportUser(
-                    // reporterId / reportedUserId MUST be Firebase Auth UIDs —
-                    // the server's resolveUniqueId middleware queries
-                    // `users.where('firebaseUid','==',uid).limit(1)`. Passing
-                    // `User.uid` (which is the Firestore doc key = numeric
-                    // uniqueId) silently fails resolution and returns
-                    // "reportedUserId does not match any known user" — pre-existing
-                    // bug surfaced during the B3 manual-QA on PR #651.
-                    reporterId = currentUser.firebaseUid,
-                    reporterName = currentUser.displayName,
-                    reporterUniqueId = currentUser.uniqueId,
-                    reportedUserId = targetUser.firebaseUid,
-                    reportedUserName = targetUser.displayName,
-                    reportedUserUniqueId = targetUser.uniqueId,
-                    conversationId = "",
+                submitUserReport(
+                    reportRepository = reportRepository,
+                    storageRepository = storageRepository,
+                    currentUser = currentUser,
+                    targetUser = targetUser,
                     reason = reason,
                     description = description,
-                    evidenceUrls = evidenceUrls,
+                    evidenceImages = evidenceImages,
                 )
             ) {
-                is Resource.Success -> {
+                UserReportOutcome.Success ->
                     _uiState.update { it.copy(isSubmittingReport = false, reportSubmitted = true) }
-                }
 
-                is Resource.Error -> {
+                UserReportOutcome.EvidenceUploadFailed ->
+                    _uiState.update { it.copy(isSubmittingReport = false, reportError = "Failed to upload evidence") }
+
+                UserReportOutcome.ReportSubmitFailed ->
                     _uiState.update { it.copy(isSubmittingReport = false, reportError = "Failed to submit report") }
-                }
-
-                is Resource.Loading -> Unit
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -1775,10 +1775,17 @@ class RoomViewModel(
 
             when (
                 reportRepository.reportUser(
-                    reporterId = currentUser.uid,
+                    // reporterId / reportedUserId MUST be Firebase Auth UIDs —
+                    // the server's resolveUniqueId middleware queries
+                    // `users.where('firebaseUid','==',uid).limit(1)`. Passing
+                    // `User.uid` (which is the Firestore doc key = numeric
+                    // uniqueId) silently fails resolution and returns
+                    // "reportedUserId does not match any known user" — pre-existing
+                    // bug surfaced during the B3 manual-QA on PR #651.
+                    reporterId = currentUser.firebaseUid,
                     reporterName = currentUser.displayName,
                     reporterUniqueId = currentUser.uniqueId,
-                    reportedUserId = targetUser.uid,
+                    reportedUserId = targetUser.firebaseUid,
                     reportedUserName = targetUser.displayName,
                     reportedUserUniqueId = targetUser.uniqueId,
                     conversationId = "",
@@ -1838,11 +1845,12 @@ class RoomViewModel(
             }
 
             when (
+                // See reportUser above for why these are firebaseUid not uid.
                 reportRepository.reportMessage(
-                    reporterId = currentUser.uid,
+                    reporterId = currentUser.firebaseUid,
                     reporterName = currentUser.displayName,
                     reporterUniqueId = currentUser.uniqueId,
-                    reportedUserId = targetUser.uid,
+                    reportedUserId = targetUser.firebaseUid,
                     reportedUserName = targetUser.displayName,
                     reportedUserUniqueId = targetUser.uniqueId,
                     conversationId = roomId,

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -1804,6 +1804,67 @@ class RoomViewModel(
         _uiState.update { it.copy(reportSubmitted = false, reportError = null) }
     }
 
+    /**
+     * Report a specific room chat message (B3 — UK OSA per-message reporting).
+     *
+     * Differs from [reportUser] in three deliberate ways: (a) no evidence upload
+     * (the message text + messageId are the evidence), (b) conversationId is the
+     * roomId so per-room admin filters scope correctly, (c) the sender is resolved
+     * from `message.senderId` rather than a tap target.
+     */
+    fun reportMessage(
+        message: Message,
+        reason: String,
+        description: String,
+    ) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSubmittingReport = true, reportError = null) }
+
+            val currentUser =
+                userCache[_uiState.value.currentUserId]
+                    ?: when (val result = userRepository.getUser(_uiState.value.currentUserId)) {
+                        is Resource.Success -> result.data
+                        else -> null
+                    }
+            val targetUser =
+                userCache[message.senderId]
+                    ?: when (val result = userRepository.getUser(message.senderId)) {
+                        is Resource.Success -> result.data
+                        else -> null
+                    }
+            if (currentUser == null || targetUser == null) {
+                _uiState.update { it.copy(isSubmittingReport = false, reportError = "Could not submit report") }
+                return@launch
+            }
+
+            when (
+                reportRepository.reportMessage(
+                    reporterId = currentUser.uid,
+                    reporterName = currentUser.displayName,
+                    reporterUniqueId = currentUser.uniqueId,
+                    reportedUserId = targetUser.uid,
+                    reportedUserName = targetUser.displayName,
+                    reportedUserUniqueId = targetUser.uniqueId,
+                    conversationId = roomId,
+                    messageId = message.messageId,
+                    messageText = message.text,
+                    reason = reason,
+                    description = description,
+                )
+            ) {
+                is Resource.Success -> {
+                    _uiState.update { it.copy(isSubmittingReport = false, reportSubmitted = true) }
+                }
+
+                is Resource.Error -> {
+                    _uiState.update { it.copy(isSubmittingReport = false, reportError = "Failed to submit report") }
+                }
+
+                is Resource.Loading -> Unit
+            }
+        }
+    }
+
     // --- Notification Queue ---
 
     private fun enqueueNotification(notification: RoomNotification) {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ChatPanel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ChatPanel.kt
@@ -89,6 +89,7 @@ fun ChatPanel(
     aliases: Map<String, String> = emptyMap(),
     translations: Map<String, String> = emptyMap(),
     onTranslateMessage: (String) -> Unit = {},
+    onReportMessage: (Message) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
@@ -185,6 +186,12 @@ fun ChatPanel(
                         onEditMessage =
                             if (isSelf && message.type == com.shyden.shytalk.core.model.MessageType.TEXT) {
                                 { onStartEditMessage(message.messageId, message.text) }
+                            } else {
+                                null
+                            },
+                        onReportMessage =
+                            if (!isSelf && message.type == com.shyden.shytalk.core.model.MessageType.TEXT && message.senderId != "system") {
+                                { onReportMessage(message) }
                             } else {
                                 null
                             },

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ChatPanel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/ChatPanel.kt
@@ -190,7 +190,7 @@ fun ChatPanel(
                                 null
                             },
                         onReportMessage =
-                            if (!isSelf && message.type == com.shyden.shytalk.core.model.MessageType.TEXT && message.senderId != "system") {
+                            if (isRoomMessageReportable(isSelf = isSelf, type = message.type, senderId = message.senderId)) {
                                 { onReportMessage(message) }
                             } else {
                                 null

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/MessageBubble.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/MessageBubble.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -112,6 +113,7 @@ fun MessageBubble(
     onTapUser: () -> Unit,
     onInvite: () -> Unit,
     onEditMessage: (() -> Unit)? = null,
+    onReportMessage: (() -> Unit)? = null,
     onTranslate: (() -> Unit)? = null,
     translatedText: String? = null,
     aliases: Map<String, String> = emptyMap(),
@@ -230,13 +232,22 @@ fun MessageBubble(
                                 MaterialTheme.colorScheme.surfaceVariant
                             },
                         modifier =
-                            if (isSelf && onEditMessage != null) {
-                                Modifier.combinedClickable(
-                                    onClick = {},
-                                    onLongClick = onEditMessage,
-                                )
-                            } else {
-                                Modifier
+                            when {
+                                isSelf && onEditMessage != null ->
+                                    Modifier
+                                        .combinedClickable(
+                                            onClick = {},
+                                            onLongClick = onEditMessage,
+                                        ).testTag("room_msg_editTarget_${message.messageId}")
+
+                                !isSelf && onReportMessage != null ->
+                                    Modifier
+                                        .combinedClickable(
+                                            onClick = {},
+                                            onLongClick = onReportMessage,
+                                        ).testTag("room_msg_reportTarget_${message.messageId}")
+
+                                else -> Modifier
                             },
                     ) {
                         Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/RoomMessageReportability.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/components/RoomMessageReportability.kt
@@ -1,0 +1,19 @@
+package com.shyden.shytalk.feature.room.components
+
+import com.shyden.shytalk.core.model.MessageType
+
+/**
+ * Decide whether a room message exposes the "report" long-press affordance.
+ *
+ * Pure function so the policy (UK OSA B3 — non-self TEXT messages from real
+ * users) is testable without spinning up Compose. ChatPanel uses this to gate
+ * the `onReportMessage` callback that MessageBubble's combinedClickable hooks
+ * into. Server-side never blocks based on these — defence is admin-side — so
+ * the gate exists purely for UX hygiene (don't show "report" on your own
+ * messages, on JOIN/GIFT events, or on system announcements).
+ */
+internal fun isRoomMessageReportable(
+    isSelf: Boolean,
+    type: MessageType,
+    senderId: String,
+): Boolean = !isSelf && type == MessageType.TEXT && senderId != "system"

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/ui/ReportMessageDialogTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/ui/ReportMessageDialogTest.kt
@@ -1,0 +1,46 @@
+package com.shyden.shytalk.core.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Lock the user-visible reason list. Both DM (PrivateChatScreen) and room
+ * (RoomScreen) surfaces pull from this constant, so a drift here changes
+ * both products' reporting taxonomy AND silently changes what the
+ * `reason` field carries on the wire to `POST /api/reports`.
+ *
+ * The admin moderation UI clusters reports by reason string for triage —
+ * adding a reason that the admin tab doesn't know about means those
+ * reports show up in "Other" rather than their own filter bucket. Pin
+ * the contents + order so future additions are a conscious, cross-cutting
+ * change.
+ */
+class ReportMessageDialogTest {
+    @Test
+    fun `reason list has exactly four entries in the canonical order`() {
+        assertEquals(
+            listOf("Spam", "Harassment", "Inappropriate Content", "Other"),
+            reportMessageReasons,
+        )
+    }
+
+    @Test
+    fun `all entries are non-blank`() {
+        // Defence against a stray empty string sneaking in via a translation
+        // refactor — the on-wire `reason` becomes "" which the admin filter
+        // treats as missing and the moderation queue loses the row.
+        for (reason in reportMessageReasons) {
+            assertTrue(reason.isNotBlank(), "Reason must be non-blank: '$reason'")
+        }
+    }
+
+    @Test
+    fun `Other is the last entry by convention`() {
+        // The "fallback" reason is always last in the radio list so it's not
+        // the default selection. A reorder that bubbled "Other" to the top
+        // would silently change which reason gets pre-selected, biasing
+        // every report whose author didn't explicitly tap a radio.
+        assertEquals("Other", reportMessageReasons.last())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/report/UserReportSubmissionTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/report/UserReportSubmissionTest.kt
@@ -1,0 +1,460 @@
+package com.shyden.shytalk.feature.report
+
+import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.data.repository.ReportRepository
+import com.shyden.shytalk.data.repository.StorageRepository
+import com.shyden.shytalk.feature.messaging.Report
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Exhaustive branch coverage for [submitUserReport]. Pins the contract so a
+ * future caller (a third report surface, an admin re-submit flow) sees the
+ * exact same outcome shape, and so a regression in the evidence-upload or
+ * Resource-mapping logic is caught without touching the VM layer.
+ *
+ * The helper exists to break the 33-line SonarCloud duplication block
+ * between RoomViewModel.reportUser and ProfileViewModel.reportUser, but the
+ * tests treat it as a first-class production contract — every Resource
+ * branch + every early-return branch + every evidence-upload count gets
+ * a row.
+ */
+class UserReportSubmissionTest {
+    @Test
+    fun `happy path with no evidence returns Success and posts to API`() =
+        runTest {
+            val report = RecordingReportRepository(reportUser = Resource.Success(Unit))
+            val storage = RecordingStorageRepository()
+            val outcome =
+                submitUserReport(
+                    reportRepository = report,
+                    storageRepository = storage,
+                    currentUser = REPORTER,
+                    targetUser = TARGET,
+                    reason = "Spam",
+                    description = "Promotional links",
+                    evidenceImages = emptyList(),
+                )
+            assertEquals(UserReportOutcome.Success, outcome)
+            assertEquals(0, storage.uploadCalls.size)
+            assertEquals(1, report.reportUserCalls.size)
+            val call = report.reportUserCalls.first()
+            assertEquals(REPORTER.firebaseUid, call.reporterId)
+            assertEquals(TARGET.firebaseUid, call.reportedUserId)
+            assertEquals(REPORTER.uniqueId, call.reporterUniqueId)
+            assertEquals(TARGET.uniqueId, call.reportedUserUniqueId)
+            assertEquals("Spam", call.reason)
+            assertEquals("Promotional links", call.description)
+            assertEquals("", call.conversationId)
+            assertTrue(call.evidenceUrls.isEmpty())
+        }
+
+    @Test
+    fun `happy path with one evidence image uploads then reports`() =
+        runTest {
+            val report = RecordingReportRepository(reportUser = Resource.Success(Unit))
+            val storage =
+                RecordingStorageRepository(
+                    uploadResults = listOf(Resource.Success("https://cdn/evidence-1.jpg")),
+                )
+            val outcome =
+                submitUserReport(
+                    reportRepository = report,
+                    storageRepository = storage,
+                    currentUser = REPORTER,
+                    targetUser = TARGET,
+                    reason = "Harassment",
+                    description = "Screenshot attached",
+                    evidenceImages = listOf(byteArrayOf(1, 2, 3) to "image/png"),
+                )
+            assertEquals(UserReportOutcome.Success, outcome)
+            assertEquals(1, storage.uploadCalls.size)
+            assertEquals(REPORTER.uid, storage.uploadCalls.first().userId)
+            assertEquals("report_evidence", storage.uploadCalls.first().path)
+            assertEquals("image/png", storage.uploadCalls.first().contentType)
+            assertEquals(
+                listOf("https://cdn/evidence-1.jpg"),
+                report.reportUserCalls.first().evidenceUrls,
+            )
+        }
+
+    @Test
+    fun `happy path with two evidence images posts both URLs in order`() =
+        runTest {
+            val report = RecordingReportRepository(reportUser = Resource.Success(Unit))
+            val storage =
+                RecordingStorageRepository(
+                    uploadResults =
+                        listOf(
+                            Resource.Success("https://cdn/a.jpg"),
+                            Resource.Success("https://cdn/b.jpg"),
+                        ),
+                )
+            val outcome =
+                submitUserReport(
+                    reportRepository = report,
+                    storageRepository = storage,
+                    currentUser = REPORTER,
+                    targetUser = TARGET,
+                    reason = "Inappropriate Content",
+                    description = "",
+                    evidenceImages =
+                        listOf(
+                            byteArrayOf(1) to "image/jpeg",
+                            byteArrayOf(2) to "image/jpeg",
+                        ),
+                )
+            assertEquals(UserReportOutcome.Success, outcome)
+            assertEquals(2, storage.uploadCalls.size)
+            assertEquals(
+                listOf("https://cdn/a.jpg", "https://cdn/b.jpg"),
+                report.reportUserCalls.first().evidenceUrls,
+            )
+        }
+
+    @Test
+    fun `evidence upload Error on first image short-circuits to EvidenceUploadFailed`() =
+        runTest {
+            val report = RecordingReportRepository(reportUser = Resource.Success(Unit))
+            val storage =
+                RecordingStorageRepository(
+                    uploadResults = listOf(Resource.Error("R2 timeout")),
+                )
+            val outcome =
+                submitUserReport(
+                    reportRepository = report,
+                    storageRepository = storage,
+                    currentUser = REPORTER,
+                    targetUser = TARGET,
+                    reason = "Other",
+                    description = "",
+                    evidenceImages =
+                        listOf(
+                            byteArrayOf(1) to "image/jpeg",
+                            byteArrayOf(2) to "image/jpeg",
+                        ),
+                )
+            assertEquals(UserReportOutcome.EvidenceUploadFailed, outcome)
+            // Second image MUST NOT be attempted after the first one fails.
+            assertEquals(1, storage.uploadCalls.size)
+            // Report endpoint MUST NOT be called when evidence upload failed.
+            assertEquals(0, report.reportUserCalls.size)
+        }
+
+    @Test
+    fun `evidence upload Error on second image still short-circuits`() =
+        runTest {
+            val report = RecordingReportRepository(reportUser = Resource.Success(Unit))
+            val storage =
+                RecordingStorageRepository(
+                    uploadResults =
+                        listOf(
+                            Resource.Success("https://cdn/a.jpg"),
+                            Resource.Error("R2 timeout"),
+                        ),
+                )
+            val outcome =
+                submitUserReport(
+                    reportRepository = report,
+                    storageRepository = storage,
+                    currentUser = REPORTER,
+                    targetUser = TARGET,
+                    reason = "Other",
+                    description = "",
+                    evidenceImages =
+                        listOf(
+                            byteArrayOf(1) to "image/jpeg",
+                            byteArrayOf(2) to "image/jpeg",
+                        ),
+                )
+            assertEquals(UserReportOutcome.EvidenceUploadFailed, outcome)
+            assertEquals(2, storage.uploadCalls.size)
+            assertEquals(0, report.reportUserCalls.size)
+        }
+
+    @Test
+    fun `evidence upload Loading is skipped without adding to URLs`() =
+        runTest {
+            // Resource.Loading is the "in-flight" sentinel and should be ignored
+            // by the helper (Unit branch). The image just isn't included in the
+            // evidence URL list; submission still proceeds.
+            val report = RecordingReportRepository(reportUser = Resource.Success(Unit))
+            val storage =
+                RecordingStorageRepository(
+                    uploadResults =
+                        listOf(
+                            Resource.Loading,
+                            Resource.Success("https://cdn/b.jpg"),
+                        ),
+                )
+            val outcome =
+                submitUserReport(
+                    reportRepository = report,
+                    storageRepository = storage,
+                    currentUser = REPORTER,
+                    targetUser = TARGET,
+                    reason = "Other",
+                    description = "",
+                    evidenceImages =
+                        listOf(
+                            byteArrayOf(1) to "image/jpeg",
+                            byteArrayOf(2) to "image/jpeg",
+                        ),
+                )
+            assertEquals(UserReportOutcome.Success, outcome)
+            assertEquals(
+                listOf("https://cdn/b.jpg"),
+                report.reportUserCalls.first().evidenceUrls,
+            )
+        }
+
+    @Test
+    fun `reportUser Resource Error maps to ReportSubmitFailed`() =
+        runTest {
+            val report =
+                RecordingReportRepository(reportUser = Resource.Error("HTTP 500"))
+            val storage = RecordingStorageRepository()
+            val outcome =
+                submitUserReport(
+                    reportRepository = report,
+                    storageRepository = storage,
+                    currentUser = REPORTER,
+                    targetUser = TARGET,
+                    reason = "Spam",
+                    description = "",
+                    evidenceImages = emptyList(),
+                )
+            assertEquals(UserReportOutcome.ReportSubmitFailed, outcome)
+        }
+
+    @Test
+    fun `reportUser Resource Loading maps to ReportSubmitFailed`() =
+        runTest {
+            // Loading from a suspend call is unusual — Resource.Loading is normally
+            // emitted from a Flow, not returned from a `suspend fun`. We still pin
+            // the mapping so a future repository that does return Loading from
+            // reportUser surfaces as a failed submission rather than a silent
+            // "report sent" toast.
+            val report = RecordingReportRepository(reportUser = Resource.Loading)
+            val storage = RecordingStorageRepository()
+            val outcome =
+                submitUserReport(
+                    reportRepository = report,
+                    storageRepository = storage,
+                    currentUser = REPORTER,
+                    targetUser = TARGET,
+                    reason = "Spam",
+                    description = "",
+                    evidenceImages = emptyList(),
+                )
+            assertEquals(UserReportOutcome.ReportSubmitFailed, outcome)
+        }
+
+    @Test
+    fun `conversationId default is empty string`() =
+        runTest {
+            val report = RecordingReportRepository(reportUser = Resource.Success(Unit))
+            val storage = RecordingStorageRepository()
+            submitUserReport(
+                reportRepository = report,
+                storageRepository = storage,
+                currentUser = REPORTER,
+                targetUser = TARGET,
+                reason = "Spam",
+                description = "",
+                evidenceImages = emptyList(),
+            )
+            assertEquals("", report.reportUserCalls.first().conversationId)
+        }
+
+    @Test
+    fun `conversationId override propagates to the API call`() =
+        runTest {
+            val report = RecordingReportRepository(reportUser = Resource.Success(Unit))
+            val storage = RecordingStorageRepository()
+            submitUserReport(
+                reportRepository = report,
+                storageRepository = storage,
+                currentUser = REPORTER,
+                targetUser = TARGET,
+                reason = "Spam",
+                description = "",
+                evidenceImages = emptyList(),
+                conversationId = "room-xyz",
+            )
+            assertEquals("room-xyz", report.reportUserCalls.first().conversationId)
+        }
+
+    @Test
+    fun `firebaseUid not uid is used as reporterId and reportedUserId`() =
+        runTest {
+            // Pinpoint regression test for the pre-existing bug: helpers MUST send
+            // currentUser.firebaseUid (not .uid). User.uid in this codebase equals
+            // the Firestore doc key (= numeric uniqueId as String), which the
+            // server's resolveUniqueId middleware cannot resolve back to a user.
+            val report = RecordingReportRepository(reportUser = Resource.Success(Unit))
+            val storage = RecordingStorageRepository()
+            val reporterWithDistinctIds =
+                User(uid = "100000001", firebaseUid = "firebase-abc-123", uniqueId = 100000001L)
+            val targetWithDistinctIds =
+                User(uid = "100000002", firebaseUid = "firebase-def-456", uniqueId = 100000002L)
+            submitUserReport(
+                reportRepository = report,
+                storageRepository = storage,
+                currentUser = reporterWithDistinctIds,
+                targetUser = targetWithDistinctIds,
+                reason = "Spam",
+                description = "",
+                evidenceImages = emptyList(),
+            )
+            val call = report.reportUserCalls.first()
+            assertEquals("firebase-abc-123", call.reporterId)
+            assertEquals("firebase-def-456", call.reportedUserId)
+            // ...not "100000001" / "100000002" — that would be the bug.
+        }
+
+    @Test
+    fun `evidence upload uses currentUser uid as the userId arg`() =
+        runTest {
+            // Evidence files are stored under the *reporter's* user folder in R2
+            // (R2_BUCKET/<reporterUid>/report_evidence/<filename>). Pin this so a
+            // future refactor doesn't accidentally store evidence under the
+            // reported user's folder (privacy violation — the reported user
+            // could later download evidence against themselves).
+            val report = RecordingReportRepository(reportUser = Resource.Success(Unit))
+            val storage =
+                RecordingStorageRepository(
+                    uploadResults = listOf(Resource.Success("https://cdn/x.jpg")),
+                )
+            submitUserReport(
+                reportRepository = report,
+                storageRepository = storage,
+                currentUser = REPORTER,
+                targetUser = TARGET,
+                reason = "Spam",
+                description = "",
+                evidenceImages = listOf(byteArrayOf(9) to "image/jpeg"),
+            )
+            assertEquals(REPORTER.uid, storage.uploadCalls.first().userId)
+        }
+
+    companion object {
+        private val REPORTER =
+            User(
+                uid = "doc-reporter",
+                firebaseUid = "fb-reporter",
+                uniqueId = 100000001L,
+                displayName = "Alice",
+            )
+        private val TARGET =
+            User(
+                uid = "doc-target",
+                firebaseUid = "fb-target",
+                uniqueId = 100000002L,
+                displayName = "Bob",
+            )
+    }
+}
+
+private data class ReportUserCall(
+    val reporterId: String,
+    val reporterName: String,
+    val reporterUniqueId: Long,
+    val reportedUserId: String,
+    val reportedUserName: String,
+    val reportedUserUniqueId: Long,
+    val conversationId: String,
+    val reason: String,
+    val description: String,
+    val evidenceUrls: List<String>,
+)
+
+private data class UploadImageCall(
+    val userId: String,
+    val path: String,
+    val contentType: String,
+)
+
+private class RecordingReportRepository(
+    private val reportUser: Resource<Unit> = Resource.Success(Unit),
+) : ReportRepository {
+    val reportUserCalls = mutableListOf<ReportUserCall>()
+
+    @Suppress("LongParameterList")
+    override suspend fun reportUser(
+        reporterId: String,
+        reporterName: String,
+        reporterUniqueId: Long,
+        reportedUserId: String,
+        reportedUserName: String,
+        reportedUserUniqueId: Long,
+        conversationId: String,
+        reason: String,
+        description: String,
+        evidenceUrls: List<String>,
+    ): Resource<Unit> {
+        reportUserCalls.add(
+            ReportUserCall(
+                reporterId,
+                reporterName,
+                reporterUniqueId,
+                reportedUserId,
+                reportedUserName,
+                reportedUserUniqueId,
+                conversationId,
+                reason,
+                description,
+                evidenceUrls.toList(),
+            ),
+        )
+        return reportUser
+    }
+
+    @Suppress("LongParameterList")
+    override suspend fun reportMessage(
+        reporterId: String,
+        reporterName: String,
+        reporterUniqueId: Long,
+        reportedUserId: String,
+        reportedUserName: String,
+        reportedUserUniqueId: Long,
+        conversationId: String,
+        messageId: String,
+        messageText: String,
+        reason: String,
+        description: String,
+    ): Resource<Unit> = Resource.Success(Unit)
+
+    override suspend fun getPendingReports(): Resource<List<Report>> = Resource.Success(emptyList())
+
+    override suspend fun resolveReport(
+        reportId: String,
+        action: String,
+    ): Resource<com.shyden.shytalk.data.repository.ResolveReportOutcome> =
+        Resource.Success(
+            com.shyden.shytalk.data.repository
+                .ResolveReportOutcome(),
+        )
+}
+
+private class RecordingStorageRepository(
+    private val uploadResults: List<Resource<String>> = emptyList(),
+) : StorageRepository {
+    val uploadCalls = mutableListOf<UploadImageCall>()
+
+    override suspend fun uploadImage(
+        userId: String,
+        path: String,
+        imageData: ByteArray,
+        contentType: String,
+    ): Resource<String> {
+        val idx = uploadCalls.size
+        uploadCalls.add(UploadImageCall(userId, path, contentType))
+        return uploadResults.getOrElse(idx) { Resource.Success("https://cdn/default-$idx.jpg") }
+    }
+
+    override suspend fun deleteImageByUrl(url: String) = Unit
+}

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/room/components/RoomMessageReportabilityTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/room/components/RoomMessageReportabilityTest.kt
@@ -1,0 +1,64 @@
+package com.shyden.shytalk.feature.room.components
+
+import com.shyden.shytalk.core.model.MessageType
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the B3 (UK OSA per-message reporting) UI gate. The 4 boolean predicates
+ * combine into 16 truth-table rows; this covers the happy path plus each
+ * predicate flipped independently so a future regression that drops one of
+ * the gates (e.g. accidentally allowing self-message reports) fails loudly.
+ */
+class RoomMessageReportabilityTest {
+    @Test
+    fun `happy path - non-self TEXT message from a real user is reportable`() {
+        assertTrue(isRoomMessageReportable(isSelf = false, type = MessageType.TEXT, senderId = "user-1"))
+    }
+
+    @Test
+    fun `self-flip - self TEXT message is NOT reportable`() {
+        assertFalse(isRoomMessageReportable(isSelf = true, type = MessageType.TEXT, senderId = "user-1"))
+    }
+
+    @Test
+    fun `type-flip SYSTEM - non-self SYSTEM message is NOT reportable`() {
+        assertFalse(isRoomMessageReportable(isSelf = false, type = MessageType.SYSTEM, senderId = "user-1"))
+    }
+
+    @Test
+    fun `type-flip JOIN - non-self JOIN message is NOT reportable`() {
+        assertFalse(isRoomMessageReportable(isSelf = false, type = MessageType.JOIN, senderId = "user-1"))
+    }
+
+    @Test
+    fun `type-flip GIFT - non-self GIFT message is NOT reportable`() {
+        assertFalse(isRoomMessageReportable(isSelf = false, type = MessageType.GIFT, senderId = "user-1"))
+    }
+
+    @Test
+    fun `sender-flip - system-sender TEXT message is NOT reportable even though type is TEXT`() {
+        // System announcements sometimes ship as TEXT with senderId="system" (admin
+        // broadcasts, room close warnings). The gate must catch this — otherwise
+        // a regular user could "report" a system message, which the server treats
+        // as a self-inflicted infraction since there is no real reportee.
+        assertFalse(isRoomMessageReportable(isSelf = false, type = MessageType.TEXT, senderId = "system"))
+    }
+
+    @Test
+    fun `compound - self AND system-type AND system-sender is NOT reportable`() {
+        // Multiple disqualifying conditions still produce false; no exotic AND/OR
+        // bug that would let one predicate accidentally override the others.
+        assertFalse(isRoomMessageReportable(isSelf = true, type = MessageType.SYSTEM, senderId = "system"))
+    }
+
+    @Test
+    fun `empty senderId - empty string is reportable per current policy`() {
+        // Lock the current behaviour: empty senderId passes the != "system" check
+        // and the gate evaluates true. If a future fix decides empty IDs should
+        // be filtered out, this test will fail loudly and force the policy change
+        // to be a conscious update (not a silent regression).
+        assertTrue(isRoomMessageReportable(isSelf = false, type = MessageType.TEXT, senderId = ""))
+    }
+}


### PR DESCRIPTION
## Summary

Two related bugs surfaced during B3 (PR #651) manual-QA — both pre-existing on main, not regressions from B3.

### Bug 1: Report endpoint never resolves users (pre-existing)

All four report-flow callers send `User.uid` as `reportedUserId` / `reporterId`. The server's `resolveUniqueId` middleware queries `users.where('firebaseUid', '==', value).limit(1)`. But `User.uid` is set from the Firestore doc key (numeric uniqueId) via `User.fromMap(map, uid=docId)` — so the server can never resolve it and every report endpoint returns 400 `"reportedUserId does not match any known user"`.

Affects: `RoomViewModel.reportUser`, `RoomViewModel.reportMessage` (B3), `PrivateChatViewModel.reportMessage`, `ProfileViewModel.reportUser`. Memory observation 224 documents the intended contract: *"Mobile clients submit reports with targetUser.uid (Firebase UID)"*.

**Fix**: switch all four callers to `targetUser.firebaseUid` + `authRepository.currentFirebaseUid`.

### Bug 2: Seed users miss `dateOfBirth` / `age` (pre-existing)

First sign-in on local hits the C8 age-verification gate, blocking every downstream QA flow. Add `dateOfBirth: "1995-06-15", age: 30, ageVerified: true` to both seeded users.

## Tests

- New RoomViewModelTest case `'reportMessage - reportedUserId is targetUser firebaseUid not User uid'` uses `uid != firebaseUid` fixture to detect regressions. The default `TestData.createTestUser` (with `firebaseUid = uid`) would mask this; the explicit fixture forces them apart.
- `TestData.createTestUser` now defaults `firebaseUid = uid` so the existing wave of test assertions (`reportedUserId = "<uid>"`) keeps passing without rewrite.
- New `express-api/tests/utils/seed-user-invariants.test.js` (12 static checks): `uid` field absent (matches prod `users.js`), `firebaseUid` set, `dateOfBirth`/`age`/`ageVerified` present, age >= 18, `identityMap` entries map to correct uniqueIds.

## Manual-QA evidence (B3 end-to-end, 2026-05-12)

Created room "B3FinalQA" as admin (100000001), injected non-self TEXT message from user@test.com (100000002), long-pressed → Report Message dialog opened, selected Spam + Submit → report landed in Firestore:

```
reporterUniqueId: 100000001
reportedUserUniqueId: 100000002
reportedUserId: nUEDLF7zdzaDt8K64kx7SjApkcBG  ← Firebase Auth UID (resolved!)
conversationId: <roomId>
messageId: b3-final-...
reason: Spam
status: pending
```

Server `resolveUniqueId` succeeded — the full end-to-end report flow is green for the first time on local.

## Verification

- [x] `:app:testDevDebugUnitTest + :shared:jvmTest` — BUILD SUCCESSFUL
- [x] `:shared:compileKotlinIosArm64` — BUILD SUCCESSFUL
- [x] 12 seed-invariant tests pass
- [x] ktlint + prettier + eslint clean (pre-commit hooks)
- [x] SonarCloud quality gate (pre-push hook) — passed
- [x] **Manual-QA on Android physical device** — B3 long-press → report dialog → submit → Firestore landing verified

## Test plan

- [ ] CI runs all checks on this branch
- [ ] PR #651 (B3) can be re-tested end-to-end after this merges
- [ ] Existing reportUser flow on Profile / Room screens now actually works on production too

🤖 Generated with [Claude Code](https://claude.com/claude-code)