### PR TITLE
fix(portal): force Google account chooser via prompt=select_account (W1 bug 1/4)

### DIFF
--- a/public/portal/portal.js
+++ b/public/portal/portal.js
@@ -349,6 +349,13 @@
       await auth.setPersistence(persistence);
 
       var provider = new firebase.auth.GoogleAuthProvider();
+      // Force the Google account chooser on EVERY sign-in. Without this
+      // parameter, Firebase silently returns the previously-authorised
+      // Google account when the user has only one or has signed in here
+      // before — removing their ability to switch accounts. roadmap-auth.js
+      // already does the same (`public/js/roadmap-auth.js:195`); this
+      // brings the portal flow into parity (W1 bundled bug fix).
+      provider.setCustomParameters({ prompt: 'select_account' });
       try {
         await auth.signInWithPopup(provider);
       } catch (popupErr) {

--- a/tests/web/portal-auth.spec.ts
+++ b/tests/web/portal-auth.spec.ts
@@ -495,6 +495,61 @@ test.describe('Portal — Message Modal Structure', () => {
   });
 });
 
+test.describe('Portal — Google OAuth provider configuration (W1 bundled bug fix)', () => {
+  // Pins the fix for "re-sign-in auto-uses last Google account" — without
+  // `provider.setCustomParameters({ prompt: 'select_account' })`, Firebase
+  // returns the previously-signed-in Google account silently, removing the
+  // user's ability to pick a different one. Roadmap-auth.js already does
+  // this; portal.js was missing it (caught during W1 bundled-bug pass).
+  test('signInWithGoogle calls setCustomParameters with prompt select_account', async ({ page }) => {
+    await page.goto('/portal/');
+    const source = await page.evaluate(async () => {
+      const res = await fetch('/portal/portal.js');
+      return res.text();
+    });
+    // Source-level assertion: the literal pattern must be present in the
+    // signInWithGoogle path. A simple `select_account` substring is too
+    // broad (would also match a comment); pin the actual API call shape.
+    expect(source).toMatch(/setCustomParameters\s*\(\s*\{\s*prompt:\s*['"]select_account['"]\s*\}\s*\)/);
+  });
+
+  test('GoogleAuthProvider is configured before any sign-in call', async ({ page }) => {
+    await page.goto('/portal/');
+    const source = await page.evaluate(async () => {
+      const res = await fetch('/portal/portal.js');
+      return res.text();
+    });
+    // The setCustomParameters call MUST come after `new GoogleAuthProvider()`
+    // and BEFORE the signInWithPopup/Redirect call. Without this ordering the
+    // parameter is ignored — Firebase reads it at popup-open time. Pin the
+    // ordering by checking the substring positions in the source.
+    const providerIdx = source.indexOf('new firebase.auth.GoogleAuthProvider()');
+    const paramsIdx = source.indexOf("setCustomParameters({ prompt: 'select_account' })");
+    const popupIdx = source.indexOf('auth.signInWithPopup(provider)');
+    expect(providerIdx).toBeGreaterThan(-1);
+    expect(paramsIdx).toBeGreaterThan(providerIdx);
+    expect(popupIdx).toBeGreaterThan(paramsIdx);
+  });
+
+  test('Apple OAuthProvider intentionally does NOT pass select_account (Apple ignores Google params)', async ({ page }) => {
+    // Apple's OAuthProvider does not honour Google's `prompt` parameter.
+    // This negative test documents the asymmetry — if someone later "fixes"
+    // portal.js by setCustomParameters-ing the Apple provider too, this
+    // test will fail loudly and force the change to be a conscious one.
+    await page.goto('/portal/');
+    const source = await page.evaluate(async () => {
+      const res = await fetch('/portal/portal.js');
+      return res.text();
+    });
+    // Find the Apple sign-in function body — between `function signInWithApple` and the next `function`.
+    const appleStart = source.indexOf('function signInWithApple');
+    expect(appleStart).toBeGreaterThan(-1);
+    const appleEnd = source.indexOf('function ', appleStart + 20);
+    const appleBody = source.slice(appleStart, appleEnd === -1 ? source.length : appleEnd);
+    expect(appleBody).not.toMatch(/setCustomParameters/);
+  });
+});
+
 test.describe('Portal — Console & Environment Checks', () => {
   test('no console errors on page load', async ({ page }) => {
     const errors: string[] = [];


### PR DESCRIPTION
## Summary
First of four W1-bundled latent web bugs. Portal Google sign-in silently returned the previously-authorised Google account; users couldn't switch accounts. Roadmap-auth.js had the right pattern; portal.js was missing it.

## Fix
Added `provider.setCustomParameters({ prompt: 'select_account' })` to `signInWithGoogle()` in `public/portal/portal.js` between the `new GoogleAuthProvider()` and the `signInWithPopup` calls — Firebase reads the prompt parameter at popup-open time, so ordering matters.

Apple OAuthProvider intentionally NOT changed — it doesn't honour Google's `prompt` parameter, and the new negative test pins that.

## Test plan
- [x] 3 new tests in `tests/web/portal-auth.spec.ts` cover: source-level setCustomParameters call, call-ordering (Provider → params → signInWithPopup), Apple negative case.
- [x] 79/79 portal-auth tests pass locally.
- [ ] CI runs full playwright matrix (now self-healing per PR #653's cache fix).

## W1 bundled bug progress
1. **Google sign-in select_account** — this PR ✓
2. COOP errors on prod — already fixed in `public/_headers:2`; memory was stale
3. `/api/firebase-config` 503 — Cloudflare Pages env var (infra, not code)
4. Watch bells re-prompt sign-in — next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)