### PR TITLE
feat(web): W1 wrap-up — close shared-header test PAGES coverage gap (+3) + redirect-branch test

### DIFF
--- a/public/events/khmer-new-year.html
+++ b/public/events/khmer-new-year.html
@@ -657,7 +657,6 @@ for (let i = 0; i < 20; i++) {
 </script>
 <script>window.EVENT_PAGE_SLUG = 'khmer-new-year';</script>
 <script src="/js/event-translations.js"></script>
-<script src="/js/shared-header.js"></script>
 <script src="/js/language-selector.js" defer></script>
 <script type="module" src="/js/seasonal-theme.js"></script>
 </body>

--- a/public/events/khmer-new-year.html
+++ b/public/events/khmer-new-year.html
@@ -657,6 +657,7 @@ for (let i = 0; i < 20; i++) {
 </script>
 <script>window.EVENT_PAGE_SLUG = 'khmer-new-year';</script>
 <script src="/js/event-translations.js"></script>
+<script src="/js/shared-header.js"></script>
 <script src="/js/language-selector.js" defer></script>
 <script type="module" src="/js/seasonal-theme.js"></script>
 </body>

--- a/tests/web/shared-header.spec.ts
+++ b/tests/web/shared-header.spec.ts
@@ -8,8 +8,12 @@ import { test, expect } from '@playwright/test';
  * - User auth state (right): avatar + name when signed in, "Sign In" when not
  * - Language selector globe button
  *
- * Intentionally excluded: /admin and /portal — both render their own custom
- * authentication UI that would conflict with the shared header.
+ * Intentionally excluded:
+ * - /admin and /portal — both render their own custom authentication UI
+ *   that would conflict with the shared header.
+ * - /events/khmer-new-year.html — a deliberately standalone seasonal
+ *   experience whose `tests/web/khmer-new-year-page.spec.ts` pins zero
+ *   navigation links in header/main.
  */
 
 const PAGES = [
@@ -21,7 +25,6 @@ const PAGES = [
   { name: 'cyber-bullying', path: '/cyber-bullying.html' },
   { name: 'do-not-sell', path: '/do-not-sell.html' },
   { name: '404', path: '/404.html' },
-  { name: 'khmer-new-year', path: '/events/khmer-new-year.html' },
 ];
 
 test.describe('Shared Header — Presence on all pages', () => {
@@ -70,11 +73,11 @@ test.describe('Shared Header — Unauthenticated state', () => {
 test.describe('Shared Header — Sign In fallback on pages without login modal', () => {
   // shared-header.js falls back to `window.location.href = '/portal/'` when
   // `window.shytalkShowLoginModal` is not registered on the host page. Only
-  // roadmap.html registers that modal hook; all event/legal/404 pages take
-  // the redirect branch. This block pins that contract on khmer-new-year so
-  // the fallback can't silently regress.
-  test('Sign In on /events/khmer-new-year.html redirects to /portal/', async ({ page }) => {
-    await page.goto('/events/khmer-new-year.html');
+  // roadmap.html registers that modal hook; all legal + 404 pages take the
+  // redirect branch. This block pins that contract on community-guidelines
+  // (a representative legal page) so the fallback can't silently regress.
+  test('Sign In on /community-guidelines.html redirects to /portal/', async ({ page }) => {
+    await page.goto('/community-guidelines.html');
     const hasModalHook = await page.evaluate(
       () => typeof (window as { shytalkShowLoginModal?: unknown }).shytalkShowLoginModal === 'function',
     );

--- a/tests/web/shared-header.spec.ts
+++ b/tests/web/shared-header.spec.ts
@@ -3,11 +3,13 @@ import { test, expect } from '@playwright/test';
 /**
  * Shared header component tests.
  *
- * The shared header appears on ALL web pages with:
+ * The shared header appears on every public marketing/legal page with:
  * - Logo (left) linking to home
  * - User auth state (right): avatar + name when signed in, "Sign In" when not
  * - Language selector globe button
- * - Consistent look across roadmap, landing, legal, portal, admin pages
+ *
+ * Intentionally excluded: /admin and /portal — both render their own custom
+ * authentication UI that would conflict with the shared header.
  */
 
 const PAGES = [
@@ -16,6 +18,10 @@ const PAGES = [
   { name: 'privacy', path: '/privacy.html' },
   { name: 'terms', path: '/terms.html' },
   { name: 'community-guidelines', path: '/community-guidelines.html' },
+  { name: 'cyber-bullying', path: '/cyber-bullying.html' },
+  { name: 'do-not-sell', path: '/do-not-sell.html' },
+  { name: '404', path: '/404.html' },
+  { name: 'khmer-new-year', path: '/events/khmer-new-year.html' },
 ];
 
 test.describe('Shared Header — Presence on all pages', () => {

--- a/tests/web/shared-header.spec.ts
+++ b/tests/web/shared-header.spec.ts
@@ -67,6 +67,25 @@ test.describe('Shared Header — Unauthenticated state', () => {
   });
 });
 
+test.describe('Shared Header — Sign In fallback on pages without login modal', () => {
+  // shared-header.js falls back to `window.location.href = '/portal/'` when
+  // `window.shytalkShowLoginModal` is not registered on the host page. Only
+  // roadmap.html registers that modal hook; all event/legal/404 pages take
+  // the redirect branch. This block pins that contract on khmer-new-year so
+  // the fallback can't silently regress.
+  test('Sign In on /events/khmer-new-year.html redirects to /portal/', async ({ page }) => {
+    await page.goto('/events/khmer-new-year.html');
+    const hasModalHook = await page.evaluate(
+      () => typeof (window as { shytalkShowLoginModal?: unknown }).shytalkShowLoginModal === 'function',
+    );
+    expect(hasModalHook).toBe(false);
+    const signInBtn = page.locator('[data-testid="header-signin-btn"]');
+    await signInBtn.waitFor({ timeout: 10_000 });
+    await signInBtn.click();
+    await page.waitForURL(/\/portal\/?$/, { timeout: 5_000 });
+  });
+});
+
 test.describe('Shared Header — Authenticated state', () => {
   test('shows user display name when authenticated', async ({ page }) => {
     await page.goto('/roadmap.html');


### PR DESCRIPTION
## Summary

Final piece of W1 (shared header on web pages). Closes the Playwright coverage gap for 3 latent pages and pins the Sign-In `/portal/` redirect-branch contract.

- `tests/web/shared-header.spec.ts` PAGES extended 5 → 8 (added 404, cyber-bullying, do-not-sell — pages that already load the header but had no presence/logo assertions).
- New describe block: `Sign In fallback on pages without login modal` — clicks Sign In on `/community-guidelines.html` (a representative legal page without `window.shytalkShowLoginModal`) and asserts navigation to `/portal/`. Previously the modal branch was tested on roadmap but the redirect branch was untested.
- Docstring rewrite: admin + portal + khmer-new-year now explicitly listed as **intentionally excluded** with reasons. khmer-new-year is a deliberately standalone seasonal page — `tests/web/khmer-new-year-page.spec.ts:105` pins `bodyLinks.toBe(0)` for header/main, which the shared-header logo `<a href="/">` would violate.

## Commit log

1. `feat(web)`: add shared-header to khmer-new-year + extend PAGES (5→9)
2. `test(web)`: pin Sign In → /portal/ redirect on khmer-new-year
3. `fix(web)`: khmer-new-year is intentionally standalone — exclude (revert #1, retarget #2 to community-guidelines)

The revert in commit 3 corrects a planning miss: chromium CI surfaced the cross-spec contract violation from `khmer-new-year-page.spec.ts` that local single-spec runs missed. Lesson saved to memory (`feedback-check-existing-page-contracts-before-adding-shared-scripts.md`).

## Test plan

- [x] `npx playwright test tests/web/shared-header.spec.ts tests/web/khmer-new-year-page.spec.ts --project=chromium` — 50/50 pass locally
- [ ] CI: full 5-browser Playwright matrix
- [ ] Visual smoke on dev: hit `/community-guidelines.html`, click Sign In, verify portal redirect

## W1 status after this PR

W1 DONE on roadmap (local). Bundled bugs already shipped: COOP (#345), firebase-config (#287/#343), Google `select_account` (#654), watch-bell race (#655 roadmap + #659 suggestions-board follow-up). Shared header live on 8 public pages; admin + portal + khmer-new-year intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)