### PR TITLE
feat(segregation): PR 1 — cohort data model + sign-in check (#17)

### DIFF
--- a/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/model/UserToMapTest.kt
@@ -84,6 +84,8 @@ private val EXPECTED_USER_MAP_KEYS =
         "ageVerificationMethod",
         "pmLocked",
         "lastPmLockCheck",
+        "cohort",
+        "cohortOverride",
     )
 
 class UserToMapTest {

--- a/express-api/src/routes/pm-lock-check.js
+++ b/express-api/src/routes/pm-lock-check.js
@@ -5,7 +5,7 @@
  * after successful sign-in. Reads the user doc, decides whether the
  * pmLocked state should change, and writes if yes — all server-side
  * because Firestore rules deny client writes to `pmLocked` /
- * `lastPmLockCheck`.
+ * `lastPmLockCheck` / `cohort`.
  *
  * Throttling: when `lastPmLockCheck` falls in the same UTC day as
  * `now()`, we skip the Firestore write entirely. Active users only
@@ -16,6 +16,16 @@
  * trigger an unlock check on another user's behalf (would be moot
  * since rules deny direct writes anyway, but gate at the route layer
  * for defence in depth).
+ *
+ * UK OSA #17 segregation extension (PR 1): the same `>=18y` predicate
+ * that drives `pmLocked` also drives the `cohort` field ("minor" |
+ * "adult"). Re-using the `lastPmLockCheck` stamp lets both fields
+ * recompute on the same daily cadence with no second throttle. The
+ * custom-claim mint that completes the cohort transition is deferred
+ * to PR 2 — until it lands, the response carries `cohortChanged` and
+ * `cohort` but NOT `forceTokenRefresh: true` (refreshing a stale
+ * claim wastes Firebase mint quota for no behavioral change). Spec:
+ * `.project/plans/2026-05-13-age-segregation-design.md`.
  */
 
 const express = require('express');
@@ -54,7 +64,7 @@ router.post('/users/:uniqueId/pm-lock-check', async (req, res) => {
   try {
     const nowMs = now();
     const todayStart = utcDayStart(nowMs);
-    let result = { pmLocked: false, unlocked: false };
+    let result = { pmLocked: false, unlocked: false, cohort: 'minor', cohortChanged: false };
 
     await db.runTransaction(async (tx) => {
       const userRef = db.doc(`users/${pathUniqueId}`);
@@ -65,33 +75,66 @@ router.post('/users/:uniqueId/pm-lock-check', async (req, res) => {
       }
       const data = snap.data();
       const currentlyLocked = data.pmLocked === true;
+      const currentCohort = typeof data.cohort === 'string' ? data.cohort : 'minor';
       const last = typeof data.lastPmLockCheck === 'number' ? data.lastPmLockCheck : null;
       const lastDay = last !== null ? utcDayStart(last) : null;
 
-      // Already-unlocked user: no-op. Don't bump throttle (no need —
-      // next read won't change outcome unless the user gets re-locked
-      // by an admin, in which case the lock side sets the stamp).
-      if (!currentlyLocked) {
-        result = { pmLocked: false, unlocked: false };
-        return;
-      }
-
-      // Already checked today: idempotent skip.
-      if (lastDay === todayStart) {
-        result = { pmLocked: true, unlocked: false, alreadyCheckedToday: true };
-        return;
-      }
-
-      // First check of the day for a locked user. Decide.
+      // Derive desired state from DOB. Null DOB → minor + locked
+      // (most-restrictive default per spec § Edge cases).
       const eligible = isAtLeast18FromDob(data.dateOfBirth, nowMs);
-      if (eligible) {
-        tx.update(userRef, { pmLocked: false, lastPmLockCheck: nowMs });
-        result = { pmLocked: false, unlocked: true };
-      } else {
-        // Still <18, just bump throttle so we don't re-scan today
-        tx.update(userRef, { lastPmLockCheck: nowMs });
-        result = { pmLocked: true, unlocked: false };
+      const desiredPmLocked = !eligible;
+      const desiredCohort = eligible ? 'adult' : 'minor';
+
+      // Already checked today: idempotent skip. The cohort + pmLocked
+      // surfaced in the response are the CURRENT stored values, not
+      // the derived ones — between the morning and evening of the
+      // same UTC day, the field is whatever yesterday's check wrote.
+      if (lastDay === todayStart) {
+        result = {
+          pmLocked: currentlyLocked,
+          unlocked: false,
+          alreadyCheckedToday: true,
+          cohort: currentCohort,
+          cohortChanged: false,
+        };
+        return;
       }
+
+      // Hot-path no-op: adult cohort AND unlocked AND derived state
+      // matches stored state. Skip even the throttle bump — dormant
+      // adult accounts must pay zero Firestore quota. Sub-18 users
+      // and mismatched-state users fall through to the write branch
+      // (even when pmLocked is false) so cohort gets backfilled.
+      if (
+        !currentlyLocked &&
+        currentCohort === 'adult' &&
+        desiredCohort === 'adult' &&
+        !desiredPmLocked
+      ) {
+        result = {
+          pmLocked: false,
+          unlocked: false,
+          cohort: 'adult',
+          cohortChanged: false,
+        };
+        return;
+      }
+
+      // Write branch — minimal payload. Always bumps lastPmLockCheck
+      // so the next call today is the same-day-throttle no-op.
+      // Each field is only written if it would change — saves
+      // Firestore quota on the common "minor stays minor" path.
+      const update = { lastPmLockCheck: nowMs };
+      if (currentlyLocked !== desiredPmLocked) update.pmLocked = desiredPmLocked;
+      if (currentCohort !== desiredCohort) update.cohort = desiredCohort;
+      tx.update(userRef, update);
+
+      result = {
+        pmLocked: desiredPmLocked,
+        unlocked: currentlyLocked && !desiredPmLocked,
+        cohort: desiredCohort,
+        cohortChanged: currentCohort !== desiredCohort,
+      };
     });
 
     if (result.__notFound) {

--- a/express-api/tests/routes/pm-lock-check.test.js
+++ b/express-api/tests/routes/pm-lock-check.test.js
@@ -134,12 +134,18 @@ describe('POST /api/users/:uniqueId/pm-lock-check', () => {
     expect(mockTxUpdate).not.toHaveBeenCalled();
   });
 
-  test('no-op for users who are not pmLocked (most common case)', async () => {
+  test('no-op for users who are not pmLocked AND already cohort=adult (hot path)', async () => {
+    // The hot-path no-op now also requires `cohort: 'adult'` — a
+    // legacy adult-user doc that predates UK OSA #17 (cohort field
+    // absent) falls through to the write branch to backfill cohort.
+    // See sibling test 'cohort backfilled from absent field ...' for
+    // that case; this test pins the all-correct-state no-op.
     mockTxGet.mockResolvedValue({
       exists: true,
       data: () => ({
         dateOfBirth: dobYearsAgo(25),
         pmLocked: false,
+        cohort: 'adult',
         lastPmLockCheck: null,
       }),
     });
@@ -148,9 +154,8 @@ describe('POST /api/users/:uniqueId/pm-lock-check', () => {
     const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
 
     expect(res.body).toMatchObject({ pmLocked: false, unlocked: false });
-    // No Firestore write at all — already-unlocked users don't need
-    // their throttle stamp bumped because the next read won't change
-    // outcome. (Would change if we ever needed to re-lock; not today.)
+    // No Firestore write at all — already-correct state means no
+    // throttle bump either, dormant adult accounts pay zero quota.
     expect(mockTxUpdate).not.toHaveBeenCalled();
   });
 
@@ -182,5 +187,241 @@ describe('POST /api/users/:uniqueId/pm-lock-check', () => {
     const app = createApp();
     const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
     expect(res.body).toMatchObject({ pmLocked: true, unlocked: false });
+  });
+
+  // ── Segregation cohort (UK OSA #17, PR 1) ──────────────────────
+  // Same first-of-day check that flips pmLocked also writes
+  // `cohort` ("minor" | "adult") derived from `>=18y`. Re-uses
+  // `lastPmLockCheck` throttle stamp. Spec:
+  // `.project/plans/2026-05-13-age-segregation-design.md`.
+
+  test('cohort flips minor→adult when sub-18 user has aged in', async () => {
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        dateOfBirth: dobYearsAgo(18),
+        pmLocked: true,
+        cohort: 'minor',
+        lastPmLockCheck: YESTERDAY_UTC_START,
+      }),
+    });
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+
+    expect(res.body).toMatchObject({
+      pmLocked: false,
+      unlocked: true,
+      cohort: 'adult',
+      cohortChanged: true,
+    });
+    expect(mockTxUpdate).toHaveBeenCalledWith(
+      'users/10000050',
+      expect.objectContaining({
+        pmLocked: false,
+        cohort: 'adult',
+        lastPmLockCheck: 1777896000000,
+      }),
+    );
+  });
+
+  test('cohort flips adult→minor when admin DOB-modify drops user under 18', async () => {
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        dateOfBirth: dobYearsAgo(17),
+        pmLocked: true,
+        cohort: 'adult',
+        lastPmLockCheck: YESTERDAY_UTC_START,
+      }),
+    });
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+
+    expect(res.body).toMatchObject({
+      pmLocked: true,
+      unlocked: false,
+      cohort: 'minor',
+      cohortChanged: true,
+    });
+    expect(mockTxUpdate).toHaveBeenCalledWith(
+      'users/10000050',
+      expect.objectContaining({
+        cohort: 'minor',
+        lastPmLockCheck: 1777896000000,
+      }),
+    );
+  });
+
+  test('cohort write skipped when minor user is still minor (no-op write branch)', async () => {
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        dateOfBirth: dobYearsAgo(16),
+        pmLocked: true,
+        cohort: 'minor',
+        lastPmLockCheck: YESTERDAY_UTC_START,
+      }),
+    });
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+
+    expect(res.body).toMatchObject({
+      pmLocked: true,
+      unlocked: false,
+      cohort: 'minor',
+      cohortChanged: false,
+    });
+    const updateArgs = mockTxUpdate.mock.calls[0][1];
+    expect(updateArgs.lastPmLockCheck).toBe(1777896000000);
+    expect(updateArgs).not.toHaveProperty('pmLocked');
+    expect(updateArgs).not.toHaveProperty('cohort');
+  });
+
+  test('cohort backfilled from absent field when adult user first hits the check', async () => {
+    // Legacy 19-y/o user whose doc predates UK OSA #17 — `cohort` is
+    // missing entirely. Must backfill to adult.
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        dateOfBirth: dobYearsAgo(19),
+        pmLocked: false,
+        lastPmLockCheck: YESTERDAY_UTC_START,
+      }),
+    });
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+
+    expect(res.body).toMatchObject({
+      pmLocked: false,
+      unlocked: false,
+      cohort: 'adult',
+      cohortChanged: true,
+    });
+    expect(mockTxUpdate).toHaveBeenCalledWith(
+      'users/10000050',
+      expect.objectContaining({ cohort: 'adult', lastPmLockCheck: 1777896000000 }),
+    );
+  });
+
+  test('already-adult unlocked user is full no-op (no write, no throttle bump)', async () => {
+    // Hot path: 25-y/o user, pmLocked=false, cohort=adult.
+    // No work needed — no doc write, no throttle bump.
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        dateOfBirth: dobYearsAgo(25),
+        pmLocked: false,
+        cohort: 'adult',
+        lastPmLockCheck: null,
+      }),
+    });
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+
+    expect(res.body).toMatchObject({
+      pmLocked: false,
+      unlocked: false,
+      cohort: 'adult',
+      cohortChanged: false,
+    });
+    expect(mockTxUpdate).not.toHaveBeenCalled();
+  });
+
+  test('same-day throttle preserves cohort field in response', async () => {
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        dateOfBirth: dobYearsAgo(20),
+        pmLocked: true,
+        cohort: 'adult',
+        lastPmLockCheck: TODAY_UTC_START + 100,
+      }),
+    });
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+
+    expect(res.body).toMatchObject({
+      pmLocked: true,
+      unlocked: false,
+      alreadyCheckedToday: true,
+      cohort: 'adult',
+      cohortChanged: false,
+    });
+    expect(mockTxUpdate).not.toHaveBeenCalled();
+  });
+
+  test('null DOB defaults cohort to minor (most-restrictive)', async () => {
+    // Spec § Edge cases: "User signs up with DOB unset → Treated as
+    // cohort = 'minor' — most-restrictive default."
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        dateOfBirth: null,
+        pmLocked: true,
+        cohort: 'adult',
+        lastPmLockCheck: YESTERDAY_UTC_START,
+      }),
+    });
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+
+    expect(res.body.cohort).toBe('minor');
+    expect(res.body.cohortChanged).toBe(true);
+    expect(mockTxUpdate).toHaveBeenCalledWith(
+      'users/10000050',
+      expect.objectContaining({ cohort: 'minor', lastPmLockCheck: 1777896000000 }),
+    );
+  });
+
+  test('epoch-zero DOB (1970-01-01) computes as adult — integer-boundary sanity', async () => {
+    // Lower-edge integer DOB. 1970-01-01 epoch zero is ~56 years
+    // before the pinned `now()` → adult. Guards against any signed/
+    // unsigned arithmetic mishap in isAtLeast18FromDob's UTC age
+    // math that might mis-handle the zero / pre-epoch boundary.
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        dateOfBirth: 0,
+        pmLocked: true,
+        cohort: 'minor',
+        lastPmLockCheck: YESTERDAY_UTC_START,
+      }),
+    });
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+
+    expect(res.body).toMatchObject({
+      pmLocked: false,
+      unlocked: true,
+      cohort: 'adult',
+      cohortChanged: true,
+    });
+    expect(mockTxUpdate).toHaveBeenCalledWith(
+      'users/10000050',
+      expect.objectContaining({ pmLocked: false, cohort: 'adult' }),
+    );
+  });
+
+  test('cohortOverride and claim-mint are NOT touched by this PR (deferred)', async () => {
+    // PR 1 scope discipline: this endpoint MUST NOT call
+    // setCustomUserClaims (deferred to PR 2). `forceTokenRefresh`
+    // MUST be false until PR 2 ships — otherwise the client
+    // refreshes a stale claim, wasting Firebase mint quota.
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        dateOfBirth: dobYearsAgo(18),
+        pmLocked: true,
+        cohort: 'minor',
+        lastPmLockCheck: YESTERDAY_UTC_START,
+      }),
+    });
+    const app = createApp();
+    const res = await request(app).post('/api/users/10000050/pm-lock-check').expect(200);
+
+    expect(res.body.cohortChanged).toBe(true);
+    expect(res.body.forceTokenRefresh ?? false).toBe(false);
+    const updateArgs = mockTxUpdate.mock.calls[0][1];
+    expect(updateArgs).not.toHaveProperty('cohortOverride');
   });
 });

--- a/express-api/tests/utils/seed-user-invariants.test.js
+++ b/express-api/tests/utils/seed-user-invariants.test.js
@@ -59,6 +59,16 @@ function describeSeededUserInvariants(label, uniqueId, firebaseVar) {
       expect(ageMatch).not.toBeNull();
       expect(Number(ageMatch[1])).toBeGreaterThanOrEqual(18);
     });
+
+    it('has cohort: "adult" so segregation gates pass on first sign-in (UK OSA #17)', () => {
+      // PR 1 of the age-segregation initiative adds a `cohort` field to
+      // every user doc. Seeded test users are 18+ (see test above), so
+      // their cohort MUST be "adult" — otherwise the first sign-in
+      // pm-lock-check would have to flip them, and any downstream test
+      // that runs BEFORE the flip would see a stale `minor` cohort and
+      // hit the wrong discovery filter / 404 path.
+      expect(block[1]).toMatch(/\bcohort:\s*"adult"/);
+    });
   });
 }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -51,7 +51,18 @@ service cloud.firestore {
                      // re-grants PM access. Both camelCase and
                      // snake_case for the dual-read defence.
                      'pmLocked', 'lastPmLockCheck',
-                     'pm_locked', 'last_pm_lock_check']);
+                     'pm_locked', 'last_pm_lock_check',
+                     // Segregation cohort (UK OSA #17, PR 1). The
+                     // server-side first-of-day check writes `cohort`
+                     // from the same `>=18y` predicate that drives
+                     // pmLocked; a client write would let a minor
+                     // user re-tag as adult and bypass every
+                     // cross-cohort gate. cohortOverride is admin-only
+                     // (also server-only). Both camel + snake variants
+                     // denied — defence against a future legacy-compat
+                     // dual-read path that could open the gate.
+                     'cohort', 'cohortOverride',
+                     'cohort_override']);
 
       // Backpack — read own, write only via API
       match /backpack/{giftId} {

--- a/local/seed.js
+++ b/local/seed.js
@@ -151,6 +151,12 @@ async function seed() {
     dateOfBirth: "1995-06-15",
     age: 30,
     ageVerified: true,
+    // UK OSA #17 segregation cohort (PR 1). Seeded users are 30, so
+    // they're adults — pinning the value here lets first-sign-in QA
+    // run without the pm-lock-check having to backfill the field
+    // (which would otherwise race with downstream test assertions
+    // that read the cohort before the check writes it).
+    cohort: "adult",
     createdAt: now,
     lastSeenAt: now,
   });
@@ -190,6 +196,8 @@ async function seed() {
     dateOfBirth: "1995-06-15",
     age: 30,
     ageVerified: true,
+    // Adult cohort — see admin block above.
+    cohort: "adult",
     createdAt: now,
     lastSeenAt: now,
   });

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/User.kt
@@ -111,6 +111,25 @@ data class User(
      * launch.
      */
     val lastPmLockCheck: Long? = null,
+    /**
+     * Segregation cohort tag (UK OSA #17). One of "minor" (< 18) or
+     * "adult" (>= 18). Server-only-write — Firestore rules deny
+     * client writes to this field. Default is most-restrictive
+     * "minor" so a legacy user doc missing the field surfaces as
+     * the safer cohort; the first sign-in pm-lock-check writes the
+     * correct value once we have a DOB. Spec:
+     * `.project/plans/2026-05-13-age-segregation-design.md`.
+     */
+    val cohort: String = "minor",
+    /**
+     * Admin-set override of [cohort] (UK OSA #17). When non-null,
+     * downstream enforcement reads `cohortOverride ?: cohort` — the
+     * override wins for every interaction gate. Only settable on
+     * accounts with `userType >= MODERATOR`; regular member accounts
+     * get a 422 from the admin-users route. Audit-logged in the
+     * same transaction as the write. Spec: see [cohort].
+     */
+    val cohortOverride: String? = null,
 ) {
     val isActivelySuspended: Boolean
         get() {
@@ -214,6 +233,8 @@ data class User(
             "ageVerificationMethod" to ageVerificationMethod,
             "pmLocked" to pmLocked,
             "lastPmLockCheck" to lastPmLockCheck,
+            "cohort" to cohort,
+            "cohortOverride" to cohortOverride,
         )
 
     companion object {
@@ -329,6 +350,8 @@ data class User(
                 ageVerificationMethod = map["ageVerificationMethod"] as? String,
                 pmLocked = map["pmLocked"].asBool(),
                 lastPmLockCheck = map["lastPmLockCheck"]?.let { timestampToMillis(it) },
+                cohort = map["cohort"] as? String ?: "minor",
+                cohortOverride = map["cohortOverride"] as? String,
             )
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/CohortUtil.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/CohortUtil.kt
@@ -1,0 +1,64 @@
+package com.shyden.shytalk.core.util
+
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Instant
+
+/**
+ * Segregation cohort constants for UK OSA #17.
+ * "minor" = under 18; "adult" = 18 or older. Spec:
+ * `.project/plans/2026-05-13-age-segregation-design.md`.
+ */
+const val COHORT_MINOR: String = "minor"
+const val COHORT_ADULT: String = "adult"
+
+/** Age at which a user crosses from minor to adult cohort. */
+const val ADULT_AGE_THRESHOLD: Int = 18
+
+/**
+ * Map a date-of-birth to the segregation cohort tag, evaluated in UTC.
+ *
+ * UTC is used (not the local system timezone) so the client agrees with
+ * the Express server about a user's cohort. A user born just before
+ * midnight UTC who lives in a +13 timezone should not "age in" 13 hours
+ * earlier on the client than on the server.
+ *
+ * `null` date-of-birth defaults to [COHORT_MINOR] (most-restrictive).
+ *
+ * @param dateOfBirthMs UTC epoch milliseconds of the user's DOB (start
+ *   of their birth day), or null when unknown.
+ * @param nowMs UTC epoch milliseconds for "now" — exposed as a parameter
+ *   (not `currentTimeMillis()`) so tests can pin the cohort decision to
+ *   a deterministic anchor date.
+ */
+fun deriveCohort(
+    dateOfBirthMs: Long?,
+    nowMs: Long,
+): String {
+    if (dateOfBirthMs == null) return COHORT_MINOR
+    val age = ageAtUtc(dateOfBirthMs, nowMs)
+    return if (age >= ADULT_AGE_THRESHOLD) COHORT_ADULT else COHORT_MINOR
+}
+
+/**
+ * Whole-years age computed in UTC, between [dateOfBirthMs] and [nowMs].
+ * Mirrors [calculateAge] but pinned to UTC and `now` is a parameter
+ * (caller controls the clock so the function is test-stable).
+ */
+private fun ageAtUtc(
+    dateOfBirthMs: Long,
+    nowMs: Long,
+): Int {
+    val tz = TimeZone.UTC
+    val today = Instant.fromEpochMilliseconds(nowMs).toLocalDateTime(tz).date
+    val birth = Instant.fromEpochMilliseconds(dateOfBirthMs).toLocalDateTime(tz).date
+    var age = today.year - birth.year
+    // Subtract one year if we haven't reached the birthday yet THIS year.
+    // Compare months first; if equal, compare days.
+    if (today.month < birth.month ||
+        (today.month == birth.month && today.day < birth.day)
+    ) {
+        age--
+    }
+    return age
+}

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/CohortUtilTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/CohortUtilTest.kt
@@ -1,0 +1,156 @@
+package com.shyden.shytalk.core.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Instant
+
+/**
+ * Tests for [deriveCohort] — the predicate that maps a UTC date-of-birth
+ * to the segregation cohort tag ("minor" | "adult"). Spec:
+ * `.project/plans/2026-05-13-age-segregation-design.md`.
+ *
+ * Boundary cases covered:
+ * - DOB null -> "minor" (most-restrictive default)
+ * - Exact 18th birthday in UTC -> "adult"
+ * - Day before 18th birthday -> "minor"
+ * - Leap-year DOB (Feb 29) -> "minor" on Feb 28 of the non-leap 18th year,
+ *   "adult" on Mar 1 (strict convention; matches UK legal default and
+ *   OSA "most-restrictive when ambiguous" posture)
+ * - 19+ years old -> "adult"
+ * - 16-17 years old -> "minor"
+ */
+class CohortUtilTest {
+    private val dayMs = 24L * 60 * 60 * 1000
+
+    /** Build a UTC start-of-day epoch-ms anchor from a Y-M-D triple. */
+    private fun utcMs(
+        year: Int,
+        month: Int, // 1-12
+        day: Int,
+    ): Long {
+        // ISO-8601 string -> kotlin.time.Instant -> ms.
+        // Pure-stdlib path avoids any kotlinx-datetime API drift.
+        val mm = month.toString().padStart(2, '0')
+        val dd = day.toString().padStart(2, '0')
+        return Instant.parse("$year-$mm-${dd}T00:00:00Z").toEpochMilliseconds()
+    }
+
+    @Test
+    fun `adult when DOB is 19 years ago in UTC`() {
+        val now = utcMs(2026, 1, 15)
+        val dob = utcMs(2007, 1, 15)
+        assertEquals("adult", deriveCohort(dob, now))
+    }
+
+    @Test
+    fun `minor when DOB is 16 years ago in UTC`() {
+        val now = utcMs(2026, 1, 15)
+        val dob = utcMs(2010, 1, 15)
+        assertEquals("minor", deriveCohort(dob, now))
+    }
+
+    @Test
+    fun `minor when DOB is 17 years ago and 1 day`() {
+        val now = utcMs(2026, 1, 15)
+        val dob = utcMs(2009, 1, 14) // 17y + 1 day
+        assertEquals("minor", deriveCohort(dob, now))
+    }
+
+    @Test
+    fun `adult on exact 18th birthday in UTC`() {
+        val dob = utcMs(2008, 1, 15)
+        val nowAt18th = utcMs(2026, 1, 15)
+        assertEquals("adult", deriveCohort(dob, nowAt18th))
+    }
+
+    @Test
+    fun `minor on day before 18th birthday`() {
+        val dob = utcMs(2008, 1, 15)
+        val nowDayBefore = utcMs(2026, 1, 15) - dayMs
+        assertEquals("minor", deriveCohort(dob, nowDayBefore))
+    }
+
+    @Test
+    fun `adult one day after 18th birthday`() {
+        val dob = utcMs(2008, 1, 15)
+        val nowDayAfter = utcMs(2026, 1, 16)
+        assertEquals("adult", deriveCohort(dob, nowDayAfter))
+    }
+
+    @Test
+    fun `leap-year DOB Feb 29 is minor on Feb 28 of 18th non-leap year`() {
+        // Born 2004-02-29. 18th anniversary in 2022 (non-leap year).
+        // Strict convention: still minor on Feb 28; turns adult on Mar 1.
+        // Matches UK legal default. OSA-safer than the lenient convention.
+        val dob = utcMs(2004, 2, 29)
+        val nowFeb28In2022 = utcMs(2022, 2, 28)
+        assertEquals("minor", deriveCohort(dob, nowFeb28In2022))
+    }
+
+    @Test
+    fun `leap-year DOB Feb 29 is adult on Mar 1 of 18th non-leap year`() {
+        val dob = utcMs(2004, 2, 29)
+        val nowMar1In2022 = utcMs(2022, 3, 1)
+        assertEquals("adult", deriveCohort(dob, nowMar1In2022))
+    }
+
+    @Test
+    fun `leap-year DOB Feb 29 is adult on Feb 29 of 18th leap year`() {
+        // Born 2004-02-29. 22 years later (2026) is also non-leap, but
+        // 2008+16=2024 would be a leap year. Sanity-check that on the
+        // exact leap-day anniversary, the user is treated as adult.
+        // Use 2020 (leap) as 16th birthday anniversary for the test —
+        // but we need 18th, so 2022 (non-leap, tested above) is the
+        // first 18th anniversary they actually experience.
+        // This test verifies that an EARLIER leap year is correctly
+        // handled: on Feb 29 of a leap year that is the user's actual
+        // age >= 18 anniversary, they are adult.
+        val dob = utcMs(1996, 2, 29)
+        val nowFeb29In2024 = utcMs(2024, 2, 29) // user is 28y, leap day
+        assertEquals("adult", deriveCohort(dob, nowFeb29In2024))
+    }
+
+    @Test
+    fun `minor when DOB is null`() {
+        // Null DOB defaults to most-restrictive cohort.
+        assertEquals("minor", deriveCohort(null, utcMs(2026, 1, 15)))
+    }
+
+    @Test
+    fun `minor immediately before birthday month`() {
+        // DOB Aug 1; now is Jul 31 of the 18th year — still 17.
+        val dob = utcMs(2008, 8, 1)
+        val nowJul31 = utcMs(2026, 7, 31)
+        assertEquals("minor", deriveCohort(dob, nowJul31))
+    }
+
+    @Test
+    fun `adult on birthday month boundary`() {
+        // DOB Aug 1; now is Aug 1 of 18th year — exactly 18.
+        val dob = utcMs(2008, 8, 1)
+        val nowAug1 = utcMs(2026, 8, 1)
+        assertEquals("adult", deriveCohort(dob, nowAug1))
+    }
+
+    @Test
+    fun `minor in early-month for late-month birthday`() {
+        // DOB Aug 20; now is Aug 10 of the 18th year — still 17.
+        val dob = utcMs(2008, 8, 20)
+        val nowAug10 = utcMs(2026, 8, 10)
+        assertEquals("minor", deriveCohort(dob, nowAug10))
+    }
+
+    @Test
+    fun `future DOB returns minor (defensive — never happens but pin the contract)`() {
+        // A clock-skew or data-entry error could surface a DOB later
+        // than now (e.g. a Firebase server-timestamp deserialised
+        // against a wrong wall clock). The age computation goes
+        // negative; deriveCohort must still return the most-
+        // restrictive "minor" cohort rather than throwing or
+        // returning adult by some int-overflow accident. Pins the
+        // defensive default for the entire negative-age branch.
+        val dob = utcMs(2030, 1, 1)
+        val now = utcMs(2020, 1, 1)
+        assertEquals("minor", deriveCohort(dob, now))
+    }
+}

--- a/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/model/UserTest.kt
+++ b/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/model/UserTest.kt
@@ -743,4 +743,132 @@ class UserTest {
         assertEquals(false, map["pmLocked"])
         assertNull(map["lastPmLockCheck"])
     }
+
+    // ── Segregation cohort fields (UK OSA #17) ───────────────────────
+    //
+    // Server-only-write. Mirrors the pmLocked / ageVerified contract —
+    // Firestore rules deny client writes to both `cohort` and
+    // `cohortOverride`. Default is most-restrictive "minor" so a legacy
+    // user doc missing the field surfaces as the safer cohort; the
+    // first sign-in check (pm-lock-check.js extension) corrects it
+    // when DOB indicates adult. Spec:
+    // `.project/plans/2026-05-13-age-segregation-design.md`.
+
+    @Test
+    fun `default cohort is minor and cohortOverride is null`() {
+        // Most-restrictive default. A default-constructed User must
+        // surface as minor — never as adult — so any caller that forgets
+        // to wire fromMap gets the safer cohort by default.
+        val user = User()
+        assertEquals("minor", user.cohort)
+        assertNull(user.cohortOverride)
+    }
+
+    @Test
+    fun `fromMap parses cohort and cohortOverride`() {
+        val map =
+            mapOf<String, Any?>(
+                "cohort" to "adult",
+                "cohortOverride" to "minor",
+            )
+        val user = User.fromMap(map, "u1")
+        assertEquals("adult", user.cohort)
+        assertEquals("minor", user.cohortOverride)
+    }
+
+    @Test
+    fun `fromMap defaults cohort to minor when absent`() {
+        // Legacy user docs predate UK OSA #17 and have no `cohort`
+        // field at all. They MUST surface as minor (most-restrictive),
+        // not as a hard error or an empty string — downstream cohort
+        // filters compare against the string literal "minor" / "adult"
+        // so an empty / missing default would silently bypass every
+        // gate. The first sign-in pm-lock-check writes the correct
+        // value once we have a DOB.
+        val user = User.fromMap(emptyMap(), "u1")
+        assertEquals("minor", user.cohort)
+        assertNull(user.cohortOverride)
+    }
+
+    @Test
+    fun `fromMap defaults cohort to minor when value is null`() {
+        // Distinct from "absent" — Firestore can return a doc where the
+        // key exists but the value is explicitly null (e.g. after a
+        // FieldValue.delete() write the field disappears, but during
+        // transit the SDK may surface it as null). Treat both the same
+        // way: surface as minor.
+        val map = mapOf<String, Any?>("cohort" to null)
+        val user = User.fromMap(map, "u1")
+        assertEquals("minor", user.cohort)
+    }
+
+    @Test
+    fun `fromMap handles null cohortOverride explicitly`() {
+        // The override is null when admin has not set a manual override.
+        // Round-tripping null cleanly is required so an admin "clear
+        // override" action writes `cohortOverride: null` and a
+        // subsequent read surfaces as null (not as an empty string).
+        val map = mapOf<String, Any?>("cohortOverride" to null)
+        val user = User.fromMap(map, "u1")
+        assertNull(user.cohortOverride)
+    }
+
+    @Test
+    fun `toMap round-trips cohort and cohortOverride`() {
+        val user = User(cohort = "adult", cohortOverride = "minor")
+        val map = user.toMap()
+        assertEquals("adult", map["cohort"])
+        assertEquals("minor", map["cohortOverride"])
+    }
+
+    @Test
+    fun `toMap writes explicit minor for new users (admin queryability)`() {
+        // Pin that newly-created user docs write the explicit `cohort:
+        // "minor"` field so an admin "find minor users" view on
+        // `where('cohort', '==', 'minor')` catches them. Same defence
+        // as the ageVerified pattern. Without this, default-constructed
+        // users would round-trip as cohort=null on the wire and miss
+        // the query.
+        val user = User()
+        val map = user.toMap()
+        assertEquals("minor", map["cohort"])
+        assertNull(map["cohortOverride"])
+    }
+
+    @Test
+    fun `cohort field accepts the two canonical tag strings`() {
+        // The model is intentionally a passive String parser (no enum)
+        // so a future "verified-adult" tag (Phase 2 of #17, not in
+        // scope) doesn't require a model migration. The two canonical
+        // values today are pinned here.
+        listOf("minor", "adult").forEach { tag ->
+            val user = User(cohort = tag)
+            assertEquals(tag, user.cohort)
+        }
+    }
+
+    @Test
+    fun `cohortOverride non-null takes precedence in the model contract`() {
+        // The model holds both fields verbatim — precedence is enforced
+        // at the rules / repo / server layers, NOT in the model. This
+        // pins that fact: a user with cohort=minor AND cohortOverride=
+        // adult retains BOTH values; downstream enforcement reads
+        // `cohortOverride ?: cohort`.
+        val user = User(cohort = "minor", cohortOverride = "adult")
+        assertEquals("minor", user.cohort)
+        assertEquals("adult", user.cohortOverride)
+    }
+
+    @Test
+    fun `fromMap preserves unrecognised cohort string for forward-compat tags`() {
+        // Spec § Open follow-ups names "verified-adult" as a future
+        // Phase 2 tag. The model is intentionally a passive String
+        // parser (not an enum) so a server that ships a new tag
+        // before the client updates surfaces the tag verbatim — never
+        // coerced to a wrong value, never thrown. This pins the
+        // additive rollout contract: server can lead, client follows.
+        val map = mapOf<String, Any?>("cohort" to "verified-adult")
+        val user = User.fromMap(map, "u1")
+        assertEquals("verified-adult", user.cohort)
+    }
 }

--- a/tests/integration/07-firestore-rules-enforcement.spec.ts
+++ b/tests/integration/07-firestore-rules-enforcement.spec.ts
@@ -219,6 +219,55 @@ test.describe("Integration — Firestore rules: users collection", () => {
     );
   });
 
+  test("user CANNOT self-modify segregation fields (cohort, cohortOverride)", async () => {
+    // UK OSA #17, PR 1: `cohort` and `cohortOverride` are server-only
+    // segregation tags. A successful self-write here would let a minor
+    // user re-tag themselves as adult and bypass every cross-cohort
+    // gate (discovery, follow, DM, room join) at the Firestore rules
+    // layer. Both camelCase and snake_case variants must be denied
+    // (defence in depth — matches the existing pmLocked / ageVerified
+    // dual-variant pattern at firestore.rules:53).
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const adminDb = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(adminDb, "users", "100000077"), {
+        firebaseUid: "uid-owner-seg",
+        cohort: "minor",
+      });
+    });
+
+    const owner = testEnv.authenticatedContext("uid-owner-seg");
+    const ownerDb = owner.firestore() as unknown as Firestore;
+    // Camel-case cohort flip — primary attack
+    await assertFails(
+      updateDoc(doc(ownerDb, "users", "100000077"), {
+        cohort: "adult",
+      }),
+    );
+    // Camel-case override — the bypass path admins use legitimately
+    await assertFails(
+      updateDoc(doc(ownerDb, "users", "100000077"), {
+        cohortOverride: "adult",
+      }),
+    );
+    // Snake-case variants — defence against a legacy-compat read path
+    // that would dual-read both forms (e.g. `gcsScore` / `gcs_score`).
+    await assertFails(
+      updateDoc(doc(ownerDb, "users", "100000077"), {
+        cohort_override: "adult",
+      }),
+    );
+    // Combined-field write in a single payload — `hasAny` implicitly
+    // catches this, but pinning it explicitly prevents a future rule
+    // refactor (e.g. splitting the deny list into per-field allow
+    // predicates) from silently opening the multi-field bypass path.
+    await assertFails(
+      updateDoc(doc(ownerDb, "users", "100000077"), {
+        cohort: "adult",
+        cohortOverride: "adult",
+      }),
+    );
+  });
+
   test("client CANNOT create a user doc directly (server only)", async () => {
     // Critical rule: user creation requires an atomic uniqueId
     // allocation + identity-map write that only the server can do.


### PR DESCRIPTION
## Summary

First of 14 PRs for UK OSA #17 age-based segregation. Spec: `.project/plans/2026-05-13-age-segregation-design.md` § PR 1.

**Purely additive — no live UX changes.** Cross-cohort enforcement layers land in PRs 2-12; migration + DEV/PROD deploy in PR 14.

- `User.cohort` + `User.cohortOverride` fields (KMP commonMain). Default is most-restrictive `"minor"`. Passive String parser (not enum) so future "verified-adult" tag round-trips cleanly.
- `firestore.rules` deny client writes to `cohort` / `cohortOverride` / `cohort_override` (camel + snake variants — mirrors `pmLocked` / `ageVerified` server-only contract).
- `pm-lock-check.js` extension: same `>=18y` predicate now also decides `cohort`, re-using the `lastPmLockCheck` UTC-day-start throttle stamp (no second stamp field). Minimal-payload write — only changed fields land in `tx.update`. Hot-path no-op skips throttle bump for already-correct adult docs; legacy adult docs missing `cohort` fall through to backfill. Response carries `cohort` + `cohortChanged`; `forceTokenRefresh` deliberately omitted (claim mint deferred to PR 2).
- `CohortUtil.deriveCohort(dobMs, nowMs)` — UTC-anchored so client + Express agree regardless of local timezone.
- `local/seed.js` stamps seeded users with `cohort: "adult"` to avoid first-sign-in races during local QA.

## Tests (TDD — RED first, GREEN second)

- **commonTest:** 14 `CohortUtilTest` (leap-year Feb 29 strict convention, exact 18th birthday UTC, future-DOB defensive minor, ...)
- **jvmTest:** 10 `UserTest` (default minor, fromMap absent / null / forward-compat string, toMap round-trip, ...)
- **Express Jest:** 9 `pm-lock-check.test.js` (aged-in flip, admin-DOB-modify adult→minor flip, no-op write branch, legacy backfill, hot-path no-op, throttle preservation, null DOB → minor, epoch-zero DOB → adult, forceTokenRefresh-deferred-to-PR2 boundary)
- **Express Jest:** 2 `seed-user-invariants.test.js` (`cohort: "adult"` pinned for admin + regular seeded user via shared helper)
- **Playwright integration:** 1 firestore.rules emulator deny test (camel + camel-override + snake-override + combined-payload deny)

## Pre-push verification

- `ktlint --relative` — clean
- `./gradlew :shared:jvmTest detekt` — BUILD SUCCESSFUL
- `./gradlew :shared:compileKotlinIosArm64` — BUILD SUCCESSFUL
- `cd express-api && node --experimental-vm-modules node_modules/.bin/jest` — 4821 passed / 8 skipped / 207 suites, zero new failures (the `npx jest` archiver-ESM failures are pre-existing on main and CI uses the experimental flag)
- code-reviewer agent — verified clean on 6 invariants; 5 low-confidence edge gaps all addressed (future DOB, epoch-zero DOB, forward-compat string passthrough, combined-field write)
- security-reviewer agent — APPROVE; no CRITICAL/HIGH; 2 MEDIUM defence-in-depth notes disposed as non-bugs (PascalCase `Cohort` variant not in deny list — no real reader; snake variant `cohort` is identical to camel — clean)

## Out-of-scope (deferred per spec)

- PR 2: custom claim mint + `forceTokenRefresh: true`
- PR 3: cross-cohort read gates in firestore.rules
- PR 4: `requireSameCohort` Express middleware
- PRs 5-11: discovery / follow / DM / room / gift / leaderboard enforcement
- PR 12: KMP repository + Compose UI filters
- PR 13: admin panel "Age Segregation" sub-tab
- PR 14: i18n + privacy + Gherkin E2E + `/manual-qa` + DEV+PROD deploy

## Test plan

- [ ] All required-status checks GREEN on CI
- [ ] SonarCloud quality gate passes
- [ ] Integration test #7 passes (rules emulator deny for `cohort` / `cohortOverride` / `cohort_override` / combined payload)
- [ ] No manual-QA required for this PR — defer to PR 14's two-pass cycle per spec § Deploy gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)