### PR TITLE
feat(seg): PR 4 of 14 — requireSameCohort middleware + audit-log (#17)

### DIFF
--- a/express-api/src/middleware/sameCohort.js
+++ b/express-api/src/middleware/sameCohort.js
@@ -1,0 +1,136 @@
+/**
+ * UK OSA #17 PR 4 — `requireSameCohort` gate + `segregationEvents`
+ * audit logger. Wired into user-to-user interaction routes so that
+ * cross-cohort requests (adult ↔ minor) return `404 Not Found` with
+ * a byte-identical body to the legitimate "target user not found"
+ * branch.
+ *
+ * The 404 (rather than 403) is deliberate: 403 leaks the existence
+ * of a cross-cohort user, which defeats the segregation goal. See
+ * `.project/plans/2026-05-13-age-segregation-design.md` § "404 not
+ * 403".
+ *
+ * Admin callers bypass the gate (they need cross-cohort visibility
+ * for moderation) and no audit doc is written for admin actions.
+ *
+ * Failure mode: if the `segregationEvents` write fails, the caller
+ * still receives the 404. The audit error is logged via `log.error`
+ * but never surfaced to the client — leaking "audit failed" would
+ * itself be an existence side-channel.
+ */
+
+const { db } = require('../utils/firebase');
+const { effectiveCohort, cohortFromClaim } = require('../utils/firebase-claims');
+const { isLiveAdmin } = require('./auth');
+const log = require('../utils/log');
+
+function surfaceOf(req) {
+  // Prefer the route template (`/users/:uniqueId/follow`) — it's the
+  // useful aggregation key for security analytics. Fall back to the
+  // concrete path if there's no matched route on the request.
+  if (req?.route?.path) {
+    return `${req.baseUrl || ''}${req.route.path}`;
+  }
+  return `${req.baseUrl || ''}${req.path || ''}`;
+}
+
+// Audit-write dedup. A determined attacker (or bot net) could spam
+// cross-cohort attempts and exhaust the Firestore daily-write quota
+// — both DoS-ing the DEV Spark-tier project and corrupting the
+// audit signal admins rely on. Synchronous LRU of recently-logged
+// `source:target:surface` tuples — write only the first hit in the
+// dedup window. The actual 404 response still fires every time —
+// only the audit doc creation is throttled.
+const AUDIT_DEDUP_WINDOW_MS = 5 * 60 * 1000;
+const AUDIT_DEDUP_MAX_KEYS = 10_000;
+const auditDedup = {
+  hits: new Map(),
+  shouldWrite(sourceId, targetId, surface) {
+    const key = `${sourceId}:${targetId}:${surface}`;
+    const now = Date.now();
+    const entry = this.hits.get(key);
+    if (entry && now < entry.expiresAt) {
+      // LRU touch: re-insert to mark as most-recent.
+      this.hits.delete(key);
+      this.hits.set(key, entry);
+      return false;
+    }
+    this.hits.set(key, { expiresAt: now + AUDIT_DEDUP_WINDOW_MS });
+    while (this.hits.size > AUDIT_DEDUP_MAX_KEYS) {
+      const oldestKey = this.hits.keys().next().value;
+      this.hits.delete(oldestKey);
+    }
+    return true;
+  },
+  reset() {
+    this.hits.clear();
+  },
+};
+
+async function requireSameCohort(req, res, targetUniqueId, fetchUserFn) {
+  // Self-target short-circuit. Centralised here so callers don't
+  // each need their own `if (caller === target) skip-gate` guard.
+  const callerUniqueId = req?.auth?.uniqueId;
+  if (
+    callerUniqueId !== undefined &&
+    callerUniqueId !== null &&
+    String(targetUniqueId) === String(callerUniqueId)
+  ) {
+    return false;
+  }
+
+  // Admin bypass — re-verifies via the live customClaims store so a
+  // demoted admin can't keep cross-cohort visibility for the rest of
+  // their ID-token lifetime (~1h). Mirrors the `requireAdmin` two-
+  // layer pattern in auth.js. 60s cache in `adminClaimCache` keeps
+  // the hot path cheap.
+  if (req?.auth?.token?.admin === true) {
+    const liveAdmin = req?.auth?.uid ? await isLiveAdmin(req.auth.uid) : false;
+    if (liveAdmin) return false;
+  }
+
+  const targetDoc = await fetchUserFn(targetUniqueId);
+  if (!targetDoc) {
+    res.status(404).json({ error: 'Not found' });
+    return true;
+  }
+
+  const callerCohort = cohortFromClaim(req);
+  const targetCohort = effectiveCohort(targetDoc);
+  if (callerCohort === targetCohort) return false;
+
+  // Cross-cohort. Fire-and-forget audit (deduped), then 404. The
+  // audit failure must NEVER leak via the response — `.catch` keeps
+  // the 404 path unconditional.
+  const surface = surfaceOf(req);
+  const sourceUniqueId = String(req?.auth?.uniqueId ?? '');
+  if (auditDedup.shouldWrite(sourceUniqueId, String(targetUniqueId), surface)) {
+    writeSegregationEvent({
+      sourceUniqueId,
+      sourceCohort: callerCohort,
+      targetUniqueId: String(targetUniqueId),
+      targetCohort,
+      surface,
+      action: 'blocked',
+      timestamp: Date.now(),
+      requestId: req?.id ?? null,
+    }).catch((err) =>
+      log.error('segregationEvents', 'write failed', { error: err?.message || String(err) }),
+    );
+  }
+
+  res.status(404).json({ error: 'Not found' });
+  return true;
+}
+
+async function writeSegregationEvent(evt) {
+  await db.collection('segregationEvents').add(evt);
+}
+
+// Test-only: reset the dedup store between tests so per-test
+// expectations on segregationEvents writes are independent.
+function _resetAuditDedup() {
+  auditDedup.reset();
+}
+
+module.exports = { requireSameCohort, writeSegregationEvent, _resetAuditDedup };

--- a/express-api/src/routes/conversations.js
+++ b/express-api/src/routes/conversations.js
@@ -9,7 +9,27 @@ const router = require('express').Router();
 const { db, rtdb, FieldValue } = require('../utils/firebase');
 const { generateId, now } = require('../utils/helpers');
 const { sendFcmToTokens, cleanupInvalidTokens } = require('../utils/fcm');
+const { requireSameCohort } = require('../middleware/sameCohort');
 const log = require('../utils/log');
+
+/**
+ * UK OSA #17 PR 4 — for 1:1 conversations, returns true (and sends a
+ * 404) if the caller and the other participant are cross-cohort.
+ * Group conversations are deferred to PR 8 (frozen-at-migration
+ * gate); they skip this helper.
+ */
+async function gateCrossCohortConversation(req, res, conv) {
+  if (conv?.isGroup) return false;
+  const participantIds = (conv?.participantIds || []).map(String);
+  if (participantIds.length !== 2) return false;
+  const callerId = String(req.auth.uniqueId);
+  const otherId = participantIds.find((p) => p !== callerId);
+  if (!otherId) return false;
+  return requireSameCohort(req, res, otherId, async () => {
+    const snap = await db.doc(`users/${otherId}`).get();
+    return snap.exists ? snap.data() : null;
+  });
+}
 
 const DEFAULT_MESSAGE_LIMIT = 50;
 const MAX_MESSAGE_LIMIT = 200;
@@ -158,10 +178,13 @@ router.get('/conversations/:id/messages', async (req, res) => {
     // Verify the requester is a participant
     const convSnap = await db.doc(`conversations/${req.params.id}`).get();
     if (!convSnap.exists) return res.status(404).json({ error: 'Conversation not found' });
-    const participantIds = convSnap.data().participantIds || [];
+    const conv = convSnap.data();
+    const participantIds = conv.participantIds || [];
     if (!participantIds.map(String).includes(String(req.auth.uniqueId))) {
       return res.status(403).json({ error: 'Not a participant of this conversation' });
     }
+
+    if (await gateCrossCohortConversation(req, res, conv)) return;
 
     const limit = Math.min(
       Number.parseInt(req.query.limit, 10) || DEFAULT_MESSAGE_LIMIT,
@@ -230,6 +253,9 @@ router.post('/conversations/:id/messages', async (req, res) => {
     if (!participantIds.includes(senderId)) {
       return res.status(403).json({ error: 'Not a participant of this conversation' });
     }
+
+    if (await gateCrossCohortConversation(req, res, convDoc)) return;
+
     const recipientIds = participantIds.filter((pid) => pid !== senderId);
     const isGroup = !!convDoc.isGroup;
     const groupName = convDoc.groupName || null;

--- a/express-api/src/routes/rooms.js
+++ b/express-api/src/routes/rooms.js
@@ -9,6 +9,7 @@ const router = require('express').Router();
 const { db, rtdb } = require('../utils/firebase');
 const { generateId, now } = require('../utils/helpers');
 const { sendFcmToTokens, cleanupInvalidTokens } = require('../utils/fcm');
+const { requireSameCohort } = require('../middleware/sameCohort');
 const log = require('../utils/log');
 
 const MAX_USER_NAME_LENGTH = 50;
@@ -50,6 +51,13 @@ router.post('/rooms/:roomId/invites/send', async (req, res) => {
     if (!roomSnap.exists) return res.status(404).json({ error: 'Room not found' });
     const room = roomSnap.data();
 
+    // UK OSA #17 PR 4 — fetch invitee up front for the cross-cohort
+    // gate; the FCM block reuses the same doc.
+    const inviteeSnap = await db.doc(`users/${inviteeId}`).get();
+    const inviteeDoc = inviteeSnap.exists ? inviteeSnap.data() : null;
+    const blocked = await requireSameCohort(req, res, inviteeId, () => inviteeDoc);
+    if (blocked) return;
+
     // Update pendingInvites on the room doc (matches Android client field name)
     const pendingInvites = room.pendingInvites || {};
     pendingInvites[inviteeId] = {
@@ -61,11 +69,7 @@ router.post('/rooms/:roomId/invites/send', async (req, res) => {
 
     // Send FCM push to invitee
     try {
-      const [inviteeSnap, inviterSnap] = await Promise.all([
-        db.doc(`users/${inviteeId}`).get(),
-        db.doc(`users/${body.invitedBy}`).get(),
-      ]);
-      const inviteeDoc = inviteeSnap.exists ? inviteeSnap.data() : null;
+      const inviterSnap = await db.doc(`users/${body.invitedBy}`).get();
       const tokens = inviteeDoc?.fcmTokens || [];
       if (tokens.length > 0) {
         const roomName = room.name || 'a room';
@@ -118,6 +122,25 @@ router.post('/rooms/:roomId/seat-requests', async (req, res) => {
 
     log.info('rooms', 'Creating seat request', { roomId, userId: uniqueId, seatIndex });
 
+    // UK OSA #17 PR 4 — fetch room + owner up front for the cross-
+    // cohort gate; reused later in the FCM push block.
+    const roomSnap = await db.doc(`rooms/${roomId}`).get();
+    if (!roomSnap.exists) return res.status(404).json({ error: 'Room not found' });
+    const room = roomSnap.data();
+
+    // A room without an `ownerId` cannot resolve a cohort for the
+    // gate (cohort stand-in = owner cohort until PR 7). Refuse the
+    // action rather than letting the API-layer gate fall through —
+    // the Firestore rules layer (PR 3) is a backstop, not the only
+    // line of defence.
+    if (!room?.ownerId) {
+      return res.status(404).json({ error: 'Room not found' });
+    }
+    const ownerSnap = await db.doc(`users/${room.ownerId}`).get();
+    const ownerDoc = ownerSnap.exists ? ownerSnap.data() : null;
+    const blocked = await requireSameCohort(req, res, room.ownerId, () => ownerDoc);
+    if (blocked) return;
+
     // Check for existing pending request
     const existingSnap = await db
       .collection(`rooms/${roomId}/seatRequests`)
@@ -151,13 +174,9 @@ router.post('/rooms/:roomId/seat-requests', async (req, res) => {
       resolvedAt: null,
     });
 
-    // Send FCM push to room owner
+    // Send FCM push to room owner (reusing the up-front fetched docs)
     try {
-      const roomSnap = await db.doc(`rooms/${roomId}`).get();
-      const room = roomSnap.exists ? roomSnap.data() : null;
       if (room?.ownerId) {
-        const ownerSnap = await db.doc(`users/${room.ownerId}`).get();
-        const ownerDoc = ownerSnap.exists ? ownerSnap.data() : null;
         const tokens = ownerDoc?.fcmTokens || [];
         if (tokens.length > 0) {
           const invalidTokens = await sendFcmToTokens(tokens, {

--- a/express-api/src/routes/users.js
+++ b/express-api/src/routes/users.js
@@ -30,6 +30,7 @@ const { buildDeletionScheduledEmail } = require('../utils/email-templates');
 const { sendFcmToTokens } = require('../utils/fcm');
 const { viewerIsBlocked } = require('../utils/block-check');
 const { mintClaimsMerging, deriveCohortFromUser } = require('../utils/firebase-claims');
+const { requireSameCohort } = require('../middleware/sameCohort');
 
 const VALID_PROVIDERS = ['google', 'apple', 'email'];
 const MIN_UNIQUE_ID = 10000000;
@@ -309,16 +310,22 @@ router.post('/users/sign-in', async (req, res) => {
 router.get('/users/:uniqueId', async (req, res) => {
   try {
     const user = await getDoc(`users/${req.params.uniqueId}`);
-    if (!user) return res.status(404).json({ error: 'User not found' });
+
+    // UK OSA #17 PR 4 — cross-cohort profile views return 404 with
+    // existence-hiding body (`{ error: 'Not found' }`), byte-identical
+    // to the legitimate "missing target" 404. Self-view bypasses the
+    // gate (caller's own profile is always visible).
+    const isSelf = String(req.auth.uniqueId) === String(req.params.uniqueId);
+    if (!isSelf && (await requireSameCohort(req, res, req.params.uniqueId, () => user))) {
+      return;
+    }
+    if (!user) return res.status(404).json({ error: 'Not found' });
 
     // C7 (block-list integrity): the target user must not be visible
     // to a viewer they have blocked. Returns 403 — the client already
     // handles 403 from interaction endpoints (gift-send) the same way.
     // Allowed exception: the user looking at their own profile.
-    if (
-      String(req.auth.uniqueId) !== String(req.params.uniqueId) &&
-      viewerIsBlocked(req.auth.uniqueId, user)
-    ) {
+    if (!isSelf && viewerIsBlocked(req.auth.uniqueId, user)) {
       return res.status(403).json({ error: 'Cannot view content of users who have blocked you' });
     }
 
@@ -807,12 +814,16 @@ router.post('/users/:uniqueId/follow', async (req, res) => {
       return res.status(400).json({ error: 'Cannot follow yourself' });
     }
 
-    // Verify target user exists. Pre-fix would let the batch write
-    // fail with a Firestore error and return 500; with the validation
-    // here, the API returns the correct 404 contract.
+    // Verify target user exists + UK OSA #17 PR 4 cross-cohort gate.
+    // requireSameCohort returns 404 with `{ error: 'Not found' }` for
+    // both missing-target AND cross-cohort cases (existence-hiding).
     const targetSnap = await db.doc(`users/${targetId}`).get();
-    if (!targetSnap.exists) {
-      return res.status(404).json({ error: 'Target user not found' });
+    if (
+      await requireSameCohort(req, res, targetId, () =>
+        targetSnap.exists ? targetSnap.data() : null,
+      )
+    ) {
+      return;
     }
 
     const batch = db.batch();
@@ -843,9 +854,32 @@ router.post('/users/:uniqueId/follow', async (req, res) => {
 router.post('/users/:uniqueId/unfollow', async (req, res) => {
   try {
     const body = req.body;
-    const targetId = body?.targetUserId;
-    if (!targetId) return res.status(400).json({ error: 'targetUserId required' });
+    const rawTargetId = body?.targetUserId;
+    if (!rawTargetId) return res.status(400).json({ error: 'targetUserId required' });
     if (requireOwner(req, res)) return;
+
+    // Strict integer validation (mirrors follow handler — Phase 2A
+    // audit H3). `Number.parseInt('123abc', 10) === 123` silently
+    // truncates, then arrayRemove(123) poisons followingIds.
+    const targetId = Number.parseInt(String(rawTargetId), 10);
+    if (!Number.isInteger(targetId) || targetId <= 0) {
+      return res.status(400).json({ error: 'targetUserId must be a positive integer' });
+    }
+    if (String(targetId) !== String(rawTargetId).trim()) {
+      return res.status(400).json({ error: 'targetUserId must be a positive integer' });
+    }
+
+    // UK OSA #17 PR 4 — cross-cohort unfollow returns 404 (existence-hiding).
+    // Even though PR 6 migration revokes cross-cohort follows server-side,
+    // a stale client retry must not leak existence of the cross-cohort user.
+    if (
+      await requireSameCohort(req, res, targetId, async () => {
+        const snap = await db.doc(`users/${Number(targetId)}`).get();
+        return snap.exists ? snap.data() : null;
+      })
+    ) {
+      return;
+    }
 
     const uniqueId = req.params.uniqueId;
     const batch = db.batch();
@@ -876,9 +910,29 @@ router.post('/users/:uniqueId/unfollow', async (req, res) => {
 router.post('/users/:uniqueId/remove-follower', async (req, res) => {
   try {
     const body = req.body;
-    const followerId = body?.followerUserId;
-    if (!followerId) return res.status(400).json({ error: 'followerUserId required' });
+    const rawFollowerId = body?.followerUserId;
+    if (!rawFollowerId) return res.status(400).json({ error: 'followerUserId required' });
     if (requireOwner(req, res)) return;
+
+    // Strict integer validation — same NaN-poisoning defence as follow.
+    const followerId = Number.parseInt(String(rawFollowerId), 10);
+    if (!Number.isInteger(followerId) || followerId <= 0) {
+      return res.status(400).json({ error: 'followerUserId must be a positive integer' });
+    }
+    if (String(followerId) !== String(rawFollowerId).trim()) {
+      return res.status(400).json({ error: 'followerUserId must be a positive integer' });
+    }
+
+    // UK OSA #17 PR 4 — cross-cohort remove-follower returns 404
+    // (existence-hiding); mirrors unfollow.
+    if (
+      await requireSameCohort(req, res, followerId, async () => {
+        const snap = await db.doc(`users/${Number(followerId)}`).get();
+        return snap.exists ? snap.data() : null;
+      })
+    ) {
+      return;
+    }
 
     const uniqueId = req.params.uniqueId;
     const batch = db.batch();
@@ -926,6 +980,13 @@ router.post('/users/:uniqueId/record-visit', async (req, res) => {
     // with success:true so the client treats the call as completed,
     // avoiding a retry loop or a UI signal that reveals block state.
     const targetUser = await getDoc(`users/${profileUniqueId}`);
+
+    // UK OSA #17 PR 4 cross-cohort gate. Same guard-pattern as
+    // requireOwner / requireAdmin: returns true when it has already
+    // sent the response (404 existence-hiding), so caller returns.
+    const blocked = await requireSameCohort(req, res, profileUniqueId, () => targetUser);
+    if (blocked) return;
+
     if (viewerIsBlocked(visitorId, targetUser)) {
       return res.json({ success: true, recorded: false });
     }

--- a/express-api/src/utils/firebase-claims.js
+++ b/express-api/src/utils/firebase-claims.js
@@ -118,10 +118,31 @@ function deriveCohortFromUser(userData, nowMs = Date.now()) {
   return 'minor';
 }
 
+/**
+ * Reads the cohort custom-claim off the verified Firebase ID token
+ * attached to a request by `middleware/auth.js`. Fail-closed to
+ * `'minor'` (most-restrictive) when the claim is missing or invalid —
+ * mirrors `effectiveCohort` / `deriveCohortFromUser` so all three
+ * "cohort resolvers" present one defensive contract to callers.
+ *
+ * A stripped or malformed claim is treated as a minor caller; this
+ * restricts the attacker to minor↔minor interactions and surfaces a
+ * meaningful `sourceCohort: 'minor'` signal in `segregationEvents`
+ * (vs. the harder-to-aggregate `undefined`).
+ */
+function cohortFromClaim(req) {
+  const claim = req?.auth?.token?.cohort;
+  if (typeof claim === 'string' && VALID_COHORTS.has(claim)) {
+    return claim;
+  }
+  return 'minor';
+}
+
 module.exports = {
   mintClaimsMerging,
   effectiveCohort,
   deriveCohortFromUser,
   isAtLeast18FromDob,
+  cohortFromClaim,
   VALID_COHORTS,
 };

--- a/express-api/tests/contracts/api-contracts.test.js
+++ b/express-api/tests/contracts/api-contracts.test.js
@@ -487,17 +487,29 @@ describe('POST /api/economy/daily-reward response contract', () => {
 describe('POST /api/rooms/:roomId/seat-requests response contract', () => {
   const { db } = require('../../src/utils/firebase');
 
+  // PR 4: room + owner fetches were hoisted out of the FCM block.
+  // Set up path-aware mocks: room exists, owner exists with no cohort
+  // (→ 'minor' matches the fail-closed caller cohort), gate allows.
+  function setupRoomMocks() {
+    mockDocGet.mockImplementation((path) => {
+      if (path?.startsWith('rooms/')) {
+        return Promise.resolve({
+          exists: true,
+          data: () => ({ ownerId: 10000099, name: 'Room' }),
+        });
+      }
+      return Promise.resolve({ exists: true, data: () => ({}) });
+    });
+  }
+
   it('returns requestId as a string on success', async () => {
-    // No existing pending request
+    setupRoomMocks();
     const mockChain = {
       where: jest.fn().mockReturnThis(),
       limit: jest.fn().mockReturnThis(),
       get: jest.fn().mockResolvedValue({ empty: true }),
     };
     db.collection.mockReturnValueOnce(mockChain);
-
-    // Room doc (for FCM - fire-and-forget)
-    mockDocGet.mockResolvedValue({ exists: false, data: () => null });
 
     const app = createApp(10000001);
     const res = await request(app)
@@ -510,6 +522,7 @@ describe('POST /api/rooms/:roomId/seat-requests response contract', () => {
   });
 
   it('returns requestId when an existing pending request is updated', async () => {
+    setupRoomMocks();
     const existingReqId = 'existing-req-id';
     const mockChain = {
       where: jest.fn().mockReturnThis(),
@@ -577,6 +590,11 @@ describe('POST /api/conversations/:id/messages response contract', () => {
           exists: true,
           data: () => conversationFixture,
         });
+      }
+      // PR 4: cohort-gate user fetch — return empty doc → 'minor'
+      // matches the fail-closed caller, gate allows.
+      if (path.startsWith('users/')) {
+        return Promise.resolve({ exists: true, data: () => ({}) });
       }
       return Promise.resolve({ exists: false, data: () => null });
     });

--- a/express-api/tests/middleware/sameCohort.test.js
+++ b/express-api/tests/middleware/sameCohort.test.js
@@ -1,0 +1,471 @@
+/**
+ * Tests for `middleware/sameCohort.js` — the cross-cohort gate that
+ * UK OSA #17 PR 4 wires into all user-to-user Express endpoints.
+ *
+ * Contract pinned by these tests:
+ *   1. Same-cohort caller → not blocked, no audit doc written.
+ *   2. Cross-cohort caller → 404 with body `{ error: 'Not found' }`
+ *      AND a `segregationEvents` audit doc with the full pair.
+ *   3. Admin caller → always allowed, no audit doc.
+ *   4. Target user with `cohortOverride` is honoured (override wins).
+ *   5. Target user missing → 404 with same `{ error: 'Not found' }`
+ *      body. Byte-identical to the cross-cohort 404 — that's the
+ *      existence-hiding semantic (no shape leak between "not there"
+ *      and "wrong cohort").
+ *   6. Stripped/invalid caller cohort claim → treated as 'minor'
+ *      (defensive fail-closed via `cohortFromClaim`).
+ *   7. Audit write failure → response is STILL 404 and `log.error`
+ *      is called (fire-and-forget; we never leak the audit failure
+ *      to the caller).
+ *   8. Surface tag captures the URL contour for aggregation.
+ */
+
+// ─── Firebase + logger + isLiveAdmin mocks ──────────────────────
+
+const mockAdd = jest.fn();
+const mockCollection = jest.fn(() => ({ add: mockAdd }));
+const mockIsLiveAdmin = jest.fn();
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    collection: (...args) => mockCollection(...args),
+  },
+}));
+
+jest.mock('../../src/middleware/auth', () => ({
+  isLiveAdmin: (...args) => mockIsLiveAdmin(...args),
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const log = require('../../src/utils/log');
+const {
+  requireSameCohort,
+  writeSegregationEvent,
+  _resetAuditDedup,
+} = require('../../src/middleware/sameCohort');
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function mockReq(overrides = {}) {
+  const hasRoute = Object.prototype.hasOwnProperty.call(overrides, 'route');
+  const { auth = {}, baseUrl = '/api', path = '/users/200/follow', route, id, ...rest } = overrides;
+  return {
+    auth: { uniqueId: 1, token: { cohort: 'adult' }, ...auth },
+    baseUrl,
+    path,
+    route: hasRoute ? route : { path: '/users/:uniqueId/follow' },
+    id,
+    ...rest,
+  };
+}
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAdd.mockReset();
+  mockAdd.mockResolvedValue({ id: 'evt_abc' });
+  mockCollection.mockClear();
+  log.error.mockReset();
+  // Default: admin claim = real admin. Tests that need the demoted-
+  // admin case explicitly override mockIsLiveAdmin.mockResolvedValueOnce(false).
+  mockIsLiveAdmin.mockReset();
+  mockIsLiveAdmin.mockResolvedValue(true);
+  // Reset the dedup LRU between tests so audit-write counts are
+  // independent.
+  _resetAuditDedup();
+});
+
+// ─── Core contract ──────────────────────────────────────────────
+
+describe('requireSameCohort — same-cohort allow path', () => {
+  test('returns false (not blocked) when caller + target are both adult', async () => {
+    const req = mockReq();
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 200, async () => ({ cohort: 'adult' }));
+
+    expect(blocked).toBe(false);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  test('returns false when caller + target are both minor', async () => {
+    const req = mockReq({ auth: { uniqueId: 50, token: { cohort: 'minor' } } });
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 51, async () => ({ cohort: 'minor' }));
+
+    expect(blocked).toBe(false);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+});
+
+describe('requireSameCohort — cross-cohort block path', () => {
+  test('adult → minor target: 404 + segregationEvents audit doc written', async () => {
+    const req = mockReq({
+      auth: { uniqueId: 1, token: { cohort: 'adult' } },
+      id: 'req_xyz',
+    });
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 200, async () => ({ cohort: 'minor' }));
+
+    expect(blocked).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+
+    expect(mockCollection).toHaveBeenCalledWith('segregationEvents');
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    const evt = mockAdd.mock.calls[0][0];
+    expect(evt).toMatchObject({
+      sourceUniqueId: '1',
+      sourceCohort: 'adult',
+      targetUniqueId: '200',
+      targetCohort: 'minor',
+      action: 'blocked',
+      requestId: 'req_xyz',
+    });
+    expect(typeof evt.timestamp).toBe('number');
+    expect(typeof evt.surface).toBe('string');
+    expect(evt.surface.length).toBeGreaterThan(0);
+  });
+
+  test('minor → adult target: same 404 shape (symmetry)', async () => {
+    const req = mockReq({ auth: { uniqueId: 50, token: { cohort: 'minor' } } });
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 100, async () => ({ cohort: 'adult' }));
+
+    expect(blocked).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+    expect(mockAdd.mock.calls[0][0]).toMatchObject({
+      sourceCohort: 'minor',
+      targetCohort: 'adult',
+    });
+  });
+
+  test('captures surface tag from req.baseUrl + req.route.path', async () => {
+    const req = mockReq({
+      baseUrl: '/api',
+      route: { path: '/users/:uniqueId/follow' },
+    });
+    const res = mockRes();
+
+    await requireSameCohort(req, res, 200, async () => ({ cohort: 'minor' }));
+
+    expect(mockAdd.mock.calls[0][0].surface).toBe('/api/users/:uniqueId/follow');
+  });
+
+  test('surface falls back to req.path when route.path is unavailable', async () => {
+    const req = mockReq({
+      baseUrl: '/api',
+      path: '/users/200/follow',
+      route: undefined,
+    });
+    const res = mockRes();
+
+    await requireSameCohort(req, res, 200, async () => ({ cohort: 'minor' }));
+
+    expect(mockAdd.mock.calls[0][0].surface).toBe('/api/users/200/follow');
+  });
+
+  test('requestId is null when req.id is absent', async () => {
+    const req = mockReq();
+    delete req.id;
+    const res = mockRes();
+
+    await requireSameCohort(req, res, 200, async () => ({ cohort: 'minor' }));
+
+    expect(mockAdd.mock.calls[0][0].requestId).toBeNull();
+  });
+});
+
+describe('requireSameCohort — admin bypass', () => {
+  test('admin caller is allowed even when target cohort differs', async () => {
+    const req = mockReq({
+      auth: { uid: 'fb-uid', uniqueId: 1, token: { admin: true, cohort: 'adult' } },
+    });
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 200, async () => ({ cohort: 'minor' }));
+
+    expect(blocked).toBe(false);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  test('admin caller does not need to fetch target user', async () => {
+    const fetchUser = jest.fn();
+    const req = mockReq({ auth: { uid: 'fb-uid', uniqueId: 1, token: { admin: true } } });
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 200, fetchUser);
+
+    expect(blocked).toBe(false);
+    expect(fetchUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('requireSameCohort — cohortOverride precedence', () => {
+  test('target.cohortOverride beats target.cohort', async () => {
+    const req = mockReq({ auth: { uniqueId: 1, token: { cohort: 'adult' } } });
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 200, async () => ({
+      cohort: 'minor',
+      cohortOverride: 'adult',
+    }));
+
+    expect(blocked).toBe(false);
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  test('invalid cohortOverride is ignored — falls back to derived cohort', async () => {
+    const req = mockReq({ auth: { uniqueId: 1, token: { cohort: 'adult' } } });
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 200, async () => ({
+      cohort: 'minor',
+      cohortOverride: 'super-admin',
+    }));
+
+    expect(blocked).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+});
+
+describe('requireSameCohort — existence-hiding', () => {
+  test('missing target returns 404 with identical body to cross-cohort block', async () => {
+    const req = mockReq();
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 999, async () => null);
+
+    expect(blocked).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+    // Existence-hiding: no audit write — the user genuinely does not
+    // exist, so there's no cross-cohort interaction to log.
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  test('undefined target user (returns undefined rather than null) also 404s', async () => {
+    const req = mockReq();
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 999, async () => undefined);
+
+    expect(blocked).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+  });
+});
+
+describe('requireSameCohort — fail-closed caller claim', () => {
+  test('stripped cohort claim is treated as minor; blocks against adult target', async () => {
+    const req = mockReq({ auth: { uniqueId: 1, token: {} } });
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 200, async () => ({ cohort: 'adult' }));
+
+    expect(blocked).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(mockAdd.mock.calls[0][0]).toMatchObject({
+      sourceCohort: 'minor',
+      targetCohort: 'adult',
+    });
+  });
+
+  test('invalid cohort claim string is treated as minor', async () => {
+    const req = mockReq({ auth: { uniqueId: 1, token: { cohort: 'staff' } } });
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 200, async () => ({ cohort: 'adult' }));
+
+    expect(blocked).toBe(true);
+    expect(mockAdd.mock.calls[0][0].sourceCohort).toBe('minor');
+  });
+});
+
+describe('requireSameCohort — fire-and-forget audit', () => {
+  test('responds 404 and logs error if segregationEvents write fails', async () => {
+    mockAdd.mockRejectedValueOnce(new Error('firestore offline'));
+    const req = mockReq({ auth: { uniqueId: 1, token: { cohort: 'adult' } } });
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 200, async () => ({ cohort: 'minor' }));
+
+    expect(blocked).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+
+    // Give the catch handler a tick to run.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(log.error).toHaveBeenCalledWith(
+      'segregationEvents',
+      'write failed',
+      expect.objectContaining({ error: 'firestore offline' }),
+    );
+  });
+});
+
+describe('writeSegregationEvent', () => {
+  test('writes to the segregationEvents collection', async () => {
+    await writeSegregationEvent({
+      sourceUniqueId: '1',
+      sourceCohort: 'adult',
+      targetUniqueId: '200',
+      targetCohort: 'minor',
+      surface: '/api/users/:uniqueId/follow',
+      action: 'blocked',
+      timestamp: 1234567890,
+      requestId: null,
+    });
+
+    expect(mockCollection).toHaveBeenCalledWith('segregationEvents');
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── Self-target short-circuit (MEDIUM 4) ───────────────────────
+
+describe('requireSameCohort — self-target short-circuit', () => {
+  test('caller targeting their own uniqueId is allowed without fetching', async () => {
+    const fetchUser = jest.fn();
+    const req = mockReq({ auth: { uniqueId: 100, token: { cohort: 'adult' } } });
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 100, fetchUser);
+
+    expect(blocked).toBe(false);
+    expect(fetchUser).not.toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  test('string vs number self-id mismatch is coerced (no false self-skip)', async () => {
+    const fetchUser = jest.fn();
+    const req = mockReq({ auth: { uniqueId: 100, token: { cohort: 'adult' } } });
+    const res = mockRes();
+
+    // String "100" should still match number 100 via String() coercion.
+    const blocked = await requireSameCohort(req, res, '100', fetchUser);
+
+    expect(blocked).toBe(false);
+    expect(fetchUser).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Live-admin check (HIGH 2) ──────────────────────────────────
+
+describe('requireSameCohort — live admin verification', () => {
+  test('admin token AND live-admin true → bypass (no audit)', async () => {
+    mockIsLiveAdmin.mockResolvedValueOnce(true);
+    const req = mockReq({
+      auth: { uid: 'fb-uid', uniqueId: 1, token: { admin: true, cohort: 'adult' } },
+    });
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 200, async () => ({ cohort: 'minor' }));
+
+    expect(blocked).toBe(false);
+    expect(mockIsLiveAdmin).toHaveBeenCalledWith('fb-uid');
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  test('admin token BUT live-admin false (demoted) → gate fires normally', async () => {
+    mockIsLiveAdmin.mockResolvedValueOnce(false);
+    const req = mockReq({
+      auth: { uid: 'demoted-uid', uniqueId: 1, token: { admin: true, cohort: 'adult' } },
+    });
+    const res = mockRes();
+
+    const blocked = await requireSameCohort(req, res, 200, async () => ({ cohort: 'minor' }));
+
+    expect(blocked).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(mockIsLiveAdmin).toHaveBeenCalledWith('demoted-uid');
+    await new Promise((r) => setImmediate(r));
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+  });
+
+  test('no admin claim → live check skipped entirely', async () => {
+    const req = mockReq({ auth: { uniqueId: 1, token: { cohort: 'adult' } } });
+    const res = mockRes();
+
+    await requireSameCohort(req, res, 200, async () => ({ cohort: 'adult' }));
+
+    expect(mockIsLiveAdmin).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Audit-write dedup (HIGH 1) ─────────────────────────────────
+
+describe('requireSameCohort — audit-write dedup', () => {
+  test('repeated cross-cohort attempts (same source/target/surface) write ONE audit doc', async () => {
+    const req1 = mockReq({ auth: { uniqueId: 1, token: { cohort: 'adult' } } });
+    const req2 = mockReq({ auth: { uniqueId: 1, token: { cohort: 'adult' } } });
+    const req3 = mockReq({ auth: { uniqueId: 1, token: { cohort: 'adult' } } });
+
+    for (const req of [req1, req2, req3]) {
+      const res = mockRes();
+      await requireSameCohort(req, res, 200, async () => ({ cohort: 'minor' }));
+      expect(res.status).toHaveBeenCalledWith(404);
+    }
+
+    await new Promise((r) => setImmediate(r));
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+  });
+
+  test('distinct targets from same source each write their own audit doc', async () => {
+    const req = mockReq({ auth: { uniqueId: 1, token: { cohort: 'adult' } } });
+
+    for (const targetId of [200, 201, 202]) {
+      const res = mockRes();
+      await requireSameCohort(req, res, targetId, async () => ({ cohort: 'minor' }));
+    }
+
+    await new Promise((r) => setImmediate(r));
+    expect(mockAdd).toHaveBeenCalledTimes(3);
+  });
+
+  test('distinct sources targeting same victim each write their own audit doc', async () => {
+    for (const sourceId of [10, 11, 12]) {
+      const req = mockReq({ auth: { uniqueId: sourceId, token: { cohort: 'adult' } } });
+      const res = mockRes();
+      await requireSameCohort(req, res, 200, async () => ({ cohort: 'minor' }));
+    }
+
+    await new Promise((r) => setImmediate(r));
+    expect(mockAdd).toHaveBeenCalledTimes(3);
+  });
+
+  test('dedup does not affect the 404 response — every attempt still 404s', async () => {
+    // Critical: dedup throttles AUDIT writes only. The caller MUST
+    // get a 404 on every cross-cohort attempt, otherwise the gate
+    // itself is bypassable post-first-write.
+    const req = mockReq({ auth: { uniqueId: 1, token: { cohort: 'adult' } } });
+    const res1 = mockRes();
+    const res2 = mockRes();
+
+    await requireSameCohort(req, res1, 200, async () => ({ cohort: 'minor' }));
+    await requireSameCohort(req, res2, 200, async () => ({ cohort: 'minor' }));
+
+    expect(res1.status).toHaveBeenCalledWith(404);
+    expect(res2.status).toHaveBeenCalledWith(404);
+  });
+});

--- a/express-api/tests/routes/conversations-coverage.test.js
+++ b/express-api/tests/routes/conversations-coverage.test.js
@@ -96,6 +96,10 @@ beforeEach(() => {
   mockDocUpdate.mockResolvedValue();
   mockRtdbSet.mockResolvedValue();
   mockSendFcmToTokens.mockResolvedValue([]);
+  // PR 4: cross-cohort middleware fetches the other 1:1 participant.
+  // Default to empty-but-existing user doc so the gate evaluates
+  // 'minor' vs 'minor' (fail-closed) and allows the request.
+  mockDocGet.mockImplementation(() => Promise.resolve({ exists: true, data: () => ({}) }));
 });
 
 // ─── App setup ───────────────────────────────────────────────────

--- a/express-api/tests/routes/conversations-same-cohort.test.js
+++ b/express-api/tests/routes/conversations-same-cohort.test.js
@@ -1,0 +1,280 @@
+/**
+ * UK OSA #17 PR 4 — `requireSameCohort` route-wiring tests for
+ * `routes/conversations.js`.
+ *
+ *   GET  /api/conversations/:id/messages
+ *   POST /api/conversations/:id/messages
+ *
+ * The gate fires on the OTHER participant in 1:1 conversations.
+ * Group conversations are deferred to PR 8 (frozen-at-migration
+ * + dedicated freeze flag) — group convs pass through this gate
+ * untouched.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// ─── Path-aware Firebase mock ───────────────────────────────────
+
+const docResponses = new Map();
+const setDoc = (path, data) => docResponses.set(path, data);
+const clearDocs = () => docResponses.clear();
+
+const mockDocGet = jest.fn();
+const mockDocSet = jest.fn().mockResolvedValue();
+const mockBatchSet = jest.fn();
+const mockBatchUpdate = jest.fn();
+const mockBatchCommit = jest.fn().mockResolvedValue();
+const mockMessagesGet = jest.fn();
+const mockSegregationAdd = jest.fn().mockResolvedValue({ id: 'evt_1' });
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    doc: jest.fn((path) => ({
+      _path: path,
+      get: () => mockDocGet(path),
+      set: (...args) => mockDocSet(path, ...args),
+    })),
+    collection: jest.fn((name) => {
+      if (name === 'segregationEvents') return { add: mockSegregationAdd };
+      // For /conversations/.../messages — orderBy().limit().get()
+      return {
+        orderBy: jest.fn(() => ({
+          limit: jest.fn(() => ({ get: mockMessagesGet })),
+        })),
+      };
+    }),
+    batch: jest.fn(() => ({
+      set: mockBatchSet,
+      update: mockBatchUpdate,
+      commit: mockBatchCommit,
+    })),
+    getAll: jest.fn().mockResolvedValue([]),
+  },
+  rtdb: {
+    ref: jest.fn(() => ({ set: jest.fn().mockResolvedValue() })),
+  },
+  FieldValue: {
+    increment: jest.fn((n) => `increment(${n})`),
+    arrayRemove: jest.fn((...args) => `arrayRemove(${args})`),
+  },
+}));
+
+jest.mock('../../src/utils/helpers', () => ({
+  generateId: () => 'msg-123',
+  now: () => 1709913600000,
+}));
+
+jest.mock('../../src/utils/fcm', () => ({
+  sendFcmToTokens: jest.fn().mockResolvedValue([]),
+  cleanupInvalidTokens: jest.fn().mockResolvedValue(),
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const mockIsLiveAdmin = jest.fn();
+jest.mock('../../src/middleware/auth', () => ({
+  isLiveAdmin: (...args) => mockIsLiveAdmin(...args),
+}));
+
+const { _resetAuditDedup } = require('../../src/middleware/sameCohort');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDocGet.mockReset();
+  mockSegregationAdd.mockReset();
+  mockSegregationAdd.mockResolvedValue({ id: 'evt_1' });
+  mockMessagesGet.mockReset();
+  mockMessagesGet.mockResolvedValue({ docs: [] });
+  mockIsLiveAdmin.mockReset();
+  mockIsLiveAdmin.mockResolvedValue(true);
+  _resetAuditDedup();
+  clearDocs();
+
+  mockDocGet.mockImplementation((path) => {
+    if (docResponses.has(path)) {
+      const data = docResponses.get(path);
+      return Promise.resolve({ exists: data !== undefined && data !== null, data: () => data });
+    }
+    return Promise.resolve({ exists: false, data: () => null });
+  });
+});
+
+// ─── App setup ───────────────────────────────────────────────────
+
+const conversationsRouter = require('../../src/routes/conversations');
+
+function createApp({
+  uid = 'firebase-uid',
+  uniqueId = 'user-A',
+  cohort = 'adult',
+  admin = false,
+} = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.auth = {
+      uid,
+      uniqueId,
+      token: { cohort, ...(admin ? { admin: true } : {}) },
+    };
+    next();
+  });
+  app.use('/api', conversationsRouter);
+  return app;
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// GET /api/conversations/:id/messages
+// ═══════════════════════════════════════════════════════════════════
+
+describe('GET /api/conversations/:id/messages — cross-cohort gate', () => {
+  test('1:1 adult ↔ minor → 404 + audit', async () => {
+    setDoc('conversations/conv-1', { participantIds: ['user-A', 'user-B'] });
+    setDoc('users/user-B', { cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/conversations/conv-1/messages');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+    expect(mockSegregationAdd.mock.calls[0][0]).toMatchObject({
+      sourceUniqueId: 'user-A',
+      sourceCohort: 'adult',
+      targetUniqueId: 'user-B',
+      targetCohort: 'minor',
+    });
+  });
+
+  test('1:1 same-cohort returns messages', async () => {
+    setDoc('conversations/conv-1', { participantIds: ['user-A', 'user-B'] });
+    setDoc('users/user-B', { cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/conversations/conv-1/messages');
+
+    expect(res.status).toBe(200);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('group conversation skips the gate (deferred to PR 8 freeze)', async () => {
+    setDoc('conversations/conv-1', {
+      participantIds: ['user-A', 'user-B', 'user-C'],
+      isGroup: true,
+      groupName: 'Hangout',
+    });
+    // No user-B/user-C cohort lookup needed — gate doesn't run.
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/conversations/conv-1/messages');
+
+    expect(res.status).toBe(200);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('admin cross-cohort access allowed', async () => {
+    setDoc('conversations/conv-1', { participantIds: ['admin-user', 'user-B'] });
+    setDoc('users/user-B', { cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 'admin-user', cohort: 'adult', admin: true });
+    const res = await request(app).get('/api/conversations/conv-1/messages');
+
+    expect(res.status).toBe(200);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('missing other participant in 1:1 returns 404 (existence-hiding)', async () => {
+    setDoc('conversations/conv-1', { participantIds: ['user-A', 'user-B'] });
+    // No user-B doc.
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/conversations/conv-1/messages');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// POST /api/conversations/:id/messages
+// ═══════════════════════════════════════════════════════════════════
+
+describe('POST /api/conversations/:id/messages — cross-cohort gate', () => {
+  test('1:1 adult sending to minor → 404 + audit, no message persisted', async () => {
+    setDoc('conversations/conv-1', { participantIds: ['user-A', 'user-B'] });
+    setDoc('users/user-B', { cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/conversations/conv-1/messages')
+      .send({ text: 'hi', type: 'TEXT', senderName: 'Adult' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  test('1:1 same-cohort send proceeds', async () => {
+    setDoc('conversations/conv-1', { participantIds: ['user-A', 'user-B'] });
+    setDoc('users/user-B', { cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/conversations/conv-1/messages')
+      .send({ text: 'hello', type: 'TEXT', senderName: 'Adult' });
+
+    expect(res.status).toBe(200);
+    expect(mockBatchCommit).toHaveBeenCalled();
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('group conversation send skips gate', async () => {
+    setDoc('conversations/conv-1', {
+      participantIds: ['user-A', 'user-B', 'user-C'],
+      isGroup: true,
+    });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/conversations/conv-1/messages')
+      .send({ text: 'group', type: 'TEXT', senderName: 'Adult' });
+
+    expect(res.status).toBe(200);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('admin cross-cohort send allowed', async () => {
+    setDoc('conversations/conv-1', { participantIds: ['admin-user', 'user-B'] });
+    setDoc('users/user-B', { cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 'admin-user', cohort: 'adult', admin: true });
+    const res = await request(app)
+      .post('/api/conversations/conv-1/messages')
+      .send({ text: 'mod note', type: 'TEXT', senderName: 'Admin' });
+
+    expect(res.status).toBe(200);
+    expect(mockBatchCommit).toHaveBeenCalled();
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('POST missing other participant returns 404 (existence-hiding)', async () => {
+    setDoc('conversations/conv-1', { participantIds: ['user-A', 'user-B'] });
+    // No user-B doc.
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/conversations/conv-1/messages')
+      .send({ text: 'hi', type: 'TEXT', senderName: 'Adult' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+});

--- a/express-api/tests/routes/conversations.test.js
+++ b/express-api/tests/routes/conversations.test.js
@@ -55,6 +55,13 @@ jest.mock('../../src/utils/helpers', () => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // PR 4: the cross-cohort middleware fetches the other participant's
+  // user doc for 1:1 convs. Default to an empty-but-existing doc so
+  // the gate evaluates 'minor' vs 'minor' (fail-closed caller cohort
+  // since these tests don't set req.auth.token.cohort) and allows the
+  // request through. Tests that need specific doc content keep using
+  // mockResolvedValueOnce — those drain before the default fires.
+  mockDocGet.mockImplementation(() => Promise.resolve({ exists: true, data: () => ({}) }));
 });
 
 // ─── App setup ───────────────────────────────────────────────────

--- a/express-api/tests/routes/error-handling.test.js
+++ b/express-api/tests/routes/error-handling.test.js
@@ -388,8 +388,20 @@ describe('rooms: POST /api/rooms/:roomId/seat-requests returns 500 on Firestore 
 
     jest.mock('../../src/utils/firebase', () => ({
       db: {
-        doc: jest.fn(() => ({
-          get: jest.fn().mockResolvedValue({ exists: false, data: () => ({}) }),
+        // PR 4: rooms.js hoists the room + owner doc fetches above
+        // the collection.get call we want to throw. Make those fetches
+        // succeed (path-aware) so execution actually reaches the
+        // throwing collection.get.
+        doc: jest.fn((path) => ({
+          get: jest
+            .fn()
+            .mockResolvedValue(
+              path?.startsWith('rooms/')
+                ? { exists: true, data: () => ({ ownerId: 'owner-abc', name: 'R' }) }
+                : path?.startsWith('users/')
+                  ? { exists: true, data: () => ({}) }
+                  : { exists: false, data: () => ({}) },
+            ),
           update: jest.fn().mockResolvedValue(),
           set: jest.fn().mockResolvedValue(),
         })),

--- a/express-api/tests/routes/rooms-same-cohort.test.js
+++ b/express-api/tests/routes/rooms-same-cohort.test.js
@@ -1,0 +1,295 @@
+/**
+ * UK OSA #17 PR 4 — `requireSameCohort` route-wiring tests for
+ * `routes/rooms.js`.
+ *
+ *   POST /api/rooms/:roomId/invites/send   → gate caller↔invitee
+ *   POST /api/rooms/:roomId/seat-requests  → gate caller↔room owner
+ *                                            (room owner's cohort is
+ *                                            the stand-in for room.cohort
+ *                                            until PR 7 ships it).
+ *
+ * Each route: cross-cohort 404 + audit, same-cohort allow, admin bypass.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// ─── Firebase mock (path-aware) ─────────────────────────────────
+
+const mockDocGet = jest.fn();
+const mockDocUpdate = jest.fn().mockResolvedValue();
+const mockDocSet = jest.fn().mockResolvedValue();
+const mockCollectionWhereGet = jest.fn();
+const mockRtdbSet = jest.fn().mockResolvedValue();
+const mockSegregationAdd = jest.fn().mockResolvedValue({ id: 'evt_1' });
+
+// Path-aware: lets each test set up specific docs by path.
+const docResponses = new Map();
+function setDoc(path, data) {
+  docResponses.set(path, data);
+}
+function clearDocs() {
+  docResponses.clear();
+}
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    doc: jest.fn((path) => ({
+      _path: path,
+      get: () => mockDocGet(path),
+      update: (...args) => mockDocUpdate(path, ...args),
+      set: (...args) => mockDocSet(path, ...args),
+    })),
+    collection: jest.fn((name) => {
+      if (name === 'segregationEvents') {
+        return { add: mockSegregationAdd };
+      }
+      return {
+        where: jest.fn(() => ({
+          where: jest.fn(() => ({
+            limit: jest.fn(() => ({ get: mockCollectionWhereGet })),
+          })),
+        })),
+      };
+    }),
+  },
+  rtdb: {
+    ref: jest.fn(() => ({ set: mockRtdbSet })),
+  },
+  FieldValue: {
+    arrayRemove: jest.fn((...args) => `arrayRemove(${args})`),
+  },
+}));
+
+jest.mock('../../src/utils/helpers', () => ({
+  generateId: () => 'req-123',
+  now: () => 1709913600000,
+}));
+
+jest.mock('../../src/utils/fcm', () => ({
+  sendFcmToTokens: jest.fn().mockResolvedValue([]),
+  cleanupInvalidTokens: jest.fn().mockResolvedValue(),
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const mockIsLiveAdmin = jest.fn();
+jest.mock('../../src/middleware/auth', () => ({
+  isLiveAdmin: (...args) => mockIsLiveAdmin(...args),
+}));
+
+const { _resetAuditDedup } = require('../../src/middleware/sameCohort');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDocGet.mockReset();
+  mockSegregationAdd.mockReset();
+  mockSegregationAdd.mockResolvedValue({ id: 'evt_1' });
+  mockCollectionWhereGet.mockReset();
+  mockCollectionWhereGet.mockResolvedValue({ empty: true, docs: [] });
+  mockIsLiveAdmin.mockReset();
+  mockIsLiveAdmin.mockResolvedValue(true);
+  _resetAuditDedup();
+  clearDocs();
+
+  mockDocGet.mockImplementation((path) => {
+    if (docResponses.has(path)) {
+      const data = docResponses.get(path);
+      return Promise.resolve({
+        exists: data !== undefined && data !== null,
+        data: () => data,
+      });
+    }
+    return Promise.resolve({ exists: false, data: () => null });
+  });
+});
+
+// ─── App setup ───────────────────────────────────────────────────
+
+const roomsRouter = require('../../src/routes/rooms');
+
+function createApp({
+  uid = 'firebase-uid',
+  uniqueId = 'user-A',
+  cohort = 'adult',
+  admin = false,
+} = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.auth = {
+      uid,
+      uniqueId,
+      token: { cohort, ...(admin ? { admin: true } : {}) },
+    };
+    next();
+  });
+  app.use('/api', roomsRouter);
+  return app;
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// POST /api/rooms/:roomId/invites/send
+// ═══════════════════════════════════════════════════════════════════
+
+describe('POST /api/rooms/:roomId/invites/send — cross-cohort gate', () => {
+  test('adult inviting minor → 404 + audit', async () => {
+    setDoc('rooms/room-1', { name: 'Room', pendingInvites: {} });
+    setDoc('users/user-B', { cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/rooms/room-1/invites/send')
+      .send({ userId: 'user-B', invitedBy: 'user-A' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+    expect(mockSegregationAdd.mock.calls[0][0]).toMatchObject({
+      sourceUniqueId: 'user-A',
+      sourceCohort: 'adult',
+      targetUniqueId: 'user-B',
+      targetCohort: 'minor',
+      action: 'blocked',
+    });
+    // Critical: pendingInvites was NOT updated — gate ran first.
+    expect(mockDocUpdate).not.toHaveBeenCalled();
+  });
+
+  test('same-cohort invite proceeds normally', async () => {
+    setDoc('rooms/room-1', { name: 'Room', pendingInvites: {} });
+    setDoc('users/user-B', { cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/rooms/room-1/invites/send')
+      .send({ userId: 'user-B', invitedBy: 'user-A' });
+
+    expect(res.status).toBe(200);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+    expect(mockDocUpdate).toHaveBeenCalled();
+  });
+
+  test('admin cross-cohort invite is allowed', async () => {
+    setDoc('rooms/room-1', { name: 'Room', pendingInvites: {} });
+    setDoc('users/user-B', { cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult', admin: true });
+    const res = await request(app)
+      .post('/api/rooms/room-1/invites/send')
+      .send({ userId: 'user-B', invitedBy: 'user-A' });
+
+    expect(res.status).toBe(200);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('missing invitee → 404 Not found (existence-hiding)', async () => {
+    setDoc('rooms/room-1', { name: 'Room', pendingInvites: {} });
+    // No setDoc for users/user-B → fetch returns exists: false.
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/rooms/room-1/invites/send')
+      .send({ userId: 'user-B', invitedBy: 'user-A' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// POST /api/rooms/:roomId/seat-requests
+// ═══════════════════════════════════════════════════════════════════
+
+describe('POST /api/rooms/:roomId/seat-requests — cross-cohort gate', () => {
+  test('adult requesting seat in minor-owned room → 404 + audit', async () => {
+    setDoc('rooms/room-1', { name: 'Minor Room', ownerId: 'owner-M' });
+    setDoc('users/owner-M', { cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/rooms/room-1/seat-requests')
+      .send({ seatIndex: 3, userName: 'Bob' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+    expect(mockSegregationAdd.mock.calls[0][0]).toMatchObject({
+      sourceUniqueId: 'user-A',
+      sourceCohort: 'adult',
+      targetUniqueId: 'owner-M',
+      targetCohort: 'minor',
+      action: 'blocked',
+    });
+    // Seat-request doc must NOT have been created.
+    expect(mockDocSet).not.toHaveBeenCalled();
+  });
+
+  test('same-cohort seat-request proceeds normally', async () => {
+    setDoc('rooms/room-1', { name: 'Adult Room', ownerId: 'owner-A' });
+    setDoc('users/owner-A', { cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/rooms/room-1/seat-requests')
+      .send({ seatIndex: 3, userName: 'Bob' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.requestId).toBe('req-123');
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+    expect(mockDocSet).toHaveBeenCalled();
+  });
+
+  test('admin cross-cohort seat-request is allowed', async () => {
+    setDoc('rooms/room-1', { name: 'Minor Room', ownerId: 'owner-M' });
+    setDoc('users/owner-M', { cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult', admin: true });
+    const res = await request(app).post('/api/rooms/room-1/seat-requests').send({ seatIndex: 3 });
+
+    expect(res.status).toBe(200);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('room without ownerId is refused (404) — cannot resolve cohort', async () => {
+    // C3 fix (code-review). A malformed room without an `ownerId`
+    // cannot resolve the cohort stand-in; we refuse rather than let
+    // the API-layer gate fall through.
+    setDoc('rooms/room-1', { name: 'Anonymous Room' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).post('/api/rooms/room-1/seat-requests').send({ seatIndex: 3 });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Room not found' });
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('missing owner doc → 404 + audit (existence-hiding via middleware)', async () => {
+    // Reviewer I-test: owner deleted scenario.
+    setDoc('rooms/room-1', { name: 'Room', ownerId: 'deleted-owner' });
+    // No setDoc for 'users/deleted-owner' → ownerDoc null.
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).post('/api/rooms/room-1/seat-requests').send({ seatIndex: 3 });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    expect(mockDocSet).not.toHaveBeenCalled();
+  });
+
+  test('missing room → 404 (existing behavior preserved)', async () => {
+    // No setDoc for rooms/room-1.
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).post('/api/rooms/room-1/seat-requests').send({ seatIndex: 3 });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/express-api/tests/routes/rooms.test.js
+++ b/express-api/tests/routes/rooms.test.js
@@ -243,23 +243,27 @@ describe('POST /api/rooms/:roomId/invites/send', () => {
     expect(mockSendFcmToTokens).not.toHaveBeenCalled();
   });
 
-  test('skips FCM when invitee does not exist', async () => {
+  test('missing invitee returns 404 (PR 4 existence-hiding) — no FCM, no invite write', async () => {
+    // Pre-PR 4 this was a silent 200 + "skip FCM" — the missing-target
+    // signal leaks invitee existence to the caller. PR 4 enforces the
+    // cross-cohort middleware's existence-hiding contract: missing
+    // target user → 404 `{ error: 'Not found' }`, no side effects.
     mockDocGet
       .mockResolvedValueOnce({
         exists: true,
         data: () => ({ name: 'Room', pendingInvites: {} }),
       })
-      .mockResolvedValueOnce({
-        exists: false,
-      });
+      .mockResolvedValueOnce({ exists: false });
 
     const app = createApp('user-A');
-    await request(app)
+    const res = await request(app)
       .post('/api/rooms/room-1/invites/send')
-      .send({ userId: 'user-B', invitedBy: 'user-A' })
-      .expect(200);
+      .send({ userId: 'user-B', invitedBy: 'user-A' });
 
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
     expect(mockSendFcmToTokens).not.toHaveBeenCalled();
+    expect(mockDocUpdate).not.toHaveBeenCalled();
   });
 
   test('uses "Someone" when inviter displayName is missing', async () => {
@@ -620,21 +624,25 @@ describe('POST /api/rooms/:roomId/seat-requests', () => {
     expect(mockCleanupInvalidTokens).toHaveBeenCalledWith(['bad'], 'owner-1');
   });
 
-  test('skips FCM when room has no ownerId', async () => {
+  test('rooms without ownerId are refused (404) — PR 4 cohort-resolution requirement', async () => {
+    // Pre-PR 4: silently allowed (created seat-request, skipped FCM).
+    // Post-PR 4: cohort gate requires a resolvable owner; refuse rather
+    // than fall through to the Firestore rules backstop. Code-review C3.
     mockCollectionGet.mockResolvedValue({ empty: true, docs: [] });
-
     mockDocGet.mockResolvedValue({
       exists: true,
       data: () => ({ name: 'Ownerless Room' }), // No ownerId
     });
 
     const app = createApp('requester-1');
-    await request(app)
+    const res = await request(app)
       .post('/api/rooms/room-1/seat-requests')
-      .send({ userName: 'Bob', seatIndex: 1 })
-      .expect(200);
+      .send({ userName: 'Bob', seatIndex: 1 });
 
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Room not found' });
     expect(mockSendFcmToTokens).not.toHaveBeenCalled();
+    expect(mockDocSet).not.toHaveBeenCalled();
   });
 
   test('skips FCM when owner has no tokens', async () => {
@@ -659,41 +667,44 @@ describe('POST /api/rooms/:roomId/seat-requests', () => {
     expect(mockSendFcmToTokens).not.toHaveBeenCalled();
   });
 
-  test('skips FCM when owner doc does not exist', async () => {
+  test('missing owner doc returns 404 (PR 4 existence-hiding)', async () => {
+    // Pre-PR 4: silently created seat-request, skipped FCM, returned
+    // 200. Post-PR 4: middleware sees null target → 404 existence-
+    // hiding. Seat-request never created.
     mockCollectionGet.mockResolvedValue({ empty: true, docs: [] });
-
     mockDocGet
       .mockResolvedValueOnce({
         exists: true,
         data: () => ({ ownerId: 'owner-1', name: 'Room' }),
       })
-      .mockResolvedValueOnce({
-        exists: false,
-      });
+      .mockResolvedValueOnce({ exists: false });
 
     const app = createApp('requester-1');
-    await request(app)
+    const res = await request(app)
       .post('/api/rooms/room-1/seat-requests')
-      .send({ userName: 'Bob', seatIndex: 1 })
-      .expect(200);
+      .send({ userName: 'Bob', seatIndex: 1 });
 
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
     expect(mockSendFcmToTokens).not.toHaveBeenCalled();
+    expect(mockDocSet).not.toHaveBeenCalled();
   });
 
-  test('skips FCM when room doc does not exist (for FCM lookup)', async () => {
+  test('missing room doc returns 404 up front (no seat-request created)', async () => {
+    // Pre-PR 4: handler created the seat-request, then discovered no
+    // room in the FCM block and silently 200'd. Post-PR 4: room fetch
+    // is hoisted; missing room → 404 before any side effects.
     mockCollectionGet.mockResolvedValue({ empty: true, docs: [] });
-
-    mockDocGet.mockResolvedValue({
-      exists: false,
-    });
+    mockDocGet.mockResolvedValue({ exists: false });
 
     const app = createApp('requester-1');
-    await request(app)
+    const res = await request(app)
       .post('/api/rooms/room-1/seat-requests')
-      .send({ userName: 'Bob', seatIndex: 1 })
-      .expect(200);
+      .send({ userName: 'Bob', seatIndex: 1 });
 
+    expect(res.status).toBe(404);
     expect(mockSendFcmToTokens).not.toHaveBeenCalled();
+    expect(mockDocSet).not.toHaveBeenCalled();
   });
 
   test('uses "a room" as roomName fallback in seat request FCM', async () => {
@@ -778,6 +789,14 @@ describe('POST /api/rooms/:roomId/seat-requests', () => {
   // --- Top-level catch block (lines 186-193) ---
 
   test('returns 500 when seat request creation throws', async () => {
+    // PR 4 hoisted the room+owner fetches to the top — pre-stage them
+    // here so execution reaches the collection lookup that throws.
+    mockDocGet
+      .mockResolvedValueOnce({
+        exists: true,
+        data: () => ({ ownerId: 'owner-1', name: 'Room' }),
+      })
+      .mockResolvedValueOnce({ exists: true, data: () => ({}) });
     mockCollectionGet.mockRejectedValue(new Error('Firestore timeout'));
 
     const app = createApp('requester-1');

--- a/express-api/tests/routes/users-missing.test.js
+++ b/express-api/tests/routes/users-missing.test.js
@@ -315,6 +315,8 @@ describe('POST /api/users/:uniqueId/follow', () => {
   it('returns 404 when target user does not exist', async () => {
     // Pre-fix: target-doesnt-exist caused a 500 (Firestore batch
     // update on non-existent doc). Now returns the correct 404.
+    // PR 4 changed the body to `{ error: 'Not found' }` so missing-
+    // target and cross-cohort 404s share an existence-hiding shape.
     mockDocGet.mockResolvedValueOnce({ exists: false });
     const app = createApp('uid-A', 10000001);
     const res = await request(app)
@@ -322,7 +324,7 @@ describe('POST /api/users/:uniqueId/follow', () => {
       .send({ targetUserId: 99999999 });
 
     expect(res.status).toBe(404);
-    expect(res.body.error).toMatch(/target user not found/i);
+    expect(res.body).toEqual({ error: 'Not found' });
   });
 });
 
@@ -347,6 +349,10 @@ describe('POST /api/users/:uniqueId/unfollow', () => {
   });
 
   it('returns 200 and removes follow relationship on success', async () => {
+    // PR 4: unfollow now fetches the target's user doc for the
+    // cross-cohort gate. Mock target as existing with no cohort
+    // (effectiveCohort → 'minor', matches the fail-closed caller).
+    mockDocGet.mockResolvedValueOnce({ exists: true, data: () => ({}) });
     const app = createApp('uid-A', 10000001);
     const res = await request(app)
       .post('/api/users/10000001/unfollow')
@@ -382,6 +388,10 @@ describe('POST /api/users/:uniqueId/remove-follower', () => {
   });
 
   it('returns 200 and removes follower relationship on success', async () => {
+    // PR 4: remove-follower now fetches the follower's user doc for
+    // the cross-cohort gate. Mock as existing same-cohort (no cohort
+    // field → 'minor', matches fail-closed caller).
+    mockDocGet.mockResolvedValueOnce({ exists: true, data: () => ({}) });
     const app = createApp('uid-A', 10000001);
     const res = await request(app)
       .post('/api/users/10000001/remove-follower')

--- a/express-api/tests/routes/users-same-cohort.test.js
+++ b/express-api/tests/routes/users-same-cohort.test.js
@@ -1,0 +1,522 @@
+/**
+ * UK OSA #17 PR 4 — `requireSameCohort` route-wiring tests for
+ * `routes/users.js`. Pins the cross-cohort 404 + `segregationEvents`
+ * audit contract for every user-to-user interaction endpoint:
+ *
+ *   GET    /api/users/:uniqueId                  (profile view)
+ *   POST   /api/users/:uniqueId/follow
+ *   POST   /api/users/:uniqueId/unfollow
+ *   POST   /api/users/:uniqueId/remove-follower
+ *   POST   /api/users/:uniqueId/record-visit
+ *
+ * Each route gets three scenarios:
+ *   1. Cross-cohort caller   → 404 `{ error: 'Not found' }` +
+ *      `segregationEvents` audit doc.
+ *   2. Same-cohort caller    → existing success path.
+ *   3. Admin caller          → bypass, success path; NO audit doc.
+ *
+ * The 404 body MUST be byte-identical to the "target does not exist"
+ * 404 — that's the existence-hiding contract.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// ─── Firebase + helper mocks ────────────────────────────────────
+
+const mockDocGet = jest.fn();
+const mockDocSet = jest.fn().mockResolvedValue();
+const mockDocUpdate = jest.fn().mockResolvedValue();
+const mockBatchSet = jest.fn();
+const mockBatchUpdate = jest.fn();
+const mockBatchCommit = jest.fn().mockResolvedValue();
+const mockSegregationAdd = jest.fn().mockResolvedValue({ id: 'evt_1' });
+const mockCollection = jest.fn((name) => {
+  if (name === 'segregationEvents') return { add: mockSegregationAdd };
+  return { add: jest.fn() };
+});
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    doc: jest.fn((path) => ({
+      _path: path,
+      get: (...args) => mockDocGet(path, ...args),
+      set: (...args) => mockDocSet(path, ...args),
+      update: (...args) => mockDocUpdate(path, ...args),
+    })),
+    batch: jest.fn(() => ({
+      set: mockBatchSet,
+      update: mockBatchUpdate,
+      commit: mockBatchCommit,
+    })),
+    collection: (...args) => mockCollection(...args),
+    runTransaction: jest.fn(),
+  },
+  auth: {
+    setCustomUserClaims: jest.fn().mockResolvedValue(),
+    getUser: jest.fn().mockResolvedValue({ customClaims: {} }),
+  },
+  FieldValue: {
+    increment: jest.fn((n) => `increment(${n})`),
+    arrayUnion: jest.fn((...args) => `arrayUnion(${args})`),
+    arrayRemove: jest.fn((...args) => `arrayRemove(${args})`),
+  },
+}));
+
+jest.mock('../../src/utils/helpers', () => ({
+  generateId: () => 'gen-id',
+  now: () => 1709913600000,
+}));
+
+jest.mock('../../src/utils/firestore-helpers', () => ({
+  getDoc: jest.fn(),
+}));
+
+const mockIsLiveAdmin = jest.fn();
+jest.mock('../../src/middleware/auth', () => ({
+  clearSuspensionCache: jest.fn(),
+  clearUniqueIdCache: jest.fn(),
+  updateUniqueIdCache: jest.fn(),
+  isLiveAdmin: (...args) => mockIsLiveAdmin(...args),
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('../../src/utils/block-check', () => ({
+  viewerIsBlocked: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../../src/utils/email', () => ({ sendEmail: jest.fn() }));
+jest.mock('../../src/utils/email-templates', () => ({ buildDeletionScheduledEmail: jest.fn() }));
+jest.mock('../../src/utils/fcm', () => ({ sendFcmToTokens: jest.fn() }));
+
+const { getDoc } = require('../../src/utils/firestore-helpers');
+const { _resetAuditDedup } = require('../../src/middleware/sameCohort');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDocGet.mockReset();
+  mockSegregationAdd.mockReset();
+  mockSegregationAdd.mockResolvedValue({ id: 'evt_1' });
+  mockIsLiveAdmin.mockReset();
+  mockIsLiveAdmin.mockResolvedValue(true);
+  _resetAuditDedup();
+});
+
+// ─── App setup with injectable cohort + admin ───────────────────
+
+const usersRouter = require('../../src/routes/users');
+
+/**
+ * Boots a test Express app whose injected auth middleware sets
+ * `req.auth = { uid, uniqueId, token: { cohort, admin? } }`.
+ */
+function createApp({
+  uid = 'firebase-uid-A',
+  uniqueId = 10000001,
+  cohort = 'adult',
+  admin = false,
+} = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.auth = { uid, uniqueId, token: { cohort, ...(admin ? { admin: true } : {}) } };
+    next();
+  });
+  app.use('/api', usersRouter);
+  return app;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+/** Set up `getDoc` to return a user doc by uniqueId. */
+function mockUserDoc(uniqueId, data) {
+  getDoc.mockImplementation((path) => {
+    if (path === `users/${uniqueId}`) return Promise.resolve(data);
+    return Promise.resolve(null);
+  });
+}
+
+/** Set up `db.doc(...).get()` to return a snapshot for a uniqueId. */
+function mockSnapshot(uniqueId, data) {
+  mockDocGet.mockImplementation((path) => {
+    if (path === `users/${uniqueId}`) {
+      return Promise.resolve({
+        exists: data !== undefined && data !== null,
+        data: () => data,
+      });
+    }
+    return Promise.resolve({ exists: false });
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// GET /api/users/:uniqueId  (profile view)
+// ═══════════════════════════════════════════════════════════════════
+
+describe('GET /api/users/:uniqueId — cross-cohort gate', () => {
+  test('adult viewing minor profile → 404 + segregationEvents audit', async () => {
+    mockUserDoc(10000200, { uniqueId: 10000200, cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app).get('/api/users/10000200');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+
+    // Flush pending fire-and-forget audit write.
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+    expect(mockSegregationAdd.mock.calls[0][0]).toMatchObject({
+      sourceUniqueId: '10000001',
+      sourceCohort: 'adult',
+      targetUniqueId: '10000200',
+      targetCohort: 'minor',
+      action: 'blocked',
+    });
+  });
+
+  test('minor viewing adult profile → 404 + audit (symmetry)', async () => {
+    mockUserDoc(10000100, { uniqueId: 10000100, cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 10000050, cohort: 'minor' });
+    const res = await request(app).get('/api/users/10000100');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+  });
+
+  test('same-cohort: adult → adult profile returns 200', async () => {
+    mockUserDoc(10000200, {
+      uniqueId: 10000200,
+      cohort: 'adult',
+      displayName: 'Bob',
+    });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app).get('/api/users/10000200');
+
+    expect(res.status).toBe(200);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('self-view always allowed regardless of cohort lookup', async () => {
+    mockUserDoc(10000001, { uniqueId: 10000001, cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app).get('/api/users/10000001');
+
+    expect(res.status).toBe(200);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('admin viewing cross-cohort profile is allowed, no audit doc', async () => {
+    mockUserDoc(10000200, { uniqueId: 10000200, cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult', admin: true });
+    const res = await request(app).get('/api/users/10000200');
+
+    expect(res.status).toBe(200);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('missing target profile returns 404 with identical body (existence-hiding)', async () => {
+    mockUserDoc(99999999, null);
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app).get('/api/users/99999999');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('caller with stripped cohort claim (no token.cohort) is treated as minor', async () => {
+    // I6 reviewer test: route-integration level coverage for the
+    // fail-closed `cohortFromClaim` path. Stripped claim → 'minor'
+    // → cannot view an adult profile.
+    mockUserDoc(10000200, { uniqueId: 10000200, cohort: 'adult' });
+
+    // createApp default cohort='adult'; override by injecting raw
+    // auth without the cohort claim.
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.auth = { uid: 'fb-uid', uniqueId: 10000001, token: {} };
+      next();
+    });
+    app.use('/api', usersRouter);
+
+    const res = await request(app).get('/api/users/10000200');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+    expect(mockSegregationAdd.mock.calls[0][0].sourceCohort).toBe('minor');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// POST /api/users/:uniqueId/follow
+// ═══════════════════════════════════════════════════════════════════
+
+describe('POST /api/users/:uniqueId/follow — cross-cohort gate', () => {
+  test('adult following minor target → 404 + audit', async () => {
+    mockSnapshot(10000200, { uniqueId: 10000200, cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/users/10000001/follow')
+      .send({ targetUserId: 10000200 });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  test('same-cohort follow succeeds and writes batch', async () => {
+    mockSnapshot(10000200, { uniqueId: 10000200, cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/users/10000001/follow')
+      .send({ targetUserId: 10000200 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+  });
+
+  test('admin cross-cohort follow is allowed', async () => {
+    mockSnapshot(10000200, { uniqueId: 10000200, cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult', admin: true });
+    const res = await request(app)
+      .post('/api/users/10000001/follow')
+      .send({ targetUserId: 10000200 });
+
+    expect(res.status).toBe(200);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+  });
+
+  test('missing target user → 404 Not found (matches cross-cohort body)', async () => {
+    mockSnapshot(99999999, null);
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/users/10000001/follow')
+      .send({ targetUserId: 99999999 });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// POST /api/users/:uniqueId/unfollow
+// ═══════════════════════════════════════════════════════════════════
+
+describe('POST /api/users/:uniqueId/unfollow — cross-cohort gate', () => {
+  test('adult unfollowing minor → 404 + audit (existence-hiding)', async () => {
+    mockSnapshot(10000200, { uniqueId: 10000200, cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/users/10000001/unfollow')
+      .send({ targetUserId: 10000200 });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  test('same-cohort unfollow succeeds', async () => {
+    mockSnapshot(10000200, { uniqueId: 10000200, cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/users/10000001/unfollow')
+      .send({ targetUserId: 10000200 });
+
+    expect(res.status).toBe(200);
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+  });
+
+  test('admin cross-cohort unfollow allowed', async () => {
+    mockSnapshot(10000200, { uniqueId: 10000200, cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult', admin: true });
+    const res = await request(app)
+      .post('/api/users/10000001/unfollow')
+      .send({ targetUserId: 10000200 });
+
+    expect(res.status).toBe(200);
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+  });
+
+  test('missing target → 404 Not found (existence-hiding via middleware)', async () => {
+    mockSnapshot(99999999, null);
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/users/10000001/unfollow')
+      .send({ targetUserId: 99999999 });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  test('non-integer targetUserId rejected with 400 (NaN-poisoning defence)', async () => {
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/users/10000001/unfollow')
+      .send({ targetUserId: '123abc' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive integer/i);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// POST /api/users/:uniqueId/remove-follower
+// ═══════════════════════════════════════════════════════════════════
+
+describe('POST /api/users/:uniqueId/remove-follower — cross-cohort gate', () => {
+  test('adult removing minor follower → 404 + audit', async () => {
+    mockSnapshot(10000200, { uniqueId: 10000200, cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/users/10000001/remove-follower')
+      .send({ followerUserId: 10000200 });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  test('same-cohort remove-follower succeeds', async () => {
+    mockSnapshot(10000200, { uniqueId: 10000200, cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/users/10000001/remove-follower')
+      .send({ followerUserId: 10000200 });
+
+    expect(res.status).toBe(200);
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+  });
+
+  test('admin cross-cohort remove-follower allowed', async () => {
+    mockSnapshot(10000200, { uniqueId: 10000200, cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult', admin: true });
+    const res = await request(app)
+      .post('/api/users/10000001/remove-follower')
+      .send({ followerUserId: 10000200 });
+
+    expect(res.status).toBe(200);
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+  });
+
+  test('missing follower → 404 Not found (existence-hiding)', async () => {
+    mockSnapshot(99999999, null);
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/users/10000001/remove-follower')
+      .send({ followerUserId: 99999999 });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  test('non-integer followerUserId rejected with 400', async () => {
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/users/10000001/remove-follower')
+      .send({ followerUserId: '123abc' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive integer/i);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// POST /api/users/:uniqueId/record-visit
+// ═══════════════════════════════════════════════════════════════════
+// Note: the *visitor* is the caller; the *profile owner* (:uniqueId)
+// is the target. record-visit gates on the profile-owner's cohort.
+
+describe('POST /api/users/:uniqueId/record-visit — cross-cohort gate', () => {
+  test('adult visitor recording on minor profile → 404 + audit', async () => {
+    // getDoc is called for both block-check AND middleware's fetch.
+    // Return the same minor profile for both.
+    mockUserDoc(10000200, { uniqueId: 10000200, cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/users/10000200/record-visit')
+      .send({ visitorId: 10000001 });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+  });
+
+  test('same-cohort visit recorded normally', async () => {
+    // getDoc returns the target user (no block) AND lets the existing
+    // stalker doc not exist (new visit).
+    getDoc.mockImplementation((path) => {
+      if (path === `users/10000200`) {
+        return Promise.resolve({ uniqueId: 10000200, cohort: 'adult' });
+      }
+      // stalker subcollection doc — return null so "new visit" path
+      // is taken (idempotent batch).
+      return Promise.resolve(null);
+    });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/users/10000200/record-visit')
+      .send({ visitorId: 10000001 });
+
+    expect(res.status).toBe(200);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('admin cross-cohort visit recorded', async () => {
+    getDoc.mockImplementation((path) => {
+      if (path === `users/10000200`) {
+        return Promise.resolve({ uniqueId: 10000200, cohort: 'minor' });
+      }
+      return Promise.resolve(null);
+    });
+
+    const app = createApp({ uniqueId: 10000001, cohort: 'adult', admin: true });
+    const res = await request(app)
+      .post('/api/users/10000200/record-visit')
+      .send({ visitorId: 10000001 });
+
+    expect(res.status).toBe(200);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+});

--- a/express-api/tests/routes/users.test.js
+++ b/express-api/tests/routes/users.test.js
@@ -708,7 +708,12 @@ describe('POST /api/users/:uniqueId/record-visit', () => {
   });
 
   test('creates new stalker doc with lastVisitedAt field', async () => {
-    getDoc.mockResolvedValue(null); // new visitor
+    // PR 4: target user fetch for cross-cohort gate happens BEFORE
+    // stalker subdoc fetch. Differentiate by path: target user exists
+    // with no cohort (→ 'minor'); stalker subdoc null = new visit.
+    getDoc.mockImplementation((path) =>
+      path === 'users/10000099' ? Promise.resolve({}) : Promise.resolve(null),
+    );
     const app = createApp('firebase-uid-visitor', 10000002);
 
     await request(app)

--- a/express-api/tests/utils/firebase-claims.test.js
+++ b/express-api/tests/utils/firebase-claims.test.js
@@ -39,6 +39,7 @@ const {
   effectiveCohort,
   deriveCohortFromUser,
   isAtLeast18FromDob,
+  cohortFromClaim,
   VALID_COHORTS,
 } = require('../../src/utils/firebase-claims');
 
@@ -270,5 +271,34 @@ describe('VALID_COHORTS allow-list', () => {
     expect(VALID_COHORTS.has('minor')).toBe(true);
     expect(VALID_COHORTS.has('Adult')).toBe(false);
     expect(VALID_COHORTS.has('verified-adult')).toBe(false);
+  });
+});
+
+describe('cohortFromClaim', () => {
+  test('returns claim when it is an allow-listed cohort', () => {
+    expect(cohortFromClaim({ auth: { token: { cohort: 'adult' } } })).toBe('adult');
+    expect(cohortFromClaim({ auth: { token: { cohort: 'minor' } } })).toBe('minor');
+  });
+
+  test('fail-closed to "minor" when claim is missing', () => {
+    expect(cohortFromClaim({ auth: { token: {} } })).toBe('minor');
+    expect(cohortFromClaim({ auth: {} })).toBe('minor');
+    expect(cohortFromClaim({})).toBe('minor');
+    expect(cohortFromClaim(null)).toBe('minor');
+    expect(cohortFromClaim(undefined)).toBe('minor');
+  });
+
+  test('fail-closed to "minor" for non-string / invalid claim values', () => {
+    expect(cohortFromClaim({ auth: { token: { cohort: null } } })).toBe('minor');
+    expect(cohortFromClaim({ auth: { token: { cohort: 42 } } })).toBe('minor');
+    expect(cohortFromClaim({ auth: { token: { cohort: true } } })).toBe('minor');
+    expect(cohortFromClaim({ auth: { token: { cohort: '' } } })).toBe('minor');
+  });
+
+  test('fail-closed to "minor" for strings not in the allow-list (case-sensitive)', () => {
+    expect(cohortFromClaim({ auth: { token: { cohort: 'Adult' } } })).toBe('minor');
+    expect(cohortFromClaim({ auth: { token: { cohort: 'ADULT' } } })).toBe('minor');
+    expect(cohortFromClaim({ auth: { token: { cohort: 'verified-adult' } } })).toBe('minor');
+    expect(cohortFromClaim({ auth: { token: { cohort: 'staff' } } })).toBe('minor');
   });
 });


### PR DESCRIPTION
## Summary

- Express middleware `requireSameCohort` that gates user-to-user interactions across cohorts: returns 404 'Not found' (existence-hiding) and writes a deduped `segregationEvents` audit doc when caller and target are different cohorts
- Wired into the user-to-user interaction surfaces that exist as Express endpoints today: `users.js` (GET profile, POST follow/unfollow/remove-follower/record-visit), `rooms.js` (POST invites/send + seat-requests), `conversations.js` (GET + POST 1:1 messages — group convs deferred to PR 8)
- Comprehensive security baked in: live admin re-check, audit-write LRU dedup, self-target short-circuit, ownerless rooms refused, NaN-poisoning defence on unfollow + remove-follower

## Scope reality vs. spec

The plan listed `users.js (follow/unfollow/list/search)`, `rooms.js (join/list/participants)`, `conversations.js (create/message)`. Of these, `list`, `search`, `join`, `participants`, and `create` are **not Express endpoints** — those actions happen client-direct-Firestore, gated at the rules layer (PR 3). This PR wires every Express endpoint where user-to-user gating is meaningful; PR 5 covers discovery/search at the Firestore query level.

## Security-review fixes baked in

- **HIGH** Live admin check via `isLiveAdmin` (auth.js) — defends against demoted-admin tokens retaining cross-cohort visibility for the rest of their ~1h JWT lifetime
- **HIGH** Audit-write dedup LRU — caps the same `source:target:surface` tuple to one write per 5-minute window, defending the Firestore quota + audit-signal integrity against attempt-spam DoS
- **MEDIUM** Self-target short-circuit centralised in the middleware (saves a Firestore read + closes the stale-token self-DoS window for own-room seat-requests)
- **MEDIUM** Ownerless rooms refused with 404 'Room not found' — the cohort gate can't resolve without an owner; fail closed rather than fall through to the Firestore rules backstop (code-review C3)
- **MEDIUM** Integer validation on `unfollow` + `remove-follower` mirrors the strict round-trip parser in `follow` (Phase 2A audit H3) — closes the NaN-poisoning vector on `followingIds`/`followerIds`

## Deferred (with rationale)

- **Stale-claim self-DoS post-age-up** (MEDIUM): a just-aged-up user gets 404s on adult-cohort interactions for up to ~1h until natural token rotation. This requires client-side `getIdToken(true)` wiring on cohort-flip detection, which is outside PR 4 scope. Tracked for the client-side PR (PR 10 / PR 12) — the design doc § "Birthday rollover during long-lived session" acknowledges this window.

## Test plan

- [x] 17 dedicated middleware tests (admin live-check, dedup, self-target, existence-hiding, audit-failure fail-closed)
- [x] 24 users.js route tests (5 routes × cross/same/admin/missing-target/stripped-claim/non-integer)
- [x] 11 rooms.js route tests (invites/send + seat-requests + ownerless + missing owner)
- [x] 10 conversations.js route tests (1:1 cross/same/admin/missing-target + group skip)
- [x] Existing test suite regression check: **4941/4941 jest pass** (8 pre-existing skips)
- [x] ktlint clean
- [x] gradle `testDevDebugUnitTest :shared:jvmTest detekt :shared:compileKotlinIosArm64` SUCCESS in 1m 27s
- [x] code-reviewer agent + security-reviewer agent reviewed; all findings addressed in this PR
- [x] Local stack stood up + Express ran against emulator (full token-mint flow deferred to CI integration tests)
- [ ] Pending: CI matrix (Playwright + E2E + integration tests against real emulator)

## References

- Spec: `.project/plans/2026-05-13-age-segregation-plan.md` § PR 4
- Issue: #17 (UK OSA age-segregation)
- Builds on: PR 1 (cohort data model), PR 2 (custom claim plumbing), PR 3 (Firestore rules cross-cohort gates + segregationEvents collection)
- Followed by: PR 5 (discovery/search filter), PR 6 (follow gate + migration), PR 7+ (room cohort, conversations migration, KMP+UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)