### PR TITLE
feat(seg): PR 6 of 14 — follow gates + relationship migration script (#17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ playwright-errors.log
 # Migration scripts (one-time use)
 scripts/migrate-*.mjs
 
+# Migration snapshots — contain displayName + cohort tags (PII-adjacent)
+express-api/migration-snapshots/
+
 # Archived Cloud Functions (deleted from project)
 functions-archive/
 

--- a/express-api/scripts/migrate-segregation-relationships.js
+++ b/express-api/scripts/migrate-segregation-relationships.js
@@ -1,0 +1,461 @@
+#!/usr/bin/env node
+/**
+ * One-shot migration: revoke pre-existing cross-cohort follow
+ * relationships and notify both parties. UK OSA #17 PR 6.
+ *
+ * Background: PR 1–5 introduced the cohort-segregation gates at the
+ * route / rules / discovery layers, but legacy follow edges from
+ * before the rollout still link `adult ↔ minor` pairs. The route
+ * gate (PR 4) hides cross-cohort interactions on the request side,
+ * but the stored edges remain inside the follower / following
+ * counts and would re-emerge if a code path bypassed the gate (or if
+ * the gate ever shipped a bug). This migration removes those edges
+ * server-side, dispatches a system PM to both parties so the
+ * disappearance is auditable, and writes a `segregationEvents` row
+ * per migrated edge so PR 3's audit collection captures the loudest
+ * cross-cohort event class.
+ *
+ * Algorithm:
+ *   1. Scan the `users` collection once, building a cohort +
+ *      displayName + blockedUserIds index.
+ *   2. For each user, walk `followingIds[]` (canonical edge
+ *      direction — A.followingIds containing B means A→B).
+ *   3. Strict integer validation on both endpoints. Non-integer ids
+ *      are treated as stale + skipped (the live follow route enforces
+ *      strict-integer; non-integers in the array are data corruption,
+ *      out of scope for this migration).
+ *   4. For each edge whose endpoint cohorts differ, record the edge;
+ *      otherwise count as preserved. Edges to ids absent from the
+ *      `users` collection are counted stale.
+ *   5. In `--apply` mode, the same scan is reused: one transaction
+ *      per edge calls `arrayRemove` on BOTH sides (mirrors how
+ *      `follow` writes both sides via batched update). Then a
+ *      `segregationEvents` audit row is written, then `sendSystemPm`
+ *      to both parties.
+ *
+ * Fail-safety:
+ *   - `--apply` requires `MIGRATION_CONFIRM=yes` env var.
+ *   - `--dry-run` and `--apply` are mutually exclusive (no silent
+ *     fallback).
+ *   - Pre-flight JSON snapshot listing every edge that WOULD be
+ *     removed, written mode 0o600 (cohort + displayName are PII).
+ *   - Each edge has its own transaction; a single failed transaction
+ *     stops the migration but already-committed edges stay durable.
+ *   - PM-dispatch failures are caught + counted (do NOT roll back the
+ *     transactional removal — the load-bearing op is the edge revoke,
+ *     and arrayRemove is idempotent, so a replay is safe).
+ *   - Block-bypass: if the recipient blocked the counterparty before
+ *     the migration ran, the system-PM substitutes "another user" for
+ *     the counterparty displayName so the blocked name does not
+ *     resurface.
+ *
+ * Cohort taxonomy is imported from `src/utils/firebase-claims` so
+ * this script's notion of `effectiveCohort` / `VALID_COHORTS` cannot
+ * drift from the live request path. A startup assertion confirms the
+ * imported set is non-empty as a defensive sanity check.
+ *
+ * Scope: this script ONLY migrates follow-graph edges. The broader
+ * segregation cutover includes additional relationship classes (1:1
+ * conversations, group conversations, rooms, stalker history) which
+ * are migrated by separate PRs in the same sequence (PR 7+). An
+ * OSA-defensibility claim that "all pre-existing cross-cohort
+ * relationships have been remediated" is FALSE on the basis of this
+ * PR alone — only the follow-edge subset is covered here.
+ *
+ * Usage:
+ *   node scripts/migrate-segregation-relationships.js --dry-run
+ *   MIGRATION_CONFIRM=yes node scripts/migrate-segregation-relationships.js --apply
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { db, FieldValue } = require('../src/utils/firebase');
+const { effectiveCohort, VALID_COHORTS } = require('../src/utils/firebase-claims');
+const { sendSystemPm } = require('../src/utils/system-pm');
+const log = require('../src/utils/log');
+
+const SAFE_DISPLAY_NAME_MAX_LEN = 64;
+const SEGREGATION_EVENTS_COLLECTION = 'segregationEvents';
+
+// Defensive: if `firebase-claims` ever expands to no/null exports,
+// fail loud at module load — better than silently treating every user
+// as `'minor'`.
+if (!(VALID_COHORTS instanceof Set) || VALID_COHORTS.size === 0) {
+  throw new Error('migrate-seg-relationships: VALID_COHORTS import is empty or invalid');
+}
+
+// Mirrors the strict-integer validation pattern used by the live
+// follow route (users.js:976-988). The follow handler refuses to
+// add non-integer ids, but legacy data may contain them — so the
+// migration validates both sides at the boundary too.
+function isPositiveIntegerString(value) {
+  if (value === null || value === undefined) return false;
+  const asStr = String(value).trim();
+  if (!/^\d+$/.test(asStr)) return false;
+  const asInt = Number.parseInt(asStr, 10);
+  return Number.isInteger(asInt) && asInt > 0 && String(asInt) === asStr;
+}
+
+function sanitiseDisplayName(raw) {
+  if (typeof raw !== 'string') return null;
+  // Defence layers, in order (ORDER MATTERS):
+  //   1. strip raw HTML brackets + ampersand so a markup-aware
+  //      renderer cannot interpret the name as tags / entities
+  //   2. collapse \r \n \t to space BEFORE the C0 strip — otherwise
+  //      the next step removes them entirely and the two halves of
+  //      a multi-line name end up adjacent, partially defeating
+  //      the injection defence (word boundaries lost)
+  //   3. collapse the unicode line / paragraph separators (U+2028 /
+  //      U+2029) to space explicitly; JS \s in step 6 would catch
+  //      these too but the explicit strip is contract-stable
+  //   4. strip C0 + DEL + C1 control range (U+0080–U+009F includes
+  //      U+0085 NEL, which some downstream renderers + log
+  //      aggregators treat as a record terminator)
+  //   5. strip zero-width / format chars: U+200B-U+200F + U+2060-U+2064
+  //      + U+FEFF (BOM) + U+061C (Arabic Letter Mark bidi formatter)
+  //   6. strip bidi overrides U+202A-U+202E + U+2066-U+2069 — RTL
+  //      spoofing of the surrounding copy
+  //   7. collapse runs of whitespace + trim
+  //   8. cap length so a 10k-char name can't blow up the PM body
+  const cleaned = raw
+    .replace(/[<>&]/g, '')
+    .replace(/[\r\n\t]/g, ' ')
+    .replace(/[\u2028\u2029]/g, ' ')
+    // eslint-disable-next-line no-control-regex -- the control chars in this range ARE the strip targets; the lint defends against accidental control chars in patterns, not intentional ones.
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, '')
+    .replace(/[\u061C\u200B-\u200F\u2060-\u2064\uFEFF]/g, '')
+    .replace(/[\u202A-\u202E\u2066-\u2069]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (cleaned.length === 0) return null;
+  if (cleaned.length > SAFE_DISPLAY_NAME_MAX_LEN) {
+    return cleaned.slice(0, SAFE_DISPLAY_NAME_MAX_LEN - 1).trimEnd() + '…';
+  }
+  return cleaned;
+}
+
+function formatRelationshipRemovedPm({ counterpartyDisplayName }) {
+  // Cohort-agnostic copy: the recipient already knows their OWN
+  // cohort, so any phrasing that says "the two of you are in
+  // different groups" lets them infer the counterparty's cohort.
+  // Stick to policy-language ("a recent change") so the notification
+  // is informative but not an inferential side-channel. The test
+  // suite pins both negative assertions (no cohort vocabulary) AND
+  // a positive assertion on the load-bearing phrase.
+  const safe = sanitiseDisplayName(counterpartyDisplayName);
+  const subject = safe ?? 'another user';
+  return [
+    `Your follow link with ${subject} has been removed as part of a recent change to how ShyTalk organises accounts.`,
+    '',
+    "This is automatic; it doesn't reflect anything either of you did, and the original link can't be restored from here.",
+    '',
+    "If you don't recognise the name, this just means a past connection has been tidied up.",
+  ].join('\n');
+}
+
+async function scanCrossCohortEdges() {
+  const usersSnap = await db.collection('users').get();
+
+  // Single-pass cohort + blocked-list index over the whole user
+  // collection. The follow-edge walk below resolves counterparty
+  // cohort via this map; non-indexed ids are treated as stale (no
+  // point-read fallback — the collection().get() snapshot is the
+  // canonical universe of users for this one-shot run).
+  const index = new Map();
+  for (const doc of usersSnap.docs) {
+    const data = doc.data();
+    index.set(doc.id, {
+      cohort: effectiveCohort(data),
+      displayName: data?.displayName ?? null,
+      blockedUserIds: Array.isArray(data?.blockedUserIds) ? data.blockedUserIds : [],
+    });
+  }
+
+  const crossCohortEdges = [];
+  let preservedFollowsCount = 0;
+  let staleEdgeCount = 0;
+
+  for (const doc of usersSnap.docs) {
+    const fromId = doc.id;
+    if (!isPositiveIntegerString(fromId)) {
+      // System user (SHYTALK_SYSTEM) or other non-numeric doc-id —
+      // legitimate, has no follow edges to migrate. Skip silently.
+      continue;
+    }
+    const data = doc.data();
+    const fromEntry = index.get(fromId);
+    const followingIds = Array.isArray(data?.followingIds) ? data.followingIds : [];
+    for (const rawTo of followingIds) {
+      if (!isPositiveIntegerString(rawTo)) {
+        // Corrupted entry: non-integer in followingIds. Skip + count
+        // — a separate dangling-id sweeper deals with cleanup.
+        staleEdgeCount += 1;
+        continue;
+      }
+      const toId = String(Number.parseInt(String(rawTo), 10));
+      const toEntry = index.get(toId);
+      if (!toEntry) {
+        // Counterparty doc not present in the scan — stale id.
+        staleEdgeCount += 1;
+        continue;
+      }
+      if (fromEntry.cohort === toEntry.cohort) {
+        preservedFollowsCount += 1;
+        continue;
+      }
+      crossCohortEdges.push({
+        from: fromId,
+        fromCohort: fromEntry.cohort,
+        fromDisplayName: fromEntry.displayName,
+        fromBlockedToUser: fromEntry.blockedUserIds.some((id) => String(id) === toId),
+        to: toId,
+        toCohort: toEntry.cohort,
+        toDisplayName: toEntry.displayName,
+        toBlockedFromUser: toEntry.blockedUserIds.some((id) => String(id) === fromId),
+      });
+    }
+  }
+
+  return {
+    crossCohortEdges,
+    affectedFollowsCount: crossCohortEdges.length,
+    preservedFollowsCount,
+    staleEdgeCount,
+  };
+}
+
+async function applyMigration({ dryRun, scan } = {}) {
+  // The caller can pre-compute the scan (main() does this so the
+  // snapshot file and the applied writes describe the same graph
+  // state — otherwise a concurrent follow/cohort flip between the
+  // two scans could make the snapshot misleading).
+  const effectiveScan = scan ?? (await scanCrossCohortEdges());
+  if (dryRun) {
+    return {
+      ...effectiveScan,
+      pmDispatchFailures: 0,
+      pmDispatchFailedRecipients: [],
+      segregationEventFailures: 0,
+    };
+  }
+
+  let pmDispatchFailures = 0;
+  // Explicit list of recipient uniqueIds whose PM dispatch failed —
+  // surfaced alongside the counter so an operator can manually
+  // re-broadcast from the snapshot. arrayRemove on the edge already
+  // committed is idempotent (no-op), so the scan won't re-pick the
+  // edge on a future run — those PMs would otherwise be lost.
+  const pmDispatchFailedRecipients = [];
+  let segregationEventFailures = 0;
+  const ranAt = Date.now();
+
+  for (const edge of effectiveScan.crossCohortEdges) {
+    // Defence in depth: the scan already rejected non-integer ids
+    // before populating the edge list, but if a future caller hands
+    // us a scan they built themselves, we re-validate at the write
+    // boundary. arrayRemove(NaN) is a silent no-op, which would
+    // leave cross-cohort edges in place — worse than a loud failure.
+    if (!isPositiveIntegerString(edge.from) || !isPositiveIntegerString(edge.to)) {
+      log.warn('migrate-seg-relationships', 'Refusing to apply non-integer edge', {
+        from: edge.from,
+        to: edge.to,
+      });
+      continue;
+    }
+    const fromIdNum = Number.parseInt(String(edge.from), 10);
+    const toIdNum = Number.parseInt(String(edge.to), 10);
+
+    await db.runTransaction(async (txn) => {
+      txn.update(db.doc(`users/${edge.from}`), {
+        followingIds: FieldValue.arrayRemove(toIdNum),
+      });
+      txn.update(db.doc(`users/${edge.to}`), {
+        followerIds: FieldValue.arrayRemove(fromIdNum),
+      });
+    });
+
+    // Audit row in the same collection PR 3's middleware writes to.
+    // Schema matches `middleware/sameCohort.writeSegregationEvent`
+    // exactly — `action` is the discriminator (no separate `type`
+    // field), `requestId: null` because there's no inbound request.
+    // Failure does NOT roll back the removal; the edge is gone
+    // either way and arrayRemove is idempotent so a replay-run is
+    // safe if operator notices a non-zero segregationEventFailures.
+    try {
+      await db.collection(SEGREGATION_EVENTS_COLLECTION).add({
+        sourceUniqueId: edge.from,
+        sourceCohort: edge.fromCohort,
+        targetUniqueId: edge.to,
+        targetCohort: edge.toCohort,
+        surface: 'scripts/migrate-segregation-relationships',
+        action: 'migration_removed',
+        timestamp: ranAt,
+        requestId: null,
+      });
+    } catch (err) {
+      segregationEventFailures += 1;
+      log.warn('migrate-seg-relationships', 'segregationEvents write failed', {
+        edge: `${edge.from}→${edge.to}`,
+        error: err?.message,
+      });
+    }
+
+    // PMs — one per side. Block-bypass: if a side previously blocked
+    // the other, omit the displayName for that side's PM so the
+    // blocked user's name does not resurface in their inbox.
+    const pmToFrom = formatRelationshipRemovedPm({
+      counterpartyDisplayName: edge.fromBlockedToUser ? null : edge.toDisplayName,
+    });
+    const pmToTo = formatRelationshipRemovedPm({
+      counterpartyDisplayName: edge.toBlockedFromUser ? null : edge.fromDisplayName,
+    });
+    try {
+      await sendSystemPm(edge.from, pmToFrom);
+    } catch (err) {
+      pmDispatchFailures += 1;
+      pmDispatchFailedRecipients.push(edge.from);
+      log.warn('migrate-seg-relationships', 'PM dispatch failed', {
+        recipient: edge.from,
+        error: err?.message,
+      });
+    }
+    try {
+      await sendSystemPm(edge.to, pmToTo);
+    } catch (err) {
+      pmDispatchFailures += 1;
+      pmDispatchFailedRecipients.push(edge.to);
+      log.warn('migrate-seg-relationships', 'PM dispatch failed', {
+        recipient: edge.to,
+        error: err?.message,
+      });
+    }
+  }
+
+  return {
+    ...effectiveScan,
+    pmDispatchFailures,
+    pmDispatchFailedRecipients,
+    segregationEventFailures,
+  };
+}
+
+async function writeSnapshot(scan) {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const dir = path.resolve(__dirname, '../migration-snapshots');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `seg-relationships-${ts}.json`);
+  fs.writeFileSync(
+    file,
+    JSON.stringify(
+      {
+        migration: 'seg-relationships',
+        ranAt: ts,
+        affectedFollowsCount: scan.affectedFollowsCount,
+        preservedFollowsCount: scan.preservedFollowsCount,
+        staleEdgeCount: scan.staleEdgeCount,
+        edges: scan.crossCohortEdges,
+      },
+      null,
+      2,
+    ),
+    // Restricted file mode — the snapshot contains displayName +
+    // cohort tags + user-id pairs, which is PII-adjacent. World-
+    // readable defaults leak the entire affected follow graph if
+    // backup tooling ever sweeps the directory.
+    { mode: 0o600 },
+  );
+  return file;
+}
+
+// Parse CLI args + env into an operation mode or an error. Pulled
+// out of main() so the flag-priority contract is unit-testable
+// without spawning a subprocess. `main()` translates the error code
+// into a `process.exit()`.
+function determineMode(args, env) {
+  const dryRun = args.includes('--dry-run');
+  const apply = args.includes('--apply');
+  if (dryRun && apply) {
+    return {
+      error: 'mutually-exclusive',
+      exitCode: 2,
+      message: '--dry-run and --apply are mutually exclusive — pick one',
+    };
+  }
+  if (!dryRun && !apply) {
+    return {
+      error: 'no-mode',
+      exitCode: 2,
+      message: 'Specify --dry-run or --apply',
+    };
+  }
+  if (apply && env.MIGRATION_CONFIRM !== 'yes') {
+    return {
+      error: 'no-confirm',
+      exitCode: 3,
+      message:
+        'Refusing to run --apply without MIGRATION_CONFIRM=yes. Run --dry-run first, review the snapshot, then re-run with both flags.',
+    };
+  }
+  return { mode: dryRun ? 'dry-run' : 'apply' };
+}
+
+async function main() {
+  const decision = determineMode(process.argv.slice(2), process.env);
+  if (decision.error) {
+    log.error('migrate-seg-relationships', decision.message);
+    process.exit(decision.exitCode);
+  }
+  const dryRun = decision.mode === 'dry-run';
+
+  log.info('migrate-seg-relationships', dryRun ? 'Starting dry-run scan' : 'Starting --apply pass');
+  const scan = await scanCrossCohortEdges();
+  const snapshotFile = await writeSnapshot(scan);
+  log.info('migrate-seg-relationships', 'Pre-flight snapshot written', { snapshotFile });
+  log.info('migrate-seg-relationships', 'Scan complete', {
+    affectedFollowsCount: scan.affectedFollowsCount,
+    preservedFollowsCount: scan.preservedFollowsCount,
+    staleEdgeCount: scan.staleEdgeCount,
+  });
+
+  if (dryRun) {
+    log.info('migrate-seg-relationships', 'Dry-run complete — no writes performed');
+    return;
+  }
+
+  const result = await applyMigration({ dryRun: false, scan });
+  log.info('migrate-seg-relationships', 'Migration complete', {
+    affectedFollowsCount: result.affectedFollowsCount,
+    preservedFollowsCount: result.preservedFollowsCount,
+    staleEdgeCount: result.staleEdgeCount,
+    pmDispatchFailures: result.pmDispatchFailures,
+    pmDispatchFailedRecipients: result.pmDispatchFailedRecipients,
+    segregationEventFailures: result.segregationEventFailures,
+  });
+}
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      // Stack-trace omitted from prod log — file paths in firebase-
+      // admin traces can hint at service-account locations. The
+      // snapshot file + ranAt timestamp are sufficient for forensics.
+      log.error('migrate-seg-relationships', 'Migration failed', { error: err.message });
+      process.exit(1);
+    });
+}
+
+module.exports = {
+  scanCrossCohortEdges,
+  applyMigration,
+  formatRelationshipRemovedPm,
+  effectiveCohort,
+  sanitiseDisplayName,
+  isPositiveIntegerString,
+  writeSnapshot,
+  determineMode,
+  VALID_COHORTS,
+  SAFE_DISPLAY_NAME_MAX_LEN,
+  SEGREGATION_EVENTS_COLLECTION,
+};

--- a/express-api/tests/scripts/migrate-segregation-relationships.test.js
+++ b/express-api/tests/scripts/migrate-segregation-relationships.test.js
@@ -675,13 +675,13 @@ describe('sanitiseDisplayName', () => {
   });
 
   test('strips zero-width / joiner / non-joiner code points', () => {
-    expect(sanitiseDisplayName('A​lice')).toBe('Alice');
-    expect(sanitiseDisplayName('A‍lice')).toBe('Alice');
+    expect(sanitiseDisplayName('A\u200Blice')).toBe('Alice');
+    expect(sanitiseDisplayName('A\u200Dlice')).toBe('Alice');
   });
 
   test('strips bidi-override code points (RTL spoofing defence)', () => {
-    expect(sanitiseDisplayName('Alice‮Bob')).toBe('AliceBob');
-    expect(sanitiseDisplayName('‭Evil‬')).toBe('Evil');
+    expect(sanitiseDisplayName('Alice\u202EBob')).toBe('AliceBob');
+    expect(sanitiseDisplayName('\u202DEvil\u202C')).toBe('Evil');
   });
 
   test('collapses newlines / tabs to single space (injection defence)', () => {

--- a/express-api/tests/scripts/migrate-segregation-relationships.test.js
+++ b/express-api/tests/scripts/migrate-segregation-relationships.test.js
@@ -1,0 +1,974 @@
+/**
+ * Tests for the one-shot cross-cohort relationship migration
+ * (`scripts/migrate-segregation-relationships.js`). UK OSA #17 PR 6.
+ *
+ * Coverage focuses on the pure scan + dry-run vs apply behaviour, the
+ * sanitisation contract for displayNames, the audit-trail writes to
+ * `segregationEvents`, the block-bypass for system PMs, the CLI flag
+ * parser (`determineMode`), and the snapshot-file writer. The actual
+ * batched-write path is mocked at the `db.runTransaction` /
+ * `db.batch` seam — Firestore atomicity itself is exercised by the
+ * Phase 3 firestore-rules / integration tests, not here.
+ *
+ * Invariants we pin:
+ *   - dry-run reports affected counts without any writes
+ *   - apply mode removes cross-cohort edges from BOTH sides
+ *   - apply mode dispatches a system PM to both ex-follower and
+ *     ex-followee, with block-bypass swapping in a generic name
+ *     when a side previously blocked the other
+ *   - apply mode writes a `segregationEvents` audit row per edge
+ *   - same-cohort follows are preserved
+ *   - idempotent: second apply on already-migrated graph is no-op
+ *   - missing / invalid cohort on the counterparty defaults to
+ *     `minor` (matches `effectiveCohort` semantics)
+ *   - non-integer ids in followingIds are skipped (counted stale)
+ *   - per-edge transaction failure surfaces but does NOT corrupt
+ *     already-committed pairs
+ *   - displayName sanitisation: HTML, control chars, bidi overrides,
+ *     newlines all stripped; max length enforced
+ *   - PM body is cohort-agnostic (privacy contract — recipient
+ *     cannot infer counterparty cohort from the body alone)
+ */
+
+const mockUsersGet = jest.fn();
+const mockSegregationEventsAdd = jest.fn();
+const mockRunTransaction = jest.fn();
+const mockBatchUpdate = jest.fn();
+const mockBatchCommit = jest.fn();
+const mockDoc = jest.fn();
+const mockSendSystemPm = jest.fn();
+const mockMkdirSync = jest.fn();
+const mockWriteFileSync = jest.fn();
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    collection: jest.fn((name) => {
+      if (name === 'users') return { get: mockUsersGet };
+      if (name === 'segregationEvents') {
+        return { add: mockSegregationEventsAdd };
+      }
+      return { get: jest.fn(), add: jest.fn() };
+    }),
+    doc: (...args) => mockDoc(...args),
+    runTransaction: (...args) => mockRunTransaction(...args),
+    batch: jest.fn(() => ({
+      update: mockBatchUpdate,
+      commit: mockBatchCommit,
+    })),
+  },
+  FieldValue: {
+    arrayRemove: (...vals) => ({ __op: 'arrayRemove', vals }),
+  },
+  auth: {},
+}));
+
+jest.mock('../../src/utils/system-pm', () => ({
+  sendSystemPm: (...args) => mockSendSystemPm(...args),
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('fs', () => ({
+  mkdirSync: (...args) => mockMkdirSync(...args),
+  writeFileSync: (...args) => mockWriteFileSync(...args),
+}));
+
+const {
+  scanCrossCohortEdges,
+  applyMigration,
+  formatRelationshipRemovedPm,
+  sanitiseDisplayName,
+  isPositiveIntegerString,
+  writeSnapshot,
+  determineMode,
+  SAFE_DISPLAY_NAME_MAX_LEN,
+} = require('../../scripts/migrate-segregation-relationships');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockBatchCommit.mockResolvedValue();
+  mockSendSystemPm.mockResolvedValue();
+  mockSegregationEventsAdd.mockResolvedValue();
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Fixture builders
+// ──────────────────────────────────────────────────────────────────
+
+function userDoc(
+  id,
+  {
+    cohort = 'minor',
+    displayName = `user${id}`,
+    following = [],
+    followers = [],
+    blocked = [],
+    cohortOverride,
+  } = {},
+) {
+  const data = {
+    id,
+    displayName,
+    cohort,
+    followingIds: following,
+    followerIds: followers,
+    blockedUserIds: blocked,
+  };
+  if (cohortOverride !== undefined) data.cohortOverride = cohortOverride;
+  return { id: String(id), data: () => data, _data: data };
+}
+
+function seedUsers(users) {
+  mockUsersGet.mockResolvedValue({ docs: users });
+
+  // doc('users/X') — write targets for the apply path. The migration
+  // does not read these (it uses the in-memory index), so return a
+  // sentinel ref. Numeric-id docs that ARE in the seed get a working
+  // `get()` so any future test that exercises a point-read path
+  // continues to work without modification.
+  const index = new Map(users.map((u) => [u.id, u]));
+  mockDoc.mockImplementation((path) => {
+    const match = /^users\/(.+)$/.exec(path);
+    if (!match) return { __ref: path };
+    const id = match[1];
+    return {
+      get: () => Promise.resolve(index.get(id) || { exists: false, data: () => null }),
+      __ref: path,
+    };
+  });
+}
+
+function seedSegregationFollowGraph() {
+  //   100 (minor)  →  200 (adult)   cross-cohort
+  //   100 (minor)  →  201 (minor)   same-cohort   (preserve)
+  //   101 (minor)  →  200 (adult)   cross-cohort
+  //   200 (adult)  →  101 (minor)   cross-cohort (reverse direction)
+  const u100 = userDoc(100, {
+    cohort: 'minor',
+    following: [200, 201],
+    followers: [],
+  });
+  const u101 = userDoc(101, {
+    cohort: 'minor',
+    following: [200],
+    followers: [200],
+  });
+  const u200 = userDoc(200, {
+    cohort: 'adult',
+    following: [101],
+    followers: [100, 101],
+  });
+  const u201 = userDoc(201, {
+    cohort: 'minor',
+    following: [],
+    followers: [100],
+  });
+  seedUsers([u100, u101, u200, u201]);
+  return { u100, u101, u200, u201 };
+}
+
+// ──────────────────────────────────────────────────────────────────
+// isPositiveIntegerString
+// ──────────────────────────────────────────────────────────────────
+
+describe('isPositiveIntegerString', () => {
+  test('accepts canonical positive integers', () => {
+    expect(isPositiveIntegerString('1')).toBe(true);
+    expect(isPositiveIntegerString('10000001')).toBe(true);
+    expect(isPositiveIntegerString(10000001)).toBe(true);
+  });
+
+  test('rejects non-integer numerics and zero / negative', () => {
+    expect(isPositiveIntegerString('0')).toBe(false);
+    expect(isPositiveIntegerString('-1')).toBe(false);
+    expect(isPositiveIntegerString('1.5')).toBe(false);
+    expect(isPositiveIntegerString('1e5')).toBe(false);
+  });
+
+  test('rejects parseInt-truncatable strings (silent-truncation defence)', () => {
+    expect(isPositiveIntegerString('123abc')).toBe(false);
+    expect(isPositiveIntegerString('  123')).toBe(true); // whitespace-only trim
+    expect(isPositiveIntegerString('123 evil')).toBe(false);
+  });
+
+  test('rejects empty / nullish / non-string-non-numeric', () => {
+    expect(isPositiveIntegerString('')).toBe(false);
+    expect(isPositiveIntegerString(null)).toBe(false);
+    expect(isPositiveIntegerString(undefined)).toBe(false);
+    expect(isPositiveIntegerString({})).toBe(false);
+    expect(isPositiveIntegerString(NaN)).toBe(false);
+  });
+
+  test('rejects non-numeric doc-ids (e.g. SHYTALK_SYSTEM)', () => {
+    expect(isPositiveIntegerString('SHYTALK_SYSTEM')).toBe(false);
+    expect(isPositiveIntegerString('admin-uid-abc123')).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// scanCrossCohortEdges
+// ──────────────────────────────────────────────────────────────────
+
+describe('scanCrossCohortEdges', () => {
+  test('identifies cross-cohort follows from both directions', async () => {
+    seedSegregationFollowGraph();
+
+    const result = await scanCrossCohortEdges();
+
+    expect(result.crossCohortEdges).toHaveLength(3);
+    const keys = result.crossCohortEdges.map((e) => `${e.from}→${e.to}`).sort();
+    expect(keys).toEqual(['100→200', '101→200', '200→101']);
+  });
+
+  test('preserves same-cohort follows', async () => {
+    seedSegregationFollowGraph();
+    const result = await scanCrossCohortEdges();
+    const crossKeys = result.crossCohortEdges.map((e) => `${e.from}→${e.to}`);
+    expect(crossKeys).not.toContain('100→201');
+  });
+
+  test('reports per-user affected counts and a total count', async () => {
+    seedSegregationFollowGraph();
+    const result = await scanCrossCohortEdges();
+    expect(result.affectedFollowsCount).toBe(3);
+    expect(result.preservedFollowsCount).toBe(1);
+  });
+
+  test('treats missing counterparty cohort as "minor" (effectiveCohort fallback)', async () => {
+    const u100 = userDoc(100, { cohort: 'adult', following: [200] });
+    const u200 = {
+      id: '200',
+      data: () => ({ id: 200, displayName: 'no-cohort', blockedUserIds: [] }),
+    };
+    seedUsers([u100, u200]);
+
+    const result = await scanCrossCohortEdges();
+    expect(result.crossCohortEdges).toHaveLength(1);
+    expect(result.crossCohortEdges[0]).toMatchObject({
+      from: '100',
+      fromCohort: 'adult',
+      to: '200',
+      toCohort: 'minor',
+    });
+  });
+
+  test('honours cohortOverride on the counterparty', async () => {
+    const u100 = userDoc(100, { cohort: 'adult', following: [200] });
+    const u200 = userDoc(200, { cohort: 'minor', cohortOverride: 'adult' });
+    seedUsers([u100, u200]);
+
+    const result = await scanCrossCohortEdges();
+    expect(result.crossCohortEdges).toHaveLength(0);
+    expect(result.preservedFollowsCount).toBe(1);
+  });
+
+  test('skips invalid cohortOverride and falls back to cohort field', async () => {
+    const u100 = userDoc(100, { cohort: 'adult', following: [200] });
+    const u200 = userDoc(200, { cohort: 'minor', cohortOverride: 'admin' });
+    seedUsers([u100, u200]);
+
+    const result = await scanCrossCohortEdges();
+    expect(result.crossCohortEdges).toHaveLength(1);
+    expect(result.crossCohortEdges[0]).toMatchObject({ from: '100', to: '200' });
+  });
+
+  test('handles users with empty / missing followingIds arrays', async () => {
+    const u100 = userDoc(100, { cohort: 'adult', following: [], followers: [] });
+    const u200 = {
+      id: '200',
+      data: () => ({ id: 200, cohort: 'adult', blockedUserIds: [] }),
+    };
+    seedUsers([u100, u200]);
+
+    const result = await scanCrossCohortEdges();
+    expect(result.crossCohortEdges).toEqual([]);
+    expect(result.affectedFollowsCount).toBe(0);
+  });
+
+  test('skips edges pointing at missing counterparty docs (stale id)', async () => {
+    const u100 = userDoc(100, { cohort: 'adult', following: [999] });
+    seedUsers([u100]);
+
+    const result = await scanCrossCohortEdges();
+    expect(result.crossCohortEdges).toEqual([]);
+    expect(result.staleEdgeCount).toBe(1);
+  });
+
+  test('skips non-integer ids in followingIds (data-corruption defence)', async () => {
+    // `'bogus'` is a legacy corrupted entry. Number('bogus') is NaN
+    // and arrayRemove(NaN) is a silent no-op, which would leak a
+    // cross-cohort edge if the migration tried to apply it. The
+    // migration must skip + count as stale instead.
+    const u100 = userDoc(100, { cohort: 'adult', following: [200, 'bogus', 0] });
+    const u200 = userDoc(200, { cohort: 'minor' });
+    seedUsers([u100, u200]);
+
+    const result = await scanCrossCohortEdges();
+    expect(result.crossCohortEdges).toHaveLength(1);
+    expect(result.crossCohortEdges[0]).toMatchObject({ from: '100', to: '200' });
+    expect(result.staleEdgeCount).toBe(2); // 'bogus' + 0
+  });
+
+  test('skips non-numeric source-user docs (e.g. SHYTALK_SYSTEM)', async () => {
+    // System user has a non-numeric doc-id and no follow edges, but
+    // even if a malformed seed somehow gave it a followingIds array,
+    // the migration must NOT try to arrayRemove on a non-integer id.
+    const uSystem = {
+      id: 'SHYTALK_SYSTEM',
+      data: () => ({
+        id: 'SHYTALK_SYSTEM',
+        cohort: 'adult',
+        followingIds: [200],
+        blockedUserIds: [],
+      }),
+    };
+    const u200 = userDoc(200, { cohort: 'minor' });
+    seedUsers([uSystem, u200]);
+
+    const result = await scanCrossCohortEdges();
+    // The system user is skipped entirely as a from-source; the
+    // potential cross-cohort edge from SHYTALK_SYSTEM is silently
+    // ignored (no edge produced, no stale count — system docs are
+    // legitimate non-numeric ids, not corruption).
+    expect(result.crossCohortEdges).toHaveLength(0);
+  });
+
+  test('records blockedUserIds in each direction for the edge', async () => {
+    // u100 blocked u200 previously; u200 did not block u100.
+    const u100 = userDoc(100, {
+      cohort: 'minor',
+      following: [200],
+      blocked: [200],
+    });
+    const u200 = userDoc(200, {
+      cohort: 'adult',
+      followers: [100],
+      blocked: [],
+    });
+    seedUsers([u100, u200]);
+
+    const result = await scanCrossCohortEdges();
+    expect(result.crossCohortEdges[0]).toMatchObject({
+      from: '100',
+      to: '200',
+      fromBlockedToUser: true,
+      toBlockedFromUser: false,
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// applyMigration — dry-run vs commit
+// ──────────────────────────────────────────────────────────────────
+
+describe('applyMigration', () => {
+  test('dry-run reports counts without invoking transactions, PMs, or audit', async () => {
+    seedSegregationFollowGraph();
+
+    const result = await applyMigration({ dryRun: true });
+
+    expect(result.affectedFollowsCount).toBe(3);
+    expect(result.preservedFollowsCount).toBe(1);
+    expect(mockRunTransaction).not.toHaveBeenCalled();
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+    expect(mockSendSystemPm).not.toHaveBeenCalled();
+    expect(mockSegregationEventsAdd).not.toHaveBeenCalled();
+  });
+
+  test('commit mode revokes both sides of each cross-cohort edge', async () => {
+    seedSegregationFollowGraph();
+    const writes = [];
+    mockRunTransaction.mockImplementation(async (fn) => {
+      const txn = {
+        update: (ref, patch) => writes.push({ ref: ref.__ref, patch }),
+      };
+      return fn(txn);
+    });
+
+    await applyMigration({ dryRun: false });
+
+    // 3 cross-cohort edges → 6 writes (one removal per side per edge).
+    expect(writes).toHaveLength(6);
+    const refs = writes.map((w) => w.ref).sort();
+    expect(refs).toContain('users/100');
+    expect(refs).toContain('users/101');
+    expect(refs).toContain('users/200');
+  });
+
+  test('commit mode passes numeric ids to arrayRemove (matches stored type)', async () => {
+    // The follow route writes `arrayUnion(targetId)` where targetId
+    // is the result of `Number.parseInt(...)` — a number. The
+    // migration must call `arrayRemove(<number>)` so the strict-
+    // equality match used by Firestore actually fires.
+    seedSegregationFollowGraph();
+    const patches = [];
+    mockRunTransaction.mockImplementation(async (fn) => {
+      const txn = {
+        update: (ref, patch) => patches.push(patch),
+      };
+      return fn(txn);
+    });
+
+    await applyMigration({ dryRun: false });
+
+    // Each patch is `{ followingIds: {__op:'arrayRemove', vals:[...]} }`
+    // or `{ followerIds: ... }`. Every value in `vals` must be a JS
+    // number (not a string).
+    for (const patch of patches) {
+      const op = patch.followingIds || patch.followerIds;
+      expect(op.__op).toBe('arrayRemove');
+      for (const v of op.vals) {
+        expect(typeof v).toBe('number');
+        expect(Number.isInteger(v)).toBe(true);
+      }
+    }
+  });
+
+  test('commit mode dispatches one system PM per cross-cohort edge to BOTH parties', async () => {
+    seedSegregationFollowGraph();
+    mockRunTransaction.mockImplementation(async (fn) => fn({ update: () => {} }));
+
+    await applyMigration({ dryRun: false });
+
+    expect(mockSendSystemPm).toHaveBeenCalledTimes(6);
+    const recipients = mockSendSystemPm.mock.calls.map((c) => c[0]).sort();
+    expect(recipients).toEqual(['100', '101', '101', '200', '200', '200']);
+  });
+
+  test('commit mode writes a segregationEvents audit row per edge', async () => {
+    // PR 3 introduced the segregationEvents collection for cross-cohort
+    // request-time audits. The migration writes one row per migrated
+    // edge with action='migration_removed' so analytics can distinguish
+    // migration removals from request-time blocks. Schema matches the
+    // PR 3 middleware writer (middleware/sameCohort.writeSegregationEvent)
+    // — `action` is the discriminator, no separate `type` field.
+    seedSegregationFollowGraph();
+    mockRunTransaction.mockImplementation(async (fn) => fn({ update: () => {} }));
+
+    await applyMigration({ dryRun: false });
+
+    expect(mockSegregationEventsAdd).toHaveBeenCalledTimes(3);
+    const rows = mockSegregationEventsAdd.mock.calls.map((c) => c[0]);
+    for (const row of rows) {
+      expect(row).toMatchObject({
+        action: 'migration_removed',
+        surface: 'scripts/migrate-segregation-relationships',
+        requestId: null,
+      });
+      expect(row).not.toHaveProperty('type'); // discriminator is `action`
+      expect(['minor', 'adult']).toContain(row.sourceCohort);
+      expect(['minor', 'adult']).toContain(row.targetCohort);
+      expect(typeof row.timestamp).toBe('number');
+      expect(typeof row.sourceUniqueId).toBe('string');
+      expect(typeof row.targetUniqueId).toBe('string');
+    }
+  });
+
+  test('block-bypass: PM omits counterparty displayName when recipient previously blocked them', async () => {
+    // u100 blocked u200; u100 must still receive the PM (the link
+    // removal is real), but the PM must NOT reveal u200's name.
+    // u200 did not block u100 → u200's PM names u100 normally.
+    const u100 = userDoc(100, {
+      cohort: 'minor',
+      displayName: 'Alice',
+      following: [200],
+      blocked: [200],
+    });
+    const u200 = userDoc(200, {
+      cohort: 'adult',
+      displayName: 'Bob',
+      followers: [100],
+      blocked: [],
+    });
+    seedUsers([u100, u200]);
+    mockRunTransaction.mockImplementation(async (fn) => fn({ update: () => {} }));
+
+    await applyMigration({ dryRun: false });
+
+    const calls = mockSendSystemPm.mock.calls;
+    const pmTo100 = calls.find((c) => c[0] === '100')[1];
+    const pmTo200 = calls.find((c) => c[0] === '200')[1];
+    expect(pmTo100).not.toContain('Bob');
+    expect(pmTo100).toContain('another user');
+    expect(pmTo200).toContain('Alice');
+  });
+
+  test('idempotent: second commit on already-migrated graph is a no-op', async () => {
+    const u100 = userDoc(100, { cohort: 'minor', following: [201] });
+    const u201 = userDoc(201, { cohort: 'minor', followers: [100] });
+    seedUsers([u100, u201]);
+
+    const result = await applyMigration({ dryRun: false });
+
+    expect(result.affectedFollowsCount).toBe(0);
+    expect(mockRunTransaction).not.toHaveBeenCalled();
+    expect(mockSendSystemPm).not.toHaveBeenCalled();
+    expect(mockSegregationEventsAdd).not.toHaveBeenCalled();
+  });
+
+  test('per-edge transaction failure surfaces, prior pairs stay committed', async () => {
+    seedSegregationFollowGraph();
+    let callIndex = 0;
+    const completed = [];
+    mockRunTransaction.mockImplementation(async (fn) => {
+      const idx = callIndex++;
+      const txn = { update: (ref) => completed.push({ idx, ref: ref.__ref }) };
+      if (idx === 1) {
+        await fn(txn);
+        throw new Error('simulated firestore failure on edge #2');
+      }
+      return fn(txn);
+    });
+
+    await expect(applyMigration({ dryRun: false })).rejects.toThrow(/edge #2/);
+    expect(completed.some((w) => w.idx === 0)).toBe(true);
+  });
+
+  test('PM dispatch failure does NOT roll back the transaction', async () => {
+    const u100 = userDoc(100, { cohort: 'minor', following: [200] });
+    const u200 = userDoc(200, { cohort: 'adult', followers: [100] });
+    seedUsers([u100, u200]);
+    mockRunTransaction.mockImplementation(async (fn) => fn({ update: () => {} }));
+    mockSendSystemPm.mockRejectedValueOnce(new Error('PM dispatch failed')).mockResolvedValue();
+
+    const result = await applyMigration({ dryRun: false });
+
+    expect(result.affectedFollowsCount).toBe(1);
+    expect(result.pmDispatchFailures).toBe(1);
+    expect(mockRunTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSegregationEventsAdd).toHaveBeenCalledTimes(1);
+  });
+
+  test('PM dispatch failure records the recipient uniqueId for ops re-broadcast', async () => {
+    // arrayRemove is idempotent → a second run sees zero cross-cohort
+    // edges → the failed PM is never re-attempted automatically. The
+    // result surfaces the specific recipient(s) so the operator can
+    // re-broadcast from the snapshot file. Without this, the count is
+    // unactionable.
+    const u100 = userDoc(100, { cohort: 'minor', following: [200] });
+    const u200 = userDoc(200, { cohort: 'adult', followers: [100] });
+    seedUsers([u100, u200]);
+    mockRunTransaction.mockImplementation(async (fn) => fn({ update: () => {} }));
+    mockSendSystemPm
+      .mockRejectedValueOnce(new Error('first PM failed'))
+      .mockRejectedValueOnce(new Error('second PM failed'));
+
+    const result = await applyMigration({ dryRun: false });
+
+    expect(result.pmDispatchFailures).toBe(2);
+    expect(result.pmDispatchFailedRecipients).toEqual(['100', '200']);
+  });
+
+  test('block-bypass: both sides blocked each other — both PMs use the generic fallback', async () => {
+    const u100 = userDoc(100, {
+      cohort: 'minor',
+      displayName: 'Alice',
+      following: [200],
+      blocked: [200],
+    });
+    const u200 = userDoc(200, {
+      cohort: 'adult',
+      displayName: 'Bob',
+      followers: [100],
+      blocked: [100],
+    });
+    seedUsers([u100, u200]);
+    mockRunTransaction.mockImplementation(async (fn) => fn({ update: () => {} }));
+
+    await applyMigration({ dryRun: false });
+
+    const calls = mockSendSystemPm.mock.calls;
+    const pmTo100 = calls.find((c) => c[0] === '100')[1];
+    const pmTo200 = calls.find((c) => c[0] === '200')[1];
+    expect(pmTo100).toContain('another user');
+    expect(pmTo200).toContain('another user');
+    expect(pmTo100).not.toContain('Bob');
+    expect(pmTo200).not.toContain('Alice');
+  });
+
+  test('segregationEvents write failure does NOT roll back the transaction or block PMs', async () => {
+    // The audit row is best-effort: a Firestore quota glitch must not
+    // hold up the migration. The edge removal is durable, the PMs go
+    // out, and the failure is counted in `segregationEventFailures`.
+    const u100 = userDoc(100, { cohort: 'minor', following: [200] });
+    const u200 = userDoc(200, { cohort: 'adult', followers: [100] });
+    seedUsers([u100, u200]);
+    mockRunTransaction.mockImplementation(async (fn) => fn({ update: () => {} }));
+    mockSegregationEventsAdd.mockRejectedValueOnce(new Error('quota exceeded'));
+
+    const result = await applyMigration({ dryRun: false });
+
+    expect(result.affectedFollowsCount).toBe(1);
+    expect(result.segregationEventFailures).toBe(1);
+    expect(mockSendSystemPm).toHaveBeenCalledTimes(2);
+  });
+
+  test('accepts a pre-computed scan, does not double-scan', async () => {
+    // main() runs the scan once and feeds the result into
+    // applyMigration so the snapshot file and the applied writes
+    // describe the same graph state. The contract: if a scan is
+    // passed, applyMigration must not re-fetch.
+    seedSegregationFollowGraph();
+    const firstScan = await scanCrossCohortEdges();
+    mockUsersGet.mockClear();
+    mockRunTransaction.mockImplementation(async (fn) => fn({ update: () => {} }));
+
+    await applyMigration({ dryRun: false, scan: firstScan });
+
+    expect(mockUsersGet).not.toHaveBeenCalled();
+  });
+
+  test('refuses to apply an edge with a non-integer endpoint (defence in depth)', async () => {
+    // The scan should never produce a non-integer-id edge, but if a
+    // future caller hands us a hand-rolled scan, the apply path
+    // re-validates and skips rather than calling arrayRemove(NaN).
+    mockRunTransaction.mockImplementation(async (fn) => fn({ update: () => {} }));
+    const handRolledScan = {
+      crossCohortEdges: [
+        {
+          from: 'SHYTALK_SYSTEM',
+          fromCohort: 'adult',
+          fromDisplayName: 'System',
+          fromBlockedToUser: false,
+          to: '200',
+          toCohort: 'minor',
+          toDisplayName: 'Bob',
+          toBlockedFromUser: false,
+        },
+      ],
+      affectedFollowsCount: 1,
+      preservedFollowsCount: 0,
+      staleEdgeCount: 0,
+    };
+
+    const result = await applyMigration({ dryRun: false, scan: handRolledScan });
+
+    expect(mockRunTransaction).not.toHaveBeenCalled();
+    expect(mockSendSystemPm).not.toHaveBeenCalled();
+    expect(mockSegregationEventsAdd).not.toHaveBeenCalled();
+    expect(result.affectedFollowsCount).toBe(1); // count comes from scan, unchanged
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// sanitiseDisplayName
+// ──────────────────────────────────────────────────────────────────
+
+describe('sanitiseDisplayName', () => {
+  test('passes a normal name unchanged (trimmed)', () => {
+    expect(sanitiseDisplayName('Alice')).toBe('Alice');
+    expect(sanitiseDisplayName('  Alice  ')).toBe('Alice');
+  });
+
+  test('strips angle brackets and ampersand', () => {
+    expect(sanitiseDisplayName('<script>')).toBe('script');
+    expect(sanitiseDisplayName('Alice & Bob')).not.toContain('&');
+  });
+
+  test('strips C0/DEL control chars', () => {
+    expect(sanitiseDisplayName('Alice Bob')).toBe('AliceBob');
+    expect(sanitiseDisplayName('AliceBob')).toBe('AliceBob');
+  });
+
+  test('strips zero-width / joiner / non-joiner code points', () => {
+    expect(sanitiseDisplayName('A​lice')).toBe('Alice');
+    expect(sanitiseDisplayName('A‍lice')).toBe('Alice');
+  });
+
+  test('strips bidi-override code points (RTL spoofing defence)', () => {
+    expect(sanitiseDisplayName('Alice‮Bob')).toBe('AliceBob');
+    expect(sanitiseDisplayName('‭Evil‬')).toBe('Evil');
+  });
+
+  test('collapses newlines / tabs to single space (injection defence)', () => {
+    // A multi-line displayName could fake a new system-message block
+    // when interpolated into a `\n`-delimited body.
+    const out = sanitiseDisplayName('Alice\n\n[fake admin notice]');
+    expect(out).not.toContain('\n');
+    expect(out).toBe('Alice [fake admin notice]');
+  });
+
+  test('caps length at SAFE_DISPLAY_NAME_MAX_LEN with ellipsis', () => {
+    const long = 'A'.repeat(SAFE_DISPLAY_NAME_MAX_LEN * 2);
+    const out = sanitiseDisplayName(long);
+    expect(out.length).toBeLessThanOrEqual(SAFE_DISPLAY_NAME_MAX_LEN);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  test('returns null for non-strings and whitespace-only', () => {
+    expect(sanitiseDisplayName(null)).toBeNull();
+    expect(sanitiseDisplayName(undefined)).toBeNull();
+    expect(sanitiseDisplayName(42)).toBeNull();
+    expect(sanitiseDisplayName({})).toBeNull();
+    expect(sanitiseDisplayName('   ')).toBeNull();
+    expect(sanitiseDisplayName('  ')).toBeNull();
+  });
+
+  test('strips C1 control range including U+0085 NEL (line terminator)', () => {
+    // U+0085 NEL is not in C0 (U+0000-001F) and not in JS \s — some
+    // downstream renderers and log aggregators (ICU, RFC-5322,
+    // syslog) treat it as a record terminator. Stripping the entire
+    // C1 range U+0080-U+009F catches NEL plus the rest of the
+    // control block.
+    const nelInjection = 'Alice\u0085[fake notice]';
+    const out = sanitiseDisplayName(nelInjection);
+    expect(out).not.toContain('\u0085');
+    expect(out).toBe('Alice[fake notice]');
+
+    expect(sanitiseDisplayName('A\u0080B')).toBe('AB');
+    expect(sanitiseDisplayName('A\u009FB')).toBe('AB');
+  });
+
+  test('collapses LINE / PARAGRAPH separators (U+2028, U+2029) to space', () => {
+    // Belt-and-braces: JS \s in step 6 would collapse these too, but
+    // the explicit strip step is contract-stable against any future
+    // narrowing of the \s regex.
+    const out = sanitiseDisplayName('Alice\u2028[fake notice]');
+    expect(out).not.toContain('\u2028');
+    expect(out).toBe('Alice [fake notice]');
+
+    const out2 = sanitiseDisplayName('Alice\u2029Bob');
+    expect(out2).not.toContain('\u2029');
+    expect(out2).toBe('Alice Bob');
+  });
+
+  test('strips U+061C Arabic Letter Mark (bidi formatter)', () => {
+    // ALM is a bidi directional hint that does not render as a glyph
+    // but can shift the visual flow of the surrounding English copy.
+    const out = sanitiseDisplayName('Alice\u061CBob');
+    expect(out).not.toContain('\u061C');
+    expect(out).toBe('AliceBob');
+  });
+
+  test('strips U+2060-U+2064 invisible format chars and U+FEFF (BOM)', () => {
+    expect(sanitiseDisplayName('A\u2060B')).toBe('AB');
+    expect(sanitiseDisplayName('A\u2061B')).toBe('AB');
+    expect(sanitiseDisplayName('A\u2064B')).toBe('AB');
+    expect(sanitiseDisplayName('A\uFEFFB')).toBe('AB');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// formatRelationshipRemovedPm
+// ──────────────────────────────────────────────────────────────────
+
+describe('formatRelationshipRemovedPm', () => {
+  test('renders the counterparty displayName into the body', () => {
+    const body = formatRelationshipRemovedPm({ counterpartyDisplayName: 'Alice' });
+    expect(body).toContain('Alice');
+  });
+
+  test('falls back to "another user" when displayName is null', () => {
+    const body = formatRelationshipRemovedPm({ counterpartyDisplayName: null });
+    expect(body).not.toContain('null');
+    expect(body).toContain('another user');
+  });
+
+  test('falls back when displayName is undefined', () => {
+    const body = formatRelationshipRemovedPm({ counterpartyDisplayName: undefined });
+    expect(body).toContain('another user');
+  });
+
+  test('falls back when displayName is whitespace-only', () => {
+    const body = formatRelationshipRemovedPm({ counterpartyDisplayName: '   ' });
+    expect(body).toContain('another user');
+  });
+
+  test('escapes raw HTML / ampersand in displayName', () => {
+    const body = formatRelationshipRemovedPm({
+      counterpartyDisplayName: '<script>x</script> & evil',
+    });
+    expect(body).not.toContain('<');
+    expect(body).not.toContain('>');
+    expect(body).not.toContain('&');
+  });
+
+  test('truncates very long names', () => {
+    const body = formatRelationshipRemovedPm({
+      counterpartyDisplayName: 'A'.repeat(500),
+    });
+    // The body header line is approximately 90 chars of fixed copy
+    // plus the (truncated) displayName, which itself is capped at
+    // SAFE_DISPLAY_NAME_MAX_LEN. The first line must therefore be
+    // bounded, not unbounded.
+    const firstLine = body.split('\n')[0];
+    expect(firstLine.length).toBeLessThan(200);
+    expect(firstLine).toContain('…');
+  });
+
+  test('includes the load-bearing cohort-agnostic phrase (positive pin)', () => {
+    // If a future copy edit drops the policy framing in favour of
+    // "your account group has changed" or similar, this assertion
+    // fails — that's intentional. The phrase IS the cohort-agnostic
+    // disclaimer.
+    const body = formatRelationshipRemovedPm({ counterpartyDisplayName: 'Alice' });
+    expect(body).toContain('recent change to how ShyTalk organises accounts');
+  });
+
+  test('is cohort-agnostic — no cohort vocabulary anywhere in body', () => {
+    // Negative pin: the recipient already knows their own cohort, so
+    // ANY of these words let them deduce the counterparty's. The
+    // denylist is intentionally wide to catch future copy drift.
+    const body = formatRelationshipRemovedPm({ counterpartyDisplayName: 'Alice' });
+    expect(body).not.toMatch(/\badult\b/i);
+    expect(body).not.toMatch(/\bminor\b/i);
+    expect(body).not.toMatch(/\bage\b/i);
+    expect(body).not.toMatch(/\bcohort\b/i);
+    expect(body).not.toMatch(/\bsegregation\b/i);
+    expect(body).not.toMatch(/\b18\+?\b/i);
+    expect(body).not.toMatch(/over 18/i);
+    expect(body).not.toMatch(/under 18/i);
+    expect(body).not.toMatch(/younger/i);
+    expect(body).not.toMatch(/older/i);
+    expect(body).not.toMatch(/\bteen\b/i);
+    expect(body).not.toMatch(/\bkid\b/i);
+    expect(body).not.toMatch(/\bdifferent group\b/i);
+    expect(body).not.toMatch(/\bnot in the same\b/i);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// determineMode — CLI flag parser
+// ──────────────────────────────────────────────────────────────────
+
+describe('determineMode', () => {
+  test('returns dry-run mode for --dry-run alone', () => {
+    expect(determineMode(['--dry-run'], {})).toEqual({ mode: 'dry-run' });
+  });
+
+  test('returns apply mode for --apply when MIGRATION_CONFIRM=yes', () => {
+    expect(determineMode(['--apply'], { MIGRATION_CONFIRM: 'yes' })).toEqual({
+      mode: 'apply',
+    });
+  });
+
+  test('refuses --apply without MIGRATION_CONFIRM=yes', () => {
+    const result = determineMode(['--apply'], {});
+    expect(result.error).toBe('no-confirm');
+    expect(result.exitCode).toBe(3);
+  });
+
+  test('refuses --apply with MIGRATION_CONFIRM set to wrong value', () => {
+    const result = determineMode(['--apply'], { MIGRATION_CONFIRM: 'YES' });
+    expect(result.error).toBe('no-confirm');
+  });
+
+  test('refuses missing both flags', () => {
+    const result = determineMode([], {});
+    expect(result.error).toBe('no-mode');
+    expect(result.exitCode).toBe(2);
+  });
+
+  test('refuses --dry-run AND --apply simultaneously (mutual exclusion)', () => {
+    // The most subtle bug class: operator sets MIGRATION_CONFIRM=yes,
+    // types both flags, and gets a dry-run pass while believing they
+    // ran --apply. Fail loud instead.
+    const result = determineMode(['--dry-run', '--apply'], { MIGRATION_CONFIRM: 'yes' });
+    expect(result.error).toBe('mutually-exclusive');
+    expect(result.exitCode).toBe(2);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// writeSnapshot
+// ──────────────────────────────────────────────────────────────────
+
+describe('writeSnapshot', () => {
+  test('creates the migration-snapshots dir if missing', async () => {
+    await writeSnapshot({
+      crossCohortEdges: [],
+      affectedFollowsCount: 0,
+      preservedFollowsCount: 0,
+      staleEdgeCount: 0,
+    });
+    expect(mockMkdirSync).toHaveBeenCalled();
+    const [dir, opts] = mockMkdirSync.mock.calls[0];
+    expect(dir).toMatch(/migration-snapshots$/);
+    expect(opts).toEqual({ recursive: true });
+  });
+
+  test('writes a JSON file with the expected top-level shape', async () => {
+    const scan = {
+      crossCohortEdges: [
+        {
+          from: '100',
+          fromCohort: 'adult',
+          fromDisplayName: 'Alice',
+          to: '200',
+          toCohort: 'minor',
+          toDisplayName: 'Bob',
+        },
+      ],
+      affectedFollowsCount: 1,
+      preservedFollowsCount: 5,
+      staleEdgeCount: 2,
+    };
+    await writeSnapshot(scan);
+
+    expect(mockWriteFileSync).toHaveBeenCalled();
+    const [file, body] = mockWriteFileSync.mock.calls[0];
+    expect(file).toMatch(/seg-relationships-.*\.json$/);
+    const parsed = JSON.parse(body);
+    expect(parsed).toMatchObject({
+      migration: 'seg-relationships',
+      affectedFollowsCount: 1,
+      preservedFollowsCount: 5,
+      staleEdgeCount: 2,
+    });
+    expect(parsed.edges).toHaveLength(1);
+    expect(parsed.edges[0]).toMatchObject({ from: '100', to: '200' });
+    expect(typeof parsed.ranAt).toBe('string');
+  });
+
+  test('writes the file with restricted mode 0o600 (PII defence)', async () => {
+    await writeSnapshot({
+      crossCohortEdges: [],
+      affectedFollowsCount: 0,
+      preservedFollowsCount: 0,
+      staleEdgeCount: 0,
+    });
+    const opts = mockWriteFileSync.mock.calls[0][2];
+    expect(opts).toEqual({ mode: 0o600 });
+  });
+
+  test('uses a filesystem-safe timestamp suffix (no colons / dots)', async () => {
+    await writeSnapshot({
+      crossCohortEdges: [],
+      affectedFollowsCount: 0,
+      preservedFollowsCount: 0,
+      staleEdgeCount: 0,
+    });
+    const file = mockWriteFileSync.mock.calls[0][0];
+    const suffix = file.match(/seg-relationships-(.+)\.json$/)[1];
+    expect(suffix).not.toContain(':');
+    expect(suffix).not.toContain('.');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Module exports — the migration's public surface is part of its
+// contract; failing to export a documented helper would break the
+// caller (main) silently and isn't caught by other tests.
+// ──────────────────────────────────────────────────────────────────
+
+describe('module exports', () => {
+  test('exposes the documented public surface', () => {
+    const mod = require('../../scripts/migrate-segregation-relationships');
+    expect(typeof mod.scanCrossCohortEdges).toBe('function');
+    expect(typeof mod.applyMigration).toBe('function');
+    expect(typeof mod.formatRelationshipRemovedPm).toBe('function');
+    expect(typeof mod.sanitiseDisplayName).toBe('function');
+    expect(typeof mod.isPositiveIntegerString).toBe('function');
+    expect(typeof mod.writeSnapshot).toBe('function');
+    expect(typeof mod.determineMode).toBe('function');
+    expect(mod.VALID_COHORTS).toBeInstanceOf(Set);
+    expect(mod.VALID_COHORTS.has('adult')).toBe(true);
+    expect(mod.VALID_COHORTS.has('minor')).toBe(true);
+    expect(typeof mod.SAFE_DISPLAY_NAME_MAX_LEN).toBe('number');
+    expect(mod.SEGREGATION_EVENTS_COLLECTION).toBe('segregationEvents');
+  });
+});

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -982,4 +982,7 @@
     <string name="age_verif_test_env_label">Test environment</string>
     <string name="age_verif_test_env_warning">Upload any image — this is a test environment, real IDs are not required and not stored long-term.</string>
 
+    <!-- UK OSA #17 PR 6: cohort-segregation relationship-removed system PM body. NOT REFERENCED by Kotlin/Swift code today — this entry is the canonical English source-of-truth for the copy that the Express migration script (express-api/scripts/migrate-segregation-relationships.js) currently hardcodes. PR 14 will add server-side locale awareness at PM-dispatch time and switch the migration to look this string up; the remaining 19 locale translations ship in PR 14 alongside that wiring. Copy is intentionally cohort-agnostic — "a recent change to how ShyTalk organises accounts" rather than "you are in different groups" — so the recipient cannot infer the counterparty's cohort. -->
+    <string name="age_seg_relationship_removed_pm">Your follow link with %1$s has been removed as part of a recent change to how ShyTalk organises accounts.\n\nThis is automatic; it doesn\'t reflect anything either of you did, and the original link can\'t be restored from here.\n\nIf you don\'t recognise the name, this just means a past connection has been tidied up.</string>
+
 </resources>


### PR DESCRIPTION
## Summary

UK OSA #17 PR 6 of 14. The follow-route same-cohort gate itself was already wired by PR 4's `requireSameCohort` middleware; this PR adds the **historical backfill migration** that revokes pre-existing cross-cohort follow edges and notifies both parties.

- New one-shot Node script `express-api/scripts/migrate-segregation-relationships.js` (`--dry-run` / `--apply`, `MIGRATION_CONFIRM=yes` required, pre-flight JSON snapshot at mode 0o600, gitignored).
- Per migrated edge: one transaction (`arrayRemove` on both sides), one `segregationEvents` audit row (`action: 'migration_removed'`, schema matches the PR 3 middleware writer), one cohort-agnostic system PM to each party.
- 61 jest tests (scan, apply, dry-run, mutual exclusion via extracted `determineMode`, snapshot JSON shape + file mode, sanitisation layer-by-layer, segregationEvents schema parity, PM failure recipient tracking, block-bypass unilateral + mutual, audit-trail failure isolation).

Resolves part of #17.

## Safety + privacy invariants

- Strict integer validation on both edge endpoints — non-integer ids in `followingIds` (data corruption) are skipped + counted, never coerced to NaN.
- `displayName` sanitisation strips HTML brackets/ampersand, C0/DEL, full C1 range (including U+0085 NEL), zero-width + format (U+200B–200F, U+2060–2064, U+FEFF, U+061C ALM), bidi overrides (U+202A–202E, U+2066–2069), explicit U+2028/U+2029, newline-to-space ordering BEFORE C0 strip, 64-char cap with ellipsis.
- PM body is cohort-agnostic: positive copy-pin on the policy phrase + 14-term denylist (adult, minor, cohort, age, 18+, older, younger, teen, kid, etc.) so a future copy edit that re-introduces inferential leakage fails CI.
- Block-bypass: PM to a side that previously blocked the other uses the generic "another user" fallback so the blocked displayName does not resurface in the inbox.
- Cohort taxonomy imported from `src/utils/firebase-claims` (single source of truth) with a module-load assertion against empty `VALID_COHORTS`.
- One transaction per edge, idempotent (arrayRemove on already-removed edge is a no-op); PM-failed recipient uniqueIds surfaced in the result for manual re-broadcast.

## Locale

`age_seg_relationship_removed_pm` added to English `values/strings.xml` as the canonical copy that the migration script currently hardcodes. PR 14 will add server-side locale awareness + the remaining 19 translations and switch the migration to look up the string. Per spec, English only in this PR; other locales deferred to PR 14.

## Scope note

This PR migrates **only** follow edges. The broader segregation cutover (1:1 conversations, group conversations, rooms, stalker history) is handled by PRs 7+ in the same sequence — see `.project/plans/2026-05-13-age-segregation-plan.md` PR Tracking section.

## Test plan

- [x] `npx jest tests/scripts/migrate-segregation-relationships.test.js` — 61/61 pass
- [x] Full Express suite — 5049 pass / 8 skipped
- [x] `./gradlew testDevDebugUnitTest :shared:jvmTest detekt :shared:compileKotlinIosArm64` — BUILD SUCCESSFUL
- [x] Pre-push SonarCloud quality gate passed locally
- [x] Code-reviewer + security-reviewer agents — all findings addressed (two rounds, see commit history for the deep-defence sanitisation, segregationEvents schema alignment, mutual-exclusion flag parser, snapshot file mode, PM recipient tracking, etc.)
- [ ] Dry-run smoke on dev once deployed (operator step, not CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)