### PR TITLE
feat(seg): PR 8 of 14 — conversation gates + migration flags + frozen-group banner

### DIFF
--- a/app/src/androidTest/java/com/shyden/shytalk/fake/FakePrivateMessageRepository.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/fake/FakePrivateMessageRepository.kt
@@ -146,6 +146,7 @@ class FakePrivateMessageRepository : PrivateMessageRepository {
 
     override suspend fun createGroupConversation(
         creatorId: String,
+        cohort: String,
         participantIds: List<String>,
         groupName: String,
         groupDescription: String?,

--- a/app/src/main/java/com/shyden/shytalk/data/repository/PrivateMessageRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/PrivateMessageRepositoryImpl.kt
@@ -455,6 +455,7 @@ class PrivateMessageRepositoryImpl(
 
     override suspend fun createGroupConversation(
         creatorId: String,
+        cohort: String,
         participantIds: List<String>,
         groupName: String,
         groupDescription: String?,
@@ -467,9 +468,15 @@ class PrivateMessageRepositoryImpl(
         firebaseCall("Failed to create group conversation") {
             val docRef = firestore.collection("conversations").document()
             val now = System.currentTimeMillis()
+            // UK OSA #17 PR 8 — create with creator alone (size==1) so
+            // the rules-side gate passes; then add each additional
+            // participant via arrayUnion which fires the per-add cohort
+            // get() in firestore.rules. Bulk-seed at create would slip
+            // cross-cohort ids past validation.
+            val initialParticipantIds = listOf(creatorId)
             val data =
                 mutableMapOf<String, Any?>(
-                    "participantIds" to participantIds,
+                    "participantIds" to initialParticipantIds,
                     "isGroup" to true,
                     "groupName" to groupName,
                     "createdBy" to creatorId,
@@ -481,18 +488,32 @@ class PrivateMessageRepositoryImpl(
                     "permissions" to permissions.toMap(),
                     "systemMessageConfig" to systemMessageConfig.toMap(),
                     "modNotifyMode" to "ALL_ADMINS",
+                    // Bound by firestore.rules to the caller's JWT
+                    // cohort claim; immutable post-create.
+                    "cohort" to cohort,
                 )
             groupDescription?.let { data["groupDescription"] = it }
             groupPhotoUrl?.let { data["groupPhotoUrl"] = it }
             docRef.set(data).await()
-            // Create userSettings docs for all participants with unreadCount: 0
+            // Add remaining members one-at-a-time. Per-add failures
+            // don't abort the call — a partial group is more useful
+            // than aborted; the creator can re-add later.
+            val extraParticipantIds = participantIds.filter { it != creatorId }
+            val finalParticipantIds = mutableListOf(creatorId)
+            for (pid in extraParticipantIds) {
+                runCatching {
+                    docRef.update("participantIds", FieldValue.arrayUnion(pid)).await()
+                    finalParticipantIds.add(pid)
+                }
+            }
             val batch = firestore.batch()
-            for (pid in participantIds) {
+            for (pid in finalParticipantIds) {
                 val settingsRef = docRef.collection("userSettings").document(pid)
                 batch.set(settingsRef, mapOf("unreadCount" to 0, "userId" to pid))
             }
             batch.commit().await()
-            Conversation.fromMap(data, docRef.id)
+            val finalData = data.toMutableMap().apply { put("participantIds", finalParticipantIds.toList()) }
+            Conversation.fromMap(finalData, docRef.id)
         }
 
     override suspend fun addGroupParticipant(

--- a/app/src/test/java/com/shyden/shytalk/data/repository/PrivateMessageRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/PrivateMessageRepositoryImplTest.kt
@@ -394,12 +394,14 @@ class PrivateMessageRepositoryImplTest {
     fun `createGroupConversation initial create writes participantIds with only creatorId (UK OSA PR 8 size-1 rule)`() =
         runTest {
             // Defensive pin on the load-bearing security invariant:
-            // the initial doc.set() at create-time must NOT bulk-seed
+            // the initial doc.set() at create-time MUST NOT bulk-seed
             // additional participants. The firestore.rules layer
-            // requires participantIds.size() == 1 on group create
-            // (see firestore.rules § "Conversations" create gate).
-            // If a future refactor reverts to bulk-write, this test
-            // detects it before the rules layer rejects in production.
+            // requires participantIds.size() == 1 on group create.
+            // Captures the data map passed to set() and asserts the
+            // size-1 invariant on the load-bearing field.
+            val capturedData = slot<Map<String, Any?>>()
+            every { mockDocRef.set(capture(capturedData)) } returns Tasks.forResult(null)
+
             val result =
                 repo.createGroupConversation(
                     creatorId = "user-1",
@@ -408,24 +410,22 @@ class PrivateMessageRepositoryImplTest {
                     groupName = "Test Group",
                 )
             assertTrue(result is Resource.Success)
-            // The returned conversation reflects ALL participants
-            // (creator + successful adds), so we cannot assert on its
-            // shape alone — the rule-defence assertion is that the
-            // mocked Firestore saw a size-1 participantIds in the
-            // initial set() call. The test mock (`FirestoreTestHarness`)
-            // exposes captures; relying here on the success path which
-            // requires the mock to accept the size-1 create.
+
+            @Suppress("UNCHECKED_CAST")
+            val initialParticipants = capturedData.captured["participantIds"] as List<String>
+            assertEquals(1, initialParticipants.size)
+            assertEquals("user-1", initialParticipants[0])
         }
 
     @Test
     fun `createGroupConversation stamps cohort field on the doc (UK OSA PR 8 rules bind)`() =
         runTest {
-            // firestore.rules requires the stamped cohort to match the
-            // caller's JWT claim. The KMP path passes the cohort
-            // through; the IMPL writes it into the created doc data.
-            // A regression that omits the field would fail the rule
-            // ("group create missing cohort field is rejected" — see
-            // tests/integration/10-firestore-cohort-rules.spec.ts).
+            // firestore.rules requires the stamped cohort to match
+            // the caller's JWT claim. A regression that omits the
+            // field would fail the rule on the real backend.
+            val capturedData = slot<Map<String, Any?>>()
+            every { mockDocRef.set(capture(capturedData)) } returns Tasks.forResult(null)
+
             val result =
                 repo.createGroupConversation(
                     creatorId = "user-1",
@@ -434,6 +434,73 @@ class PrivateMessageRepositoryImplTest {
                     groupName = "Cohort-stamped",
                 )
             assertTrue(result is Resource.Success)
+            assertEquals("minor", capturedData.captured["cohort"])
+        }
+
+    @Test
+    fun `createGroupConversation calls update once per extra participant (one-at-a-time growth)`() =
+        runTest {
+            // Mirrors the rules' one-at-a-time per-add invariant: the
+            // impl must NOT bulk-add via a single doc.set. Each extra
+            // participant gets its own update + arrayUnion so the
+            // per-add cohort `get()` in firestore.rules fires per id.
+            val result =
+                repo.createGroupConversation(
+                    creatorId = "user-1",
+                    cohort = "adult",
+                    participantIds = listOf("user-2", "user-3", "user-4"),
+                    groupName = "Multi-add",
+                )
+            assertTrue(result is Resource.Success)
+
+            io.mockk.verify(exactly = 3) {
+                mockDocRef.update("participantIds", any())
+            }
+        }
+
+    @Test
+    fun `createGroupConversation per-participant add failure does not abort the call`() =
+        runTest {
+            // Partial-group is more useful than aborted-group: a
+            // failed add for one member leaves an orphaned single-
+            // member group the creator can re-add to. This is a
+            // deliberate UX trade-off documented in the impl.
+            every { mockDocRef.update("participantIds", any()) } returns
+                Tasks.forException(RuntimeException("transient firestore error"))
+
+            val result =
+                repo.createGroupConversation(
+                    creatorId = "user-1",
+                    cohort = "adult",
+                    participantIds = listOf("user-2"),
+                    groupName = "Partial-add",
+                )
+            // Despite the update failure, the create as a whole
+            // succeeds — the initial doc.set is the load-bearing op.
+            assertTrue(result is Resource.Success)
+        }
+
+    @Test
+    fun `createGroupConversation deduplicates creator from the extra-participants loop`() =
+        runTest {
+            // If the caller mistakenly includes the creator's id in
+            // the participantIds list (common UX shape: ViewModel
+            // passes the full member list), the loop must skip the
+            // creator (already added at create time). Otherwise the
+            // initial doc.set's [creator] + arrayUnion(creator) is a
+            // no-op write that wastes a Firestore quota slot.
+            val result =
+                repo.createGroupConversation(
+                    creatorId = "user-1",
+                    cohort = "adult",
+                    participantIds = listOf("user-1", "user-2"),
+                    groupName = "Dedup-creator",
+                )
+            assertTrue(result is Resource.Success)
+            // Only user-2 should trigger an update (user-1 dedup'd).
+            io.mockk.verify(exactly = 1) {
+                mockDocRef.update("participantIds", any())
+            }
         }
 
     // endregion

--- a/app/src/test/java/com/shyden/shytalk/data/repository/PrivateMessageRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/PrivateMessageRepositoryImplTest.kt
@@ -383,8 +383,55 @@ class PrivateMessageRepositoryImplTest {
             val result =
                 repo.createGroupConversation(
                     creatorId = "user-1",
+                    cohort = "adult",
                     participantIds = listOf("user-2", "user-3"),
                     groupName = "Test Group",
+                )
+            assertTrue(result is Resource.Success)
+        }
+
+    @Test
+    fun `createGroupConversation initial create writes participantIds with only creatorId (UK OSA PR 8 size-1 rule)`() =
+        runTest {
+            // Defensive pin on the load-bearing security invariant:
+            // the initial doc.set() at create-time must NOT bulk-seed
+            // additional participants. The firestore.rules layer
+            // requires participantIds.size() == 1 on group create
+            // (see firestore.rules § "Conversations" create gate).
+            // If a future refactor reverts to bulk-write, this test
+            // detects it before the rules layer rejects in production.
+            val result =
+                repo.createGroupConversation(
+                    creatorId = "user-1",
+                    cohort = "adult",
+                    participantIds = listOf("user-2", "user-3"),
+                    groupName = "Test Group",
+                )
+            assertTrue(result is Resource.Success)
+            // The returned conversation reflects ALL participants
+            // (creator + successful adds), so we cannot assert on its
+            // shape alone — the rule-defence assertion is that the
+            // mocked Firestore saw a size-1 participantIds in the
+            // initial set() call. The test mock (`FirestoreTestHarness`)
+            // exposes captures; relying here on the success path which
+            // requires the mock to accept the size-1 create.
+        }
+
+    @Test
+    fun `createGroupConversation stamps cohort field on the doc (UK OSA PR 8 rules bind)`() =
+        runTest {
+            // firestore.rules requires the stamped cohort to match the
+            // caller's JWT claim. The KMP path passes the cohort
+            // through; the IMPL writes it into the created doc data.
+            // A regression that omits the field would fail the rule
+            // ("group create missing cohort field is rejected" — see
+            // tests/integration/10-firestore-cohort-rules.spec.ts).
+            val result =
+                repo.createGroupConversation(
+                    creatorId = "user-1",
+                    cohort = "minor",
+                    participantIds = listOf("user-2"),
+                    groupName = "Cohort-stamped",
                 )
             assertTrue(result is Resource.Success)
         }

--- a/app/src/test/java/com/shyden/shytalk/feature/messaging/GroupSetupViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/messaging/GroupSetupViewModelTest.kt
@@ -237,7 +237,9 @@ class GroupSetupViewModelTest {
 
             assertFalse(vm.uiState.value.isCreating)
             assertNull(vm.uiState.value.createdConversationId)
-            coVerify(exactly = 0) { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+            coVerify(
+                exactly = 0,
+            ) { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         }
 
     @Test
@@ -274,7 +276,7 @@ class GroupSetupViewModelTest {
                     isGroup = true,
                     groupName = "Test Group",
                 )
-            coEvery { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+            coEvery { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
                 Resource.Success(mockConversation)
 
             val vm = createViewModel("u1")
@@ -303,7 +305,7 @@ class GroupSetupViewModelTest {
                     conversationId = "new-conv-2",
                     isGroup = true,
                 )
-            coEvery { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+            coEvery { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
                 Resource.Success(mockConversation)
 
             val vm = createViewModel("u1")
@@ -476,7 +478,9 @@ class GroupSetupViewModelTest {
 
             assertFalse(vm.uiState.value.isCreating)
             assertNull(vm.uiState.value.createdConversationId)
-            coVerify(exactly = 0) { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+            coVerify(
+                exactly = 0,
+            ) { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         }
 
     @Test
@@ -494,7 +498,7 @@ class GroupSetupViewModelTest {
                     isGroup = true,
                     groupName = "Study Group",
                 )
-            coEvery { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+            coEvery { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
                 Resource.Success(mockConversation)
 
             val vm = createViewModel("u1,u2")
@@ -531,7 +535,9 @@ class GroupSetupViewModelTest {
             assertTrue(vm.uiState.value.error is UiText.Res)
             assertFalse(vm.uiState.value.isCreating)
             assertNull(vm.uiState.value.createdConversationId)
-            coVerify(exactly = 0) { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+            coVerify(
+                exactly = 0,
+            ) { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         }
 
     @Test
@@ -541,7 +547,7 @@ class GroupSetupViewModelTest {
                 Resource.Success(
                     listOf(TestData.createTestUser(uid = "u1")),
                 )
-            coEvery { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+            coEvery { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
                 Resource.Error("Server error")
 
             val vm = createViewModel("u1")

--- a/app/src/test/java/com/shyden/shytalk/feature/messaging/GroupSetupViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/messaging/GroupSetupViewModelTest.kt
@@ -585,4 +585,181 @@ class GroupSetupViewModelTest {
 
             assertEquals(0, vm.uiState.value.ownedGroupCount)
         }
+
+    // ===== UK OSA #17 PR 8 — cohort fetch on group create =====
+
+    @Test
+    fun `createGroup uses caller cohort (adult) on createGroupConversation call`() =
+        runTest {
+            // The firestore.rules layer binds the stamped cohort to
+            // the JWT claim. The ViewModel fetches the creator's
+            // effective cohort and passes it through; a regression
+            // that dropped the cohort parameter would silently break
+            // group creation at the rules layer.
+            coEvery { userRepository.getUsers(listOf("u1")) } returns
+                Resource.Success(listOf(TestData.createTestUser(uid = "u1")))
+            coEvery { userRepository.getUser("me") } returns
+                Resource.Success(TestData.createTestUser(uid = "me").copy(cohort = "adult"))
+            coEvery { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+                Resource.Success(
+                    com.shyden.shytalk.core.model.Conversation(
+                        conversationId = "g1",
+                        isGroup = true,
+                    ),
+                )
+
+            val vm = createViewModel("u1")
+            advanceUntilIdle()
+
+            vm.setGroupName("Adult Group")
+            vm.createGroup()
+            advanceUntilIdle()
+
+            coVerify {
+                pmRepository.createGroupConversation(
+                    creatorId = "me",
+                    cohort = "adult",
+                    participantIds = any(),
+                    groupName = "Adult Group",
+                    groupDescription = any(),
+                    groupPhotoUrl = any(),
+                    adminIds = any(),
+                    modIds = any(),
+                    permissions = any(),
+                    systemMessageConfig = any(),
+                )
+            }
+        }
+
+    @Test
+    fun `createGroup uses cohortOverride when set (overrides user cohort)`() =
+        runTest {
+            // Admin-set cohortOverride takes precedence over the
+            // user's `cohort` field — matches the server-side
+            // `effectiveCohort` helper. Without honouring the
+            // override, an adult user demoted to minor via admin
+            // action could still create adult groups.
+            coEvery { userRepository.getUsers(listOf("u1")) } returns
+                Resource.Success(listOf(TestData.createTestUser(uid = "u1")))
+            coEvery { userRepository.getUser("me") } returns
+                Resource.Success(
+                    TestData.createTestUser(uid = "me").copy(cohort = "adult").copy(cohortOverride = "minor"),
+                )
+            coEvery { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+                Resource.Success(
+                    com.shyden.shytalk.core.model.Conversation(
+                        conversationId = "g1",
+                        isGroup = true,
+                    ),
+                )
+
+            val vm = createViewModel("u1")
+            advanceUntilIdle()
+
+            vm.setGroupName("Override Group")
+            vm.createGroup()
+            advanceUntilIdle()
+
+            coVerify {
+                pmRepository.createGroupConversation(
+                    creatorId = any(),
+                    cohort = "minor",
+                    participantIds = any(),
+                    groupName = any(),
+                    groupDescription = any(),
+                    groupPhotoUrl = any(),
+                    adminIds = any(),
+                    modIds = any(),
+                    permissions = any(),
+                    systemMessageConfig = any(),
+                )
+            }
+        }
+
+    @Test
+    fun `createGroup falls back to minor when getUser fails (fail-closed default)`() =
+        runTest {
+            // Per design (mirrors HomeViewModel.createRoom): if the
+            // user lookup fails, stamp the most-restrictive cohort.
+            // A more permissive default would let a transient error
+            // open the gate.
+            coEvery { userRepository.getUsers(listOf("u1")) } returns
+                Resource.Success(listOf(TestData.createTestUser(uid = "u1")))
+            coEvery { userRepository.getUser("me") } returns Resource.Error("Network down")
+            coEvery { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+                Resource.Success(
+                    com.shyden.shytalk.core.model.Conversation(
+                        conversationId = "g1",
+                        isGroup = true,
+                    ),
+                )
+
+            val vm = createViewModel("u1")
+            advanceUntilIdle()
+
+            vm.setGroupName("Failed-Lookup Group")
+            vm.createGroup()
+            advanceUntilIdle()
+
+            coVerify {
+                pmRepository.createGroupConversation(
+                    creatorId = any(),
+                    cohort = "minor",
+                    participantIds = any(),
+                    groupName = any(),
+                    groupDescription = any(),
+                    groupPhotoUrl = any(),
+                    adminIds = any(),
+                    modIds = any(),
+                    permissions = any(),
+                    systemMessageConfig = any(),
+                )
+            }
+        }
+
+    @Test
+    fun `createGroup ignores invalid cohortOverride (uses user cohort instead)`() =
+        runTest {
+            // Defensive — only 'adult' or 'minor' are valid cohort
+            // values. If admin storage corruption produces
+            // `cohortOverride: 'verified-adult'`, the ViewModel must
+            // ignore it and fall back to `user.cohort` rather than
+            // stamping a non-enum value that firestore.rules would
+            // reject.
+            coEvery { userRepository.getUsers(listOf("u1")) } returns
+                Resource.Success(listOf(TestData.createTestUser(uid = "u1")))
+            coEvery { userRepository.getUser("me") } returns
+                Resource.Success(
+                    TestData.createTestUser(uid = "me").copy(cohort = "adult").copy(cohortOverride = "verified-adult"),
+                )
+            coEvery { pmRepository.createGroupConversation(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+                Resource.Success(
+                    com.shyden.shytalk.core.model.Conversation(
+                        conversationId = "g1",
+                        isGroup = true,
+                    ),
+                )
+
+            val vm = createViewModel("u1")
+            advanceUntilIdle()
+
+            vm.setGroupName("Invalid Override")
+            vm.createGroup()
+            advanceUntilIdle()
+
+            coVerify {
+                pmRepository.createGroupConversation(
+                    creatorId = any(),
+                    cohort = "adult",
+                    participantIds = any(),
+                    groupName = any(),
+                    groupDescription = any(),
+                    groupPhotoUrl = any(),
+                    adminIds = any(),
+                    modIds = any(),
+                    permissions = any(),
+                    systemMessageConfig = any(),
+                )
+            }
+        }
 }

--- a/express-api/scripts/migrate-segregation-relationships.js
+++ b/express-api/scripts/migrate-segregation-relationships.js
@@ -154,6 +154,44 @@ function formatRelationshipRemovedPm({ counterpartyDisplayName }) {
   ].join('\n');
 }
 
+// UK OSA #17 PR 8 — sibling for 1:1 conversation hide. Same
+// load-bearing copy contract as PR 6 / PR 7 (cohort-agnostic body,
+// shared "recent change to how ShyTalk organises accounts" phrase).
+// Block-bypass: when the recipient previously blocked the
+// counterparty, caller passes `null` so the blocked displayName is
+// not resurfaced.
+function formatConversationHiddenPm({ counterpartyDisplayName } = {}) {
+  const safe = sanitiseDisplayName(counterpartyDisplayName);
+  const subject = safe ?? 'another user';
+  return [
+    `Your thread with ${subject} has been preserved but cannot continue, as part of a recent change to how ShyTalk organises accounts.`,
+    '',
+    "This is automatic and doesn't reflect anything either of you did. New messages can't be sent here, and the thread no longer appears in your inbox.",
+    '',
+    "If you don't recognise the name, this just means a past conversation has been tidied up.",
+  ].join('\n');
+}
+
+// UK OSA #17 PR 8 — sibling for group freeze. Sent to every existing
+// group member individually (no in-group system message — that would
+// require a new helper, and a per-member PM keeps the dispatch
+// idempotent + uses the existing sendSystemPm pipeline). The PM body
+// names the group and signals the "preserved but cannot grow further"
+// contract from the design doc. Cohort-agnostic — the recipient
+// already knows their own cohort, so any cohort vocabulary would let
+// them deduce which member's cohort caused the freeze.
+function formatGroupFrozenPm({ groupName } = {}) {
+  const safe = sanitiseDisplayName(groupName);
+  const subject = safe ?? 'a group';
+  return [
+    `The group "${subject}" has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.`,
+    '',
+    "You can still read and post in the group. This is automatic and doesn't reflect anything you did.",
+    '',
+    'New groups you create or join from now on will be unaffected.',
+  ].join('\n');
+}
+
 // UK OSA #17 PR 7 — sibling of `formatRelationshipRemovedPm` for
 // room eviction. Reuses `sanitiseDisplayName` (same sanitisation
 // contract: HTML brackets stripped, C0/C1 + bidi + ZW chars purged,
@@ -660,6 +698,294 @@ async function applyRoomMigration({ dryRun, scan } = {}) {
   };
 }
 
+// ──────────────────────────────────────────────────────────────────
+// UK OSA #17 PR 8 — Conversation migration (1:1 hide + group freeze)
+// ──────────────────────────────────────────────────────────────────
+//
+// Two outcomes:
+//
+//   • 1:1 cross-cohort (DM): set BOTH `crossCohortAtMigration: true`
+//     AND `frozenAtMigration: true`. The first flag is the load-
+//     bearing rules-side hide (firestore.rules denies reads on the
+//     parent conv doc + every subcollection when set, per PR 3). The
+//     `frozenAtMigration` flag is a semantic marker — useful when the
+//     client can read the doc (admin tools, migration-paused window)
+//     so the "no further messages" intent is visible in the data.
+//
+//   • Group cross-cohort: set ONLY `frozenAtMigration: true`. Per the
+//     design doc (line 137), existing members keep read+write access
+//     to the frozen thread. The freeze is participant-list only — no
+//     new members can be added (rules-side gate). NOT setting the
+//     `crossCohortAtMigration` flag here is deliberate: setting it
+//     would orphan the group from the list (it'd be hidden from every
+//     member's inbox), defeating the "preserved but cannot grow"
+//     semantics.
+//
+// Block-bypass: 1:1 PMs swap in "another user" when the recipient
+// previously blocked the counterparty (mirrors PR 6 follow-edge
+// migration). Group PMs are cohort-agnostic and address every member
+// individually — no in-group system message (would require a new
+// helper; per-member PM reuses the existing sendSystemPm pipeline).
+
+const SCAN_CONVO_1TO1_SURFACE = 'scripts/migrate-segregation-conversations-1to1';
+const SCAN_CONVO_GROUP_SURFACE = 'scripts/migrate-segregation-conversations-group';
+
+function classifyConversation(convData, userIndex) {
+  const participantIds = Array.isArray(convData?.participantIds) ? convData.participantIds : [];
+  if (participantIds.length < 2) return { kind: 'skip' };
+
+  const cohorts = participantIds.map((pid) => {
+    const u = userIndex.get(String(pid));
+    return u?.cohort ?? 'minor';
+  });
+  const distinct = new Set(cohorts);
+  if (distinct.size === 1) return { kind: 'same-cohort' };
+
+  // isGroup is the discriminator — a 2-member group remains a group,
+  // not a 1:1 (different freeze semantics: groups keep list visibility
+  // and read+write; 1:1 gets hidden + write-locked).
+  if (convData?.isGroup) {
+    return { kind: 'cross-cohort-group', participantIds };
+  }
+  if (participantIds.length === 2) {
+    return { kind: 'cross-cohort-1to1', participantIds };
+  }
+  // 1:1-shaped but >2 participants (data corruption: isGroup=false
+  // with >2 ids). Treat as a group so the freeze semantics apply (the
+  // 1:1 hide path assumes exactly 2 participants for the PM dispatch).
+  return { kind: 'cross-cohort-group', participantIds };
+}
+
+async function scanCrossCohortConversations() {
+  const [usersSnap, convsSnap] = await Promise.all([
+    db.collection('users').get(),
+    db.collection('conversations').get(),
+  ]);
+
+  // Reuse the same user-index shape as the follow-edge + room scans
+  // (cohort + displayName + blockedUserIds). Single pass over the
+  // users collection — the conversation walk reads from this map only.
+  const userIndex = new Map();
+  for (const doc of usersSnap.docs) {
+    const data = doc.data();
+    userIndex.set(doc.id, {
+      cohort: effectiveCohort(data),
+      displayName: data?.displayName ?? null,
+      blockedUserIds: Array.isArray(data?.blockedUserIds) ? data.blockedUserIds : [],
+    });
+  }
+
+  const oneToOneEntries = [];
+  const groupEntries = [];
+  let preservedConversationsCount = 0;
+  let alreadyFlaggedCount = 0;
+  let skippedConversationsCount = 0;
+
+  for (const doc of convsSnap.docs) {
+    const data = doc.data() || {};
+    const cls = classifyConversation(data, userIndex);
+    if (cls.kind === 'skip') {
+      skippedConversationsCount += 1;
+      continue;
+    }
+    if (cls.kind === 'same-cohort') {
+      preservedConversationsCount += 1;
+      continue;
+    }
+
+    // Idempotence: re-running on already-migrated convs must be a
+    // no-op. 1:1 requires BOTH flags set; group requires just the
+    // freeze flag. If only one of the 1:1 flags is set, treat as
+    // not-yet-flagged so the apply pass re-runs and completes the
+    // pair (defence against partially-applied prior runs).
+    if (cls.kind === 'cross-cohort-1to1') {
+      if (data.crossCohortAtMigration === true && data.frozenAtMigration === true) {
+        alreadyFlaggedCount += 1;
+        continue;
+      }
+    } else if (cls.kind === 'cross-cohort-group') {
+      if (data.frozenAtMigration === true) {
+        alreadyFlaggedCount += 1;
+        continue;
+      }
+    }
+
+    if (cls.kind === 'cross-cohort-1to1') {
+      const [aId, bId] = cls.participantIds.map(String);
+      const aEntry = userIndex.get(aId);
+      const bEntry = userIndex.get(bId);
+      oneToOneEntries.push({
+        conversationId: doc.id,
+        participantIds: [aId, bId],
+        participantCohorts: [aEntry?.cohort ?? 'minor', bEntry?.cohort ?? 'minor'],
+        participantDisplayNames: [aEntry?.displayName ?? null, bEntry?.displayName ?? null],
+        blockedBetween: [
+          (aEntry?.blockedUserIds ?? []).some((id) => String(id) === bId),
+          (bEntry?.blockedUserIds ?? []).some((id) => String(id) === aId),
+        ],
+      });
+    } else {
+      groupEntries.push({
+        conversationId: doc.id,
+        groupName: data.groupName ?? null,
+        participantIds: cls.participantIds.map(String),
+      });
+    }
+  }
+
+  return {
+    oneToOneEntries,
+    groupEntries,
+    affectedOneToOneCount: oneToOneEntries.length,
+    affectedGroupCount: groupEntries.length,
+    preservedConversationsCount,
+    alreadyFlaggedCount,
+    skippedConversationsCount,
+  };
+}
+
+async function applyConversationMigration({ dryRun, scan } = {}) {
+  const effectiveScan = scan ?? (await scanCrossCohortConversations());
+  if (dryRun) {
+    return {
+      ...effectiveScan,
+      pmDispatchFailures: 0,
+      pmDispatchFailedRecipients: [],
+      segregationEventFailures: 0,
+    };
+  }
+
+  let pmDispatchFailures = 0;
+  const pmDispatchFailedRecipients = [];
+  let segregationEventFailures = 0;
+  const ranAt = Date.now();
+
+  // Phase A — 1:1 cross-cohort: set both flags, audit, PM both sides.
+  for (const entry of effectiveScan.oneToOneEntries) {
+    await db.runTransaction(async (txn) => {
+      txn.update(db.doc(`conversations/${entry.conversationId}`), {
+        crossCohortAtMigration: true,
+        frozenAtMigration: true,
+        frozenAtMigrationAt: ranAt,
+      });
+    });
+
+    // Audit: one row per 1:1 (the two participants are symmetric; one
+    // row captures the pair). source = first participant; the analytics
+    // join key is `targetConversationId`, which lets downstream queries
+    // count distinct migrated threads regardless of source/target
+    // direction.
+    try {
+      await db.collection(SEGREGATION_EVENTS_COLLECTION).add({
+        sourceUniqueId: entry.participantIds[0],
+        sourceCohort: entry.participantCohorts[0],
+        targetUniqueId: entry.participantIds[1],
+        targetCohort: entry.participantCohorts[1],
+        targetConversationId: entry.conversationId,
+        surface: SCAN_CONVO_1TO1_SURFACE,
+        action: 'conversation_1to1_hidden',
+        timestamp: ranAt,
+        requestId: null,
+      });
+    } catch (err) {
+      segregationEventFailures += 1;
+      log.warn('migrate-seg-conversations', 'segregationEvents write failed (1:1)', {
+        conversationId: entry.conversationId,
+        error: err?.message,
+      });
+    }
+
+    // PMs — one per side, with block-bypass per side. Same idempotence
+    // contract as PR 6: a re-run after PM failure is safe because the
+    // flag-set transaction is idempotent (re-writing the same flag is
+    // a no-op) and the scan filters out fully-flagged convs.
+    const [aBlocked, bBlocked] = entry.blockedBetween;
+    const pmToA = formatConversationHiddenPm({
+      counterpartyDisplayName: aBlocked ? null : entry.participantDisplayNames[1],
+    });
+    const pmToB = formatConversationHiddenPm({
+      counterpartyDisplayName: bBlocked ? null : entry.participantDisplayNames[0],
+    });
+    try {
+      await sendSystemPm(entry.participantIds[0], pmToA);
+    } catch (err) {
+      pmDispatchFailures += 1;
+      pmDispatchFailedRecipients.push(entry.participantIds[0]);
+      log.warn('migrate-seg-conversations', 'PM dispatch failed (1:1)', {
+        recipient: entry.participantIds[0],
+        error: err?.message,
+      });
+    }
+    try {
+      await sendSystemPm(entry.participantIds[1], pmToB);
+    } catch (err) {
+      pmDispatchFailures += 1;
+      pmDispatchFailedRecipients.push(entry.participantIds[1]);
+      log.warn('migrate-seg-conversations', 'PM dispatch failed (1:1)', {
+        recipient: entry.participantIds[1],
+        error: err?.message,
+      });
+    }
+  }
+
+  // Phase B — group freeze: set frozenAtMigration only (NOT
+  // crossCohortAtMigration — keep group visible), audit once per
+  // group, PM every member individually.
+  for (const entry of effectiveScan.groupEntries) {
+    await db.runTransaction(async (txn) => {
+      txn.update(db.doc(`conversations/${entry.conversationId}`), {
+        frozenAtMigration: true,
+        frozenAtMigrationAt: ranAt,
+      });
+    });
+
+    try {
+      await db.collection(SEGREGATION_EVENTS_COLLECTION).add({
+        sourceUniqueId: '0',
+        sourceCohort: 'mixed',
+        targetUniqueId: entry.conversationId,
+        targetConversationId: entry.conversationId,
+        surface: SCAN_CONVO_GROUP_SURFACE,
+        action: 'group_frozen',
+        timestamp: ranAt,
+        requestId: null,
+      });
+    } catch (err) {
+      segregationEventFailures += 1;
+      log.warn('migrate-seg-conversations', 'segregationEvents write failed (group)', {
+        conversationId: entry.conversationId,
+        error: err?.message,
+      });
+    }
+
+    // One PM per group member. Skip non-integer ids (system / corrupt
+    // entries) to mirror the PR 7 room migration defence — sendSystemPm
+    // doesn't validate ids itself.
+    const body = formatGroupFrozenPm({ groupName: entry.groupName });
+    for (const pid of entry.participantIds) {
+      if (!isPositiveIntegerString(pid)) continue;
+      try {
+        await sendSystemPm(pid, body);
+      } catch (err) {
+        pmDispatchFailures += 1;
+        pmDispatchFailedRecipients.push(pid);
+        log.warn('migrate-seg-conversations', 'PM dispatch failed (group)', {
+          conversationId: entry.conversationId,
+          recipient: pid,
+          error: err?.message,
+        });
+      }
+    }
+  }
+
+  return {
+    ...effectiveScan,
+    pmDispatchFailures,
+    pmDispatchFailedRecipients,
+    segregationEventFailures,
+  };
+}
+
 async function writeSnapshot(scan) {
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
   const dir = path.resolve(__dirname, '../migration-snapshots');
@@ -754,6 +1080,16 @@ async function main() {
     staleParticipantCount: roomScan.staleParticipantCount,
   });
 
+  // Phase 3: conversation migration (PR 8) — 1:1 hide + group freeze.
+  const convoScan = await scanCrossCohortConversations();
+  log.info('migrate-seg-relationships', 'Conversation scan complete', {
+    affectedOneToOneCount: convoScan.affectedOneToOneCount,
+    affectedGroupCount: convoScan.affectedGroupCount,
+    preservedConversationsCount: convoScan.preservedConversationsCount,
+    alreadyFlaggedCount: convoScan.alreadyFlaggedCount,
+    skippedConversationsCount: convoScan.skippedConversationsCount,
+  });
+
   if (dryRun) {
     log.info('migrate-seg-relationships', 'Dry-run complete — no writes performed');
     return;
@@ -778,6 +1114,16 @@ async function main() {
     pmDispatchFailedRecipients: roomResult.pmDispatchFailedRecipients,
     segregationEventFailures: roomResult.segregationEventFailures,
   });
+
+  const convoResult = await applyConversationMigration({ dryRun: false, scan: convoScan });
+  log.info('migrate-seg-relationships', 'Conversation migration complete', {
+    affectedOneToOneCount: convoResult.affectedOneToOneCount,
+    affectedGroupCount: convoResult.affectedGroupCount,
+    alreadyFlaggedCount: convoResult.alreadyFlaggedCount,
+    pmDispatchFailures: convoResult.pmDispatchFailures,
+    pmDispatchFailedRecipients: convoResult.pmDispatchFailedRecipients,
+    segregationEventFailures: convoResult.segregationEventFailures,
+  });
 }
 
 if (require.main === module) {
@@ -795,10 +1141,14 @@ if (require.main === module) {
 module.exports = {
   scanCrossCohortEdges,
   scanCrossCohortRooms,
+  scanCrossCohortConversations,
   applyMigration,
   applyRoomMigration,
+  applyConversationMigration,
   formatRelationshipRemovedPm,
   formatRoomEjectionPm,
+  formatConversationHiddenPm,
+  formatGroupFrozenPm,
   effectiveCohort,
   sanitiseDisplayName,
   isPositiveIntegerString,

--- a/express-api/src/middleware/sameCohort.js
+++ b/express-api/src/middleware/sameCohort.js
@@ -129,8 +129,21 @@ async function writeSegregationEvent(evt) {
 
 // Test-only: reset the dedup store between tests so per-test
 // expectations on segregationEvents writes are independent.
-function _resetAuditDedup() {
-  auditDedup.reset();
-}
+//
+// SECURITY: gate the export behind a test-env check. Reachable from a
+// production route file (via `require` of this middleware) would let a
+// route inadvertently — or maliciously — wipe the dedup window, which
+// would let an attacker spam the audit collection without throttling
+// (DoS the Spark-tier Firestore quota; corrupt the signal admins read).
+// The export is a no-op outside Jest / explicit test env.
+const _resetAuditDedup =
+  process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID !== undefined
+    ? function _resetAuditDedupTestOnly() {
+        auditDedup.reset();
+      }
+    : function _resetAuditDedupNoop() {
+        // Intentional no-op outside tests. The dedup store is the
+        // load-bearing audit-DoS defence in production.
+      };
 
 module.exports = { requireSameCohort, writeSegregationEvent, _resetAuditDedup };

--- a/express-api/src/routes/conversations.js
+++ b/express-api/src/routes/conversations.js
@@ -10,15 +10,49 @@ const { db, rtdb, FieldValue } = require('../utils/firebase');
 const { generateId, now } = require('../utils/helpers');
 const { sendFcmToTokens, cleanupInvalidTokens } = require('../utils/fcm');
 const { requireSameCohort } = require('../middleware/sameCohort');
+const { isLiveAdmin } = require('../middleware/auth');
+const { auditAdminFlagBypass } = require('../utils/segregation-audit');
 const log = require('../utils/log');
 
 /**
- * UK OSA #17 PR 4 — for 1:1 conversations, returns true (and sends a
- * 404) if the caller and the other participant are cross-cohort.
- * Group conversations are deferred to PR 8 (frozen-at-migration
- * gate); they skip this helper.
+ * UK OSA #17 PR 4 + PR 8 — combined gate for conversation reads.
+ *
+ * Two gate paths, in order:
+ *
+ *   1. (PR 8) `crossCohortAtMigration: true` → 404 regardless of
+ *      current cohorts. Set by the migration script on 1:1 cross-
+ *      cohort threads. The flag is the load-bearing rules-side hide
+ *      (firestore.rules denies reads on the parent + every
+ *      subcollection when set, per PR 3); Express mirrors the 404
+ *      as defence in depth. Admin callers are exempt (live-admin
+ *      re-check, same pattern as `requireSameCohort`) — moderators
+ *      need cross-cohort visibility for forensics. No audit row is
+ *      written here: the migration already wrote one per migrated
+ *      thread, and a per-request audit on a known-blocked thread
+ *      would be noise.
+ *
+ *   2. (PR 4) Runtime cohort gate — 1:1 only. Looks up the OTHER
+ *      participant's current cohort and 404s if it mismatches the
+ *      caller's. Group conversations skip both gates (the freeze
+ *      semantics for groups are participant-list only — existing
+ *      members keep read+write per design doc § "Migration").
  */
 async function gateCrossCohortConversation(req, res, conv) {
+  if (conv?.crossCohortAtMigration === true) {
+    // Admin re-check matches requireSameCohort's pattern (60s
+    // adminClaimCache, demoted-admin defence). Honoured here so a
+    // mod can read a hidden thread for an appeal without bypassing
+    // the rest of the gate machinery.
+    if (req?.auth?.token?.admin === true) {
+      const liveAdmin = req?.auth?.uid ? await isLiveAdmin(req.auth.uid) : false;
+      if (liveAdmin) {
+        auditAdminFlagBypass(req, String(req?.params?.id ?? ''));
+        return false;
+      }
+    }
+    res.status(404).json({ error: 'Not found' });
+    return true;
+  }
   if (conv?.isGroup) return false;
   const participantIds = (conv?.participantIds || []).map(String);
   if (participantIds.length !== 2) return false;

--- a/express-api/src/utils/segregation-audit.js
+++ b/express-api/src/utils/segregation-audit.js
@@ -1,0 +1,54 @@
+/**
+ * UK OSA #17 PR 8 — segregation audit helpers.
+ *
+ * Centralised here (not in `src/middleware/sameCohort.js`) so the
+ * helper is callable from any route file without dragging in the
+ * `requireSameCohort` middleware machinery. The migration script
+ * (`scripts/migrate-segregation-relationships.js`) writes the bulk
+ * audit rows; these helpers capture per-request events.
+ *
+ *   - `auditAdminFlagBypass`: an admin moderator read a thread that
+ *     was hidden by `crossCohortAtMigration: true`. Forensic record
+ *     for UK OSA / GDPR Article 30 auditability.
+ *
+ * Fire-and-forget by design. Failure must NEVER block the calling
+ * response (would itself be an existence side-channel). Errors are
+ * swallowed because (a) the migration script already wrote a
+ * permanent row per migrated thread, (b) PR 4's auditDedup row fires
+ * for the runtime cohort gate path, so the admin-bypass row is
+ * supplemental telemetry, not the only signal.
+ */
+
+const { db } = require('./firebase');
+
+function surfaceOf(req) {
+  if (req?.route?.path) {
+    return `${req.baseUrl || ''}${req.route.path}`;
+  }
+  return `${req.baseUrl || ''}${req?.path || ''}`;
+}
+
+function auditAdminFlagBypass(req, conversationId) {
+  const callerId = String(req?.auth?.uniqueId ?? '');
+  db.collection('segregationEvents')
+    .add({
+      sourceUniqueId: callerId,
+      sourceCohort: req?.auth?.token?.cohort || 'unknown',
+      targetUniqueId: conversationId,
+      targetConversationId: conversationId,
+      targetCohort: 'mixed',
+      surface: surfaceOf(req),
+      action: 'admin_flag_bypass',
+      timestamp: Date.now(),
+      requestId: req?.id ?? null,
+    })
+    .catch(() => {
+      // Audit-write failure does not surface to the response: a
+      // failed audit is a known-acceptable trade-off here since the
+      // migration script already wrote a row per migrated thread.
+      // Logging a failure here would also leak "audit attempted"
+      // signals across requests.
+    });
+}
+
+module.exports = { auditAdminFlagBypass };

--- a/express-api/tests/middleware/sameCohort.test.js
+++ b/express-api/tests/middleware/sameCohort.test.js
@@ -469,3 +469,49 @@ describe('requireSameCohort — audit-write dedup', () => {
     expect(res2.status).toHaveBeenCalledWith(404);
   });
 });
+
+// UK OSA #17 PR 8 — `_resetAuditDedup` export hardening.
+// In test env (NODE_ENV=test OR JEST_WORKER_ID set), the export is
+// the real reset function. In production it's a no-op. Both branches
+// must be exercised for SonarCloud coverage; the in-test branch is
+// covered by every other test that calls `_resetAuditDedup`. The
+// no-op branch needs an isolated module re-load with the env vars
+// cleared.
+describe('_resetAuditDedup export-hardening (production no-op branch)', () => {
+  test('returns a no-op function in non-test env (NODE_ENV unset + JEST_WORKER_ID unset)', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    const originalJestWorkerId = process.env.JEST_WORKER_ID;
+    try {
+      delete process.env.NODE_ENV;
+      delete process.env.JEST_WORKER_ID;
+      jest.isolateModules(() => {
+        const mod = require('../../src/middleware/sameCohort');
+        // The function exists but is a no-op — calling it must NOT
+        // throw and must NOT touch any underlying state.
+        expect(typeof mod._resetAuditDedup).toBe('function');
+        expect(() => mod._resetAuditDedup()).not.toThrow();
+        // No return value contract — just verify it's callable.
+        expect(mod._resetAuditDedup()).toBeUndefined();
+      });
+    } finally {
+      if (originalNodeEnv !== undefined) process.env.NODE_ENV = originalNodeEnv;
+      if (originalJestWorkerId !== undefined) process.env.JEST_WORKER_ID = originalJestWorkerId;
+    }
+  });
+
+  test('returns the real reset function when JEST_WORKER_ID is set (Jest worker env)', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    try {
+      delete process.env.NODE_ENV;
+      process.env.JEST_WORKER_ID = '1';
+      jest.isolateModules(() => {
+        const mod = require('../../src/middleware/sameCohort');
+        // Calling reset should not throw — it actually resets the
+        // dedup. This is the "Jest worker auto-detect" branch.
+        expect(() => mod._resetAuditDedup()).not.toThrow();
+      });
+    } finally {
+      if (originalNodeEnv !== undefined) process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+});

--- a/express-api/tests/routes/conversations-cohort.test.js
+++ b/express-api/tests/routes/conversations-cohort.test.js
@@ -1,0 +1,414 @@
+/**
+ * UK OSA #17 PR 8 — Conversation cohort-flag gate tests.
+ *
+ * PR 4 already pinned the runtime cohort gate on 1:1 conversations
+ * (`tests/routes/conversations-same-cohort.test.js`). This file
+ * covers the migration-flag gate added in PR 8:
+ *
+ *   • `crossCohortAtMigration: true` on a 1:1 → GET / POST messages
+ *     return 404 (existence-hiding) regardless of the current cohort
+ *     state of either participant. The flag is the load-bearing
+ *     rules-side hide (firestore.rules locks every subcollection
+ *     when set, per PR 3) — Express mirrors the 404 as defence in
+ *     depth so admin-SDK or future direct paths get the same gate.
+ *
+ *   • `frozenAtMigration: true` on a GROUP → GET / POST messages
+ *     STILL work. Design line 137: "Existing members keep read+write
+ *     access to the frozen thread." The freeze is participant-list
+ *     only (rules-side gate on growth, no Express change). This file
+ *     pins the positive contract — POST messages must NOT 404 just
+ *     because the group is frozen.
+ *
+ * Crucially, NO audit row is written on the flag-blocked path: the
+ * migration script already wrote a `conversation_1to1_hidden` row
+ * per migrated thread, so a per-request audit here would be noisy
+ * duplication. The PR 4 audit-dedup logic still fires for the
+ * runtime cohort gate (target user's cohort mismatches caller's) —
+ * the two gates are independent.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// ─── Path-aware Firebase mock (shared with conversations-same-cohort) ──
+
+const docResponses = new Map();
+const setDoc = (path, data) => docResponses.set(path, data);
+const clearDocs = () => docResponses.clear();
+
+const mockDocGet = jest.fn();
+const mockDocSet = jest.fn().mockResolvedValue();
+const mockBatchSet = jest.fn();
+const mockBatchUpdate = jest.fn();
+const mockBatchCommit = jest.fn().mockResolvedValue();
+const mockMessagesGet = jest.fn();
+const mockSegregationAdd = jest.fn().mockResolvedValue({ id: 'evt_1' });
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    doc: jest.fn((path) => ({
+      _path: path,
+      get: () => mockDocGet(path),
+      set: (...args) => mockDocSet(path, ...args),
+    })),
+    collection: jest.fn((name) => {
+      if (name === 'segregationEvents') return { add: mockSegregationAdd };
+      return {
+        orderBy: jest.fn(() => ({
+          limit: jest.fn(() => ({ get: mockMessagesGet })),
+        })),
+      };
+    }),
+    batch: jest.fn(() => ({
+      set: mockBatchSet,
+      update: mockBatchUpdate,
+      commit: mockBatchCommit,
+    })),
+    getAll: jest.fn().mockResolvedValue([]),
+  },
+  rtdb: {
+    ref: jest.fn(() => ({ set: jest.fn().mockResolvedValue() })),
+  },
+  FieldValue: {
+    increment: jest.fn((n) => `increment(${n})`),
+    arrayRemove: jest.fn((...args) => `arrayRemove(${args})`),
+  },
+}));
+
+jest.mock('../../src/utils/helpers', () => ({
+  generateId: () => 'msg-123',
+  now: () => 1709913600000,
+}));
+
+jest.mock('../../src/utils/fcm', () => ({
+  sendFcmToTokens: jest.fn().mockResolvedValue([]),
+  cleanupInvalidTokens: jest.fn().mockResolvedValue(),
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const mockIsLiveAdmin = jest.fn();
+jest.mock('../../src/middleware/auth', () => ({
+  isLiveAdmin: (...args) => mockIsLiveAdmin(...args),
+}));
+
+const { _resetAuditDedup } = require('../../src/middleware/sameCohort');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDocGet.mockReset();
+  mockSegregationAdd.mockReset();
+  mockSegregationAdd.mockResolvedValue({ id: 'evt_1' });
+  mockMessagesGet.mockReset();
+  mockMessagesGet.mockResolvedValue({ docs: [] });
+  mockIsLiveAdmin.mockReset();
+  mockIsLiveAdmin.mockResolvedValue(true);
+  _resetAuditDedup();
+  clearDocs();
+
+  mockDocGet.mockImplementation((path) => {
+    if (docResponses.has(path)) {
+      const data = docResponses.get(path);
+      return Promise.resolve({ exists: data !== undefined && data !== null, data: () => data });
+    }
+    return Promise.resolve({ exists: false, data: () => null });
+  });
+});
+
+const conversationsRouter = require('../../src/routes/conversations');
+
+function createApp({
+  uid = 'firebase-uid',
+  uniqueId = 'user-A',
+  cohort = 'adult',
+  admin = false,
+} = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.auth = {
+      uid,
+      uniqueId,
+      token: { cohort, ...(admin ? { admin: true } : {}) },
+    };
+    next();
+  });
+  app.use('/api', conversationsRouter);
+  return app;
+}
+
+// ══════════════════════════════════════════════════════════════════
+// GET /api/conversations/:id/messages — crossCohortAtMigration flag
+// ══════════════════════════════════════════════════════════════════
+
+describe('GET /api/conversations/:id/messages — crossCohortAtMigration flag', () => {
+  test('1:1 with flag set → 404 (existence-hiding) even when cohorts match', async () => {
+    // Both users are adult — runtime cohort gate passes — but the
+    // migration flag is the authoritative hide. This is the defence-
+    // in-depth assertion: the flag wins regardless of current state.
+    setDoc('conversations/conv-1', {
+      participantIds: ['user-A', 'user-B'],
+      crossCohortAtMigration: true,
+    });
+    setDoc('users/user-B', { cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/conversations/conv-1/messages');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+  });
+
+  test('1:1 flag-blocked path does NOT write a segregationEvents row (migration already wrote one)', async () => {
+    setDoc('conversations/conv-1', {
+      participantIds: ['user-A', 'user-B'],
+      crossCohortAtMigration: true,
+    });
+    setDoc('users/user-B', { cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    await request(app).get('/api/conversations/conv-1/messages');
+
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('1:1 with flag absent → falls through to runtime cohort gate', async () => {
+    // Sanity: the flag check must not break the existing PR 4 gate
+    // when the flag is missing. Cross-cohort runtime → 404 + audit.
+    setDoc('conversations/conv-1', { participantIds: ['user-A', 'user-B'] });
+    setDoc('users/user-B', { cohort: 'minor' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/conversations/conv-1/messages');
+
+    expect(res.status).toBe(404);
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+  });
+
+  test('1:1 with flag explicitly false → behaves like unflagged', async () => {
+    setDoc('conversations/conv-1', {
+      participantIds: ['user-A', 'user-B'],
+      crossCohortAtMigration: false,
+    });
+    setDoc('users/user-B', { cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/conversations/conv-1/messages');
+
+    expect(res.status).toBe(200);
+  });
+
+  test('admin bypass — admin can still read flagged 1:1 for moderation', async () => {
+    // Mirrors the PR 4 admin bypass on the runtime cohort gate. The
+    // migration flag is operationally identical (a hide signal), and
+    // admins need visibility for forensics / appeals.
+    setDoc('conversations/conv-1', {
+      participantIds: ['admin-user', 'user-B'],
+      crossCohortAtMigration: true,
+    });
+    setDoc('users/user-B', { cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 'admin-user', cohort: 'adult', admin: true });
+    const res = await request(app).get('/api/conversations/conv-1/messages');
+
+    expect(res.status).toBe(200);
+  });
+
+  test('admin bypass writes a `admin_flag_bypass` segregationEvents audit row (UK OSA forensic accountability)', async () => {
+    // The migration captured each thread once; this row captures the
+    // moderator's access for GDPR Article 30 / UK OSA audit-trail.
+    // Without it, privileged access to age-segregated data leaves
+    // no trail.
+    setDoc('conversations/conv-audit', {
+      participantIds: ['admin-user', 'user-B'],
+      crossCohortAtMigration: true,
+    });
+    setDoc('users/user-B', { cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 'admin-user', cohort: 'adult', admin: true });
+    await request(app).get('/api/conversations/conv-audit/messages');
+    await new Promise((r) => setImmediate(r));
+
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+    expect(mockSegregationAdd.mock.calls[0][0]).toMatchObject({
+      sourceUniqueId: 'admin-user',
+      sourceCohort: 'adult',
+      targetUniqueId: 'conv-audit',
+      targetConversationId: 'conv-audit',
+      targetCohort: 'mixed',
+      action: 'admin_flag_bypass',
+    });
+    expect(typeof mockSegregationAdd.mock.calls[0][0].timestamp).toBe('number');
+  });
+
+  test('admin bypass audit failure does NOT block the 200 response (side-channel defence)', async () => {
+    setDoc('conversations/conv-audit-fail', {
+      participantIds: ['admin-user', 'user-B'],
+      crossCohortAtMigration: true,
+    });
+    setDoc('users/user-B', { cohort: 'adult' });
+    mockSegregationAdd.mockRejectedValueOnce(new Error('quota exhausted'));
+
+    const app = createApp({ uniqueId: 'admin-user', cohort: 'adult', admin: true });
+    const res = await request(app).get('/api/conversations/conv-audit-fail/messages');
+
+    expect(res.status).toBe(200);
+  });
+
+  test('non-participant on flagged 1:1 → 403 (participant check fires first, no info leak)', async () => {
+    // The participant check at the top of the handler runs before the
+    // gate. A non-participant gets 403 (the standard "not your conv"
+    // response), not 404 — but they don't get the cohort-leak signal
+    // either, since the 403 doesn't expose the flag's presence.
+    setDoc('conversations/conv-1', {
+      participantIds: ['user-X', 'user-Y'],
+      crossCohortAtMigration: true,
+    });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/conversations/conv-1/messages');
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+// POST /api/conversations/:id/messages — crossCohortAtMigration flag
+// ══════════════════════════════════════════════════════════════════
+
+describe('POST /api/conversations/:id/messages — crossCohortAtMigration flag', () => {
+  test('1:1 with flag set → 404 + no message persisted', async () => {
+    setDoc('conversations/conv-1', {
+      participantIds: ['user-A', 'user-B'],
+      crossCohortAtMigration: true,
+    });
+    setDoc('users/user-B', { cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/conversations/conv-1/messages')
+      .send({ text: 'hi', type: 'TEXT', senderName: 'Adult' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  test('1:1 flag-blocked POST does NOT write a segregationEvents row', async () => {
+    setDoc('conversations/conv-1', {
+      participantIds: ['user-A', 'user-B'],
+      crossCohortAtMigration: true,
+    });
+    setDoc('users/user-B', { cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    await request(app)
+      .post('/api/conversations/conv-1/messages')
+      .send({ text: 'hi', type: 'TEXT', senderName: 'Adult' });
+
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('1:1 admin POST on flagged conv → 200 (admin moderation bypass)', async () => {
+    setDoc('conversations/conv-1', {
+      participantIds: ['admin-user', 'user-B'],
+      crossCohortAtMigration: true,
+    });
+    setDoc('users/user-B', { cohort: 'adult' });
+
+    const app = createApp({ uniqueId: 'admin-user', cohort: 'adult', admin: true });
+    const res = await request(app)
+      .post('/api/conversations/conv-1/messages')
+      .send({ text: 'mod note', type: 'TEXT', senderName: 'Admin' });
+
+    expect(res.status).toBe(200);
+    expect(mockBatchCommit).toHaveBeenCalled();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+// Group `frozenAtMigration` — positive pin: existing members keep
+// read+write per design doc line 137. The freeze is participant-list
+// only (rules-side gate on growth), NOT a message gate.
+// ══════════════════════════════════════════════════════════════════
+
+describe('Group frozenAtMigration — read+write preserved for existing members', () => {
+  test('GET messages on frozen group → 200 (members keep read access)', async () => {
+    setDoc('conversations/conv-1', {
+      participantIds: ['user-A', 'user-B', 'user-C'],
+      isGroup: true,
+      groupName: 'Frozen Hangout',
+      frozenAtMigration: true,
+    });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/conversations/conv-1/messages');
+
+    expect(res.status).toBe(200);
+  });
+
+  test('POST messages on frozen group → 200 (members keep write access)', async () => {
+    setDoc('conversations/conv-1', {
+      participantIds: ['user-A', 'user-B', 'user-C'],
+      isGroup: true,
+      groupName: 'Frozen Hangout',
+      frozenAtMigration: true,
+    });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/conversations/conv-1/messages')
+      .send({ text: 'still here', type: 'TEXT', senderName: 'Adult' });
+
+    expect(res.status).toBe(200);
+    expect(mockBatchCommit).toHaveBeenCalled();
+  });
+
+  test('frozen group never writes a segregationEvents row on message ops (group freeze ≠ cohort block)', async () => {
+    setDoc('conversations/conv-1', {
+      participantIds: ['user-A', 'user-B'],
+      isGroup: true,
+      frozenAtMigration: true,
+    });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    await request(app).get('/api/conversations/conv-1/messages');
+    await request(app)
+      .post('/api/conversations/conv-1/messages')
+      .send({ text: 'ok', type: 'TEXT', senderName: 'A' });
+
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+// Edge — group also flagged crossCohortAtMigration (shouldn't happen
+// per design but defend anyway: the 1:1 hide flag wins even on
+// isGroup=true). Future-proofing assertion: if some operator
+// accidentally sets the flag on a group, the gate fires.
+// ══════════════════════════════════════════════════════════════════
+
+describe('Defense-in-depth — crossCohortAtMigration wins regardless of isGroup', () => {
+  test('group with crossCohortAtMigration set (corrupted state) → 404 on GET', async () => {
+    setDoc('conversations/conv-1', {
+      participantIds: ['user-A', 'user-B', 'user-C'],
+      isGroup: true,
+      groupName: 'Mistakenly Flagged',
+      crossCohortAtMigration: true,
+    });
+
+    const app = createApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/conversations/conv-1/messages');
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/express-api/tests/scripts/migrate-segregation-relationships.test.js
+++ b/express-api/tests/scripts/migrate-segregation-relationships.test.js
@@ -32,6 +32,7 @@
 
 const mockUsersGet = jest.fn();
 const mockRoomsGet = jest.fn();
+const mockConversationsGet = jest.fn();
 const mockSegregationEventsAdd = jest.fn();
 const mockRunTransaction = jest.fn();
 const mockBatchUpdate = jest.fn();
@@ -46,6 +47,7 @@ jest.mock('../../src/utils/firebase', () => ({
     collection: jest.fn((name) => {
       if (name === 'users') return { get: mockUsersGet };
       if (name === 'rooms') return { get: mockRoomsGet };
+      if (name === 'conversations') return { get: mockConversationsGet };
       if (name === 'segregationEvents') {
         return { add: mockSegregationEventsAdd };
       }
@@ -82,10 +84,14 @@ jest.mock('fs', () => ({
 const {
   scanCrossCohortEdges,
   scanCrossCohortRooms,
+  scanCrossCohortConversations,
   applyMigration,
   applyRoomMigration,
+  applyConversationMigration,
   formatRelationshipRemovedPm,
   formatRoomEjectionPm,
+  formatConversationHiddenPm,
+  formatGroupFrozenPm,
   sanitiseDisplayName,
   isPositiveIntegerString,
   writeSnapshot,
@@ -1514,6 +1520,692 @@ describe('formatRoomEjectionPm', () => {
   });
 });
 
+// ══════════════════════════════════════════════════════════════════
+// UK OSA #17 PR 8 — Conversation migration (1:1 hide + group freeze)
+// ══════════════════════════════════════════════════════════════════
+
+// ──────────────────────────────────────────────────────────────────
+// Conversation fixture builders
+// ──────────────────────────────────────────────────────────────────
+
+function convDoc(
+  id,
+  {
+    participantIds = [],
+    isGroup = false,
+    groupName = null,
+    crossCohortAtMigration,
+    frozenAtMigration,
+  } = {},
+) {
+  const data = {
+    id,
+    participantIds,
+    isGroup,
+  };
+  if (groupName !== null) data.groupName = groupName;
+  if (crossCohortAtMigration !== undefined) data.crossCohortAtMigration = crossCohortAtMigration;
+  if (frozenAtMigration !== undefined) data.frozenAtMigration = frozenAtMigration;
+  return { id: String(id), data: () => data, _data: data };
+}
+
+function seedConversations(convs) {
+  mockConversationsGet.mockResolvedValue({ docs: convs });
+}
+
+// Default — most tests want zero rooms in the index so the room scan
+// doesn't pollute their docs. Tests that DO seed rooms call
+// seedRooms() themselves and override this.
+beforeEach(() => {
+  mockConversationsGet.mockResolvedValue({ docs: [] });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// scanCrossCohortConversations
+// ──────────────────────────────────────────────────────────────────
+
+describe('scanCrossCohortConversations', () => {
+  test('classifies a 1:1 adult↔minor conversation as cross-cohort 1:1', async () => {
+    seedUsers([
+      userDoc(100, { cohort: 'adult', displayName: 'Alice' }),
+      userDoc(200, { cohort: 'minor', displayName: 'Bob' }),
+    ]);
+    seedConversations([convDoc('dm_100_200', { participantIds: ['100', '200'], isGroup: false })]);
+
+    const scan = await scanCrossCohortConversations();
+
+    expect(scan.oneToOneEntries).toHaveLength(1);
+    expect(scan.groupEntries).toHaveLength(0);
+    expect(scan.oneToOneEntries[0]).toMatchObject({
+      conversationId: 'dm_100_200',
+      participantIds: ['100', '200'],
+      participantCohorts: ['adult', 'minor'],
+      participantDisplayNames: ['Alice', 'Bob'],
+    });
+    expect(scan.affectedOneToOneCount).toBe(1);
+    expect(scan.affectedGroupCount).toBe(0);
+  });
+
+  test('classifies a cross-cohort group as group (not 1:1) regardless of size', async () => {
+    seedUsers([
+      userDoc(100, { cohort: 'adult' }),
+      userDoc(200, { cohort: 'minor' }),
+      userDoc(201, { cohort: 'adult' }),
+    ]);
+    seedConversations([
+      convDoc('g1', {
+        participantIds: ['100', '200', '201'],
+        isGroup: true,
+        groupName: 'Hangout',
+      }),
+    ]);
+
+    const scan = await scanCrossCohortConversations();
+
+    expect(scan.oneToOneEntries).toHaveLength(0);
+    expect(scan.groupEntries).toHaveLength(1);
+    expect(scan.groupEntries[0]).toMatchObject({
+      conversationId: 'g1',
+      groupName: 'Hangout',
+      participantIds: ['100', '200', '201'],
+    });
+    expect(scan.affectedGroupCount).toBe(1);
+  });
+
+  test('preserves same-cohort 1:1 and same-cohort groups', async () => {
+    seedUsers([
+      userDoc(100, { cohort: 'adult' }),
+      userDoc(101, { cohort: 'adult' }),
+      userDoc(102, { cohort: 'adult' }),
+    ]);
+    seedConversations([
+      convDoc('dm_100_101', { participantIds: ['100', '101'] }),
+      convDoc('g1', { participantIds: ['100', '101', '102'], isGroup: true, groupName: 'Same' }),
+    ]);
+
+    const scan = await scanCrossCohortConversations();
+
+    expect(scan.oneToOneEntries).toHaveLength(0);
+    expect(scan.groupEntries).toHaveLength(0);
+    expect(scan.preservedConversationsCount).toBe(2);
+  });
+
+  test('counts already-flagged 1:1 conversations as alreadyFlagged (idempotent)', async () => {
+    seedUsers([userDoc(100, { cohort: 'adult' }), userDoc(200, { cohort: 'minor' })]);
+    seedConversations([
+      convDoc('dm_100_200', {
+        participantIds: ['100', '200'],
+        crossCohortAtMigration: true,
+        frozenAtMigration: true,
+      }),
+    ]);
+
+    const scan = await scanCrossCohortConversations();
+
+    expect(scan.oneToOneEntries).toHaveLength(0);
+    expect(scan.alreadyFlaggedCount).toBe(1);
+  });
+
+  test('counts already-flagged frozen groups as alreadyFlagged (idempotent)', async () => {
+    seedUsers([userDoc(100, { cohort: 'adult' }), userDoc(200, { cohort: 'minor' })]);
+    seedConversations([
+      convDoc('g1', {
+        participantIds: ['100', '200'],
+        isGroup: true,
+        frozenAtMigration: true,
+      }),
+    ]);
+
+    const scan = await scanCrossCohortConversations();
+
+    expect(scan.groupEntries).toHaveLength(0);
+    expect(scan.alreadyFlaggedCount).toBe(1);
+  });
+
+  test('treats participants absent from users index as "minor" (fail-closed)', async () => {
+    seedUsers([userDoc(100, { cohort: 'adult' })]);
+    seedConversations([convDoc('dm_100_999', { participantIds: ['100', '999'] })]);
+
+    const scan = await scanCrossCohortConversations();
+
+    expect(scan.oneToOneEntries).toHaveLength(1);
+    expect(scan.oneToOneEntries[0].participantCohorts).toEqual(['adult', 'minor']);
+  });
+
+  test('skips conversations with <2 participants (data corruption)', async () => {
+    seedUsers([userDoc(100, { cohort: 'adult' })]);
+    seedConversations([
+      convDoc('lonely', { participantIds: ['100'] }),
+      convDoc('empty', { participantIds: [] }),
+    ]);
+
+    const scan = await scanCrossCohortConversations();
+
+    expect(scan.oneToOneEntries).toHaveLength(0);
+    expect(scan.groupEntries).toHaveLength(0);
+    expect(scan.skippedConversationsCount).toBe(2);
+  });
+
+  test('records block-bypass flags when a side previously blocked the other', async () => {
+    seedUsers([
+      userDoc(100, { cohort: 'adult', displayName: 'Alice', blocked: [200] }),
+      userDoc(200, { cohort: 'minor', displayName: 'Bob' }),
+    ]);
+    seedConversations([convDoc('dm_100_200', { participantIds: ['100', '200'] })]);
+
+    const scan = await scanCrossCohortConversations();
+
+    expect(scan.oneToOneEntries[0].blockedBetween).toEqual([true, false]);
+  });
+
+  test('treats 2-participant isGroup=true as group, not 1:1', async () => {
+    // Edge case: small group of 2. The classifier should follow
+    // isGroup, not participantIds.length — a 2-member group remains a
+    // group (frozenAtMigration only) and does NOT get the 1:1 hide
+    // flag (crossCohortAtMigration would orphan it from the list-rules
+    // path designed for 1:1 DMs).
+    seedUsers([userDoc(100, { cohort: 'adult' }), userDoc(200, { cohort: 'minor' })]);
+    seedConversations([
+      convDoc('tiny_group', {
+        participantIds: ['100', '200'],
+        isGroup: true,
+        groupName: 'Just Us',
+      }),
+    ]);
+
+    const scan = await scanCrossCohortConversations();
+
+    expect(scan.oneToOneEntries).toHaveLength(0);
+    expect(scan.groupEntries).toHaveLength(1);
+  });
+
+  test('treats absent isGroup field as 1:1 for 2-participant conv (default falsy)', async () => {
+    // Backward-compat: pre-PR-8 conversation docs may lack the
+    // isGroup field. For 2 participants, the classifier treats this
+    // as 1:1 (the historical default) and the migration applies the
+    // 1:1 hide flag pair. If a future schema migration adds an
+    // explicit `isGroup: false`, this test continues to pass.
+    seedUsers([userDoc(100, { cohort: 'adult' }), userDoc(200, { cohort: 'minor' })]);
+    // Note: convDoc omits the isGroup field by default (not even
+    // setting it to false) since the helper uses the default arg.
+    mockConversationsGet.mockResolvedValue({
+      docs: [
+        {
+          id: 'legacy_dm',
+          data: () => ({ participantIds: ['100', '200'] }),
+        },
+      ],
+    });
+
+    const scan = await scanCrossCohortConversations();
+
+    expect(scan.oneToOneEntries).toHaveLength(1);
+    expect(scan.oneToOneEntries[0].conversationId).toBe('legacy_dm');
+    expect(scan.groupEntries).toHaveLength(0);
+  });
+
+  test('treats isGroup=false with >2 participants as group (data-corruption fallback)', async () => {
+    // Corruption: isGroup:false yet 3+ participants. The 1:1 hide
+    // flow assumes exactly 2 participants for the PM dispatch; the
+    // corruption fallback routes these into the group path so the
+    // freeze flag is set + every member gets a PM (and no 1:1 path
+    // tries to index into participantIds[2] with undefined cohort).
+    seedUsers([
+      userDoc(100, { cohort: 'adult' }),
+      userDoc(101, { cohort: 'adult' }),
+      userDoc(200, { cohort: 'minor' }),
+    ]);
+    mockConversationsGet.mockResolvedValue({
+      docs: [
+        {
+          id: 'corrupt_three_no_group',
+          data: () => ({
+            participantIds: ['100', '101', '200'],
+            isGroup: false, // contradicts size
+          }),
+        },
+      ],
+    });
+
+    const scan = await scanCrossCohortConversations();
+
+    expect(scan.oneToOneEntries).toHaveLength(0);
+    expect(scan.groupEntries).toHaveLength(1);
+    expect(scan.groupEntries[0].conversationId).toBe('corrupt_three_no_group');
+    expect(scan.groupEntries[0].participantIds).toEqual(['100', '101', '200']);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// applyConversationMigration
+// ──────────────────────────────────────────────────────────────────
+
+describe('applyConversationMigration', () => {
+  beforeEach(() => {
+    mockRunTransaction.mockImplementation(async (fn) => {
+      const txn = {
+        get: jest.fn(),
+        update: jest.fn(),
+        set: jest.fn(),
+        delete: jest.fn(),
+      };
+      return fn(txn);
+    });
+  });
+
+  test('dry-run reports counts without invoking transactions, PMs, or audit', async () => {
+    seedUsers([userDoc(100, { cohort: 'adult' }), userDoc(200, { cohort: 'minor' })]);
+    seedConversations([convDoc('dm_100_200', { participantIds: ['100', '200'] })]);
+
+    const result = await applyConversationMigration({ dryRun: true });
+
+    expect(mockRunTransaction).not.toHaveBeenCalled();
+    expect(mockSendSystemPm).not.toHaveBeenCalled();
+    expect(mockSegregationEventsAdd).not.toHaveBeenCalled();
+    expect(result.affectedOneToOneCount).toBe(1);
+  });
+
+  test('commit mode sets BOTH crossCohortAtMigration AND frozenAtMigration on 1:1', async () => {
+    seedUsers([userDoc(100, { cohort: 'adult' }), userDoc(200, { cohort: 'minor' })]);
+    seedConversations([convDoc('dm_100_200', { participantIds: ['100', '200'] })]);
+
+    const mockUpdate = jest.fn();
+    mockRunTransaction.mockImplementationOnce(async (fn) => fn({ update: mockUpdate }));
+
+    await applyConversationMigration({ dryRun: false });
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    const [, patch] = mockUpdate.mock.calls[0];
+    expect(patch.crossCohortAtMigration).toBe(true);
+    expect(patch.frozenAtMigration).toBe(true);
+    expect(typeof patch.frozenAtMigrationAt).toBe('number');
+  });
+
+  test('commit mode sets ONLY frozenAtMigration on cross-cohort group (no crossCohortAtMigration)', async () => {
+    // Design: groups keep read/write for existing members but cannot
+    // grow. Setting crossCohortAtMigration would hide the group from
+    // the list (defeating "preserved but cannot grow further"). The
+    // group's freeze is participant-list only.
+    seedUsers([
+      userDoc(100, { cohort: 'adult' }),
+      userDoc(200, { cohort: 'minor' }),
+      userDoc(201, { cohort: 'adult' }),
+    ]);
+    seedConversations([
+      convDoc('g1', {
+        participantIds: ['100', '200', '201'],
+        isGroup: true,
+        groupName: 'Hangout',
+      }),
+    ]);
+
+    const mockUpdate = jest.fn();
+    mockRunTransaction.mockImplementationOnce(async (fn) => fn({ update: mockUpdate }));
+
+    await applyConversationMigration({ dryRun: false });
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    const [, patch] = mockUpdate.mock.calls[0];
+    expect(patch.frozenAtMigration).toBe(true);
+    expect(patch.crossCohortAtMigration).toBeUndefined();
+  });
+
+  test('commit mode dispatches a PM to BOTH 1:1 participants', async () => {
+    seedUsers([
+      userDoc(100, { cohort: 'adult', displayName: 'Alice' }),
+      userDoc(200, { cohort: 'minor', displayName: 'Bob' }),
+    ]);
+    seedConversations([convDoc('dm_100_200', { participantIds: ['100', '200'] })]);
+
+    await applyConversationMigration({ dryRun: false });
+
+    expect(mockSendSystemPm).toHaveBeenCalledTimes(2);
+    const recipients = mockSendSystemPm.mock.calls.map((c) => c[0]).sort();
+    expect(recipients).toEqual(['100', '200']);
+  });
+
+  test('1:1 PM applies block-bypass — recipient who blocked the other gets generic counterparty', async () => {
+    seedUsers([
+      userDoc(100, { cohort: 'adult', displayName: 'Alice', blocked: [200] }),
+      userDoc(200, { cohort: 'minor', displayName: 'Bob' }),
+    ]);
+    seedConversations([convDoc('dm_100_200', { participantIds: ['100', '200'] })]);
+
+    await applyConversationMigration({ dryRun: false });
+
+    const callByRecipient = new Map(mockSendSystemPm.mock.calls.map((c) => [c[0], c[1]]));
+    // 100 blocked 200 → 100's PM must NOT contain "Bob"
+    expect(callByRecipient.get('100')).not.toContain('Bob');
+    // 200 did not block 100 → 200's PM names Alice
+    expect(callByRecipient.get('200')).toContain('Alice');
+  });
+
+  test('commit mode dispatches one PM per group member (informing every member)', async () => {
+    seedUsers([
+      userDoc(100, { cohort: 'adult' }),
+      userDoc(200, { cohort: 'minor' }),
+      userDoc(201, { cohort: 'adult' }),
+    ]);
+    seedConversations([
+      convDoc('g1', {
+        participantIds: ['100', '200', '201'],
+        isGroup: true,
+        groupName: 'Hangout',
+      }),
+    ]);
+
+    await applyConversationMigration({ dryRun: false });
+
+    expect(mockSendSystemPm).toHaveBeenCalledTimes(3);
+    const recipients = mockSendSystemPm.mock.calls.map((c) => c[0]).sort();
+    expect(recipients).toEqual(['100', '200', '201']);
+  });
+
+  test('group PM body contains the group name', async () => {
+    seedUsers([userDoc(100, { cohort: 'adult' }), userDoc(200, { cohort: 'minor' })]);
+    seedConversations([
+      convDoc('g1', {
+        participantIds: ['100', '200'],
+        isGroup: true,
+        groupName: 'Movie Club',
+      }),
+    ]);
+
+    await applyConversationMigration({ dryRun: false });
+
+    for (const call of mockSendSystemPm.mock.calls) {
+      expect(call[1]).toContain('Movie Club');
+    }
+  });
+
+  test('writes a segregationEvents audit row per 1:1 + per cross-cohort group', async () => {
+    seedUsers([
+      userDoc(100, { cohort: 'adult' }),
+      userDoc(200, { cohort: 'minor' }),
+      userDoc(201, { cohort: 'adult' }),
+    ]);
+    seedConversations([
+      convDoc('dm_100_200', { participantIds: ['100', '200'] }),
+      convDoc('g1', {
+        participantIds: ['100', '200', '201'],
+        isGroup: true,
+        groupName: 'Hangout',
+      }),
+    ]);
+
+    await applyConversationMigration({ dryRun: false });
+
+    expect(mockSegregationEventsAdd).toHaveBeenCalledTimes(2);
+    const surfaces = mockSegregationEventsAdd.mock.calls.map((c) => c[0].surface).sort();
+    expect(surfaces).toEqual([
+      'scripts/migrate-segregation-conversations-1to1',
+      'scripts/migrate-segregation-conversations-group',
+    ]);
+    const actions = mockSegregationEventsAdd.mock.calls.map((c) => c[0].action).sort();
+    expect(actions).toEqual(['conversation_1to1_hidden', 'group_frozen']);
+  });
+
+  test('1:1 audit row pins source/target cohorts + conversation id', async () => {
+    seedUsers([userDoc(100, { cohort: 'adult' }), userDoc(200, { cohort: 'minor' })]);
+    seedConversations([convDoc('dm_100_200', { participantIds: ['100', '200'] })]);
+
+    await applyConversationMigration({ dryRun: false });
+
+    expect(mockSegregationEventsAdd).toHaveBeenCalledTimes(1);
+    const audit = mockSegregationEventsAdd.mock.calls[0][0];
+    expect(audit).toMatchObject({
+      sourceUniqueId: '100',
+      sourceCohort: 'adult',
+      targetUniqueId: '200',
+      targetCohort: 'minor',
+      targetConversationId: 'dm_100_200',
+      action: 'conversation_1to1_hidden',
+    });
+    expect(typeof audit.timestamp).toBe('number');
+  });
+
+  test('idempotent — second commit on already-migrated convs is a no-op', async () => {
+    seedUsers([userDoc(100, { cohort: 'adult' }), userDoc(200, { cohort: 'minor' })]);
+    seedConversations([
+      convDoc('dm_100_200', {
+        participantIds: ['100', '200'],
+        crossCohortAtMigration: true,
+        frozenAtMigration: true,
+      }),
+    ]);
+
+    const result = await applyConversationMigration({ dryRun: false });
+
+    expect(mockRunTransaction).not.toHaveBeenCalled();
+    expect(mockSendSystemPm).not.toHaveBeenCalled();
+    expect(mockSegregationEventsAdd).not.toHaveBeenCalled();
+    expect(result.affectedOneToOneCount).toBe(0);
+    expect(result.alreadyFlaggedCount).toBe(1);
+  });
+
+  test('per-conversation transaction failure surfaces but does NOT corrupt prior convs', async () => {
+    seedUsers([
+      userDoc(100, { cohort: 'adult' }),
+      userDoc(101, { cohort: 'adult' }),
+      userDoc(200, { cohort: 'minor' }),
+      userDoc(201, { cohort: 'minor' }),
+    ]);
+    seedConversations([
+      convDoc('dm_100_200', { participantIds: ['100', '200'] }),
+      convDoc('dm_101_201', { participantIds: ['101', '201'] }),
+    ]);
+
+    mockRunTransaction
+      .mockImplementationOnce(async (fn) => fn({ update: jest.fn() })) // first ok
+      .mockImplementationOnce(async () => {
+        throw new Error('contention');
+      });
+
+    await expect(applyConversationMigration({ dryRun: false })).rejects.toThrow('contention');
+    expect(mockRunTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  test('PM dispatch failure does NOT roll back flag-set transaction', async () => {
+    seedUsers([userDoc(100, { cohort: 'adult' }), userDoc(200, { cohort: 'minor' })]);
+    seedConversations([convDoc('dm_100_200', { participantIds: ['100', '200'] })]);
+    mockSendSystemPm.mockRejectedValueOnce(new Error('PM service down'));
+
+    const result = await applyConversationMigration({ dryRun: false });
+
+    expect(result.pmDispatchFailures).toBe(1);
+    expect(mockRunTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  test('segregationEvents write failure does NOT block PM or flag write', async () => {
+    seedUsers([userDoc(100, { cohort: 'adult' }), userDoc(200, { cohort: 'minor' })]);
+    seedConversations([convDoc('dm_100_200', { participantIds: ['100', '200'] })]);
+    mockSegregationEventsAdd.mockRejectedValueOnce(new Error('quota exhausted'));
+
+    const result = await applyConversationMigration({ dryRun: false });
+
+    expect(result.segregationEventFailures).toBe(1);
+    expect(mockSendSystemPm).toHaveBeenCalled();
+    expect(mockRunTransaction).toHaveBeenCalled();
+  });
+
+  test('accepts a pre-computed scan, does not double-scan', async () => {
+    seedUsers([userDoc(100, { cohort: 'adult' }), userDoc(200, { cohort: 'minor' })]);
+    seedConversations([convDoc('dm_100_200', { participantIds: ['100', '200'] })]);
+    const scan = await scanCrossCohortConversations();
+    mockConversationsGet.mockClear();
+    mockUsersGet.mockClear();
+
+    await applyConversationMigration({ dryRun: false, scan });
+
+    expect(mockConversationsGet).not.toHaveBeenCalled();
+    expect(mockUsersGet).not.toHaveBeenCalled();
+  });
+
+  test('group PM dispatch failure tracks each failed recipient', async () => {
+    seedUsers([
+      userDoc(100, { cohort: 'adult' }),
+      userDoc(200, { cohort: 'minor' }),
+      userDoc(201, { cohort: 'adult' }),
+    ]);
+    seedConversations([
+      convDoc('g1', {
+        participantIds: ['100', '200', '201'],
+        isGroup: true,
+        groupName: 'X',
+      }),
+    ]);
+    // Fail PM for 200 only.
+    mockSendSystemPm.mockImplementation(async (recipient) => {
+      if (recipient === '200') throw new Error('PM down for 200');
+    });
+
+    const result = await applyConversationMigration({ dryRun: false });
+
+    expect(result.pmDispatchFailures).toBe(1);
+    expect(result.pmDispatchFailedRecipients).toEqual(['200']);
+  });
+
+  test('group PMs skip non-integer participant ids (data corruption defence)', async () => {
+    seedUsers([userDoc(100, { cohort: 'adult' }), userDoc(200, { cohort: 'minor' })]);
+    seedConversations([
+      convDoc('g1', {
+        participantIds: ['100', '200', 'SHYTALK_SYSTEM', 'not-a-number'],
+        isGroup: true,
+        groupName: 'Mixed',
+      }),
+    ]);
+
+    await applyConversationMigration({ dryRun: false });
+
+    const recipients = mockSendSystemPm.mock.calls.map((c) => c[0]).sort();
+    expect(recipients).toEqual(['100', '200']);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// formatConversationHiddenPm — cohort-agnostic PM for 1:1 hide
+// ──────────────────────────────────────────────────────────────────
+
+describe('formatConversationHiddenPm', () => {
+  test('includes the sanitised counterparty displayName when provided', () => {
+    const body = formatConversationHiddenPm({ counterpartyDisplayName: 'Alice' });
+    expect(body).toContain('Alice');
+  });
+
+  test('falls back to "another user" when displayName is null (block-bypass)', () => {
+    const body = formatConversationHiddenPm({ counterpartyDisplayName: null });
+    expect(body).toContain('another user');
+    expect(body).not.toContain('null');
+  });
+
+  test('falls back when displayName is whitespace-only', () => {
+    const body = formatConversationHiddenPm({ counterpartyDisplayName: '   ' });
+    expect(body).toContain('another user');
+  });
+
+  test('strips raw HTML brackets + ampersand (XSS defence)', () => {
+    const body = formatConversationHiddenPm({
+      counterpartyDisplayName: '<script>alert(1)</script> & evil',
+    });
+    expect(body).not.toContain('<script>');
+    expect(body).not.toContain('</script>');
+    expect(body).not.toContain('&');
+  });
+
+  test('truncates very long displayNames', () => {
+    const body = formatConversationHiddenPm({ counterpartyDisplayName: 'A'.repeat(500) });
+    const firstLine = body.split('\n')[0];
+    expect(firstLine.length).toBeLessThan(200);
+    expect(firstLine).toContain('…');
+  });
+
+  test('is cohort-agnostic — no cohort vocabulary anywhere in body', () => {
+    const body = formatConversationHiddenPm({ counterpartyDisplayName: 'Alice' });
+    expect(body).not.toMatch(/\badult\b/i);
+    expect(body).not.toMatch(/\bminor\b/i);
+    expect(body).not.toMatch(/\bage\b/i);
+    expect(body).not.toMatch(/\bcohort\b/i);
+    expect(body).not.toMatch(/\bsegregation\b/i);
+    expect(body).not.toMatch(/under 18/i);
+    expect(body).not.toMatch(/over 18/i);
+    expect(body).not.toMatch(/younger/i);
+    expect(body).not.toMatch(/older/i);
+    expect(body).not.toMatch(/\bteen\b/i);
+    expect(body).not.toMatch(/\bkid\b/i);
+    expect(body).not.toMatch(/\bdifferent group\b/i);
+    expect(body).not.toMatch(/\bnot in the same\b/i);
+  });
+
+  test('includes the load-bearing cohort-agnostic phrase (positive pin)', () => {
+    const body = formatConversationHiddenPm({ counterpartyDisplayName: 'Alice' });
+    expect(body).toContain('recent change to how ShyTalk organises accounts');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────
+// formatGroupFrozenPm — cohort-agnostic PM for group freeze
+// ──────────────────────────────────────────────────────────────────
+
+describe('formatGroupFrozenPm', () => {
+  test('includes the sanitised group name when provided', () => {
+    const body = formatGroupFrozenPm({ groupName: 'Movie Club' });
+    expect(body).toContain('Movie Club');
+  });
+
+  test('falls back to "a group" when groupName is null', () => {
+    const body = formatGroupFrozenPm({ groupName: null });
+    expect(body).toContain('a group');
+    expect(body).not.toContain('null');
+  });
+
+  test('falls back when groupName is whitespace-only', () => {
+    const body = formatGroupFrozenPm({ groupName: '   ' });
+    expect(body).toContain('a group');
+  });
+
+  test('strips raw HTML brackets + ampersand (XSS defence)', () => {
+    const body = formatGroupFrozenPm({ groupName: '<b>Evil</b> & co' });
+    expect(body).not.toContain('<b>');
+    expect(body).not.toContain('</b>');
+    expect(body).not.toContain('&');
+  });
+
+  test('truncates very long group names', () => {
+    const body = formatGroupFrozenPm({ groupName: 'G'.repeat(500) });
+    const firstLine = body.split('\n')[0];
+    expect(firstLine.length).toBeLessThan(200);
+    expect(firstLine).toContain('…');
+  });
+
+  test('mentions that no new members can be added (load-bearing semantics)', () => {
+    // Positive pin on the phrase that signals the "preserved but
+    // cannot grow further" contract per the design doc. Copy edits
+    // may rephrase but must keep the no-new-members signal.
+    const body = formatGroupFrozenPm({ groupName: 'Movie Club' });
+    expect(body.toLowerCase()).toMatch(/new members|cannot grow|cannot be added/);
+  });
+
+  test('is cohort-agnostic — no cohort vocabulary anywhere in body', () => {
+    const body = formatGroupFrozenPm({ groupName: 'Movie Club' });
+    expect(body).not.toMatch(/\badult\b/i);
+    expect(body).not.toMatch(/\bminor\b/i);
+    expect(body).not.toMatch(/\bage\b/i);
+    expect(body).not.toMatch(/\bcohort\b/i);
+    expect(body).not.toMatch(/\bsegregation\b/i);
+    expect(body).not.toMatch(/under 18/i);
+    expect(body).not.toMatch(/over 18/i);
+    expect(body).not.toMatch(/younger/i);
+    expect(body).not.toMatch(/older/i);
+    expect(body).not.toMatch(/\bteen\b/i);
+    expect(body).not.toMatch(/\bkid\b/i);
+  });
+
+  test('includes the load-bearing cohort-agnostic phrase (positive pin)', () => {
+    const body = formatGroupFrozenPm({ groupName: 'Movie Club' });
+    expect(body).toContain('recent change to how ShyTalk organises accounts');
+  });
+});
+
 // ──────────────────────────────────────────────────────────────────
 // determineMode — CLI flag parser
 // ──────────────────────────────────────────────────────────────────
@@ -1643,10 +2335,14 @@ describe('module exports', () => {
     const mod = require('../../scripts/migrate-segregation-relationships');
     expect(typeof mod.scanCrossCohortEdges).toBe('function');
     expect(typeof mod.scanCrossCohortRooms).toBe('function');
+    expect(typeof mod.scanCrossCohortConversations).toBe('function');
     expect(typeof mod.applyMigration).toBe('function');
     expect(typeof mod.applyRoomMigration).toBe('function');
+    expect(typeof mod.applyConversationMigration).toBe('function');
     expect(typeof mod.formatRelationshipRemovedPm).toBe('function');
     expect(typeof mod.formatRoomEjectionPm).toBe('function');
+    expect(typeof mod.formatConversationHiddenPm).toBe('function');
+    expect(typeof mod.formatGroupFrozenPm).toBe('function');
     expect(typeof mod.sanitiseDisplayName).toBe('function');
     expect(typeof mod.isPositiveIntegerString).toBe('function');
     expect(typeof mod.writeSnapshot).toBe('function');

--- a/express-api/tests/utils/segregation-audit.test.js
+++ b/express-api/tests/utils/segregation-audit.test.js
@@ -1,0 +1,132 @@
+/**
+ * UK OSA #17 PR 8 — unit tests for `src/utils/segregation-audit.js`.
+ *
+ * Direct coverage of the audit helper's branches: surface resolution
+ * (route.path vs path fallback), missing auth/req fields (optional-
+ * chain defensives), fire-and-forget failure swallowing. Without
+ * these tests the new-code coverage drops below SonarCloud's 80%
+ * gate because each optional-chain branch counts as an uncovered
+ * condition.
+ */
+
+const mockAdd = jest.fn();
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    collection: jest.fn(() => ({ add: (...args) => mockAdd(...args) })),
+  },
+}));
+
+const { auditAdminFlagBypass } = require('../../src/utils/segregation-audit');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAdd.mockResolvedValue({ id: 'evt_1' });
+});
+
+describe('auditAdminFlagBypass', () => {
+  test('writes a segregationEvents row with happy-path req fields', () => {
+    const req = {
+      auth: {
+        uniqueId: '12345',
+        token: { cohort: 'adult' },
+      },
+      baseUrl: '/api',
+      route: { path: '/conversations/:id/messages' },
+      id: 'req-abc',
+    };
+    auditAdminFlagBypass(req, 'conv-1');
+
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    expect(mockAdd.mock.calls[0][0]).toMatchObject({
+      sourceUniqueId: '12345',
+      sourceCohort: 'adult',
+      targetUniqueId: 'conv-1',
+      targetConversationId: 'conv-1',
+      targetCohort: 'mixed',
+      surface: '/api/conversations/:id/messages',
+      action: 'admin_flag_bypass',
+      requestId: 'req-abc',
+    });
+    expect(typeof mockAdd.mock.calls[0][0].timestamp).toBe('number');
+  });
+
+  test('falls back to req.path when req.route is absent', () => {
+    const req = {
+      auth: { uniqueId: '12345', token: { cohort: 'adult' } },
+      baseUrl: '/api',
+      path: '/conversations/abc/messages',
+    };
+    auditAdminFlagBypass(req, 'conv-1');
+
+    expect(mockAdd.mock.calls[0][0].surface).toBe('/api/conversations/abc/messages');
+  });
+
+  test('handles missing baseUrl (defaults to empty string)', () => {
+    const req = {
+      auth: { uniqueId: '12345', token: { cohort: 'adult' } },
+      route: { path: '/conversations/:id' },
+    };
+    auditAdminFlagBypass(req, 'conv-1');
+
+    expect(mockAdd.mock.calls[0][0].surface).toBe('/conversations/:id');
+  });
+
+  test('handles missing req.auth (sourceUniqueId becomes empty string)', () => {
+    const req = { baseUrl: '/api', route: { path: '/x' } };
+    auditAdminFlagBypass(req, 'conv-1');
+
+    expect(mockAdd.mock.calls[0][0].sourceUniqueId).toBe('');
+  });
+
+  test('handles missing req.auth.token.cohort (sourceCohort defaults to "unknown")', () => {
+    const req = {
+      auth: { uniqueId: '12345' },
+      baseUrl: '/api',
+      route: { path: '/x' },
+    };
+    auditAdminFlagBypass(req, 'conv-1');
+
+    expect(mockAdd.mock.calls[0][0].sourceCohort).toBe('unknown');
+  });
+
+  test('handles missing req.id (requestId becomes null)', () => {
+    const req = {
+      auth: { uniqueId: '12345', token: { cohort: 'adult' } },
+      baseUrl: '/api',
+      route: { path: '/x' },
+    };
+    auditAdminFlagBypass(req, 'conv-1');
+
+    expect(mockAdd.mock.calls[0][0].requestId).toBe(null);
+  });
+
+  test('swallows db.collection().add() failure (fire-and-forget)', async () => {
+    mockAdd.mockRejectedValueOnce(new Error('quota exhausted'));
+    const req = {
+      auth: { uniqueId: '12345', token: { cohort: 'adult' } },
+      baseUrl: '/api',
+      route: { path: '/x' },
+    };
+    // Must not throw despite the rejected add().
+    expect(() => auditAdminFlagBypass(req, 'conv-1')).not.toThrow();
+    // Allow the rejected promise's .catch to settle.
+    await new Promise((r) => setImmediate(r));
+  });
+
+  test('handles entirely empty req (no auth, no route, no path)', () => {
+    auditAdminFlagBypass({}, 'conv-empty');
+
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    expect(mockAdd.mock.calls[0][0]).toMatchObject({
+      sourceUniqueId: '',
+      sourceCohort: 'unknown',
+      targetUniqueId: 'conv-empty',
+      targetConversationId: 'conv-empty',
+      targetCohort: 'mixed',
+      surface: '',
+      action: 'admin_flag_bypass',
+      requestId: null,
+    });
+  });
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -382,20 +382,25 @@ service cloud.firestore {
         && !request.resource.data.diff(resource.data).affectedKeys()
              .hasAny(['crossCohortAtMigration', 'frozenAtMigration', 'frozenAtMigrationAt'])
         && (
-          request.resource.data.participantIds == resource.data.participantIds
+          // No growth (shrinkage, no-op, or non-participantIds-only
+          // edit): always allowed. `new.removeAll(old).size() == 0`
+          // means new is a subset of old — covers both unchanged and
+          // shrinkage. Frozen groups can shrink (members can leave /
+          // be kicked); only growth is gated.
+          request.resource.data.participantIds
+            .removeAll(resource.data.participantIds).size() == 0
           || (
+            // Growth path: blocked when frozen, one-at-a-time,
+            // cohort-matched. Bulk cross-cohort adds would slip past
+            // the per-add `get()` if size were unbounded.
             resource.data.get('frozenAtMigration', false) != true
             && request.resource.data.participantIds
-                 .removeAll(resource.data.participantIds).size() <= 1
-            && (
-              request.resource.data.participantIds
-                .removeAll(resource.data.participantIds).size() == 0
-              || get(/databases/$(database)/documents/users/$(
-                   request.resource.data.participantIds
-                     .removeAll(resource.data.participantIds)[0]
-                 )).data.get('cohort', 'minor')
-                 == request.auth.token.get('cohort', 'minor')
-            )
+                 .removeAll(resource.data.participantIds).size() == 1
+            && get(/databases/$(database)/documents/users/$(
+                 request.resource.data.participantIds
+                   .removeAll(resource.data.participantIds)[0]
+               )).data.get('cohort', 'minor')
+               == request.auth.token.get('cohort', 'minor')
           )
         );
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -311,9 +311,93 @@ service cloud.firestore {
       allow list: if request.auth != null
                   && string(callerUniqueId()) in resource.data.participantIds
                   && resource.data.get('crossCohortAtMigration', false) != true;
-      allow create: if request.auth != null;
+      // UK OSA #17 PR 8 — create gate. Caller MUST be in
+      // participantIds (no proxy creation), MUST NOT stamp the
+      // server-only migration flags (defence against pre-emptive
+      // griefing via flagged-thread create on deterministic
+      // dm_<a>_<b> IDs), AND:
+      //   • 1:1 (size == 2 and isGroup != true): exactly 2 distinct
+      //     participants, and the OTHER participant's current cohort
+      //     claim must match the caller's. The other-id is derived by
+      //     removing the caller from participantIds — a single
+      //     `get()` resolves the cohort. Caller's cohort comes from
+      //     the server-signed JWT claim (PR 2), so client-side cohort
+      //     forging requires forging the JWT — which they cannot.
+      //   • Group (isGroup == true): the stamped `cohort` field must
+      //     equal the caller's claim AND be in the enum
+      //     ['adult','minor'] (future-cohort-name corruption
+      //     defence). The group MUST be created with the caller as
+      //     the SOLE participant (size == 1) — additional members
+      //     are added one-at-a-time via the update path, where the
+      //     per-add cohort gate fires. Rules cannot iterate
+      //     participantIds within the 10-get-per-eval budget, so
+      //     bulk-create with cross-cohort members is closed
+      //     structurally by forcing single-member create.
+      allow create: if request.auth != null
+        && string(callerUniqueId()) in request.resource.data.participantIds
+        && request.resource.data.get('crossCohortAtMigration', false) == false
+        && request.resource.data.get('frozenAtMigration', false) == false
+        && (
+          request.resource.data.get('isGroup', false) == true
+            ? (
+              request.resource.data.get('cohort', '')
+                == request.auth.token.get('cohort', 'minor')
+              && request.resource.data.get('cohort', '') in ['adult', 'minor']
+              && request.resource.data.participantIds.size() == 1
+            )
+            : (
+              request.resource.data.participantIds.size() == 2
+              && request.resource.data.participantIds[0]
+                 != request.resource.data.participantIds[1]
+              && get(/databases/$(database)/documents/users/$(
+                   request.resource.data.participantIds.removeAll([string(callerUniqueId())])[0]
+                 )).data.get('cohort', 'minor')
+                 == request.auth.token.get('cohort', 'minor')
+            )
+        );
+      // UK OSA #17 PR 8 — update gate. Caller must be a participant,
+      // AND:
+      //   • Migration flags (crossCohortAtMigration, frozenAtMigration,
+      //     frozenAtMigrationAt) are SERVER-ONLY — clients cannot
+      //     mutate them (set, clear, or change). Migration writes
+      //     via Admin SDK which bypasses these rules. Without this
+      //     `hasNone` guard, a participant could clear
+      //     crossCohortAtMigration to un-hide a migrated 1:1, or set
+      //     it to grief a counterpart, or clear frozenAtMigration to
+      //     unfreeze a group then bulk-add members.
+      //   • Participant-list growth is constrained:
+      //       - `frozenAtMigration: true` blocks ALL participant
+      //         additions ("preserved but cannot grow further").
+      //       - Growth limited to one id per update (the
+      //         `removeAll(...).size() <= 1` cap) — bulk-add in a
+      //         single update would slip cross-cohort ids past the
+      //         per-add cohort `get()`.
+      //       - The added id's current cohort must match the
+      //         caller's JWT claim.
+      // Removals (size == 0) and non-participantIds changes are
+      // unaffected — members can leave / be kicked from frozen
+      // groups, and lastMessage / groupName updates flow.
       allow update: if request.auth != null
-                    && string(callerUniqueId()) in resource.data.participantIds;
+        && string(callerUniqueId()) in resource.data.participantIds
+        && !request.resource.data.diff(resource.data).affectedKeys()
+             .hasAny(['crossCohortAtMigration', 'frozenAtMigration', 'frozenAtMigrationAt'])
+        && (
+          request.resource.data.participantIds == resource.data.participantIds
+          || (
+            resource.data.get('frozenAtMigration', false) != true
+            && request.resource.data.participantIds
+                 .removeAll(resource.data.participantIds).size() <= 1
+            && (
+              request.resource.data.participantIds
+                .removeAll(resource.data.participantIds).size() == 0
+              || get(/databases/$(database)/documents/users/$(
+                   request.resource.data.participantIds
+                     .removeAll(resource.data.participantIds)[0]
+                 )).data.get('cohort', 'minor')
+                 == request.auth.token.get('cohort', 'minor')
+            )
+          )
+        );
 
       // Subcollection reads MUST propagate the `crossCohortAtMigration`
       // flag from the parent conversation doc — otherwise a participant
@@ -321,12 +405,21 @@ service cloud.firestore {
       // parent doc but can still read messages / edits / userSettings /
       // mutes / mod_log directly by path, leaking the full thread
       // contents. UK OSA #17 — PR 3.
+      //
+      // UK OSA #17 PR 8 — `create` MUST also propagate the flag:
+      // without the migration-flag check on messages.create, a
+      // participant in a flagged 1:1 thread could still POST messages
+      // by direct Firestore SDK, bypassing the Express route gate.
+      // The flag's full contract per design § Migration is "no further
+      // messages can be sent" — the rules layer enforces this so the
+      // Express route is defence-in-depth, not the load-bearing gate.
       match /messages/{messageId} {
         allow read: if request.auth != null
           && string(callerUniqueId()) in get(/databases/$(database)/documents/conversations/$(conversationId)).data.participantIds
           && get(/databases/$(database)/documents/conversations/$(conversationId)).data.get('crossCohortAtMigration', false) != true;
         allow create: if request.auth != null
-          && string(callerUniqueId()) in get(/databases/$(database)/documents/conversations/$(conversationId)).data.participantIds;
+          && string(callerUniqueId()) in get(/databases/$(database)/documents/conversations/$(conversationId)).data.participantIds
+          && get(/databases/$(database)/documents/conversations/$(conversationId)).data.get('crossCohortAtMigration', false) != true;
         allow update, delete: if request.auth != null
           && (string(callerUniqueId()) == resource.data.senderId
               || string(callerUniqueId()) in get(/databases/$(database)/documents/conversations/$(conversationId)).data.groupAdminIds
@@ -337,16 +430,23 @@ service cloud.firestore {
             && string(callerUniqueId()) in get(/databases/$(database)/documents/conversations/$(conversationId)).data.participantIds
             && get(/databases/$(database)/documents/conversations/$(conversationId)).data.get('crossCohortAtMigration', false) != true;
           allow create: if request.auth != null
-            && string(callerUniqueId()) in get(/databases/$(database)/documents/conversations/$(conversationId)).data.participantIds;
+            && string(callerUniqueId()) in get(/databases/$(database)/documents/conversations/$(conversationId)).data.participantIds
+            && get(/databases/$(database)/documents/conversations/$(conversationId)).data.get('crossCohortAtMigration', false) != true;
         }
       }
 
-      // User-specific conversation settings — own settings, or participant can init others during group creation
+      // User-specific conversation settings — own settings, or participant can init others during group creation.
+      // UK OSA #17 PR 8 — `write` MUST propagate crossCohortAtMigration
+      // (sibling of the `read` gate one line up). Otherwise a
+      // participant in a migration-hidden 1:1 can still mute/unmute,
+      // toggle preferences, etc. inside the locked thread — a
+      // data-hygiene leak and potential observable-side-channel.
       match /userSettings/{settingsId} {
         allow read: if request.auth != null
           && string(callerUniqueId()) in get(/databases/$(database)/documents/conversations/$(conversationId)).data.participantIds
           && get(/databases/$(database)/documents/conversations/$(conversationId)).data.get('crossCohortAtMigration', false) != true;
         allow write: if request.auth != null
+          && get(/databases/$(database)/documents/conversations/$(conversationId)).data.get('crossCohortAtMigration', false) != true
           && (string(callerUniqueId()) == settingsId
               || string(callerUniqueId()) in get(/databases/$(database)/documents/conversations/$(conversationId)).data.groupAdminIds);
       }
@@ -357,12 +457,18 @@ service cloud.firestore {
           && string(callerUniqueId()) == settingsId;
       }
 
-      // Mutes — participants read, admins/mods can mute/unmute members
+      // Mutes — participants read, admins/mods can mute/unmute members.
+      // UK OSA #17 PR 8 — `write` MUST propagate crossCohortAtMigration
+      // (sibling of the `read` gate). Otherwise an admin/mod in a
+      // hidden cross-cohort group can still mute members, leaking
+      // observable state writes into a thread the rules layer says
+      // does not exist for the affected participants.
       match /mutes/{muteId} {
         allow read: if request.auth != null
           && string(callerUniqueId()) in get(/databases/$(database)/documents/conversations/$(conversationId)).data.participantIds
           && get(/databases/$(database)/documents/conversations/$(conversationId)).data.get('crossCohortAtMigration', false) != true;
         allow write: if request.auth != null
+          && get(/databases/$(database)/documents/conversations/$(conversationId)).data.get('crossCohortAtMigration', false) != true
           && (string(callerUniqueId()) == muteId
               || string(callerUniqueId()) in get(/databases/$(database)/documents/conversations/$(conversationId)).data.groupAdminIds
               || string(callerUniqueId()) in get(/databases/$(database)/documents/conversations/$(conversationId)).data.groupModIds);

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">إرفاق الأدلة</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">لا يمكنك مراسلة هذا المستخدم</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">لا يمكنك مراسلة هذا الشخص لأننا نعتقد أن عمره أقل من 18 عامًا.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">Beweise beifügen</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">Sie können diesem Benutzer keine Nachrichten senden</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Sie können dieser Person keine Nachricht senden, da wir davon ausgehen, dass sie unter 18 Jahre alt ist.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">Adjuntar evidencia</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">No puedes enviar mensajes a este usuario.</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">No puede enviar mensajes a esta persona porque creemos que es menor de 18 años.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -480,6 +480,7 @@
     <string name="attach_evidence">Joindre des preuves</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">Vous ne pouvez pas envoyer de message à cet utilisateur</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Vous ne pouvez pas envoyer de message à cette personne car nous pensons qu\'elle a moins de 18 ans.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">साक्ष्य संलग्न करें</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">आप इस उपयोगकर्ता को संदेश नहीं भेज सकते</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">आप इस व्यक्ति को संदेश नहीं भेज सकते क्योंकि हमारा मानना ​​है कि उनकी आयु 18 वर्ष से कम है।</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-id/strings.xml
+++ b/shared/src/commonMain/composeResources/values-id/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">Lampirkan Bukti</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">Anda tidak dapat mengirim pesan kepada pengguna ini</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Anda tidak dapat mengirim pesan kepada orang ini karena kami yakin mereka berusia di bawah 18 tahun.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">Allega prove</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">Non puoi inviare messaggi a questo utente</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Non puoi inviare messaggi a questa persona perché riteniamo che abbia meno di 18 anni.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">証拠を添付する</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">このユーザーにはメッセージを送信できません</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">この人は 18 歳未満であると思われるため、メッセージを送信できません。</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-km/strings.xml
+++ b/shared/src/commonMain/composeResources/values-km/strings.xml
@@ -495,6 +495,7 @@
     <string name="attach_evidence">ភ្ជាប់ភស្តុតាង</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">អ្នកមិនអាចផ្ញើសារទៅកាន់អ្នកប្រើប្រាស់នេះបានទេ។</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">អ្នកមិនអាចផ្ញើសារទៅកាន់បុគ្គលនេះបានទេ ដោយសារយើងជឿថាពួកគេមានអាយុក្រោម 18 ឆ្នាំ។</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-ko/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ko/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">증거 첨부</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">이 사용자에게 메시지를 보낼 수 없습니다.</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">이 사람은 18세 미만인 것으로 판단되므로 메시지를 보낼 수 없습니다.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">Bewijsmateriaal bijvoegen</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">Je kunt deze gebruiker geen bericht sturen</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Je kunt deze persoon geen bericht sturen omdat we denken dat hij/zij jonger is dan 18 jaar.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-pl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pl/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">Dołącz dowody</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">Nie możesz wysyłać wiadomości do tego użytkownika</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Nie możesz wysłać wiadomości do tej osoby, ponieważ według nas ma ona mniej niż 18 lat.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">Anexar evidências</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">Você não pode enviar mensagens para este usuário</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Você não pode enviar mensagens para essa pessoa porque acreditamos que ela tem menos de 18 anos.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">Прикрепите доказательства</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">Вы не можете отправить сообщение этому пользователю</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Вы не можете отправить сообщение этому человеку, поскольку мы считаем, что ему меньше 18 лет.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-sv/strings.xml
+++ b/shared/src/commonMain/composeResources/values-sv/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">Bifoga bevis</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">Du kan inte skicka meddelanden till den här användaren</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Du kan inte skicka meddelanden till den här personen eftersom vi tror att de är under 18 år.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-th/strings.xml
+++ b/shared/src/commonMain/composeResources/values-th/strings.xml
@@ -479,6 +479,7 @@
     <string name="attach_evidence">แนบหลักฐาน</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">คุณไม่สามารถส่งข้อความถึงผู้ใช้รายนี้ได้</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">คุณไม่สามารถส่งข้อความถึงบุคคลนี้ได้เนื่องจากเราเชื่อว่าพวกเขาอายุต่ำกว่า 18 ปี</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-tr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tr/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">Kanıt Ekle</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">Bu kullanıcıya mesaj gönderemezsiniz</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Bu kişiye mesaj gönderemezsiniz çünkü onun 18 yaşının altında olduğunu düşünüyoruz.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -480,6 +480,7 @@
     <string name="attach_evidence">Додайте докази</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">Ви не можете надіслати повідомлення цьому користувачеві</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Ви не можете надіслати повідомлення цій особі, оскільки ми вважаємо, що їй менше 18 років.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-vi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-vi/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">Đính kèm bằng chứng</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">Bạn không thể nhắn tin cho người dùng này</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">Bạn không thể nhắn tin cho người này vì chúng tôi tin rằng họ dưới 18 tuổi.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -481,6 +481,7 @@
     <string name="attach_evidence">附上证据</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cant_message_user">您无法向该用户发送消息</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pm_locked_other_user_notice">您不能向此人发送消息，因为我们认为他们未满 18 岁。</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -259,6 +259,7 @@
     <string name="all_admins_and_mods">All admins &amp; mods</string>
     <string name="attach_evidence">Attach Evidence</string>
     <string name="cant_message_user">You can't message this user</string>
+    <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <string name="pm_locked_other_user_notice">You cannot message this person because we believe they are under 18.</string>
     <string name="chat">Chat</string>
     <string name="close_group">Close Group</string>

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/Conversation.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/Conversation.kt
@@ -51,6 +51,13 @@ data class Conversation(
     val systemMessageConfig: SystemMessageConfig = SystemMessageConfig(),
     val modNotifyMode: String = "ALL_ADMINS",
     val settings: ConversationSettings? = null,
+    // UK OSA #17 PR 8 — segregation migration freeze flag (server-only).
+    // Set on cross-cohort threads at migration. For groups, the conv
+    // stays visible to existing members but no new members can join
+    // (rules-side gate). UI surfaces a banner so members see the
+    // "preserved but cannot grow" semantics. PR 12 wires the KMP
+    // filter that hides flagged 1:1s from the list.
+    val frozenAtMigration: Boolean = false,
 ) {
     val isOneOnOne: Boolean get() = !isGroup
 
@@ -70,6 +77,13 @@ data class Conversation(
             else -> GroupRole.MEMBER
         }
 
+    // Note: `frozenAtMigration` is DELIBERATELY omitted from
+    // `toMap()` — it is a server-only flag, set by the migration
+    // script via Admin SDK and immutable from clients per
+    // firestore.rules. Including it here would let any client
+    // round-trip + write-back clobber the flag (resetting a frozen
+    // group to unfrozen during a benign edit). The omission is
+    // pinned by `ConversationBusinessTest.fromMap` / toMap tests.
     fun toMap(): Map<String, Any?> =
         buildMap {
             put("conversationId", conversationId)
@@ -141,6 +155,7 @@ data class Conversation(
                     (map["settings"] as? Map<String, Any?>)?.let { s ->
                         ConversationSettings.fromMap(s, s["userId"] as? String ?: "")
                     },
+                frozenAtMigration = map["frozenAtMigration"].asBool(),
             )
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/PrivateMessageRepository.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/PrivateMessageRepository.kt
@@ -111,9 +111,20 @@ interface PrivateMessageRepository {
         query: String,
     ): Resource<List<PrivateMessage>>
 
+    /**
+     * UK OSA #17 PR 8 — the `cohort` parameter is bound by
+     * `firestore.rules` to the creator's JWT cohort claim. Mismatch
+     * fails the create. The rule additionally requires
+     * `participantIds.size() == 1` at create — the implementation
+     * MUST therefore (1) create the doc with just the creator, then
+     * (2) add each additional participant one-at-a-time via update
+     * (which fires the per-add cohort gate). Bulk-create with
+     * cross-cohort members is structurally closed at the rules layer.
+     */
     @Suppress("kotlin:S107")
     suspend fun createGroupConversation(
         creatorId: String,
+        cohort: String,
         participantIds: List<String>,
         groupName: String,
         groupDescription: String? = null,

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/GroupSetupViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/GroupSetupViewModel.kt
@@ -209,10 +209,27 @@ class GroupSetupViewModel(
                     .keys
                     .toList()
 
+            // UK OSA #17 PR 8 — fetch the caller's cohort to stamp on
+            // the new group. The firestore.rules layer binds the
+            // value to the server-signed JWT claim. We fall back to
+            // "minor" (most restrictive) on lookup failure — matches
+            // the PR 7 room-create pattern.
+            val cohort =
+                when (val userResult = userRepository.getUser(currentUserId)) {
+                    is Resource.Success -> {
+                        val user = userResult.data
+                        val override = user.cohortOverride
+                        if (override == "adult" || override == "minor") override else user.cohort
+                    }
+
+                    else -> "minor"
+                }
+
             when (
                 val result =
                     pmRepository.createGroupConversation(
                         creatorId = currentUserId,
+                        cohort = cohort,
                         participantIds = (listOf(currentUserId) + state.selectedUsers.map { it.uid }).distinct(),
                         groupName = state.groupName.trim(),
                         groupDescription = state.groupDescription.trim().ifBlank { null },

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/PrivateChatScreen.kt
@@ -427,6 +427,28 @@ fun PrivateChatScreen(
                 }
             }
 
+            // UK OSA #17 PR 8 — frozenAtMigration banner.
+            // Surfaces "preserved but cannot grow further" semantics on
+            // groups where the segregation migration set the freeze.
+            // The 1:1 case is hidden from the list entirely (PR 12 KMP
+            // filter + PR 3 rules) so this branch fires mainly for
+            // groups, with the same copy serving the rare direct-nav
+            // 1:1 case as defensive fallback. Informational tone
+            // (tertiaryContainer), not error.
+            if (uiState.conversation?.frozenAtMigration == true) {
+                Surface(
+                    modifier = Modifier.fillMaxWidth().testTag("privateChat_frozenBanner"),
+                    color = MaterialTheme.colorScheme.tertiaryContainer,
+                ) {
+                    Text(
+                        text = stringResource(Res.string.group_frozen_banner),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                }
+            }
+
             // Search bar
             if (uiState.isSearching) {
                 Surface(

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/model/ConversationBusinessTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/model/ConversationBusinessTest.kt
@@ -110,4 +110,75 @@ class ConversationBusinessTest {
             )
         assertEquals(GroupRole.MEMBER, conversation.roleOf("regular-user"))
     }
+
+    // ── frozenAtMigration (UK OSA #17 PR 8) ──────────────────────────────
+
+    @Test
+    fun `frozenAtMigration defaults to false`() {
+        // Defensive default — clients that pre-date the field land in
+        // the no-banner path. Setting the default to true would render
+        // the frozen banner on every existing conversation immediately
+        // after rollout.
+        val conversation = Conversation()
+        assertEquals(false, conversation.frozenAtMigration)
+    }
+
+    @Test
+    fun `fromMap reads frozenAtMigration when present`() {
+        val conv =
+            Conversation.fromMap(
+                mapOf(
+                    "participantIds" to listOf("100", "200"),
+                    "frozenAtMigration" to true,
+                ),
+                "convo-1",
+            )
+        assertTrue(conv.frozenAtMigration)
+    }
+
+    @Test
+    fun `fromMap defaults frozenAtMigration to false when absent`() {
+        // Backward-compat: every pre-PR-8 conv doc lacks the field.
+        // `asBool()` on null returns false — the safe default that
+        // keeps existing convs out of the freeze banner path.
+        val conv =
+            Conversation.fromMap(
+                mapOf("participantIds" to listOf("100", "200")),
+                "convo-1",
+            )
+        assertEquals(false, conv.frozenAtMigration)
+    }
+
+    @Test
+    fun `fromMap reads frozenAtMigration false explicitly`() {
+        val conv =
+            Conversation.fromMap(
+                mapOf(
+                    "participantIds" to listOf("100", "200"),
+                    "frozenAtMigration" to false,
+                ),
+                "convo-1",
+            )
+        assertEquals(false, conv.frozenAtMigration)
+    }
+
+    @Test
+    fun `toMap deliberately omits frozenAtMigration (server-only flag immutability defence)`() {
+        // The flag is set ONLY by the migration script via Admin SDK.
+        // If `toMap()` included the flag, every benign client write
+        // (groupName edit, etc.) would round-trip the value back to
+        // Firestore — and a client that constructed a Conversation
+        // with `frozenAtMigration=false` (the default) and wrote it
+        // back via `toMap()` would clobber a previously-frozen flag
+        // to false. firestore.rules independently blocks this on
+        // update, but the data-model-layer defence is the first line.
+        val conv =
+            Conversation(
+                conversationId = "convo-1",
+                participantIds = listOf("100", "200"),
+                isGroup = true,
+                frozenAtMigration = true,
+            )
+        assertEquals(false, conv.toMap().containsKey("frozenAtMigration"))
+    }
 }

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosPrivateMessageRepositoryImpl.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosPrivateMessageRepositoryImpl.kt
@@ -455,6 +455,7 @@ class IosPrivateMessageRepositoryImpl(
 
     override suspend fun createGroupConversation(
         creatorId: String,
+        cohort: String,
         participantIds: List<String>,
         groupName: String,
         groupDescription: String?,
@@ -467,9 +468,15 @@ class IosPrivateMessageRepositoryImpl(
         firebaseCall("Failed to create group conversation") {
             val docRef = firestore.collection("conversations").document
             val now = currentTimeMillis()
+            // UK OSA #17 PR 8 — create with creator alone (size==1) so
+            // the rules-side gate passes; then add each additional
+            // participant via arrayUnion which fires the per-add cohort
+            // get() in firestore.rules. Bulk-seed at create would slip
+            // cross-cohort ids past validation.
+            val initialParticipantIds = listOf(creatorId)
             val data =
                 mutableMapOf<String, Any?>(
-                    "participantIds" to participantIds,
+                    "participantIds" to initialParticipantIds,
                     "isGroup" to true,
                     "groupName" to groupName,
                     "createdBy" to creatorId,
@@ -481,17 +488,36 @@ class IosPrivateMessageRepositoryImpl(
                     "permissions" to permissions.toMap(),
                     "systemMessageConfig" to systemMessageConfig.toMap(),
                     "modNotifyMode" to "ALL_ADMINS",
+                    // Bound by firestore.rules to the caller's JWT
+                    // cohort claim; immutable post-create.
+                    "cohort" to cohort,
                 )
             groupDescription?.let { data["groupDescription"] = it }
             groupPhotoUrl?.let { data["groupPhotoUrl"] = it }
             docRef.set(data)
+            // Add the remaining members one-at-a-time. A failed add
+            // leaves an orphaned single-member group, recoverable
+            // because the creator can still close or re-add later. We
+            // do not fail the overall call on a single add failure —
+            // the partial group is more useful than an aborted one.
+            val extraParticipantIds = participantIds.filter { it != creatorId }
+            val finalParticipantIds = mutableListOf(creatorId)
+            for (pid in extraParticipantIds) {
+                runCatching {
+                    docRef.updateFields {
+                        "participantIds" to FieldValue.arrayUnion(pid)
+                    }
+                    finalParticipantIds.add(pid)
+                }
+            }
             val batch = firestore.batch()
-            for (pid in participantIds) {
+            for (pid in finalParticipantIds) {
                 val settingsRef = docRef.collection("userSettings").document(pid)
                 batch.set(settingsRef, mapOf("unreadCount" to 0, "userId" to pid))
             }
             batch.commit()
-            Conversation.fromMap(data, docRef.id)
+            val finalData = data.toMutableMap().apply { put("participantIds", finalParticipantIds.toList()) }
+            Conversation.fromMap(finalData, docRef.id)
         }
 
     override suspend fun addGroupParticipant(

--- a/tests/integration/10-firestore-cohort-rules.spec.ts
+++ b/tests/integration/10-firestore-cohort-rules.spec.ts
@@ -1460,3 +1460,671 @@ test.describe("Integration — rooms join gate (cross-cohort + third-party-id-sm
     );
   });
 });
+
+// ───────────────────────────────────────────────────────────────
+// UK OSA #17 PR 8 — Conversation create-time gate + group freeze
+// ───────────────────────────────────────────────────────────────
+//
+// PR 3 (above) pins the cross-cohort READ gate via the
+// `crossCohortAtMigration` flag. PR 8 closes the create + add holes:
+//
+//   • Caller MUST be in `participantIds` on create (no proxy creation
+//     — an attacker could otherwise spawn DMs between two victims).
+//   • 1:1 create requires the OTHER participant's CURRENT cohort
+//     (read at create time via a single `get()`) matches the caller's
+//     JWT claim. Cross-cohort DM creation is blocked client-side
+//     without an Express broker endpoint.
+//   • Group create requires the stamped `cohort` field matches the
+//     caller's claim. Per-member validation is deferred to the add
+//     path (one `get()` per add is tractable; N-get on create is not
+//     within the 10-get-per-eval limit for large groups).
+//   • Participant ADD on update (group growth) checks each new id's
+//     cohort, AND is blocked entirely when `frozenAtMigration: true`.
+//   • Member REMOVAL (shrinkage) and non-participantIds updates
+//     (lastMessage, groupName) remain allowed even on frozen groups —
+//     freeze is "no growth," not "no edits."
+
+test.describe("Integration — cohort gate: conversations create-time bind", () => {
+  test("adult caller CAN create 1:1 with another adult", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "users", "200000400"), { cohort: "adult" });
+      await setDoc(doc(db, "users", "200000401"), { cohort: "adult" });
+    });
+    const caller = testEnv.authenticatedContext("uid-create-1to1-ok", {
+      uniqueId: "200000400",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertSucceeds(
+      setDoc(doc(db, "conversations", "dm_400_401"), {
+        participantIds: ["200000400", "200000401"],
+        isGroup: false,
+        createdAt: Date.now(),
+      }),
+    );
+  });
+
+  test("adult caller CANNOT create 1:1 with a minor (cross-cohort blocked)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "users", "200000402"), { cohort: "adult" });
+      await setDoc(doc(db, "users", "200000403"), { cohort: "minor" });
+    });
+    const caller = testEnv.authenticatedContext("uid-create-1to1-bad", {
+      uniqueId: "200000402",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(doc(db, "conversations", "dm_402_403"), {
+        participantIds: ["200000402", "200000403"],
+        isGroup: false,
+        createdAt: Date.now(),
+      }),
+    );
+  });
+
+  test("caller NOT in participantIds CANNOT create (no proxy creation)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "users", "200000404"), { cohort: "adult" });
+      await setDoc(doc(db, "users", "200000405"), { cohort: "adult" });
+    });
+    const eve = testEnv.authenticatedContext("uid-create-proxy-eve", {
+      uniqueId: "200000499",
+      cohort: "adult",
+    });
+    const db = eve.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(doc(db, "conversations", "dm_404_405"), {
+        // Eve isn't a participant — must be rejected.
+        participantIds: ["200000404", "200000405"],
+        isGroup: false,
+      }),
+    );
+  });
+
+  test("group create with cohort field matching caller's claim is allowed", async () => {
+    const caller = testEnv.authenticatedContext("uid-group-create-ok", {
+      uniqueId: "200000406",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertSucceeds(
+      setDoc(doc(db, "conversations", "group-ok-1"), {
+        participantIds: ["200000406"],
+        isGroup: true,
+        groupName: "My group",
+        cohort: "adult",
+      }),
+    );
+  });
+
+  test("group create with cohort field mismatching caller's claim is rejected (forging defence)", async () => {
+    const caller = testEnv.authenticatedContext("uid-group-create-bad", {
+      uniqueId: "200000407",
+      cohort: "minor",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(doc(db, "conversations", "group-bad-1"), {
+        participantIds: ["200000407"],
+        isGroup: true,
+        groupName: "Forged",
+        cohort: "adult", // claim says minor — must reject
+      }),
+    );
+  });
+
+  test("group create missing cohort field is rejected", async () => {
+    const caller = testEnv.authenticatedContext("uid-group-create-nocohort", {
+      uniqueId: "200000408",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(doc(db, "conversations", "group-nocohort-1"), {
+        participantIds: ["200000408"],
+        isGroup: true,
+        groupName: "Missing tag",
+        // no cohort
+      }),
+    );
+  });
+});
+
+test.describe("Integration — conversation participant ADD gate + frozenAtMigration freeze", () => {
+  test("group admin CAN add a same-cohort participant (single-add)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "users", "200000410"), { cohort: "adult" });
+      await setDoc(doc(db, "users", "200000411"), { cohort: "adult" });
+      await setDoc(doc(db, "conversations", "group-add-ok"), {
+        participantIds: ["200000410"],
+        isGroup: true,
+        groupName: "G",
+        cohort: "adult",
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-add-ok", {
+      uniqueId: "200000410",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertSucceeds(
+      updateDoc(doc(db, "conversations", "group-add-ok"), {
+        participantIds: ["200000410", "200000411"],
+      }),
+    );
+  });
+
+  test("group admin CANNOT add a cross-cohort participant", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "users", "200000412"), { cohort: "adult" });
+      await setDoc(doc(db, "users", "200000413"), { cohort: "minor" });
+      await setDoc(doc(db, "conversations", "group-add-bad"), {
+        participantIds: ["200000412"],
+        isGroup: true,
+        cohort: "adult",
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-add-bad", {
+      uniqueId: "200000412",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      updateDoc(doc(db, "conversations", "group-add-bad"), {
+        participantIds: ["200000412", "200000413"],
+      }),
+    );
+  });
+
+  test("group admin CANNOT add ANY participant when frozenAtMigration is true", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "users", "200000414"), { cohort: "adult" });
+      await setDoc(doc(db, "users", "200000415"), { cohort: "adult" });
+      await setDoc(doc(db, "conversations", "group-frozen-1"), {
+        participantIds: ["200000414"],
+        isGroup: true,
+        cohort: "adult",
+        frozenAtMigration: true,
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-frozen-add", {
+      uniqueId: "200000414",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      updateDoc(doc(db, "conversations", "group-frozen-1"), {
+        participantIds: ["200000414", "200000415"],
+      }),
+    );
+  });
+
+  test("group admin CAN remove a participant from a frozenAtMigration group (shrinkage allowed)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "conversations", "group-frozen-shrink"), {
+        participantIds: ["200000416", "200000417"],
+        isGroup: true,
+        cohort: "adult",
+        frozenAtMigration: true,
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-frozen-shrink", {
+      uniqueId: "200000416",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertSucceeds(
+      updateDoc(doc(db, "conversations", "group-frozen-shrink"), {
+        participantIds: ["200000416"],
+      }),
+    );
+  });
+
+  test("group admin CAN update non-participant fields on a frozen group (lastMessage, etc.)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "conversations", "group-frozen-lastmsg"), {
+        participantIds: ["200000418", "200000419"],
+        isGroup: true,
+        cohort: "adult",
+        frozenAtMigration: true,
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-frozen-lastmsg", {
+      uniqueId: "200000418",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertSucceeds(
+      updateDoc(doc(db, "conversations", "group-frozen-lastmsg"), {
+        lastMessage: {
+          text: "still chatting",
+          senderId: "200000418",
+          createdAt: Date.now(),
+        },
+        lastMessageAt: Date.now(),
+      }),
+    );
+  });
+
+  test("group admin CANNOT bulk-add multiple participants in one update (one-at-a-time invariant)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "users", "200000420"), { cohort: "adult" });
+      await setDoc(doc(db, "users", "200000421"), { cohort: "adult" });
+      await setDoc(doc(db, "users", "200000422"), { cohort: "adult" });
+      await setDoc(doc(db, "conversations", "group-bulk-add"), {
+        participantIds: ["200000420"],
+        isGroup: true,
+        cohort: "adult",
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-bulk-add", {
+      uniqueId: "200000420",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      updateDoc(doc(db, "conversations", "group-bulk-add"), {
+        participantIds: ["200000420", "200000421", "200000422"],
+      }),
+    );
+  });
+});
+
+test.describe("Integration — messages.create gate (1:1 cross-cohort migration freeze)", () => {
+  test("participant CANNOT create message on a 1:1 flagged crossCohortAtMigration", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "conversations", "dm_msg_blocked"), {
+        participantIds: ["200000430", "200000431"],
+        crossCohortAtMigration: true,
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-msg-blocked", {
+      uniqueId: "200000430",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(doc(db, "conversations", "dm_msg_blocked", "messages", "m1"), {
+        senderId: "200000430",
+        text: "should not land",
+        createdAt: Date.now(),
+      }),
+    );
+  });
+
+  test("participant CAN create message on a non-flagged 1:1", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "conversations", "dm_msg_ok"), {
+        participantIds: ["200000432", "200000433"],
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-msg-ok", {
+      uniqueId: "200000432",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertSucceeds(
+      setDoc(doc(db, "conversations", "dm_msg_ok", "messages", "m1"), {
+        senderId: "200000432",
+        text: "hi",
+        createdAt: Date.now(),
+      }),
+    );
+  });
+
+  test("participant CAN create message on a frozen GROUP (frozen ≠ message-block for groups)", async () => {
+    // Per design § Migration (line 137): existing members keep
+    // read+write access to frozen groups. The freeze is participant-
+    // list only.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "conversations", "group-frozen-msg"), {
+        participantIds: ["200000434", "200000435"],
+        isGroup: true,
+        cohort: "adult",
+        frozenAtMigration: true,
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-frozen-msg", {
+      uniqueId: "200000434",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertSucceeds(
+      setDoc(doc(db, "conversations", "group-frozen-msg", "messages", "m1"), {
+        senderId: "200000434",
+        text: "still here",
+        createdAt: Date.now(),
+      }),
+    );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────
+// UK OSA #17 PR 8 — Migration-flag immutability + server-only fields
+// + create-time defences against pre-emptive flag stamping
+// ───────────────────────────────────────────────────────────────
+//
+// These tests defend the server-only contract on `crossCohortAtMigration`,
+// `frozenAtMigration`, and `frozenAtMigrationAt`. The migration script
+// (run via Admin SDK) is the only legitimate writer. Without the
+// rules-side immutability + create-stamp block, a participant can:
+//   (1) clear `crossCohortAtMigration` to un-hide a migrated 1:1,
+//   (2) set `crossCohortAtMigration` to grief a counterpart by
+//       hiding a thread they share,
+//   (3) clear `frozenAtMigration` on a group to un-freeze it, then
+//       bulk-add cross-cohort members (two-step attack),
+//   (4) pre-emptively stamp the flags on a NEW conversation at a
+//       deterministic dm_<a>_<b> ID, denying the legitimate pair
+//       from ever opening that thread (subsequent same-id create
+//       collides; the existing flagged doc denies all reads).
+
+test.describe("Integration — conversation migration-flag immutability", () => {
+  test("participant CANNOT clear crossCohortAtMigration on a flagged 1:1 (un-hide attack)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "conversations", "dm_flag_clear"), {
+        participantIds: ["200000440", "200000441"],
+        crossCohortAtMigration: true,
+        frozenAtMigration: true,
+      });
+    });
+    // Note: participant can't READ the flagged conv (PR 3 rule) but
+    // can still SUBMIT an update — rules evaluate against the
+    // server-side resource. Test that the update is rejected even
+    // though caller is in participantIds.
+    const caller = testEnv.authenticatedContext("uid-flag-clear", {
+      uniqueId: "200000440",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      updateDoc(doc(db, "conversations", "dm_flag_clear"), {
+        crossCohortAtMigration: false,
+      }),
+    );
+  });
+
+  test("participant CANNOT set crossCohortAtMigration on a non-flagged thread (grief attack)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "conversations", "dm_flag_set"), {
+        participantIds: ["200000442", "200000443"],
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-flag-set", {
+      uniqueId: "200000442",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      updateDoc(doc(db, "conversations", "dm_flag_set"), {
+        crossCohortAtMigration: true,
+      }),
+    );
+  });
+
+  test("participant CANNOT clear frozenAtMigration on a frozen group (two-step bulk-add precursor)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "conversations", "group-frozen-unfreeze"), {
+        participantIds: ["200000444", "200000445"],
+        isGroup: true,
+        cohort: "adult",
+        frozenAtMigration: true,
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-unfreeze", {
+      uniqueId: "200000444",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      updateDoc(doc(db, "conversations", "group-frozen-unfreeze"), {
+        frozenAtMigration: false,
+      }),
+    );
+  });
+
+  test("participant CANNOT set frozenAtMigration=true on an unfrozen group (self-freeze attack)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "conversations", "group-self-freeze"), {
+        participantIds: ["200000446", "200000447"],
+        isGroup: true,
+        cohort: "adult",
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-self-freeze", {
+      uniqueId: "200000446",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      updateDoc(doc(db, "conversations", "group-self-freeze"), {
+        frozenAtMigration: true,
+      }),
+    );
+  });
+
+  test("participant CANNOT mutate frozenAtMigrationAt timestamp", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "conversations", "group-ts-tamper"), {
+        participantIds: ["200000448", "200000449"],
+        isGroup: true,
+        cohort: "adult",
+        frozenAtMigration: true,
+        frozenAtMigrationAt: 1000000000,
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-ts-tamper", {
+      uniqueId: "200000448",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      updateDoc(doc(db, "conversations", "group-ts-tamper"), {
+        frozenAtMigrationAt: 2000000000,
+      }),
+    );
+  });
+});
+
+test.describe("Integration — conversation create cannot stamp migration flags", () => {
+  test("caller CANNOT stamp crossCohortAtMigration=true on a NEW 1:1 (pre-empt grief)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "users", "200000450"), { cohort: "adult" });
+      await setDoc(doc(db, "users", "200000451"), { cohort: "adult" });
+    });
+    const caller = testEnv.authenticatedContext("uid-stamp-cross", {
+      uniqueId: "200000450",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(doc(db, "conversations", "dm_450_451"), {
+        participantIds: ["200000450", "200000451"],
+        isGroup: false,
+        crossCohortAtMigration: true,
+      }),
+    );
+  });
+
+  test("caller CANNOT stamp frozenAtMigration=true on a NEW group (pre-empt self-freeze)", async () => {
+    const caller = testEnv.authenticatedContext("uid-stamp-frozen", {
+      uniqueId: "200000452",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(doc(db, "conversations", "group-stamp-frozen"), {
+        participantIds: ["200000452"],
+        isGroup: true,
+        cohort: "adult",
+        frozenAtMigration: true,
+      }),
+    );
+  });
+});
+
+test.describe("Integration — conversation create structural defences", () => {
+  test("group create with >1 participants is rejected (bulk-seed defence)", async () => {
+    // Per design — group must be created with caller alone, then
+    // members added one-at-a-time via update where the per-add
+    // cohort gate fires. Bulk-seed at create would slip cross-cohort
+    // members past the per-add validation.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "users", "200000460"), { cohort: "adult" });
+      await setDoc(doc(db, "users", "200000461"), { cohort: "adult" });
+    });
+    const caller = testEnv.authenticatedContext("uid-bulk-seed", {
+      uniqueId: "200000460",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(doc(db, "conversations", "group-bulk-seed"), {
+        participantIds: ["200000460", "200000461"],
+        isGroup: true,
+        cohort: "adult",
+      }),
+    );
+  });
+
+  test("group create with non-enum cohort value is rejected", async () => {
+    const caller = testEnv.authenticatedContext("uid-bad-cohort", {
+      uniqueId: "200000462",
+      cohort: "verified-adult", // claim is non-enum (future drift)
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(doc(db, "conversations", "group-bad-cohort"), {
+        participantIds: ["200000462"],
+        isGroup: true,
+        cohort: "verified-adult",
+      }),
+    );
+  });
+
+  test("1:1 create with duplicate caller-id participantIds is rejected", async () => {
+    // Defensive — if both participantIds were the caller, the rules'
+    // removeAll(caller) would return [] and the .data.cohort read
+    // would error. The explicit distinct-participants check makes
+    // the rule semantics clear.
+    const caller = testEnv.authenticatedContext("uid-dup-self", {
+      uniqueId: "200000463",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(doc(db, "conversations", "dm_dup_self"), {
+        participantIds: ["200000463", "200000463"],
+        isGroup: false,
+      }),
+    );
+  });
+
+  test("1:1 create with missing OTHER user doc is rejected (fail-closed)", async () => {
+    // The cohort-check `get()` resolves to null when the other doc
+    // doesn't exist — rules evaluator returns false (deny). Pins the
+    // fail-closed default; a future refactor that changes the
+    // null-handling semantics would break this test.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "users", "200000464"), { cohort: "adult" });
+      // user 200000465 deliberately not seeded
+    });
+    const caller = testEnv.authenticatedContext("uid-missing-other", {
+      uniqueId: "200000464",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(doc(db, "conversations", "dm_464_465"), {
+        participantIds: ["200000464", "200000465"],
+        isGroup: false,
+      }),
+    );
+  });
+});
+
+test.describe("Integration — flagged conversation subcollection write propagation", () => {
+  test("participant CANNOT write userSettings on a flagged 1:1 (write-side flag propagation)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "conversations", "dm_us_write_blocked"), {
+        participantIds: ["200000470", "200000471"],
+        crossCohortAtMigration: true,
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-us-write", {
+      uniqueId: "200000470",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(
+        doc(db, "conversations", "dm_us_write_blocked", "userSettings", "200000470"),
+        { unreadCount: 0, isHidden: true },
+      ),
+    );
+  });
+
+  test("participant CAN write userSettings on a non-flagged conversation", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "conversations", "dm_us_write_ok"), {
+        participantIds: ["200000472", "200000473"],
+      });
+    });
+    const caller = testEnv.authenticatedContext("uid-us-write-ok", {
+      uniqueId: "200000472",
+      cohort: "adult",
+    });
+    const db = caller.firestore() as unknown as Firestore;
+    await assertSucceeds(
+      setDoc(
+        doc(db, "conversations", "dm_us_write_ok", "userSettings", "200000472"),
+        { unreadCount: 0, isHidden: false },
+      ),
+    );
+  });
+
+  test("admin/mod CANNOT write mutes on a flagged conversation", async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore() as unknown as Firestore;
+      await setDoc(doc(db, "conversations", "group_mutes_blocked"), {
+        participantIds: ["200000474", "200000475"],
+        groupAdminIds: ["200000474"],
+        groupModIds: [],
+        crossCohortAtMigration: true,
+      });
+    });
+    const admin = testEnv.authenticatedContext("uid-mutes-admin", {
+      uniqueId: "200000474",
+      cohort: "adult",
+    });
+    const db = admin.firestore() as unknown as Firestore;
+    await assertFails(
+      setDoc(
+        doc(db, "conversations", "group_mutes_blocked", "mutes", "200000475"),
+        { mutedAt: Date.now(), mutedBy: "200000474" },
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- **Conversation cohort gates** at firestore.rules level — create blocks proxy creation + cross-cohort 1:1 + group bulk-seed; update blocks server-only flag tampering + cross-cohort growth + frozen-group additions.
- **Migration script Phase 3 (conversations)** — 1:1 cross-cohort gets `crossCohortAtMigration: true` + `frozenAtMigration: true` (hidden from list + read-denied); group cross-cohort gets `frozenAtMigration: true` only (preserved but cannot grow further). Per-side PMs with block-bypass, cohort-agnostic copy.
- **Frozen-group banner** in `PrivateChatScreen` with `group_frozen_banner` string in all 20 locales.
- **Defence in depth** — Express `gateCrossCohortConversation` 404s on `crossCohortAtMigration: true` regardless of current cohorts. Admin moderation bypass with live re-check, audited via new `admin_flag_bypass` segregationEvents row.

## Test plan
- [x] **5155 Express Jest tests pass** (216 suites, +60 new tests across migration + route + audit-helper paths)
- [x] **Kotlin tests pass** — testDevDebugUnitTest + :shared:jvmTest + detekt all clean
- [x] **iOS arm64 compile succeeds** — KMP shared compiles for both platforms
- [x] **firestore.rules compile** via `firebase deploy --dry-run`
- [x] **ktlint clean** on all 10 modified Kotlin files
- [x] **Prettier clean** on all 6 modified Express JS files
- [x] **Code reviewer agent** + **security reviewer agent** run; 12 findings addressed (4 critical, 3 high, 2 medium, 3 low) — full list in commit body
- [x] **Integration tests (firestore rules emulator)** — 26 new tests across create gates, flag immutability, missing-user fail-closed, subcollection write propagation. To be exercised by CI emulator.
- [ ] **Playwright** — N/A (no web UI changes; admin panel unaffected)
- [ ] **Local /manual-qa** — Deferred to dev-deploy step after merge.

## Files
39 files changed: +2620 / -27
- `firestore.rules` (+88 / -10)
- `express-api/src/routes/conversations.js`, `scripts/migrate-segregation-relationships.js`, `src/utils/segregation-audit.js` (new), `src/middleware/sameCohort.js`
- `tests/routes/conversations-cohort.test.js` (new), `tests/scripts/migrate-segregation-relationships.test.js`
- `shared/src/commonMain/...Conversation.kt`, `PrivateMessageRepository.kt`, `PrivateChatScreen.kt`, `GroupSetupViewModel.kt`
- `shared/src/iosMain/...IosPrivateMessageRepositoryImpl.kt`
- `app/src/main/...PrivateMessageRepositoryImpl.kt`
- 21 `strings.xml` files (20 locales + default) — `group_frozen_banner` string
- `app/src/test/...GroupSetupViewModelTest.kt`, `PrivateMessageRepositoryImplTest.kt`
- `app/src/androidTest/...FakePrivateMessageRepository.kt`
- `tests/integration/10-firestore-cohort-rules.spec.ts`
- `shared/src/commonTest/...ConversationBusinessTest.kt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)