### PR TITLE
feat(seg): PR 10 of 14 — leaderboard + gift-wall cohort filters (#17)

### DIFF
--- a/express-api/src/routes/config.js
+++ b/express-api/src/routes/config.js
@@ -16,7 +16,9 @@
 const crypto = require('node:crypto');
 const router = require('express').Router();
 const { db } = require('../utils/firebase');
-const { requireAdmin } = require('../middleware/auth');
+const { requireAdmin, isLiveAdmin } = require('../middleware/auth');
+const { cohortFromClaim } = require('../utils/firebase-claims');
+const { filterListByCohort } = require('../utils/cohort-filter');
 const { queryDocs } = require('../utils/firestore-helpers');
 const log = require('../utils/log');
 
@@ -811,13 +813,25 @@ router.get('/broadcasts', async (req, res) => {
 });
 
 // -- Get gift rankings --
+// PR 10 (UK OSA #17) — inner cohort filter. Entries are stamped at write
+// time by economy.js updateGiftRankings; legacy entries pre-PR-10 fall
+// back to a per-entry users/<id> lookup (cohort-filter.js). Admin
+// (live-verified) bypasses the filter. `totalSent` is preserved as a
+// global stat — only the per-user rankings array is cohort-restricted.
 router.get('/gift-rankings/:giftId', async (req, res) => {
   try {
     const snap = await db.doc(`giftRankings/${req.params.giftId}`).get();
     const doc = snap.exists ? snap.data() : null;
+    const allRankings = doc?.rankings || [];
+
+    const isAdmin = req?.auth?.token?.admin === true && Boolean(await isLiveAdmin(req.auth?.uid));
+
+    const rankings = isAdmin
+      ? allRankings
+      : await filterListByCohort(allRankings, cohortFromClaim(req), 'userId');
 
     return res.json({
-      rankings: doc?.rankings || [],
+      rankings,
       totalSent: doc?.totalSent || 0,
       lastUpdated: doc?.lastUpdated || null,
     });

--- a/express-api/src/routes/economy.js
+++ b/express-api/src/routes/economy.js
@@ -25,8 +25,10 @@ const crypto = require('node:crypto');
 const router = require('express').Router();
 const { db, FieldValue } = require('../utils/firebase');
 const { generateId, now, todayStr, yesterdayStr } = require('../utils/helpers');
-const { requireAdmin } = require('../middleware/auth');
+const { requireAdmin, isLiveAdmin } = require('../middleware/auth');
 const { requireSameCohort } = require('../middleware/sameCohort');
+const { effectiveCohort, cohortFromClaim } = require('../utils/firebase-claims');
+const { filterListByCohort } = require('../utils/cohort-filter');
 const log = require('../utils/log');
 const { verifyProductPurchase, verifySubscription } = require('../utils/playStore');
 const { verifyApplePurchase } = require('../utils/appleStore');
@@ -157,20 +159,29 @@ async function addBroadcast(data) {
  * field — the receivedCount remains accurate, which is the
  * primary-display value.
  */
-async function updateGiftWall(recipientId, giftId, senderId, quantity) {
+async function updateGiftWall(recipientId, giftId, senderId, quantity, senderCohort) {
   const wallRef = db.doc(`users/${recipientId}/giftWall/${giftId}`);
   const wallSnap = await wallRef.get();
   const wallDoc = wallSnap.exists ? wallSnap.data() : null;
 
   const senders = wallDoc?.senders || [];
 
-  // Update or add sender (best-effort — see function header)
+  // Update or add sender (best-effort — see function header). PR 10:
+  // stamp the sender's cohort on the entry so the read path can apply
+  // the inner-list filter without a per-entry live lookup. Existing
+  // pre-PR-10 entries that lack `cohort` are also backfilled on next
+  // send — the legacy-fallback in cohort-filter.js handles the rest.
   const existingSender = senders.find((s) => s.senderId === senderId);
   if (existingSender) {
     existingSender.sendCount = (existingSender.sendCount || 0) + quantity;
     existingSender.lastSentAt = now();
+    if (senderCohort && !existingSender.cohort) {
+      existingSender.cohort = senderCohort;
+    }
   } else {
-    senders.push({ senderId, sendCount: quantity, lastSentAt: now() });
+    const entry = { senderId, sendCount: quantity, lastSentAt: now() };
+    if (senderCohort) entry.cohort = senderCohort;
+    senders.push(entry);
   }
 
   // Sort senders by count descending, keep top 50
@@ -236,27 +247,36 @@ async function writeRoomGiftMessage(roomId, senderId, senderName, text, giftId, 
  * concurrent updates can drop entries — but the totalSent counter
  * remains accurate.
  */
-async function updateGiftRankings(recipientId, giftId, quantity) {
+async function updateGiftRankings(recipientId, giftId, quantity, recipientCohort) {
   try {
     const rankRef = db.doc(`giftRankings/${giftId}`);
     const rankSnap = await rankRef.get();
     const rankDoc = rankSnap.exists ? rankSnap.data() : {};
     const rankings = rankDoc.rankings || [];
 
-    // Find or add recipient in rankings
+    // Find or add recipient in rankings. PR 10: stamp the recipient's
+    // cohort so the read path can filter cross-cohort entries without
+    // a per-entry live lookup. Pre-PR-10 entries lacking `cohort` are
+    // backfilled on next send; legacy-fallback in cohort-filter.js
+    // handles unrewritten rows.
     const existing = rankings.find((r) => r.userId === recipientId);
     if (existing) {
       existing.count = (existing.count || 0) + quantity;
+      if (recipientCohort && !existing.cohort) {
+        existing.cohort = recipientCohort;
+      }
     } else {
       // Get recipient display info
       const userSnap = await db.doc(`users/${recipientId}`).get();
       const user = userSnap.exists ? userSnap.data() : {};
-      rankings.push({
+      const entry = {
         userId: recipientId,
         count: quantity,
         displayName: userField(user, 'displayName', 'display_name') || '',
         profilePhotoUrl: userField(user, 'profilePhotoUrl', 'profile_photo_url') || '',
-      });
+      };
+      if (recipientCohort) entry.cohort = recipientCohort;
+      rankings.push(entry);
     }
 
     // Sort by count descending, keep top 100
@@ -288,21 +308,6 @@ async function updateGiftRankings(recipientId, giftId, quantity) {
 
 // ─── Shared gift helpers ─────────────────────────────────────────
 // (block-check helpers live in ../utils/block-check — imported above)
-
-/**
- * Load the target user doc and refuse with 403 if they have blocked
- * the caller (C7). Returns false when 403 was sent — caller must
- * `return` immediately to avoid double-send. Returns true to continue.
- */
-async function refuseIfTargetBlocksViewer(req, res) {
-  const snap = await db.doc(`users/${req.params.uniqueId}`).get();
-  const target = snap.exists ? snap.data() : null;
-  if (viewerIsBlocked(req.auth.uniqueId, target)) {
-    res.status(403).json({ error: 'Cannot view content of users who have blocked you' });
-    return false;
-  }
-  return true;
-}
 
 /** Compute daily reward from config and streak. */
 function computeDailyReward(config, newStreak, isSuperShy) {
@@ -784,6 +789,12 @@ router.post('/economy/gift', async (req, res) => {
       return res.status(402).json({ error: 'Insufficient items in backpack' });
     if (await requireSameCohort(req, res, recipientId, () => recipient)) return;
 
+    // PR 10: snapshot cohorts for write-time stamping on rankings + wall.
+    // Sender cohort comes from the JWT claim (single source of truth used
+    // by the gate above); recipient cohort comes from their user doc.
+    const senderCohort = cohortFromClaim(req);
+    const recipientCohort = effectiveCohort(recipient);
+
     const blockError = checkBlockRelationship(sender, recipient, uniqueId, recipientId);
     if (blockError) {
       log.warn('economy', 'Gift blocked: sender/recipient blocked', {
@@ -815,7 +826,7 @@ router.post('/economy/gift', async (req, res) => {
     });
 
     // Update recipient gift wall
-    await updateGiftWall(recipientId, giftId, uniqueId, quantity);
+    await updateGiftWall(recipientId, giftId, uniqueId, quantity, senderCohort);
 
     // Credit beans (atomic increment to avoid race conditions)
     await db.doc(`users/${recipientId}`).update({ shyBeans: FieldValue.increment(beanReward) });
@@ -895,7 +906,7 @@ router.post('/economy/gift', async (req, res) => {
     }
 
     // Update gift rankings incrementally
-    await updateGiftRankings(recipientId, giftId, quantity);
+    await updateGiftRankings(recipientId, giftId, quantity, recipientCohort);
 
     res.json({ success: true, beanReward, giftName: gift.name, quantity });
   } catch (err) {
@@ -931,6 +942,10 @@ router.post('/economy/gift-direct', async (req, res) => {
     // UK OSA #17 PR 9 — cohort gate. Collapses missing-recipient and
     // cross-cohort branches into a byte-identical 404 'Not found'.
     if (await requireSameCohort(req, res, recipientId, () => recipient)) return;
+
+    // PR 10: snapshot cohorts for write-time stamping.
+    const senderCohort = cohortFromClaim(req);
+    const recipientCohort = effectiveCohort(recipient);
 
     const blockError = checkBlockRelationship(sender, recipient, uniqueId, recipientId);
     if (blockError) {
@@ -973,7 +988,7 @@ router.post('/economy/gift-direct', async (req, res) => {
     }
 
     // Gift wall
-    await updateGiftWall(recipientId, giftId, uniqueId, quantity);
+    await updateGiftWall(recipientId, giftId, uniqueId, quantity, senderCohort);
 
     // Beans (atomic)
     await db.doc(`users/${recipientId}`).update({ shyBeans: FieldValue.increment(beanReward) });
@@ -1037,7 +1052,7 @@ router.post('/economy/gift-direct', async (req, res) => {
     }
 
     // Update gift rankings incrementally
-    await updateGiftRankings(recipientId, giftId, quantity);
+    await updateGiftRankings(recipientId, giftId, quantity, recipientCohort);
 
     res.json({ success: true, beanReward, giftName: gift.name, coinsSpent: totalCost, quantity });
   } catch (err) {
@@ -1118,6 +1133,13 @@ router.post('/economy/gift-batch', async (req, res) => {
       if (await requireSameCohort(req, res, recipientIds[i], () => recipientData)) return;
     }
 
+    // PR 10: sender cohort is constant across the batch; recipient
+    // cohort varies and is computed per-iteration below. Same-cohort
+    // is already enforced for every recipient above, so in practice
+    // senderCohort === recipientCohort for every iteration — we still
+    // pass both explicitly so the stamping logic is straightforward.
+    const senderCohort = cohortFromClaim(req);
+
     // Check block relationships — UK OSA requires blocking prevents ALL contact
     for (let i = 0; i < recipientIds.length; i++) {
       if (!recipientSnaps[i].exists) continue;
@@ -1160,10 +1182,11 @@ router.post('/economy/gift-batch', async (req, res) => {
       const recipientBeans = userField(recipient, 'shyBeans', 'shy_beans') || 0;
 
       const beanReward = Math.floor(coinValue * config.beanConversionRate * quantity);
+      const recipientCohort = effectiveCohort(recipient);
 
       // Gift wall + beans (atomic) + transaction
-      await updateGiftWall(recipientId, giftId, uniqueId, quantity);
-      await updateGiftRankings(recipientId, giftId, quantity);
+      await updateGiftWall(recipientId, giftId, uniqueId, quantity, senderCohort);
+      await updateGiftRankings(recipientId, giftId, quantity, recipientCohort);
       await db.doc(`users/${recipientId}`).update({ shyBeans: FieldValue.increment(beanReward) });
 
       const recipientTxId = generateId();
@@ -1255,6 +1278,10 @@ router.post('/economy/backpack-send', async (req, res) => {
     // cross-cohort branches into a byte-identical 404 'Not found'.
     if (await requireSameCohort(req, res, recipientId, () => recipient)) return;
 
+    // PR 10: snapshot cohorts for write-time stamping on each item.
+    const senderCohort = cohortFromClaim(req);
+    const recipientCohort = effectiveCohort(recipient);
+
     const blockError = checkBlockRelationship(sender, recipient, uniqueId, recipientId);
     if (blockError) {
       log.warn('economy', 'Gift blocked: sender/recipient blocked', {
@@ -1295,8 +1322,8 @@ router.post('/economy/backpack-send', async (req, res) => {
       totalBeanReward += beanReward;
 
       // Gift wall + rankings
-      await updateGiftWall(recipientId, item.giftId, uniqueId, qty);
-      await updateGiftRankings(recipientId, item.giftId, qty);
+      await updateGiftWall(recipientId, item.giftId, uniqueId, qty, senderCohort);
+      await updateGiftRankings(recipientId, item.giftId, qty, recipientCohort);
     }
 
     // Atomic: bean credit + ALL backpack deletes in the same batch.
@@ -1916,9 +1943,22 @@ router.get('/users/:uniqueId/backpack', async (req, res) => {
 // ── Gift wall ──
 router.get('/users/:uniqueId/gift-wall', async (req, res) => {
   try {
+    // PR 10 — outer cohort gate. The target's gift wall is itself a
+    // user-owned list, so cross-cohort callers get the byte-identical
+    // 404 existence-hider. Target doc is fetched once and shared with
+    // the block check below.
+    const targetSnap = await db.doc(`users/${req.params.uniqueId}`).get();
+    const target = targetSnap.exists ? targetSnap.data() : null;
+
+    if (await requireSameCohort(req, res, req.params.uniqueId, () => target)) return;
+
     // C7 (block-list integrity): a user who has been blocked by the
-    // target must not be able to see the target's gift wall.
-    if (!(await refuseIfTargetBlocksViewer(req, res))) return;
+    // target must not be able to see the target's gift wall. Runs
+    // AFTER the cohort gate so 403 only fires for same-cohort blocks
+    // (cross-cohort would have already returned 404).
+    if (target && viewerIsBlocked(req.auth.uniqueId, target)) {
+      return res.status(403).json({ error: 'Cannot view content of users who have blocked you' });
+    }
 
     const snap = await db.collection(`users/${req.params.uniqueId}/giftWall`).get();
     const results = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
@@ -1932,17 +1972,38 @@ router.get('/users/:uniqueId/gift-wall', async (req, res) => {
 // ── Gift wall senders ──
 router.get('/users/:uniqueId/gift-wall/:giftId/senders', async (req, res) => {
   try {
+    // PR 10 — outer cohort gate (mirrors the gift-wall handler above).
+    const targetSnap = await db.doc(`users/${req.params.uniqueId}`).get();
+    const target = targetSnap.exists ? targetSnap.data() : null;
+
+    if (await requireSameCohort(req, res, req.params.uniqueId, () => target)) return;
+
     // C7: same block check as the parent gift-wall list — the sender
     // list is a strict subset of gift-wall data.
-    if (!(await refuseIfTargetBlocksViewer(req, res))) return;
+    if (target && viewerIsBlocked(req.auth.uniqueId, target)) {
+      return res.status(403).json({ error: 'Cannot view content of users who have blocked you' });
+    }
 
     const docSnap = await db
       .doc(`users/${req.params.uniqueId}/giftWall/${req.params.giftId}`)
       .get();
     const senders = docSnap.exists ? docSnap.data().senders || [] : [];
+
+    // PR 10 — inner cohort filter. Admin (live-verified) bypasses the
+    // filter to retain moderation visibility. Otherwise each sender's
+    // cohort comes from a stamped `cohort` field (PR 10 write-time) or
+    // falls back to a per-entry users/<id> lookup for legacy rows. The
+    // deleted-user case is dropped explicitly so a deleted account
+    // can't leak as a same-minor-cohort entry to minor callers.
+    const isAdmin = req?.auth?.token?.admin === true && Boolean(await isLiveAdmin(req.auth.uid));
+
+    const filtered = isAdmin
+      ? senders.slice()
+      : await filterListByCohort(senders, cohortFromClaim(req), 'senderId');
+
     // Sort by sendCount descending
-    senders.sort((a, b) => (b.sendCount || 0) - (a.sendCount || 0));
-    res.json(senders);
+    filtered.sort((a, b) => (b.sendCount || 0) - (a.sendCount || 0));
+    res.json(filtered);
   } catch (err) {
     log.error('economy', 'GET /users/:uniqueId/gift-wall/:giftId/senders failed', {
       error: err.message,

--- a/express-api/src/utils/cohort-filter.js
+++ b/express-api/src/utils/cohort-filter.js
@@ -1,0 +1,49 @@
+/**
+ * UK OSA #17 PR 10 — list-body cohort filter.
+ *
+ * Companion to `middleware/sameCohort.js` (which handles the *outer*
+ * 404-existence-hiding gate). This module handles the *inner* gate:
+ * given a list of entries that each point to a user, filter out the
+ * entries whose owner is cross-cohort to the caller.
+ *
+ * Resolution rules per entry:
+ *   1. If the entry has a stamped `cohort` field in the
+ *      `VALID_COHORTS` allow-list → use it. Zero Firestore reads.
+ *   2. Else (legacy entry, pre-PR-10) → live-look up `users/<id>` and
+ *      derive via `effectiveCohort`. Zero-downtime migration: old
+ *      entries Just Work until they're rewritten by the write-time
+ *      stamping in `updateGiftRankings` / `updateGiftWall`.
+ *   3. If the live lookup returns a non-existent doc → return null
+ *      (drop the entry). This is the deleted-user case: WITHOUT
+ *      explicit drop, `effectiveCohort(null) → 'minor'` would leak
+ *      the existence of deleted users to minor callers as
+ *      "same-cohort" entries.
+ *
+ * Tests live in `tests/routes/leaderboards-cohort.test.js`.
+ */
+
+const { db } = require('./firebase');
+const { effectiveCohort, VALID_COHORTS } = require('./firebase-claims');
+
+async function resolveEntryCohort(entry, userId) {
+  if (entry && typeof entry.cohort === 'string' && VALID_COHORTS.has(entry.cohort)) {
+    return entry.cohort;
+  }
+  if (!userId) return null;
+  const snap = await db.doc(`users/${userId}`).get();
+  if (!snap.exists) return null;
+  return effectiveCohort(snap.data());
+}
+
+async function filterListByCohort(items, callerCohort, idField) {
+  if (!Array.isArray(items) || items.length === 0) return [];
+  const resolved = await Promise.all(
+    items.map(async (item) => {
+      const cohort = await resolveEntryCohort(item, item?.[idField]);
+      return cohort === callerCohort ? item : null;
+    }),
+  );
+  return resolved.filter((x) => x !== null);
+}
+
+module.exports = { resolveEntryCohort, filterListByCohort };

--- a/express-api/tests/routes/config.test.js
+++ b/express-api/tests/routes/config.test.js
@@ -36,6 +36,10 @@ jest.mock('../../src/utils/firebase', () => ({
 
 jest.mock('../../src/middleware/auth', () => ({
   requireAdmin: jest.fn(() => false), // default: allow admin
+  // PR 10: gift-rankings route live-verifies admin to bypass the
+  // inner cohort filter. Default to true so admin-token tests retain
+  // their original full-list behavior.
+  isLiveAdmin: jest.fn().mockResolvedValue(true),
 }));
 
 beforeEach(() => {

--- a/express-api/tests/routes/economy-queries.test.js
+++ b/express-api/tests/routes/economy-queries.test.js
@@ -254,7 +254,13 @@ describe('GET /api/users/:uniqueId/gift-wall/:giftId/senders', () => {
   });
 
   test('returns empty array when gift wall doc does not exist', async () => {
-    mockDocGet.mockResolvedValue({ exists: false });
+    // PR 10: the cohort gate fetches the target user doc before the
+    // wall-doc lookup. Stage the user doc as existing so the gate
+    // passes, then let the global override return exists:false for
+    // the subsequent wall-doc fetch.
+    mockDocGet
+      .mockResolvedValueOnce({ exists: true, data: () => ({ blockedUserIds: [] }) })
+      .mockResolvedValue({ exists: false });
 
     const app = createApp('user-A');
     const res = await request(app).get('/api/users/user-B/gift-wall/gift-rose/senders');

--- a/express-api/tests/routes/leaderboards-cohort.test.js
+++ b/express-api/tests/routes/leaderboards-cohort.test.js
@@ -1,0 +1,670 @@
+/**
+ * UK OSA #17 PR 10 — leaderboard / stalker / gift-wall same-cohort
+ * filters.
+ *
+ * Two distinct gate shapes are exercised here:
+ *
+ *   1. Outer-list 404 gate (mirrors PR 4-9 pattern). Endpoints that
+ *      expose a target user's own list — gift-wall and its per-gift
+ *      senders view — return the byte-identical existence-hiding 404
+ *      when the caller is cross-cohort to the target.
+ *
+ *   2. Inner-list filter (new pattern). Endpoints whose response body
+ *      is an array of user-keyed entries — gift-rankings (global
+ *      per-gift leaderboard) and the senders array nested inside a
+ *      same-cohort gift-wall view — filter cross-cohort entries out
+ *      in-memory. Entries are tagged with their owner's cohort at
+ *      write time (updateGiftRankings / updateGiftWall); legacy
+ *      entries that pre-date PR 10 fall back to a single per-entry
+ *      users/<id> lookup at read time so the migration is zero-
+ *      downtime.
+ *
+ * Stalker reads are intentionally not covered here: there is no user-
+ * facing GET endpoint for the stalkers subcollection (admin only via
+ * admin-users.js, and the iOS/Android clients read the subcollection
+ * directly through firestore.rules which are gated in PR 3 / PR 12).
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+const mockDocGet = jest.fn();
+const mockDocUpdate = jest.fn().mockResolvedValue();
+const mockDocSet = jest.fn().mockResolvedValue();
+const mockSegregationAdd = jest.fn().mockResolvedValue({ id: 'evt_1' });
+const mockCollectionGet = jest.fn().mockResolvedValue({ empty: true, docs: [] });
+
+const docResponses = new Map();
+function setDoc(path, data) {
+  docResponses.set(path, data);
+}
+function clearDocs() {
+  docResponses.clear();
+}
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    doc: jest.fn((path) => ({
+      _path: path,
+      get: () => mockDocGet(path),
+      update: (...args) => mockDocUpdate(path, ...args),
+      set: (...args) => mockDocSet(path, ...args),
+    })),
+    collection: jest.fn((name) => {
+      if (name === 'segregationEvents') {
+        return { add: mockSegregationAdd };
+      }
+      // Default chainable that supports the patterns used by routes
+      // exercised here: .get(), .count().get(), .orderBy().limit().get().
+      // The aggregate count returns 0 so addBroadcast's prune path
+      // short-circuits without needing batch-delete plumbing.
+      const emptyAggregate = { get: () => Promise.resolve({ data: () => ({ count: 0 }) }) };
+      const emptyQuery = {
+        limit: () => ({ get: () => Promise.resolve({ empty: true, docs: [] }) }),
+        get: () => Promise.resolve({ empty: true, docs: [] }),
+      };
+      return {
+        get: () => mockCollectionGet(name),
+        count: () => emptyAggregate,
+        orderBy: () => emptyQuery,
+      };
+    }),
+    batch: jest.fn(() => ({
+      set: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      commit: jest.fn().mockResolvedValue(),
+    })),
+    // Inline transaction: t.get/update/delete delegate to the same
+    // doc-path mocks the rest of the suite uses, so write-time tests
+    // that POST /economy/gift can reach updateGiftWall + updateGiftRankings.
+    runTransaction: jest.fn(async (cb) => {
+      const tx = {
+        get: (ref) => mockDocGet(ref?._path),
+        update: (ref, ...args) => mockDocUpdate(ref?._path, ...args),
+        set: (ref, ...args) => mockDocSet(ref?._path, ...args),
+        delete: jest.fn(),
+      };
+      return cb(tx);
+    }),
+  },
+  FieldValue: {
+    increment: jest.fn((n) => `increment(${n})`),
+  },
+}));
+
+jest.mock('../../src/utils/helpers', () => ({
+  generateId: () => 'id-123',
+  now: () => 1709913600000,
+  todayStr: () => '2026-05-15',
+  yesterdayStr: () => '2026-05-14',
+}));
+
+const mockIsLiveAdmin = jest.fn();
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn(() => false),
+  isLiveAdmin: (...args) => mockIsLiveAdmin(...args),
+}));
+
+jest.mock('../../src/utils/playStore', () => ({
+  verifyProductPurchase: jest.fn(),
+  verifySubscription: jest.fn(),
+}));
+
+jest.mock('../../src/utils/appleStore', () => ({
+  verifyApplePurchase: jest.fn(),
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const { _resetAuditDedup } = require('../../src/middleware/sameCohort');
+const economyRouter = require('../../src/routes/economy');
+const configRouter = require('../../src/routes/config');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDocGet.mockReset();
+  mockDocUpdate.mockReset();
+  mockDocSet.mockReset();
+  mockSegregationAdd.mockReset();
+  mockCollectionGet.mockReset();
+  mockIsLiveAdmin.mockReset();
+  _resetAuditDedup();
+  clearDocs();
+  economyRouter._resetConfigCache?.();
+
+  mockDocUpdate.mockResolvedValue();
+  mockDocSet.mockResolvedValue();
+  mockSegregationAdd.mockResolvedValue({ id: 'evt_1' });
+  mockIsLiveAdmin.mockResolvedValue(true);
+  mockCollectionGet.mockResolvedValue({ empty: true, docs: [] });
+
+  mockDocGet.mockImplementation((path) => {
+    if (docResponses.has(path)) {
+      const data = docResponses.get(path);
+      return Promise.resolve({
+        exists: data !== undefined && data !== null,
+        id: path.split('/').pop(),
+        data: () => data,
+      });
+    }
+    return Promise.resolve({
+      exists: false,
+      id: path.split('/').pop(),
+      data: () => null,
+    });
+  });
+});
+
+function createEconomyApp({ uniqueId = 'user-A', cohort = 'adult', admin = false } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.auth = {
+      uid: 'firebase-uid-' + uniqueId,
+      uniqueId,
+      token: { cohort, ...(admin ? { admin: true } : {}) },
+    };
+    next();
+  });
+  app.use('/api', economyRouter);
+  return app;
+}
+
+function createConfigApp({ uniqueId = 'user-A', cohort = 'adult', admin = false } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.auth = {
+      uid: 'firebase-uid-' + uniqueId,
+      uniqueId,
+      token: { cohort, ...(admin ? { admin: true } : {}) },
+    };
+    next();
+  });
+  app.use('/api', configRouter);
+  return app;
+}
+
+function stageGiftWallCollection(uniqueId, docs) {
+  mockCollectionGet.mockImplementation((path) => {
+    if (path === `users/${uniqueId}/giftWall`) {
+      return Promise.resolve({
+        empty: docs.length === 0,
+        docs: docs.map((d) => ({ id: d.id, data: () => d })),
+      });
+    }
+    return Promise.resolve({ empty: true, docs: [] });
+  });
+}
+
+describe('GET /api/users/:uniqueId/gift-wall - outer cohort gate', () => {
+  test('cross-cohort target -> 404 + audit, no list returned', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'minor' });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/users/user-B/gift-wall');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+    expect(mockSegregationAdd.mock.calls[0][0]).toMatchObject({
+      sourceUniqueId: 'user-A',
+      sourceCohort: 'adult',
+      targetUniqueId: 'user-B',
+      targetCohort: 'minor',
+      action: 'blocked',
+    });
+    expect(mockCollectionGet).not.toHaveBeenCalled();
+  });
+
+  test('same-cohort target -> 200 + full list, no audit', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'adult' });
+    stageGiftWallCollection('user-B', [
+      { id: 'gift-1', receivedCount: 5, senders: [] },
+      { id: 'gift-2', receivedCount: 3, senders: [] },
+    ]);
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/users/user-B/gift-wall');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0]).toMatchObject({ id: 'gift-1', receivedCount: 5 });
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('self-view always allowed (no cohort lookup)', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    stageGiftWallCollection('user-A', [{ id: 'gift-1', receivedCount: 1, senders: [] }]);
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/users/user-A/gift-wall');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+
+  test('admin caller -> bypass, 200 even cross-cohort', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'minor' });
+    stageGiftWallCollection('user-B', [{ id: 'gift-1', receivedCount: 10, senders: [] }]);
+    mockIsLiveAdmin.mockResolvedValue(true);
+
+    const app = createEconomyApp({ uniqueId: 'admin-1', cohort: 'adult', admin: true });
+    const res = await request(app).get('/api/users/user-B/gift-wall');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+
+  test('stale-admin token (live no longer admin) -> 404 blocked', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'minor' });
+    mockIsLiveAdmin.mockResolvedValue(false);
+
+    const app = createEconomyApp({ uniqueId: 'ex-admin', cohort: 'adult', admin: true });
+    const res = await request(app).get('/api/users/user-B/gift-wall');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+  });
+
+  test('missing target -> 404 (byte-identical existence-hiding)', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/users/user-Z/gift-wall');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+  });
+
+  test('blocked viewer -> 403 (block check still runs after cohort pass)', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'adult', blockedUserIds: ['user-A'] });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/users/user-B/gift-wall');
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Cannot view content of users who have blocked you' });
+    expect(mockSegregationAdd).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/users/:uniqueId/gift-wall/:giftId/senders - outer gate + inner filter', () => {
+  test('cross-cohort target -> 404 + audit', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'minor' });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/users/user-B/gift-wall/gift-1/senders');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+  });
+
+  test('same-cohort target -> filter inner senders by cohort', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'adult' });
+    setDoc('users/user-B/giftWall/gift-1', {
+      giftId: 'gift-1',
+      receivedCount: 30,
+      senders: [
+        { senderId: 's1', sendCount: 20, cohort: 'adult' },
+        { senderId: 's2', sendCount: 5, cohort: 'minor' },
+        { senderId: 's3', sendCount: 5, cohort: 'adult' },
+      ],
+    });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/users/user-B/gift-wall/gift-1/senders');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body.map((s) => s.senderId)).toEqual(['s1', 's3']);
+    expect(res.body[0]).toMatchObject({ senderId: 's1', sendCount: 20 });
+  });
+
+  test('all senders cross-cohort -> 200 + empty array (gift visible, no senders)', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'adult' });
+    setDoc('users/user-B/giftWall/gift-1', {
+      senders: [
+        { senderId: 's1', sendCount: 20, cohort: 'minor' },
+        { senderId: 's2', sendCount: 5, cohort: 'minor' },
+      ],
+    });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/users/user-B/gift-wall/gift-1/senders');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  test('legacy sender without cohort field -> live-lookup fallback', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'adult' });
+    setDoc('users/s-legacy-adult', { cohort: 'adult' });
+    setDoc('users/s-legacy-minor', { cohort: 'minor' });
+    setDoc('users/user-B/giftWall/gift-1', {
+      senders: [
+        { senderId: 's-legacy-adult', sendCount: 10 },
+        { senderId: 's-legacy-minor', sendCount: 8 },
+      ],
+    });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/users/user-B/gift-wall/gift-1/senders');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].senderId).toBe('s-legacy-adult');
+  });
+
+  test('legacy sender lookup of missing user -> drop the entry (no leak)', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'adult' });
+    setDoc('users/user-B/giftWall/gift-1', {
+      senders: [{ senderId: 's-deleted', sendCount: 99 }],
+    });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/users/user-B/gift-wall/gift-1/senders');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  test('admin caller -> bypass outer gate AND skip inner filter (sees all senders)', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'minor' });
+    setDoc('users/user-B/giftWall/gift-1', {
+      senders: [
+        { senderId: 's1', sendCount: 20, cohort: 'adult' },
+        { senderId: 's2', sendCount: 10, cohort: 'minor' },
+      ],
+    });
+    mockIsLiveAdmin.mockResolvedValue(true);
+
+    const app = createEconomyApp({ uniqueId: 'admin-1', cohort: 'adult', admin: true });
+    const res = await request(app).get('/api/users/user-B/gift-wall/gift-1/senders');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body.map((s) => s.senderId)).toEqual(['s1', 's2']);
+  });
+
+  test('missing gift doc -> 200 + empty array (cohort-passing target)', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'adult' });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/users/user-B/gift-wall/gift-1/senders');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  test('senders sorted by sendCount desc after filter', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'adult' });
+    setDoc('users/user-B/giftWall/gift-1', {
+      senders: [
+        { senderId: 's-low', sendCount: 1, cohort: 'adult' },
+        { senderId: 's-mid', sendCount: 5, cohort: 'minor' },
+        { senderId: 's-high', sendCount: 20, cohort: 'adult' },
+      ],
+    });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/users/user-B/gift-wall/gift-1/senders');
+
+    expect(res.body.map((s) => s.senderId)).toEqual(['s-high', 's-low']);
+  });
+});
+
+describe('GET /api/gift-rankings/:giftId - inner cohort filter', () => {
+  test('caller-cohort filter applied; totalSent preserved as global stat', async () => {
+    setDoc('giftRankings/gift-1', {
+      rankings: [
+        { userId: 'u1', count: 100, cohort: 'adult', displayName: 'A1', rank: 1 },
+        { userId: 'u2', count: 80, cohort: 'minor', displayName: 'M1', rank: 2 },
+        { userId: 'u3', count: 60, cohort: 'adult', displayName: 'A2', rank: 3 },
+      ],
+      totalSent: 240,
+      lastUpdated: 1709913600000,
+    });
+
+    const app = createConfigApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/gift-rankings/gift-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.rankings).toHaveLength(2);
+    expect(res.body.rankings.map((r) => r.userId)).toEqual(['u1', 'u3']);
+    expect(res.body.totalSent).toBe(240);
+    expect(res.body.lastUpdated).toBe(1709913600000);
+  });
+
+  test('minor caller sees only minor entries', async () => {
+    setDoc('giftRankings/gift-1', {
+      rankings: [
+        { userId: 'u1', count: 100, cohort: 'adult' },
+        { userId: 'u2', count: 80, cohort: 'minor' },
+        { userId: 'u3', count: 60, cohort: 'adult' },
+        { userId: 'u4', count: 40, cohort: 'minor' },
+      ],
+      totalSent: 280,
+    });
+
+    const app = createConfigApp({ uniqueId: 'user-M', cohort: 'minor' });
+    const res = await request(app).get('/api/gift-rankings/gift-1');
+
+    expect(res.body.rankings.map((r) => r.userId)).toEqual(['u2', 'u4']);
+  });
+
+  test('admin caller -> full unfiltered list', async () => {
+    setDoc('giftRankings/gift-1', {
+      rankings: [
+        { userId: 'u1', count: 100, cohort: 'adult' },
+        { userId: 'u2', count: 80, cohort: 'minor' },
+      ],
+      totalSent: 180,
+    });
+    mockIsLiveAdmin.mockResolvedValue(true);
+
+    const app = createConfigApp({ uniqueId: 'admin-1', cohort: 'adult', admin: true });
+    const res = await request(app).get('/api/gift-rankings/gift-1');
+
+    expect(res.body.rankings).toHaveLength(2);
+  });
+
+  test('legacy entries without cohort -> live-lookup fallback', async () => {
+    setDoc('users/u-legacy-adult', { cohort: 'adult' });
+    setDoc('users/u-legacy-minor', { cohort: 'minor' });
+    setDoc('giftRankings/gift-1', {
+      rankings: [
+        { userId: 'u-legacy-adult', count: 50 },
+        { userId: 'u-legacy-minor', count: 30 },
+      ],
+      totalSent: 80,
+    });
+
+    const app = createConfigApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/gift-rankings/gift-1');
+
+    expect(res.body.rankings).toHaveLength(1);
+    expect(res.body.rankings[0].userId).toBe('u-legacy-adult');
+  });
+
+  test('legacy entry pointing to deleted user -> dropped (no existence leak)', async () => {
+    setDoc('giftRankings/gift-1', {
+      rankings: [{ userId: 'u-deleted', count: 99 }],
+      totalSent: 99,
+    });
+
+    const app = createConfigApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/gift-rankings/gift-1');
+
+    expect(res.body.rankings).toEqual([]);
+    expect(res.body.totalSent).toBe(99);
+  });
+
+  test('missing rankings doc -> 200 + empty rankings + zero totals', async () => {
+    const app = createConfigApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/gift-rankings/gift-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      rankings: [],
+      totalSent: 0,
+      lastUpdated: null,
+    });
+  });
+
+  test('all entries filtered -> 200 + empty rankings + preserved totalSent', async () => {
+    setDoc('giftRankings/gift-1', {
+      rankings: [
+        { userId: 'u1', count: 100, cohort: 'minor' },
+        { userId: 'u2', count: 50, cohort: 'minor' },
+      ],
+      totalSent: 150,
+    });
+
+    const app = createConfigApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app).get('/api/gift-rankings/gift-1');
+
+    expect(res.body.rankings).toEqual([]);
+    expect(res.body.totalSent).toBe(150);
+  });
+
+  test('caller with no cohort claim -> no entries returned (fail-closed)', async () => {
+    setDoc('giftRankings/gift-1', {
+      rankings: [{ userId: 'u1', count: 100, cohort: 'adult' }],
+      totalSent: 100,
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.auth = {
+        uid: 'firebase-uid-x',
+        uniqueId: 'user-X',
+        token: {},
+      };
+      next();
+    });
+    app.use('/api', configRouter);
+
+    const res = await request(app).get('/api/gift-rankings/gift-1');
+    expect(res.body.rankings).toEqual([]);
+  });
+});
+
+describe('Write-time cohort snapshot - PR 10 forward-compat', () => {
+  test('updateGiftRankings stamps recipient cohort on first send', async () => {
+    setDoc('config/economy', {
+      beanConversionRate: 0.6,
+      beanRedeemBonusThreshold: 2000,
+      beanRedeemBonusMultiplier: 1.1,
+      pullCosts: { 1: 10, 10: 100, 100: 1000 },
+      broadcastSendThreshold: 0,
+      broadcastWinThreshold: 5000,
+      dailyBase: 50,
+    });
+    setDoc('users/user-A', { cohort: 'adult', shyCoins: 1000 });
+    setDoc('users/user-B', { cohort: 'adult', shyBeans: 0, displayName: 'B' });
+    setDoc('gifts/gift-1', { coinValue: 10, name: 'Rose' });
+    setDoc('users/user-A/backpack/gift-1', { quantity: 5 });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    const res = await request(app)
+      .post('/api/economy/gift')
+      .send({ recipientId: 'user-B', giftId: 'gift-1', quantity: 1 });
+
+    expect(res.status).toBe(200);
+
+    const rankingsSetCall = mockDocSet.mock.calls.find((c) => c[0] === 'giftRankings/gift-1');
+    expect(rankingsSetCall).toBeDefined();
+    const payload = rankingsSetCall[1];
+    expect(payload.rankings).toHaveLength(1);
+    expect(payload.rankings[0]).toMatchObject({
+      userId: 'user-B',
+      count: 1,
+      cohort: 'adult',
+    });
+  });
+
+  test('updateGiftWall stamps sender cohort on first send', async () => {
+    setDoc('config/economy', {
+      beanConversionRate: 0.6,
+      beanRedeemBonusThreshold: 2000,
+      beanRedeemBonusMultiplier: 1.1,
+      pullCosts: { 1: 10, 10: 100, 100: 1000 },
+      broadcastSendThreshold: 0,
+      broadcastWinThreshold: 5000,
+      dailyBase: 50,
+    });
+    setDoc('users/user-A', { cohort: 'adult', shyCoins: 1000 });
+    setDoc('users/user-B', { cohort: 'adult', shyBeans: 0, displayName: 'B' });
+    setDoc('gifts/gift-1', { coinValue: 10, name: 'Rose' });
+    setDoc('users/user-A/backpack/gift-1', { quantity: 5 });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    await request(app)
+      .post('/api/economy/gift')
+      .send({ recipientId: 'user-B', giftId: 'gift-1', quantity: 1 });
+
+    const wallSetCall = mockDocSet.mock.calls.find((c) => c[0] === 'users/user-B/giftWall/gift-1');
+    expect(wallSetCall).toBeDefined();
+    const payload = wallSetCall[1];
+    expect(payload.senders).toHaveLength(1);
+    expect(payload.senders[0]).toMatchObject({
+      senderId: 'user-A',
+      sendCount: 1,
+      cohort: 'adult',
+    });
+  });
+});
+
+describe('Audit dedup for gift-wall outer gate', () => {
+  test('repeat (source, target, surface) within window -> single audit doc', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'minor' });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    await request(app).get('/api/users/user-B/gift-wall');
+    await request(app).get('/api/users/user-B/gift-wall');
+    await request(app).get('/api/users/user-B/gift-wall');
+
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(1);
+  });
+
+  test('different target -> fresh audit', async () => {
+    setDoc('users/user-A', { cohort: 'adult' });
+    setDoc('users/user-B', { cohort: 'minor' });
+    setDoc('users/user-C', { cohort: 'minor' });
+
+    const app = createEconomyApp({ uniqueId: 'user-A', cohort: 'adult' });
+    await request(app).get('/api/users/user-B/gift-wall');
+    await request(app).get('/api/users/user-C/gift-wall');
+
+    await new Promise((r) => setImmediate(r));
+    expect(mockSegregationAdd).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

UK OSA #17 age-segregation continued (PR 10 of 14). Adds same-cohort filtering to the three list-shaped read endpoints that expose user-keyed data:

- `GET /api/users/:uniqueId/gift-wall` — outer 404 gate
- `GET /api/users/:uniqueId/gift-wall/:giftId/senders` — outer 404 + inner filter
- `GET /api/gift-rankings/:giftId` — inner filter

The **inner-list filter** is a new gate shape (PRs 4-9 only had outer 404 gates):

- Entries are stamped at write time with the owner's cohort by `updateGiftWall` + `updateGiftRankings`
- Legacy entries pre-PR-10 fall back to a per-entry `users/<id>` lookup so the migration is zero-downtime
- Deleted-user entries are explicitly dropped to avoid an existence side-channel (`effectiveCohort(null) → 'minor'` would otherwise leak deleted accounts to minor callers as same-cohort entries)
- Admin (live-verified) bypasses the filter to keep moderation visibility

## Changes

- New helper: `src/utils/cohort-filter.js` (`resolveEntryCohort` + `filterListByCohort`) — covers both list shapes
- `economy.js`: `updateGiftWall` / `updateGiftRankings` now stamp cohort; 4 POST handlers thread sender + recipient cohorts through (gift, gift-direct, gift-batch, backpack-send); 2 GET handlers gain the outer + inner gates
- `config.js`: `GET /gift-rankings/:giftId` gains inner filter with admin bypass
- 27 new tests in `tests/routes/leaderboards-cohort.test.js` pin the full contract: outer gate, inner filter, write-time stamping, admin bypass + stale-admin demotion, audit dedup, legacy fallback, deleted-user drop, fail-closed on missing cohort claim

Stalker reads are intentionally out of scope: there's no user-facing GET endpoint for the stalkers subcollection. Admin reads are `admin-users.js`; client reads go through `firestore.rules` which are gated in PRs 3 / 12.

## Test plan

- [x] New leaderboards-cohort suite: 27/27 pass
- [x] Existing economy.test.js + economy-cohort.test.js + economy-queries.test.js + config.test.js: 101/101 pass (2 minor mock updates: `isLiveAdmin` mock added; stale "missing target user" test updated to stage the user doc so the new cohort gate passes)
- [x] Full express suite: 5221 passing, 8 skipped, 0 new failures
- [x] `npm run lint`: 0 errors

> Note: pre-existing data-export-builder.test.js failures (29) are an unrelated Jest-ESM/archiver-v8 issue — same failure count on plain main. Not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)