### PR TITLE
feat(seg): PR 12 of 14 — KMP client + Compose UI + iOS cohort filter parity (#17)

### DIFF
--- a/app/src/test/java/com/shyden/shytalk/feature/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/home/HomeViewModelTest.kt
@@ -57,6 +57,12 @@ class HomeViewModelTest {
         every { userRepository.userUpdates } returns MutableSharedFlow()
         coEvery { userRepository.getBlockedUserIds(currentUserId) } returns Resource.Success(emptySet())
         coEvery { roomRepository.findActiveRoomByOwner(any()) } returns null
+        // UK OSA #17 PR 12 — the cohort gate fails closed when the viewer's
+        // User doc cannot be resolved. Provide a baseline mock so every test
+        // sees a same-cohort viewer by default; tests can `coEvery` override
+        // for adult-viewer / null-viewer scenarios.
+        coEvery { userRepository.getUser(currentUserId) } returns
+            Resource.Success(TestData.createTestUser(uid = currentUserId))
     }
 
     @After
@@ -790,5 +796,167 @@ class HomeViewModelTest {
 
             assertFalse(vm.uiState.value.showReplaceRoomConfirmation)
             assertNull(vm.uiState.value.pendingRoomName)
+        }
+
+    // ===== UK OSA #17 PR 12 — client-side cohort gate =====
+
+    @Test
+    fun `adult viewer sees only adult-owned rooms when batch is mixed`() =
+        runTest {
+            coEvery { userRepository.getUser(currentUserId) } returns
+                Resource.Success(TestData.createTestUser(uid = currentUserId, cohort = "adult"))
+            coEvery { userRepository.getUsers(any()) } returns
+                Resource.Success(
+                    listOf(
+                        TestData.createTestUser(uid = "owner-adult", cohort = "adult"),
+                        TestData.createTestUser(uid = "owner-minor", cohort = "minor"),
+                    ),
+                )
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            roomsFlow.emit(
+                listOf(
+                    TestData.createTestRoom(roomId = "r-adult", ownerId = "owner-adult"),
+                    TestData.createTestRoom(roomId = "r-minor", ownerId = "owner-minor"),
+                ),
+            )
+            advanceUntilIdle()
+
+            val rooms = vm.uiState.value.rooms
+            assertEquals(1, rooms.size)
+            assertEquals("r-adult", rooms[0].roomId)
+        }
+
+    @Test
+    fun `minor viewer drops adult-owned room`() =
+        runTest {
+            coEvery { userRepository.getUser(currentUserId) } returns
+                Resource.Success(TestData.createTestUser(uid = currentUserId, cohort = "minor"))
+            coEvery { userRepository.getUsers(any()) } returns
+                Resource.Success(
+                    listOf(TestData.createTestUser(uid = "owner-adult", cohort = "adult")),
+                )
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            roomsFlow.emit(listOf(TestData.createTestRoom(ownerId = "owner-adult")))
+            advanceUntilIdle()
+
+            assertTrue(
+                vm.uiState.value.rooms
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun `cohort gate fails closed when viewer User cannot be resolved`() =
+        runTest {
+            // Both batch and direct getUser fallback return Error → viewer
+            // unresolvable → drop all rooms (fail-closed, matches
+            // ConversationListViewModel for OSA consistency).
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Error("fetch failed")
+            coEvery { userRepository.getUsers(any()) } returns
+                Resource.Success(
+                    listOf(TestData.createTestUser(uid = "owner-1", cohort = "minor")),
+                )
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            roomsFlow.emit(listOf(TestData.createTestRoom(ownerId = "owner-1")))
+            advanceUntilIdle()
+
+            assertTrue(
+                vm.uiState.value.rooms
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun `cohortOverride on viewer is honoured by the gate`() =
+        runTest {
+            // Stored cohort is "minor" but admin override uplifts to "adult".
+            coEvery { userRepository.getUser(currentUserId) } returns
+                Resource.Success(
+                    TestData.createTestUser(
+                        uid = currentUserId,
+                        cohort = "minor",
+                        cohortOverride = "adult",
+                    ),
+                )
+            coEvery { userRepository.getUsers(any()) } returns
+                Resource.Success(
+                    listOf(TestData.createTestUser(uid = "owner-adult", cohort = "adult")),
+                )
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            roomsFlow.emit(listOf(TestData.createTestRoom(ownerId = "owner-adult")))
+            advanceUntilIdle()
+
+            assertEquals(1, vm.uiState.value.rooms.size)
+        }
+
+    @Test
+    fun `cross-cohort seated user is redacted from seatUsers map`() =
+        runTest {
+            coEvery { userRepository.getUser(currentUserId) } returns
+                Resource.Success(TestData.createTestUser(uid = currentUserId, cohort = "adult"))
+            // Owner is adult (so room passes gate), but a seated user is
+            // a minor → must be dropped from seatUsers (defense-in-depth
+            // for mid-session cohort flips).
+            val seats =
+                ChatRoom.DEFAULT_SEATS
+                    .toMutableMap()
+                    .apply {
+                        this["0"] =
+                            com.shyden.shytalk.core.model.Seat(
+                                userId = "owner-adult",
+                                state = com.shyden.shytalk.core.model.SeatState.OCCUPIED,
+                            )
+                        this["1"] =
+                            com.shyden.shytalk.core.model.Seat(
+                                userId = "seat-minor",
+                                state = com.shyden.shytalk.core.model.SeatState.OCCUPIED,
+                            )
+                    }
+            coEvery { userRepository.getUsers(any()) } returns
+                Resource.Success(
+                    listOf(
+                        TestData.createTestUser(uid = "owner-adult", cohort = "adult"),
+                        TestData.createTestUser(uid = "seat-minor", cohort = "minor"),
+                    ),
+                )
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            roomsFlow.emit(
+                listOf(TestData.createTestRoom(roomId = "r1", ownerId = "owner-adult", seats = seats)),
+            )
+            advanceUntilIdle()
+
+            assertEquals(1, vm.uiState.value.rooms.size)
+            assertTrue("seat-minor" !in vm.uiState.value.seatUsers)
+            assertTrue("owner-adult" in vm.uiState.value.seatUsers)
+        }
+
+    @Test
+    fun `doCreateRoom uses effectiveCohort with invalid cohort falling back to minor`() =
+        runTest {
+            // Corrupted Firestore cohort field — must NOT be passed
+            // straight through to createRoom; effectiveCohort fails
+            // closed to "minor".
+            coEvery { userRepository.getUser(currentUserId) } returns
+                Resource.Success(
+                    TestData.createTestUser(uid = currentUserId, cohort = "corrupted"),
+                )
+            val vm = createViewModel()
+            advanceUntilIdle()
+            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Success("rid")
+
+            vm.createRoom("My Room")
+            advanceUntilIdle()
+
+            coVerify { roomRepository.createRoom("My Room", currentUserId, "minor") }
         }
 }

--- a/app/src/test/java/com/shyden/shytalk/feature/messaging/ConversationListViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/messaging/ConversationListViewModelTest.kt
@@ -825,6 +825,95 @@ class ConversationListViewModelTest {
             )
         }
 
+    // ===== UK OSA #17 PR 12 — client-side cohort gate =====
+
+    @Test
+    fun `1-to-1 conversation with cross-cohort other user is dropped`() =
+        runTest {
+            // Adult viewer; the 1:1 counterparty is a minor → drop.
+            val currentUser = TestData.createTestUser(uid = currentUserId, cohort = "adult")
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(currentUser)
+            coEvery { userRepository.getUsers(any()) } returns
+                Resource.Success(
+                    listOf(TestData.createTestUser(uid = "minor-buddy", cohort = "minor")),
+                )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            conversationsFlow.emit(
+                listOf(
+                    TestData.createTestConversation(
+                        conversationId = "conv-cross",
+                        participantIds = listOf(currentUserId, "minor-buddy"),
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertTrue(
+                vm.uiState.value.conversations
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun `1-to-1 conversation with frozenAtMigration is dropped`() =
+        runTest {
+            // PR 8 frozen migration flag on a 1:1 thread → drop.
+            val currentUser = TestData.createTestUser(uid = currentUserId, cohort = "adult")
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(currentUser)
+            coEvery { userRepository.getUsers(any()) } returns
+                Resource.Success(
+                    listOf(TestData.createTestUser(uid = "buddy", cohort = "adult")),
+                )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            conversationsFlow.emit(
+                listOf(
+                    TestData
+                        .createTestConversation(
+                            conversationId = "conv-frozen",
+                            participantIds = listOf(currentUserId, "buddy"),
+                        ).copy(frozenAtMigration = true),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertTrue(
+                vm.uiState.value.conversations
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun `same-cohort 1-to-1 conversation is kept`() =
+        runTest {
+            val currentUser = TestData.createTestUser(uid = currentUserId, cohort = "adult")
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(currentUser)
+            coEvery { userRepository.getUsers(any()) } returns
+                Resource.Success(
+                    listOf(TestData.createTestUser(uid = "buddy-adult", cohort = "adult")),
+                )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            conversationsFlow.emit(
+                listOf(
+                    TestData.createTestConversation(
+                        conversationId = "conv-ok",
+                        participantIds = listOf(currentUserId, "buddy-adult"),
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(1, vm.uiState.value.conversations.size)
+        }
+
     // ===== clearError =====
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/feature/messaging/NewMessageViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/messaging/NewMessageViewModelTest.kt
@@ -370,4 +370,75 @@ class NewMessageViewModelTest {
                     .isEmpty(),
             )
         }
+
+    // ===== UK OSA #17 PR 12 — client-side cohort gate =====
+
+    @Test
+    fun `adult viewer drops cross-cohort users from availableUsers`() =
+        runTest {
+            val currentUser =
+                TestData.createTestUser(
+                    uid = "me",
+                    cohort = "adult",
+                    followerIds = setOf("adult-pal", "minor-pal"),
+                    followingIds = emptySet(),
+                )
+            coEvery { userRepository.getUser("me") } returns Resource.Success(currentUser)
+            coEvery { userRepository.getUsers(any()) } returns
+                Resource.Success(
+                    listOf(
+                        TestData.createTestUser(uid = "adult-pal", cohort = "adult"),
+                        TestData.createTestUser(uid = "minor-pal", cohort = "minor"),
+                    ),
+                )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf("adult-pal"),
+                vm.uiState.value.availableUsers
+                    .map { it.uid },
+            )
+        }
+
+    @Test
+    fun `adult viewer drops cross-cohort recent users`() =
+        runTest {
+            val currentUser =
+                TestData.createTestUser(
+                    uid = "me",
+                    cohort = "adult",
+                    followerIds = setOf("adult-pal"),
+                )
+            coEvery { userRepository.getUser("me") } returns Resource.Success(currentUser)
+            // First call is loadAvailableUsers → followerIds, second is
+            // recent users by ID. Loosen the matcher: same mock for both.
+            coEvery { userRepository.getUsers(any()) } returns
+                Resource.Success(
+                    listOf(
+                        TestData.createTestUser(uid = "adult-pal", cohort = "adult"),
+                        TestData.createTestUser(uid = "minor-pal", cohort = "minor"),
+                    ),
+                )
+            // Force a recent-conversations list with a minor counterparty.
+            every { pmRepository.getConversations("me") } returns
+                flowOf(
+                    listOf(
+                        TestData.createTestConversation(
+                            conversationId = "recent-1",
+                            participantIds = listOf("me", "minor-pal"),
+                        ),
+                    ),
+                )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // minor-pal should not appear in recentUsers (cohort filter)
+            assertTrue(
+                vm.uiState.value.recentUsers
+                    .none { it.uid == "minor-pal" },
+            )
+        }
 }

--- a/app/src/test/java/com/shyden/shytalk/feature/profile/FollowListViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/profile/FollowListViewModelTest.kt
@@ -855,4 +855,110 @@ class FollowListViewModelTest {
 
             assertFalse(vm.uiState.value.isSuperShy)
         }
+
+    // ===== UK OSA #17 PR 12 — client-side cohort gate =====
+
+    @Test
+    fun `adult viewer's followers list drops minor follower`() =
+        runTest {
+            // Adult viewer's own profile, minor follower must be filtered out.
+            val profileUser =
+                TestData.createTestUser(
+                    uid = currentUserId,
+                    cohort = "adult",
+                    followerIds = setOf("follower-adult", "follower-minor"),
+                )
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(profileUser)
+            coEvery { userRepository.getUsers(any()) } returns
+                Resource.Success(
+                    listOf(
+                        TestData.createTestUser(uid = "follower-adult", cohort = "adult"),
+                        TestData.createTestUser(uid = "follower-minor", cohort = "minor"),
+                    ),
+                )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val followerUids =
+                vm.uiState.value.followers
+                    .map { it.uid }
+            assertEquals(listOf("follower-adult"), followerUids)
+        }
+
+    @Test
+    fun `cross-cohort stalker is dropped from both stalkers list and stalkerUsers map`() =
+        runTest {
+            val profileUser =
+                TestData.createTestUser(
+                    uid = currentUserId,
+                    cohort = "adult",
+                    followerIds = emptySet(),
+                    followingIds = emptySet(),
+                )
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Success(profileUser)
+            coEvery { userRepository.getUsers(emptyList()) } returns Resource.Success(emptyList())
+            coEvery { userRepository.getStalkers(currentUserId) } returns
+                Resource.Success(
+                    listOf(
+                        TestData.createTestProfileVisitor(visitorId = "visitor-adult"),
+                        TestData.createTestProfileVisitor(visitorId = "visitor-minor"),
+                    ),
+                )
+            // Stalker users are fetched via a separate getUsers(visitorIds) call.
+            coEvery { userRepository.getUsers(listOf("visitor-adult", "visitor-minor")) } returns
+                Resource.Success(
+                    listOf(
+                        TestData.createTestUser(uid = "visitor-adult", cohort = "adult"),
+                        TestData.createTestUser(uid = "visitor-minor", cohort = "minor"),
+                    ),
+                )
+
+            val vm = createViewModel(initialTab = "stalkers")
+            advanceUntilIdle()
+
+            assertTrue("visitor-minor" !in vm.uiState.value.stalkerUsers)
+            assertTrue("visitor-adult" in vm.uiState.value.stalkerUsers)
+            assertEquals(
+                listOf("visitor-adult"),
+                vm.uiState.value.stalkers
+                    .map { it.visitorId },
+            )
+        }
+
+    @Test
+    fun `viewer null on non-own list fails closed to empty followers and following`() =
+        runTest {
+            // Viewing another user's profile, but our own User getUser
+            // returns Error → viewer null → fail-closed (lists empty).
+            val otherUserId = "other-user"
+            val otherProfile =
+                TestData.createTestUser(
+                    uid = otherUserId,
+                    cohort = "adult",
+                    followerIds = setOf("follower-1"),
+                    followingIds = setOf("following-1"),
+                )
+            coEvery { userRepository.getUser(otherUserId) } returns Resource.Success(otherProfile)
+            coEvery { userRepository.getUser(currentUserId) } returns Resource.Error("fetch failed")
+            coEvery { userRepository.getUsers(any()) } returns
+                Resource.Success(
+                    listOf(
+                        TestData.createTestUser(uid = "follower-1"),
+                        TestData.createTestUser(uid = "following-1"),
+                    ),
+                )
+
+            val vm = createViewModel(profileUid = otherUserId)
+            advanceUntilIdle()
+
+            assertTrue(
+                vm.uiState.value.followers
+                    .isEmpty(),
+            )
+            assertTrue(
+                vm.uiState.value.following
+                    .isEmpty(),
+            )
+        }
 }

--- a/app/src/test/java/com/shyden/shytalk/testutil/TestData.kt
+++ b/app/src/test/java/com/shyden/shytalk/testutil/TestData.kt
@@ -54,8 +54,12 @@ object TestData {
         suspensionAppealStatus: String? = null,
         isSuperShy: Boolean = false,
         language: String = "en",
+        cohort: String = "minor",
+        cohortOverride: String? = null,
     ) = User(
         uid = uid,
+        cohort = cohort,
+        cohortOverride = cohortOverride,
         // Default firebaseUid to uid so the existing wave of tests (which only
         // pass `uid = "..."`) gets a populated firebaseUid for free. Production
         // code paths that now send `User.firebaseUid` for report endpoints

--- a/iosApp/iosApp/LiveKitBridge.swift
+++ b/iosApp/iosApp/LiveKitBridge.swift
@@ -12,7 +12,23 @@ class LiveKitBridgeImpl: NSObject, shared.LiveKitBridge, RoomDelegate {
         self.kotlinDelegate = delegate
     }
 
+    /// UK OSA #17 PR 12 — defence-in-depth pre-connect validation.
+    /// The server gate (`express-api/src/routes/livekit.js`) refuses to
+    /// mint a token for a cross-cohort room (404 + audit log), so a
+    /// valid token *should* always be cohort-clean. These checks catch
+    /// the residual risk of a tampered Kotlin layer that forges or
+    /// retains a stale token, and of a Kotlin-layer bug that points
+    /// the bridge at a non-ShyTalk LiveKit host.
     func connect(url: String, token: String) {
+        guard LiveKitBridgeImpl.isAllowedURL(url) else {
+            kotlinDelegate?.onConnectionFailed(error: "invalid_livekit_url")
+            return
+        }
+        guard LiveKitBridgeImpl.isValidToken(token) else {
+            kotlinDelegate?.onConnectionFailed(error: "missing_livekit_token")
+            return
+        }
+
         let room = Room(delegate: self)
         self.room = room
 
@@ -25,6 +41,33 @@ class LiveKitBridgeImpl: NSObject, shared.LiveKitBridge, RoomDelegate {
                 }
             }
         }
+    }
+
+    /// Allow-list of LiveKit URLs the bridge will accept. Matches the
+    /// hosts configured by `express-api/src/utils/livekit-region.js`:
+    /// localhost for local dev, the two Oracle Cloud VMs for dev/prod
+    /// (London + Singapore). Anything else is rejected before any
+    /// network call is made.
+    /// Empty/whitespace-only tokens are rejected before any network call.
+    /// Catches the residual risk of the Kotlin layer passing through a
+    /// stale or zeroed-out token after a failed mint, where the empty
+    /// string would otherwise crash LiveKit's JWT parser deep inside an
+    /// async `Task` and surface as an opaque "Connection failed" error.
+    static func isValidToken(_ token: String) -> Bool {
+        return !token.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    static func isAllowedURL(_ url: String) -> Bool {
+        guard let parsed = URL(string: url), let host = parsed.host else { return false }
+        let scheme = parsed.scheme?.lowercased() ?? ""
+        let isLocalhost = (host == "localhost" || host == "127.0.0.1")
+        let isLoopbackOk = isLocalhost && (scheme == "ws" || scheme == "wss")
+        let isTLS = (scheme == "wss")
+        let allowedHosts: Set<String> = [
+            "livekit.shytalk.shyden.co.uk",
+            "livekit-eu.shytalk.shyden.co.uk",
+        ]
+        return isLoopbackOk || (isTLS && allowedHosts.contains(host))
     }
 
     func disconnect() {

--- a/iosApp/iosAppTests/AgeSegregationTests.swift
+++ b/iosApp/iosAppTests/AgeSegregationTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import iosApp
+
+/// UK OSA #17 PR 12 — XCTest for the iOS LiveKitBridge defence-in-depth
+/// pre-connect URL allow-list. The server-side cohort gate (Express
+/// `routes/livekit.js`) refuses to mint tokens for cross-cohort rooms,
+/// so a valid token is *expected* to already be cohort-clean. These
+/// tests pin the bridge's residual defenses: it must refuse any LiveKit
+/// URL that is not localhost (local dev) or the two Oracle Cloud hosts
+/// (dev/prod EU + Singapore).
+///
+/// Regression coverage:
+/// - Attacker tampering with the Kotlin layer to swap in a malicious URL
+/// - Buggy Region API returning a non-allowed URL
+/// - Stale build pointed at a deprecated host
+final class AgeSegregationTests: XCTestCase {
+    // MARK: - Allowed hosts
+
+    func test_isAllowedURL_acceptsProductionSingapore() {
+        XCTAssertTrue(LiveKitBridgeImpl.isAllowedURL("wss://livekit.shytalk.shyden.co.uk"))
+    }
+
+    func test_isAllowedURL_acceptsProductionLondon() {
+        XCTAssertTrue(LiveKitBridgeImpl.isAllowedURL("wss://livekit-eu.shytalk.shyden.co.uk"))
+    }
+
+    func test_isAllowedURL_acceptsLocalhostWS_forLocalDev() {
+        XCTAssertTrue(LiveKitBridgeImpl.isAllowedURL("ws://localhost:7880"))
+    }
+
+    func test_isAllowedURL_acceptsLocalhost127001() {
+        XCTAssertTrue(LiveKitBridgeImpl.isAllowedURL("ws://127.0.0.1:7880"))
+    }
+
+    // MARK: - Rejected hosts (attacker / misconfiguration paths)
+
+    func test_isAllowedURL_rejectsArbitraryHost() {
+        XCTAssertFalse(LiveKitBridgeImpl.isAllowedURL("wss://evil.example.com"))
+    }
+
+    func test_isAllowedURL_rejectsHttpScheme() {
+        // LiveKit cannot run over HTTP; this also blocks downgrade attacks.
+        XCTAssertFalse(LiveKitBridgeImpl.isAllowedURL("http://livekit.shytalk.shyden.co.uk"))
+    }
+
+    func test_isAllowedURL_rejectsHttpsScheme() {
+        // HTTPS is not a LiveKit scheme; rejecting prevents subtle misconfig.
+        XCTAssertFalse(LiveKitBridgeImpl.isAllowedURL("https://livekit.shytalk.shyden.co.uk"))
+    }
+
+    func test_isAllowedURL_rejectsPlainWSToProductionHost() {
+        // Production must use wss:// — plain ws:// to a public host would
+        // expose the token over an unencrypted channel.
+        XCTAssertFalse(LiveKitBridgeImpl.isAllowedURL("ws://livekit.shytalk.shyden.co.uk"))
+    }
+
+    func test_isAllowedURL_rejectsEmptyString() {
+        XCTAssertFalse(LiveKitBridgeImpl.isAllowedURL(""))
+    }
+
+    func test_isAllowedURL_rejectsMalformedURL() {
+        XCTAssertFalse(LiveKitBridgeImpl.isAllowedURL("not-a-url"))
+    }
+
+    func test_isAllowedURL_rejectsLookalikeDomain() {
+        // Subtle phishing — same suffix, different host.
+        XCTAssertFalse(LiveKitBridgeImpl.isAllowedURL("wss://livekit.shytalk.shyden-co-uk.attacker.com"))
+    }
+
+    // MARK: - Token validation (empty / whitespace-only)
+
+    func test_isValidToken_acceptsRegularToken() {
+        XCTAssertTrue(LiveKitBridgeImpl.isValidToken("eyJhbGciOi.JWT.payload.signature"))
+    }
+
+    func test_isValidToken_rejectsEmptyString() {
+        XCTAssertFalse(LiveKitBridgeImpl.isValidToken(""))
+    }
+
+    func test_isValidToken_rejectsWhitespaceOnly() {
+        // A whitespace-only token would also crash LiveKit's JWT parser.
+        XCTAssertFalse(LiveKitBridgeImpl.isValidToken("   "))
+        XCTAssertFalse(LiveKitBridgeImpl.isValidToken("\t\n "))
+    }
+
+    func test_isValidToken_acceptsTokenWithInternalWhitespace() {
+        // Real JWTs never contain whitespace, but the validator only
+        // rejects EMPTY/WHITESPACE-ONLY. A token with leading whitespace
+        // followed by content still passes (the JWT decoder will reject
+        // it downstream with a clearer error than "missing_livekit_token").
+        XCTAssertTrue(LiveKitBridgeImpl.isValidToken(" not-empty "))
+    }
+}

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -989,4 +989,7 @@
     <!-- UK OSA #17 PR 7: cohort-segregation room-ejection system PM body. Sibling of age_seg_relationship_removed_pm — same English-only-in-this-PR contract; remaining 19 locales ship in PR 14 alongside server-side locale awareness. The %1$s placeholder is the (sanitised) room name. Copy reuses the load-bearing "a recent change to how ShyTalk organises accounts" phrase so the user-facing voice is consistent across PR 6 + PR 7 ejection paths. Cohort-agnostic by construction — see formatRoomEjectionPm test for the full denylist. -->
     <string name="age_seg_room_removed_pm">You\'ve been removed from %1$s as part of a recent change to how ShyTalk organises accounts.\n\nThis is automatic and doesn\'t reflect anything you did. The room itself is fine; we just can\'t keep you in it under the new arrangement.\n\nYou can still create or join other rooms in your usual way.</string>
 
+    <!-- UK OSA #17 PR 12: cohort-segregation placeholder label used by Compose UI to render a generic "unavailable" tile when the cross-cohort filter (CrossCohortPolicy.PLACEHOLDER) drops an item from a list. English-only in this PR; remaining 19 locales ship in PR 14 with the locale-awareness sweep. Cohort-agnostic by construction — must never name "minor" / "adult" / age, since the placeholder is rendered to the OTHER cohort and would otherwise leak the dropped item's cohort. -->
+    <string name="age_seg_unavailable">Unavailable</string>
+
 </resources>

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/CohortAwareItemFilter.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/CohortAwareItemFilter.kt
@@ -1,0 +1,117 @@
+package com.shyden.shytalk.core.util
+
+import com.shyden.shytalk.core.model.User
+
+// UK OSA #17 PR 12 — client-side defence-in-depth cohort filter.
+//
+// KMP mirror of `express-api/src/utils/cohort-filter.js`. The server is
+// the primary enforcement layer (rules + Express middleware + list
+// filters). This module catches the cases the server can't:
+//   1. Stale offline cache items where the OWNER aged-up across cohorts
+//      after the cache was populated.
+//   2. Direct fetches (deep-link / notification / stale follow id) that
+//      bypass the server's list endpoint and its built-in filter.
+//   3. Tampered builds where modified clients skip the server's filter.
+//
+// Pure-function module — no I/O, no Firestore reads. Caller is expected
+// to already have the `cohort`/`cohortOverride` fields on the items it
+// wants to filter (server stamps these at write-time, PRs 7-10).
+
+/** Cross-cohort handling policy chosen by each call site. */
+enum class CrossCohortPolicy {
+    /**
+     * Preserve list cardinality — render an "unavailable" placeholder
+     * tile in the cross-cohort row's place. Use in browse/discovery
+     * surfaces where a list-length change would reveal cohort boundaries
+     * to a fingerprinting observer (anti-fingerprinting).
+     */
+    PLACEHOLDER,
+
+    /**
+     * Drop cross-cohort entries entirely. Use in picker surfaces (new
+     * message recipient, gift recipient, group-add) where an
+     * un-selectable row has no UX value and only adds friction.
+     */
+    HIDE,
+}
+
+/** Decision for one item: visible, placeholder, or hidden. */
+sealed interface CohortVisibility {
+    data object Visible : CohortVisibility
+
+    data object PlaceholderUnavailable : CohortVisibility
+
+    data object Hidden : CohortVisibility
+}
+
+/** Resolved entry for a list — either the original item or a placeholder. */
+sealed interface CohortFilteredEntry<out T> {
+    data class Visible<T>(
+        val item: T,
+    ) : CohortFilteredEntry<T>
+
+    /** Stable identifier so Compose `LazyColumn` `key {}` blocks remain consistent. */
+    data class Placeholder(
+        val key: String,
+    ) : CohortFilteredEntry<Nothing>
+}
+
+private fun normalize(cohort: String): String =
+    when (cohort) {
+        COHORT_ADULT -> COHORT_ADULT
+        COHORT_MINOR -> COHORT_MINOR
+        else -> COHORT_MINOR
+    }
+
+/**
+ * Decide the per-item visibility outcome. Pure function — caller chooses
+ * how to render each case. Invalid cohort strings fail closed to "minor"
+ * (most-restrictive) per the OSA fail-closed-when-ambiguous rule.
+ */
+fun cohortVisibility(
+    viewerCohort: String,
+    itemCohort: String,
+    policy: CrossCohortPolicy,
+): CohortVisibility {
+    val v = normalize(viewerCohort)
+    val i = normalize(itemCohort)
+    if (v == i) return CohortVisibility.Visible
+    return when (policy) {
+        CrossCohortPolicy.PLACEHOLDER -> CohortVisibility.PlaceholderUnavailable
+        CrossCohortPolicy.HIDE -> CohortVisibility.Hidden
+    }
+}
+
+/**
+ * Filter a list of users for [viewer]. PLACEHOLDER policy preserves
+ * cardinality (cross-cohort entries become [CohortFilteredEntry.Placeholder]
+ * with a stable key); HIDE drops them entirely.
+ */
+fun filterUsersByCohort(
+    viewer: User,
+    users: List<User>,
+    policy: CrossCohortPolicy = CrossCohortPolicy.PLACEHOLDER,
+): List<CohortFilteredEntry<User>> {
+    if (users.isEmpty()) return emptyList()
+    val viewerCohort = viewer.effectiveCohort
+    return users.mapNotNull { u ->
+        when (cohortVisibility(viewerCohort, u.effectiveCohort, policy)) {
+            CohortVisibility.Visible -> CohortFilteredEntry.Visible(u)
+            CohortVisibility.PlaceholderUnavailable -> CohortFilteredEntry.Placeholder(u.uid)
+            CohortVisibility.Hidden -> null
+        }
+    }
+}
+
+/**
+ * Drop cross-cohort users from a list (HIDE policy). Use at call sites
+ * where placeholder rows have no UX value (recipient pickers, follow
+ * lists, stalker lists). Equivalent to filtering on [User.effectiveCohort]
+ * but goes through the central [cohortVisibility] decision so the
+ * fail-closed-on-invalid-cohort rule applies uniformly.
+ */
+fun List<User>.filterSameCohortAs(viewer: User): List<User> {
+    if (isEmpty()) return this
+    val viewerCohort = viewer.effectiveCohort
+    return filter { cohortVisibility(viewerCohort, it.effectiveCohort, CrossCohortPolicy.HIDE) == CohortVisibility.Visible }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/CohortUtil.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/CohortUtil.kt
@@ -1,5 +1,6 @@
 package com.shyden.shytalk.core.util
 
+import com.shyden.shytalk.core.model.User
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Instant
@@ -12,8 +13,34 @@ import kotlin.time.Instant
 const val COHORT_MINOR: String = "minor"
 const val COHORT_ADULT: String = "adult"
 
+/** Allow-list of accepted cohort strings — anything else fails closed to minor. */
+private val VALID_COHORTS: Set<String> = setOf(COHORT_MINOR, COHORT_ADULT)
+
 /** Age at which a user crosses from minor to adult cohort. */
 const val ADULT_AGE_THRESHOLD: Int = 18
+
+/**
+ * KMP mirror of `express-api/src/utils/firebase-claims.js::effectiveCohort`.
+ * Resolution order:
+ *   1. `cohortOverride` if allow-listed (admin-set, audit-logged)
+ *   2. `cohort` if allow-listed (DOB-derived by pm-lock-check)
+ *   3. `"minor"` — most-restrictive default
+ *
+ * Keep in lock-step with the Express helper. Divergence means a user
+ * the server filters out is still visible client-side (or vice versa).
+ */
+fun effectiveCohort(
+    cohort: String,
+    cohortOverride: String?,
+): String {
+    if (cohortOverride != null && cohortOverride in VALID_COHORTS) return cohortOverride
+    if (cohort in VALID_COHORTS) return cohort
+    return COHORT_MINOR
+}
+
+/** Convenience: resolve the effective cohort for a [User] doc. */
+val User.effectiveCohort: String
+    get() = effectiveCohort(cohort, cohortOverride)
 
 /**
  * Map a date-of-birth to the segregation cohort tag, evaluated in UTC.

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeViewModel.kt
@@ -6,10 +6,13 @@ import com.shyden.shytalk.core.model.Banner
 import com.shyden.shytalk.core.model.ChatRoom
 import com.shyden.shytalk.core.model.SeatState
 import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.util.COHORT_MINOR
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.core.util.currentTimeMillis
+import com.shyden.shytalk.core.util.effectiveCohort
 import com.shyden.shytalk.core.util.logE
 import com.shyden.shytalk.core.util.logI
+import com.shyden.shytalk.core.util.logW
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.BannerRepository
 import com.shyden.shytalk.data.repository.RoomRepository
@@ -147,12 +150,21 @@ class HomeViewModel(
             userRepository.userUpdates.collect { updatedUser ->
                 if (updatedUser.uid in userCache) {
                     cacheUser(updatedUser.uid, updatedUser)
+                    val viewer = userCache[currentUserId]
                     _uiState.update { state ->
+                        // UK OSA #17 PR 12 — re-apply the seat-user
+                        // cohort redaction after every user-update so a
+                        // mid-session cohort flip (admin override / age-
+                        // up) immediately drops the user from the seat
+                        // map. Without this, a cross-cohort identity
+                        // would linger on the home screen until the
+                        // next manual refresh.
+                        val nextMap =
+                            state.seatUsers.let { map ->
+                                if (updatedUser.uid in map) map + (updatedUser.uid to updatedUser) else map
+                            }
                         state.copy(
-                            seatUsers =
-                                state.seatUsers.let { map ->
-                                    if (updatedUser.uid in map) map + (updatedUser.uid to updatedUser) else map
-                                },
+                            seatUsers = viewer?.let { redactCrossCohortSeatUsers(nextMap, it) } ?: nextMap,
                         )
                     }
                 }
@@ -221,7 +233,11 @@ class HomeViewModel(
     private suspend fun filterAndEmitRooms() {
         val userId = currentUserId ?: return
 
-        // Collect all user IDs we need: owners + seated users (lazy sequences)
+        // Collect all user IDs we need: owners + seated users (lazy sequences).
+        // The viewer's own User is fetched via a separate getUser(userId) call
+        // below — keeping it off the batch path avoids an extra getUsers call
+        // during the init-time empty-rooms pass that pinned existing test
+        // assertions on the exact `getUsers` invocation count.
         val ownerIds = allRooms.asSequence().map { it.ownerId }.toSet()
         val seatedUserIds =
             allRooms
@@ -246,8 +262,39 @@ class HomeViewModel(
             }
         }
 
+        // UK OSA #17 PR 12 — guarantee the viewer's User is cached
+        // before the cohort gate runs. A viewer browsing rooms without
+        // owning or sitting in any won't be present in the batch fetch
+        // above, so we fall back to a direct getUser(userId) here.
+        // Without this fallback, the cohort gate fails closed and the
+        // user would see an empty home screen on every cold start.
+        if (userId !in userCache) {
+            when (val result = userRepository.getUser(userId)) {
+                is Resource.Success -> cacheUser(userId, result.data)
+                else -> Unit
+            }
+        }
+
+        // UK OSA #17 PR 12 — client-side defence-in-depth cohort gate.
+        // Server already filters cross-cohort rooms out of the active
+        // listing; this guard catches stale offline-cache rooms and
+        // deep-linked rooms that bypassed the listing filter.
+        // Fail-CLOSED when the viewer's User doc cannot be resolved
+        // (batch + getUser fallback both failed). The same fail-closed
+        // posture is used by ConversationListViewModel.loadConversation
+        // Details for OSA consistency: a minor viewer must never see
+        // adult rooms, even on a transient Firestore hiccup.
+        val viewerUser = userCache[userId]
+        val cohortGated =
+            if (viewerUser == null) {
+                logW(TAG, "Cohort gate fail-closed — viewer User not resolvable; emitting empty room list")
+                emptyList()
+            } else {
+                filterRoomsByCohort(allRooms, viewerUser, userCache)
+            }
+
         val filtered =
-            allRooms
+            cohortGated
                 .filter { room ->
                     // Exclude closed rooms (safety net — query should already filter these)
                     if (room.state == com.shyden.shytalk.core.model.RoomState.CLOSED) return@filter false
@@ -271,11 +318,22 @@ class HomeViewModel(
                     }.toSet()
             }
 
+        // Redact cross-cohort seat users — defence-in-depth so any
+        // mid-session cohort flip (admin override, age-up) does not
+        // expose foreign-cohort identities to the viewer.
+        val filteredSeatUsers = userCache.filterKeys { key -> key in filteredSeatedUserIds }
+        val redactedSeatUsers =
+            if (viewerUser != null) {
+                redactCrossCohortSeatUsers(filteredSeatUsers, viewerUser)
+            } else {
+                filteredSeatUsers
+            }
+
         _uiState.update {
             it.copy(
                 rooms = filtered,
                 isLoading = false,
-                seatUsers = userCache.filterKeys { key -> key in filteredSeatedUserIds },
+                seatUsers = redactedSeatUsers,
             )
         }
     }
@@ -334,15 +392,16 @@ class HomeViewModel(
         // — the JWT claim is server-minted from `effectiveCohort`
         // which honours the override, so the stamped value MUST match
         // or the firestore.rules create-bind rejects.
+        // UK OSA #17 PR 12 — route through the central
+        // `User.effectiveCohort` extension so an invalid `cohort` field
+        // also fails closed to "minor" (the prior inline check honoured
+        // override but accepted any `cohort` string, even a corrupted
+        // Firestore value, which would be rejected by the rules-layer
+        // create-bind and surface as a confusing error to the user).
         val cohort =
             when (val userResult = userRepository.getUser(userId)) {
-                is Resource.Success -> {
-                    val user = userResult.data
-                    val override = user.cohortOverride
-                    if (override == "adult" || override == "minor") override else user.cohort
-                }
-
-                else -> "minor"
+                is Resource.Success -> userResult.data.effectiveCohort
+                else -> COHORT_MINOR
             }
 
         when (val result = roomRepository.createRoom(name, userId, cohort)) {

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/RoomCohortGate.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/RoomCohortGate.kt
@@ -1,0 +1,42 @@
+package com.shyden.shytalk.feature.home
+
+import com.shyden.shytalk.core.model.ChatRoom
+import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.util.effectiveCohort
+
+/**
+ * Returns true iff [room] should be visible to [viewer] under the
+ * UK OSA #17 cohort-segregation rule. The room is visible when the
+ * resolved owner's effective cohort matches the viewer's. Missing
+ * owner from cache fails closed (drop) — there is no safe assumption
+ * a minor caller can make about a room whose cohort we cannot prove.
+ */
+fun isRoomVisibleToCohort(
+    room: ChatRoom,
+    viewer: User,
+    userCache: Map<String, User>,
+): Boolean {
+    val owner = userCache[room.ownerId] ?: return false
+    return owner.effectiveCohort == viewer.effectiveCohort
+}
+
+/** Drops cross-cohort rooms from a list. Pure function, no I/O. */
+fun filterRoomsByCohort(
+    rooms: List<ChatRoom>,
+    viewer: User,
+    userCache: Map<String, User>,
+): List<ChatRoom> = rooms.filter { isRoomVisibleToCohort(it, viewer, userCache) }
+
+/**
+ * Defense-in-depth: redact (drop) cross-cohort seated users from the
+ * map exposed to the home screen. Same-cohort rooms can still contain
+ * a seated user whose cohort flipped mid-session (admin override, age-
+ * up); redaction prevents leaking their identity to the viewer.
+ */
+fun redactCrossCohortSeatUsers(
+    seatUsers: Map<String, User>,
+    viewer: User,
+): Map<String, User> {
+    val viewerCohort = viewer.effectiveCohort
+    return seatUsers.filterValues { it.effectiveCohort == viewerCohort }
+}

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ConversationListViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/ConversationListViewModel.kt
@@ -8,6 +8,7 @@ import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.util.Constants
 import com.shyden.shytalk.core.util.ModerationFilter
 import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.core.util.effectiveCohort
 import com.shyden.shytalk.core.util.logE
 import com.shyden.shytalk.core.util.logI
 import com.shyden.shytalk.core.util.logW
@@ -168,7 +169,7 @@ class ConversationListViewModel(
         }
 
         // Show conversations with inline settings — no background refresh needed
-        val conversationsWithDetails = buildConversationList(conversations, blockedByMe)
+        val conversationsWithDetails = buildConversationList(conversations, blockedByMe, currentUser)
         emitSortedConversations(conversationsWithDetails)
     }
 
@@ -176,8 +177,10 @@ class ConversationListViewModel(
     private fun buildConversationList(
         conversations: List<Conversation>,
         blockedByMe: Set<String>,
-    ): List<ConversationWithUser> =
-        conversations.mapNotNull { conversation ->
+        currentUser: User,
+    ): List<ConversationWithUser> {
+        val viewerCohort = currentUser.effectiveCohort
+        return conversations.mapNotNull { conversation ->
             val settings = settingsCache[conversation.conversationId]
 
             // Filter hidden conversations (unless a new message arrived after hiding)
@@ -199,15 +202,29 @@ class ConversationListViewModel(
                     groupPhotoUrl = conversation.groupPhotoUrl,
                 )
             } else {
+                // UK OSA #17 PR 12 — drop migration-frozen 1:1 threads.
+                // PR 8 set frozenAtMigration on cross-cohort 1:1 threads
+                // at the regulatory rollout; the comment on Conversation
+                // states the KMP filter lands in PR 12 (this PR).
+                if (conversation.frozenAtMigration) return@mapNotNull null
+
                 val otherUserId = conversation.otherUserId(currentUserId) ?: return@mapNotNull null
                 val otherUser = userCache[otherUserId]
 
-                // Skip blocking checks for system user
+                // Skip blocking + cohort checks for the system user — system
+                // notifications must reach every account regardless of cohort.
                 val isSystemConversation = otherUserId == Constants.SYSTEM_USER_ID
                 if (!isSystemConversation) {
                     val blockedByTarget = otherUser?.blockedUserIds?.contains(currentUserId) == true
                     val isBlocked = otherUserId in blockedByMe || blockedByTarget
                     if (isBlocked) return@mapNotNull null
+
+                    // Defence-in-depth: drop any cross-cohort 1:1 thread
+                    // that escaped the PR 8 migration (stale offline cache
+                    // / deep-link / age-up after thread was cached).
+                    if (otherUser != null && otherUser.effectiveCohort != viewerCohort) {
+                        return@mapNotNull null
+                    }
                 }
 
                 ConversationWithUser(
@@ -218,6 +235,7 @@ class ConversationListViewModel(
                 )
             }
         }
+    }
 
     private fun emitSortedConversations(list: List<ConversationWithUser>) {
         val sorted =

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/NewMessageViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/messaging/NewMessageViewModel.kt
@@ -6,6 +6,7 @@ import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.util.Constants
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.core.util.UiText
+import com.shyden.shytalk.core.util.filterSameCohortAs
 import com.shyden.shytalk.core.util.logI
 import com.shyden.shytalk.data.repository.AuthRepository
 import com.shyden.shytalk.data.repository.PrivateMessageRepository
@@ -48,6 +49,15 @@ class NewMessageViewModel(
     private val currentUserId: String = authRepository.currentUserId ?: ""
     private var searchJob: Job? = null
 
+    /**
+     * UK OSA #17 PR 12 — cached viewer doc for the client-side cohort
+     * filter. Set by [loadAvailableUsers] (which already fetches it for
+     * `followerIds + followingIds`). Other loaders use it via
+     * [filterSameCohortAs] to apply HIDE policy to picker rows: there is
+     * no UX value in showing un-messageable cross-cohort users.
+     */
+    private var viewerUser: User? = null
+
     init {
         logI(TAG, "Initializing new message screen")
         loadAvailableUsers()
@@ -68,6 +78,7 @@ class NewMessageViewModel(
                         return@launch
                     }
                 }
+            viewerUser = currentUser
 
             val allIds =
                 (currentUser.followerIds + currentUser.followingIds)
@@ -81,10 +92,12 @@ class NewMessageViewModel(
 
             when (val result = userRepository.getUsers(allIds)) {
                 is Resource.Success -> {
+                    // Defence-in-depth cohort filter (HIDE policy on picker)
+                    val sameCohort = result.data.filterSameCohortAs(currentUser)
                     _uiState.update {
                         it.copy(
                             isLoading = false,
-                            availableUsers = result.data.sortedBy { u -> u.displayName.lowercase() },
+                            availableUsers = sameCohort.sortedBy { u -> u.displayName.lowercase() },
                         )
                     }
                 }
@@ -114,7 +127,11 @@ class NewMessageViewModel(
                             // Maintain the order from recentUserIds
                             val usersMap = result.data.associateBy { it.uid }
                             val ordered = recentUserIds.mapNotNull { usersMap[it] }
-                            _uiState.update { it.copy(recentUsers = ordered) }
+                            // Defence-in-depth: drop cross-cohort recent
+                            // users. Fall back to empty when viewer not
+                            // yet loaded — fail-closed for picker rows.
+                            val filtered = viewerUser?.let { ordered.filterSameCohortAs(it) } ?: emptyList()
+                            _uiState.update { it.copy(recentUsers = filtered) }
                         }
 
                         else -> Unit
@@ -180,10 +197,14 @@ class NewMessageViewModel(
                 _uiState.update { it.copy(isSearchingAll = true) }
                 when (val result = pmRepository.searchUsers(query, currentUserId)) {
                     is Resource.Success -> {
+                        // Defence-in-depth cohort filter on search results
+                        // (server already filters via PR 5 — this is the
+                        // client mirror for tampered-build/stale-cache).
+                        val filtered = viewerUser?.let { result.data.filterSameCohortAs(it) } ?: emptyList()
                         _uiState.update {
                             it.copy(
                                 isSearchingAll = false,
-                                allUsersSearchResults = result.data,
+                                allUsersSearchResults = filtered,
                             )
                         }
                     }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/FollowListViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/profile/FollowListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.shyden.shytalk.core.model.ProfileVisitor
 import com.shyden.shytalk.core.model.User
 import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.core.util.filterSameCohortAs
 import com.shyden.shytalk.core.util.logE
 import com.shyden.shytalk.core.util.logI
 import com.shyden.shytalk.data.repository.AuthRepository
@@ -49,6 +50,16 @@ class FollowListViewModel(
     private val _uiState = MutableStateFlow(FollowListUiState())
     val uiState: StateFlow<FollowListUiState> = _uiState.asStateFlow()
 
+    /**
+     * UK OSA #17 PR 12 — cached viewer for the [observeUserUpdates]
+     * re-filter path. A mid-session cohort flip pushed through the
+     * userUpdates flow must immediately drop the user from the
+     * follower / following / stalker lists; we need the viewer's
+     * effective cohort at that point but no longer have access to it
+     * via the load path. Set by [loadData].
+     */
+    private var viewer: User? = null
+
     init {
         val currentUid = authRepository.currentUserId ?: ""
         val tab =
@@ -83,10 +94,44 @@ class FollowListViewModel(
         viewModelScope.launch {
             userRepository.userUpdates.collect { updatedUser ->
                 _uiState.update { state ->
-                    state.copy(
-                        followers = state.followers.map { if (it.uid == updatedUser.uid) updatedUser else it },
-                        following = state.following.map { if (it.uid == updatedUser.uid) updatedUser else it },
-                    )
+                    // Apply the user-update in place, then re-filter
+                    // through the cohort gate so a mid-session cohort
+                    // flip (admin override / age-up) immediately drops
+                    // the user from both lists. UK OSA #17 PR 12 — the
+                    // observer path must not undo the load-time filter.
+                    val nextFollowers =
+                        state.followers.map { if (it.uid == updatedUser.uid) updatedUser else it }
+                    val nextFollowing =
+                        state.following.map { if (it.uid == updatedUser.uid) updatedUser else it }
+                    val nextStalkerUsers =
+                        if (updatedUser.uid in state.stalkerUsers) {
+                            state.stalkerUsers + (updatedUser.uid to updatedUser)
+                        } else {
+                            state.stalkerUsers
+                        }
+                    val v = viewer
+                    if (v != null) {
+                        val filteredFollowers = nextFollowers.filterSameCohortAs(v)
+                        val filteredFollowing = nextFollowing.filterSameCohortAs(v)
+                        val filteredStalkerUsers =
+                            nextStalkerUsers.values
+                                .toList()
+                                .filterSameCohortAs(v)
+                                .associateBy { it.uid }
+                        val filteredStalkers = state.stalkers.filter { it.visitorId in filteredStalkerUsers.keys }
+                        state.copy(
+                            followers = filteredFollowers,
+                            following = filteredFollowing,
+                            stalkers = filteredStalkers,
+                            stalkerUsers = filteredStalkerUsers,
+                        )
+                    } else {
+                        state.copy(
+                            followers = nextFollowers,
+                            following = nextFollowing,
+                            stalkerUsers = nextStalkerUsers,
+                        )
+                    }
                 }
             }
         }
@@ -119,23 +164,32 @@ class FollowListViewModel(
             val isFollowingHidden = !_uiState.value.isOwnList && profileUser.hideFollowing
             val followingIdsList = if (isFollowingHidden) emptyList() else profileUser.followingIds.toList()
 
-            // Load current user's follow data for button states
+            // Load current user's follow data for button states. We also
+            // capture the viewer's full User doc — UK OSA #17 PR 12 needs
+            // their `cohort` / `cohortOverride` to drive the client-side
+            // defence-in-depth filter that drops cross-cohort users from
+            // the follower / following / stalker lists.
             val currentUid = _uiState.value.currentUserId
             var myFollowingIds: Set<String> = emptySet()
             var myFollowerIds: Set<String> = emptySet()
             var myBlockedIds: Set<String> = emptySet()
+            var loadedViewer: User? = null
             if (_uiState.value.isOwnList) {
                 myFollowingIds = profileUser.followingIds
                 myFollowerIds = profileUser.followerIds
                 myBlockedIds = profileUser.blockedUserIds
+                loadedViewer = profileUser
             } else if (currentUid.isNotEmpty()) {
                 val myResult = userRepository.getUser(currentUid)
                 if (myResult is Resource.Success) {
                     myFollowingIds = myResult.data.followingIds
                     myFollowerIds = myResult.data.followerIds
                     myBlockedIds = myResult.data.blockedUserIds
+                    loadedViewer = myResult.data
                 }
             }
+            // Cache for observer-path re-filtering.
+            viewer = loadedViewer
 
             // Batch-fetch all user objects
             val allIds = (followerIdsList + followingIdsList).distinct()
@@ -176,18 +230,39 @@ class FollowListViewModel(
                 }
             }
 
+            // UK OSA #17 PR 12 — client-side defence-in-depth: drop
+            // cross-cohort users from each list. HIDE policy (not
+            // PLACEHOLDER) because anonymous placeholder rows in a
+            // follower list would leak cross-cohort follower counts to
+            // fingerprinting observers and present creepy UX.
+            // Fail-closed: when the viewer's User cannot be resolved,
+            // drop EVERY list entry rather than leaking cross-cohort
+            // identities through a half-built session.
+            val rawFollowers = followerIdsList.mapNotNull { id -> allUsers[id] }
+            val rawFollowing = followingIdsList.mapNotNull { id -> allUsers[id] }
+            val filteredFollowers = loadedViewer?.let { rawFollowers.filterSameCohortAs(it) } ?: emptyList()
+            val filteredFollowing = loadedViewer?.let { rawFollowing.filterSameCohortAs(it) } ?: emptyList()
+            val filteredStalkerUsers =
+                loadedViewer?.let { v ->
+                    stalkerUserMap.values
+                        .toList()
+                        .filterSameCohortAs(v)
+                        .associateBy { it.uid }
+                } ?: emptyMap()
+            val filteredStalkers = stalkerList.filter { it.visitorId in filteredStalkerUsers.keys }
+
             _uiState.update {
                 it.copy(
                     isLoading = false,
                     isSuperShy = profileUser.isSuperShy,
-                    followers = followerIdsList.mapNotNull { id -> allUsers[id] },
-                    following = followingIdsList.mapNotNull { id -> allUsers[id] },
+                    followers = filteredFollowers,
+                    following = filteredFollowing,
                     currentUserFollowingIds = myFollowingIds,
                     currentUserFollowerIds = myFollowerIds,
                     currentUserBlockedIds = myBlockedIds,
                     followingHidden = isFollowingHidden,
-                    stalkers = stalkerList,
-                    stalkerUsers = stalkerUserMap,
+                    stalkers = filteredStalkers,
+                    stalkerUsers = filteredStalkerUsers,
                     stalkersLastViewedAt = stalkersLastViewed,
                 )
             }

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/CohortAwareItemFilterTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/CohortAwareItemFilterTest.kt
@@ -1,0 +1,181 @@
+package com.shyden.shytalk.core.util
+
+import com.shyden.shytalk.core.model.User
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [cohortVisibility] and [filterUsersByCohort] — the client-side
+ * defence-in-depth layer (UK OSA #17 PR 12). The server already filters
+ * lists per cohort, so this layer only catches:
+ *   - stale offline-cache items that have aged-up across cohorts
+ *   - direct fetches that bypass the server's list endpoint
+ *   - tampered builds whose modified clients skip server filters
+ *
+ * Semantics MUST mirror `express-api/src/utils/cohort-filter.js` so a
+ * server-blocked user is also client-blocked, and vice versa.
+ */
+class CohortAwareItemFilterTest {
+    @Test
+    fun `same-cohort returns Visible regardless of policy`() {
+        assertEquals(
+            CohortVisibility.Visible,
+            cohortVisibility(COHORT_ADULT, COHORT_ADULT, CrossCohortPolicy.PLACEHOLDER),
+        )
+        assertEquals(
+            CohortVisibility.Visible,
+            cohortVisibility(COHORT_ADULT, COHORT_ADULT, CrossCohortPolicy.HIDE),
+        )
+        assertEquals(
+            CohortVisibility.Visible,
+            cohortVisibility(COHORT_MINOR, COHORT_MINOR, CrossCohortPolicy.HIDE),
+        )
+    }
+
+    @Test
+    fun `cross-cohort PLACEHOLDER policy returns Unavailable`() {
+        assertEquals(
+            CohortVisibility.PlaceholderUnavailable,
+            cohortVisibility(COHORT_ADULT, COHORT_MINOR, CrossCohortPolicy.PLACEHOLDER),
+        )
+        assertEquals(
+            CohortVisibility.PlaceholderUnavailable,
+            cohortVisibility(COHORT_MINOR, COHORT_ADULT, CrossCohortPolicy.PLACEHOLDER),
+        )
+    }
+
+    @Test
+    fun `cross-cohort HIDE policy returns Hidden`() {
+        assertEquals(
+            CohortVisibility.Hidden,
+            cohortVisibility(COHORT_ADULT, COHORT_MINOR, CrossCohortPolicy.HIDE),
+        )
+        assertEquals(
+            CohortVisibility.Hidden,
+            cohortVisibility(COHORT_MINOR, COHORT_ADULT, CrossCohortPolicy.HIDE),
+        )
+    }
+
+    @Test
+    fun `invalid cohort strings fall back to minor — most restrictive`() {
+        // Garbage viewerCohort treated as minor → cross with adult item
+        assertEquals(
+            CohortVisibility.PlaceholderUnavailable,
+            cohortVisibility("garbage", COHORT_ADULT, CrossCohortPolicy.PLACEHOLDER),
+        )
+        // Garbage itemCohort treated as minor → adult viewer is cross
+        assertEquals(
+            CohortVisibility.PlaceholderUnavailable,
+            cohortVisibility(COHORT_ADULT, "", CrossCohortPolicy.PLACEHOLDER),
+        )
+        // Both garbage → both minor → Visible
+        assertEquals(
+            CohortVisibility.Visible,
+            cohortVisibility("foo", "bar", CrossCohortPolicy.PLACEHOLDER),
+        )
+    }
+
+    @Test
+    fun `filterUsersByCohort with PLACEHOLDER preserves cardinality`() {
+        val viewer = User(uid = "v", cohort = COHORT_ADULT)
+        val users =
+            listOf(
+                User(uid = "a", cohort = COHORT_ADULT),
+                User(uid = "m", cohort = COHORT_MINOR),
+                User(uid = "a2", cohort = COHORT_ADULT),
+            )
+
+        val result = filterUsersByCohort(viewer, users, CrossCohortPolicy.PLACEHOLDER)
+
+        assertEquals(3, result.size, "PLACEHOLDER preserves count")
+        assertTrue(result[0] is CohortFilteredEntry.Visible)
+        assertTrue(result[1] is CohortFilteredEntry.Placeholder)
+        assertTrue(result[2] is CohortFilteredEntry.Visible)
+    }
+
+    @Test
+    fun `filterUsersByCohort with HIDE drops cross-cohort`() {
+        val viewer = User(uid = "v", cohort = COHORT_ADULT)
+        val users =
+            listOf(
+                User(uid = "a", cohort = COHORT_ADULT),
+                User(uid = "m", cohort = COHORT_MINOR),
+                User(uid = "a2", cohort = COHORT_ADULT),
+            )
+
+        val result = filterUsersByCohort(viewer, users, CrossCohortPolicy.HIDE)
+
+        assertEquals(2, result.size, "HIDE removes cross-cohort entries")
+        val visibleUids = result.filterIsInstance<CohortFilteredEntry.Visible<User>>().map { it.item.uid }
+        assertEquals(listOf("a", "a2"), visibleUids)
+    }
+
+    @Test
+    fun `filterUsersByCohort honours cohortOverride on viewer and item`() {
+        // Viewer's cohort is "minor" but admin override makes them effective adult
+        val viewer = User(uid = "v", cohort = COHORT_MINOR, cohortOverride = COHORT_ADULT)
+        val users =
+            listOf(
+                User(uid = "a", cohort = COHORT_ADULT, cohortOverride = null),
+                // Item's underlying cohort adult but admin clamped to minor → cross-cohort
+                User(uid = "clamped", cohort = COHORT_ADULT, cohortOverride = COHORT_MINOR),
+            )
+
+        val result = filterUsersByCohort(viewer, users, CrossCohortPolicy.HIDE)
+        assertEquals(1, result.size)
+        assertEquals(
+            "a",
+            (result.single() as CohortFilteredEntry.Visible<User>).item.uid,
+        )
+    }
+
+    @Test
+    fun `empty list returns empty result`() {
+        val viewer = User(uid = "v", cohort = COHORT_ADULT)
+        assertEquals(emptyList(), filterUsersByCohort(viewer, emptyList(), CrossCohortPolicy.PLACEHOLDER))
+        assertEquals(emptyList(), filterUsersByCohort(viewer, emptyList(), CrossCohortPolicy.HIDE))
+    }
+
+    @Test
+    fun `placeholder entries carry stable item key for Compose re-keying`() {
+        val viewer = User(uid = "v", cohort = COHORT_ADULT)
+        val users = listOf(User(uid = "minor-1", cohort = COHORT_MINOR))
+
+        val result = filterUsersByCohort(viewer, users, CrossCohortPolicy.PLACEHOLDER)
+        val placeholder = result.single() as CohortFilteredEntry.Placeholder
+        assertEquals("minor-1", placeholder.key)
+    }
+
+    @Test
+    fun `filterSameCohortAs is shorthand for HIDE-policy filter`() {
+        val viewer = User(uid = "v", cohort = COHORT_ADULT)
+        val users =
+            listOf(
+                User(uid = "a", cohort = COHORT_ADULT),
+                User(uid = "m", cohort = COHORT_MINOR),
+                User(uid = "a2", cohort = COHORT_ADULT),
+            )
+
+        assertEquals(listOf("a", "a2"), users.filterSameCohortAs(viewer).map { it.uid })
+    }
+
+    @Test
+    fun `filterSameCohortAs on empty list returns empty`() {
+        val viewer = User(uid = "v", cohort = COHORT_ADULT)
+        assertEquals(emptyList(), emptyList<User>().filterSameCohortAs(viewer))
+    }
+
+    @Test
+    fun `filterSameCohortAs honours cohortOverride end-to-end`() {
+        val viewer = User(uid = "v", cohort = COHORT_MINOR, cohortOverride = COHORT_ADULT)
+        val users =
+            listOf(
+                User(uid = "a", cohort = COHORT_ADULT),
+                User(uid = "a-clamped", cohort = COHORT_ADULT, cohortOverride = COHORT_MINOR),
+                User(uid = "m", cohort = COHORT_MINOR),
+            )
+
+        assertEquals(listOf("a"), users.filterSameCohortAs(viewer).map { it.uid })
+    }
+}

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/EffectiveCohortTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/EffectiveCohortTest.kt
@@ -1,0 +1,70 @@
+package com.shyden.shytalk.core.util
+
+import com.shyden.shytalk.core.model.User
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EffectiveCohortTest {
+    @Test
+    fun `cohortOverride wins when allow-listed`() {
+        assertEquals(COHORT_ADULT, effectiveCohort(cohort = COHORT_MINOR, cohortOverride = COHORT_ADULT))
+        assertEquals(COHORT_MINOR, effectiveCohort(cohort = COHORT_ADULT, cohortOverride = COHORT_MINOR))
+    }
+
+    @Test
+    fun `cohort returned when cohortOverride is null`() {
+        assertEquals(COHORT_ADULT, effectiveCohort(cohort = COHORT_ADULT, cohortOverride = null))
+        assertEquals(COHORT_MINOR, effectiveCohort(cohort = COHORT_MINOR, cohortOverride = null))
+    }
+
+    @Test
+    fun `invalid cohortOverride falls back to cohort`() {
+        assertEquals(COHORT_ADULT, effectiveCohort(cohort = COHORT_ADULT, cohortOverride = "super-adult"))
+        assertEquals(COHORT_ADULT, effectiveCohort(cohort = COHORT_ADULT, cohortOverride = ""))
+    }
+
+    @Test
+    fun `invalid cohort falls back to minor`() {
+        assertEquals(COHORT_MINOR, effectiveCohort(cohort = "gibberish", cohortOverride = null))
+        assertEquals(COHORT_MINOR, effectiveCohort(cohort = "", cohortOverride = null))
+    }
+
+    @Test
+    fun `both invalid yields minor (most-restrictive)`() {
+        assertEquals(COHORT_MINOR, effectiveCohort(cohort = "x", cohortOverride = "y"))
+    }
+
+    @Test
+    fun `User extension returns effective cohort`() {
+        val minorUser = User(cohort = COHORT_MINOR, cohortOverride = null)
+        val adultUser = User(cohort = COHORT_ADULT, cohortOverride = null)
+        val overriddenMinor = User(cohort = COHORT_ADULT, cohortOverride = COHORT_MINOR)
+        val invalidOverride = User(cohort = COHORT_ADULT, cohortOverride = "garbage")
+
+        assertEquals(COHORT_MINOR, minorUser.effectiveCohort)
+        assertEquals(COHORT_ADULT, adultUser.effectiveCohort)
+        assertEquals(COHORT_MINOR, overriddenMinor.effectiveCohort)
+        assertEquals(COHORT_ADULT, invalidOverride.effectiveCohort)
+    }
+
+    @Test
+    fun `mirror of Express utils firebase-claims effectiveCohort`() {
+        // Same truth table as express-api/src/utils/firebase-claims.js
+        // effectiveCohort(). Keep these in lock-step — divergence
+        // between server and client would mean a user blocked by the
+        // server is still visible client-side (or vice versa), defeating
+        // the defence-in-depth design.
+        val cases =
+            listOf(
+                Triple(COHORT_ADULT, null, COHORT_ADULT),
+                Triple(COHORT_MINOR, null, COHORT_MINOR),
+                Triple(COHORT_ADULT, COHORT_MINOR, COHORT_MINOR),
+                Triple(COHORT_MINOR, COHORT_ADULT, COHORT_ADULT),
+                Triple(COHORT_ADULT, "junk", COHORT_ADULT),
+                Triple("junk", null, COHORT_MINOR),
+            )
+        for ((cohort, override, expected) in cases) {
+            assertEquals(expected, effectiveCohort(cohort, override), "cohort=$cohort override=$override")
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/home/RoomCohortGateTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/home/RoomCohortGateTest.kt
@@ -1,0 +1,147 @@
+package com.shyden.shytalk.feature.home
+
+import com.shyden.shytalk.core.model.ChatRoom
+import com.shyden.shytalk.core.model.User
+import com.shyden.shytalk.core.util.COHORT_ADULT
+import com.shyden.shytalk.core.util.COHORT_MINOR
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pure-helper tests for the home-screen room cohort gate (UK OSA #17
+ * PR 12). The gate is the *client-side mirror* of the Firestore rule
+ * gate from PR 3 + the Express room-join gate from PR 7. The server
+ * already filters cross-cohort rooms out of the active-rooms listing,
+ * so this client gate exists to catch:
+ *   - stale offline-cache rooms where the owner aged-up since cache
+ *     was populated
+ *   - deep-linked rooms (notification, share link) where the listing
+ *     filter was bypassed
+ *
+ * Failure mode: cross-cohort room renders to a minor → safeguarding
+ * incident. Therefore the test bias is "drop on any ambiguity"
+ * (most-restrictive).
+ */
+class RoomCohortGateTest {
+    private fun room(
+        roomId: String,
+        ownerId: String,
+    ) = ChatRoom(roomId = roomId, ownerId = ownerId)
+
+    private fun adult(uid: String) = User(uid = uid, cohort = COHORT_ADULT)
+
+    private fun minor(uid: String) = User(uid = uid, cohort = COHORT_MINOR)
+
+    @Test
+    fun `same-cohort room visible to viewer`() {
+        val viewer = adult("v")
+        val r = room("r1", "owner-a")
+        val cache = mapOf("owner-a" to adult("owner-a"))
+
+        assertTrue(isRoomVisibleToCohort(r, viewer, cache))
+    }
+
+    @Test
+    fun `cross-cohort room hidden from viewer`() {
+        val viewer = adult("v")
+        val r = room("r1", "owner-m")
+        val cache = mapOf("owner-m" to minor("owner-m"))
+
+        assertFalse(isRoomVisibleToCohort(r, viewer, cache))
+    }
+
+    @Test
+    fun `cross-cohort room with PLACEHOLDER decision still drops from active list`() {
+        // Even when display policy is PLACEHOLDER elsewhere, the room
+        // gate at the list level always drops (rooms are an enter-able
+        // resource — there is no UX value in showing an un-enterable
+        // tile, and rendering the placeholder would leak the existence
+        // of cross-cohort rooms in the minor's UI).
+        val viewer = minor("v")
+        val r = room("r1", "owner-a")
+        val cache = mapOf("owner-a" to adult("owner-a"))
+
+        assertFalse(isRoomVisibleToCohort(r, viewer, cache))
+    }
+
+    @Test
+    fun `owner missing from cache fails closed (drops room)`() {
+        // No cached owner doc → cannot prove same-cohort → drop (most
+        // restrictive). The active-rooms query batch-loads owners, so
+        // a miss usually means the doc was deleted (account reaped).
+        val viewer = adult("v")
+        val r = room("r1", "owner-ghost")
+        val cache = emptyMap<String, User>()
+
+        assertFalse(isRoomVisibleToCohort(r, viewer, cache))
+    }
+
+    @Test
+    fun `cohortOverride on owner is honored`() {
+        // Owner's stored cohort is "adult" but admin clamped them to
+        // "minor" → effective cohort = minor → drop for adult viewer.
+        val viewer = adult("v")
+        val ownerClamped = User(uid = "owner", cohort = COHORT_ADULT, cohortOverride = COHORT_MINOR)
+        val r = room("r1", "owner")
+        val cache = mapOf("owner" to ownerClamped)
+
+        assertFalse(isRoomVisibleToCohort(r, viewer, cache))
+    }
+
+    @Test
+    fun `viewer with cohortOverride uses effective cohort`() {
+        // Viewer's stored cohort is "minor" but admin uplifted to "adult"
+        // → can see adult rooms.
+        val viewer = User(uid = "v", cohort = COHORT_MINOR, cohortOverride = COHORT_ADULT)
+        val r = room("r1", "owner-a")
+        val cache = mapOf("owner-a" to adult("owner-a"))
+
+        assertTrue(isRoomVisibleToCohort(r, viewer, cache))
+    }
+
+    @Test
+    fun `filterRoomsByCohort drops mixed list to same-cohort only`() {
+        val viewer = adult("v")
+        val rooms =
+            listOf(
+                room("r-a1", "owner-a1"),
+                room("r-m", "owner-m"),
+                room("r-a2", "owner-a2"),
+            )
+        val cache =
+            mapOf(
+                "owner-a1" to adult("owner-a1"),
+                "owner-m" to minor("owner-m"),
+                "owner-a2" to adult("owner-a2"),
+            )
+
+        val result = filterRoomsByCohort(rooms, viewer, cache)
+        assertEquals(listOf("r-a1", "r-a2"), result.map { it.roomId })
+    }
+
+    @Test
+    fun `filterRoomsByCohort empty input returns empty`() {
+        val viewer = adult("v")
+        assertEquals(emptyList(), filterRoomsByCohort(emptyList(), viewer, emptyMap()))
+    }
+
+    @Test
+    fun `redactCrossCohortSeatUsers replaces foreign-cohort entries with placeholder`() {
+        // Defense-in-depth: even if a room slipped through the room
+        // gate (e.g. owner same-cohort but a seated user is cross-
+        // cohort after their cohort flipped mid-session), the seat-
+        // user map should not expose their identity to the viewer.
+        val viewer = adult("v")
+        val seatUsers =
+            mapOf(
+                "u1" to adult("u1"),
+                "u2" to minor("u2"),
+                "u3" to adult("u3"),
+            )
+
+        val redacted = redactCrossCohortSeatUsers(seatUsers, viewer)
+        assertEquals(setOf("u1", "u3"), redacted.keys)
+    }
+}


### PR DESCRIPTION
## Summary

UK OSA #17 PR 12 of 14 — client-side defence-in-depth cohort filter. Mirrors the server-side gates from PRs 3-11. The server's listing filter remains the authoritative gate; this PR catches the residual cases the server can't: stale offline cache, deep-link bypass, and tampered-build skips.

## Architecture

- **`CohortAwareItemFilter`** — pure-function primitives (`CrossCohortPolicy { PLACEHOLDER, HIDE }`, `cohortVisibility()`, `filterUsersByCohort()`, `filterSameCohortAs()`).
- **`CohortUtil.effectiveCohort()`** — KMP mirror of `express-api/src/utils/firebase-claims.js::effectiveCohort` + `User.effectiveCohort` extension. Truth-table lock-step with server.
- **`RoomCohortGate`** — `filterRoomsByCohort()` + `redactCrossCohortSeatUsers()`; missing-owner fails closed.
- **HomeViewModel** — fail-closed cohort gate on rooms + seat redaction; `doCreateRoom` routes through `User.effectiveCohort`; `observeUserUpdates` re-applies redaction on every push.
- **FollowListViewModel** — HIDE policy on followers / following / stalkers; observer re-applies filter.
- **NewMessageViewModel** — HIDE policy on `availableUsers`, `recentUsers`, `allUsersSearchResults` (pickers shouldn't show un-messageable rows).
- **ConversationListViewModel** — drops 1:1 threads with `frozenAtMigration` (PR 8 contract) and cross-cohort 1:1 counterparties.
- **iOS LiveKitBridge** — pre-connect URL allow-list (localhost + Oracle Cloud hosts) and empty/whitespace token guard.

## Test plan

- [x] commonTest: `CohortAwareItemFilterTest` (15), `EffectiveCohortTest` (6), `RoomCohortGateTest` (9) — all GREEN.
- [x] jvmTest: `HomeViewModelTest` (+6 cohort tests), `FollowListViewModelTest` (+3), `ConversationListViewModelTest` (+3), `NewMessageViewModelTest` (+2). 2143 tests pass.
- [x] XCTest: `AgeSegregationTests.swift` — 14 tests covering URL allow-list + token validator.
- [x] iOS arm64 compile: `:shared:compileKotlinIosArm64` BUILD SUCCESSFUL.
- [x] Detekt + ktlint: clean.
- [x] SonarCloud quality gate: passed.
- [ ] Manual QA (deferred to PR 14 alongside Gherkin + locale sweep + DEV deploy).

## Fail-closed contract (OSA compliance)

When the viewer's `User` doc cannot be resolved (Firestore miss + getUser fallback both fail):
- HomeViewModel emits **empty rooms** (was fail-open in a draft; corrected after code review).
- FollowListViewModel emits **empty followers + following** for non-own lists.
- ConversationListViewModel emits **empty conversations** (matches PR 11 `pmLocked` fail-closed posture).

Aligned across all three VMs for OSA consistency: a minor must never see adult-cohort content on a transient cache miss.

## Deferred to PR 14 (per plan)

- GiftWallViewModel client filter — server PR 10 is authoritative; VM has no `UserRepository` dependency, gift-wall data has no `cohort` field. Marginal DiD value doesn't justify the refactor.
- AndroidTest Gherkin coverage (`age_segregation_discovery.feature`, `age_segregation_age_up.feature`) — plan stages these in PR 14 with the i18n sweep.
- Remaining 19 locale translations for `age_seg_unavailable` — PR 14 sweep.

## Code review

Strict code-reviewer agent run on the branch surfaced 3 Critical + 8 Important findings; ALL addressed before push (HomeViewModel fail-closed alignment, observer-path re-filtering for HomeVM + FollowListVM, `doCreateRoom` routed through `effectiveCohort`, LiveKit empty-token static helper + XCTest, TestData cohort params, 14 missing VM-layer tests added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)