### PR TITLE
fix(qa): build-flavor toggle for anti-emulator/anti-root gate

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,16 @@ android {
             buildConfigField("String", "WORKER_URL", "\"https://dev-api.shytalk.shyden.co.uk\"")
             buildConfigField("String", "LIVEKIT_SERVER_URL", "\"${System.getenv("LIVEKIT_URL") ?: ""}\"")
             buildConfigField("Boolean", "BYPASS_DEVICE_CHECKS", "false")
+            // Anti-emulator + anti-root screen gate. ON in prod by default;
+            // OFF in dev so autonomous QA + manual testers can use the
+            // Android emulator (which MainActivity blocks via
+            // DeviceSecurityChecker.isUnsafe()). Distinct from
+            // BYPASS_DEVICE_CHECKS which gates auth-stage device-binding
+            // checks. Hackability note: this is a const-folded boolean
+            // baked into the APK; defence-in-depth, not load-bearing.
+            // The real cross-cohort + suspension enforcement lives in
+            // Firestore rules + Express middleware (server-side).
+            buildConfigField("Boolean", "BYPASS_EMULATOR_GATE", "true")
             buildConfigField("String", "WEB_CLIENT_ID", "\"881846974606-kv99pjv92i6me0emb2j3uacbhnqqvfj4.apps.googleusercontent.com\"")
             buildConfigField("String", "RTDB_URL", "\"https://shytalk-dev-default-rtdb.europe-west1.firebasedatabase.app\"")
             buildConfigField("String", "EMAIL_LINK_DOMAIN", "\"dev.shytalk.shyden.co.uk\"")
@@ -66,6 +76,11 @@ android {
             buildConfigField("String", "WORKER_URL", "\"https://api.shytalk.shyden.co.uk\"")
             buildConfigField("String", "LIVEKIT_SERVER_URL", "\"${System.getenv("LIVEKIT_URL") ?: ""}\"")
             buildConfigField("Boolean", "BYPASS_DEVICE_CHECKS", "false")
+            // Anti-emulator + anti-root screen gate is ENABLED in prod —
+            // the only flavor that ships to real users. See dev flavor
+            // for hackability notes (defence-in-depth, server-side gates
+            // remain enforced regardless of this flag).
+            buildConfigField("Boolean", "BYPASS_EMULATOR_GATE", "false")
             buildConfigField("String", "WEB_CLIENT_ID", "\"517834977595-cdu78p6q7vg57utpsvtik04c195lbh8b.apps.googleusercontent.com\"")
             buildConfigField("String", "RTDB_URL", "\"https://shytalk-7ba69-default-rtdb.asia-southeast1.firebasedatabase.app\"")
             buildConfigField("String", "EMAIL_LINK_DOMAIN", "\"shytalk.shyden.co.uk\"")
@@ -98,6 +113,10 @@ android {
             // Google framework error when tapped on local builds.
             buildConfigField("String", "WEB_CLIENT_ID", "\"\"")
             buildConfigField("Boolean", "BYPASS_DEVICE_CHECKS", "true")
+            // Local flavor — emulator gate disabled (same rationale as dev:
+            // tests + manual QA need to run on the Android emulator against
+            // local Firebase emulators).
+            buildConfigField("Boolean", "BYPASS_EMULATOR_GATE", "true")
             // Dev sign-in shortcut — only present on local-emulator builds.
             // Empty on dev / prod so reverse-engineering the production APK
             // can't extract a usable seed credential. Mirrors `local/seed.js`
@@ -123,6 +142,11 @@ android {
     buildTypes {
         debug {
             buildConfigField("Boolean", "BYPASS_DEVICE_CHECKS", "true")
+            // Any *-debug build (devDebug, prodDebug, localDebug) also
+            // bypasses the emulator gate. Production users only ever get
+            // the *-release variant via Play Store, so this is a debugger-
+            // ergonomics override that never reaches end users.
+            buildConfigField("Boolean", "BYPASS_EMULATOR_GATE", "true")
         }
         release {
             isMinifyEnabled = true

--- a/app/src/main/java/com/shyden/shytalk/MainActivity.kt
+++ b/app/src/main/java/com/shyden/shytalk/MainActivity.kt
@@ -42,9 +42,9 @@ import com.shyden.shytalk.core.push.verifyPushNavigation
 import com.shyden.shytalk.core.room.ActiveRoomManager
 import com.shyden.shytalk.core.room.RoomLifecycleManager
 import com.shyden.shytalk.core.room.RoomService
-import com.shyden.shytalk.core.util.DeviceSecurityChecker
 import com.shyden.shytalk.core.util.LanguagePreference
 import com.shyden.shytalk.core.util.Resource
+import com.shyden.shytalk.core.util.UnsafeDeviceGate
 import com.shyden.shytalk.data.remote.AppConfigService
 import com.shyden.shytalk.data.remote.StartingScreen
 import com.shyden.shytalk.data.remote.WorkerApiClient
@@ -210,7 +210,9 @@ class MainActivity : AppCompatActivity() {
                         // Don't run further checks if blocked
                         if (blockingScreen != null) return@LaunchedEffect
 
-                        isUnsafe = DeviceSecurityChecker.isUnsafe()
+                        // Anti-emulator / anti-root gate. See UnsafeDeviceGate
+                        // for the bypass logic + flavor-by-flavor matrix.
+                        isUnsafe = UnsafeDeviceGate.isBlocked()
                         when (val result = appConfigService.getLatestVersionInfo()) {
                             is Resource.Success -> {
                                 val (minVersionCode, latestVersionCode, latestVersionName) = result.data

--- a/app/src/main/java/com/shyden/shytalk/core/util/UnsafeDeviceGate.kt
+++ b/app/src/main/java/com/shyden/shytalk/core/util/UnsafeDeviceGate.kt
@@ -1,0 +1,30 @@
+package com.shyden.shytalk.core.util
+
+import com.shyden.shytalk.BuildConfig
+
+/**
+ * Thin wrapper around [DeviceSecurityChecker.isUnsafe] that respects the
+ * build-flavor `BYPASS_EMULATOR_GATE` flag.
+ *
+ * The flag is set per flavor in `app/build.gradle.kts`:
+ *   - prod = false (gate enforced; this is the only flavor that ships to real users)
+ *   - dev  = true  (autonomous QA + manual testers can use the Android emulator)
+ *   - local = true (Firebase-emulator stack also needs to support emulator clients)
+ *   - any *-debug build (devDebug, prodDebug, localDebug) = true (debugger ergonomics)
+ *
+ * Existing as a testable wrapper, not a one-liner inside MainActivity, so
+ * we can assert the bypass behavior without mocking BuildConfig (which is
+ * a const-folded field).
+ */
+object UnsafeDeviceGate {
+    /**
+     * Returns true if the device should be blocked at startup.
+     *
+     * @param bypassEmulatorGate test-injected override. Defaults to the
+     *   BuildConfig flag. Tests pass `true`/`false` explicitly.
+     */
+    fun isBlocked(bypassEmulatorGate: Boolean = BuildConfig.BYPASS_EMULATOR_GATE): Boolean {
+        if (bypassEmulatorGate) return false
+        return DeviceSecurityChecker.isUnsafe()
+    }
+}

--- a/app/src/test/java/com/shyden/shytalk/core/util/UnsafeDeviceGateTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/util/UnsafeDeviceGateTest.kt
@@ -1,0 +1,85 @@
+package com.shyden.shytalk.core.util
+
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Behavioural pins for the build-flavor anti-emulator / anti-root gate.
+ *
+ * The wrapper exists so this contract is testable without mocking BuildConfig
+ * (which is const-folded by the Kotlin compiler). Tests inject the bypass
+ * flag explicitly via the named parameter.
+ *
+ * Matrix verified:
+ *  - bypass=true  + checker says unsafe → NOT blocked (dev/local/any-debug)
+ *  - bypass=false + checker says unsafe → BLOCKED   (prod release)
+ *  - bypass=true  + checker says safe   → NOT blocked
+ *  - bypass=false + checker says safe   → NOT blocked
+ *  - default arg path reads BuildConfig.BYPASS_EMULATOR_GATE
+ */
+class UnsafeDeviceGateTest {
+    @After
+    fun tearDown() {
+        unmockkObject(DeviceSecurityChecker)
+    }
+
+    @Test
+    fun `isBlocked returns false when bypass=true and device is unsafe`() {
+        mockkObject(DeviceSecurityChecker)
+        every { DeviceSecurityChecker.isUnsafe() } returns true
+
+        assertFalse(
+            "Dev/local/debug builds must NOT block even when the device is rooted/emulated",
+            UnsafeDeviceGate.isBlocked(bypassEmulatorGate = true),
+        )
+    }
+
+    @Test
+    fun `isBlocked returns true when bypass=false and device is unsafe`() {
+        mockkObject(DeviceSecurityChecker)
+        every { DeviceSecurityChecker.isUnsafe() } returns true
+
+        assertTrue(
+            "Prod release builds MUST block rooted/emulated devices",
+            UnsafeDeviceGate.isBlocked(bypassEmulatorGate = false),
+        )
+    }
+
+    @Test
+    fun `isBlocked returns false when bypass=true and device is safe`() {
+        mockkObject(DeviceSecurityChecker)
+        every { DeviceSecurityChecker.isUnsafe() } returns false
+
+        assertFalse(UnsafeDeviceGate.isBlocked(bypassEmulatorGate = true))
+    }
+
+    @Test
+    fun `isBlocked returns false when bypass=false and device is safe`() {
+        mockkObject(DeviceSecurityChecker)
+        every { DeviceSecurityChecker.isUnsafe() } returns false
+
+        assertFalse(UnsafeDeviceGate.isBlocked(bypassEmulatorGate = false))
+    }
+
+    @Test
+    fun `isBlocked default-arg path does not crash and respects checker on clean JVM`() {
+        // No mocking — runs against the real DeviceSecurityChecker which, on
+        // a clean JVM test environment, returns false for all checks. We
+        // assert only that the call resolves without throwing and the
+        // result is consistent with the JVM checker behavior. Whether the
+        // gate is bypassed depends on the test variant's BuildConfig
+        // (devDebug/prodDebug etc.), so we don't assert a specific bool.
+        val result = UnsafeDeviceGate.isBlocked()
+        // Clean JVM is never unsafe per DeviceSecurityCheckerTest, so the
+        // gate must NEVER block here regardless of the bypass flag value.
+        assertFalse(
+            "Clean JVM test env must never trigger the gate",
+            result,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
The anti-emulator + anti-root screen (`UnsafeDeviceScreen`) is fired by `MainActivity` whenever `DeviceSecurityChecker.isUnsafe()` returns true. Currently it ALWAYS runs, which blocks autonomous QA + manual testers from using the Android emulator on dev/local flavors.

This adds `BYPASS_EMULATOR_GATE` as a per-flavor BuildConfig field and gates `isUnsafe` execution behind it. Prod is unchanged.

## Flavor matrix
| Flavor / type | `BYPASS_EMULATOR_GATE` | Behaviour |
|---|---|---|
| **prod (release)** | `false` | Gate enforced — the only flavor that ships to real users via Play Store |
| **dev (any)** | `true` | Autonomous QA + manual testers on emulator |
| **local (any)** | `true` | Firebase-emulator clients on emulator |
| **any *-debug** | `true` (overrides) | Debugger ergonomics; never reaches end users |

## Why distinct from `BYPASS_DEVICE_CHECKS`
`BYPASS_DEVICE_CHECKS` already exists but gates *auth-stage device-binding* in `AuthViewModel` (different feature). Repurposing it would silently broaden its blast radius. The two concerns now live behind two flags.

## Hackability note
This is a const-folded boolean baked into the APK. An attacker with apktool can flip it. Defence-in-depth, not load-bearing — real enforcement (cohort gates, suspensions, bans) lives in Firestore rules + Express middleware (server-side) and remains intact regardless of this flag.

## Refactor: testable wrapper
Extracted the guarded logic into `UnsafeDeviceGate.isBlocked(bypassEmulatorGate)` so the contract is testable without mocking `BuildConfig` (a const-folded field). 5 new tests pin the matrix.

## Test plan
- [x] `ktlint`: clean
- [x] `./gradlew testDevDebugUnitTest :shared:jvmTest detekt`: green (1m 02s)
- [x] `./gradlew :shared:compileKotlinIosArm64`: green
- [ ] CI green
- [ ] Post-merge: rebuild dev-debug APK, install on emulator, verify app proceeds past the previous "Device Not Supported" screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)