### PR TITLE
fix(qa,ci): deploy Firestore indexes via CI + correct admin-claim key

### DIFF
--- a/.github/actions/deploy-firebase-rules/action.yml
+++ b/.github/actions/deploy-firebase-rules/action.yml
@@ -1,5 +1,5 @@
-name: 'Deploy Firebase Rules'
-description: 'Deploy Firestore and/or RTDB rules to a Firebase project'
+name: 'Deploy Firebase Rules + Indexes'
+description: 'Deploy Firestore rules + composite indexes and/or RTDB rules to a Firebase project'
 inputs:
   service-account-json:
     description: 'Firebase service account JSON (secret value)'
@@ -11,6 +11,10 @@ inputs:
     description: 'Deploy Firestore rules'
     required: false
     default: 'true'
+  deploy-firestore-indexes:
+    description: 'Deploy Firestore composite indexes from firestore.indexes.json'
+    required: false
+    default: 'true'
   deploy-database:
     description: 'Deploy RTDB rules'
     required: false
@@ -18,12 +22,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Deploy Firebase rules
+    - name: Deploy Firebase rules + indexes
       shell: bash
       env:
         SA_JSON: ${{ inputs.service-account-json }}
         PROJECT: ${{ inputs.firebase-project }}
         DEPLOY_FIRESTORE: ${{ inputs.deploy-firestore }}
+        DEPLOY_FIRESTORE_INDEXES: ${{ inputs.deploy-firestore-indexes }}
         DEPLOY_DATABASE: ${{ inputs.deploy-database }}
       run: |
         set -euo pipefail
@@ -36,6 +41,16 @@ runs:
         export GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa.json
         if [ "$DEPLOY_FIRESTORE" = "true" ]; then
           firebase deploy --only firestore:rules --project "$PROJECT" --non-interactive
+        fi
+        if [ "$DEPLOY_FIRESTORE_INDEXES" = "true" ]; then
+          # Composite indexes declared in firestore.indexes.json. Without
+          # this step every new index landed in the repo but never reached
+          # the target project — queries that needed the index returned
+          # 500 FAILED_PRECONDITION until someone manually ran the deploy.
+          # /manual-qa cycle 1 (2026-05-16) caught this: cohort+lastSeenAt
+          # and cohort+displayName indexes were declared but never deployed
+          # to shytalk-dev, breaking /users/discover and /users/search.
+          firebase deploy --only firestore:indexes --project "$PROJECT" --non-interactive
         fi
         if [ "$DEPLOY_DATABASE" = "true" ]; then
           firebase deploy --only database --project "$PROJECT" --non-interactive

--- a/express-api/scripts/provision-test-personas.js
+++ b/express-api/scripts/provision-test-personas.js
@@ -374,10 +374,18 @@ function buildUserDoc(p, fbUid, opts = {}) {
   return doc;
 }
 
-/** Custom-claims shape — uniqueId + cohort + optional isAdmin. */
+/**
+ * Custom-claims shape — uniqueId + cohort + optional admin.
+ *
+ * Claim key is `admin` (not `isAdmin`) to match the live middleware in
+ * express-api/src/middleware/auth.js:241 which reads
+ * `customClaims?.admin === true`. The persona registry uses
+ * `isAdmin: true` as the INPUT flag for readability; the OUTPUT claim
+ * key must be `admin` or the admin middleware silently 403s.
+ */
 function buildClaims(p) {
   const claims = { uniqueId: p.uniqueId, cohort: p.cohort };
-  if (p.isAdmin) claims.isAdmin = true;
+  if (p.isAdmin) claims.admin = true;
   return claims;
 }
 

--- a/express-api/tests/scripts/provision-test-personas.test.js
+++ b/express-api/tests/scripts/provision-test-personas.test.js
@@ -245,17 +245,22 @@ describe('buildUserDoc', () => {
 // ── buildClaims ─────────────────────────────────────────────────────
 
 describe('buildClaims', () => {
-  test('non-admin claims include uniqueId + cohort, no isAdmin', () => {
+  test('non-admin claims include uniqueId + cohort, no admin / isAdmin', () => {
     const alice = personas.find((p) => p.id === 'P-02');
     const claims = buildClaims(alice);
     expect(claims).toEqual({ uniqueId: 50000010, cohort: 'adult' });
+    expect(claims).not.toHaveProperty('admin');
     expect(claims).not.toHaveProperty('isAdmin');
   });
 
-  test('P-12 Greta claims include isAdmin: true', () => {
+  test('P-12 Greta claims include admin: true (NOT isAdmin)', () => {
+    // Live middleware reads `customClaims?.admin === true` — the claim
+    // key must be `admin`. If this test ever asserts `isAdmin` again,
+    // every admin endpoint will silently 403 for Greta.
     const greta = personas.find((p) => p.id === 'P-12');
     const claims = buildClaims(greta);
-    expect(claims).toEqual({ uniqueId: 90000001, cohort: 'adult', isAdmin: true });
+    expect(claims).toEqual({ uniqueId: 90000001, cohort: 'adult', admin: true });
+    expect(claims).not.toHaveProperty('isAdmin');
   });
 
   test('minor persona claims still set cohort correctly', () => {
@@ -349,16 +354,18 @@ describe('upsertPersona (stubbed IO)', () => {
     expect(stubs.auth.updateUser).toHaveBeenCalledTimes(1);
   });
 
-  test('sets isAdmin claim only for P-12 Greta', async () => {
+  test('sets admin claim only for P-12 Greta (key must be `admin`, not `isAdmin`)', async () => {
     const gStubs = makeStubs();
     await upsertPersona(greta, { ...gStubs, pw });
     const gretaClaimCall = gStubs.authCalls.find((c) => c[0] === 'setClaims');
-    expect(gretaClaimCall[2]).toEqual({ uniqueId: 90000001, cohort: 'adult', isAdmin: true });
+    expect(gretaClaimCall[2]).toEqual({ uniqueId: 90000001, cohort: 'adult', admin: true });
+    expect(gretaClaimCall[2]).not.toHaveProperty('isAdmin');
 
     const alice = personas.find((p) => p.id === 'P-02');
     const aStubs = makeStubs();
     await upsertPersona(alice, { ...aStubs, pw });
     const aliceClaimCall = aStubs.authCalls.find((c) => c[0] === 'setClaims');
+    expect(aliceClaimCall[2]).not.toHaveProperty('admin');
     expect(aliceClaimCall[2]).not.toHaveProperty('isAdmin');
   });
 


### PR DESCRIPTION
## Summary

Two systemic Blockers from `/manual-qa` cycle 1 against shytalk-dev (2026-05-16). Both fixes close the gap that lets the bug class recur, not just the immediate symptom.

### Blocker A — CI never deploys Firestore composite indexes

`deploy-firebase-rules` action shipped `firestore:rules` + `database` but never `firestore:indexes`. Every new index landed in `firestore.indexes.json` but never reached the target Firebase project — queries that needed the index returned 500 `FAILED_PRECONDITION` until someone manually ran the firebase CLI from a laptop.

Caught when probing dev: `users: cohort + lastSeenAt` and `users: cohort + displayName` (declared since PR 14 of the OSA epic) were missing from shytalk-dev, breaking `/users/discover` and the displayName branch of `/users/search` for every persona.

Confirmed via Firebase MCP `firestore_list_indexes` — the `users` collection on shytalk-dev had only `isSuperShy + superShyExpiry`, missing both cohort composites.

**Fix**: add a `deploy-firestore-indexes` input (default `true`) to the action that runs `firebase deploy --only firestore:indexes`. Both `deploy-dev.yml` and `deploy-prod.yml` use this action with no override → both environments are covered automatically. Next deploy on either env will sync index state.

### Blocker B — admin claim key mismatch

`provision-test-personas.js` (merged in #678) set `customClaims.isAdmin = true`, but the live middleware (`express-api/src/middleware/auth.js:241`) reads `customClaims?.admin === true`. Greta (P-12) silently 403ed from every admin endpoint despite being marked admin in the registry. Same class as the `ageVerified` vs `isAgeVerified` field-name bug the code-review agent caught in #678 — claim/field-key drift between writer and reader.

**Fix**: `buildClaims()` now writes `claims.admin = true` (not `isAdmin`). The registry input field stays `isAdmin: true` for readability — only the output claim key flips. Jest tests updated to pin the live-middleware contract (`admin` key required, `isAdmin` key forbidden).

## Regression guards (gitignored test plan)

Per the new TDD-journey-first rule, both bugs now have permanent regression scenarios in `.project/test-plans/manual/`:

- `j07-bug-discover-missing-index` — asserts `/users/discover` and `/users/search?q=<name>` return 200 (composite indexes deployed)
- `j12-bug-admin-claim-name` — asserts Greta has `admin: true` claim and reaches admin endpoints

## Test plan

- [x] Targeted Jest suite (39 contract tests) green
- [x] Full express-api suite (5322 tests) green
- [x] Personas re-provisioned on shytalk-dev with corrected admin claim
- [x] Post-fix manual probe: Greta `GET /api/user/50000010` → 200, Alice → 403
- [ ] CI green on this PR
- [ ] Merge + trigger deploy-dev → confirm indexes appear on shytalk-dev
- [ ] /manual-qa cycle 2 probe: `/users/discover` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)