### PR TITLE
feat(qa,runner): Firestore read matchers — unblocks OSA #17 prod-gate verification

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -379,6 +379,59 @@ const matchers = [
       return { ok: true };
     },
   },
+
+  // ── Firestore read assertions (v2) ──
+  // ctx.db is a Firestore Admin SDK instance (provided in main()) or a Map-
+  // backed stub in tests. Handlers below treat the doc()->get() shape as the
+  // common surface and never reach for fields beyond .exists / .data().
+  {
+    pattern: /^the database has document "([^"]+)" with field "([^"]+)" equal to (.+)$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db (firebase-admin Firestore) not initialised' };
+      const docPath = m[1];
+      const field = m[2];
+      const expected = parseLiteral(m[3].trim());
+      const snap = await ctx.db.doc(docPath).get();
+      if (!snap.exists) {
+        return { ok: false, error: `document "${docPath}" does not exist` };
+      }
+      const actual = snap.data()?.[field];
+      if (actual !== expected) {
+        return {
+          ok: false,
+          error: `field "${field}" on "${docPath}" was ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`,
+        };
+      }
+      return { ok: true };
+    },
+  },
+  {
+    pattern: /^the database has document "([^"]+)" with field "([^"]+)" containing (.+)$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db (firebase-admin Firestore) not initialised' };
+      const docPath = m[1];
+      const field = m[2];
+      const needle = parseLiteral(m[3].trim());
+      const snap = await ctx.db.doc(docPath).get();
+      if (!snap.exists) {
+        return { ok: false, error: `document "${docPath}" does not exist` };
+      }
+      const actual = snap.data()?.[field];
+      if (!Array.isArray(actual)) {
+        return {
+          ok: false,
+          error: `field "${field}" on "${docPath}" was ${JSON.stringify(actual)}, expected an array`,
+        };
+      }
+      if (!actual.includes(needle)) {
+        return {
+          ok: false,
+          error: `field "${field}" on "${docPath}" (=${JSON.stringify(actual)}) does not contain ${JSON.stringify(needle)}`,
+        };
+      }
+      return { ok: true };
+    },
+  },
 ];
 
 // ── Step execution ──────────────────────────────────────────────────
@@ -571,6 +624,12 @@ async function main() {
     process.exit(2);
   }
 
+  // Lazy require — keeps the test surface free of firebase-admin side effects.
+  // The util initialises Admin SDK using GOOGLE_APPLICATION_CREDENTIALS for
+  // dev/prod or the emulator host for local. Operator must export the
+  // service-account creds for dev target before running.
+  const { db } = require('../src/utils/firebase');
+
   const ctx = {
     target: opts.target,
     apiBase: TARGETS[opts.target].apiBase,
@@ -580,6 +639,7 @@ async function main() {
     lastResponse: null,
     locale: 'en',
     fetch: globalThis.fetch,
+    db,
   };
 
   const files = opts.journey

--- a/express-api/tests/scripts/fixtures/sample-firestore-reads.feature
+++ b/express-api/tests/scripts/fixtures/sample-firestore-reads.feature
@@ -1,0 +1,33 @@
+# Fixture for the v2 Firestore-read matchers. Not a real journey —
+# the syntactic surface is what the parser + new matchers must handle.
+
+Feature: Fixture Firestore read matchers
+
+  Background:
+    Given the local stack is healthy
+
+  @blocker
+  Scenario: doc-field equality assertion passes when field matches
+    Given Alice [P-02] is signed in
+    Then the database has document "users/50000010" with field "cohort" equal to "adult"
+    Then the database has document "users/50000010" with field "uniqueId" equal to 50000010
+
+  @blocker
+  Scenario: doc-field equality assertion fails when field drifts
+    Given Alice [P-02] is signed in
+    Then the database has document "users/50000010" with field "cohort" equal to "BOGUS_NEVER_USED_VALUE"
+
+  @blocker
+  Scenario: missing doc is a finding (not a silent pass)
+    Given Alice [P-02] is signed in
+    Then the database has document "users/99999999" with field "cohort" equal to "adult"
+
+  @regression
+  Scenario: array-field containing assertion passes when element is present
+    Given Alice [P-02] is signed in
+    Then the database has document "users/50000010" with field "followingIds" containing 50000060
+
+  @regression
+  Scenario: array-field containing assertion fails when element is absent
+    Given Alice [P-02] is signed in
+    Then the database has document "users/50000010" with field "followingIds" containing 60000010

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -443,3 +443,290 @@ describe('runFeatureFile end-to-end (stubbed fetch)', () => {
     expect(wrongStatus.error).toContain('999');
   });
 });
+
+// ── Firestore-read matchers (v2) — stubbed db ──────────────────────
+
+function makeFakeDb(docs = {}) {
+  return {
+    doc: (docPath) => ({
+      get: async () => {
+        const data = docs[docPath];
+        return {
+          exists: data !== undefined,
+          data: () => data,
+        };
+      },
+    }),
+  };
+}
+
+describe('Firestore doc-field equal-to matcher', () => {
+  test('passes when string field matches', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({ 'users/50000010': { cohort: 'adult', uniqueId: 50000010 } }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "cohort" equal to "adult"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('passes when numeric field matches', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({ 'users/50000010': { cohort: 'adult', uniqueId: 50000010 } }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "uniqueId" equal to 50000010',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('fails when string field drifts', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({ 'users/50000010': { cohort: 'minor' } }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "cohort" equal to "adult"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('cohort');
+    expect(r.error).toContain('minor');
+    expect(r.error).toContain('adult');
+  });
+
+  test('fails loudly when doc is missing — does NOT silently pass', async () => {
+    const ctx = makeCtx({ db: makeFakeDb({}) });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/99999999" with field "cohort" equal to "adult"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/does not exist|missing|not found/i);
+  });
+
+  test('fails with explicit error when ctx.db is not initialized', async () => {
+    const ctx = makeCtx(); // no db
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/1" with field "cohort" equal to "adult"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/db|firestore|admin/i);
+  });
+
+  test('handles boolean literal', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({ 'users/50000010': { isAgeVerified: true } }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "isAgeVerified" equal to true',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('Firestore doc-field containing matcher (array membership)', () => {
+  test('passes when array contains the numeric element', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({
+        'users/50000010': { followingIds: [50000020, 50000060, 50000040] },
+      }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "followingIds" containing 50000060',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('passes when array contains the string element', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({
+        'rooms/r1': { participantIds: ['fb-uid-a', 'fb-uid-b'] },
+      }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "rooms/r1" with field "participantIds" containing "fb-uid-b"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('fails when element is absent', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({ 'users/50000010': { followingIds: [50000020, 50000040] } }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "followingIds" containing 60000010',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('followingIds');
+    expect(r.error).toContain('60000010');
+  });
+
+  test('fails when field is not an array', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({ 'users/50000010': { followingIds: 'not-an-array' } }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "followingIds" containing 60000010',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/array|not.*array|type/i);
+  });
+
+  test('fails loudly when doc is missing', async () => {
+    const ctx = makeCtx({ db: makeFakeDb({}) });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/99999999" with field "followingIds" containing 1',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/does not exist|missing|not found/i);
+  });
+});
+
+describe('Firestore matchers end-to-end via runFeatureFile', () => {
+  function makeFetchAndDb(docs) {
+    return {
+      fetch: jest.fn(async (url) => {
+        if (typeof url === 'string' && url.includes('signInWithPassword')) {
+          const idToken =
+            'h.' +
+            Buffer.from(JSON.stringify({ uniqueId: 50000010, admin: false })).toString(
+              'base64url',
+            ) +
+            '.s';
+          return {
+            status: 200,
+            json: async () => ({ idToken, refreshToken: 'rt', localId: 'fb-1' }),
+          };
+        }
+        if (typeof url === 'string' && url.endsWith('/api/health')) {
+          return { status: 200, json: async () => ({ ok: true }) };
+        }
+        return { status: 500, text: async () => '{}' };
+      }),
+      db: makeFakeDb(docs),
+    };
+  }
+
+  test('happy-path scenario with correct doc data passes', async () => {
+    const ctx = makeCtx(
+      makeFetchAndDb({
+        'users/50000010': {
+          cohort: 'adult',
+          uniqueId: 50000010,
+          followingIds: [50000020, 50000060],
+        },
+      }),
+    );
+    const { findings, scenarioReports } = await runFeatureFile(
+      path.join(FIXTURE_DIR, 'sample-firestore-reads.feature'),
+      ctx,
+    );
+    const happyReport = scenarioReports.find(
+      (s) => s.scenario === 'doc-field equality assertion passes when field matches',
+    );
+    expect(happyReport.status).toBe('pass');
+    const happyFindings = findings.filter((f) => f.scenario === happyReport.scenario);
+    expect(happyFindings).toEqual([]);
+  });
+
+  test('drifted-field scenario produces a Blocker finding (regression-grade)', async () => {
+    const ctx = makeCtx(
+      makeFetchAndDb({
+        'users/50000010': {
+          cohort: 'adult',
+          uniqueId: 50000010,
+          followingIds: [50000020, 50000060],
+        },
+      }),
+    );
+    const { findings } = await runFeatureFile(
+      path.join(FIXTURE_DIR, 'sample-firestore-reads.feature'),
+      ctx,
+    );
+    const drift = findings.find(
+      (f) => f.scenario === 'doc-field equality assertion fails when field drifts',
+    );
+    expect(drift).toBeDefined();
+    expect(drift.severity).toBe('Blocker');
+    expect(drift.error).toMatch(/cohort/);
+  });
+
+  test('missing-doc scenario surfaces a finding (no silent pass)', async () => {
+    const ctx = makeCtx(makeFetchAndDb({ 'users/50000010': { cohort: 'adult' } }));
+    const { findings } = await runFeatureFile(
+      path.join(FIXTURE_DIR, 'sample-firestore-reads.feature'),
+      ctx,
+    );
+    const missing = findings.find(
+      (f) => f.scenario === 'missing doc is a finding (not a silent pass)',
+    );
+    expect(missing).toBeDefined();
+  });
+
+  test('array-containing happy and unhappy paths both classified correctly', async () => {
+    const ctx = makeCtx(
+      makeFetchAndDb({
+        'users/50000010': {
+          cohort: 'adult',
+          followingIds: [50000020, 50000060],
+        },
+      }),
+    );
+    const { findings, scenarioReports } = await runFeatureFile(
+      path.join(FIXTURE_DIR, 'sample-firestore-reads.feature'),
+      ctx,
+    );
+    const happyArray = scenarioReports.find(
+      (s) => s.scenario === 'array-field containing assertion passes when element is present',
+    );
+    expect(happyArray.status).toBe('pass');
+    const unhappyArray = findings.find(
+      (f) => f.scenario === 'array-field containing assertion fails when element is absent',
+    );
+    expect(unhappyArray).toBeDefined();
+    expect(unhappyArray.severity).toBe('Blocker'); // @regression
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the two highest-leverage Firestore Admin SDK assertion verbs to the step-binding runner.
- Covers 84% of field-comparison verbs across all 19 journey files (61 `equal to` + 23 `containing`).
- 13 new tests TDD red→green; full express suite green (5378/5386, 8 pre-existing skips).

## Why
The OSA #17 epic shipped 14 PRs touching cohort enforcement across rooms, gifts, conversations, leaderboards, FCM, and admin. Per the strengthened prod-readiness gate memory rule, every affected behavior must be verified GREEN on dev via a journey scenario before prod deploy is unblocked. Today's runner can only assert API response shape — it cannot read Firestore state. This PR adds the foundation so OSA gap-fill scenarios (Fill-1 migration regression, Fill-3 frozen-conversation banner, Fill-4 LiveKit cohort claim, Fill-5 P2P coin transfer) become actually runnable on dev.

## What's in
- `scripts/manual-qa-runner.js`: 2 new matchers + ctx.db wired in main()
  - `Then the database has document "<path>" with field "<X>" equal to <literal>`
  - `Then the database has document "<path>" with field "<X>" containing <literal>`
- `tests/scripts/manual-qa-runner.test.js`: 13 new tests covering happy path, drift, missing doc, wrong-shape field, uninitialised db
- `tests/scripts/fixtures/sample-firestore-reads.feature`: committed fixture (deterministic surface for tests; independent of the gitignored journey files)

## Failure modes covered
- Missing doc → finding (never silent pass)
- Field drift → finding with both expected + actual values in error message
- `containing` against non-array field → finding with shape-mismatch error
- Uninitialised ctx.db → clear operator error pointing at firebase-admin init

## Out of scope (follow-up PRs in the v2 sequence)
- PR-B: bulk-query matcher (`Then the database has N entries in "<col>" matching {<pred>}`) — 22 uses across journeys
- PR-C: state-seed matchers (`Given <Persona> has shyCoins=<N>`, `Given the conversation doc ... has field ...`) — 17 uses
- PR-D: platform-aware sign-in (`Given X on Platform is signed in with cohort=Y`)
- PR-E: JWT-payload nested-field assertion
- PR-F: actually run the runner against dev and capture cycle output

## Test plan
- [x] `npm test` green (5378 passed, 8 pre-existing skipped)
- [x] Targeted suite `tests/scripts/manual-qa-runner.test.js` 56/56 green
- [x] ESLint clean on changed files
- [x] Prettier clean
- [x] Pre-push hook (gradle + sonar + ktlint + iOS compile) green
- [ ] Cycle against dev — deferred to PR-F after the rest of the v2 matchers land

🤖 Generated with [Claude Code](https://claude.com/claude-code)