### PR TITLE
feat(qa,runner): Firestore bulk-query matcher + jsonish predicate parser

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -379,6 +379,59 @@ const matchers = [
       return { ok: true };
     },
   },
+
+  // ── Firestore read assertions (v2) ──
+  // ctx.db is a Firestore Admin SDK instance (provided in main()) or a Map-
+  // backed stub in tests. Handlers below treat the doc()->get() shape as the
+  // common surface and never reach for fields beyond .exists / .data().
+  {
+    pattern: /^the database has document "([^"]+)" with field "([^"]+)" equal to (.+)$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db (firebase-admin Firestore) not initialised' };
+      const docPath = m[1];
+      const field = m[2];
+      const expected = parseLiteral(m[3].trim());
+      const snap = await ctx.db.doc(docPath).get();
+      if (!snap.exists) {
+        return { ok: false, error: `document "${docPath}" does not exist` };
+      }
+      const actual = snap.data()?.[field];
+      if (actual !== expected) {
+        return {
+          ok: false,
+          error: `field "${field}" on "${docPath}" was ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`,
+        };
+      }
+      return { ok: true };
+    },
+  },
+  {
+    pattern: /^the database has document "([^"]+)" with field "([^"]+)" containing (.+)$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db (firebase-admin Firestore) not initialised' };
+      const docPath = m[1];
+      const field = m[2];
+      const needle = parseLiteral(m[3].trim());
+      const snap = await ctx.db.doc(docPath).get();
+      if (!snap.exists) {
+        return { ok: false, error: `document "${docPath}" does not exist` };
+      }
+      const actual = snap.data()?.[field];
+      if (!Array.isArray(actual)) {
+        return {
+          ok: false,
+          error: `field "${field}" on "${docPath}" was ${JSON.stringify(actual)}, expected an array`,
+        };
+      }
+      if (!actual.includes(needle)) {
+        return {
+          ok: false,
+          error: `field "${field}" on "${docPath}" (=${JSON.stringify(actual)}) does not contain ${JSON.stringify(needle)}`,
+        };
+      }
+      return { ok: true };
+    },
+  },
 ];
 
 // ── Step execution ──────────────────────────────────────────────────
@@ -571,6 +624,12 @@ async function main() {
     process.exit(2);
   }
 
+  // Lazy require — keeps the test surface free of firebase-admin side effects.
+  // The util initialises Admin SDK using GOOGLE_APPLICATION_CREDENTIALS for
+  // dev/prod or the emulator host for local. Operator must export the
+  // service-account creds for dev target before running.
+  const { db } = require('../src/utils/firebase');
+
   const ctx = {
     target: opts.target,
     apiBase: TARGETS[opts.target].apiBase,
@@ -580,6 +639,7 @@ async function main() {
     lastResponse: null,
     locale: 'en',
     fetch: globalThis.fetch,
+    db,
   };
 
   const files = opts.journey

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -432,6 +432,33 @@ const matchers = [
       return { ok: true };
     },
   },
+  {
+    pattern: /^the database has (\d+) entries in "([^"]+)" matching \{(.*)\}$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db (firebase-admin Firestore) not initialised' };
+      const expected = parseInt(m[1], 10);
+      const colPath = m[2];
+      const predicateText = m[3].trim();
+      let predicate;
+      try {
+        predicate = parseJsonishPredicate(predicateText);
+      } catch (e) {
+        return { ok: false, error: `predicate parse error: ${e.message}` };
+      }
+      const snap = await ctx.db.collection(colPath).get();
+      const docs = (snap.docs || []).map((d) => d.data());
+      const matching = docs.filter((doc) =>
+        Object.entries(predicate).every(([k, v]) => doc[k] === v),
+      );
+      if (matching.length !== expected) {
+        return {
+          ok: false,
+          error: `collection "${colPath}" had ${matching.length} entries matching predicate (=${JSON.stringify(predicate)}), expected ${expected}`,
+        };
+      }
+      return { ok: true };
+    },
+  },
 ];
 
 // ── Step execution ──────────────────────────────────────────────────
@@ -545,6 +572,63 @@ function parseLiteral(raw) {
   if (/^-?\d+\.\d+$/.test(raw)) return parseFloat(raw);
   if (raw.startsWith('"') && raw.endsWith('"')) return raw.slice(1, -1);
   return raw;
+}
+
+/**
+ * Parse a jsonish predicate (the inner text between { and }) into an object.
+ * Tokenises by commas while respecting double-quoted strings — values that
+ * contain commas (e.g. `body: "hi adam, welcome"`) parse correctly.
+ *
+ * Throws on:
+ *  - unresolved placeholders like `{newUniqueId}` (no quotes; literal var ref)
+ *    so the operator gets an actionable error pointing at the missing
+ *    variable-resolution feature
+ *  - malformed key:value pairs
+ *
+ * Returns an object with parsed key→value pairs (string keys; values typed
+ * via parseLiteral).
+ */
+function parseJsonishPredicate(text) {
+  const out = {};
+  if (text === '' || text === undefined) return out;
+  const pairs = [];
+  let buf = '';
+  let inString = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === '"' && text[i - 1] !== '\\') inString = !inString;
+    if (c === ',' && !inString) {
+      pairs.push(buf);
+      buf = '';
+      continue;
+    }
+    buf += c;
+  }
+  if (buf.trim() !== '') pairs.push(buf);
+
+  for (const raw of pairs) {
+    const trimmed = raw.trim();
+    if (trimmed === '') continue;
+    // Split on the first colon outside a quoted string.
+    let colonIdx = -1;
+    let q = false;
+    for (let i = 0; i < trimmed.length; i++) {
+      if (trimmed[i] === '"' && trimmed[i - 1] !== '\\') q = !q;
+      if (trimmed[i] === ':' && !q) {
+        colonIdx = i;
+        break;
+      }
+    }
+    if (colonIdx === -1) throw new Error(`malformed pair (no colon): "${trimmed}"`);
+    const key = trimmed.slice(0, colonIdx).trim();
+    const valRaw = trimmed.slice(colonIdx + 1).trim();
+    // Detect unresolved placeholder {name} — bare identifier in braces.
+    if (/^\{[A-Za-z_][\w]*\}$/.test(valRaw)) {
+      throw new Error(`unresolved placeholder ${valRaw} (variable resolution not yet implemented)`);
+    }
+    out[key] = parseLiteral(valRaw);
+  }
+  return out;
 }
 
 function formatReport(allFindings, allScenarioReports, target, cycleNumber) {
@@ -685,6 +769,7 @@ module.exports = {
   decodeJwtPayload,
   pickField,
   parseLiteral,
+  parseJsonishPredicate,
   formatReport,
   TARGETS,
 };

--- a/express-api/tests/scripts/fixtures/sample-firestore-queries.feature
+++ b/express-api/tests/scripts/fixtures/sample-firestore-queries.feature
@@ -1,0 +1,37 @@
+# Fixture for the v2 Firestore bulk-query matchers. Not a real journey —
+# the syntactic surface is what the parser + matchers must handle.
+
+Feature: Fixture Firestore bulk-query matchers
+
+  Background:
+    Given the local stack is healthy
+
+  @blocker
+  Scenario: count matching the expected positive value passes
+    Given Alice [P-02] is signed in
+    Then the database has 1 entries in "auditLog" matching {action: "blocked", sourceId: 50000010, targetId: 60000010, reason: "cohort_mismatch"}
+
+  @blocker
+  Scenario: count matching zero passes when collection has no matches
+    Given Alice [P-02] is signed in
+    Then the database has 0 entries in "auditLog" matching {action: "device.ban"}
+
+  @blocker
+  Scenario: count drift produces a finding
+    Given Alice [P-02] is signed in
+    Then the database has 5 entries in "auditLog" matching {action: "blocked"}
+
+  @regression
+  Scenario: empty predicate counts everything in the collection
+    Given Alice [P-02] is signed in
+    Then the database has 3 entries in "auditLog" matching {}
+
+  @regression
+  Scenario: predicate-with-string value matches only string-equal docs
+    Given Alice [P-02] is signed in
+    Then the database has 1 entries in "auditLog" matching {action: "age_verification.approve"}
+
+  @regression
+  Scenario: subcollection path works (slash-separated)
+    Given Alice [P-02] is signed in
+    Then the database has 2 entries in "users/50000010/gifts" matching {giftId: "rose"}

--- a/express-api/tests/scripts/fixtures/sample-firestore-reads.feature
+++ b/express-api/tests/scripts/fixtures/sample-firestore-reads.feature
@@ -1,0 +1,33 @@
+# Fixture for the v2 Firestore-read matchers. Not a real journey —
+# the syntactic surface is what the parser + new matchers must handle.
+
+Feature: Fixture Firestore read matchers
+
+  Background:
+    Given the local stack is healthy
+
+  @blocker
+  Scenario: doc-field equality assertion passes when field matches
+    Given Alice [P-02] is signed in
+    Then the database has document "users/50000010" with field "cohort" equal to "adult"
+    Then the database has document "users/50000010" with field "uniqueId" equal to 50000010
+
+  @blocker
+  Scenario: doc-field equality assertion fails when field drifts
+    Given Alice [P-02] is signed in
+    Then the database has document "users/50000010" with field "cohort" equal to "BOGUS_NEVER_USED_VALUE"
+
+  @blocker
+  Scenario: missing doc is a finding (not a silent pass)
+    Given Alice [P-02] is signed in
+    Then the database has document "users/99999999" with field "cohort" equal to "adult"
+
+  @regression
+  Scenario: array-field containing assertion passes when element is present
+    Given Alice [P-02] is signed in
+    Then the database has document "users/50000010" with field "followingIds" containing 50000060
+
+  @regression
+  Scenario: array-field containing assertion fails when element is absent
+    Given Alice [P-02] is signed in
+    Then the database has document "users/50000010" with field "followingIds" containing 60000010

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -19,6 +19,7 @@ const {
   decodeJwtPayload,
   pickField,
   parseLiteral,
+  parseJsonishPredicate,
   executeStep,
   runFeatureFile,
 } = require('../../scripts/manual-qa-runner');
@@ -168,6 +169,68 @@ describe('parseLiteral', () => {
   });
   test('bare strings', () => {
     expect(parseLiteral('bareword')).toBe('bareword');
+  });
+});
+
+// ── parseJsonishPredicate ──────────────────────────────────────────
+
+describe('parseJsonishPredicate', () => {
+  test('empty input returns empty object', () => {
+    expect(parseJsonishPredicate('')).toEqual({});
+  });
+
+  test('single key:value pair', () => {
+    expect(parseJsonishPredicate('action: "blocked"')).toEqual({ action: 'blocked' });
+  });
+
+  test('multiple pairs, mixed types', () => {
+    expect(
+      parseJsonishPredicate(
+        'action: "blocked", sourceId: 50000040, targetId: 60000010, reason: "cohort_mismatch"',
+      ),
+    ).toEqual({
+      action: 'blocked',
+      sourceId: 50000040,
+      targetId: 60000010,
+      reason: 'cohort_mismatch',
+    });
+  });
+
+  test('quoted-string value containing a comma is NOT split mid-string', () => {
+    expect(
+      parseJsonishPredicate('senderId: 50000010, body: "hi adam, welcome to shytalk"'),
+    ).toEqual({
+      senderId: 50000010,
+      body: 'hi adam, welcome to shytalk',
+    });
+  });
+
+  test('boolean and null literals', () => {
+    expect(parseJsonishPredicate('frozen: true, deleted: false, parent: null')).toEqual({
+      frozen: true,
+      deleted: false,
+      parent: null,
+    });
+  });
+
+  test('unresolved placeholder throws actionable error', () => {
+    expect(() => parseJsonishPredicate('targetId: {newUniqueId}')).toThrow(
+      /placeholder.*newUniqueId/i,
+    );
+  });
+
+  test('malformed pair (missing colon) throws', () => {
+    expect(() => parseJsonishPredicate('not_a_pair')).toThrow(/no colon/i);
+  });
+
+  test('handles trailing whitespace', () => {
+    expect(parseJsonishPredicate('a: 1  ,  b: 2  ')).toEqual({ a: 1, b: 2 });
+  });
+
+  test('quoted string with internal colon does not split key', () => {
+    expect(parseJsonishPredicate('url: "https://example.com:8080/x"')).toEqual({
+      url: 'https://example.com:8080/x',
+    });
   });
 });
 
@@ -728,5 +791,233 @@ describe('Firestore matchers end-to-end via runFeatureFile', () => {
     );
     expect(unhappyArray).toBeDefined();
     expect(unhappyArray.severity).toBe('Blocker'); // @regression
+  });
+});
+
+// ── Firestore bulk-query matcher (v2) — stubbed db ────────────────
+
+// Fake Firestore: extend to support .collection(path).get() returning docs.
+function makeFakeDbWithCollections(collections = {}, docs = {}) {
+  return {
+    doc: (docPath) => ({
+      get: async () => {
+        const data = docs[docPath];
+        return { exists: data !== undefined, data: () => data };
+      },
+    }),
+    collection: (colPath) => ({
+      get: async () => ({
+        docs: (collections[colPath] || []).map((d, i) => ({
+          id: d._id || `auto-${i}`,
+          data: () => d,
+        })),
+      }),
+    }),
+  };
+}
+
+describe('Firestore bulk-query matcher (entries-matching)', () => {
+  test('passes when actual count equals expected', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDbWithCollections({
+        auditLog: [
+          { action: 'blocked', sourceId: 50000010, targetId: 60000010, reason: 'cohort_mismatch' },
+          { action: 'blocked', sourceId: 50000040, targetId: 60000010, reason: 'cohort_mismatch' },
+        ],
+      }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has 1 entries in "auditLog" matching {action: "blocked", sourceId: 50000010, targetId: 60000010, reason: "cohort_mismatch"}',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('passes when expected count is zero and predicate filters everything out', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDbWithCollections({
+        auditLog: [{ action: 'blocked' }, { action: 'blocked' }],
+      }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has 0 entries in "auditLog" matching {action: "device.ban"}',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('fails when count drifts', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDbWithCollections({
+        auditLog: [{ action: 'blocked' }, { action: 'blocked' }],
+      }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has 5 entries in "auditLog" matching {action: "blocked"}',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('2');
+    expect(r.error).toContain('5');
+  });
+
+  test('predicate filters by ALL keys (AND semantics)', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDbWithCollections({
+        auditLog: [
+          { action: 'blocked', sourceId: 1 },
+          { action: 'blocked', sourceId: 2 },
+          { action: 'other', sourceId: 1 },
+        ],
+      }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has 1 entries in "auditLog" matching {action: "blocked", sourceId: 1}',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('empty predicate counts every doc in the collection', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDbWithCollections({
+        auditLog: [{ a: 1 }, { b: 2 }, { c: 3 }],
+      }),
+    });
+    const r = await executeStep(
+      { kind: 'Then', text: 'the database has 3 entries in "auditLog" matching {}' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('subcollection path with slashes works', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDbWithCollections({
+        'users/50000010/gifts': [{ giftId: 'rose' }, { giftId: 'rose' }, { giftId: 'crown' }],
+      }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has 2 entries in "users/50000010/gifts" matching {giftId: "rose"}',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('fails with explicit error when ctx.db is missing', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has 1 entries in "auditLog" matching {action: "blocked"}',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/db|firestore|admin/i);
+  });
+
+  test('numeric and string predicate values both supported', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDbWithCollections({
+        auditLog: [
+          { action: 'blocked', sourceId: 50000010 },
+          { action: 'blocked', sourceId: '50000010' }, // wrong type — should NOT match
+        ],
+      }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has 1 entries in "auditLog" matching {sourceId: 50000010}',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('predicate with placeholder {var} reports an actionable error', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDbWithCollections({ auditLog: [] }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has 1 entries in "auditLog" matching {targetId: 50000010, sourceId: {newUniqueId}}',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/placeholder|unresolved|newUniqueId/i);
+  });
+});
+
+describe('Firestore bulk-query end-to-end via runFeatureFile', () => {
+  function fetchOk() {
+    return jest.fn(async (url) => {
+      if (typeof url === 'string' && url.includes('signInWithPassword')) {
+        const idToken =
+          'h.' +
+          Buffer.from(JSON.stringify({ uniqueId: 50000010, admin: false })).toString('base64url') +
+          '.s';
+        return {
+          status: 200,
+          json: async () => ({ idToken, refreshToken: 'rt', localId: 'fb-1' }),
+        };
+      }
+      if (typeof url === 'string' && url.endsWith('/api/health')) {
+        return { status: 200, json: async () => ({ ok: true }) };
+      }
+      return { status: 500, text: async () => '{}' };
+    });
+  }
+
+  test('happy collection state — positive, zero, and subcollection scenarios all pass', async () => {
+    const ctx = makeCtx({
+      fetch: fetchOk(),
+      db: makeFakeDbWithCollections({
+        auditLog: [
+          { action: 'blocked', sourceId: 50000010, targetId: 60000010, reason: 'cohort_mismatch' },
+          { action: 'age_verification.approve', targetId: 50000010, adminId: 90000001 },
+          { action: 'something_else' },
+        ],
+        'users/50000010/gifts': [{ giftId: 'rose' }, { giftId: 'rose' }, { giftId: 'crown' }],
+      }),
+    });
+    const { findings, scenarioReports } = await runFeatureFile(
+      path.join(FIXTURE_DIR, 'sample-firestore-queries.feature'),
+      ctx,
+    );
+    const positive = scenarioReports.find(
+      (s) => s.scenario === 'count matching the expected positive value passes',
+    );
+    expect(positive.status).toBe('pass');
+    const zero = scenarioReports.find(
+      (s) => s.scenario === 'count matching zero passes when collection has no matches',
+    );
+    expect(zero.status).toBe('pass');
+    const sub = scenarioReports.find(
+      (s) => s.scenario === 'subcollection path works (slash-separated)',
+    );
+    expect(sub.status).toBe('pass');
+    // The drift scenario expects 5 but the seeded collection only has 1 'blocked' entry.
+    const drift = findings.find((f) => f.scenario === 'count drift produces a finding');
+    expect(drift).toBeDefined();
+    expect(drift.severity).toBe('Blocker');
   });
 });

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -443,3 +443,290 @@ describe('runFeatureFile end-to-end (stubbed fetch)', () => {
     expect(wrongStatus.error).toContain('999');
   });
 });
+
+// ── Firestore-read matchers (v2) — stubbed db ──────────────────────
+
+function makeFakeDb(docs = {}) {
+  return {
+    doc: (docPath) => ({
+      get: async () => {
+        const data = docs[docPath];
+        return {
+          exists: data !== undefined,
+          data: () => data,
+        };
+      },
+    }),
+  };
+}
+
+describe('Firestore doc-field equal-to matcher', () => {
+  test('passes when string field matches', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({ 'users/50000010': { cohort: 'adult', uniqueId: 50000010 } }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "cohort" equal to "adult"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('passes when numeric field matches', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({ 'users/50000010': { cohort: 'adult', uniqueId: 50000010 } }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "uniqueId" equal to 50000010',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('fails when string field drifts', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({ 'users/50000010': { cohort: 'minor' } }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "cohort" equal to "adult"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('cohort');
+    expect(r.error).toContain('minor');
+    expect(r.error).toContain('adult');
+  });
+
+  test('fails loudly when doc is missing — does NOT silently pass', async () => {
+    const ctx = makeCtx({ db: makeFakeDb({}) });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/99999999" with field "cohort" equal to "adult"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/does not exist|missing|not found/i);
+  });
+
+  test('fails with explicit error when ctx.db is not initialized', async () => {
+    const ctx = makeCtx(); // no db
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/1" with field "cohort" equal to "adult"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/db|firestore|admin/i);
+  });
+
+  test('handles boolean literal', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({ 'users/50000010': { isAgeVerified: true } }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "isAgeVerified" equal to true',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('Firestore doc-field containing matcher (array membership)', () => {
+  test('passes when array contains the numeric element', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({
+        'users/50000010': { followingIds: [50000020, 50000060, 50000040] },
+      }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "followingIds" containing 50000060',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('passes when array contains the string element', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({
+        'rooms/r1': { participantIds: ['fb-uid-a', 'fb-uid-b'] },
+      }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "rooms/r1" with field "participantIds" containing "fb-uid-b"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('fails when element is absent', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({ 'users/50000010': { followingIds: [50000020, 50000040] } }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "followingIds" containing 60000010',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('followingIds');
+    expect(r.error).toContain('60000010');
+  });
+
+  test('fails when field is not an array', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({ 'users/50000010': { followingIds: 'not-an-array' } }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/50000010" with field "followingIds" containing 60000010',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/array|not.*array|type/i);
+  });
+
+  test('fails loudly when doc is missing', async () => {
+    const ctx = makeCtx({ db: makeFakeDb({}) });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "users/99999999" with field "followingIds" containing 1',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/does not exist|missing|not found/i);
+  });
+});
+
+describe('Firestore matchers end-to-end via runFeatureFile', () => {
+  function makeFetchAndDb(docs) {
+    return {
+      fetch: jest.fn(async (url) => {
+        if (typeof url === 'string' && url.includes('signInWithPassword')) {
+          const idToken =
+            'h.' +
+            Buffer.from(JSON.stringify({ uniqueId: 50000010, admin: false })).toString(
+              'base64url',
+            ) +
+            '.s';
+          return {
+            status: 200,
+            json: async () => ({ idToken, refreshToken: 'rt', localId: 'fb-1' }),
+          };
+        }
+        if (typeof url === 'string' && url.endsWith('/api/health')) {
+          return { status: 200, json: async () => ({ ok: true }) };
+        }
+        return { status: 500, text: async () => '{}' };
+      }),
+      db: makeFakeDb(docs),
+    };
+  }
+
+  test('happy-path scenario with correct doc data passes', async () => {
+    const ctx = makeCtx(
+      makeFetchAndDb({
+        'users/50000010': {
+          cohort: 'adult',
+          uniqueId: 50000010,
+          followingIds: [50000020, 50000060],
+        },
+      }),
+    );
+    const { findings, scenarioReports } = await runFeatureFile(
+      path.join(FIXTURE_DIR, 'sample-firestore-reads.feature'),
+      ctx,
+    );
+    const happyReport = scenarioReports.find(
+      (s) => s.scenario === 'doc-field equality assertion passes when field matches',
+    );
+    expect(happyReport.status).toBe('pass');
+    const happyFindings = findings.filter((f) => f.scenario === happyReport.scenario);
+    expect(happyFindings).toEqual([]);
+  });
+
+  test('drifted-field scenario produces a Blocker finding (regression-grade)', async () => {
+    const ctx = makeCtx(
+      makeFetchAndDb({
+        'users/50000010': {
+          cohort: 'adult',
+          uniqueId: 50000010,
+          followingIds: [50000020, 50000060],
+        },
+      }),
+    );
+    const { findings } = await runFeatureFile(
+      path.join(FIXTURE_DIR, 'sample-firestore-reads.feature'),
+      ctx,
+    );
+    const drift = findings.find(
+      (f) => f.scenario === 'doc-field equality assertion fails when field drifts',
+    );
+    expect(drift).toBeDefined();
+    expect(drift.severity).toBe('Blocker');
+    expect(drift.error).toMatch(/cohort/);
+  });
+
+  test('missing-doc scenario surfaces a finding (no silent pass)', async () => {
+    const ctx = makeCtx(makeFetchAndDb({ 'users/50000010': { cohort: 'adult' } }));
+    const { findings } = await runFeatureFile(
+      path.join(FIXTURE_DIR, 'sample-firestore-reads.feature'),
+      ctx,
+    );
+    const missing = findings.find(
+      (f) => f.scenario === 'missing doc is a finding (not a silent pass)',
+    );
+    expect(missing).toBeDefined();
+  });
+
+  test('array-containing happy and unhappy paths both classified correctly', async () => {
+    const ctx = makeCtx(
+      makeFetchAndDb({
+        'users/50000010': {
+          cohort: 'adult',
+          followingIds: [50000020, 50000060],
+        },
+      }),
+    );
+    const { findings, scenarioReports } = await runFeatureFile(
+      path.join(FIXTURE_DIR, 'sample-firestore-reads.feature'),
+      ctx,
+    );
+    const happyArray = scenarioReports.find(
+      (s) => s.scenario === 'array-field containing assertion passes when element is present',
+    );
+    expect(happyArray.status).toBe('pass');
+    const unhappyArray = findings.find(
+      (f) => f.scenario === 'array-field containing assertion fails when element is absent',
+    );
+    expect(unhappyArray).toBeDefined();
+    expect(unhappyArray.severity).toBe('Blocker'); // @regression
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `Then the database has N entries in "<col>" matching {<pred>}` — the verb every OSA scenario uses to assert auditLog side effects of cross-cohort attempts.
- Hand-rolled jsonish predicate parser respects quoted strings, so values containing commas/colons (e.g. `body: "hi adam, welcome to shytalk"`, `url: "https://x:8080/p"`) parse correctly.
- Unresolved placeholders like `{newUniqueId}` throw an actionable error pointing at variable resolution (arriving in a later v2 PR).

## Stacked on
Builds on top of #681 (Firestore read matchers). Merge #681 first, then this.

## What's in
- `scripts/manual-qa-runner.js`: new bulk-query matcher + `parseJsonishPredicate` exported
- `tests/scripts/manual-qa-runner.test.js`: 9 bulk-query tests + 9 predicate-parser tests
- `tests/scripts/fixtures/sample-firestore-queries.feature`: deterministic fixture

## Why it matters for OSA #17
v1 + PR-A can confirm an API returned 404, but cannot prove the audit row was written. A bug where the gate returns 404 *and skips audit-log write* would pass the v1 runner. This matcher closes that gap — exactly the bug class OSA #17 is supposed to prevent.

## Test plan
- [x] Targeted suite: 75/75 green
- [x] Full express suite: 5397/5405 (8 pre-existing skips)
- [x] ESLint clean
- [x] Prettier clean
- [x] Pre-push hook (gradle + sonar + ktlint + iOS compile) — passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)