### PR TITLE
feat(qa,runner): OSA Background verbs + deploy tooling + provisioner exit fix

### DIFF
--- a/express-api/scripts/dev-runner-bootstrap.sh
+++ b/express-api/scripts/dev-runner-bootstrap.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# dev-runner-bootstrap.sh — diagnose dev Firebase access, then run the
+# manual-qa runner against dev with zero further operator input.
+#
+# Designed to run ON the dev express-api server, where the dev SA file
+# and PERSONAS_PASSWORD already live (or will be set).
+#
+# Phases:
+#   1. Verify .env env keys are set
+#   2. Probe firebase-admin init + Firestore read (20s timeout)
+#   3. Run provisioner with line-buffered output (so progress is visible)
+#   4. Run manual-qa runner against dev journeys
+#
+# Exits non-zero on first phase failure so problems surface clearly.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."  # express-api root
+
+# Helpers -------------------------------------------------------------
+ok()   { printf '\033[32m✓\033[0m %s\n' "$*"; }
+fail() { printf '\033[31m✗\033[0m %s\n' "$*" >&2; exit 1; }
+step() { printf '\n\033[1m== %s ==\033[0m\n' "$*"; }
+
+# Phase 1 — env-key presence ------------------------------------------
+step "Phase 1: env keys present in .env"
+for key in GOOGLE_APPLICATION_CREDENTIALS FIREBASE_PROJECT_ID PERSONAS_PASSWORD; do
+  if grep -q "^${key}=" .env 2>/dev/null; then
+    ok "$key set"
+  else
+    fail "$key missing in .env"
+  fi
+done
+
+# Phase 2 — firebase-admin can authenticate + read Firestore ----------
+step "Phase 2: firebase-admin connectivity probe (20s timeout)"
+cat > ./probe.js <<'PROBE_EOF'
+require('dotenv').config();
+const a = require('firebase-admin');
+a.initializeApp();
+const projectId = a.app().options.projectId
+  || process.env.FIREBASE_PROJECT_ID
+  || process.env.GCLOUD_PROJECT;
+console.log('project=' + projectId);
+if (projectId && projectId.includes('prod')) {
+  console.error('ABORT: project ID resolved to a prod-looking value');
+  process.exit(2);
+}
+// Probe both endpoints the provisioner depends on:
+//  - firestore.googleapis.com (Firestore Admin)
+//  - identitytoolkit.googleapis.com (Firebase Auth Admin)
+async function main() {
+  const t0 = Date.now();
+  try {
+    const snap = await a.firestore().collection('users').limit(1).get();
+    console.log('firestore_ok docs=' + snap.size + ' elapsed=' + (Date.now() - t0) + 'ms');
+  } catch (e) {
+    console.error('firestore_err ' + (e.message || e));
+    process.exit(3);
+  }
+  const t1 = Date.now();
+  try {
+    // listUsers is the lightest Auth admin call — paginated, returns first 1 user.
+    await a.auth().listUsers(1);
+    console.log('auth_ok elapsed=' + (Date.now() - t1) + 'ms');
+  } catch (e) {
+    console.error('auth_err ' + (e.message || e));
+    process.exit(4);
+  }
+  process.exit(0);
+}
+main();
+PROBE_EOF
+if ! timeout 25 node ./probe.js; then
+  fail "probe failed or timed out — check SA + project + network to googleapis.com"
+fi
+ok "firebase-admin authenticated, Firestore + Auth both reachable"
+
+# Phase 3 — run provisioner with line-buffered output -----------------
+step "Phase 3: provision 19 personas against dev"
+# `script` makes node treat stdout as a TTY → line buffering, real-time output.
+# Fallback to plain node if `script` is missing.
+if command -v script >/dev/null 2>&1; then
+  script -qc 'node -r dotenv/config scripts/provision-test-personas.js' /dev/null
+else
+  node -r dotenv/config scripts/provision-test-personas.js
+fi
+ok "provisioner finished"
+
+# Phase 4 — run manual-qa runner --------------------------------------
+step "Phase 4: manual-qa runner cycle 1 against dev"
+# Requires the journey plan dir to exist on the server. If it doesn't, the
+# operator must scp .project/test-plans/manual/ here first.
+PLAN_DIR="${PLAN_DIR:-${HOME}/express-api/.project/test-plans/manual}"
+if [ ! -d "$PLAN_DIR" ]; then
+  fail "PLAN_DIR not found at $PLAN_DIR — scp .project/test-plans/manual/ here first"
+fi
+# FIREBASE_DEV_API_KEY is the Web API key from app/src/dev/google-services.json
+# `current_key` — a public client identifier, not a secret. The runner needs
+# it to call Firebase Auth REST identitytoolkit for password sign-in.
+# Extract via grep+cut rather than `source .env` so values with shell-special
+# chars elsewhere in .env (e.g. SMTP_PASS) don't break parsing.
+if [ -z "${FIREBASE_DEV_API_KEY:-}" ]; then
+  FIREBASE_DEV_API_KEY="$(grep -E '^FIREBASE_DEV_API_KEY=' .env 2>/dev/null | head -1 | cut -d= -f2-)"
+  export FIREBASE_DEV_API_KEY
+fi
+if [ -z "${FIREBASE_DEV_API_KEY:-}" ]; then
+  fail "FIREBASE_DEV_API_KEY not found in .env and not exported"
+fi
+node -r dotenv/config scripts/manual-qa-runner.js \
+  --target dev \
+  --plan-dir "$PLAN_DIR" \
+  --cycle 1 \
+  2>&1 | tee /tmp/manual-qa-cycle-1.log
+ok "runner finished — report at /tmp/manual-qa-cycle-1.md and log at /tmp/manual-qa-cycle-1.log"

--- a/express-api/scripts/dev-runner-deploy-and-run.sh
+++ b/express-api/scripts/dev-runner-deploy-and-run.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# dev-runner-deploy-and-run.sh — one-shot driver for the dev manual-qa cycle.
+#
+# Runs the four steps that were previously four separate `!` commands:
+#   1. Idempotently ensure FIREBASE_DEV_API_KEY is in the server's .env.
+#   2. scp the dev-runner-bootstrap.sh to the server.
+#   3. scp the .project/test-plans/manual/ journey plan to the server.
+#   4. Execute the bootstrap on the server (which provisions personas and
+#      runs the manual-qa cycle against dev).
+#
+# Self-contained — no operator input needed beyond running this script.
+# Designed to be invoked from the laptop, drives the dev Oracle Cloud VM.
+#
+# Exit status:
+#   0 — bootstrap completed; cycle report exists at /tmp/manual-qa-cycle-1.md
+#   1+ — any phase failure (network, scp, remote bootstrap)
+#
+# Configuration via env (sensible defaults baked in):
+#   DEV_HOST           — default 145.241.224.13 (Oracle Cloud dev VM)
+#   SSH_KEY            — default ~/.ssh/shytalk-oci
+#   DEV_API_KEY        — default value from app/src/dev/google-services.json
+
+set -euo pipefail
+
+DEV_HOST="${DEV_HOST:-145.241.224.13}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/shytalk-oci}"
+# Firebase Web API key for the dev project. Public client identifier (ships
+# in every Android APK), but the repo secret scanner flags any AIza-prefixed
+# string, so the value is sourced from env. Pull it from
+# app/src/dev/google-services.json field `current_key`:
+#   export DEV_API_KEY="$(jq -r '.client[0].api_key[0].current_key' \
+#     "$(git rev-parse --show-toplevel)/app/src/dev/google-services.json")"
+if [ -z "${DEV_API_KEY:-}" ]; then
+  echo "✗ DEV_API_KEY env var not set" >&2
+  echo "  Source it from app/src/dev/google-services.json:" >&2
+  echo "    export DEV_API_KEY=\"\$(jq -r '.client[0].api_key[0].current_key' \\" >&2
+  echo "      \"\$(git rev-parse --show-toplevel)/app/src/dev/google-services.json\")\"" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+ssh_cmd() {
+  ssh -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=10 "ubuntu@${DEV_HOST}" "$@"
+}
+scp_cmd() {
+  scp -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=10 "$@"
+}
+
+# ── Phase 1 — ensure required keys in remote .env ───────────────────
+echo "== Phase 1: ensure required env keys in ~/express-api/.env =="
+# Idempotent appends — only adds a key if missing. Values are public-ish:
+#   - FIREBASE_DEV_API_KEY: ships in Android APK (public client identifier)
+#   - GOOGLE_APPLICATION_CREDENTIALS: filesystem path on the server (not a secret)
+#   - FIREBASE_PROJECT_ID: project name (public)
+ssh_cmd "grep -q '^FIREBASE_DEV_API_KEY=' ~/express-api/.env || echo 'FIREBASE_DEV_API_KEY=${DEV_API_KEY}' >> ~/express-api/.env"
+ssh_cmd "grep -q '^GOOGLE_APPLICATION_CREDENTIALS=' ~/express-api/.env || echo 'GOOGLE_APPLICATION_CREDENTIALS=/home/ubuntu/express-api/shytalk-dev-firebase-adminsdk.json' >> ~/express-api/.env"
+ssh_cmd "grep -q '^FIREBASE_PROJECT_ID=' ~/express-api/.env || echo 'FIREBASE_PROJECT_ID=shytalk-dev' >> ~/express-api/.env"
+echo "✓ required keys ensured in .env"
+
+# ── Phase 2 — upload runner + provisioner + bootstrap scripts ───────
+# The dev VM's express-api may not have the latest runner v2 matchers
+# (deploys lag). scp the scripts that the bootstrap will exec.
+echo "== Phase 2: upload runner + provisioner + bootstrap scripts =="
+scp_cmd \
+  "${REPO_ROOT}/express-api/scripts/dev-runner-bootstrap.sh" \
+  "${REPO_ROOT}/express-api/scripts/manual-qa-runner.js" \
+  "${REPO_ROOT}/express-api/scripts/provision-test-personas.js" \
+  "ubuntu@${DEV_HOST}:~/express-api/scripts/"
+echo "✓ scripts uploaded"
+
+# ── Phase 3 — upload journey plan ────────────────────────────────────
+echo "== Phase 3: upload .project/test-plans/manual/ =="
+ssh_cmd "mkdir -p ~/express-api/.project/test-plans/manual"
+scp_cmd -r "${REPO_ROOT}/.project/test-plans/manual/" "ubuntu@${DEV_HOST}:~/express-api/.project/test-plans/"
+echo "✓ journey plan uploaded"
+
+# ── Phase 4 — run bootstrap on the server ───────────────────────────
+echo "== Phase 4: execute dev-runner-bootstrap on the server =="
+echo "(this will provision 19 personas + run cycle 1 against dev — ~3-5 min)"
+ssh_cmd "bash ~/express-api/scripts/dev-runner-bootstrap.sh"
+echo "✓ bootstrap finished — cycle report on server at /tmp/manual-qa-cycle-1.md"
+
+# ── Phase 5 — pull the cycle report back ────────────────────────────
+echo "== Phase 5: pull cycle report back =="
+scp_cmd "ubuntu@${DEV_HOST}:/tmp/manual-qa-cycle-1.md" /tmp/manual-qa-cycle-1.md 2>/dev/null \
+  && echo "✓ report saved to /tmp/manual-qa-cycle-1.md" \
+  || echo "⚠ report not found on server — bootstrap may have errored early"

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -207,6 +207,44 @@ const matchers = [
       return { ok: true };
     },
   },
+  // OSA migration-state precondition (j19). The dev environment migration is
+  // a one-shot script whose terminal-state side-effect is a doc at
+  // `ops/segregation-migration` carrying `lastMigrationRunAt`. j19 scenarios
+  // assume that state and verify the post-migration invariants.
+  {
+    pattern:
+      /^the dev environment migration ran at least once \(lastMigrationRunAt is set in "([^"]+)"\)$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db (firebase-admin Firestore) not initialised' };
+      const docPath = m[1];
+      const snap = await ctx.db.doc(docPath).get();
+      if (!snap.exists) {
+        return {
+          ok: false,
+          error: `migration never run: "${docPath}" does not exist`,
+        };
+      }
+      const data = snap.data();
+      if (!data.lastMigrationRunAt) {
+        return {
+          ok: false,
+          error: `migration ops/segregation-migration exists but lacks lastMigrationRunAt`,
+        };
+      }
+      return { ok: true };
+    },
+  },
+  // LiveKit Docker precondition (j09). For local target, this would probe
+  // ws://localhost:7880; for dev/prod, dev uses real LiveKit at
+  // livekit-eu.shytalk.shyden.co.uk and this verb is informational only.
+  // MVP: no-op pass for all targets — actual websocket probe is future work
+  // (track via a follow-up issue if the j09 contract needs strict liveness).
+  {
+    pattern: /^the LiveKit Docker container is running on ws:\/\/[^\s]+$/,
+    async handler(_m, _ctx) {
+      return { ok: true };
+    },
+  },
   {
     pattern: /^the device locale is "([a-z]{2})"$/,
     async handler(m, ctx) {
@@ -221,9 +259,20 @@ const matchers = [
   // treats platform as informational only: the same Firebase identity is used
   // regardless of the asserted client platform. The `at the "X" screen`
   // suffix is a UI hint that the runner ignores in MVP.
+  //
+  // PR-E loosens the trailing context to also tolerate:
+  //   - `with cohort=adult` qualifier (informational — actual cohort comes
+  //     from the JWT custom claim once signed in)
+  //   - `AND on <Other Platform>` multi-device clause (informational —
+  //     runner signs the same Firebase user in once)
+  //   - parenthetical informational notes like `(same Firebase user)`,
+  //     `(same-cohort minor)`, `(DOB=2007-01-01 in users doc)`
+  //
+  // The strategy is permissive consumption: anything after `is signed in`
+  // that doesn't drive a distinct API call is treated as documentation.
   {
     pattern:
-      /^([A-Z][a-z]+)(?:\s*\[(P-\d{2})\])?\s+is signed in(?:\s+on\s+\w+(?:\s+\w+){0,2})?(?:\s+\(no admin claim\))?(?:\s+at\s+the\s+"[^"]+"\s+screen)?$/,
+      /^([A-Z][a-z]+)(?:\s*\[(P-\d{2})\])?\s+is signed in(?:\s+on\s+\w+(?:\s+\w+){0,2})?(?:\s+AND\s+on\s+\w+(?:\s+\w+){0,2})?(?:\s+with\s+cohort=\w+)?(?:\s+\([^)]*\))?(?:\s+\(no admin claim\))?(?:\s+at\s+the\s+"[^"]+"\s+screen)?$/,
     async handler(m, ctx) {
       const name = m[1];
       const personas = loadPersonas();

--- a/express-api/scripts/provision-test-personas.js
+++ b/express-api/scripts/provision-test-personas.js
@@ -545,6 +545,11 @@ if (require.main === module) {
     console.log('Applying social graph...');
     await applySocialGraph(buildSocialGraphWrites(personas), ctx);
     console.log('PROVISION_ALL_OK count=' + personas.length);
+    // firebase-admin keeps the event loop alive via idle HTTP/2 keep-alive
+    // connections and metric-export timers. Force-exit so callers that
+    // chain the next step (e.g. dev-runner-bootstrap.sh Phase 4) don't
+    // wedge waiting for a graceful drain that never comes.
+    process.exit(0);
   })().catch((e) => {
     console.error('PROVISION_FAIL', e?.message || e);
     process.exit(1);

--- a/express-api/tests/scripts/fixtures/sample-osa-background.feature
+++ b/express-api/tests/scripts/fixtures/sample-osa-background.feature
@@ -1,0 +1,27 @@
+# Fixture for the v2.E Background verbs the OSA journey scenarios use.
+# These are the exact verb shapes that landed in cycle 1 as STEP_NOT_IMPLEMENTED.
+
+Feature: Fixture OSA background verbs
+
+  Background:
+    Given the local stack is healthy
+
+  @blocker
+  Scenario: sign-in tolerates with-cohort qualifier
+    Given Alice [P-02] is signed in on Android with cohort=adult (DOB=2007-01-01 in users doc)
+    Then the database has document "users/50000010" with field "uniqueId" equal to 50000010
+
+  @blocker
+  Scenario: sign-in tolerates multi-platform "AND on" form
+    Given Alice [P-02] is signed in on Web Chromium AND on Android (same Firebase user)
+    Then the database has document "users/50000010" with field "uniqueId" equal to 50000010
+
+  @blocker
+  Scenario: migration-state precondition passes when ops doc exists
+    Given the dev environment migration ran at least once (lastMigrationRunAt is set in "ops/segregation-migration")
+    Then the database has document "ops/segregation-migration" with field "lastMigrationRunAt" equal to 1700000000000
+
+  @regression
+  Scenario: livekit-docker precondition is a no-op against dev/prod
+    Given the LiveKit Docker container is running on ws://localhost:7880
+    Then the database has document "users/50000010" with field "uniqueId" equal to 50000010

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -1259,3 +1259,152 @@ describe('State-seed end-to-end via runFeatureFile', () => {
     expect(findings).toEqual([]);
   });
 });
+
+// ── PR-E: OSA Background verbs (the cycle-1 finding gap) ───────────
+
+describe('OSA Background verbs (cycle 1 findings)', () => {
+  function withSignInFetch() {
+    return jest.fn(async (url) => {
+      if (typeof url === 'string' && url.includes('signInWithPassword')) {
+        const idToken =
+          'h.' +
+          Buffer.from(JSON.stringify({ uniqueId: 50000010, admin: false })).toString('base64url') +
+          '.s';
+        return {
+          status: 200,
+          json: async () => ({ idToken, refreshToken: 'r', localId: 'f' }),
+        };
+      }
+      if (typeof url === 'string' && url.endsWith('/api/health')) {
+        return { status: 200, json: async () => ({ ok: true }) };
+      }
+      return { status: 500, text: async () => '{}' };
+    });
+  }
+
+  test('sign-in tolerates "with cohort=X" qualifier', async () => {
+    const ctx = makeCtx({ fetch: withSignInFetch() });
+    const r = await executeStep(
+      {
+        kind: 'Given',
+        text: 'Hayato [P-06] is signed in on Android with cohort=adult (DOB=2007-01-01 in users doc)',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(ctx.sessions.get('Hayato')).toBeDefined();
+  });
+
+  test('sign-in tolerates "AND on <Platform>" multi-device form', async () => {
+    const ctx = makeCtx({ fetch: withSignInFetch() });
+    const r = await executeStep(
+      {
+        kind: 'Given',
+        text: 'Vexa [P-07] is signed in on Web Chromium AND on Android (same Firebase user)',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(ctx.sessions.get('Vexa')).toBeDefined();
+  });
+
+  test('sign-in tolerates trailing parenthetical context', async () => {
+    const ctx = makeCtx({ fetch: withSignInFetch() });
+    const r = await executeStep(
+      {
+        kind: 'Given',
+        text: 'Marcus [P-04] is signed in on Android (same-cohort minor) at the "discovery" screen',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('migration-state precondition passes when ops/segregation-migration exists', async () => {
+    const ctx = makeCtx({
+      db: makeFakeDb({
+        'ops/segregation-migration': { lastMigrationRunAt: Date.now() },
+      }),
+    });
+    const r = await executeStep(
+      {
+        kind: 'Given',
+        text: 'the dev environment migration ran at least once (lastMigrationRunAt is set in "ops/segregation-migration")',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('migration-state precondition fails when ops doc is missing', async () => {
+    const ctx = makeCtx({ db: makeFakeDb({}) });
+    const r = await executeStep(
+      {
+        kind: 'Given',
+        text: 'the dev environment migration ran at least once (lastMigrationRunAt is set in "ops/segregation-migration")',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/migration|ops\/segregation-migration|never run/i);
+  });
+
+  test('LiveKit Docker precondition is a no-op for dev target', async () => {
+    const ctx = makeCtx({ target: 'dev' });
+    const r = await executeStep(
+      {
+        kind: 'Given',
+        text: 'the LiveKit Docker container is running on ws://localhost:7880',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('LiveKit Docker precondition passes for local (MVP — no actual WS probe)', async () => {
+    const ctx = makeCtx({ target: 'local' });
+    const r = await executeStep(
+      {
+        kind: 'Given',
+        text: 'the LiveKit Docker container is running on ws://localhost:7880',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('OSA Background verbs end-to-end via runFeatureFile', () => {
+  test('all four fixture scenarios pass against a seeded fake', async () => {
+    const fetchOk = jest.fn(async (url) => {
+      if (typeof url === 'string' && url.includes('signInWithPassword')) {
+        const idToken =
+          'h.' + Buffer.from(JSON.stringify({ uniqueId: 50000010 })).toString('base64url') + '.s';
+        return {
+          status: 200,
+          json: async () => ({ idToken, refreshToken: 'r', localId: 'f' }),
+        };
+      }
+      if (typeof url === 'string' && url.endsWith('/api/health')) {
+        return { status: 200, json: async () => ({ ok: true }) };
+      }
+      return { status: 500, text: async () => '{}' };
+    });
+    const ctx = makeCtx({
+      target: 'dev',
+      fetch: fetchOk,
+      db: makeFakeDb({
+        'users/50000010': { uniqueId: 50000010, cohort: 'adult' },
+        'ops/segregation-migration': { lastMigrationRunAt: 1700000000000 },
+      }),
+    });
+    const { findings, scenarioReports } = await runFeatureFile(
+      path.join(FIXTURE_DIR, 'sample-osa-background.feature'),
+      ctx,
+    );
+    for (const sr of scenarioReports) {
+      expect(sr.status).toBe('pass');
+    }
+    expect(findings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Cycle 1 against dev produced 80/80 Minor STEP_NOT_IMPLEMENTED — every scenario stalled at its first Background Given. This PR closes that gap with 4 new matchers plus the operator tooling to run the cycle end-to-end.

## Background matchers added
- **Sign-in tolerates trailing context** — `with cohort=X`, `AND on <Other>`, parenthetical notes like `(DOB=2007-01-01 in users doc)`. The runner already authenticates and resolves cohort via JWT claim; the trailing context is documentation.
- **Migration-state precondition (j19)** — checks Firestore `ops/segregation-migration` doc exists with `lastMigrationRunAt` field. Fails loudly if the migration was never run.
- **LiveKit Docker precondition (j09)** — no-op pass; dev/prod use real LiveKit, local-target probe deferred.

## Provisioner fix
`scripts/provision-test-personas.js` now `process.exit(0)`s after PROVISION_ALL_OK. Without this, firebase-admin's HTTP/2 keep-alive timers held the event loop open indefinitely, wedging the bootstrap pipeline (observed: 10+ minute hangs after logical work completed).

## Operator tooling (checked in)
- `scripts/dev-runner-bootstrap.sh` — runs on dev server, 4-phase pipeline (env check → connectivity probe → provisioner → runner). Aborts on prod-looking project ID.
- `scripts/dev-runner-deploy-and-run.sh` — runs on operator laptop, one-shot: syncs server .env, scp's scripts + journey plan, executes bootstrap, pulls cycle report. Requires `DEV_API_KEY` env var (sourced from `app/src/dev/google-services.json` `current_key` — public client identifier, env-var to satisfy secret scanner).

## Test plan
- [x] 7 new unit tests + 1 end-to-end fixture test
- [x] Full runner suite: 98/98 green
- [x] Full express suite: 5420/5428 (8 pre-existing skips)
- [x] ESLint clean on changed files (8 pre-existing console-warning in provisioner)
- [x] Prettier clean
- [x] Pre-push hook (gradle + sonar + ktlint + iOS compile) passed

## What this unlocks
After merge, the next bootstrap run should produce **0 STEP_NOT_IMPLEMENTED** on the OSA-critical Backgrounds (j04 / j08 / j09 / j19) — those scenarios will execute past their Givens and exercise the actual contract assertions. That's the cycle-2 result the prod-readiness gate is waiting on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)