### PR TITLE
feat(qa): test-persona picker on SignInScreen (dev + local flavors)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,6 +87,24 @@ android {
                 "LOCAL_DEV_PASSWORD",
                 "\"${(project.findProperty("DEV_QA_PASSWORD") as? String) ?: System.getenv("DEV_QA_PASSWORD") ?: ""}\"",
             )
+            // Shared password for the 17 test personas (P-02..P-19) baked
+            // into dev/local builds for the in-screen persona picker. Same
+            // sourcing semantics as LOCAL_DEV_PASSWORD above but a separate
+            // value because the picker uses email-per-persona + shared
+            // password whereas the single-account shortcut uses one
+            // email/password pair. Operator-opt-in:
+            //   DEV_QA_PERSONAS_PASSWORD=<openssl rand -base64 24> \
+            //   ./gradlew assembleDevDebug
+            // Empty → picker UI never renders (fail-closed). The personas'
+            // emails are public (committed in DevPersonas.kt) — only the
+            // password is sensitive. Must match the value used by the
+            // express-api provisioner (PERSONAS_PASSWORD env var) that
+            // created the personas' Firebase Auth accounts.
+            buildConfigField(
+                "String",
+                "DEV_QA_PERSONAS_PASSWORD",
+                "\"${(project.findProperty("DEV_QA_PERSONAS_PASSWORD") as? String) ?: System.getenv("DEV_QA_PERSONAS_PASSWORD") ?: ""}\"",
+            )
         }
         create("prod") {
             dimension = "env"
@@ -105,6 +123,9 @@ android {
             buildConfigField("String", "LOCAL_HOST", "\"\"")
             buildConfigField("String", "LOCAL_DEV_EMAIL", "\"\"")
             buildConfigField("String", "LOCAL_DEV_PASSWORD", "\"\"")
+            // Prod never bakes the persona-picker password — production
+            // builds must not expose any test-account shortcut.
+            buildConfigField("String", "DEV_QA_PERSONAS_PASSWORD", "\"\"")
         }
         create("local") {
             dimension = "env"
@@ -141,6 +162,12 @@ android {
             // (the source of truth for the credential).
             buildConfigField("String", "LOCAL_DEV_EMAIL", "\"claude-test@shytalk.dev\"")
             buildConfigField("String", "LOCAL_DEV_PASSWORD", "\"localdev123\"")
+            // Local flavor talks to Firebase emulators which seed the 17
+            // test personas via local/seed.js with a fixed dev password.
+            // Hardcoded here so the persona picker works out-of-the-box
+            // when an operator runs `./gradlew installLocalDebug` against
+            // a freshly started emulator stack — no env var needed.
+            buildConfigField("String", "DEV_QA_PERSONAS_PASSWORD", "\"localdev123\"")
         }
     }
 

--- a/app/src/main/java/com/shyden/shytalk/MainActivity.kt
+++ b/app/src/main/java/com/shyden/shytalk/MainActivity.kt
@@ -118,6 +118,7 @@ class MainActivity : AppCompatActivity() {
             value = BuildConfig.FLAVOR == "local",
             devPassword = BuildConfig.LOCAL_DEV_PASSWORD,
             devEmail = BuildConfig.LOCAL_DEV_EMAIL,
+            devPersonasPassword = BuildConfig.DEV_QA_PERSONAS_PASSWORD,
             googleWebClientId = BuildConfig.WEB_CLIENT_ID,
         )
         // Drives the PreviewWatermark overlay — non-prod builds get a

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/BuildVariant.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/BuildVariant.kt
@@ -18,6 +18,7 @@ data class BuildVariantConfig(
     val isLocalEmulator: Boolean = false,
     val localDevPassword: String? = null,
     val localDevEmail: String? = null,
+    val localDevPersonasPassword: String? = null,
     val googleWebClientId: String? = null,
     val iosDeviceId: String? = null,
     val environment: String = "prod",
@@ -73,6 +74,7 @@ object BuildVariant {
     val isLocalEmulator: Boolean get() = holder.isLocalEmulator
     val localDevPassword: String? get() = holder.localDevPassword
     val localDevEmail: String? get() = holder.localDevEmail
+    val localDevPersonasPassword: String? get() = holder.localDevPersonasPassword
     val googleWebClientId: String? get() = holder.googleWebClientId
 
     /**
@@ -100,6 +102,33 @@ object BuildVariant {
         get() =
             !holder.localDevEmail.isNullOrEmpty() &&
                 !holder.localDevPassword.isNullOrEmpty()
+
+    /**
+     * Whether the "Sign in as test persona" picker on SignInScreen
+     * should be available on this build. Derives from `localDevPersonasPassword`
+     * presence — same fail-closed rule as [isDevSignInAvailable]: no
+     * baked credential → no UI affordance → the picker can't drive a
+     * sign-in even if surfaced.
+     *
+     * Matrix:
+     *   - local flavor: hardcoded → true (same `localdev123` works for all
+     *     emulator-seeded personas since the emulator's Auth user-creation
+     *     script reuses the same password).
+     *   - dev flavor: read from `DEV_QA_PERSONAS_PASSWORD` env var at
+     *     build time. Default empty → false. Operator opts in by passing
+     *     it to `gradlew assembleDevDebug` to enable journey-based
+     *     manual-qa cycles against dev Firebase.
+     *   - prod flavor: always empty → always false (prod APK never bakes
+     *     a shared test password).
+     *
+     * Distinct from [isDevSignInAvailable] (single-account shortcut)
+     * because the picker uses email-per-persona + shared-password,
+     * whereas the shortcut uses a single hardcoded account. Both can
+     * be enabled on the same build; SignInScreen renders one button
+     * for each available path.
+     */
+    val isPersonaPickerAvailable: Boolean
+        get() = !holder.localDevPersonasPassword.isNullOrEmpty()
 
     /**
      * iOS-only stable per-device identifier, eagerly computed in
@@ -220,6 +249,7 @@ object BuildVariant {
         value: Boolean,
         devPassword: String? = null,
         devEmail: String? = null,
+        devPersonasPassword: String? = null,
         googleWebClientId: String? = null,
     ) {
         holder =
@@ -227,6 +257,7 @@ object BuildVariant {
                 isLocalEmulator = value,
                 localDevPassword = devPassword?.takeIf { it.isNotEmpty() },
                 localDevEmail = devEmail?.takeIf { it.isNotEmpty() },
+                localDevPersonasPassword = devPersonasPassword?.takeIf { it.isNotEmpty() },
                 googleWebClientId = googleWebClientId?.takeIf { it.isNotEmpty() },
             )
     }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/DevPersonas.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/DevPersonas.kt
@@ -1,0 +1,52 @@
+package com.shyden.shytalk.core
+
+/**
+ * Registry of test personas baked into dev/local builds for the
+ * `/manual-qa` journey test plan. Each persona's email is committed
+ * (public — the provisioner's JS file already exposes them) and is
+ * paired at sign-in time with the shared `localDevPersonasPassword`
+ * baked at build time. Empty password → picker UI never renders, so
+ * the email list cannot drive a real sign-in even if surfaced.
+ *
+ * Source of truth: `express-api/scripts/provision-test-personas.js`.
+ * Keep the two lists in sync — a personas-tests integration check in
+ * `BuildVariantTest` pins the count so an out-of-sync add is loud.
+ */
+data class DevPersona(
+    /** P-02..P-19 stable identifier mirroring the provisioner registry. */
+    val id: String,
+    /** Firebase Auth email — sign-in identifier. */
+    val email: String,
+    /** Human label including persona role hint. */
+    val displayName: String,
+    /** Cohort label rendered as a badge in the picker row. */
+    val cohort: Cohort,
+) {
+    enum class Cohort { ADULT, MINOR }
+}
+
+/**
+ * Ordered list shown in the in-screen persona picker. Order mirrors
+ * the journey test plan's natural reading order (j01 first → j19).
+ * Adding a persona: append to this list AND the provisioner.
+ */
+val devPersonas: List<DevPersona> =
+    listOf(
+        DevPersona("P-02", "adult-power@shytalk.dev", "Alice (P-02 adult power)", DevPersona.Cohort.ADULT),
+        DevPersona("P-04", "minor-power@shytalk.dev", "Marcus (P-04 minor power)", DevPersona.Cohort.MINOR),
+        DevPersona("P-05", "lapsed-adult@shytalk.dev", "Lena (P-05 lapsed)", DevPersona.Cohort.ADULT),
+        DevPersona("P-06", "dob-mismatch@shytalk.dev", "Hayato (P-06 DOB mismatch)", DevPersona.Cohort.ADULT),
+        DevPersona("P-07", "adult-prober@shytalk.dev", "Vexa (P-07 cross-cohort prober)", DevPersona.Cohort.ADULT),
+        DevPersona("P-08", "harasser@shytalk.dev", "Raul (P-08 harasser)", DevPersona.Cohort.ADULT),
+        DevPersona("P-09", "victim@shytalk.dev", "Nora (P-09 victim)", DevPersona.Cohort.ADULT),
+        DevPersona("P-10", "host@shytalk.dev", "Theo (P-10 voice host)", DevPersona.Cohort.ADULT),
+        DevPersona("P-11", "joiner-flaky@shytalk.dev", "Ines (P-11 flaky-net joiner)", DevPersona.Cohort.ADULT),
+        DevPersona("P-12", "admin@shytalk.dev", "Greta (P-12 admin)", DevPersona.Cohort.ADULT),
+        DevPersona("P-13", "rtl-user@shytalk.dev", "Layla (P-13 ar)", DevPersona.Cohort.ADULT),
+        DevPersona("P-14", "cjk-user@shytalk.dev", "Kenji (P-14 ja)", DevPersona.Cohort.ADULT),
+        DevPersona("P-15", "mc-singer@shytalk.dev", "Selma (P-15 MC Singer)", DevPersona.Cohort.ADULT),
+        DevPersona("P-16", "mc-event-host@shytalk.dev", "Tariq (P-16 Event Host)", DevPersona.Cohort.ADULT),
+        DevPersona("P-17", "teacher@shytalk.dev", "Bao (P-17 Teacher)", DevPersona.Cohort.ADULT),
+        DevPersona("P-18", "student@shytalk.dev", "Yuki (P-18 Student)", DevPersona.Cohort.ADULT),
+        DevPersona("P-19", "officia@shytalk.dev", "ShyTalk Official", DevPersona.Cohort.ADULT),
+    )

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/SignInScreen.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/auth/SignInScreen.kt
@@ -1,14 +1,20 @@
 package com.shyden.shytalk.feature.auth
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material3.AlertDialog
@@ -34,6 +40,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.shyden.shytalk.core.BuildVariant
+import com.shyden.shytalk.core.DevPersona
+import com.shyden.shytalk.core.devPersonas
 import com.shyden.shytalk.core.ui.StyledSnackbarHost
 import com.shyden.shytalk.core.util.SecureStorage
 import com.shyden.shytalk.core.util.logW
@@ -295,6 +303,7 @@ fun SignInScreen(
 
             // Track which provider is actively signing in (null = none)
             var signingInProvider by remember { mutableStateOf<String?>(null) }
+            var showPersonaPicker by remember { mutableStateOf(false) }
 
             LaunchedEffect(uiState.isLoading, uiState.error) {
                 if (!uiState.isLoading && signingInProvider != null) {
@@ -463,6 +472,163 @@ fun SignInScreen(
                     Text("Dev Sign-In", color = MaterialTheme.colorScheme.tertiary)
                 }
             }
+
+            // Persona-picker sign-in. Distinct from the single-account Dev
+            // Sign-In above: the picker lets QA operators pick from the 17
+            // test personas (P-02..P-19) so journey scenarios that target
+            // a specific persona (e.g. j04 Hayato DOB-flip, j08 Vexa cross-
+            // cohort prober) can run against the right Firebase identity
+            // without a rebuild between personas. Same fail-closed gate as
+            // isDevSignInAvailable — empty baked password → button hidden.
+            //
+            // Available on:
+            //   - local flavor (hardcoded "localdev123"; matches local/seed.js
+            //     which seeds the 17 personas into the Firebase Auth emulator
+            //     with that password)
+            //   - dev flavor when built with `-PDEV_QA_PERSONAS_PASSWORD=…`
+            //     or `DEV_QA_PERSONAS_PASSWORD=…` env var. The value must
+            //     match the `PERSONAS_PASSWORD` env var the express-api
+            //     provisioner used to create the persona accounts on dev
+            //     Firebase Auth.
+            if (BuildVariant.isPersonaPickerAvailable) {
+                Spacer(modifier = Modifier.height(12.dp))
+                TextButton(
+                    onClick = { showPersonaPicker = true },
+                    enabled = !isBusy,
+                    modifier = Modifier.testTag("persona_picker_open"),
+                ) {
+                    Text(
+                        "Sign in as test persona",
+                        color = MaterialTheme.colorScheme.tertiary,
+                    )
+                }
+            }
+
+            // Persona picker dialog. Shown only when explicitly opened by
+            // the button above. Defence-in-depth re-check of
+            // isPersonaPickerAvailable inside the click handler — same
+            // Frida-mitigation pattern as the single-account Dev Sign-In.
+            if (showPersonaPicker && BuildVariant.isPersonaPickerAvailable) {
+                AlertDialog(
+                    onDismissRequest = { if (!isBusy) showPersonaPicker = false },
+                    confirmButton = {},
+                    dismissButton = {
+                        TextButton(
+                            onClick = { showPersonaPicker = false },
+                            enabled = !isBusy,
+                        ) { Text("Cancel") }
+                    },
+                    title = { Text("Sign in as test persona") },
+                    text = {
+                        // Bounded height so the dialog scrolls rather than
+                        // pushing the buttons off-screen on a short device.
+                        LazyColumn(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .heightIn(max = 400.dp),
+                        ) {
+                            items(devPersonas, key = { it.id }) { persona ->
+                                PersonaPickerRow(
+                                    persona = persona,
+                                    enabled = !isBusy,
+                                    onClick = {
+                                        if (isBusy) return@PersonaPickerRow
+                                        val sharedPw = BuildVariant.localDevPersonasPassword
+                                        if (sharedPw.isNullOrEmpty()) {
+                                            logW(
+                                                "SignInScreen",
+                                                "Persona picker invoked but localDevPersonasPassword is empty",
+                                            )
+                                            return@PersonaPickerRow
+                                        }
+                                        showPersonaPicker = false
+                                        signingInProvider = "dev"
+                                        scope.launch {
+                                            try {
+                                                performDevSignIn(
+                                                    email = persona.email,
+                                                    password = sharedPw,
+                                                )
+                                                viewModel.resolveAfterExternalSignIn(
+                                                    "email",
+                                                    persona.email,
+                                                )
+                                            } catch (e: kotlinx.coroutines.CancellationException) {
+                                                throw e
+                                            } catch (e: Exception) {
+                                                logW(
+                                                    "SignInScreen",
+                                                    "Persona sign-in failed for ${persona.id}",
+                                                    e,
+                                                )
+                                                snackbarHostState.showSnackbar(
+                                                    "Persona sign-in failed",
+                                                )
+                                            } finally {
+                                                signingInProvider = null
+                                            }
+                                        }
+                                    },
+                                )
+                            }
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PersonaPickerRow(
+    persona: DevPersona,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(enabled = enabled, onClick = onClick)
+                .padding(vertical = 12.dp, horizontal = 8.dp)
+                .testTag("persona_row_${persona.id}"),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                persona.displayName,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                persona.email,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Surface(
+            color =
+                when (persona.cohort) {
+                    DevPersona.Cohort.ADULT -> MaterialTheme.colorScheme.primaryContainer
+                    DevPersona.Cohort.MINOR -> MaterialTheme.colorScheme.secondaryContainer
+                },
+            shape = RoundedCornerShape(8.dp),
+        ) {
+            Text(
+                text =
+                    when (persona.cohort) {
+                        DevPersona.Cohort.ADULT -> "adult"
+                        DevPersona.Cohort.MINOR -> "minor"
+                    },
+                color =
+                    when (persona.cohort) {
+                        DevPersona.Cohort.ADULT -> MaterialTheme.colorScheme.onPrimaryContainer
+                        DevPersona.Cohort.MINOR -> MaterialTheme.colorScheme.onSecondaryContainer
+                    },
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            )
         }
     }
 }

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/BuildVariantTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/BuildVariantTest.kt
@@ -576,4 +576,94 @@ class BuildVariantTest {
             "clearing credentials must reset the derived flag (no lingering true)",
         )
     }
+
+    // ── isPersonaPickerAvailable matrix (PR B v2 — persona picker) ──
+
+    @Test
+    fun `localDevPersonasPassword defaults to null`() {
+        BuildVariant.initLocalEmulator(false)
+        assertNull(BuildVariant.localDevPersonasPassword)
+    }
+
+    @Test
+    fun `localDevPersonasPassword captures non-empty value`() {
+        BuildVariant.initLocalEmulator(value = true, devPersonasPassword = "spw")
+        assertEquals("spw", BuildVariant.localDevPersonasPassword)
+    }
+
+    @Test
+    fun `localDevPersonasPassword coerces empty string to null`() {
+        // Android's BuildConfig.DEV_QA_PERSONAS_PASSWORD is "" on prod
+        // and on dev builds without the env var. Setter must coerce
+        // so isPersonaPickerAvailable reads false uniformly.
+        BuildVariant.initLocalEmulator(value = true, devPersonasPassword = "")
+        assertNull(BuildVariant.localDevPersonasPassword)
+    }
+
+    @Test
+    fun `isPersonaPickerAvailable defaults to false`() {
+        BuildVariant.initLocalEmulator(false)
+        assertFalse(BuildVariant.isPersonaPickerAvailable)
+    }
+
+    @Test
+    fun `isPersonaPickerAvailable is true when shared password is baked`() {
+        BuildVariant.initLocalEmulator(value = true, devPersonasPassword = "spw")
+        assertTrue(BuildVariant.isPersonaPickerAvailable)
+    }
+
+    @Test
+    fun `isPersonaPickerAvailable is false when password is empty string`() {
+        BuildVariant.initLocalEmulator(value = true, devPersonasPassword = "")
+        assertFalse(
+            BuildVariant.isPersonaPickerAvailable,
+            "empty string must not enable the picker (fail-closed)",
+        )
+    }
+
+    @Test
+    fun `isPersonaPickerAvailable resets when shared password is cleared`() {
+        BuildVariant.initLocalEmulator(value = true, devPersonasPassword = "spw")
+        assertTrue(BuildVariant.isPersonaPickerAvailable)
+
+        BuildVariant.initLocalEmulator(value = false)
+        assertFalse(
+            BuildVariant.isPersonaPickerAvailable,
+            "clearing the shared password must reset the derived flag",
+        )
+    }
+
+    @Test
+    fun `picker and single-account dev sign-in are independent`() {
+        // Both can be enabled at once (local flavor); both can be disabled
+        // (prod). The derivations don't cross-pollute.
+        BuildVariant.initLocalEmulator(
+            value = true,
+            devEmail = "single@example",
+            devPassword = "sgl",
+            devPersonasPassword = "spw",
+        )
+        assertTrue(BuildVariant.isDevSignInAvailable)
+        assertTrue(BuildVariant.isPersonaPickerAvailable)
+
+        // Picker password only — single-account stays off.
+        BuildVariant.initLocalEmulator(value = true, devPersonasPassword = "spw")
+        assertFalse(
+            BuildVariant.isDevSignInAvailable,
+            "no single-account creds → single-account button hidden",
+        )
+        assertTrue(BuildVariant.isPersonaPickerAvailable)
+
+        // Single-account creds only — picker stays off.
+        BuildVariant.initLocalEmulator(
+            value = true,
+            devEmail = "single@example",
+            devPassword = "sgl",
+        )
+        assertTrue(BuildVariant.isDevSignInAvailable)
+        assertFalse(
+            BuildVariant.isPersonaPickerAvailable,
+            "no shared password → picker button hidden",
+        )
+    }
 }

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/DevPersonasTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/DevPersonasTest.kt
@@ -1,0 +1,105 @@
+package com.shyden.shytalk.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the `devPersonas` registry against the provisioner contract:
+ *
+ *  - Every id matches the `P-NN` pattern from
+ *    `express-api/scripts/provision-test-personas.js`.
+ *  - Every email lives under `@shytalk.dev` (the dev Firebase Auth tenant).
+ *  - No duplicate ids or emails (would silently make a picker row
+ *    sign in as the wrong account).
+ *  - The 17 well-known journey-critical personas are present
+ *    (P-02 Alice, P-04 Marcus, P-06 Hayato, P-07 Vexa, P-12 Greta,
+ *    P-19 Officia) — explicit pins so a refactor that accidentally
+ *    drops one is loud.
+ */
+class DevPersonasTest {
+    @Test
+    fun `registry has the 17 stable personas`() {
+        // P-02..P-19 minus P-03 (Mia is ephemeral, not provisioned).
+        assertEquals(17, devPersonas.size)
+    }
+
+    @Test
+    fun `every id matches P-NN format`() {
+        val pattern = Regex("""^P-\d{2}$""")
+        for (p in devPersonas) {
+            assertTrue(pattern.matches(p.id), "Bad id format: ${p.id}")
+        }
+    }
+
+    @Test
+    fun `every email lives under shytalk dot dev`() {
+        for (p in devPersonas) {
+            assertTrue(
+                p.email.endsWith("@shytalk.dev"),
+                "Email not in dev tenant: ${p.email}",
+            )
+        }
+    }
+
+    @Test
+    fun `ids are unique`() {
+        val ids = devPersonas.map { it.id }
+        assertEquals(ids.size, ids.toSet().size, "Duplicate persona ids")
+    }
+
+    @Test
+    fun `emails are unique`() {
+        val emails = devPersonas.map { it.email }
+        assertEquals(emails.size, emails.toSet().size, "Duplicate persona emails")
+    }
+
+    @Test
+    fun `display names are non-blank`() {
+        for (p in devPersonas) {
+            assertTrue(p.displayName.isNotBlank(), "Blank displayName for ${p.id}")
+        }
+    }
+
+    @Test
+    fun `journey-critical personas are pinned by id`() {
+        // If a refactor accidentally drops one of these, the journey
+        // test plan breaks silently — pin them explicitly.
+        val byId = devPersonas.associateBy { it.id }
+        for (id in listOf("P-02", "P-04", "P-06", "P-07", "P-12", "P-19")) {
+            assertNotNull(byId[id], "Missing journey-critical persona $id")
+        }
+    }
+
+    @Test
+    fun `P-04 Marcus is the minor cohort`() {
+        val marcus = devPersonas.first { it.id == "P-04" }
+        assertEquals(DevPersona.Cohort.MINOR, marcus.cohort)
+        assertEquals("minor-power@shytalk.dev", marcus.email)
+    }
+
+    @Test
+    fun `P-07 Vexa is the cross-cohort prober (adult cohort)`() {
+        val vexa = devPersonas.first { it.id == "P-07" }
+        assertEquals(DevPersona.Cohort.ADULT, vexa.cohort)
+        assertEquals("adult-prober@shytalk.dev", vexa.email)
+    }
+
+    @Test
+    fun `P-12 Greta is the admin (adult cohort)`() {
+        val greta = devPersonas.first { it.id == "P-12" }
+        assertEquals(DevPersona.Cohort.ADULT, greta.cohort)
+        assertEquals("admin@shytalk.dev", greta.email)
+    }
+
+    @Test
+    fun `exactly one MINOR cohort persona is registered`() {
+        // The journey plan only includes Marcus as a stable minor. Mia
+        // (the post-flip minor) is ephemeral. If a future change adds
+        // another stable minor, update this expectation deliberately.
+        val minors = devPersonas.filter { it.cohort == DevPersona.Cohort.MINOR }
+        assertEquals(1, minors.size, "Expected exactly 1 stable minor persona")
+        assertEquals("P-04", minors[0].id)
+    }
+}


### PR DESCRIPTION
## Summary

Extends PR B (#677) — adds an in-screen picker letting QA operators sign in as any of the 17 stable test personas (P-02..P-19) without rebuilding the APK between personas. Unblocks task #41 (OSA UI verification) by making the journey test plan's per-persona scenarios runnable in series on a single build.

## What changes

| File | Change |
|---|---|
| `shared/.../core/DevPersonas.kt` (new) | 17 hardcoded personas: id, email, displayName, cohort enum |
| `shared/.../core/BuildVariant.kt` | New `localDevPersonasPassword` field + `isPersonaPickerAvailable` derived flag |
| `shared/.../feature/auth/SignInScreen.kt` | New "Sign in as test persona" button → AlertDialog with LazyColumn of personas |
| `app/build.gradle.kts` | New `DEV_QA_PERSONAS_PASSWORD` BuildConfig field per flavor |
| `app/.../MainActivity.kt` | Wires the new field into `BuildVariant.initLocalEmulator` |
| `shared/.../commonTest/.../BuildVariantTest.kt` | +7 tests for the picker matrix |
| `shared/.../commonTest/.../DevPersonasTest.kt` (new) | +11 tests for the registry contract |

## Security model

Identical fail-closed pattern as PR B:
- **Persona emails are public** — already committed in `express-api/scripts/provision-test-personas.js`
- **Only the shared password is sensitive** — baked from `DEV_QA_PERSONAS_PASSWORD` env var at build time
- **Empty baked value → picker hidden → no UI affordance to sign in** (defence-in-depth re-checked inside the click handler)
- **prod flavor**: hardcoded `""` → picker never renders, regardless of env vars at build time

## Flavor matrix

| Flavor | Source | Default | Picker available? |
|---|---|---|---|
| dev | `-PDEV_QA_PERSONAS_PASSWORD=` or env var | empty | only when operator opts in |
| local | hardcoded `"localdev123"` (matches `local/seed.js`) | always set | yes |
| prod | hardcoded `""` | always empty | no, ever |

## Tests

17 new test cases, all green via `./gradlew testDevDebugUnitTest :shared:jvmTest detekt`:
- `BuildVariantTest`: empty-coerce-to-null, capture, clear-on-reset, independence from `isDevSignInAvailable`
- `DevPersonasTest`: persona-id format pin, email-tenant pin, uniqueness, journey-critical persona presence (P-02 Alice, P-04 Marcus, P-06 Hayato, P-07 Vexa, P-12 Greta, P-19 Officia), Marcus is the MINOR cohort, exactly one stable minor exists

## Pre-push checklist

- [x] ktlint --relative — clean
- [x] `./gradlew testDevDebugUnitTest :shared:jvmTest detekt` — green
- [x] `./gradlew :shared:compileKotlinIosArm64` — green (KMP tri-platform compat)
- [x] `./gradlew :app:compileDevDebugKotlin` — green

## Test plan

- [ ] After merge: rebuild dev APK with `DEV_QA_PERSONAS_PASSWORD=<value> ./gradlew installDevDebug`
- [ ] Launch app on physical device — verify "Sign in as test persona" button appears below "Dev Sign-In"
- [ ] Tap button → verify picker dialog renders all 17 personas with name + email + cohort badge
- [ ] Tap Vexa → verify sign-in succeeds and `users/50000040` doc accessible
- [ ] Tap Marcus → verify sign-in succeeds and `users/60000010` doc accessible
- [ ] Sign out, retry with each journey-critical persona (Hayato, Greta, etc.)
- [ ] Then proceed with task #41 journey verification proper

🤖 Generated with [Claude Code](https://claude.com/claude-code)