### PR TITLE
ci: wire DEV_QA_PERSONAS_PASSWORD into dev APK builds

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -310,6 +310,9 @@ jobs:
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           LIVEKIT_URL: ${{ secrets.LIVEKIT_URL }}
+          # See pr-checks.yml's matching env for rationale. The persona
+          # picker on dev variant only appears when this is non-empty.
+          DEV_QA_PERSONAS_PASSWORD: ${{ secrets.DEV_QA_PERSONAS_PASSWORD }}
         run: |
           ./gradlew assembleDevRelease
           mkdir -p dev-release-apk

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -138,6 +138,14 @@ jobs:
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD || 'android' }}
           LIVEKIT_URL: ${{ secrets.LIVEKIT_URL || 'wss://placeholder.livekit.cloud' }}
+          # Bake the persona-picker password into the dev APK so journey-based
+          # manual QA on dev variant can sign in as P-02..P-19 personas
+          # without OAuth. Must match the value the express-api provisioner
+          # used to create the dev Firebase Auth accounts (PERSONAS_PASSWORD).
+          # Falls back to empty → picker UI fails closed (BuildVariant.kt's
+          # isPersonaPickerAvailable returns false). See app/build.gradle.kts
+          # line 105 for the buildConfigField wiring.
+          DEV_QA_PERSONAS_PASSWORD: ${{ secrets.DEV_QA_PERSONAS_PASSWORD }}
         run: ./gradlew testDevDebugUnitTest :shared:jvmTest detekt assembleDevRelease jacocoDevDebugUnitTestReport --parallel
 
       - name: Publish unit test report


### PR DESCRIPTION
## Summary
- Pass `DEV_QA_PERSONAS_PASSWORD` from a (yet-to-be-added) repo secret into the gradle `assembleDevRelease` build in both `pr-checks.yml` and `deploy-dev.yml`
- Enables the "Sign in as test persona" picker on dev-flavor APKs once the secret value is added
- Pure-additive — without the secret, the picker UI fails closed (per `BuildVariant.kt:isPersonaPickerAvailable`)

## Why
The canonical journey-test auth path for the dev variant uses email-per-persona + shared password (no OAuth). The wiring on the build side already exists in `app/build.gradle.kts:105` — this PR just feeds the value through from CI.

## Operator action required
After this merges, add the repo secret:

```
gh secret set DEV_QA_PERSONAS_PASSWORD --body '<value-from-provisioner>'
```

The value must match the `PERSONAS_PASSWORD` env var used by `express-api/scripts/provision-test-personas.js` when it created the P-02..P-19 Firebase Auth accounts on the dev project.

## Test plan
- [ ] Add the secret in repo settings
- [ ] Trigger a fresh `Deploy To Dev` run
- [ ] Install the new dev APK on the OnePlus device
- [ ] Sign-In screen now shows "Sign in as test persona" → tap → picker opens with P-02..P-19 personas → tap any persona → real Firebase Auth call to dev → signed-in state

🤖 Generated with [Claude Code](https://claude.com/claude-code)