### PR TITLE
ci: speed up iOS deploys back toward historical 25-30 min baseline

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -474,21 +474,28 @@ jobs:
         if: steps.kmp-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          # --max-workers=1: K/N link tasks can deadlock when run in
-          # parallel (xcodebuild's nested gradle call hung 39+ min before
-          # this flag was added). Serializing all gradle tasks is the
-          # safe baseline; on a 14GB macos-latest runner with multiple
-          # parallel K/N processes potentially needing ~3-5GB each plus
-          # competing for the konan compiler cache, parallelism is a
-          # net-negative anyway.
-          ./gradlew :shared:linkReleaseFrameworkIosArm64 :shared:linkDebugFrameworkIosArm64 --max-workers=1
+          # Only Release here — Debug is built by xcodebuild's nested
+          # gradle call in the Compile Kotlin Framework build phase,
+          # protected by --max-workers in pbxproj. Pre-building Debug
+          # in warm-up only shifts ~25 min between steps without saving
+          # total time, and the historical fast warm-up (pre-2026-04-28)
+          # only ever did Release.
+          ./gradlew :shared:linkReleaseFrameworkIosArm64
 
       - name: Cache Xcode derived data
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: xcode-derived-${{ hashFiles('iosApp/**', 'shared/build/bin/iosArm64/releaseFramework/**') }}
-          restore-keys: xcode-derived-
+          # Key anchored on Swift sources + the workspace/project files only.
+          # Previous key hashed `iosApp/**` (transitively includes the .bak
+          # files the diagnostic step left behind + Pods/) and the live
+          # framework build output, both of which churn enough to make the
+          # cache miss on most runs. New key is stable across runs that
+          # only change KMP sources or workflows.
+          key: xcode-derived-${{ runner.os }}-${{ hashFiles('iosApp/iosApp.xcodeproj/project.pbxproj', 'iosApp/iosApp.xcworkspace/contents.xcworkspacedata', 'iosApp/Podfile.lock', 'iosApp/iosApp/**/*.swift', 'iosApp/iosApp/ExportOptions.plist') }}
+          restore-keys: |
+            xcode-derived-${{ runner.os }}-
+            xcode-derived-
 
       - name: Install CocoaPods
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -447,10 +447,9 @@ jobs:
       - name: Build KMP shared framework for iOS
         run: |
           set -euo pipefail
-          # See deploy-dev.yml's matching step — --max-workers=1 avoids the
-          # parallel K/N link deadlock; also pre-build Debug so xcodebuild's
-          # nested gradle call finds it UP-TO-DATE.
-          ./gradlew :shared:linkReleaseFrameworkIosArm64 :shared:linkDebugFrameworkIosArm64 --max-workers=1
+          # See deploy-dev.yml's matching step — Release only; Debug is
+          # built by xcodebuild's nested gradle call.
+          ./gradlew :shared:linkReleaseFrameworkIosArm64
 
       - name: Install CocoaPods
         run: |
@@ -769,9 +768,9 @@ jobs:
             konan-${{ runner.os }}-
 
       - name: Build KMP shared framework for iOS Simulator
-        # --max-workers=1 — see deploy-dev.yml's matching step. Same
-        # parallel-K/N-link deadlock would apply on Sim too.
-        run: ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64 --max-workers=1
+        # Single task → --max-workers is a no-op here. Deadlock
+        # protection lives in pbxproj's build-phase script.
+        run: ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
 
       - name: Install CocoaPods
         run: cd iosApp && pod install

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -119,10 +119,12 @@ jobs:
 
       - name: Build shared KMP framework for iOS Simulator
         if: steps.check-tests.outputs.has_tests == 'true'
-        # --max-workers=1 — see deploy-dev.yml's matching step. The KMP
-        # plugin can deadlock on parallel K/N link tasks under macOS
-        # runner memory pressure; serializing is safer than fast.
-        run: ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64 --max-workers=1
+        # Single task → --max-workers is a no-op here (gradle has nothing
+        # to parallelise within one task). The deadlock protection lives
+        # in iosApp.xcodeproj/project.pbxproj's Compile Kotlin Framework
+        # build phase script where xcodebuild's nested gradle call
+        # naturally tries to do multiple K/N variants in parallel.
+        run: ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
 
       - name: Install CocoaPods
         if: steps.check-tests.outputs.has_tests == 'true'

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -407,7 +407,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode --max-workers=1\n";
+			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode --max-workers=2\n";
 		};
 		11FD2A8F46925E7FD8E8CD14 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Summary
Reverts unnecessary work my own earlier hang-fix commits added, plus tightens the Xcode DerivedData cache key, with the goal of restoring deploy-dev to the historical ~25-30 min total instead of the current ~40-50 min.

## Changes
| File | Change |
|---|---|
| `deploy-dev.yml` warm-up | Build only `linkReleaseFrameworkIosArm64` (drop the Debug pre-build). Debug is still built — just by xcodebuild's nested gradle, where pbxproj's `--max-workers` protects it. |
| `deploy-prod.yml` warm-up | Same revert. |
| `iosApp.xcodeproj/project.pbxproj` | Bump build-phase `--max-workers=1` → `--max-workers=2`. Allows some parallelism while preventing the original 3-way K/N deadlock. Step-level 50-min timeout still catches recurrence. |
| `deploy-dev.yml` DerivedData cache | Tighter key: `iosApp/iosApp.xcodeproj/project.pbxproj` + `.xcworkspace/contents.xcworkspacedata` + `Podfile.lock` + `iosApp/iosApp/**/*.swift` + `ExportOptions.plist`. Old key hashed `iosApp/**` (churns from `.bak`, Pods/) + live build output (changes every run). Restore-keys add OS fallback. |
| `ios-tests.yml` + `smoke-test-ios-boot` warm-ups | Drop redundant `--max-workers=1` from single-task gradle calls. |

## Risk
- `--max-workers=2` could re-deadlock if my understanding is wrong about the contention mode. **Mitigation**: the 50-min step timeout on Build/archive catches it cleanly. Cost of a wrong-bet validation run is one CI cycle, no laptop crash, $0.
- DerivedData cache miss on first new-key run — expected, harmless, just one slow run before warm.

## Validation
Plan: dispatch deploy-dev on this branch once the in-flight `main` deploy finishes, compare iOS distribute timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)