### PR TITLE
ci(pr-checks): enable path-gated iOS E2E (symmetric with android-e2e)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -284,7 +284,19 @@ jobs:
       (needs.test-backend.result == 'success' || needs.test-backend.result == 'skipped')
     uses: ./.github/workflows/ios-tests.yml
     with:
-      ios: 'none'
+      # Default iOS device for PR runs. Mirror of android-e2e's
+      # `android: '33-phone'` — one device, latest stable iOS, single
+      # form-factor. The job-level `if:` above already gates on
+      # `app_changed` + `skip_ios_e2e`, so this only runs when
+      # iOS-relevant code changes (and not when the PR body has the
+      # `[skip-ios-e2e]` marker).
+      #
+      # Was 'none' until 2026-05-21, which made the matrix expand to
+      # zero devices in ios-tests.yml's resolve-inputs job — the
+      # entire iOS E2E surface was symbolic. Pinned to a specific
+      # device via tests/scripts/pr-checks-ios-gating.test.js to
+      # prevent silent regression back to 'none'.
+      ios: '18.1-iphone'
       parallel: true
       ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit

--- a/express-api/tests/scripts/pr-checks-ios-gating.test.js
+++ b/express-api/tests/scripts/pr-checks-ios-gating.test.js
@@ -1,0 +1,93 @@
+/**
+ * PR Checks iOS E2E gating regression test.
+ *
+ * The `ios-e2e` job in `.github/workflows/pr-checks.yml` should mirror
+ * the `android-e2e` job's gating pattern: run when iOS-relevant code
+ * (app/, shared/, iosApp/, gradle files — same set that flips
+ * `detect-changes.outputs.app_changed`) actually changes, AND respect
+ * the `[skip-ios-e2e]` PR-body marker.
+ *
+ * Before this test was added, the workflow passed `ios: 'none'` to
+ * ios-tests.yml unconditionally, so the iOS E2E job was effectively
+ * dead code — its skeleton ran but the device matrix expanded to zero
+ * and no actual tests executed. That's an asymmetry with android-e2e
+ * (`android: '33-phone'`) without any documented rationale, and it
+ * silently dropped iOS coverage on every PR — including PRs that touched
+ * iOS files. This test pins the corrected gating in place so a future
+ * change can't quietly disable iOS coverage again.
+ *
+ * Implementation: regex assertions on the raw workflow YAML. A full
+ * YAML parser dependency is overkill for the surface we're testing
+ * (~30 lines of one job block), and avoids dragging js-yaml into the
+ * test runtime just for this.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const PR_CHECKS_PATH = path.join(REPO_ROOT, '.github/workflows/pr-checks.yml');
+
+function extractIosE2eJob(yamlText) {
+  // Capture the ios-e2e job block: from `  ios-e2e:` to the next
+  // top-level job declaration (a line starting with two spaces + word
+  // + colon). The lazy `[\s\S]+?` keeps the capture small, and the
+  // lookahead anchors on the next job header (`gate:` currently
+  // follows `ios-e2e:` in pr-checks.yml). If ios-e2e ever becomes the
+  // last job, this match will fail loudly and the test driver will
+  // raise the diagnostic below — that's the desired failure mode.
+  const match = yamlText.match(/^ {2}ios-e2e:\n([\s\S]+?)(?=^ {2}\w[\w-]*:\n)/m);
+  if (!match) {
+    throw new Error(
+      `Could not locate the ios-e2e job in ${PR_CHECKS_PATH}. The job ` +
+        'declaration moved or was deleted — update this test to match.',
+    );
+  }
+  return match[1];
+}
+
+describe('pr-checks.yml — ios-e2e job gating', () => {
+  let yamlText;
+  let iosE2eBlock;
+
+  beforeAll(() => {
+    yamlText = fs.readFileSync(PR_CHECKS_PATH, 'utf8');
+    iosE2eBlock = extractIosE2eJob(yamlText);
+  });
+
+  test('ios-e2e job exists in pr-checks.yml', () => {
+    expect(iosE2eBlock).toMatch(/uses:\s+\.\/\.github\/workflows\/ios-tests\.yml/);
+  });
+
+  test('passes a non-empty device matrix to ios-tests.yml (not "none")', () => {
+    // The literal `ios: 'none'` makes ios-tests.yml resolve to zero
+    // devices and the actual E2E job is skipped — leaving the PR
+    // checks reporting iOS as green when nothing was actually tested.
+    // Anything other than 'none' is acceptable; the test gates against
+    // the specific historical regression.
+    const iosInputMatch = iosE2eBlock.match(/\bios:\s+'([^']+)'/);
+    expect(iosInputMatch).toBeTruthy();
+    const iosValue = iosInputMatch[1];
+    expect(iosValue).not.toBe('none');
+  });
+
+  test('default device is the latest-iOS iPhone (cheapest single matrix entry)', () => {
+    // Pin the specific choice so future changes are deliberate. If
+    // matrix policy changes (e.g. add iPad or older iOS by default),
+    // update this assertion at the same time.
+    expect(iosE2eBlock).toMatch(/\bios:\s+'18\.1-iphone'/);
+  });
+
+  test('job-level if-gate matches android-e2e symmetric pattern (app_changed + skip-marker)', () => {
+    // Same shape as android-e2e — fires when KMP/iOS code changes
+    // AND the PR-body marker `[skip-ios-e2e]` is not set. Without
+    // both checks present we either over-fire (every PR including
+    // workflow-only) or fail to honour the operator escape hatch.
+    expect(iosE2eBlock).toMatch(/needs\.detect-changes\.outputs\.app_changed\s*==\s*'true'/);
+    expect(iosE2eBlock).toMatch(/needs\.detect-changes\.outputs\.skip_ios_e2e\s*!=\s*'true'/);
+  });
+
+  test('parallel mode is on (same as android-e2e)', () => {
+    expect(iosE2eBlock).toMatch(/parallel:\s+true/);
+  });
+});


### PR DESCRIPTION
## Summary
- PR Checks was passing `ios: 'none'` to `ios-tests.yml`, expanding the device matrix to zero and skipping the entire iOS E2E build silently
- Change to `'18.1-iphone'` (one device, latest stable iOS) — symmetric with android-e2e's `'33-phone'`
- Job-level `if:` was already correct (`app_changed && skip_ios_e2e != 'true'`), so we ONLY run iOS E2E when iOS code actually changes
- TDD: regression test added (`pr-checks-ios-gating.test.js`) pins the choice; would catch any future revert to `'none'`

## TDD trace

| Phase | Action | Result |
|---|---|---|
| Red | Added 5-assertion test against the pre-fix YAML | 2/5 fail (the `not-'none'` + `'18.1-iphone'` assertions) |
| Green | Changed line 287 from `'none'` to `'18.1-iphone'` | 5/5 pass |
| Lint | `actionlint` + `eslint` on the new test | clean |

## What this PR exercises in its own pr-checks run

| Case | Expected behavior |
|---|---|
| This PR (workflow + test file only — no `iosApp/**`, no `shared/**`) | `app_changed == false` → ios-e2e job-level `if:` evaluates false → **iOS E2E skipped** at the job gate, same as today. Validates the gating still respects path-based skipping. |
| Future PR touching `iosApp/iosApp/*.swift` | `app_changed == true` → ios-e2e runs with iPhone 18.1 device. |
| Future PR with `[skip-ios-e2e]` body marker | `skip_ios_e2e == true` → ios-e2e skipped regardless of file changes. |

## Test plan
- [x] Local jest pass (5/5)
- [x] Local actionlint clean
- [x] Local eslint clean
- [ ] PR Checks pass (will reflect this PR's own gating — iOS E2E should SKIP because no iOS files touched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)