### PR TITLE
ci: cache KMP intermediate state to skip K/N re-compile on warm runs

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -463,6 +463,28 @@ jobs:
           restore-keys: |
             konan-${{ runner.os }}-
 
+      # Wider cache for K/N intermediate state — without these dirs on
+      # disk, gradle's UP-TO-DATE check on K/N compile tasks fails even
+      # when the final framework IS cached (the narrow step below), and
+      # forces a fresh K/N compile. Source hashes drive invalidation;
+      # restore-keys give partial-match warmth so a touched-source PR
+      # gets incremental rather than from-scratch compile.
+      #
+      # Pinned by tests/scripts/deploy-dev-kmp-cache.test.js to prevent
+      # silent shrinkage of the cache surface back to framework-only.
+      - name: Cache KMP intermediate build state
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            shared/build/classes
+            shared/build/kotlin
+            shared/build/intermediates
+            shared/build/kotlinTransformedMetadataLibraries
+            shared/build/generated
+          key: kmp-intermediates-${{ runner.os }}-${{ hashFiles('shared/src/**', 'shared/build.gradle.kts', 'gradle/libs.versions.toml') }}
+          restore-keys: |
+            kmp-intermediates-${{ runner.os }}-
+
       - name: Cache KMP shared framework
         id: kmp-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/express-api/tests/scripts/deploy-dev-kmp-cache.test.js
+++ b/express-api/tests/scripts/deploy-dev-kmp-cache.test.js
@@ -1,0 +1,95 @@
+/**
+ * Asserts the broader KMP intermediate-state cache exists alongside the
+ * narrow final-framework cache in deploy-dev.yml's distribute-ios job.
+ *
+ * Background: PR #690 added two caches to the iOS path:
+ *   - `~/.konan` (Kotlin/Native compiler distribution + platform libs)
+ *   - `shared/build/bin/iosArm64/releaseFramework` (final framework binary)
+ *
+ * That left the K/N intermediate compile outputs (incremental kotlin
+ * state, classes, intermediates, transformed metadata, generated code)
+ * UN-cached. Even when the framework cache hit, gradle re-ran the K/N
+ * compile tasks because their declared intermediate inputs were missing.
+ * This PR adds a third cache step covering those intermediates, keyed
+ * on the source files + build config so it invalidates appropriately.
+ *
+ * Implementation: regex assertions on the raw workflow YAML, same
+ * pattern as `pr-checks-ios-gating.test.js`. Avoids adding js-yaml
+ * just for one more structural test.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const DEPLOY_DEV_PATH = path.join(REPO_ROOT, '.github/workflows/deploy-dev.yml');
+
+function extractDistributeIosJob(yamlText) {
+  // Capture the distribute-ios job block: from `  distribute-ios:`
+  // to the next top-level job header. Same regex shape as the
+  // ios-e2e extractor in pr-checks-ios-gating.test.js.
+  const match = yamlText.match(/^ {2}distribute-ios:\n([\s\S]+?)(?=^ {2}\w[\w-]*:\n)/m);
+  if (!match) {
+    throw new Error(
+      `Could not locate the distribute-ios job in ${DEPLOY_DEV_PATH}. ` +
+        'The job declaration moved or was deleted — update this test to match.',
+    );
+  }
+  return match[1];
+}
+
+describe('deploy-dev.yml — KMP intermediate cache', () => {
+  let yamlText;
+  let distributeIosBlock;
+
+  beforeAll(() => {
+    yamlText = fs.readFileSync(DEPLOY_DEV_PATH, 'utf8');
+    distributeIosBlock = extractDistributeIosJob(yamlText);
+  });
+
+  test('the existing ~/.konan cache step is preserved', () => {
+    // Sanity check — the PR adds caching but must NOT remove what
+    // PR #690 already established. ~/.konan covers the compiler
+    // distribution + platform libs, which are version-stable and
+    // expensive to re-download.
+    expect(distributeIosBlock).toMatch(/path:\s+~\/\.konan/);
+  });
+
+  test('the existing framework binary cache step is preserved', () => {
+    // The narrow framework cache (`shared/build/bin/iosArm64/releaseFramework`)
+    // remains useful as a "is this exact framework already on disk"
+    // shortcut for the warm-up step's `if: cache-hit != 'true'` skip.
+    expect(distributeIosBlock).toMatch(/path:\s+shared\/build\/bin\/iosArm64\/releaseFramework/);
+  });
+
+  test('caches the KMP intermediate compile state (classes, kotlin, intermediates)', () => {
+    // The actual perf-relevant change. Without these, gradle's
+    // UP-TO-DATE check on K/N tasks fails because their declared
+    // intermediate inputs/outputs aren't on disk — even when the
+    // final framework IS cached. That forces a fresh K/N compile.
+    expect(distributeIosBlock).toMatch(/path:\s*\|[\s\S]*?shared\/build\/classes/);
+    expect(distributeIosBlock).toMatch(/path:\s*\|[\s\S]*?shared\/build\/kotlin\b/);
+    expect(distributeIosBlock).toMatch(/path:\s*\|[\s\S]*?shared\/build\/intermediates/);
+  });
+
+  test('intermediates cache key invalidates on source + build-config + version changes', () => {
+    // Cache key must hash inputs that gradle considers when deciding
+    // whether the K/N output is up-to-date. Source files, the module
+    // build script, and the version catalog. Missing any of these
+    // would either (a) under-invalidate (stale builds shipping) or
+    // (b) over-invalidate (cache never hits in practice).
+    expect(distributeIosBlock).toMatch(
+      /key:\s+kmp-intermediates-[^\n]*hashFiles\('shared\/src\/\*\*'[^)]*'shared\/build\.gradle\.kts'[^)]*'gradle\/libs\.versions\.toml'/,
+    );
+  });
+
+  test('intermediates cache uses OS-scoped restore-keys for partial-match warm', () => {
+    // When source changes invalidate the exact key, restore-keys
+    // gives us a partial warm restore from a prior commit's
+    // intermediates. Gradle's incremental compilation does the
+    // diff and skips unchanged sub-tasks.
+    expect(distributeIosBlock).toMatch(
+      /restore-keys:[\s\S]*?kmp-intermediates-\$\{\{\s*runner\.os\s*\}\}-/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a third cache step in `deploy-dev.yml`'s `distribute-ios` job covering `shared/build/{classes,kotlin,intermediates,kotlinTransformedMetadataLibraries,generated}` — the K/N intermediate state that's currently un-cached
- Gradle's UP-TO-DATE check on K/N compile tasks declares its outputs in those dirs. Without them on disk, gradle considers the tasks non-current and re-runs the full K/N compile every time, **even when the final framework cache hits**
- Companion to PR #690's `~/.konan` cache (compiler + platform libs) and the existing narrow framework cache

## Why this specifically
PR #707 validation showed iOS distribute at ~68 min on warm `~/.konan`. Step breakdown:
- Build KMP warm-up: 24 min (K/N compile)
- Build, archive, export: 37 min (xcodebuild + nested gradle K/N + Swift + IPA)

The K/N compile is happening **twice** per run (warm-up Release + nested-gradle Debug), each ~12-15 min. That's the workload this PR targets: with intermediate state cached, gradle's UP-TO-DATE check passes and the K/N compile becomes near-instant for the unchanged-source case.

## TDD
| Phase | Action | Result |
|---|---|---|
| Red | `jest tests/scripts/deploy-dev-kmp-cache.test.js` | 3/5 fail (new cache step assertions) |
| Green | Added cache step to `distribute-ios` job | 5/5 pass |
| Lint | actionlint + eslint + prettier | clean |

## Test plan
- [x] Local jest pass (5/5)
- [ ] Cold-run iOS deploy on this branch — populates the cache for the first time (no speed change expected)
- [ ] Second iOS deploy on this branch — should drop noticeably as cache restores
- [ ] PR Checks pass

## Risks
- **Stale cache shipping broken builds**: cache key includes `shared/src/**`, `shared/build.gradle.kts`, `gradle/libs.versions.toml` — any source/build/kotlin-version change invalidates. Risk surface is low.
- **Cache size**: the new step caches ~hundreds of MB of intermediates. GitHub's per-repo cache limit is 10GB; we have a few caches already but well under limit. If we hit it, oldest caches auto-evict.
- **`restore-keys` partial match could restore incompatible intermediates**: gradle's incremental compile diffs and recovers, but worst case is one slow run while it rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)