### PR TITLE
ci(deploy-dev): serialize via concurrency group

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -38,6 +38,18 @@ permissions:
   contents: write # needed by playwright-tests.yml allure-report (gh-pages deploy)
   actions: read
 
+# Dev deploys must serialize. Parallel dev deploys can race on the
+# London Express VM (scp tarball + pm2 restart), on Firebase App
+# Distribution upload slots, and on TestFlight build-number
+# assignment. cancel-in-progress: false makes queued deploys wait
+# for the running one to complete rather than preempting it — a
+# partial rollback halfway through a multi-step deploy leaves the
+# env in an undefined state. Mirrors deploy-prod.yml's matching
+# block. Pinned by tests/scripts/deploy-dev-concurrency.test.js.
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/express-api/tests/scripts/deploy-dev-concurrency.test.js
+++ b/express-api/tests/scripts/deploy-dev-concurrency.test.js
@@ -1,0 +1,58 @@
+/**
+ * Asserts that `.github/workflows/deploy-dev.yml` declares a concurrency
+ * group so only one dev deploy runs at a time. Parallel dev deploys can:
+ *   - Race on the same Express deployment target (London VM)
+ *   - Race on Firebase App Distribution upload slots
+ *   - Race on TestFlight build-number assignment (CFBundleVersion derived
+ *     from GITHUB_RUN_NUMBER — fine in isolation, but two concurrent
+ *     deploys both pushing means tester surface flips between builds)
+ *
+ * Per-2026-05-21 user policy: dev deploys MUST queue, never run in
+ * parallel. Mirrors the existing `concurrency: deploy-prod` setting
+ * in deploy-prod.yml.
+ *
+ * cancel-in-progress: false is deliberate — a queued deploy waiting on
+ * a running one shouldn't preempt it. The running deploy completes,
+ * THEN the queued one starts.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const DEPLOY_DEV_PATH = path.join(REPO_ROOT, '.github/workflows/deploy-dev.yml');
+
+describe('deploy-dev.yml — concurrency policy', () => {
+  let yamlText;
+
+  beforeAll(() => {
+    yamlText = fs.readFileSync(DEPLOY_DEV_PATH, 'utf8');
+  });
+
+  // Each assertion checks ONE line independently — actionlint validates
+  // the YAML's overall structural correctness, so we don't need cross-
+  // line regex anchoring (which is the only thing that gets Sonar
+  // grumpy about backtracking). Three lines all present = concurrency
+  // block is in place.
+
+  test('top-level concurrency block is declared', () => {
+    // Anchored at column 0 to ensure we're checking the top-level
+    // workflow concurrency (not some hypothetical job-level one).
+    expect(yamlText).toMatch(/^concurrency:$/m);
+  });
+
+  test('concurrency group is "deploy-dev" (own queue, not shared with prod)', () => {
+    // Distinct group from deploy-prod so a prod deploy can run in
+    // parallel with a dev deploy — they target different VMs +
+    // Firebase projects and have no shared state.
+    expect(yamlText).toMatch(/^ {2}group: deploy-dev$/m);
+  });
+
+  test("cancel-in-progress is false (queue, don't preempt)", () => {
+    // The running deploy should complete before the queued one
+    // starts. Cancelling mid-run would leave the dev environment in
+    // an undefined state (partial backend deploy + cancelled Android
+    // distribution etc.).
+    expect(yamlText).toMatch(/^ {2}cancel-in-progress: false$/m);
+  });
+});

--- a/scripts/check-workflow-concurrency-scoping.sh
+++ b/scripts/check-workflow-concurrency-scoping.sh
@@ -24,6 +24,7 @@ INTENTIONAL_GLOBALS=(
   "e2e-tests"           # Android emulator resource contention on gh-hosted runner
   "ios-tests"           # iOS simulator resource contention on gh-hosted runner
   "gh-pages-deploy"     # only one gh-pages deploy can land at a time
+  "deploy-dev"          # single dev environment (London Express VM + Firebase App Distribution + TestFlight queue), no parallel deploys
   "deploy-prod"         # single prod environment, no parallel deploys
   "release-main"        # single release pipeline owns version bump + tag
 )


### PR DESCRIPTION
## Summary
- Add `concurrency: { group: deploy-dev, cancel-in-progress: false }` to `.github/workflows/deploy-dev.yml`
- Mirrors the same setting already present in `deploy-prod.yml`
- Per 2026-05-21 operator policy: dev deploys MUST queue, never run in parallel

## Why
Parallel dev deploys race on:
- London Express VM scp + pm2 restart (one scp landing mid-pm2-restart can corrupt the deploy)
- Firebase App Distribution upload slots
- TestFlight build-number assignment (parallel deploys flip the "current TestFlight build" for testers in rapid succession)

`cancel-in-progress: false` makes queued deploys wait for the running one rather than preempting it. Cancelling a multi-step deploy mid-run leaves the env in an undefined state (partial backend + cancelled Android etc.).

Distinct group from `deploy-prod` so prod and dev can still run concurrently — they target different VMs + Firebase projects and have zero shared state.

## TDD
| Phase | Action | Result |
|---|---|---|
| Red | jest `tests/scripts/deploy-dev-concurrency.test.js` against current YAML | 3/3 fail (no concurrency block) |
| Green | Added the block | 3/3 pass |
| Lint | actionlint + eslint | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)