### PR TITLE
ci: expose Android-local APK + iOS-dev IPA as downloadable artifacts

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -618,6 +618,19 @@ jobs:
           fi
           echo "Exported IPA: ${ipas[0]} ($(du -h "${ipas[0]}" | cut -f1))"
 
+      # Surface the IPA as a workflow artifact so an AFK operator can pull
+      # it via `gh run download <run-id> -n dev-ios-ipa` and install on a
+      # physical iPhone via `xcrun devicectl device install app …` without
+      # needing to accept a TestFlight invite + wait for App Store Connect
+      # processing. The TestFlight upload still happens in the next step
+      # for the normal tester distribution flow.
+      - name: Upload IPA as workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dev-ios-ipa
+          path: ${{ runner.temp }}/export/*.ipa
+          retention-days: 7
+
       - name: Upload to TestFlight
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -148,6 +148,23 @@ jobs:
           DEV_QA_PERSONAS_PASSWORD: ${{ secrets.DEV_QA_PERSONAS_PASSWORD }}
         run: ./gradlew testDevDebugUnitTest :shared:jvmTest detekt assembleDevRelease jacocoDevDebugUnitTestReport --parallel
 
+      # Also build the local-flavor APK so AFK operators / automation can
+      # install it on test devices without needing the local emulator
+      # stack running. The KMP shared framework is already compiled by
+      # the assembleDevRelease step above, so this only adds the Android
+      # local-flavor link + APK package step (~30-60s).
+      - name: Build localDebug APK
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD || 'android' }}
+          LIVEKIT_URL: ${{ secrets.LIVEKIT_URL || 'wss://placeholder.livekit.cloud' }}
+        run: ./gradlew assembleLocalDebug
+
+      - name: Upload localDebug APK
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: local-debug-apk
+          path: app/build/outputs/apk/local/debug/*.apk
+
       - name: Publish unit test report
         uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2
         if: always()

--- a/express-api/tests/scripts/afk-install-artifacts.test.js
+++ b/express-api/tests/scripts/afk-install-artifacts.test.js
@@ -1,0 +1,74 @@
+/**
+ * Asserts the CI artifact surface needed for autonomous install of
+ * dev + local flavors on both Android devices and iPhones.
+ *
+ * Today's gap (audit 2026-05-21):
+ *   - Android dev:    pr-checks.yml uploads `dev-release-apk` ✓
+ *   - Android local:  NO local-debug build target in CI → no artifact
+ *   - iOS dev:        deploy-dev.yml exports an IPA to $RUNNER_TEMP
+ *                     but uploads only to TestFlight, no workflow
+ *                     artifact → can't be `gh run download`'d
+ *   - iOS local:      no Xcode scheme exists for local flavor →
+ *                     deferred; not covered by this test
+ *
+ * This PR adds the missing two artifact uploads so an AFK operator
+ * (or automation) can install fresh Android local / iOS dev builds
+ * without manual TestFlight invites or local builds.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const PR_CHECKS_PATH = path.join(REPO_ROOT, '.github/workflows/pr-checks.yml');
+const DEPLOY_DEV_PATH = path.join(REPO_ROOT, '.github/workflows/deploy-dev.yml');
+
+describe('CI artifact surface for AFK install', () => {
+  describe('pr-checks.yml — Android local-flavor APK', () => {
+    let yamlText;
+
+    beforeAll(() => {
+      yamlText = fs.readFileSync(PR_CHECKS_PATH, 'utf8');
+    });
+
+    test('runs assembleLocalDebug somewhere in the workflow', () => {
+      // Either alongside the existing assembleDevRelease or in a
+      // dedicated step — gradle is happy either way. Both build
+      // KMP shared once and reuse it for both flavors.
+      expect(yamlText).toMatch(/\bassembleLocalDebug\b/);
+    });
+
+    test('uploads the local-debug APK as a workflow artifact', () => {
+      // Operator pulls via `gh run download <run-id> -n local-debug-apk`
+      // mirroring the existing dev-release-apk download path.
+      expect(yamlText).toMatch(/name:\s+local-debug-apk/);
+    });
+  });
+
+  describe('deploy-dev.yml — iOS dev IPA artifact', () => {
+    let yamlText;
+
+    beforeAll(() => {
+      yamlText = fs.readFileSync(DEPLOY_DEV_PATH, 'utf8');
+    });
+
+    test('uploads the exported IPA as a workflow artifact', () => {
+      // The xcodebuild -exportArchive step already writes the IPA to
+      // $RUNNER_TEMP/export/*.ipa for the subsequent TestFlight upload
+      // step. We just need an actions/upload-artifact step in between
+      // (or after) so AFK install can grab it without needing a
+      // TestFlight tester invite.
+      expect(yamlText).toMatch(/name:\s+dev-ios-ipa/);
+    });
+
+    test('IPA artifact path points at the export directory', () => {
+      // The export dir is `${{ runner.temp }}/export` (Actions
+      // expression syntax — required in `path:` fields where shell
+      // env vars like $RUNNER_TEMP are NOT expanded). Asserting the
+      // path uses the runner.temp reference avoids a future
+      // move-the-IPA-elsewhere change silently breaking this.
+      expect(yamlText).toMatch(/name: dev-ios-ipa/);
+      expect(yamlText).toMatch(/path:\s+\$\{\{\s*runner\.temp\s*\}\}\/export\/\*\.ipa/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Enables AFK-driven install of every CI-buildable flavor/platform combo via `gh run download`. Closes the gap between today's "dev APK only" artifact surface and the operator policy of self-driving install on both devices.

## Coverage after this PR

| Combo | Artifact | Status |
|---|---|---|
| Android-dev | `dev-release-apk` | already there (unchanged) |
| **Android-local** | **`local-debug-apk`** | **NEW — added in pr-checks.yml** |
| **iOS-dev** | **`dev-ios-ipa`** | **NEW — added in deploy-dev.yml** |
| iOS-local | n/a | **deferred** — no Xcode scheme exists for local flavor |

## Changes
- `pr-checks.yml`: new "Build localDebug APK" + "Upload localDebug APK" steps, after the existing dev build. KMP shared is already compiled by the preceding step so this only adds the Android local-flavor link + APK package (~30-60s).
- `deploy-dev.yml`: `actions/upload-artifact` step between `exportArchive` and `Upload to TestFlight`. Surfaces `${{ runner.temp }}/export/*.ipa` as the `dev-ios-ipa` artifact with 7-day retention.

## iOS-local note
The iOS project has only one Xcode scheme (`iosApp.xcscheme`); there's no "local" flavor at the Xcode level. Adding one requires a Configuration + scheme + variant Info.plist pointing at localhost services — a meaningful project surgery. Not included here; iOS-local stays a follow-up.

## TDD
| Phase | Action | Result |
|---|---|---|
| Red | jest `tests/scripts/afk-install-artifacts.test.js` against current YAML | 4/4 fail (no local-flavor build, no IPA upload) |
| Green | Added both artifact uploads | 4/4 pass |
| Lint | actionlint + eslint + prettier + concurrency-scoping | clean |

## How operators / automation use this after merge

```bash
# Latest CI run id for HEAD on main
RUN_ID=$(gh api 'repos/ShydenMcM/ShyTalk/actions/workflows/pr-checks.yml/runs?branch=main&status=success&per_page=1' --jq '.workflow_runs[0].id')

# Android dev (already worked):
gh run download $RUN_ID -n dev-release-apk -R ShydenMcM/ShyTalk --dir /tmp/apk
adb install -r /tmp/apk/*.apk

# Android local (NEW):
gh run download $RUN_ID -n local-debug-apk -R ShydenMcM/ShyTalk --dir /tmp/apk
adb install -r /tmp/apk/*.apk

# iOS dev (NEW — via the most recent deploy-dev run):
DEV_RUN=$(gh api 'repos/ShydenMcM/ShyTalk/actions/workflows/deploy-dev.yml/runs?branch=main&status=success&per_page=1' --jq '.workflow_runs[0].id')
gh run download $DEV_RUN -n dev-ios-ipa -R ShydenMcM/ShyTalk --dir /tmp/ipa
xcrun devicectl device install app --device <UDID> /tmp/ipa/*.ipa
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)