### PR TITLE
ci: resource-diet the local stack for 8GB-MacBook journey testing

### DIFF
--- a/express-api/tests/scripts/local-stack-resource-diet.test.js
+++ b/express-api/tests/scripts/local-stack-resource-diet.test.js
@@ -131,13 +131,11 @@ describe('Local-stack resource diet', () => {
       expect(scriptText).not.toMatch(/^export JAVA_TOOL_OPTIONS=/m);
     });
 
-    // start.sh has a later `./gradlew` invocation (Step 7). Verify
-    // the firebase emulator launch precedes it, since the env-scoping
-    // depends on order: if gradlew ran first, env-prefix on a later
-    // command can't retroactively scope. Match the operative lines
-    // (the `env ... firebase emulators:start` line and the actual
-    // `cd ... && ./gradlew ...` line) rather than bare substrings,
-    // since both names also appear in comments earlier in the file.
+    // start.sh has a later `./gradlew assembleLocalDebug` invocation
+    // (Step 7). Verify the firebase emulator launch precedes it,
+    // since the env-scoping depends on order. Both names appear in
+    // comments earlier in the file, so we match operative-line
+    // patterns rather than bare substrings.
     test('the env-prefixed firebase launch runs before any gradlew invocation', () => {
       // Operative firebase line: starts with `env ` at column 0.
       const firebaseMatch = scriptText.match(
@@ -146,10 +144,52 @@ describe('Local-stack resource diet', () => {
       // Operative gradlew line: `./gradlew` preceded by whitespace
       // OR `&&` — i.e. actual shell command, not a comment word.
       const gradlewMatch = scriptText.match(/(?:&&|\s)\.\/gradlew\b/);
+      // I1 fix (round 2): both are REQUIRED to exist — without the
+      // gradlew call this whole ordering test is meaningless, and a
+      // PR that removes the gradlew call should fail loudly, not
+      // silently vacuously-pass.
       expect(firebaseMatch).not.toBeNull();
-      if (gradlewMatch !== null) {
-        expect(firebaseMatch.index).toBeLessThan(gradlewMatch.index);
-      }
+      expect(gradlewMatch).not.toBeNull();
+      expect(firebaseMatch.index).toBeLessThan(gradlewMatch.index);
+    });
+
+    // I2 fix (round 2): pin the trailing `&`. Without `&`, the script
+    // blocks at the firebase emulators:start call indefinitely and
+    // never reaches Step 3 onward. `FIREBASE_PID=$!` would capture
+    // the wrong PID (the shell's, not firebase's).
+    test('firebase emulator launch is backgrounded with trailing &', () => {
+      expect(scriptText).toMatch(/^ {2}--export-on-exit=local\/firebase-emulator-data &$/m);
+    });
+
+    // Coverage gap (round 2): pin the FIREBASE_PID=$! capture
+    // immediately after the firebase backgrounded command. A refactor
+    // that moves it or captures the wrong PID would break cleanup
+    // (the trap function relies on FIREBASE_PID being valid).
+    test('FIREBASE_PID is captured on the line immediately after the firebase & command', () => {
+      const lines = scriptText.split('\n');
+      const ampLineIdx = lines.findIndex((l) =>
+        l.match(/^ {2}--export-on-exit=local\/firebase-emulator-data &$/),
+      );
+      expect(ampLineIdx).toBeGreaterThanOrEqual(0);
+      expect(lines[ampLineIdx + 1]).toMatch(/^FIREBASE_PID=\$!$/);
+    });
+  });
+
+  // Coverage gap (round 2): exercise the error branch of
+  // extractServiceBlock so a malformed-yaml or renamed-service
+  // regression surfaces with the intended diagnostic, not a silent
+  // beforeAll crash that takes down every test in the file.
+  describe('extractServiceBlock helper — error branch', () => {
+    let yamlText;
+
+    beforeAll(() => {
+      yamlText = fs.readFileSync(COMPOSE_PATH, 'utf8');
+    });
+
+    test('throws a clear error for unknown service names', () => {
+      expect(() => extractServiceBlock(yamlText, 'nonexistent-service')).toThrow(
+        /Could not find service "nonexistent-service"/,
+      );
     });
   });
 });

--- a/express-api/tests/scripts/local-stack-resource-diet.test.js
+++ b/express-api/tests/scripts/local-stack-resource-diet.test.js
@@ -212,14 +212,41 @@ describe('Local-stack resource diet', () => {
       // a legitimate node invocation has no reason to contain `|`.
       const apiLine = lines[apiLineIdx];
       expect(apiLine.includes('|')).toBe(false);
+      // I2 fix (round 4): also pin that process substitution is the
+      // mechanism. Without this, a future edit to `> /dev/null` would
+      // pass the pipe-absence check while discarding all API output —
+      // silently regressing log visibility (the whole reason sed was
+      // there in the first place).
+      expect(apiLine.includes('>(')).toBe(true);
       expect(lines[apiLineIdx + 1]).toMatch(/^API_PID=\$!$/);
     });
 
     // Round-3 gap: pin the keep-alive `wait $FIREBASE_PID` line at
     // the end of start.sh. A rename of the PID variable would break
     // the script's "keep running until Ctrl+C" behaviour silently.
-    test('keep-alive at end of script waits on $FIREBASE_PID', () => {
-      expect(scriptText).toMatch(/^wait "?\$FIREBASE_PID"?$/m);
+    //
+    // Round-4 fix (C1): `|| true` is required. Under `set -e`, an
+    // unguarded `wait` propagates a non-zero exit code from a crashed
+    // Firebase emulator and aborts the shell BEFORE reaching the
+    // cleanup() call below. That leaves Docker containers running.
+    // `|| true` makes the wait fall through to cleanup regardless of
+    // Firebase's exit code.
+    test('keep-alive uses `wait $FIREBASE_PID || true` (guarded against set-e)', () => {
+      expect(scriptText).toMatch(/^wait "?\$FIREBASE_PID"? \|\| true$/m);
+    });
+
+    // Round-4 fix (I1): the keep-alive wait must be positioned AFTER
+    // the "Press Ctrl+C to stop..." banner — without this, a refactor
+    // moving the wait earlier (e.g., to step 3 for readiness) would
+    // pass the line-content test but break the run-until-Ctrl+C
+    // contract by hanging mid-startup before the user-facing banner.
+    test('keep-alive wait is positioned after the Press-Ctrl+C banner', () => {
+      const lines = scriptText.split('\n');
+      const bannerIdx = lines.findIndex((l) => l.includes('Press Ctrl+C'));
+      const waitIdx = lines.findIndex((l) => /^wait "?\$FIREBASE_PID"? \|\| true$/.test(l));
+      expect(bannerIdx).toBeGreaterThanOrEqual(0);
+      expect(waitIdx).toBeGreaterThanOrEqual(0);
+      expect(waitIdx).toBeGreaterThan(bannerIdx);
     });
   });
 

--- a/express-api/tests/scripts/local-stack-resource-diet.test.js
+++ b/express-api/tests/scripts/local-stack-resource-diet.test.js
@@ -100,6 +100,24 @@ describe('Local-stack resource diet', () => {
     test('mailpit has memswap_limit 128m (swap disabled)', () => {
       expect(mailpitBlock).toMatch(/^ {4}memswap_limit: 128m$/m);
     });
+
+    // Round-3 gap: pin the relationship mem_limit == memswap_limit so a
+    // future edit that touches only memswap_limit (intent: enable swap
+    // headroom) breaks loudly, surfacing the policy decision rather than
+    // silently passing the two independent value tests.
+    const memEqualitySpec = [
+      ['livekit', () => livekitBlock],
+      ['minio', () => minioBlock],
+      ['mailpit', () => mailpitBlock],
+    ];
+    test.each(memEqualitySpec)('%s mem_limit equals memswap_limit', (_, getBlock) => {
+      const block = getBlock();
+      const memLimit = block.match(/^ {4}mem_limit: (\S+)$/m)?.[1];
+      const memswapLimit = block.match(/^ {4}memswap_limit: (\S+)$/m)?.[1];
+      expect(memLimit).toBeDefined();
+      expect(memswapLimit).toBeDefined();
+      expect(memLimit).toBe(memswapLimit);
+    });
   });
 
   describe('start.sh — Firebase Emulator JVM heap cap is scoped to the firebase process', () => {
@@ -173,6 +191,36 @@ describe('Local-stack resource diet', () => {
       expect(ampLineIdx).toBeGreaterThanOrEqual(0);
       expect(lines[ampLineIdx + 1]).toMatch(/^FIREBASE_PID=\$!$/);
     });
+
+    // Round-3 gap (I3 — real bug): pin that the Express API's
+    // backgrounded `node` command captures `node`'s PID, not the PID
+    // of a downstream pipe command. The original line piped node
+    // through sed for colour-prefix, which makes `$!` capture sed's
+    // PID — cleanup would kill sed but orphan node, leaving the API
+    // port held open. The fix replaces the pipe with process
+    // substitution (`> >(sed ...) 2>&1`), so node remains the
+    // backgrounded process and $! captures it.
+    test('API_PID is captured immediately after a backgrounded node, with no pipe before &', () => {
+      const lines = scriptText.split('\n');
+      const apiLineIdx = lines.findIndex((l) => l.match(/\bnode src\/index\.js\b.*&\s*$/));
+      expect(apiLineIdx).toBeGreaterThanOrEqual(0);
+      // The line must NOT contain a pipe (`|`) — if it does, $!
+      // captures the last pipeline stage's PID, not node's. Process
+      // substitution `>(...)` is fine because the parens are not a
+      // pipe character. Plain `.includes('|')` is non-regex and
+      // can't backtrack — surface-level check is sufficient because
+      // a legitimate node invocation has no reason to contain `|`.
+      const apiLine = lines[apiLineIdx];
+      expect(apiLine.includes('|')).toBe(false);
+      expect(lines[apiLineIdx + 1]).toMatch(/^API_PID=\$!$/);
+    });
+
+    // Round-3 gap: pin the keep-alive `wait $FIREBASE_PID` line at
+    // the end of start.sh. A rename of the PID variable would break
+    // the script's "keep running until Ctrl+C" behaviour silently.
+    test('keep-alive at end of script waits on $FIREBASE_PID', () => {
+      expect(scriptText).toMatch(/^wait "?\$FIREBASE_PID"?$/m);
+    });
   });
 
   // Coverage gap (round 2): exercise the error branch of
@@ -189,6 +237,29 @@ describe('Local-stack resource diet', () => {
     test('throws a clear error for unknown service names', () => {
       expect(() => extractServiceBlock(yamlText, 'nonexistent-service')).toThrow(
         /Could not find service "nonexistent-service"/,
+      );
+    });
+
+    // Round-3 gap (I4): the helper constructs a RegExp from the
+    // service-name arg. A name with regex metacharacters (e.g.
+    // `livekit.*`) would build a valid but over-broad pattern.
+    // The helper has no input sanitisation — for now only
+    // hard-coded service names are passed, but a future
+    // dynamic-name caller would silently match the wrong block or
+    // hit confusing failures. Pin the failure-with-metachar case so
+    // a future input-sanitisation refactor is forced through TDD.
+    test('does not silently succeed for service names with regex metacharacters', () => {
+      // Currently `livekit.*` would match `^  livekit:` (since
+      // `.*` matches zero chars) — i.e. it WOULD pass through and
+      // return livekit's block, which is wrong. This test pins
+      // the current (limited) behaviour and forces the next caller
+      // who hits this case to add explicit sanitisation.
+      //
+      // Per the round-3 reviewer: this is a low-severity coverage
+      // gap, low-priority because no current caller passes user
+      // input. Pinning makes the gap visible.
+      expect(() => extractServiceBlock(yamlText, 'livekit.*nonexistent')).toThrow(
+        /Could not find service "livekit\.\*nonexistent"/,
       );
     });
   });

--- a/express-api/tests/scripts/local-stack-resource-diet.test.js
+++ b/express-api/tests/scripts/local-stack-resource-diet.test.js
@@ -1,24 +1,18 @@
 /**
  * Pins the local-stack memory caps so the 8GB MacBook can run the
- * full local Firebase Emulator + Docker stack + Express + Playwright
- * during journey testing without crossing the OOM threshold.
+ * full local Firebase Emulator + Docker stack during journey testing
+ * without crossing the OOM threshold.
  *
- * Without caps:
- *   - Docker containers default to "use whatever's available"; under
- *     load LiveKit + MinIO + Mailpit can balloon past 2 GB combined
- *   - Firebase Emulator JVM defaults to a ~4 GB heap on macOS
+ * Caps applied (rationale per service in the YAML comments):
+ *   - livekit:        256m  (Go binary)
+ *   - minio:          512m  (S3-like, small fixture data)
+ *   - mailpit:        128m  (in-memory SMTP sink)
+ *   - emulator JVM:   1g    (firestore + auth fixture sizes)
  *
- * Caps applied (rationale per service in the workflow comments):
- *   - livekit:  256m  — small Go server, no media transcoding in tests
- *   - minio:    512m  — S3-like; small fixture data only
- *   - mailpit:  128m  — tiny mail interceptor
- *   - emulator: 1g    — Java; firestore + auth + RTDB in one JVM
- *
- * Total local-stack ceiling: ~1.9 GB. Combined with the ~6 GB
- * baseline (Claude, MCPs, system services, browsers under test) this
- * leaves ~100 MB - 1 GB of headroom on an 8 GB Mac depending on what
- * else is open — sufficient if `feedback-prepush-sonar-no-verify-on-8gb`
- * style measures are also applied.
+ * Implementation: regex assertions on the raw YAML / shell text via
+ * an extract-per-service-block helper that anchors each assertion to
+ * a single block. Avoids the cross-boundary false-positive class
+ * caught by code-review on the first cut of this file.
  */
 
 const fs = require('fs');
@@ -28,63 +22,134 @@ const REPO_ROOT = path.resolve(__dirname, '../../..');
 const COMPOSE_PATH = path.join(REPO_ROOT, 'local/docker-compose.yml');
 const START_SH_PATH = path.join(REPO_ROOT, 'local/start.sh');
 
+/**
+ * Extract a single service's YAML block from docker-compose.yml so
+ * subsequent assertions are scoped to ONE service and can't drift
+ * across boundaries (e.g. asserting livekit's cap by accidentally
+ * matching minio's). Anchored on the `^  <name>:$` line and stops
+ * at the next `^  <word>:$` line.
+ */
+function extractServiceBlock(yamlText, serviceName) {
+  const lines = yamlText.split('\n');
+  const startPattern = new RegExp(`^  ${serviceName}:$`);
+  const nextServicePattern = /^ {2}\w[\w-]*:$/;
+  let inBlock = false;
+  const block = [];
+  for (const line of lines) {
+    if (startPattern.test(line)) {
+      inBlock = true;
+      continue;
+    }
+    if (inBlock) {
+      if (nextServicePattern.test(line)) break;
+      block.push(line);
+    }
+  }
+  if (!inBlock) {
+    throw new Error(
+      `Could not find service "${serviceName}" in ${COMPOSE_PATH}. ` +
+        'Service was renamed or removed — update this test to match.',
+    );
+  }
+  return block.join('\n');
+}
+
 describe('Local-stack resource diet', () => {
-  describe('docker-compose.yml — per-service mem_limit', () => {
+  describe('docker-compose.yml — per-service memory caps', () => {
     let yamlText;
+    let livekitBlock;
+    let minioBlock;
+    let mailpitBlock;
 
     beforeAll(() => {
       yamlText = fs.readFileSync(COMPOSE_PATH, 'utf8');
+      livekitBlock = extractServiceBlock(yamlText, 'livekit');
+      minioBlock = extractServiceBlock(yamlText, 'minio');
+      mailpitBlock = extractServiceBlock(yamlText, 'mailpit');
     });
 
-    test('livekit service has mem_limit 256m', () => {
-      // livekit-server is a Go binary; ~50-100MB steady-state.
-      // 256m caps it under load (peer connections, audio relay)
-      // without strangling the normal path.
-      expect(yamlText).toMatch(/^ {2}livekit:[\s\S]+?mem_limit:\s+256m/m);
+    // Service-body lines under a top-level `  service:` header are
+    // indented with exactly 4 spaces in this file's YAML style. Using
+    // ` {4}` (fixed-width) avoids sonarjs/slow-regex flagging on the
+    // unbounded `\s+` quantifier, and is also more precise.
+
+    // livekit — Go binary, ~50-100MB steady-state; 256m cap is generous
+    // but prevents balloon under voice-room peer-connection spikes.
+    test('livekit has mem_limit 256m', () => {
+      expect(livekitBlock).toMatch(/^ {4}mem_limit: 256m$/m);
     });
 
-    test('minio service has mem_limit 512m', () => {
-      // MinIO is more memory-hungry than livekit because it pages
-      // recent blocks. 512m is generous for the small fixture data
-      // we exercise in tests.
-      expect(yamlText).toMatch(/^ {2}minio:[\s\S]+?mem_limit:\s+512m/m);
+    test('livekit has memswap_limit 256m (swap disabled)', () => {
+      expect(livekitBlock).toMatch(/^ {4}memswap_limit: 256m$/m);
     });
 
-    test('mailpit service has mem_limit 128m', () => {
-      // Mailpit is a tiny in-memory SMTP sink — 128m is plenty.
-      expect(yamlText).toMatch(/^ {2}mailpit:[\s\S]+?mem_limit:\s+128m/m);
+    // minio — pages recent blocks; 512m is generous for fixture sizes.
+    test('minio has mem_limit 512m', () => {
+      expect(minioBlock).toMatch(/^ {4}mem_limit: 512m$/m);
+    });
+
+    test('minio has memswap_limit 512m (swap disabled)', () => {
+      expect(minioBlock).toMatch(/^ {4}memswap_limit: 512m$/m);
+    });
+
+    // mailpit — tiny in-memory SMTP sink, 128m is plenty.
+    test('mailpit has mem_limit 128m', () => {
+      expect(mailpitBlock).toMatch(/^ {4}mem_limit: 128m$/m);
+    });
+
+    test('mailpit has memswap_limit 128m (swap disabled)', () => {
+      expect(mailpitBlock).toMatch(/^ {4}memswap_limit: 128m$/m);
     });
   });
 
-  describe('start.sh — Firebase Emulator JVM heap cap', () => {
+  describe('start.sh — Firebase Emulator JVM heap cap is scoped to the firebase process', () => {
     let scriptText;
 
     beforeAll(() => {
       scriptText = fs.readFileSync(START_SH_PATH, 'utf8');
     });
 
-    test('JAVA_TOOL_OPTIONS sets -Xmx1g for firebase emulators:start', () => {
-      // The Firebase emulator suite runs Firestore + Auth + RTDB
-      // + UI in one JVM. Default heap is ~4 GB on macOS — overkill
-      // for our fixture sizes. Cap at 1g to free ~3 GB of headroom
-      // for browser-under-test + iOS-simulator-replacement work.
-      //
-      // `JAVA_TOOL_OPTIONS` is honoured by every JVM start in the
-      // shell scope, not just firebase's. That's intentional: any
-      // gradle/firebase-rules-deploy work that piggybacks on the
-      // running shell gets the same cap.
-      expect(scriptText).toMatch(/JAVA_TOOL_OPTIONS=.*-Xmx1g/);
+    // The cap is applied via `env VAR=val cmd` prefix so it scopes to
+    // the firebase CLI process only — NOT exported at shell-scope where
+    // it would leak into the later `./gradlew` invocation in Step 7
+    // and starve Kotlin compilation (which needs 2-4 GB heap).
+    test('uses env-prefix scoping, not a shell-scope export', () => {
+      // The operative line must be of the form
+      // `env JAVA_TOOL_OPTIONS="-Xmx1g" npx firebase emulators:start ...`
+      // anchored at line-start to skip comments that reference the
+      // identifier.
+      expect(scriptText).toMatch(/^env JAVA_TOOL_OPTIONS="-Xmx1g" npx firebase emulators:start/m);
     });
 
-    test('JAVA_TOOL_OPTIONS export precedes the emulator launch', () => {
-      // The env var must be in scope BEFORE `firebase emulators:start`
-      // runs — otherwise the spawned JVM uses the default heap. Use
-      // line-index comparison rather than a fragile regex.
-      const exportIdx = scriptText.indexOf('JAVA_TOOL_OPTIONS');
-      const launchIdx = scriptText.indexOf('firebase emulators:start');
-      expect(exportIdx).toBeGreaterThanOrEqual(0);
-      expect(launchIdx).toBeGreaterThanOrEqual(0);
-      expect(exportIdx).toBeLessThan(launchIdx);
+    // Defence-in-depth against C1 recurring: ensure a shell-scope
+    // `export JAVA_TOOL_OPTIONS=...` doesn't sneak back in. The
+    // env-prefix form above is the ONLY acceptable scoping.
+    test('does NOT export JAVA_TOOL_OPTIONS at shell scope (would leak into gradlew)', () => {
+      // Match `export JAVA_TOOL_OPTIONS` anchored at line-start so
+      // comments mentioning the identifier don't false-positive. The
+      // `env` prefix on the operative line doesn't match this pattern.
+      expect(scriptText).not.toMatch(/^export JAVA_TOOL_OPTIONS=/m);
+    });
+
+    // start.sh has a later `./gradlew` invocation (Step 7). Verify
+    // the firebase emulator launch precedes it, since the env-scoping
+    // depends on order: if gradlew ran first, env-prefix on a later
+    // command can't retroactively scope. Match the operative lines
+    // (the `env ... firebase emulators:start` line and the actual
+    // `cd ... && ./gradlew ...` line) rather than bare substrings,
+    // since both names also appear in comments earlier in the file.
+    test('the env-prefixed firebase launch runs before any gradlew invocation', () => {
+      // Operative firebase line: starts with `env ` at column 0.
+      const firebaseMatch = scriptText.match(
+        /^env JAVA_TOOL_OPTIONS=.*npx firebase emulators:start/m,
+      );
+      // Operative gradlew line: `./gradlew` preceded by whitespace
+      // OR `&&` — i.e. actual shell command, not a comment word.
+      const gradlewMatch = scriptText.match(/(?:&&|\s)\.\/gradlew\b/);
+      expect(firebaseMatch).not.toBeNull();
+      if (gradlewMatch !== null) {
+        expect(firebaseMatch.index).toBeLessThan(gradlewMatch.index);
+      }
     });
   });
 });

--- a/express-api/tests/scripts/local-stack-resource-diet.test.js
+++ b/express-api/tests/scripts/local-stack-resource-diet.test.js
@@ -1,0 +1,90 @@
+/**
+ * Pins the local-stack memory caps so the 8GB MacBook can run the
+ * full local Firebase Emulator + Docker stack + Express + Playwright
+ * during journey testing without crossing the OOM threshold.
+ *
+ * Without caps:
+ *   - Docker containers default to "use whatever's available"; under
+ *     load LiveKit + MinIO + Mailpit can balloon past 2 GB combined
+ *   - Firebase Emulator JVM defaults to a ~4 GB heap on macOS
+ *
+ * Caps applied (rationale per service in the workflow comments):
+ *   - livekit:  256m  — small Go server, no media transcoding in tests
+ *   - minio:    512m  — S3-like; small fixture data only
+ *   - mailpit:  128m  — tiny mail interceptor
+ *   - emulator: 1g    — Java; firestore + auth + RTDB in one JVM
+ *
+ * Total local-stack ceiling: ~1.9 GB. Combined with the ~6 GB
+ * baseline (Claude, MCPs, system services, browsers under test) this
+ * leaves ~100 MB - 1 GB of headroom on an 8 GB Mac depending on what
+ * else is open — sufficient if `feedback-prepush-sonar-no-verify-on-8gb`
+ * style measures are also applied.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const COMPOSE_PATH = path.join(REPO_ROOT, 'local/docker-compose.yml');
+const START_SH_PATH = path.join(REPO_ROOT, 'local/start.sh');
+
+describe('Local-stack resource diet', () => {
+  describe('docker-compose.yml — per-service mem_limit', () => {
+    let yamlText;
+
+    beforeAll(() => {
+      yamlText = fs.readFileSync(COMPOSE_PATH, 'utf8');
+    });
+
+    test('livekit service has mem_limit 256m', () => {
+      // livekit-server is a Go binary; ~50-100MB steady-state.
+      // 256m caps it under load (peer connections, audio relay)
+      // without strangling the normal path.
+      expect(yamlText).toMatch(/^ {2}livekit:[\s\S]+?mem_limit:\s+256m/m);
+    });
+
+    test('minio service has mem_limit 512m', () => {
+      // MinIO is more memory-hungry than livekit because it pages
+      // recent blocks. 512m is generous for the small fixture data
+      // we exercise in tests.
+      expect(yamlText).toMatch(/^ {2}minio:[\s\S]+?mem_limit:\s+512m/m);
+    });
+
+    test('mailpit service has mem_limit 128m', () => {
+      // Mailpit is a tiny in-memory SMTP sink — 128m is plenty.
+      expect(yamlText).toMatch(/^ {2}mailpit:[\s\S]+?mem_limit:\s+128m/m);
+    });
+  });
+
+  describe('start.sh — Firebase Emulator JVM heap cap', () => {
+    let scriptText;
+
+    beforeAll(() => {
+      scriptText = fs.readFileSync(START_SH_PATH, 'utf8');
+    });
+
+    test('JAVA_TOOL_OPTIONS sets -Xmx1g for firebase emulators:start', () => {
+      // The Firebase emulator suite runs Firestore + Auth + RTDB
+      // + UI in one JVM. Default heap is ~4 GB on macOS — overkill
+      // for our fixture sizes. Cap at 1g to free ~3 GB of headroom
+      // for browser-under-test + iOS-simulator-replacement work.
+      //
+      // `JAVA_TOOL_OPTIONS` is honoured by every JVM start in the
+      // shell scope, not just firebase's. That's intentional: any
+      // gradle/firebase-rules-deploy work that piggybacks on the
+      // running shell gets the same cap.
+      expect(scriptText).toMatch(/JAVA_TOOL_OPTIONS=.*-Xmx1g/);
+    });
+
+    test('JAVA_TOOL_OPTIONS export precedes the emulator launch', () => {
+      // The env var must be in scope BEFORE `firebase emulators:start`
+      // runs — otherwise the spawned JVM uses the default heap. Use
+      // line-index comparison rather than a fragile regex.
+      const exportIdx = scriptText.indexOf('JAVA_TOOL_OPTIONS');
+      const launchIdx = scriptText.indexOf('firebase emulators:start');
+      expect(exportIdx).toBeGreaterThanOrEqual(0);
+      expect(launchIdx).toBeGreaterThanOrEqual(0);
+      expect(exportIdx).toBeLessThan(launchIdx);
+    });
+  });
+});

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   livekit:
     image: livekit/livekit-server:v1.9.1
+    # Resource diet 2026-05-21: cap to 256m. livekit-server is a Go
+    # binary, ~50-100MB steady-state. The cap prevents balloon under
+    # peer-connection spikes during voice-room test scenarios. Pinned
+    # by tests/scripts/local-stack-resource-diet.test.js.
+    mem_limit: 256m
     ports:
       - "7880:7880"
       - "7881:7881"
@@ -12,6 +17,9 @@ services:
 
   minio:
     image: minio/minio:RELEASE.2025-03-12T18-04-18Z
+    # MinIO pages recent blocks; 512m is generous for fixture-sized
+    # objects in tests but caps runaway allocation.
+    mem_limit: 512m
     ports:
       - "9002:9000"
       - "9001:9001"
@@ -22,6 +30,8 @@ services:
 
   mailpit:
     image: axllent/mailpit:v1.21
+    # Tiny in-memory SMTP sink; 128m is plenty.
+    mem_limit: 128m
     ports:
       - "1025:1025"
       - "8025:8025"

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -5,7 +5,13 @@ services:
     # binary, ~50-100MB steady-state. The cap prevents balloon under
     # peer-connection spikes during voice-room test scenarios. Pinned
     # by tests/scripts/local-stack-resource-diet.test.js.
+    #
+    # memswap_limit equals mem_limit so Docker disables swap for this
+    # container. Without this, Docker's default doubles the effective
+    # memory to mem_limit + mem_limit-of-swap, silently degrading host
+    # performance under spike instead of failing loud at the cap.
     mem_limit: 256m
+    memswap_limit: 256m
     ports:
       - "7880:7880"
       - "7881:7881"
@@ -18,8 +24,9 @@ services:
   minio:
     image: minio/minio:RELEASE.2025-03-12T18-04-18Z
     # MinIO pages recent blocks; 512m is generous for fixture-sized
-    # objects in tests but caps runaway allocation.
+    # objects in tests. memswap_limit pinned equal to disable swap.
     mem_limit: 512m
+    memswap_limit: 512m
     ports:
       - "9002:9000"
       - "9001:9001"
@@ -30,8 +37,10 @@ services:
 
   mailpit:
     image: axllent/mailpit:v1.21
-    # Tiny in-memory SMTP sink; 128m is plenty.
+    # Tiny in-memory SMTP sink. memswap_limit pinned equal to disable
+    # swap (no balloon possible).
     mem_limit: 128m
+    memswap_limit: 128m
     ports:
       - "1025:1025"
       - "8025:8025"

--- a/local/start.sh
+++ b/local/start.sh
@@ -45,6 +45,15 @@ docker compose -f "$SCRIPT_DIR/docker-compose.yml" up -d
 # =============================================================================
 echo "==> Step 2/8: Starting Firebase Emulators..."
 cd "$PROJECT_ROOT"
+# Resource diet 2026-05-21: cap the Firebase emulator JVM heap at 1g.
+# Default heap on macOS is ~4 GB which is overkill for our fixture-sized
+# Firestore + Auth + RTDB data. Capping to 1g frees ~3 GB of headroom on
+# the 8 GB MacBook for browsers-under-test, gradle K/N, and the iOS
+# devicectl tunnel during journey-test cycles. JAVA_TOOL_OPTIONS is
+# honoured by every JVM start in scope — that's intentional: any
+# piggy-backed gradle / firebase-rules-deploy in the same shell gets
+# the same cap. Pinned by tests/scripts/local-stack-resource-diet.test.js.
+export JAVA_TOOL_OPTIONS="-Xmx1g"
 npx firebase emulators:start \
   --project=demo-shytalk \
   --import=local/firebase-emulator-data \

--- a/local/start.sh
+++ b/local/start.sh
@@ -46,15 +46,15 @@ docker compose -f "$SCRIPT_DIR/docker-compose.yml" up -d
 echo "==> Step 2/8: Starting Firebase Emulators..."
 cd "$PROJECT_ROOT"
 # Resource diet 2026-05-21: cap the Firebase emulator JVM heap at 1g.
-# Default heap on macOS is ~4 GB which is overkill for our fixture-sized
-# Firestore + Auth + RTDB data. Capping to 1g frees ~3 GB of headroom on
-# the 8 GB MacBook for browsers-under-test, gradle K/N, and the iOS
-# devicectl tunnel during journey-test cycles. JAVA_TOOL_OPTIONS is
-# honoured by every JVM start in scope — that's intentional: any
-# piggy-backed gradle / firebase-rules-deploy in the same shell gets
-# the same cap. Pinned by tests/scripts/local-stack-resource-diet.test.js.
-export JAVA_TOOL_OPTIONS="-Xmx1g"
-npx firebase emulators:start \
+# Default heap on macOS is ~4 GB which is overkill for fixture-sized
+# Firestore + Auth data. `env VAR=val cmd` scopes JAVA_TOOL_OPTIONS to
+# the firebase CLI process ONLY — it must NOT leak into later steps
+# like Step 7's `./gradlew assembleLocalDebug` which needs the full
+# Gradle daemon heap (Kotlin compile peaks at 2-4 GB; capping it to
+# 1g would OOM the build). `$!` after `env … cmd &` still captures
+# the right PID because env exec()s into cmd via execvp.
+# Pinned by tests/scripts/local-stack-resource-diet.test.js.
+env JAVA_TOOL_OPTIONS="-Xmx1g" npx firebase emulators:start \
   --project=demo-shytalk \
   --import=local/firebase-emulator-data \
   --export-on-exit=local/firebase-emulator-data &

--- a/local/start.sh
+++ b/local/start.sh
@@ -99,7 +99,15 @@ echo "==> Step 4/8: Seeding data..."
 # Step 5: Start Express API (background)
 # =============================================================================
 echo "==> Step 5/8: Starting Express API..."
-cd "$PROJECT_ROOT/express-api" && NODE_ENV=local TEST_API_KEY=local-test-key node src/index.js 2>&1 | sed 's/^/[API] /' &
+# Use process substitution `> >(sed ...)` instead of a pipe so the
+# colour-prefix on stdout doesn't make `$!` capture sed's PID
+# instead of node's. The pre-substitution form (`node ... | sed ... &`)
+# made `API_PID=$!` capture sed; cleanup's `kill "$API_PID"` killed
+# sed but orphaned node, leaving port 3000 held open across runs.
+# With process substitution, node remains the operative backgrounded
+# process and $! captures it. Pinned by
+# tests/scripts/local-stack-resource-diet.test.js (round 3 fix).
+cd "$PROJECT_ROOT/express-api" && NODE_ENV=local TEST_API_KEY=local-test-key node src/index.js > >(sed 's/^/[API] /') 2>&1 &
 API_PID=$!
 cd "$PROJECT_ROOT"
 

--- a/local/start.sh
+++ b/local/start.sh
@@ -177,7 +177,15 @@ echo "  View Allure:      npx allure serve allure-results"
 echo ""
 echo "Press Ctrl+C to stop..."
 
-# Keep running until Ctrl+C
-wait $FIREBASE_PID
+# Keep running until Ctrl+C. The `|| true` is required: this script
+# runs under `set -e` (line 2), and `wait` returns Firebase's exit
+# code on natural Firebase termination. On a Firebase crash (non-zero
+# exit), the unguarded `wait` would abort the shell via set -e BEFORE
+# reaching the cleanup() call below — leaving Docker containers
+# (LiveKit, MinIO, Mailpit) running indefinitely. The existing INT/TERM
+# trap covers Ctrl+C, not set-e-induced exits. `|| true` makes the
+# wait fall through to the cleanup line regardless of Firebase's
+# exit code. Pinned by tests/scripts/local-stack-resource-diet.test.js.
+wait $FIREBASE_PID || true
 echo "Firebase emulators exited."
 cleanup


### PR DESCRIPTION
## Summary
Phase 1 of the 2026-05-21 sequential build-out. Caps memory defaults on local-stack services so the full journey-test phase fits on the 8GB Mac without OOM.

## Changes
| File | Change |
|---|---|
| `local/docker-compose.yml` | `mem_limit:` on each service — livekit 256m / minio 512m / mailpit 128m |
| `local/start.sh` | `export JAVA_TOOL_OPTIONS="-Xmx1g"` before `firebase emulators:start` (caps Firebase emulator JVM heap from ~4 GB default to 1 GB) |
| `tests/scripts/local-stack-resource-diet.test.js` | 5 jest assertions pinning each cap |

## Math
Total local-stack ceiling after diet: ~1.9 GB (vs effectively-unbounded today). With ~6 GB baseline (Claude, MCPs, system, browsers), this leaves ~100 MB–1 GB of headroom — sufficient when combined with [feedback-prepush-sonar-no-verify-on-8gb](https://github.com/anthropics/claude-code/blob/main) discipline.

## TDD trace
| Phase | Action | Result |
|---|---|---|
| Red | jest against pre-diet config | 5/5 fail (no mem_limits, no JAVA_TOOL_OPTIONS) |
| Green | Applied the caps | 5/5 pass |
| Lint | eslint + prettier + actionlint | clean |

## Workflow
Continuous-review-loop policy: this PR enters `code-reviewer` agent review next. Auto-merge when zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)