### PR TITLE
ci: expose local-debug-apk + dev-ios-ipa as downloadable artifacts

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -630,6 +630,11 @@ jobs:
         with:
           name: dev-ios-ipa
           path: ${{ runner.temp }}/export/*.ipa
+          # if-no-files-found: error — the upstream step already
+          # validates IPA count via shell glob + exit 1, so this is
+          # defence-in-depth. Without it, an unexpected file-naming
+          # change could silently upload an empty artifact.
+          if-no-files-found: error
           retention-days: 7
 
       - name: Upload to TestFlight

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -618,6 +618,20 @@ jobs:
           fi
           echo "Exported IPA: ${ipas[0]} ($(du -h "${ipas[0]}" | cut -f1))"
 
+      # Surface the IPA as a workflow artifact so an AFK operator can
+      # pull it via `gh run download <run-id> -n dev-ios-ipa` and
+      # install on a physical iPhone via
+      # `xcrun devicectl device install app --device <UDID> path/to/*.ipa`
+      # without needing a TestFlight tester invite + waiting for App
+      # Store Connect processing. TestFlight upload still happens in
+      # the next step for the normal tester-distribution flow.
+      - name: Upload IPA as workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dev-ios-ipa
+          path: ${{ runner.temp }}/export/*.ipa
+          retention-days: 7
+
       - name: Upload to TestFlight
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -154,10 +154,14 @@ jobs:
       # KMP shared framework is already compiled by assembleDevRelease
       # above; this only adds the Android local-flavor link + package
       # step (~30-60s incremental cost).
+      #
+      # No env vars needed: the `local` flavor hardcodes its LiveKit
+      # URL (`ws://$localHostAlias:7880`) and DEV_QA_PERSONAS_PASSWORD
+      # (`localdev123`) in app/build.gradle.kts, and `assembleLocalDebug`
+      # uses the debug build type which does NOT reference the release
+      # signing config (so KEYSTORE_PASSWORD is dead). Removing them
+      # avoids misleading future maintainers.
       - name: Build localDebug APK
-        env:
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD || 'android' }}
-          LIVEKIT_URL: ${{ secrets.LIVEKIT_URL || 'wss://placeholder.livekit.cloud' }}
         run: ./gradlew assembleLocalDebug
 
       - name: Upload localDebug APK
@@ -165,6 +169,13 @@ jobs:
         with:
           name: local-debug-apk
           path: app/build/outputs/apk/local/debug/*.apk
+          # if-no-files-found: error — failing-loud when the glob
+          # matches zero files. Default `warn` would produce a
+          # SUCCESSFUL empty-zip upload, breaking AFK install
+          # silently (gh run download would succeed with an empty
+          # directory).
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Publish unit test report
         uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -148,6 +148,24 @@ jobs:
           DEV_QA_PERSONAS_PASSWORD: ${{ secrets.DEV_QA_PERSONAS_PASSWORD }}
         run: ./gradlew testDevDebugUnitTest :shared:jvmTest detekt assembleDevRelease jacocoDevDebugUnitTestReport --parallel
 
+      # Also build the local-flavor APK so AFK operators / automation
+      # can install it on test devices without needing a local Firebase
+      # emulator + Express stack running just to produce the APK. The
+      # KMP shared framework is already compiled by assembleDevRelease
+      # above; this only adds the Android local-flavor link + package
+      # step (~30-60s incremental cost).
+      - name: Build localDebug APK
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD || 'android' }}
+          LIVEKIT_URL: ${{ secrets.LIVEKIT_URL || 'wss://placeholder.livekit.cloud' }}
+        run: ./gradlew assembleLocalDebug
+
+      - name: Upload localDebug APK
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: local-debug-apk
+          path: app/build/outputs/apk/local/debug/*.apk
+
       - name: Publish unit test report
         uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2
         if: always()

--- a/express-api/tests/scripts/afk-install-artifacts.test.js
+++ b/express-api/tests/scripts/afk-install-artifacts.test.js
@@ -1,0 +1,89 @@
+/**
+ * Asserts the CI artifact surface needed for autonomous install of
+ * dev + local flavors on both physical devices (OnePlus + iPhone).
+ *
+ * Today's gap (audit 2026-05-21):
+ *   - Android dev:    pr-checks.yml uploads `dev-release-apk` ✓
+ *   - Android local:  no local-flavor build target in CI → no artifact
+ *   - iOS dev:        deploy-dev.yml exports an IPA to ${runner.temp}
+ *                     but uploads only to TestFlight, no workflow
+ *                     artifact → `gh run download` can't pull it
+ *   - iOS local:      no Xcode scheme exists for local flavor —
+ *                     covered by Phase 3, not this PR
+ *
+ * This PR adds the two missing artifact uploads so an AFK operator
+ * (or automation) can install fresh Android local / iOS dev builds
+ * without manual TestFlight invites or local builds.
+ *
+ * Implementation: regex assertions on the raw YAML, anchored to the
+ * specific workflow + step structure to avoid cross-step drift.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const PR_CHECKS_PATH = path.join(REPO_ROOT, '.github/workflows/pr-checks.yml');
+const DEPLOY_DEV_PATH = path.join(REPO_ROOT, '.github/workflows/deploy-dev.yml');
+
+describe('CI artifact surface for AFK install', () => {
+  describe('pr-checks.yml — Android local-flavor APK', () => {
+    let yamlText;
+
+    beforeAll(() => {
+      yamlText = fs.readFileSync(PR_CHECKS_PATH, 'utf8');
+    });
+
+    test('runs assembleLocalDebug somewhere in the workflow', () => {
+      // Either as its own step or alongside the existing
+      // assembleDevRelease. The KMP shared framework is compiled once
+      // and reused for both flavors so the incremental cost is low.
+      expect(yamlText).toMatch(/\bassembleLocalDebug\b/);
+    });
+
+    test('uploads the local-debug APK as a workflow artifact named local-debug-apk', () => {
+      // Operator pulls via `gh run download <run-id> -n local-debug-apk`
+      // mirroring the existing dev-release-apk download path.
+      expect(yamlText).toMatch(/name:\s+local-debug-apk/);
+    });
+
+    test('the local-debug-apk path points at the gradle output dir', () => {
+      // gradle's assembleLocalDebug emits to
+      // `app/build/outputs/apk/local/debug/`. Slice + substring match
+      // rather than multi-line regex to avoid sonarjs backtracking
+      // flags — we narrow to the ~200 chars after the `name:` line
+      // and assert the path substring appears within that window.
+      const nameIdx = yamlText.indexOf('name: local-debug-apk');
+      expect(nameIdx).toBeGreaterThanOrEqual(0);
+      const sliceAfter = yamlText.slice(nameIdx, nameIdx + 200);
+      expect(sliceAfter).toContain('path: app/build/outputs/apk/local/debug/*.apk');
+    });
+  });
+
+  describe('deploy-dev.yml — iOS dev IPA artifact', () => {
+    let yamlText;
+
+    beforeAll(() => {
+      yamlText = fs.readFileSync(DEPLOY_DEV_PATH, 'utf8');
+    });
+
+    test('uploads the exported IPA as a workflow artifact named dev-ios-ipa', () => {
+      // The xcodebuild -exportArchive step writes the IPA to
+      // ${runner.temp}/export/*.ipa for the subsequent TestFlight
+      // upload. We add a workflow-artifact upload between (or after)
+      // so AFK install can grab it without a TestFlight tester invite.
+      expect(yamlText).toMatch(/name:\s+dev-ios-ipa/);
+    });
+
+    test('dev-ios-ipa path points at the runner.temp export directory', () => {
+      // Actions-expression `${{ runner.temp }}` is required here —
+      // shell-env `$RUNNER_TEMP` is NOT expanded in the `path:` field
+      // of an `actions/upload-artifact` step. Slice + substring match
+      // for the same reason as the local-debug-apk test above.
+      const nameIdx = yamlText.indexOf('name: dev-ios-ipa');
+      expect(nameIdx).toBeGreaterThanOrEqual(0);
+      const sliceAfter = yamlText.slice(nameIdx, nameIdx + 200);
+      expect(sliceAfter).toContain('path: ${{ runner.temp }}/export/*.ipa');
+    });
+  });
+});

--- a/express-api/tests/scripts/afk-install-artifacts.test.js
+++ b/express-api/tests/scripts/afk-install-artifacts.test.js
@@ -2,21 +2,25 @@
  * Asserts the CI artifact surface needed for autonomous install of
  * dev + local flavors on both physical devices (OnePlus + iPhone).
  *
- * Today's gap (audit 2026-05-21):
- *   - Android dev:    pr-checks.yml uploads `dev-release-apk` ✓
- *   - Android local:  no local-flavor build target in CI → no artifact
- *   - iOS dev:        deploy-dev.yml exports an IPA to ${runner.temp}
- *                     but uploads only to TestFlight, no workflow
- *                     artifact → `gh run download` can't pull it
- *   - iOS local:      no Xcode scheme exists for local flavor —
- *                     covered by Phase 3, not this PR
+ * Coverage after PR #713:
+ *   - Android dev:    pr-checks.yml uploads `dev-release-apk` (pre-existing)
+ *   - Android local:  pr-checks.yml uploads `local-debug-apk`   (this PR)
+ *   - iOS dev:        deploy-dev.yml uploads `dev-ios-ipa`       (this PR)
+ *   - iOS local:      out of scope — no Xcode scheme exists (Phase 3)
  *
- * This PR adds the two missing artifact uploads so an AFK operator
- * (or automation) can install fresh Android local / iOS dev builds
- * without manual TestFlight invites or local builds.
+ * Each upload pins:
+ *   - name (artifact identifier for `gh run download`)
+ *   - path (gradle output dir / runner.temp export dir)
+ *   - if-no-files-found: error  (fail loud on empty glob — without
+ *     this, the default `warn` produces a successful empty-zip
+ *     upload that breaks AFK install silently)
+ *   - retention-days: 7 (matched between APK and IPA for consistency)
  *
- * Implementation: regex assertions on the raw YAML, anchored to the
- * specific workflow + step structure to avoid cross-step drift.
+ * Implementation: block-extraction helper similar to the Phase 1
+ * pattern in `local-stack-resource-diet.test.js` /
+ * `pr-checks-ios-gating.test.js`. Anchors each assertion to a
+ * specific upload-artifact step block so a comment elsewhere in
+ * the YAML mentioning the artifact name can't drift the match.
  */
 
 const fs = require('fs');
@@ -26,64 +30,124 @@ const REPO_ROOT = path.resolve(__dirname, '../../..');
 const PR_CHECKS_PATH = path.join(REPO_ROOT, '.github/workflows/pr-checks.yml');
 const DEPLOY_DEV_PATH = path.join(REPO_ROOT, '.github/workflows/deploy-dev.yml');
 
+/**
+ * Extract an `actions/upload-artifact` step block by its artifact
+ * `name:` value. Returns the YAML text from the `- name: Upload …`
+ * step header through the end of that step's `with:` block (i.e.
+ * up to the next `      - name:` step header or the next top-level
+ * key). Anchors assertions to a single step so they can't drift to
+ * another step's `with:` block.
+ */
+function extractUploadStep(yamlText, artifactName) {
+  const lines = yamlText.split('\n');
+  const nameLine = `          name: ${artifactName}`;
+  const startIdx = lines.findIndex((l) => l === nameLine);
+  if (startIdx < 0) {
+    throw new Error(
+      `Could not find upload-artifact step for name "${artifactName}". ` +
+        'Step was renamed, removed, or indentation changed.',
+    );
+  }
+  // From the name line, walk back to the step header `- name: …`
+  let headerIdx = startIdx;
+  while (headerIdx > 0 && !lines[headerIdx].match(/^ {6}- name:/)) headerIdx--;
+  // From the name line, walk forward until the next `      - name:`
+  // step header or `^[a-zA-Z]` top-level key.
+  let endIdx = startIdx + 1;
+  while (endIdx < lines.length) {
+    if (lines[endIdx].match(/^ {6}- name:/)) break;
+    if (lines[endIdx].match(/^[a-zA-Z_]/)) break;
+    endIdx++;
+  }
+  return lines.slice(headerIdx, endIdx).join('\n');
+}
+
 describe('CI artifact surface for AFK install', () => {
   describe('pr-checks.yml — Android local-flavor APK', () => {
+    let yamlText;
+    let uploadBlock;
+
+    beforeAll(() => {
+      yamlText = fs.readFileSync(PR_CHECKS_PATH, 'utf8');
+      uploadBlock = extractUploadStep(yamlText, 'local-debug-apk');
+    });
+
+    test('runs assembleLocalDebug somewhere in the workflow', () => {
+      expect(yamlText).toMatch(/\bassembleLocalDebug\b/);
+    });
+
+    test('upload step uses the local-debug-apk artifact name', () => {
+      expect(uploadBlock).toContain('name: local-debug-apk');
+    });
+
+    test('path points at the gradle local-debug output dir', () => {
+      expect(uploadBlock).toContain('path: app/build/outputs/apk/local/debug/*.apk');
+    });
+
+    test('if-no-files-found: error (fail loud on empty glob)', () => {
+      // Default `warn` would silently produce an empty zip — gh run
+      // download would succeed with an empty dir, breaking AFK
+      // install. `error` is the only acceptable value here.
+      expect(uploadBlock).toContain('if-no-files-found: error');
+    });
+
+    test('retention-days is set (avoids 90-day default accumulation)', () => {
+      expect(uploadBlock).toMatch(/^ {10}retention-days: 7$/m);
+    });
+  });
+
+  describe('deploy-dev.yml — iOS dev IPA artifact', () => {
+    let yamlText;
+    let uploadBlock;
+
+    beforeAll(() => {
+      yamlText = fs.readFileSync(DEPLOY_DEV_PATH, 'utf8');
+      uploadBlock = extractUploadStep(yamlText, 'dev-ios-ipa');
+    });
+
+    test('upload step uses the dev-ios-ipa artifact name', () => {
+      expect(uploadBlock).toContain('name: dev-ios-ipa');
+    });
+
+    test('path points at the runner.temp export directory', () => {
+      // Actions-expression `${{ runner.temp }}` is required here —
+      // shell-env `$RUNNER_TEMP` is NOT expanded in the `path:`
+      // field of an upload-artifact step.
+      expect(uploadBlock).toContain('path: ${{ runner.temp }}/export/*.ipa');
+    });
+
+    test('if-no-files-found: error (defence-in-depth for naming changes)', () => {
+      expect(uploadBlock).toContain('if-no-files-found: error');
+    });
+
+    test('retention-days is 7 (matches APK retention for consistency)', () => {
+      expect(uploadBlock).toMatch(/^ {10}retention-days: 7$/m);
+    });
+
+    test('upload step runs BEFORE the TestFlight upload step', () => {
+      // The IPA artifact must be uploaded before the TestFlight
+      // upload step. If the order were reversed, a TestFlight
+      // failure could short-circuit the workflow before the
+      // operator-facing artifact was produced.
+      const uploadStepIdx = yamlText.indexOf('name: dev-ios-ipa');
+      const testflightStepIdx = yamlText.indexOf('Upload to TestFlight');
+      expect(uploadStepIdx).toBeGreaterThanOrEqual(0);
+      expect(testflightStepIdx).toBeGreaterThanOrEqual(0);
+      expect(uploadStepIdx).toBeLessThan(testflightStepIdx);
+    });
+  });
+
+  describe('extractUploadStep helper — error branch', () => {
     let yamlText;
 
     beforeAll(() => {
       yamlText = fs.readFileSync(PR_CHECKS_PATH, 'utf8');
     });
 
-    test('runs assembleLocalDebug somewhere in the workflow', () => {
-      // Either as its own step or alongside the existing
-      // assembleDevRelease. The KMP shared framework is compiled once
-      // and reused for both flavors so the incremental cost is low.
-      expect(yamlText).toMatch(/\bassembleLocalDebug\b/);
-    });
-
-    test('uploads the local-debug APK as a workflow artifact named local-debug-apk', () => {
-      // Operator pulls via `gh run download <run-id> -n local-debug-apk`
-      // mirroring the existing dev-release-apk download path.
-      expect(yamlText).toMatch(/name:\s+local-debug-apk/);
-    });
-
-    test('the local-debug-apk path points at the gradle output dir', () => {
-      // gradle's assembleLocalDebug emits to
-      // `app/build/outputs/apk/local/debug/`. Slice + substring match
-      // rather than multi-line regex to avoid sonarjs backtracking
-      // flags — we narrow to the ~200 chars after the `name:` line
-      // and assert the path substring appears within that window.
-      const nameIdx = yamlText.indexOf('name: local-debug-apk');
-      expect(nameIdx).toBeGreaterThanOrEqual(0);
-      const sliceAfter = yamlText.slice(nameIdx, nameIdx + 200);
-      expect(sliceAfter).toContain('path: app/build/outputs/apk/local/debug/*.apk');
-    });
-  });
-
-  describe('deploy-dev.yml — iOS dev IPA artifact', () => {
-    let yamlText;
-
-    beforeAll(() => {
-      yamlText = fs.readFileSync(DEPLOY_DEV_PATH, 'utf8');
-    });
-
-    test('uploads the exported IPA as a workflow artifact named dev-ios-ipa', () => {
-      // The xcodebuild -exportArchive step writes the IPA to
-      // ${runner.temp}/export/*.ipa for the subsequent TestFlight
-      // upload. We add a workflow-artifact upload between (or after)
-      // so AFK install can grab it without a TestFlight tester invite.
-      expect(yamlText).toMatch(/name:\s+dev-ios-ipa/);
-    });
-
-    test('dev-ios-ipa path points at the runner.temp export directory', () => {
-      // Actions-expression `${{ runner.temp }}` is required here —
-      // shell-env `$RUNNER_TEMP` is NOT expanded in the `path:` field
-      // of an `actions/upload-artifact` step. Slice + substring match
-      // for the same reason as the local-debug-apk test above.
-      const nameIdx = yamlText.indexOf('name: dev-ios-ipa');
-      expect(nameIdx).toBeGreaterThanOrEqual(0);
-      const sliceAfter = yamlText.slice(nameIdx, nameIdx + 200);
-      expect(sliceAfter).toContain('path: ${{ runner.temp }}/export/*.ipa');
+    test('throws a clear error for unknown artifact names', () => {
+      expect(() => extractUploadStep(yamlText, 'nonexistent-artifact')).toThrow(
+        /Could not find upload-artifact step for name "nonexistent-artifact"/,
+      );
     });
   });
 });

--- a/express-api/tests/scripts/afk-install-artifacts.test.js
+++ b/express-api/tests/scripts/afk-install-artifacts.test.js
@@ -11,16 +11,13 @@
  * Each upload pins:
  *   - name (artifact identifier for `gh run download`)
  *   - path (gradle output dir / runner.temp export dir)
- *   - if-no-files-found: error  (fail loud on empty glob — without
- *     this, the default `warn` produces a successful empty-zip
- *     upload that breaks AFK install silently)
- *   - retention-days: 7 (matched between APK and IPA for consistency)
+ *   - if-no-files-found: error  (fail loud on empty glob)
+ *   - retention-days: 7
  *
- * Implementation: block-extraction helper similar to the Phase 1
- * pattern in `local-stack-resource-diet.test.js` /
- * `pr-checks-ios-gating.test.js`. Anchors each assertion to a
- * specific upload-artifact step block so a comment elsewhere in
- * the YAML mentioning the artifact name can't drift the match.
+ * Implementation: an `extractStep(yaml, stepName)` helper that
+ * matches step header by exact string equality (no regex
+ * backtracking, no anchor-to-comment drift class). All assertions
+ * are scoped to a specific step block.
  */
 
 const fs = require('fs');
@@ -31,67 +28,84 @@ const PR_CHECKS_PATH = path.join(REPO_ROOT, '.github/workflows/pr-checks.yml');
 const DEPLOY_DEV_PATH = path.join(REPO_ROOT, '.github/workflows/deploy-dev.yml');
 
 /**
- * Extract an `actions/upload-artifact` step block by its artifact
- * `name:` value. Returns the YAML text from the `- name: Upload …`
- * step header through the end of that step's `with:` block (i.e.
- * up to the next `      - name:` step header or the next top-level
- * key). Anchors assertions to a single step so they can't drift to
- * another step's `with:` block.
+ * Extract a workflow step's full YAML block by its `- name:` header.
+ *
+ * Walks the file line-by-line, finds the exact `      - name: <stepName>`
+ * header line (6-space indent, step-list level), then captures every
+ * subsequent line until the next `      - name:` step header or the
+ * next top-level YAML key (column 0). Returns the joined block.
+ *
+ * Exact string equality on the header line (not regex) eliminates the
+ * anchor-to-comment-class of bug: a comment elsewhere in the file
+ * containing the step name can't match because comments are prefixed
+ * with `#` and don't equal the literal header string.
  */
-function extractUploadStep(yamlText, artifactName) {
+function extractStep(yamlText, stepName) {
   const lines = yamlText.split('\n');
-  const nameLine = `          name: ${artifactName}`;
-  const startIdx = lines.findIndex((l) => l === nameLine);
+  const stepHeader = `      - name: ${stepName}`;
+  const startIdx = lines.findIndex((l) => l === stepHeader);
   if (startIdx < 0) {
     throw new Error(
-      `Could not find upload-artifact step for name "${artifactName}". ` +
-        'Step was renamed, removed, or indentation changed.',
+      `Could not find step "${stepName}" in workflow file. ` +
+        'Step was renamed, removed, or indentation changed — ' +
+        'update this test to match.',
     );
   }
-  // From the name line, walk back to the step header `- name: …`
-  let headerIdx = startIdx;
-  while (headerIdx > 0 && !lines[headerIdx].match(/^ {6}- name:/)) headerIdx--;
-  // From the name line, walk forward until the next `      - name:`
-  // step header or `^[a-zA-Z]` top-level key.
   let endIdx = startIdx + 1;
   while (endIdx < lines.length) {
-    if (lines[endIdx].match(/^ {6}- name:/)) break;
-    if (lines[endIdx].match(/^[a-zA-Z_]/)) break;
+    // Next step header at the same indent level terminates this block.
+    if (lines[endIdx].startsWith('      - name:')) break;
+    // Top-level YAML key (column 0, non-comment) also terminates.
+    if (lines[endIdx].length > 0 && !lines[endIdx].startsWith(' ')) break;
     endIdx++;
   }
-  return lines.slice(headerIdx, endIdx).join('\n');
+  return lines.slice(startIdx, endIdx).join('\n');
 }
 
 describe('CI artifact surface for AFK install', () => {
   describe('pr-checks.yml — Android local-flavor APK', () => {
     let yamlText;
+    let buildBlock;
     let uploadBlock;
 
     beforeAll(() => {
       yamlText = fs.readFileSync(PR_CHECKS_PATH, 'utf8');
-      uploadBlock = extractUploadStep(yamlText, 'local-debug-apk');
+      buildBlock = extractStep(yamlText, 'Build localDebug APK');
+      uploadBlock = extractStep(yamlText, 'Upload localDebug APK');
     });
 
-    test('runs assembleLocalDebug somewhere in the workflow', () => {
-      expect(yamlText).toMatch(/\bassembleLocalDebug\b/);
+    test('Build localDebug APK step runs assembleLocalDebug', () => {
+      expect(buildBlock).toContain('./gradlew assembleLocalDebug');
     });
 
-    test('upload step uses the local-debug-apk artifact name', () => {
+    test('Build localDebug APK step has no dead env vars (KEYSTORE_PASSWORD, LIVEKIT_URL)', () => {
+      // The `local` flavor hardcodes both values in
+      // app/build.gradle.kts (LIVEKIT_URL as `ws://$localHostAlias:7880`,
+      // KEYSTORE_PASSWORD is only consumed by signingConfigs.release
+      // which the debug build type doesn't reference). Carrying these
+      // env vars over from the dev step would mislead future
+      // maintainers into thinking the local-debug build needs
+      // release-signing credentials.
+      expect(buildBlock).not.toContain('KEYSTORE_PASSWORD');
+      expect(buildBlock).not.toContain('LIVEKIT_URL');
+    });
+
+    test('Upload localDebug APK step uses the local-debug-apk artifact name', () => {
       expect(uploadBlock).toContain('name: local-debug-apk');
     });
 
-    test('path points at the gradle local-debug output dir', () => {
+    test('Upload localDebug APK path points at the gradle local-debug output dir', () => {
       expect(uploadBlock).toContain('path: app/build/outputs/apk/local/debug/*.apk');
     });
 
-    test('if-no-files-found: error (fail loud on empty glob)', () => {
+    test('Upload localDebug APK uses if-no-files-found: error (fail loud on empty glob)', () => {
       // Default `warn` would silently produce an empty zip — gh run
       // download would succeed with an empty dir, breaking AFK
       // install. `error` is the only acceptable value here.
       expect(uploadBlock).toContain('if-no-files-found: error');
     });
 
-    test('retention-days is set (avoids 90-day default accumulation)', () => {
+    test('Upload localDebug APK has retention-days: 7 (matches IPA retention)', () => {
       expect(uploadBlock).toMatch(/^ {10}retention-days: 7$/m);
     });
   });
@@ -102,51 +116,51 @@ describe('CI artifact surface for AFK install', () => {
 
     beforeAll(() => {
       yamlText = fs.readFileSync(DEPLOY_DEV_PATH, 'utf8');
-      uploadBlock = extractUploadStep(yamlText, 'dev-ios-ipa');
+      uploadBlock = extractStep(yamlText, 'Upload IPA as workflow artifact');
     });
 
-    test('upload step uses the dev-ios-ipa artifact name', () => {
+    test('Upload IPA step uses the dev-ios-ipa artifact name', () => {
       expect(uploadBlock).toContain('name: dev-ios-ipa');
     });
 
-    test('path points at the runner.temp export directory', () => {
+    test('Upload IPA path points at the runner.temp export directory', () => {
       // Actions-expression `${{ runner.temp }}` is required here —
       // shell-env `$RUNNER_TEMP` is NOT expanded in the `path:`
       // field of an upload-artifact step.
       expect(uploadBlock).toContain('path: ${{ runner.temp }}/export/*.ipa');
     });
 
-    test('if-no-files-found: error (defence-in-depth for naming changes)', () => {
+    test('Upload IPA uses if-no-files-found: error (defence-in-depth for naming changes)', () => {
       expect(uploadBlock).toContain('if-no-files-found: error');
     });
 
-    test('retention-days is 7 (matches APK retention for consistency)', () => {
+    test('Upload IPA has retention-days: 7 (matches APK retention for consistency)', () => {
       expect(uploadBlock).toMatch(/^ {10}retention-days: 7$/m);
     });
 
-    test('upload step runs BEFORE the TestFlight upload step', () => {
-      // The IPA artifact must be uploaded before the TestFlight
-      // upload step. If the order were reversed, a TestFlight
-      // failure could short-circuit the workflow before the
-      // operator-facing artifact was produced.
-      const uploadStepIdx = yamlText.indexOf('name: dev-ios-ipa');
-      const testflightStepIdx = yamlText.indexOf('Upload to TestFlight');
+    test('Upload IPA step runs BEFORE the Upload to TestFlight step', () => {
+      // Anchor to step headers (unambiguous — appear exactly once),
+      // NOT to artifact name strings (which appear in both comments
+      // and the actual `name:` field and would resolve to the
+      // first occurrence — likely a comment).
+      const uploadStepIdx = yamlText.indexOf('- name: Upload IPA as workflow artifact');
+      const testflightStepIdx = yamlText.indexOf('- name: Upload to TestFlight');
       expect(uploadStepIdx).toBeGreaterThanOrEqual(0);
       expect(testflightStepIdx).toBeGreaterThanOrEqual(0);
       expect(uploadStepIdx).toBeLessThan(testflightStepIdx);
     });
   });
 
-  describe('extractUploadStep helper — error branch', () => {
+  describe('extractStep helper — error branch', () => {
     let yamlText;
 
     beforeAll(() => {
       yamlText = fs.readFileSync(PR_CHECKS_PATH, 'utf8');
     });
 
-    test('throws a clear error for unknown artifact names', () => {
-      expect(() => extractUploadStep(yamlText, 'nonexistent-artifact')).toThrow(
-        /Could not find upload-artifact step for name "nonexistent-artifact"/,
+    test('throws a clear error for unknown step names', () => {
+      expect(() => extractStep(yamlText, 'Nonexistent Step Name')).toThrow(
+        /Could not find step "Nonexistent Step Name"/,
       );
     });
   });

--- a/express-api/tests/scripts/afk-install-artifacts.test.js
+++ b/express-api/tests/scripts/afk-install-artifacts.test.js
@@ -35,22 +35,43 @@ const DEPLOY_DEV_PATH = path.join(REPO_ROOT, '.github/workflows/deploy-dev.yml')
  * subsequent line until the next `      - name:` step header or the
  * next top-level YAML key (column 0). Returns the joined block.
  *
+ * Contract — failure modes:
+ *   - Zero matches → throws "Could not find step …"
+ *   - More than one match → throws "Ambiguous step name …" (no silent
+ *     first-match — the helper does NOT pick a block when the name is
+ *     duplicated across jobs in the same file; callers must use a
+ *     uniquely-named step header or scope by job)
+ *   - Non-6-space-indented input (e.g. composite-action YAMLs with
+ *     4-space step indent) → throws "Could not find step" because the
+ *     hardcoded `      - name:` prefix won't match
+ *
  * Exact string equality on the header line (not regex) eliminates the
- * anchor-to-comment-class of bug: a comment elsewhere in the file
+ * anchor-to-comment class of bug: a comment elsewhere in the file
  * containing the step name can't match because comments are prefixed
  * with `#` and don't equal the literal header string.
  */
 function extractStep(yamlText, stepName) {
   const lines = yamlText.split('\n');
   const stepHeader = `      - name: ${stepName}`;
-  const startIdx = lines.findIndex((l) => l === stepHeader);
-  if (startIdx < 0) {
+  const matches = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i] === stepHeader) matches.push(i);
+  }
+  if (matches.length === 0) {
     throw new Error(
       `Could not find step "${stepName}" in workflow file. ` +
-        'Step was renamed, removed, or indentation changed — ' +
-        'update this test to match.',
+        'Step was renamed, removed, or indentation changed (helper ' +
+        'requires 6-space step indent) — update this test to match.',
     );
   }
+  if (matches.length > 1) {
+    throw new Error(
+      `Ambiguous step name "${stepName}": found at lines ${matches
+        .map((i) => i + 1)
+        .join(', ')}. Use a more specific name or scope to a single job.`,
+    );
+  }
+  const startIdx = matches[0];
   let endIdx = startIdx + 1;
   while (endIdx < lines.length) {
     // Next step header at the same indent level terminates this block.
@@ -161,6 +182,33 @@ describe('CI artifact surface for AFK install', () => {
     test('throws a clear error for unknown step names', () => {
       expect(() => extractStep(yamlText, 'Nonexistent Step Name')).toThrow(
         /Could not find step "Nonexistent Step Name"/,
+      );
+    });
+
+    // I2 (round 3): the helper must NOT silently first-match when a
+    // step name is duplicated across jobs in the same file. In
+    // deploy-dev.yml, "Install dependencies" appears in both the
+    // `sanity-check` and `smoke-tests` jobs. Calling extractStep with
+    // an ambiguous name would silently return the first match — a
+    // latent footgun. The contract is: throw with line numbers so the
+    // caller knows to disambiguate.
+    test('throws when a step name appears in more than one job', () => {
+      const deployYaml = fs.readFileSync(DEPLOY_DEV_PATH, 'utf8');
+      expect(() => extractStep(deployYaml, 'Install dependencies')).toThrow(
+        /Ambiguous step name "Install dependencies": found at lines/,
+      );
+    });
+
+    // I3 (round 3): the helper hardcodes a 6-space step indent —
+    // appropriate for top-level workflow YAMLs in this repo, but not
+    // for composite-action YAMLs under .github/actions/ which use a
+    // 4-space step indent. Document this contract explicitly so a
+    // future reuse attempt against the wrong file shape fails loudly
+    // rather than silently returning a one-line block.
+    test('throws when YAML uses non-6-space step indentation', () => {
+      const fourSpaceIndent = '    - name: Some Step\n      run: echo hi\n';
+      expect(() => extractStep(fourSpaceIndent, 'Some Step')).toThrow(
+        /Could not find step "Some Step"/,
       );
     });
   });


### PR DESCRIPTION
## Summary
Phase 2 of the 2026-05-21 sequential build-out. Re-authors the content of closed PR #711 under the continuous-review-loop policy. Adds two missing CI artifacts so `gh run download` can fetch fresh builds for AFK install on both physical devices.

## Coverage after this PR
| Combo | Artifact | Status |
|---|---|---|
| Android-dev | `dev-release-apk` | already there (unchanged) |
| **Android-local** | **`local-debug-apk`** | **NEW** |
| **iOS-dev** | **`dev-ios-ipa`** | **NEW** |
| iOS-local | n/a | **deferred — Phase 3** (no Xcode scheme exists) |

## TDD
| Phase | Action | Result |
|---|---|---|
| Red | jest against current YAML | 5/5 fail |
| Green | Added both artifact uploads | 5/5 pass |
| Lint | eslint + prettier + actionlint + sonarjs | clean |

## Review workflow
Continuous-review-loop policy: this PR enters `code-reviewer` agent review next. Auto-merge when zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)