### PR TITLE
ios(local) 3.1: Local.xcconfig foundation for iOS local flavor

### DIFF
--- a/express-api/tests/scripts/ios-local-xcconfig.test.js
+++ b/express-api/tests/scripts/ios-local-xcconfig.test.js
@@ -119,4 +119,18 @@ describe('iosApp/Configurations/Local.xcconfig', () => {
     expect(xcconfigText.endsWith('\n')).toBe(true);
     expect(xcconfigText.endsWith('\n\n')).toBe(false);
   });
+
+  // Defensive trip-wire against the most common xcconfig-newbie
+  // mistake: writing `${LOCAL_HOST}` (shell expansion) where
+  // `$(LOCAL_HOST)` (Xcode build-setting expansion) is required.
+  // The shell form is a silent no-op in Xcode — the value becomes
+  // the literal `${LOCAL_HOST}` string rather than being substituted.
+  // No value line should contain the `${…}` shape.
+  test('no value line uses shell-style ${VAR} expansion (xcconfig requires $(VAR))', () => {
+    const valueLines = xcconfigText.split('\n').filter((l) => /^[A-Z_][A-Z0-9_]*\s*=/.test(l));
+    expect(valueLines.length).toBeGreaterThan(0);
+    valueLines.forEach((line) => {
+      expect(line).not.toMatch(/\$\{[A-Z_]/);
+    });
+  });
 });

--- a/express-api/tests/scripts/ios-local-xcconfig.test.js
+++ b/express-api/tests/scripts/ios-local-xcconfig.test.js
@@ -6,23 +6,16 @@
  * the Android `local` product flavor declared in `app/build.gradle.kts`.
  * Like Android local, it points the app at:
  *   - localhost Express API (port 3000)
- *   - localhost LiveKit (port 7880)
- *   - The `demo-shytalk` Firebase Emulator project
+ *   - localhost LiveKit signalling (port 7880)
+ *   - The `demo-shytalk` Firebase Emulator project (Firestore/Auth)
+ *   - The RTDB emulator (port 9000, namespace `demo-shytalk-default-rtdb`)
  *   - A `.local` bundle-id suffix so it can be installed alongside the
  *     dev variant on a single device
  *
  * Phase 3.1 (this PR) adds the file in isolation — it is NOT yet
- * referenced by the Xcode project. Subsequent sub-PRs:
- *   3.2 — add Debug-Local + Release-Local build configurations to
- *         iosApp.xcodeproj that consume this xcconfig
- *   3.3 — add iosApp-Local scheme bound to the new configurations
- *   3.4 — add GoogleService-Info-Local.plist (demo-shytalk) and the
- *         AppDelegate / iOSApp.swift selection logic
- *   3.5 — CI integration: build + upload as `local-ios-ipa` artifact
- *
- * Splitting Phase 3 into incremental PRs minimises the blast radius
- * of pbxproj surgery in 3.2 — if that PR goes wrong it only affects
- * the build configurations, not the foundation values that 3.1 sets.
+ * referenced by the Xcode project. Subsequent sub-PRs handle pbxproj
+ * surgery (3.2), scheme (3.3), GoogleService-Info + AppDelegate logic
+ * (3.4), and CI integration (3.5).
  */
 
 const fs = require('fs');
@@ -35,13 +28,18 @@ describe('iosApp/Configurations/Local.xcconfig', () => {
   let xcconfigText;
 
   beforeAll(() => {
-    expect(fs.existsSync(XCCONFIG_PATH)).toBe(true);
+    // Guard rather than assert — keeps the failure origin readable.
+    // The named "file exists at the expected path" test below is the
+    // canonical existence assertion. If the file is missing, this
+    // guard throws with a clear message and Jest reports a setup
+    // failure pointing at the right line.
+    if (!fs.existsSync(XCCONFIG_PATH)) {
+      throw new Error(`xcconfig not found at expected path: ${XCCONFIG_PATH}`);
+    }
     xcconfigText = fs.readFileSync(XCCONFIG_PATH, 'utf8');
   });
 
   test('file exists at the expected path', () => {
-    // beforeAll already asserts existence; this test makes the
-    // existence contract explicit at the suite level.
     expect(fs.existsSync(XCCONFIG_PATH)).toBe(true);
   });
 
@@ -54,33 +52,71 @@ describe('iosApp/Configurations/Local.xcconfig', () => {
 
   // Operator-overridable. Default `localhost` works on iOS Simulator
   // (shares the Mac's network namespace). For a physical iPhone the
-  // operator must override to the Mac's local-network IP (mDNS .local
-  // hostname or 192.168.x.y) at build time:
+  // operator must override to the Mac's local-network IP or mDNS .local
+  // hostname at build time:
   //
   //   xcodebuild -configuration Debug-Local LOCAL_HOST=Macbook.local …
   //
-  // Documented in this file's comment block; pinned at the variable
-  // name level here, value (`localhost`) checked separately below.
+  // Documented in the xcconfig's comment block; pinned at the variable
+  // value level here.
   test('declares LOCAL_HOST variable (defaults to localhost)', () => {
     expect(xcconfigText).toMatch(/^LOCAL_HOST\s*=\s*localhost$/m);
   });
 
-  test('declares LOCAL_API_BASE_URL pointing at LOCAL_HOST:3000', () => {
-    // Express API runs on port 3000 in the local stack (per
-    // local/start.sh Step 5). Variable interpolation `${LOCAL_HOST}`
-    // is the xcconfig idiom — gets resolved at build time.
+  // Variable interpolation in xcconfig uses the `$(VAR)` form. NOT
+  // `${VAR}` — that's the shell idiom and would be a silent no-op in
+  // Xcode build settings (the value would be literal `${LOCAL_HOST}`
+  // instead of being expanded).
+  test('declares LOCAL_API_BASE_URL pointing at $(LOCAL_HOST):3000', () => {
     expect(xcconfigText).toMatch(/^LOCAL_API_BASE_URL\s*=\s*http:\/\/\$\(LOCAL_HOST\):3000$/m);
   });
 
-  test('declares LOCAL_LIVEKIT_URL pointing at LOCAL_HOST:7880', () => {
-    // LiveKit Docker container exposes 7880 per local/docker-compose.yml.
+  // LiveKit signalling port. The Docker container also exposes 7881
+  // and 7882 for WebRTC media — the SFU advertises those back during
+  // the signalling handshake, so we only point at 7880 here.
+  test('declares LOCAL_LIVEKIT_URL pointing at $(LOCAL_HOST):7880', () => {
     expect(xcconfigText).toMatch(/^LOCAL_LIVEKIT_URL\s*=\s*ws:\/\/\$\(LOCAL_HOST\):7880$/m);
   });
 
+  // Matches the `--project=demo-shytalk` flag in
+  // `firebase emulators:start` (local/start.sh Step 2). The `demo-`
+  // prefix is Firebase's emulator-only namespace.
   test('declares LOCAL_FIREBASE_PROJECT_ID = demo-shytalk', () => {
-    // Matches the `--project=demo-shytalk` flag in
-    // `firebase emulators:start` (local/start.sh Step 2). The
-    // `demo-` prefix is Firebase's emulator-only namespace.
     expect(xcconfigText).toMatch(/^LOCAL_FIREBASE_PROJECT_ID\s*=\s*demo-shytalk$/m);
+  });
+
+  // RTDB emulator endpoint. Sibling of Android's `RTDB_URL` in
+  // app/build.gradle.kts. The `?ns=…` query string is the namespace
+  // selector the Firebase RTDB emulator expects.
+  test('declares LOCAL_FIREBASE_RTDB_URL pointing at $(LOCAL_HOST):9000 with namespace', () => {
+    expect(xcconfigText).toMatch(
+      /^LOCAL_FIREBASE_RTDB_URL\s*=\s*http:\/\/\$\(LOCAL_HOST\):9000\?ns=demo-shytalk-default-rtdb$/m,
+    );
+  });
+
+  // Pin the total variable count so a stray addition (typo, copy-paste,
+  // experimental key) doesn't silently land alongside the documented
+  // six. Six values × 1 line each, no continuation lines in the
+  // current file.
+  test('contains exactly six variable declarations', () => {
+    const varLines = xcconfigText.match(/^[A-Z_][A-Z0-9_]*\s*=/gm);
+    expect(varLines).not.toBeNull();
+    expect(varLines.length).toBe(6);
+  });
+
+  // Phase 3.2 may add `#include "Pods/Target Support Files/…"` once
+  // CocoaPods integration cascades. For Phase 3.1, no #include should
+  // exist — the file is standalone. Pinning this catches a premature
+  // include sneaking in via copy-paste from another xcconfig.
+  test('contains no #include directives in Phase 3.1', () => {
+    expect(xcconfigText).not.toMatch(/^#include/m);
+  });
+
+  // Xcode's own file editor ends xcconfig files with a trailing
+  // newline. A tool that strips it would silently churn the file on
+  // every save. Pin it.
+  test('ends with a single trailing newline', () => {
+    expect(xcconfigText.endsWith('\n')).toBe(true);
+    expect(xcconfigText.endsWith('\n\n')).toBe(false);
   });
 });

--- a/express-api/tests/scripts/ios-local-xcconfig.test.js
+++ b/express-api/tests/scripts/ios-local-xcconfig.test.js
@@ -1,0 +1,86 @@
+/**
+ * Pins the iOS local-flavor Build Configuration file's existence
+ * and key build-setting variables.
+ *
+ * This file is the foundation of the iOS-local flavor — a sibling of
+ * the Android `local` product flavor declared in `app/build.gradle.kts`.
+ * Like Android local, it points the app at:
+ *   - localhost Express API (port 3000)
+ *   - localhost LiveKit (port 7880)
+ *   - The `demo-shytalk` Firebase Emulator project
+ *   - A `.local` bundle-id suffix so it can be installed alongside the
+ *     dev variant on a single device
+ *
+ * Phase 3.1 (this PR) adds the file in isolation — it is NOT yet
+ * referenced by the Xcode project. Subsequent sub-PRs:
+ *   3.2 — add Debug-Local + Release-Local build configurations to
+ *         iosApp.xcodeproj that consume this xcconfig
+ *   3.3 — add iosApp-Local scheme bound to the new configurations
+ *   3.4 — add GoogleService-Info-Local.plist (demo-shytalk) and the
+ *         AppDelegate / iOSApp.swift selection logic
+ *   3.5 — CI integration: build + upload as `local-ios-ipa` artifact
+ *
+ * Splitting Phase 3 into incremental PRs minimises the blast radius
+ * of pbxproj surgery in 3.2 — if that PR goes wrong it only affects
+ * the build configurations, not the foundation values that 3.1 sets.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const XCCONFIG_PATH = path.join(REPO_ROOT, 'iosApp/Configurations/Local.xcconfig');
+
+describe('iosApp/Configurations/Local.xcconfig', () => {
+  let xcconfigText;
+
+  beforeAll(() => {
+    expect(fs.existsSync(XCCONFIG_PATH)).toBe(true);
+    xcconfigText = fs.readFileSync(XCCONFIG_PATH, 'utf8');
+  });
+
+  test('file exists at the expected path', () => {
+    // beforeAll already asserts existence; this test makes the
+    // existence contract explicit at the suite level.
+    expect(fs.existsSync(XCCONFIG_PATH)).toBe(true);
+  });
+
+  // Mirror of Android's `applicationIdSuffix = ".local"`. Allows the
+  // local-flavor iOS app to be installed alongside the dev variant
+  // on the same physical device for side-by-side comparison.
+  test('declares BUNDLE_ID_SUFFIX = .local', () => {
+    expect(xcconfigText).toMatch(/^BUNDLE_ID_SUFFIX\s*=\s*\.local$/m);
+  });
+
+  // Operator-overridable. Default `localhost` works on iOS Simulator
+  // (shares the Mac's network namespace). For a physical iPhone the
+  // operator must override to the Mac's local-network IP (mDNS .local
+  // hostname or 192.168.x.y) at build time:
+  //
+  //   xcodebuild -configuration Debug-Local LOCAL_HOST=Macbook.local …
+  //
+  // Documented in this file's comment block; pinned at the variable
+  // name level here, value (`localhost`) checked separately below.
+  test('declares LOCAL_HOST variable (defaults to localhost)', () => {
+    expect(xcconfigText).toMatch(/^LOCAL_HOST\s*=\s*localhost$/m);
+  });
+
+  test('declares LOCAL_API_BASE_URL pointing at LOCAL_HOST:3000', () => {
+    // Express API runs on port 3000 in the local stack (per
+    // local/start.sh Step 5). Variable interpolation `${LOCAL_HOST}`
+    // is the xcconfig idiom — gets resolved at build time.
+    expect(xcconfigText).toMatch(/^LOCAL_API_BASE_URL\s*=\s*http:\/\/\$\(LOCAL_HOST\):3000$/m);
+  });
+
+  test('declares LOCAL_LIVEKIT_URL pointing at LOCAL_HOST:7880', () => {
+    // LiveKit Docker container exposes 7880 per local/docker-compose.yml.
+    expect(xcconfigText).toMatch(/^LOCAL_LIVEKIT_URL\s*=\s*ws:\/\/\$\(LOCAL_HOST\):7880$/m);
+  });
+
+  test('declares LOCAL_FIREBASE_PROJECT_ID = demo-shytalk', () => {
+    // Matches the `--project=demo-shytalk` flag in
+    // `firebase emulators:start` (local/start.sh Step 2). The
+    // `demo-` prefix is Firebase's emulator-only namespace.
+    expect(xcconfigText).toMatch(/^LOCAL_FIREBASE_PROJECT_ID\s*=\s*demo-shytalk$/m);
+  });
+});

--- a/iosApp/Configurations/Local.xcconfig
+++ b/iosApp/Configurations/Local.xcconfig
@@ -1,0 +1,42 @@
+// iosApp/Configurations/Local.xcconfig
+//
+// Build settings for the iOS local-flavor variant. Sibling of the
+// Android `local` product flavor declared in `app/build.gradle.kts`.
+//
+// This file is the FOUNDATION (Phase 3.1) of a multi-PR build-out
+// per the 2026-05-21 operator directive. It is NOT yet referenced by
+// the Xcode project — the new Debug-Local + Release-Local build
+// configurations that consume these values are added in Phase 3.2.
+//
+// Variable contracts:
+//   BUNDLE_ID_SUFFIX        — `.local` so the app installs alongside
+//                             the dev variant on a single device.
+//                             Applied to PRODUCT_BUNDLE_IDENTIFIER in
+//                             Phase 3.2.
+//   LOCAL_HOST              — Network address the iPhone uses to
+//                             reach the operator's local stack.
+//                             Default `localhost` works on iOS
+//                             Simulator (shares the Mac's network).
+//                             For a physical iPhone, operator MUST
+//                             override to the Mac's local-network IP
+//                             or mDNS hostname at build time:
+//                               xcodebuild -configuration Debug-Local \
+//                                 LOCAL_HOST=Macbook.local …
+//   LOCAL_API_BASE_URL      — Express API URL. Express listens on
+//                             :3000 per local/start.sh Step 5.
+//   LOCAL_LIVEKIT_URL       — LiveKit signalling URL. Container
+//                             exposes :7880 per local/docker-compose.yml.
+//   LOCAL_FIREBASE_PROJECT_ID — `demo-shytalk` matches the
+//                             `--project=demo-shytalk` flag in
+//                             firebase emulators:start. The `demo-`
+//                             prefix is Firebase's emulator-only
+//                             namespace; no real Firebase project
+//                             with that ID exists or can be created.
+//
+// Pinned by: express-api/tests/scripts/ios-local-xcconfig.test.js
+
+BUNDLE_ID_SUFFIX = .local
+LOCAL_HOST = localhost
+LOCAL_API_BASE_URL = http://$(LOCAL_HOST):3000
+LOCAL_LIVEKIT_URL = ws://$(LOCAL_HOST):7880
+LOCAL_FIREBASE_PROJECT_ID = demo-shytalk

--- a/iosApp/Configurations/Local.xcconfig
+++ b/iosApp/Configurations/Local.xcconfig
@@ -49,8 +49,20 @@
 //                             on :9000 (firebase.json `database.port`).
 //                             `?ns=demo-shytalk-default-rtdb` query
 //                             string is the namespace selector the
-//                             emulator expects. Sibling of Android's
-//                             `RTDB_URL` in app/build.gradle.kts.
+//                             emulator expects.
+//
+//                             NOTE on iOS-vs-Android divergence: the
+//                             Android Firebase SDK auto-derives the
+//                             namespace from FirebaseOptions, so
+//                             `app/build.gradle.kts`'s Android
+//                             `RTDB_URL` is `http://host:9000` with
+//                             no `?ns=` query. The iOS Firebase SDK
+//                             does NOT auto-derive; pointing it at
+//                             the emulator without an explicit `?ns=`
+//                             selector connects to the wrong default
+//                             namespace. The divergence is in the
+//                             SDKs, not the data — both URLs reach
+//                             the same logical RTDB instance.
 //
 // xcconfig syntax notes for future maintainers:
 //   - Variable expansion uses `$(VAR)` — NOT `${VAR}` (that's shell).

--- a/iosApp/Configurations/Local.xcconfig
+++ b/iosApp/Configurations/Local.xcconfig
@@ -22,16 +22,44 @@
 //                             or mDNS hostname at build time:
 //                               xcodebuild -configuration Debug-Local \
 //                                 LOCAL_HOST=Macbook.local …
+//                             KNOWN GOTCHA — see Phase 3.3 scope note:
+//                             LiveKitBridge.swift's `isAllowedURL`
+//                             allow-list only accepts `localhost` /
+//                             `127.0.0.1` for `ws://`. Overriding to
+//                             an mDNS hostname is rejected at runtime
+//                             until 3.3 extends the allow-list.
 //   LOCAL_API_BASE_URL      — Express API URL. Express listens on
 //                             :3000 per local/start.sh Step 5.
-//   LOCAL_LIVEKIT_URL       — LiveKit signalling URL. Container
-//                             exposes :7880 per local/docker-compose.yml.
-//   LOCAL_FIREBASE_PROJECT_ID — `demo-shytalk` matches the
-//                             `--project=demo-shytalk` flag in
-//                             firebase emulators:start. The `demo-`
-//                             prefix is Firebase's emulator-only
-//                             namespace; no real Firebase project
-//                             with that ID exists or can be created.
+//   LOCAL_LIVEKIT_URL       — LiveKit signalling URL. LiveKit
+//                             container exposes 7880 (signalling)
+//                             plus 7881/7882 (WebRTC media) per
+//                             local/docker-compose.yml. We point at
+//                             7880 only — the SFU advertises the
+//                             media ports back during the signalling
+//                             handshake.
+//   LOCAL_FIREBASE_PROJECT_ID  — `demo-shytalk` matches the
+//                                `--project=demo-shytalk` flag in
+//                                firebase emulators:start. The
+//                                `demo-` prefix is Firebase's
+//                                emulator-only namespace; no real
+//                                Firebase project with that ID can
+//                                exist.
+//   LOCAL_FIREBASE_RTDB_URL — Realtime Database emulator URL.
+//                             Firebase emulator suite exposes RTDB
+//                             on :9000 (firebase.json `database.port`).
+//                             `?ns=demo-shytalk-default-rtdb` query
+//                             string is the namespace selector the
+//                             emulator expects. Sibling of Android's
+//                             `RTDB_URL` in app/build.gradle.kts.
+//
+// xcconfig syntax notes for future maintainers:
+//   - Variable expansion uses `$(VAR)` — NOT `${VAR}` (that's shell).
+//   - `//` is the comment introducer.
+//   - In Phase 3.2 when this is referenced as a baseConfigurationReference,
+//     CocoaPods integration may require an `#include` of the
+//     Pods-iosApp.<config>.xcconfig at the top of THIS file. The
+//     include MUST go above the variable declarations so the Pods
+//     values cascade as the base layer and our values override them.
 //
 // Pinned by: express-api/tests/scripts/ios-local-xcconfig.test.js
 
@@ -40,3 +68,4 @@ LOCAL_HOST = localhost
 LOCAL_API_BASE_URL = http://$(LOCAL_HOST):3000
 LOCAL_LIVEKIT_URL = ws://$(LOCAL_HOST):7880
 LOCAL_FIREBASE_PROJECT_ID = demo-shytalk
+LOCAL_FIREBASE_RTDB_URL = http://$(LOCAL_HOST):9000?ns=demo-shytalk-default-rtdb


### PR DESCRIPTION
## Summary
First of 5 sub-PRs in Phase 3 of the 2026-05-21 sequential build-out. Adds the iOS local-flavor's build-setting foundation file. The file is NOT yet referenced by the Xcode project — that's Phase 3.2.

## Changes
- `iosApp/Configurations/Local.xcconfig` — new file with 5 documented build variables (BUNDLE_ID_SUFFIX, LOCAL_HOST, LOCAL_API_BASE_URL, LOCAL_LIVEKIT_URL, LOCAL_FIREBASE_PROJECT_ID)
- `express-api/tests/scripts/ios-local-xcconfig.test.js` — 6 jest assertions pinning file existence + each variable's value

## Why this sub-PR is safe
Adding an xcconfig file that isn't referenced by the project has zero risk of corrupting `iosApp.xcodeproj/project.pbxproj`. The risky pbxproj surgery is in PR 3.2. Splitting Phase 3 this way means a botched 3.2 doesn't lose the foundation values established here.

## Sub-PR roadmap for Phase 3
| Sub-PR | Purpose |
|---|---|
| **3.1 (this PR)** | Local.xcconfig file + tests |
| 3.2 | Debug-Local + Release-Local build configurations in pbxproj |
| 3.3 | iosApp-Local scheme |
| 3.4 | GoogleService-Info-Local.plist + AppDelegate selection logic |
| 3.5 | CI integration (build local-ios + upload as artifact) |

## TDD
| Phase | Action | Result |
|---|---|---|
| Red | jest pre-file | 6/6 fail (file doesn't exist) |
| Green | Added xcconfig + Configurations/ dir | 6/6 pass |
| Lint | eslint + prettier | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)