### PR TITLE
fix(ios): handle empty response body in StartingScreenService

### DIFF
--- a/iosApp/iosApp/feature/starting/StartingScreenService.swift
+++ b/iosApp/iosApp/feature/starting/StartingScreenService.swift
@@ -46,12 +46,16 @@ class StartingScreenService {
             throw URLError(.badServerResponse)
         }
 
-        // Empty body means "no screens active" — return early. Must
-        // precede JSONSerialization.jsonObject(), which THROWS on
-        // empty data (NSCocoaError 3840) rather than returning nil
-        // for the as? cast to handle. Pinned by
-        // testFetchStartingScreens_emptyData.
-        if data.isEmpty {
+        // No-content body means "no screens active" — return early.
+        // Covers zero bytes, whitespace-only, and newline-only bodies.
+        // Must precede JSONSerialization.jsonObject(), which THROWS
+        // on any of these (NSCocoaError 3840) rather than returning
+        // nil for the as? cast to handle. Pinned by
+        // testFetchStartingScreens_emptyData,
+        // testFetchStartingScreens_whitespaceOnlyBody, and
+        // testFetchStartingScreens_newlineOnlyBody.
+        if let str = String(data: data, encoding: .utf8),
+           str.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return [:]
         }
 

--- a/iosApp/iosApp/feature/starting/StartingScreenService.swift
+++ b/iosApp/iosApp/feature/starting/StartingScreenService.swift
@@ -46,12 +46,17 @@ class StartingScreenService {
             throw URLError(.badServerResponse)
         }
 
+        // Empty body means "no screens active" — return early. Must
+        // precede JSONSerialization.jsonObject(), which THROWS on
+        // empty data (NSCocoaError 3840) rather than returning nil
+        // for the as? cast to handle. Pinned by
+        // testFetchStartingScreens_emptyData.
+        if data.isEmpty {
+            return [:]
+        }
+
         // Parse: { "screenId": { ...fields } }
         guard let raw = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            // If the response is empty or not a dictionary, return empty
-            if data.isEmpty {
-                return [:]
-            }
             throw URLError(.cannotParseResponse)
         }
 

--- a/iosApp/iosAppTests/StartingScreenServiceTests.swift
+++ b/iosApp/iosAppTests/StartingScreenServiceTests.swift
@@ -120,9 +120,50 @@ final class StartingScreenServiceTests: XCTestCase {
         XCTAssertTrue(screens.isEmpty)
     }
 
+    // Regression: JSONSerialization.jsonObject(with: Data()) throws
+    // NSCocoaError 3840 — not nil for the as? cast to handle. The
+    // service must early-return [:] BEFORE the JSONSerialization call.
+    // Pinned by PR #716.
     func testFetchStartingScreens_emptyData() async throws {
         let data = Data()
         let session = mockSession(data: data)
+        let service = makeService(session: session)
+
+        let screens = try await service.fetchStartingScreens()
+
+        XCTAssertTrue(screens.isEmpty)
+    }
+
+    // Regression: a whitespace-only body (`"   "`, `" \n "`, etc.) is
+    // semantically equivalent to empty — JSONSerialization throws
+    // NSCocoaError 3840 on it too. The empty-body guard must use
+    // `String(data:).trimmingCharacters(in: .whitespacesAndNewlines)`
+    // so the same fast-path catches both. PR #716 review round 1 I1.
+    func testFetchStartingScreens_whitespaceOnlyBody() async throws {
+        let data = "   \n  \r\n  ".data(using: .utf8)!
+        let session = mockSession(data: data)
+        let service = makeService(session: session)
+
+        let screens = try await service.fetchStartingScreens()
+
+        XCTAssertTrue(screens.isEmpty)
+    }
+
+    func testFetchStartingScreens_newlineOnlyBody() async throws {
+        let data = "\n".data(using: .utf8)!
+        let session = mockSession(data: data)
+        let service = makeService(session: session)
+
+        let screens = try await service.fetchStartingScreens()
+
+        XCTAssertTrue(screens.isEmpty)
+    }
+
+    // HTTP 204 No Content — the API's "no screens active" semantic.
+    // Status passes the 200-299 guard, then the empty-body fast-path
+    // returns [:]. PR #716 review round 1 M2.
+    func testFetchStartingScreens_http204_returnsEmpty() async throws {
+        let session = mockSession(data: Data(), statusCode: 204)
         let service = makeService(session: session)
 
         let screens = try await service.fetchStartingScreens()
@@ -140,8 +181,17 @@ final class StartingScreenServiceTests: XCTestCase {
         do {
             _ = try await service.fetchStartingScreens()
             XCTFail("Expected error for malformed JSON")
-        } catch {
-            // Expected — cannotParseResponse or JSONSerialization error
+        } catch let error as NSError {
+            // NSCocoaError 3840 from JSONSerialization, OR
+            // URLError(.cannotParseResponse) if the parse returns a
+            // value that fails the dict cast — both are acceptable
+            // for malformed input. Reject any other error class.
+            let isCocoaParse = error.domain == NSCocoaErrorDomain && error.code == 3840
+            let isURLParse = (error as? URLError)?.code == .cannotParseResponse
+            XCTAssertTrue(
+                isCocoaParse || isURLParse,
+                "Expected NSCocoaError 3840 or URLError.cannotParseResponse, got \(error)"
+            )
         }
     }
 
@@ -153,8 +203,12 @@ final class StartingScreenServiceTests: XCTestCase {
         do {
             _ = try await service.fetchStartingScreens()
             XCTFail("Expected error for JSON array")
+        } catch let error as URLError {
+            // JSON parses successfully but the as? [String: Any] cast
+            // fails, hitting the explicit throw URLError(.cannotParseResponse).
+            XCTAssertEqual(error.code, .cannotParseResponse)
         } catch {
-            // Expected — response is not a dictionary
+            XCTFail("Expected URLError.cannotParseResponse, got \(error)")
         }
     }
 
@@ -222,8 +276,10 @@ final class StartingScreenServiceTests: XCTestCase {
         do {
             _ = try await service.fetchStartingScreens()
             XCTFail("Expected error for 500 response")
+        } catch let error as URLError {
+            XCTAssertEqual(error.code, .badServerResponse)
         } catch {
-            // Expected
+            XCTFail("Expected URLError.badServerResponse, got \(error)")
         }
     }
 
@@ -235,8 +291,10 @@ final class StartingScreenServiceTests: XCTestCase {
         do {
             _ = try await service.fetchStartingScreens()
             XCTFail("Expected error for 404 response")
+        } catch let error as URLError {
+            XCTAssertEqual(error.code, .badServerResponse)
         } catch {
-            // Expected
+            XCTFail("Expected URLError.badServerResponse, got \(error)")
         }
     }
 


### PR DESCRIPTION
## Summary
- **Bug**: `testFetchStartingScreens_emptyData` failed in CI with NSCocoaError 3840 ("Unable to parse empty data") — `JSONSerialization.jsonObject(with: Data())` throws on empty input.
- **Root cause**: the `if data.isEmpty { return [:] }` guard was inside the `else` branch of `guard let raw = try JSONSerialization.jsonObject(...) as? [String: Any]` — only reached when the `try` succeeded but the cast failed. For truly empty `Data()`, the `try` throws BEFORE the guard's else is evaluated, making the fallback dead code.
- **Fix**: move the `data.isEmpty` early-return BEFORE the JSONSerialization call.

## Context
- Surfaced by PR #714's fresh PR Checks run on `ci/ios-local-3-1-xcconfig` (the first iOS-touching PR after PR #708 enabled iOS E2E gating + PR #715 unblocked `build-ios`). The bug is pre-existing.
- No new test needed — the existing `testFetchStartingScreens_emptyData` unit test (`iosApp/iosAppTests/StartingScreenServiceTests.swift:123-131`) goes from red to green with this fix.
- Locally validated by inspection (8GB laptop, xcodebuild OOM risk under the standing AFK constraint — CI is the validator).
- Once merged, PR #714 will need its branch re-synced with main to re-trigger PR Checks with the fix in place.

## Test plan
- [ ] CI's `ios-e2e / iOS E2E (iOS 18.1, iphone)` job passes (was failing on `StartingScreenServiceTests`)
- [ ] CI's `ios-e2e / Build iOS` continues to pass with the new 60-min timeout from PR #715
- [ ] All Android E2E and lint jobs continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)