### PR TITLE
ios(local) 3.3 v2: test-target Local configurations (with observability)

### DIFF
--- a/express-api/tests/scripts/ios-local-3-3-test-target-configs.test.js
+++ b/express-api/tests/scripts/ios-local-3-3-test-target-configs.test.js
@@ -1,0 +1,179 @@
+/**
+ * iosApp.xcodeproj — Phase 3.3 test-target Local configurations
+ *
+ * Continuation of Phase 3.2 (PR #717) which added Debug-Local +
+ * Release-Local on the PROJECT-level and iosApp-target lists.
+ * Phase 3.3 (this PR) extends the same script to also populate:
+ *   - iosAppTests target XCConfigurationList
+ *   - iosAppUITests target XCConfigurationList
+ *
+ * Why test targets need Local configs: when iosApp is built with
+ * Debug-Local, `xcodebuild test` against that scheme picks the
+ * matching test-target configuration — without a Debug-Local
+ * config on iosAppTests, Xcode falls back to the
+ * defaultConfigurationName (Release), causing the tests to build
+ * with different SWIFT_VERSION + entitlements than the app under
+ * test. The TestFlight + CocoaPods stack also expects per-config
+ * parity across all targets.
+ *
+ * Out of scope (deferred to later sub-PRs):
+ *   - 3.4 — Pods-iosApp.{debug,release}-local.xcconfig generation
+ *   - 3.5 — Local scheme + LiveKitBridge.isAllowedURL extension
+ *
+ * Implementation: same xcodeproj ruby script as 3.2, extended with
+ * two more target loops. Self-heal migration branch continues to
+ * apply (empty build_settings → cloned from sibling).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const PBXPROJ = path.join(REPO_ROOT, 'iosApp/iosApp.xcodeproj/project.pbxproj');
+const ADD_SCRIPT = path.join(REPO_ROOT, 'scripts/ios/add-local-configurations.rb');
+
+// UUIDs of the test-target XCConfigurationLists (verified from the
+// committed pbxproj — see existing tests in ios-local-configurations
+// .test.js's "test targets are NOT modified in Phase 3.2" assertion).
+const IOSAPPTESTS_LIST_UUID = 'A10008002600000000000001';
+const IOSAPPUITESTS_LIST_UUID = '08EFC4EBCF29E72CA6FC9F2A';
+
+/**
+ * Extract an XCConfigurationList block by its UUID. Line-anchored
+ * with leading `\n` per the same fix applied to extractGroupBlock
+ * in PR #717. The XCConfigurationList section is small enough that
+ * substring-match risk is low, but consistency is cheap.
+ */
+function extractConfigurationList(pbxproj, uuid) {
+  const sectionStart = pbxproj.indexOf('/* Begin XCConfigurationList section */');
+  const sectionEnd = pbxproj.indexOf('/* End XCConfigurationList section */');
+  if (sectionStart < 0 || sectionEnd < 0) {
+    throw new Error('XCConfigurationList section markers not found.');
+  }
+  const section = pbxproj.slice(sectionStart, sectionEnd);
+  const marker = `\n\t\t${uuid} `;
+  const markerIdx = section.indexOf(marker);
+  if (markerIdx < 0) {
+    throw new Error(`XCConfigurationList ${uuid} not found.`);
+  }
+  const blockStart = markerIdx + 1;
+  const blockEnd = section.indexOf('\n\t\t};', blockStart);
+  return section.slice(blockStart, blockEnd + '\n\t\t};'.length);
+}
+
+/**
+ * Find all XCBuildConfiguration blocks by name. Returns array of
+ * { uuid, block }. Same helper used in PR #717 — duplicated here
+ * to keep this test file self-contained.
+ */
+function findBuildConfigurationsByName(pbxproj, name) {
+  const sectionStart = pbxproj.indexOf('/* Begin XCBuildConfiguration section */');
+  const sectionEnd = pbxproj.indexOf('/* End XCBuildConfiguration section */');
+  const section = pbxproj.slice(sectionStart, sectionEnd);
+  const results = [];
+  const blockRegex = /\t\t([0-9A-F]{24}) \/\* ([^*]+?) \*\/ = \{([\s\S]+?)\n\t\t\};/g;
+  let m;
+  while ((m = blockRegex.exec(section)) !== null) {
+    const [, uuid, declaredName, body] = m;
+    if (declaredName.trim() === name) {
+      results.push({ uuid, block: body });
+    }
+  }
+  return results;
+}
+
+describe('iosApp.xcodeproj — Phase 3.3 test-target Local configurations', () => {
+  let pbxproj;
+
+  beforeAll(() => {
+    pbxproj = fs.readFileSync(PBXPROJ, 'utf8');
+  });
+
+  describe('XCConfigurationList membership', () => {
+    test('iosAppTests target list now includes Debug-Local', () => {
+      const block = extractConfigurationList(pbxproj, IOSAPPTESTS_LIST_UUID);
+      expect(block).toMatch(/\* Debug-Local \*\/,/);
+    });
+
+    test('iosAppTests target list now includes Release-Local', () => {
+      const block = extractConfigurationList(pbxproj, IOSAPPTESTS_LIST_UUID);
+      expect(block).toMatch(/\* Release-Local \*\/,/);
+    });
+
+    test('iosAppUITests target list now includes Debug-Local', () => {
+      const block = extractConfigurationList(pbxproj, IOSAPPUITESTS_LIST_UUID);
+      expect(block).toMatch(/\* Debug-Local \*\/,/);
+    });
+
+    test('iosAppUITests target list now includes Release-Local', () => {
+      const block = extractConfigurationList(pbxproj, IOSAPPUITESTS_LIST_UUID);
+      expect(block).toMatch(/\* Release-Local \*\/,/);
+    });
+
+    test('iosAppTests defaultConfigurationName remains Release (not changed by 3.3)', () => {
+      const block = extractConfigurationList(pbxproj, IOSAPPTESTS_LIST_UUID);
+      expect(block).toContain('defaultConfigurationName = Release;');
+    });
+
+    test('iosAppUITests defaultConfigurationName remains Release (not changed by 3.3)', () => {
+      const block = extractConfigurationList(pbxproj, IOSAPPUITESTS_LIST_UUID);
+      expect(block).toContain('defaultConfigurationName = Release;');
+    });
+  });
+
+  describe('Total count of Local configurations across all lists', () => {
+    test('Debug-Local now appears as a name on 4 XCBuildConfigurations (was 2)', () => {
+      // 2 from Phase 3.2 (project + iosApp target) + 2 new from
+      // Phase 3.3 (iosAppTests + iosAppUITests targets).
+      const matches = findBuildConfigurationsByName(pbxproj, 'Debug-Local');
+      expect(matches).toHaveLength(4);
+    });
+
+    test('Release-Local now appears as a name on 4 XCBuildConfigurations (was 2)', () => {
+      const matches = findBuildConfigurationsByName(pbxproj, 'Release-Local');
+      expect(matches).toHaveLength(4);
+    });
+  });
+
+  describe('Build settings inheritance (CocoaPods consistency)', () => {
+    // Phase 3.2 review round 4 found that CocoaPods rejects
+    // `pod install` if SWIFT_VERSION is inconsistent across configs
+    // within the same target. Test-target configs need the same
+    // SWIFT_VERSION as their Debug/Release siblings for the same
+    // reason. The script's clone_settings_from_sibling helper
+    // handles this.
+    test('iosAppTests Debug-Local inherits SWIFT_VERSION from iosAppTests Debug', () => {
+      const debugLocals = findBuildConfigurationsByName(pbxproj, 'Debug-Local');
+      // 4 total — find the iosAppTests one. We identify it by the
+      // presence of `BUNDLE_LOADER` or `TEST_HOST` in build_settings
+      // — those are iosAppTests-specific.
+      const iosAppTestsConfig = debugLocals.find(
+        (m) => m.block.includes('BUNDLE_LOADER') || m.block.includes('TEST_HOST'),
+      );
+      expect(iosAppTestsConfig).toBeDefined();
+      expect(iosAppTestsConfig.block).toContain('SWIFT_VERSION = 5.0;');
+    });
+
+    test('iosAppUITests Debug-Local inherits SWIFT_VERSION from iosAppUITests Debug', () => {
+      const debugLocals = findBuildConfigurationsByName(pbxproj, 'Debug-Local');
+      // iosAppUITests configs have `TEST_TARGET_NAME` set.
+      const iosAppUITestsConfig = debugLocals.find((m) =>
+        m.block.includes('TEST_TARGET_NAME'),
+      );
+      expect(iosAppUITestsConfig).toBeDefined();
+      expect(iosAppUITestsConfig.block).toContain('SWIFT_VERSION = 5.0;');
+    });
+  });
+
+  describe('Ruby script extension', () => {
+    test('script references iosAppTests target', () => {
+      const scriptText = fs.readFileSync(ADD_SCRIPT, 'utf8');
+      expect(scriptText).toContain('iosAppTests');
+    });
+
+    test('script references iosAppUITests target', () => {
+      const scriptText = fs.readFileSync(ADD_SCRIPT, 'utf8');
+      expect(scriptText).toContain('iosAppUITests');
+    });
+  });
+});

--- a/express-api/tests/scripts/ios-local-3-3-test-target-configs.test.js
+++ b/express-api/tests/scripts/ios-local-3-3-test-target-configs.test.js
@@ -157,11 +157,99 @@ describe('iosApp.xcodeproj — Phase 3.3 test-target Local configurations', () =
     test('iosAppUITests Debug-Local inherits SWIFT_VERSION from iosAppUITests Debug', () => {
       const debugLocals = findBuildConfigurationsByName(pbxproj, 'Debug-Local');
       // iosAppUITests configs have `TEST_TARGET_NAME` set.
-      const iosAppUITestsConfig = debugLocals.find((m) =>
-        m.block.includes('TEST_TARGET_NAME'),
-      );
+      const iosAppUITestsConfig = debugLocals.find((m) => m.block.includes('TEST_TARGET_NAME'));
       expect(iosAppUITestsConfig).toBeDefined();
       expect(iosAppUITestsConfig.block).toContain('SWIFT_VERSION = 5.0;');
+    });
+
+    // Round 1 I-3: Release-Local SWIFT_VERSION on both test targets.
+    // The CocoaPods consistency failure that motivated 3.2 round 4
+    // applies equally to Release builds — if pod install is ever
+    // run against the Release-Local scheme, an empty SWIFT_VERSION
+    // would fail the same way. Pinning both Debug and Release.
+    test('iosAppTests Release-Local inherits SWIFT_VERSION from iosAppTests Release', () => {
+      const releaseLocals = findBuildConfigurationsByName(pbxproj, 'Release-Local');
+      const iosAppTestsConfig = releaseLocals.find(
+        (m) => m.block.includes('BUNDLE_LOADER') || m.block.includes('TEST_HOST'),
+      );
+      expect(iosAppTestsConfig).toBeDefined();
+      expect(iosAppTestsConfig.block).toContain('SWIFT_VERSION = 5.0;');
+    });
+
+    test('iosAppUITests Release-Local inherits SWIFT_VERSION from iosAppUITests Release', () => {
+      const releaseLocals = findBuildConfigurationsByName(pbxproj, 'Release-Local');
+      const iosAppUITestsConfig = releaseLocals.find((m) => m.block.includes('TEST_TARGET_NAME'));
+      expect(iosAppUITestsConfig).toBeDefined();
+      expect(iosAppUITestsConfig.block).toContain('SWIFT_VERSION = 5.0;');
+    });
+
+    // Round 1 I-2: VALIDATE_PRODUCT asymmetry.
+    // The existing iosAppUITests Release config carries
+    // `VALIDATE_PRODUCT = YES` (a Release-only setting that catches
+    // provisioning issues on archive). Debug-Local should NOT inherit
+    // it (clone is from Debug, not Release). Release-Local SHOULD
+    // inherit it (clone is from Release). The asymmetry is a real
+    // contract: VALIDATE_PRODUCT on a simulator Debug build creates
+    // false-positive provisioning errors.
+    test('iosAppUITests Debug-Local does NOT carry VALIDATE_PRODUCT', () => {
+      const debugLocals = findBuildConfigurationsByName(pbxproj, 'Debug-Local');
+      const uiTestsDebugLocal = debugLocals.find((m) => m.block.includes('TEST_TARGET_NAME'));
+      expect(uiTestsDebugLocal).toBeDefined();
+      expect(uiTestsDebugLocal.block).not.toContain('VALIDATE_PRODUCT');
+    });
+
+    test('iosAppUITests Release-Local carries VALIDATE_PRODUCT = YES (inherited from Release)', () => {
+      const releaseLocals = findBuildConfigurationsByName(pbxproj, 'Release-Local');
+      const uiTestsReleaseLocal = releaseLocals.find((m) => m.block.includes('TEST_TARGET_NAME'));
+      expect(uiTestsReleaseLocal).toBeDefined();
+      expect(uiTestsReleaseLocal.block).toContain('VALIDATE_PRODUCT = YES');
+    });
+  });
+
+  // Round 1 I-4: NO baseConfigurationReference on any of the 4 new
+  // test-target Local configs. Phase 3.4 (CocoaPods integration) is
+  // the only thing allowed to add base refs to target-level configs,
+  // and only after the explicit pod-install step. A copy-paste of
+  // the project-level config creation block that accidentally adds
+  // `base_configuration_reference = xcconfig_ref` to the test target
+  // creation would be caught by these tests.
+  describe('Phase 3.3 NO baseConfigurationReference (Phase 3.4 scope)', () => {
+    test('iosAppTests Debug-Local has NO baseConfigurationReference', () => {
+      const matches = findBuildConfigurationsByName(pbxproj, 'Debug-Local');
+      const iosAppTestsConfig = matches.find(
+        (m) =>
+          (m.block.includes('BUNDLE_LOADER') || m.block.includes('TEST_HOST')) &&
+          !m.block.includes('baseConfigurationReference'),
+      );
+      expect(iosAppTestsConfig).toBeDefined();
+    });
+
+    test('iosAppTests Release-Local has NO baseConfigurationReference', () => {
+      const matches = findBuildConfigurationsByName(pbxproj, 'Release-Local');
+      const iosAppTestsConfig = matches.find(
+        (m) =>
+          (m.block.includes('BUNDLE_LOADER') || m.block.includes('TEST_HOST')) &&
+          !m.block.includes('baseConfigurationReference'),
+      );
+      expect(iosAppTestsConfig).toBeDefined();
+    });
+
+    test('iosAppUITests Debug-Local has NO baseConfigurationReference', () => {
+      const matches = findBuildConfigurationsByName(pbxproj, 'Debug-Local');
+      const uiTestsConfig = matches.find(
+        (m) =>
+          m.block.includes('TEST_TARGET_NAME') && !m.block.includes('baseConfigurationReference'),
+      );
+      expect(uiTestsConfig).toBeDefined();
+    });
+
+    test('iosAppUITests Release-Local has NO baseConfigurationReference', () => {
+      const matches = findBuildConfigurationsByName(pbxproj, 'Release-Local');
+      const uiTestsConfig = matches.find(
+        (m) =>
+          m.block.includes('TEST_TARGET_NAME') && !m.block.includes('baseConfigurationReference'),
+      );
+      expect(uiTestsConfig).toBeDefined();
     });
   });
 

--- a/express-api/tests/scripts/ios-local-configurations.test.js
+++ b/express-api/tests/scripts/ios-local-configurations.test.js
@@ -409,14 +409,19 @@ describe('iosApp.xcodeproj — Phase 3.2 Local build configurations', () => {
     // The test:
     //   (1) invokes the script via execFileSync
     //   (2) asserts exit 0
-    //   (3) asserts stdout contains the 5 "(no-op)" lines
+    //   (3) asserts stdout contains all 9 "(no-op)" lines (one per
+    //       script step that has an idempotency check: 1 file-ref +
+    //       2 project-level + 2 iosApp-target + 2 iosAppTests-target
+    //       + 2 iosAppUITests-target) — Phase 3.3 expanded from 5 to 9
     //   (4) re-reads pbxproj and asserts structural invariants
     //       are unchanged from before (Debug-Local count, Release-
     //       Local count, Local.xcconfig file-ref UUID stable)
     //
     // Skips gracefully if ruby+xcodeproj-gem unavailable (Linux CI).
     // On macOS CI this runs and exercises the script's no-op paths
-    // (script lines 67-71, 79-82, 101-105) end-to-end.
+    // (the empty-settings self-heal branch in the new
+    // add_local_configs_to_target helper) end-to-end across all
+    // three targets.
     test('script is structurally idempotent — re-run preserves all configurations and file refs', () => {
       try {
         // eslint-disable-next-line sonarjs/no-os-command-from-path
@@ -451,6 +456,23 @@ describe('iosApp.xcodeproj — Phase 3.2 Local build configurations', () => {
       );
       expect(stdout).toContain(
         'iosApp-target XCBuildConfiguration already present: Release-Local (no-op)',
+      );
+      // Phase 3.3 additions — review round 1 I-1 fix. The script
+      // emits a no-op for each of the 4 new test-target Local
+      // configs on re-run. Without these assertions, a regression
+      // that silently skips one of the 3.3 target loops would pass
+      // the existing 5 assertions.
+      expect(stdout).toContain(
+        'iosAppTests-target XCBuildConfiguration already present: Debug-Local (no-op)',
+      );
+      expect(stdout).toContain(
+        'iosAppTests-target XCBuildConfiguration already present: Release-Local (no-op)',
+      );
+      expect(stdout).toContain(
+        'iosAppUITests-target XCBuildConfiguration already present: Debug-Local (no-op)',
+      );
+      expect(stdout).toContain(
+        'iosAppUITests-target XCBuildConfiguration already present: Release-Local (no-op)',
       );
 
       // (4) structural invariants unchanged

--- a/express-api/tests/scripts/ios-local-configurations.test.js
+++ b/express-api/tests/scripts/ios-local-configurations.test.js
@@ -443,7 +443,8 @@ describe('iosApp.xcodeproj — Phase 3.2 Local build configurations', () => {
         encoding: 'utf8',
       });
 
-      // (3) the 5 no-op stdout messages
+      // (3) the 9 no-op stdout messages (5 from Phase 3.2 + 4 from
+      // Phase 3.3 — iosAppTests + iosAppUITests target loops).
       expect(stdout).toContain('PBXFileReference already present: Local.xcconfig (no-op)');
       expect(stdout).toContain(
         'Project-level XCBuildConfiguration already present: Debug-Local (no-op)',

--- a/express-api/tests/scripts/ios-local-configurations.test.js
+++ b/express-api/tests/scripts/ios-local-configurations.test.js
@@ -173,14 +173,16 @@ describe('iosApp.xcodeproj — Phase 3.2 Local build configurations', () => {
     // Two per configuration name: one at project-level (058558B0
     // list) and one at iosApp-target-level (058558B1 list). Test
     // targets are Phase 3.3 — explicitly NOT counted here.
-    test('Debug-Local appears as an XCBuildConfiguration name exactly twice (project + iosApp target)', () => {
+    test('Debug-Local appears as an XCBuildConfiguration name exactly four times (project + 3 targets)', () => {
+      // Phase 3.2 added project + iosApp target. Phase 3.3 (PR after
+      // this one) added iosAppTests + iosAppUITests targets. Total: 4.
       const count = countMatches(pbxproj, /\n\t{3}name = "Debug-Local";/g);
-      expect(count).toBe(2);
+      expect(count).toBe(4);
     });
 
-    test('Release-Local appears as an XCBuildConfiguration name exactly twice (project + iosApp target)', () => {
+    test('Release-Local appears as an XCBuildConfiguration name exactly four times (project + 3 targets)', () => {
       const count = countMatches(pbxproj, /\n\t{3}name = "Release-Local";/g);
-      expect(count).toBe(2);
+      expect(count).toBe(4);
     });
 
     test('Local.xcconfig appears as a baseConfigurationReference comment exactly twice (project-level Debug-Local + Release-Local)', () => {
@@ -209,16 +211,12 @@ describe('iosApp.xcodeproj — Phase 3.2 Local build configurations', () => {
       expect(block).toMatch(/\* Release-Local \*\/,/);
     });
 
-    test('test targets are NOT modified in Phase 3.2 (deferred to 3.3)', () => {
-      // iosAppTests list — must NOT yet contain Local configs.
-      const testsBlock = extractConfigurationList(pbxproj, 'A10008002600000000000001');
-      expect(testsBlock).not.toMatch(/Debug-Local/);
-      expect(testsBlock).not.toMatch(/Release-Local/);
-      // iosAppUITests list — same.
-      const uitestsBlock = extractConfigurationList(pbxproj, '08EFC4EBCF29E72CA6FC9F2A');
-      expect(uitestsBlock).not.toMatch(/Debug-Local/);
-      expect(uitestsBlock).not.toMatch(/Release-Local/);
-    });
+    // Removed 'test targets are NOT modified in Phase 3.2 (deferred
+    // to 3.3)' — that assertion was correct when Phase 3.2 was the
+    // tip, but Phase 3.3 (PR after this one) intentionally crosses
+    // that boundary. The positive-state assertions for test-target
+    // Local configs are in
+    // tests/scripts/ios-local-3-3-test-target-configs.test.js.
 
     test('project-level defaultConfigurationName remains Release (not changed by Local addition)', () => {
       const block = extractConfigurationList(pbxproj, '058558B0273AAA2400C9D062');
@@ -244,18 +242,32 @@ describe('iosApp.xcodeproj — Phase 3.2 Local build configurations', () => {
     // config wholesale) would break the planned 3.4 integration
     // silently.
     test('iosApp-target Debug-Local has NO baseConfigurationReference (Phase 3.4 scope)', () => {
+      // After Phase 3.3, 4 Debug-Local matches exist: project +
+      // iosApp + iosAppTests + iosAppUITests. Identify the iosApp
+      // one specifically — it has neither BUNDLE_LOADER (iosAppTests
+      // marker) nor TEST_TARGET_NAME (iosAppUITests marker) nor
+      // a baseConfigurationReference (project-level marker).
       const matches = findBuildConfigurationsByName(pbxproj, 'Debug-Local');
-      // Two matches: one project-level (has base ref), one iosApp-target (no base ref).
-      expect(matches).toHaveLength(2);
-      const targetLevel = matches.find((m) => !m.block.includes('baseConfigurationReference'));
-      expect(targetLevel).toBeDefined();
+      expect(matches).toHaveLength(4);
+      const iosAppTarget = matches.find(
+        (m) =>
+          !m.block.includes('baseConfigurationReference') &&
+          !m.block.includes('BUNDLE_LOADER') &&
+          !m.block.includes('TEST_TARGET_NAME'),
+      );
+      expect(iosAppTarget).toBeDefined();
     });
 
     test('iosApp-target Release-Local has NO baseConfigurationReference (Phase 3.4 scope)', () => {
       const matches = findBuildConfigurationsByName(pbxproj, 'Release-Local');
-      expect(matches).toHaveLength(2);
-      const targetLevel = matches.find((m) => !m.block.includes('baseConfigurationReference'));
-      expect(targetLevel).toBeDefined();
+      expect(matches).toHaveLength(4);
+      const iosAppTarget = matches.find(
+        (m) =>
+          !m.block.includes('baseConfigurationReference') &&
+          !m.block.includes('BUNDLE_LOADER') &&
+          !m.block.includes('TEST_TARGET_NAME'),
+      );
+      expect(iosAppTarget).toBeDefined();
     });
 
     // Round 1 Gap 3 — UUID fidelity. The original test asserted
@@ -324,16 +336,28 @@ describe('iosApp.xcodeproj — Phase 3.2 Local build configurations', () => {
     // like IPHONEOS_DEPLOYMENT_TARGET).
     test('iosApp-target Debug-Local inherits SWIFT_VERSION = "5.0" from Debug', () => {
       const matches = findBuildConfigurationsByName(pbxproj, 'Debug-Local');
-      const targetLevel = matches.find((m) => !m.block.includes('baseConfigurationReference'));
-      expect(targetLevel).toBeDefined();
-      expect(targetLevel.block).toContain('SWIFT_VERSION = 5.0;');
+      // After Phase 3.3 the iosApp-target Debug-Local is identified
+      // by absence of base ref + absence of test-target markers.
+      const iosAppTarget = matches.find(
+        (m) =>
+          !m.block.includes('baseConfigurationReference') &&
+          !m.block.includes('BUNDLE_LOADER') &&
+          !m.block.includes('TEST_TARGET_NAME'),
+      );
+      expect(iosAppTarget).toBeDefined();
+      expect(iosAppTarget.block).toContain('SWIFT_VERSION = 5.0;');
     });
 
     test('iosApp-target Release-Local inherits SWIFT_VERSION = "5.0" from Release', () => {
       const matches = findBuildConfigurationsByName(pbxproj, 'Release-Local');
-      const targetLevel = matches.find((m) => !m.block.includes('baseConfigurationReference'));
-      expect(targetLevel).toBeDefined();
-      expect(targetLevel.block).toContain('SWIFT_VERSION = 5.0;');
+      const iosAppTarget = matches.find(
+        (m) =>
+          !m.block.includes('baseConfigurationReference') &&
+          !m.block.includes('BUNDLE_LOADER') &&
+          !m.block.includes('TEST_TARGET_NAME'),
+      );
+      expect(iosAppTarget).toBeDefined();
+      expect(iosAppTarget.block).toContain('SWIFT_VERSION = 5.0;');
     });
 
     // PBXFileReference for Local.xcconfig must declare the xcconfig

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -767,6 +767,45 @@
 			};
 			name = "Debug-Local";
 		};
+		480632AC7A73B19D3B0F0A9C /* Debug-Local */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = F3XX4PM3MF;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSPrincipalClass = "";
+				INFOPLIST_KEY_UIRequiredDeviceCapabilities = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shyden.shytalk.uitests;
+				PRODUCT_NAME = iosAppUITests;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = iosApp;
+			};
+			name = "Debug-Local";
+		};
+		72E9E241689731FF5ECEA7E8 /* Release-Local */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = F3XX4PM3MF;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSPrincipalClass = "";
+				INFOPLIST_KEY_UIRequiredDeviceCapabilities = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shyden.shytalk.uitests;
+				PRODUCT_NAME = iosAppUITests;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = iosApp;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Release-Local";
+		};
 		9C42CB3D0291CB25483D5375 /* Release-Local */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -916,6 +955,25 @@
 			};
 			name = "Debug-Local";
 		};
+		E9758D13F6ACD50BFF803680 /* Debug-Local */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = F3XX4PM3MF;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shyden.shytalk.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iosApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/iosApp";
+			};
+			name = "Debug-Local";
+		};
 		EC30098239A66F4B6AB2CC80 /* Release-Local */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DCA2BF0B8EEF6C0696E649B2 /* Local.xcconfig */;
@@ -973,6 +1031,25 @@
 			};
 			name = "Release-Local";
 		};
+		FC13A86CE4CDB1386EA94D38 /* Release-Local */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = F3XX4PM3MF;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shyden.shytalk.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iosApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/iosApp";
+			};
+			name = "Release-Local";
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1003,6 +1080,8 @@
 			buildConfigurations = (
 				30A29A68A2F6F23AE86D0CC5 /* Release */,
 				A8CC4EE65441124E76D797CD /* Debug */,
+				480632AC7A73B19D3B0F0A9C /* Debug-Local */,
+				72E9E241689731FF5ECEA7E8 /* Release-Local */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1012,6 +1091,8 @@
 			buildConfigurations = (
 				A10009002600000000000001 /* Debug */,
 				A10009002600000000000002 /* Release */,
+				E9758D13F6ACD50BFF803680 /* Debug-Local */,
+				FC13A86CE4CDB1386EA94D38 /* Release-Local */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/scripts/ios/add-local-configurations.rb
+++ b/scripts/ios/add-local-configurations.rb
@@ -120,34 +120,50 @@ NEW_CONFIG_NAMES.each do |name|
   puts "Added project-level XCBuildConfiguration: #{name}"
 end
 
-# ── 3. Add Debug-Local + Release-Local to iosApp target list ──────
-# Target-level configs have NO base reference at 3.2 — CocoaPods
-# integration in Phase 3.4 will inject Pods-iosApp.debug-local
-# .xcconfig as the base. Until then, target configs inherit
-# baseline settings (SWIFT_VERSION, codesign, etc.) from their
-# Debug/Release sibling via the cloned build_settings.
-iosapp_target = project.targets.find { |t| t.name == TARGET_NAME } ||
-                raise("Could not find iosApp target in project.")
+# ── Helper: add Debug-Local + Release-Local to a TARGET's list ────
+# Target-level configs have NO base reference — CocoaPods integration
+# in Phase 3.4 will inject Pods-<target>.debug-local.xcconfig as the
+# base. Until then, target configs inherit baseline settings
+# (SWIFT_VERSION, codesign, IPHONEOS_DEPLOYMENT_TARGET, BUNDLE_LOADER
+# for test targets, etc.) from their Debug/Release sibling via the
+# cloned build_settings.
+def add_local_configs_to_target(project, target_name, label)
+  target = project.targets.find { |t| t.name == target_name } ||
+           raise("Could not find target #{target_name} in project.")
 
-NEW_CONFIG_NAMES.each do |name|
-  existing = iosapp_target.build_configuration_list.build_configurations.find { |c| c.name == name }
-  if existing
-    # Same self-heal migration as the project-level loop above.
-    if existing.build_settings.empty?
-      existing.build_settings = clone_settings_from_sibling(iosapp_target.build_configuration_list, name)
-      puts "Updated iosApp-target XCBuildConfiguration: #{name} (back-filled empty build_settings)"
-    else
-      puts "iosApp-target XCBuildConfiguration already present: #{name} (no-op)"
+  NEW_CONFIG_NAMES.each do |name|
+    existing = target.build_configuration_list.build_configurations.find { |c| c.name == name }
+    if existing
+      # Self-heal migration (see project-level loop above).
+      if existing.build_settings.empty?
+        existing.build_settings = clone_settings_from_sibling(target.build_configuration_list, name)
+        puts "Updated #{label} XCBuildConfiguration: #{name} (back-filled empty build_settings)"
+      else
+        puts "#{label} XCBuildConfiguration already present: #{name} (no-op)"
+      end
+      next
     end
-    next
-  end
 
-  config = project.new(Xcodeproj::Project::Object::XCBuildConfiguration)
-  config.name = name
-  config.build_settings = clone_settings_from_sibling(iosapp_target.build_configuration_list, name)
-  iosapp_target.build_configuration_list.build_configurations << config
-  puts "Added iosApp-target XCBuildConfiguration: #{name}"
+    config = project.new(Xcodeproj::Project::Object::XCBuildConfiguration)
+    config.name = name
+    config.build_settings = clone_settings_from_sibling(target.build_configuration_list, name)
+    target.build_configuration_list.build_configurations << config
+    puts "Added #{label} XCBuildConfiguration: #{name}"
+  end
 end
+
+# ── 3. iosApp target (Phase 3.2) ──────────────────────────────────
+add_local_configs_to_target(project, 'iosApp', 'iosApp-target')
+
+# ── 4. iosAppTests + iosAppUITests targets (Phase 3.3) ────────────
+# When iosApp is built with Debug-Local, `xcodebuild test` against
+# that scheme picks the matching test-target configuration. Without
+# Local configs on the test targets, Xcode falls back to
+# defaultConfigurationName (Release) which has different SWIFT_VERSION
+# / entitlements than the app build — `pod install` would also barf
+# on the inconsistency.
+add_local_configs_to_target(project, 'iosAppTests', 'iosAppTests-target')
+add_local_configs_to_target(project, 'iosAppUITests', 'iosAppUITests-target')
 
 project.save
 puts "\nSaved iosApp.xcodeproj."

--- a/scripts/ios/add-local-configurations.rb
+++ b/scripts/ios/add-local-configurations.rb
@@ -3,7 +3,7 @@
 
 # scripts/ios/add-local-configurations.rb
 #
-# Phase 3.2 of the iOS-local build-out: adds Debug-Local and
+# Phase 3.2-3.3 of the iOS-local build-out: adds Debug-Local and
 # Release-Local XCBuildConfigurations to iosApp.xcodeproj.
 #
 # Scope:
@@ -12,11 +12,15 @@
 #     baseConfigurationReference (the file added by PR #714).
 #   - iosApp TARGET-level configuration list — both configs added,
 #     no base reference (CocoaPods integration is Phase 3.4).
+#   - iosAppTests + iosAppUITests TARGET-level configuration lists
+#     (Phase 3.3, PR #719) — both configs added, no base reference,
+#     build_settings cloned from each target's Debug/Release sibling
+#     so SWIFT_VERSION + BUNDLE_LOADER + TEST_TARGET_NAME inherit
+#     correctly.
 #   - The Local.xcconfig file itself is added as a PBXFileReference
 #     under iosApp/Configurations/ if not already present.
 #
 # Out of scope (deferred to later sub-PRs):
-#   - 3.3 — iosAppTests + iosAppUITests target configurations
 #   - 3.4 — Pods-iosApp.{debug,release}-local.xcconfig generation
 #   - 3.5 — Local scheme + LiveKitBridge.isAllowedURL extension
 #
@@ -30,7 +34,9 @@
 # Usage:
 #   ruby scripts/ios/add-local-configurations.rb
 #
-# Verified by: express-api/tests/scripts/ios-local-configurations.test.js
+# Verified by:
+#   - express-api/tests/scripts/ios-local-configurations.test.js (3.2)
+#   - express-api/tests/scripts/ios-local-3-3-test-target-configs.test.js (3.3)
 
 require 'xcodeproj'
 


### PR DESCRIPTION
## Summary
Re-attempt of Phase 3.3 (originally PR #719, closed). Same changes — extends `scripts/ios/add-local-configurations.rb` to add `Debug-Local` + `Release-Local` to `iosAppTests` and `iosAppUITests` target XCConfigurationLists. Build settings cloned from each target's Debug/Release sibling.

## What's different from PR #719
- Now lands AFTER PR #720 (xcodebuild log artifact upload). If CI's `Build iOS app for testing` fails like #719 did at 40m34s, the full xcodebuild log is downloadable via `gh run download <run-id> -n ios-xcodebuild-logs` instead of being lost in GH Actions' 48k-line log truncation.

## Why retry
PR #719's iOS build failure was likely caused by the test-target Local configs themselves (PR #720's build-only diagnostic merge confirmed the build passes without the 3.3 changes). With observability in place, we can now see *what* xcodebuild rejects.

## Test plan
- [ ] If CI passes — Phase 3.3 ships and we move to 3.4 (CocoaPods integration)
- [ ] If CI fails — download `ios-xcodebuild-logs` artifact, identify the root cause from the full xcodebuild error, fix surgically, retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)