### PR TITLE
feat(android-driver): implement androidOpensTab via shared main-nav helper

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -229,11 +229,14 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     }
   };
 
-  // Tap a bottom-nav tab by name. The matcher (manual-qa-runner.js
-  // ~line 12035, Wake 100: "<Name>'s Android UI navigates back to the
-  // <tab> tab") passes the persona name as the first argument (logging
-  // convention) and the tab identifier as the second. Only the tab arg
-  // affects behaviour.
+  // Shared main-nav tab tapper used by both androidNavigatesBackToTab
+  // (Wake 100, "<Name>'s Android UI navigates back to the <tab> tab")
+  // and androidOpensTab (Wake 92, "<Name> [P-NN] (cohort) opens the
+  // <tab> tab on Android"). Mechanically identical — both matchers
+  // map to "tap the bottom-nav tab with the given name" — but kept
+  // as separate driver methods so future divergence (e.g. "open" may
+  // one day launch a full activity while "navigate back" stays a pure
+  // tap) doesn't need API churn.
   //
   // Candidate testTag forms tried in order:
   //   1. `main_<lowered>Tab` — the ACTUAL pattern in
@@ -244,7 +247,7 @@ async function createAndroidDriver({ serial: preferred } = {}) {
   //   2-4. Generic fallbacks for any future surface that doesn't
   //      follow the main-nav convention.
   // First match wins.
-  driver.androidNavigatesBackToTab = async (_name, tab) => {
+  async function tapMainNavTab(label, tab) {
     const lowered = tab.toLowerCase();
     const candidates = [`main_${lowered}Tab`, lowered, `tab_${lowered}`, `bottomNav_${lowered}`];
     for (const candidate of candidates) {
@@ -257,10 +260,15 @@ async function createAndroidDriver({ serial: preferred } = {}) {
       }
     }
     console.error(
-      `[android-driver] androidNavigatesBackToTab(${tab}) — no testTag matched any of ${candidates.join(', ')}`,
+      `[android-driver] ${label}(${tab}) — no testTag matched any of ${candidates.join(', ')}`,
     );
     return false;
-  };
+  }
+
+  driver.androidNavigatesBackToTab = async (_name, tab) =>
+    tapMainNavTab('androidNavigatesBackToTab', tab);
+
+  driver.androidOpensTab = async (_name, tab) => tapMainNavTab('androidOpensTab', tab);
 
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -226,3 +226,112 @@ describe('android-adb-driver — androidNavigatesBackToTab', () => {
     expect(okB).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidOpensTab', () => {
+  // Wake 92 matcher (manual-qa-runner.js ~line 10755):
+  //   `<Name> [P-NN] (cohort) opens the <X> tab on Android`
+  // calls driver.androidOpensTab(name, tab). Mechanically identical
+  // to Wake 100's androidNavigatesBackToTab — both tap the bottom-
+  // nav tab with the given name. Kept as separate methods so
+  // semantically-divergent behaviour (e.g. "open" might one day
+  // launch a full screen, while "navigate back" stays a pure tab
+  // tap) can land on the right method without API churn.
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('rooms tab — taps main_roomsTab via the shared main-nav helper', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('main_roomsTab', '[0,1900][270,2100]'),
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidOpensTab('Marcus', 'rooms');
+    await jest.advanceTimersByTimeAsync(500);
+    const ok = await promise;
+
+    expect(ok).toBe(true);
+    const tapCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'tap'"));
+    expect(tapCall).toBeDefined();
+    expect(tapCall[0]).toContain("'135'");
+    expect(tapCall[0]).toContain("'2000'");
+  });
+
+  test('home tab — case-insensitive lookup falls through to bare-name candidate', async () => {
+    // The j17-teacher-classroom.feature scenario uses tab name "home",
+    // which doesn't exist in MainScreen.kt (no main_homeTab). Driver
+    // falls through to the bare-name candidate `home`. If the app ever
+    // gains a Home tab with testTag `home` (not `main_homeTab`), this
+    // test stays green.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('home', '[100,500][400,700]'),
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidOpensTab('Marcus', 'home');
+    await jest.advanceTimersByTimeAsync(500);
+    const ok = await promise;
+
+    expect(ok).toBe(true);
+    const tapCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'tap'"));
+    expect(tapCall).toBeDefined();
+    expect(tapCall[0]).toContain("'250'");
+    expect(tapCall[0]).toContain("'600'");
+    // Same candidate iteration as androidNavigatesBackToTab — pinning
+    // count enforces both methods stay on the shared helper.
+    const dumpCalls = execSync.mock.calls.filter((c) => c[0].includes("'uiautomator' 'dump'"));
+    expect(dumpCalls.length).toBe(2);
+  });
+
+  test('returns false when no candidate matches', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('unrelated_tag'),
+    });
+    const driver = await createAndroidDriver();
+    const ok = await driver.androidOpensTab('Marcus', 'nonexistent');
+
+    expect(ok).toBe(false);
+    const tapCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'tap'"));
+    expect(tapCall).toBeUndefined();
+  });
+
+  test('shared logic with androidNavigatesBackToTab — same dump, same tap centre', async () => {
+    // Both methods route through the same private helper, so given
+    // identical dump + tab input they should produce identical
+    // behaviour. Locks the "they share an implementation" invariant.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('main_messagesTab', '[300,1900][600,2100]'),
+    });
+    const driver = await createAndroidDriver();
+    const pOpen = driver.androidOpensTab('Marcus', 'messages');
+    await jest.advanceTimersByTimeAsync(500);
+    const openOk = await pOpen;
+    const openTap = execSync.mock.calls.find((c) => c[0].includes("'input' 'tap'"));
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('main_messagesTab', '[300,1900][600,2100]'),
+    });
+    const driver2 = await createAndroidDriver();
+    const pNav = driver2.androidNavigatesBackToTab('Marcus', 'messages');
+    await jest.advanceTimersByTimeAsync(500);
+    const navOk = await pNav;
+    const navTap = execSync.mock.calls.find((c) => c[0].includes("'input' 'tap'"));
+
+    expect(openOk).toBe(true);
+    expect(navOk).toBe(true);
+    // Same tap coordinates: centre of [300,1900][600,2100] = (450, 2000).
+    expect(openTap[0]).toContain("'450'");
+    expect(openTap[0]).toContain("'2000'");
+    expect(navTap[0]).toContain("'450'");
+    expect(navTap[0]).toContain("'2000'");
+  });
+});

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -299,12 +299,24 @@ describe('android-adb-driver — androidOpensTab', () => {
     expect(ok).toBe(false);
     const tapCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'tap'"));
     expect(tapCall).toBeUndefined();
+    // Round 1 I-1: same 4-candidate-exhaustion pin as the
+    // androidNavigatesBackToTab no-match test. Catches a future
+    // short-circuit refactor that bails after 1 or 2 candidates
+    // on androidOpensTab specifically (the shared helper's
+    // exhaustion is observable from both call sites).
+    const dumpCalls = execSync.mock.calls.filter((c) => c[0].includes("'uiautomator' 'dump'"));
+    expect(dumpCalls.length).toBe(4);
   });
 
   test('shared logic with androidNavigatesBackToTab — same dump, same tap centre', async () => {
-    // Both methods route through the same private helper, so given
-    // identical dump + tab input they should produce identical
-    // behaviour. Locks the "they share an implementation" invariant.
+    // Given identical dump XML and tab name, both methods produce
+    // identical tap coordinates. Structural delegation (both call
+    // the private `tapMainNavTab` helper) is verified by code
+    // review — the helper is a private closure inaccessible to
+    // external duplication. Round 1 I-2: prior comment overclaimed
+    // this test "locks the share-an-implementation invariant" — it
+    // doesn't (a copy-paste duplication would still pass). The
+    // structural lock is the helper being private.
     mockExec({
       "'uiautomator' 'dump'": '',
       "'cat' '/sdcard/dump.xml'": dumpWithId('main_messagesTab', '[300,1900][600,2100]'),


### PR DESCRIPTION
## Summary
Phase 4 PR #2 — implements the Wake 92 driver method (`<Name> [P-NN] (cohort) opens the <X> tab on Android`) via shared logic with PR #723's `androidNavigatesBackToTab`.

## What changes
- Extracted the candidate-list+tap+settle pattern from `androidNavigatesBackToTab` into a private `tapMainNavTab(label, tab)` helper inside `createAndroidDriver`.
- Both `androidNavigatesBackToTab` and the new `androidOpensTab` delegate to it. Keeping them as separate named methods preserves matcher-dispatch contracts and lets future semantic divergence land on the right method.

## Tests
4 new tests in `express-api/tests/scripts/drivers/android-adb-driver.test.js` (total 11):
- Happy path: `androidOpensTab('Marcus', 'rooms')` taps `main_roomsTab`
- Fallthrough: `home` (not in MainScreen.kt) falls through to bare-name candidate; explicit dump-call-count assertion
- No-match: returns false, no tap issued
- Shared-logic invariant: both methods produce identical tap centre for the same input

Matcher dispatch already covered by Wake 92 describe block in `manual-qa-runner.test.js:18261`.

## Test plan
- [ ] CI `Test Backend` passes (11 driver tests + 1869 full backend suite)
- [ ] CI `Lint` passes (prettier --check from express-api cwd is clean per memory feedback-prettier-check-from-express-api-cwd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)