### PR TITLE
feat(android-driver): implement androidIsStillInRoom via room-marker dump scan

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -308,6 +308,27 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return new RegExp(`(?<![\\w-])(?:text|content-desc)="[^"]*${escBanner}[^"]*"`).test(dump);
   };
 
+  // Wake 84 — "<Name>'s Android UI is still in the room". Returns
+  // true if any of the room-screen markers appears in the UI dump.
+  // The persona name is a logging hint (matcher convention); only
+  // the dump scan determines the answer.
+  //
+  // Markers (grounded to real Compose testTags):
+  //   - room_seatGrid (RoomScreen.kt:718) — central body component
+  //   - room_roomName (RoomToolbar.kt:60) — toolbar title
+  //   - room_backButton (RoomToolbar.kt:84) — toolbar back button
+  // Any one is sufficient evidence the user is on the room screen.
+  // Listing multiple defends against partial-render race conditions
+  // (e.g. toolbar drawn but seat grid still loading) — first match
+  // wins.
+  driver.androidIsStillInRoom = async (_name) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    const markers = ['room_seatGrid', 'room_roomName', 'room_backButton'];
+    // eslint-disable-next-line sonarjs/slow-regex
+    return markers.some((m) => new RegExp(`resource-id="(?:[^"]*:id/)?${m}"`).test(dump));
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -546,3 +546,103 @@ describe('android-adb-driver — androidShowsBanner', () => {
     expect(okB).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidIsStillInRoom', () => {
+  // Wake 84 matcher (manual-qa-runner.js ~line 9433):
+  //   `<Name>'s Android UI is still in the room`
+  // Returns true if any of the room-screen markers appears in the
+  // UI dump. Markers grounded to real Compose testTags:
+  //   shared/.../feature/room/RoomScreen.kt:718 (room_seatGrid)
+  //   shared/.../feature/room/components/RoomToolbar.kt:60 (room_roomName)
+  //   shared/.../feature/room/components/RoomToolbar.kt:84 (room_backButton)
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('room_seatGrid present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" bounds="[0,200][1080,1200]" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsStillInRoom('Adam')).toBe(true);
+  });
+
+  test('room_roomName present → true (toolbar marker)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_roomName" bounds="[100,50][800,150]" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsStillInRoom('Adam')).toBe(true);
+  });
+
+  test('room_backButton present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_backButton" bounds="[0,50][100,150]" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsStillInRoom('Adam')).toBe(true);
+  });
+
+  test('returns false when none of the room markers are present', async () => {
+    // User left the room — dump shows home-screen markers (roomList_emptyState
+    // from HomeScreen.kt) instead of room ones.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomList_emptyState" bounds="[0,200][1080,1200]" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsStillInRoom('Adam')).toBe(false);
+  });
+
+  test('returns false when UI dump is empty (driver failure)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsStillInRoom('Adam')).toBe(false);
+  });
+
+  test('substring false-positive guarded — partial-match in unrelated id does NOT match', async () => {
+    // A resource-id like 'something_room_seatGrid_other' has the marker
+    // text as a substring but doesn't have the marker as a proper
+    // resource-id name. The regex's (?:[^"]*:id/)? group requires
+    // either a real :id/ separator or starting at the attribute opener,
+    // so the marker must be the actual name segment after :id/.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="something_room_seatGrid_other" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsStillInRoom('Adam')).toBe(false);
+  });
+
+  test('persona name is ignored — same dump, different persona yields same result', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />',
+    });
+    const driver = await createAndroidDriver();
+    const okA = await driver.androidIsStillInRoom('Adam');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okB = await driver2.androidIsStillInRoom('Bea');
+
+    expect(okA).toBe(true);
+    expect(okB).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -611,17 +611,46 @@ describe('android-adb-driver — androidIsStillInRoom', () => {
   });
 
   test('substring false-positive guarded — partial-match in unrelated id does NOT match', async () => {
-    // A resource-id like 'something_room_seatGrid_other' has the marker
-    // text as a substring but doesn't have the marker as a proper
-    // resource-id name. The regex's (?:[^"]*:id/)? group requires
-    // either a real :id/ separator or starting at the attribute opener,
-    // so the marker must be the actual name segment after :id/.
+    // Both regex boundaries enforced:
+    //   LEFT: the pattern starts with literal `resource-id="` then
+    //     either `[^"]*:id/` or empty. With empty, the marker must
+    //     be at attribute-start (right after `="`).
+    //   RIGHT: literal `"` follows the marker. `_other"` between
+    //     marker and `"` breaks the match.
     mockExec({
       "'uiautomator' 'dump'": '',
       "'cat' '/sdcard/dump.xml'": '<node resource-id="something_room_seatGrid_other" />',
     });
     const driver = await createAndroidDriver();
     expect(await driver.androidIsStillInRoom('Adam')).toBe(false);
+  });
+
+  test('left-prefix-only false positive — "unrelated_room_seatGrid" does NOT match (Round 1 I-1)', async () => {
+    // Marker at attribute-end (right-quote boundary holds) but with
+    // a leading prefix and no :id/. The optional `[^"]*:id/` group
+    // can't consume `unrelated_` (no `:id/` to consume against), so
+    // it matches empty and the marker is required at attribute-start
+    // — but the attribute starts with `unrelated_`. Mismatch.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="unrelated_room_seatGrid" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsStillInRoom('Adam')).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true (Round 1 M-1)', async () => {
+    // Some emulator dumps emit `resource-id="room_seatGrid"` without
+    // the `com.shyden.shytalk.local:id/` package prefix (older
+    // uiautomator or non-standard build variants). The optional
+    // `[^"]*:id/` group's empty alternative handles this — pin the
+    // empty-branch behaviour with this test.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="room_seatGrid" bounds="[0,0][100,100]" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsStillInRoom('Adam')).toBe(true);
   });
 
   test('persona name is ignored — same dump, different persona yields same result', async () => {


### PR DESCRIPTION
## Summary
Phase 4 PR #4. Wake 84 matcher (`<Name>'s Android UI is still in the room`). Returns true if any of three real RoomScreen testTag markers appears in the UI dump.

## Markers
Grounded to real Compose code:
- `room_seatGrid` (`shared/src/.../feature/room/RoomScreen.kt:718`)
- `room_roomName` (`shared/src/.../feature/room/components/RoomToolbar.kt:60`)
- `room_backButton` (`shared/src/.../feature/room/components/RoomToolbar.kt:84`)

Listing multiple defends against partial-render race conditions (toolbar drawn but seat grid still loading).

## Tests (7 new, 30 total in file)
- Each marker individually → true
- No marker → false
- Empty dump → false
- Substring false-positive guarded
- Persona name ignored

## Test plan
- [ ] CI `Test Backend` passes (30 driver tests)
- [ ] CI `Lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)