### PR TITLE
feat(android-driver): implement androidIsNoLongerInVoiceRoom

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -308,25 +308,38 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return new RegExp(`(?<![\\w-])(?:text|content-desc)="[^"]*${escBanner}[^"]*"`).test(dump);
   };
 
-  // Wake 84 — "<Name>'s Android UI is still in the room". Returns
-  // true if any of the room-screen markers appears in the UI dump.
-  // The persona name is a logging hint (matcher convention); only
-  // the dump scan determines the answer.
-  //
-  // Markers (grounded to real Compose testTags):
+  // Room-screen presence detection. Returns true iff any of the
+  // room-screen markers (grounded to real Compose testTags) appears
+  // in the dump:
   //   - room_seatGrid (RoomScreen.kt:718) — central body component
   //   - room_roomName (RoomToolbar.kt:60) — toolbar title
   //   - room_backButton (RoomToolbar.kt:84) — toolbar back button
-  // Any one is sufficient evidence the user is on the room screen.
-  // Listing multiple defends against partial-render race conditions
-  // (e.g. toolbar drawn but seat grid still loading) — first match
-  // wins.
-  driver.androidIsStillInRoom = async (_name) => {
-    const dump = await driver.androidUiDump();
-    if (!dump) return false;
+  // Any one is sufficient. Listing multiple defends against partial-
+  // render race conditions (e.g. toolbar drawn but seat grid still
+  // loading). Shared by androidIsStillInRoom (Wake 84) and
+  // androidIsNoLongerInVoiceRoom (Wake 105).
+  function isInRoomScreen(dump) {
     const markers = ['room_seatGrid', 'room_roomName', 'room_backButton'];
     // eslint-disable-next-line sonarjs/slow-regex
     return markers.some((m) => new RegExp(`resource-id="(?:[^"]*:id/)?${m}"`).test(dump));
+  }
+
+  // Wake 84 — "<Name>'s Android UI is still in the room".
+  driver.androidIsStillInRoom = async (_name) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    return isInRoomScreen(dump);
+  };
+
+  // Wake 105 — "<Name>'s Android UI is no longer in the voice room".
+  // Inverse of androidIsStillInRoom. CRITICALLY: returns false (not
+  // true) when the dump is empty — an empty dump means "can't
+  // confirm", not "confirmed gone". Otherwise a dump failure would
+  // incorrectly assert the user has left the room.
+  driver.androidIsNoLongerInVoiceRoom = async (_name) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    return !isInRoomScreen(dump);
   };
 
   // Open named screen — launches the local-build app via MainActivity.

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -717,6 +717,21 @@ describe('android-adb-driver — androidIsNoLongerInVoiceRoom', () => {
     expect(await driver.androidIsNoLongerInVoiceRoom('Adam')).toBe(false);
   });
 
+  test('room_backButton present → false (still in room) — Round 1 I-1', async () => {
+    // Round 1 I-1: independently pin all three markers from the
+    // androidIsNoLongerInVoiceRoom side. Without this, a future
+    // refactor that drops room_backButton from the shared marker
+    // list would only fail androidIsStillInRoom's tests, not this
+    // method's — leaving the negative-assertion contract incomplete.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_backButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsNoLongerInVoiceRoom('Adam')).toBe(false);
+  });
+
   test('empty dump → false (CANNOT CONFIRM — defends against false positives)', async () => {
     // An empty dump (driver dump failure or transient state) is
     // ambiguous — the user could be anywhere. The safe answer for

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -675,3 +675,109 @@ describe('android-adb-driver — androidIsStillInRoom', () => {
     expect(okB).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidIsNoLongerInVoiceRoom', () => {
+  // Wake 105 matcher (manual-qa-runner.js ~line 12893):
+  //   `<Name>'s Android UI is no longer in the voice room`
+  // Returns true if NONE of the room-screen markers appears in the
+  // dump. Critically: empty dump returns FALSE (not true) — can't
+  // confirm the user has left without evidence.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('no room markers in dump → true (user has left)', async () => {
+    // Dump shows home-screen markers, no room.kt markers.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomList_emptyState" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsNoLongerInVoiceRoom('Adam')).toBe(true);
+  });
+
+  test('room_seatGrid present → false (still in room)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsNoLongerInVoiceRoom('Adam')).toBe(false);
+  });
+
+  test('room_roomName present → false (still in room)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_roomName" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsNoLongerInVoiceRoom('Adam')).toBe(false);
+  });
+
+  test('empty dump → false (CANNOT CONFIRM — defends against false positives)', async () => {
+    // An empty dump (driver dump failure or transient state) is
+    // ambiguous — the user could be anywhere. The safe answer for
+    // 'no longer in room' is FALSE: we cannot confirm departure.
+    // This pairs with androidIsStillInRoom also returning false on
+    // empty dump — both methods err on the side of "can't confirm".
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsNoLongerInVoiceRoom('Adam')).toBe(false);
+  });
+
+  test('paired with androidIsStillInRoom — both false on empty dump (not opposites)', async () => {
+    // Both methods return FALSE when the dump is empty. This is
+    // intentional — the answer to both 'still in room' and 'no
+    // longer in room' is 'unknown' rather than asymmetric default.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidIsStillInRoom('Adam')).toBe(false);
+    expect(await driver.androidIsNoLongerInVoiceRoom('Adam')).toBe(false);
+  });
+
+  test('paired with androidIsStillInRoom — opposite values on populated dump', async () => {
+    // On a non-empty dump, the two methods MUST return opposite
+    // values via the shared isInRoomScreen helper.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />',
+    });
+    const driver = await createAndroidDriver();
+    const stillIn = await driver.androidIsStillInRoom('Adam');
+    const noLonger = await driver.androidIsNoLongerInVoiceRoom('Adam');
+    expect(stillIn).toBe(true);
+    expect(noLonger).toBe(false);
+  });
+
+  test('persona name is ignored — same dump, different persona yields same result', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomList_emptyState" />',
+    });
+    const driver = await createAndroidDriver();
+    const okA = await driver.androidIsNoLongerInVoiceRoom('Adam');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomList_emptyState" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okB = await driver2.androidIsNoLongerInVoiceRoom('Bea');
+
+    expect(okA).toBe(true);
+    expect(okB).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 4 PR #5. Wake 105 matcher (`<Name>'s Android UI is no longer in the voice room`). Inverse of Wake 84 shipped in PR #726.

## Refactor
Extracted the marker-list scan into a private `isInRoomScreen(dump)` helper inside `createAndroidDriver`. Both `androidIsStillInRoom` and `androidIsNoLongerInVoiceRoom` delegate to it — markers stay in sync in one place.

## Critical contract
Empty dump returns **false** for both methods. An empty dump is ambiguous; asymmetric default (e.g. assuming user is gone on empty dump) would create false-positive room-exit assertions on transient states.

## Tests (7 new, 39 total in file)
- No room markers → true
- Each room marker present → false (3 cases)
- Empty dump → false (load-bearing "cannot confirm" case)
- Paired invariants: both false on empty; opposite on populated
- Persona name ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)