### PR TITLE
feat(android-driver): implement androidNavigatesToWarningScreen

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -342,6 +342,24 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return !isInRoomScreen(dump);
   };
 
+  // Wake 101 — "<Name>'s Android UI navigates to the warning screen".
+  // Presence assertion for WarningScreen.kt's testTags:
+  //   - warning_title (WarningScreen.kt:82) — title text
+  //   - warning_communityStandardsLink (WarningScreen.kt:112)
+  //   - warning_acknowledgeButton (WarningScreen.kt:123)
+  // Any one is sufficient — first match wins.
+  driver.androidNavigatesToWarningScreen = async (_name) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    const markers = [
+      'warning_title',
+      'warning_communityStandardsLink',
+      'warning_acknowledgeButton',
+    ];
+    // eslint-disable-next-line sonarjs/slow-regex
+    return markers.some((m) => new RegExp(`resource-id="(?:[^"]*:id/)?${m}"`).test(dump));
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -796,3 +796,105 @@ describe('android-adb-driver — androidIsNoLongerInVoiceRoom', () => {
     expect(okB).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidNavigatesToWarningScreen', () => {
+  // Wake 101 matcher (manual-qa-runner.js ~line 12240):
+  //   `<Name>'s Android UI navigates to the warning screen`
+  // Returns true if any of the WarningScreen.kt testTags is in
+  // the UI dump. Grounded markers:
+  //   warning_title (WarningScreen.kt:82)
+  //   warning_communityStandardsLink (WarningScreen.kt:112)
+  //   warning_acknowledgeButton (WarningScreen.kt:123)
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('warning_title present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/warning_title" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToWarningScreen('Adam')).toBe(true);
+  });
+
+  test('warning_communityStandardsLink present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/warning_communityStandardsLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToWarningScreen('Adam')).toBe(true);
+  });
+
+  test('warning_acknowledgeButton present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/warning_acknowledgeButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToWarningScreen('Adam')).toBe(true);
+  });
+
+  test('no warning markers → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToWarningScreen('Adam')).toBe(false);
+  });
+
+  test('empty dump → false (cannot confirm)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToWarningScreen('Adam')).toBe(false);
+  });
+
+  test('substring false-positive guarded — pre_warning_title does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_warning_title_x" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToWarningScreen('Adam')).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="warning_title" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToWarningScreen('Adam')).toBe(true);
+  });
+
+  test('persona name is ignored — same dump, different persona yields same result', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/warning_title" />',
+    });
+    const driver = await createAndroidDriver();
+    const okA = await driver.androidNavigatesToWarningScreen('Adam');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/warning_title" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okB = await driver2.androidNavigatesToWarningScreen('Bea');
+
+    expect(okA).toBe(true);
+    expect(okB).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 4 PR #6. Wake 101 matcher (`<Name>'s Android UI navigates to the warning screen`). Presence assertion via 3 real WarningScreen.kt testTags:
- `warning_title` (line 82)
- `warning_communityStandardsLink` (line 112)
- `warning_acknowledgeButton` (line 123)

Any one is sufficient. Pattern identical to PR #726/#727's room-marker scan.

## Tests (8 new, 48 total)
- Each marker individually → true
- No warning markers → false
- Empty dump → false
- Substring false-positive guarded
- Bare resource-id (no package prefix) → true
- Persona name ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)