### PR TITLE
feat(android-driver): implement androidShowsWarningScreenOnRelaunch + extract dumpHasAnyMarker helper

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -308,20 +308,42 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return new RegExp(`(?<![\\w-])(?:text|content-desc)="[^"]*${escBanner}[^"]*"`).test(dump);
   };
 
-  // Room-screen presence detection. Returns true iff any of the
-  // room-screen markers (grounded to real Compose testTags) appears
-  // in the dump:
+  // Generic "does the UI dump contain ANY of these resource-id
+  // testTags?" predicate. Handles both the package-qualified form
+  // (`resource-id="com.shyden.shytalk.local:id/<tag>"`) and the
+  // bare form (`resource-id="<tag>"`). First match wins.
+  //
+  // Shared by every screen-presence assertion (room, warning, profile,
+  // etc.). Centralising the regex means CRLF/quote/anchor concerns
+  // live in one place and Phase 4 methods that follow can just pass
+  // a marker list.
+  function dumpHasAnyMarker(dump, markers) {
+    // eslint-disable-next-line sonarjs/slow-regex
+    return markers.some((m) => new RegExp(`resource-id="(?:[^"]*:id/)?${m}"`).test(dump));
+  }
+
+  // Room-screen markers (grounded to real Compose testTags):
   //   - room_seatGrid (RoomScreen.kt:718) — central body component
   //   - room_roomName (RoomToolbar.kt:60) — toolbar title
   //   - room_backButton (RoomToolbar.kt:84) — toolbar back button
-  // Any one is sufficient. Listing multiple defends against partial-
-  // render race conditions (e.g. toolbar drawn but seat grid still
-  // loading). Shared by androidIsStillInRoom (Wake 84) and
-  // androidIsNoLongerInVoiceRoom (Wake 105).
+  // Listing multiple defends against partial-render race conditions
+  // (e.g. toolbar drawn but seat grid still loading).
+  const ROOM_MARKERS = ['room_seatGrid', 'room_roomName', 'room_backButton'];
   function isInRoomScreen(dump) {
-    const markers = ['room_seatGrid', 'room_roomName', 'room_backButton'];
-    // eslint-disable-next-line sonarjs/slow-regex
-    return markers.some((m) => new RegExp(`resource-id="(?:[^"]*:id/)?${m}"`).test(dump));
+    return dumpHasAnyMarker(dump, ROOM_MARKERS);
+  }
+
+  // Warning-screen markers (WarningScreen.kt testTags):
+  //   - warning_title (line 82)
+  //   - warning_communityStandardsLink (line 112)
+  //   - warning_acknowledgeButton (line 123)
+  const WARNING_MARKERS = [
+    'warning_title',
+    'warning_communityStandardsLink',
+    'warning_acknowledgeButton',
+  ];
+  function isOnWarningScreen(dump) {
+    return dumpHasAnyMarker(dump, WARNING_MARKERS);
   }
 
   // Wake 84 — "<Name>'s Android UI is still in the room".
@@ -342,22 +364,24 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return !isInRoomScreen(dump);
   };
 
-  // Wake 101 — "<Name>'s Android UI navigates to the warning screen".
-  // Presence assertion for WarningScreen.kt's testTags:
-  //   - warning_title (WarningScreen.kt:82) — title text
-  //   - warning_communityStandardsLink (WarningScreen.kt:112)
-  //   - warning_acknowledgeButton (WarningScreen.kt:123)
-  // Any one is sufficient — first match wins.
+  // Wake 101 (first variant) — "<Name>'s Android UI navigates to the
+  // warning screen". Presence assertion via WARNING_MARKERS.
   driver.androidNavigatesToWarningScreen = async (_name) => {
     const dump = await driver.androidUiDump();
     if (!dump) return false;
-    const markers = [
-      'warning_title',
-      'warning_communityStandardsLink',
-      'warning_acknowledgeButton',
-    ];
-    // eslint-disable-next-line sonarjs/slow-regex
-    return markers.some((m) => new RegExp(`resource-id="(?:[^"]*:id/)?${m}"`).test(dump));
+    return isOnWarningScreen(dump);
+  };
+
+  // Wake 101 (second variant) — "<Name>'s Android UI shows the
+  // warning screen again on next launch". Semantically distinct
+  // from navigates-to (this is post-relaunch persistence), but
+  // mechanically identical: assert the warning screen is currently
+  // visible. Both methods share isOnWarningScreen via the marker
+  // helper so the testTag contract stays in one place.
+  driver.androidShowsWarningScreenOnRelaunch = async (_name) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    return isOnWarningScreen(dump);
   };
 
   // Open named screen — launches the local-build app via MainActivity.

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -930,6 +930,19 @@ describe('android-adb-driver — androidShowsWarningScreenOnRelaunch', () => {
     expect(await driver.androidShowsWarningScreenOnRelaunch('Adam')).toBe(true);
   });
 
+  // Round 1 I-1: independently pin the third WARNING_MARKER from this
+  // method's perspective. Symmetric with the Wake 101 first-variant
+  // suite (PR #728) which tests all three.
+  test('warning_communityStandardsLink present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/warning_communityStandardsLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsWarningScreenOnRelaunch('Adam')).toBe(true);
+  });
+
   test('no warning markers → false', async () => {
     mockExec({
       "'uiautomator' 'dump'": '',
@@ -947,6 +960,54 @@ describe('android-adb-driver — androidShowsWarningScreenOnRelaunch', () => {
     });
     const driver = await createAndroidDriver();
     expect(await driver.androidShowsWarningScreenOnRelaunch('Adam')).toBe(false);
+  });
+
+  // Round 1 I-2: bare resource-id (no package prefix) coverage from
+  // this method's perspective — symmetric with the first Wake 101
+  // variant's suite.
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="warning_title" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsWarningScreenOnRelaunch('Adam')).toBe(true);
+  });
+
+  // Round 1 I-3: right-boundary false-positive guard — `pre_warning_title_x`
+  // has the marker as a substring but with both left and right
+  // padding. The regex correctly rejects.
+  test('substring false-positive guarded — pre_warning_title_x does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_warning_title_x" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsWarningScreenOnRelaunch('Adam')).toBe(false);
+  });
+
+  // Round 1 P-1: persona name invariance — symmetric with every
+  // other method's suite in this file.
+  test('persona name is ignored — same dump, different persona yields same result', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/warning_title" />',
+    });
+    const driver = await createAndroidDriver();
+    const okA = await driver.androidShowsWarningScreenOnRelaunch('Adam');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/warning_title" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okB = await driver2.androidShowsWarningScreenOnRelaunch('Bea');
+
+    expect(okA).toBe(true);
+    expect(okB).toBe(true);
   });
 
   test('paired with androidNavigatesToWarningScreen — same dump yields same result', async () => {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -898,3 +898,71 @@ describe('android-adb-driver — androidNavigatesToWarningScreen', () => {
     expect(okB).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsWarningScreenOnRelaunch', () => {
+  // Wake 101 (second variant, manual-qa-runner.js ~line 12268):
+  //   `<Name>'s Android UI shows the warning screen again on next launch`
+  // Semantically distinct from androidNavigatesToWarningScreen
+  // (this is post-relaunch persistence) but mechanically identical:
+  // assert the warning screen is currently visible. Both methods
+  // share the same WARNING_MARKERS via isOnWarningScreen.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('warning_title present → true (after relaunch)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/warning_title" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsWarningScreenOnRelaunch('Adam')).toBe(true);
+  });
+
+  test('warning_acknowledgeButton present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/warning_acknowledgeButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsWarningScreenOnRelaunch('Adam')).toBe(true);
+  });
+
+  test('no warning markers → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsWarningScreenOnRelaunch('Adam')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsWarningScreenOnRelaunch('Adam')).toBe(false);
+  });
+
+  test('paired with androidNavigatesToWarningScreen — same dump yields same result', async () => {
+    // Both methods route through isOnWarningScreen via the shared
+    // dumpHasAnyMarker helper. Locks the invariant that they remain
+    // synchronised — a future divergence in one without the other
+    // would be a contract violation.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/warning_title" />',
+    });
+    const driver = await createAndroidDriver();
+    const navigates = await driver.androidNavigatesToWarningScreen('Adam');
+    const relaunch = await driver.androidShowsWarningScreenOnRelaunch('Adam');
+    expect(navigates).toBe(true);
+    expect(relaunch).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 4 PR #7. Wake 101 second variant — `<Name>'s Android UI shows the warning screen again on next launch`. Semantically distinct from Wake 101's first variant (this asserts persistence across app relaunch) but mechanically identical: same warning-screen testTag markers.

## Refactor
Extracted `dumpHasAnyMarker(dump, markers)` as a generic helper inside `createAndroidDriver`. Centralises the `resource-id="(?:[^"]*:id/)?<tag>"` regex pattern so future screen-presence Phase 4 methods just pass a marker list.

- `ROOM_MARKERS` / `isInRoomScreen` — used by Wake 84 and Wake 105 (PRs #726, #727)
- `WARNING_MARKERS` / `isOnWarningScreen` — used by Wake 101 (both variants — this PR + #728)

## Tests (5 new, 53 total)
- `warning_title` / `warning_acknowledgeButton` individually → true
- No warning markers → false
- Empty dump → false
- Paired-twin invariant (both Wake 101 variants yield same answer on same dump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)