### PR TITLE
feat(android-driver): implement androidNavigatesToProfileScreen

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -346,6 +346,21 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return dumpHasAnyMarker(dump, WARNING_MARKERS);
   }
 
+  // Profile-screen markers (ProfileScreen.kt testTags):
+  //   - profile_displayName (lines 507, 992) — title text
+  //   - profile_walletButton (line 1146)
+  //   - profile_followButton (lines 1179, 1188)
+  //   - profile_messageButton (line 1198)
+  const PROFILE_MARKERS = [
+    'profile_displayName',
+    'profile_walletButton',
+    'profile_followButton',
+    'profile_messageButton',
+  ];
+  function isOnProfileScreen(dump) {
+    return dumpHasAnyMarker(dump, PROFILE_MARKERS);
+  }
+
   // Wake 84 — "<Name>'s Android UI is still in the room".
   driver.androidIsStillInRoom = async (_name) => {
     const dump = await driver.androidUiDump();
@@ -401,6 +416,14 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     const escReason = reason.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     // eslint-disable-next-line sonarjs/slow-regex
     return new RegExp(`(?<![\\w-])(?:text|content-desc)="[^"]*${escReason}[^"]*"`).test(dump);
+  };
+
+  // Wake 96 — "<Name>'s Android UI navigates to the profile screen".
+  // Presence assertion via PROFILE_MARKERS.
+  driver.androidNavigatesToProfileScreen = async (_name) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    return isOnProfileScreen(dump);
   };
 
   // Open named screen — launches the local-build app via MainActivity.

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -1254,6 +1254,21 @@ describe('android-adb-driver — androidNavigatesToProfileScreen', () => {
     expect(await driver.androidNavigatesToProfileScreen('Adam')).toBe(false);
   });
 
+  test('right-boundary false-positive guarded — profile_displayName_extra does NOT match', async () => {
+    // Round 1 minor: isolate the right-side padding case from the
+    // both-sides case above. Pins that the closing-quote anchor
+    // alone (no left-prefix help) correctly rejects suffix-padded
+    // tags. Important because the optional `[^"]*:id/` group's
+    // package-qualified form is exercised here too.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_displayName_extra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToProfileScreen('Adam')).toBe(false);
+  });
+
   test('bare resource-id (no package prefix) → true', async () => {
     mockExec({
       "'uiautomator' 'dump'": '',

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -1176,3 +1176,112 @@ describe('android-adb-driver — androidShowsWarningScreenWithReason', () => {
     expect(okB).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidNavigatesToProfileScreen', () => {
+  // Wake 96 matcher — `<Name>'s Android UI navigates to the profile screen`.
+  // Presence assertion via 4 real ProfileScreen.kt testTags:
+  //   profile_displayName (507, 992), profile_walletButton (1146),
+  //   profile_followButton (1179, 1188), profile_messageButton (1198).
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('profile_displayName present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_displayName" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToProfileScreen('Adam')).toBe(true);
+  });
+
+  test('profile_walletButton present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_walletButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToProfileScreen('Adam')).toBe(true);
+  });
+
+  test('profile_followButton present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToProfileScreen('Adam')).toBe(true);
+  });
+
+  test('profile_messageButton present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_messageButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToProfileScreen('Adam')).toBe(true);
+  });
+
+  test('no profile markers → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToProfileScreen('Adam')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToProfileScreen('Adam')).toBe(false);
+  });
+
+  test('substring false-positive guarded — pre_profile_displayName_x does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_profile_displayName_x" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToProfileScreen('Adam')).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="profile_displayName" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToProfileScreen('Adam')).toBe(true);
+  });
+
+  test('persona name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_displayName" />',
+    });
+    const driver = await createAndroidDriver();
+    const okA = await driver.androidNavigatesToProfileScreen('Adam');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_displayName" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okB = await driver2.androidNavigatesToProfileScreen('Bea');
+
+    expect(okA).toBe(true);
+    expect(okB).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 4 PR #9. Wake 96 matcher (`<Name>'s Android UI navigates to the profile screen`). Presence assertion via 4 real ProfileScreen.kt testTags:
- `profile_displayName` (lines 507, 992)
- `profile_walletButton` (line 1146)
- `profile_followButton` (lines 1179, 1188)
- `profile_messageButton` (line 1198)

`PROFILE_MARKERS` + `isOnProfileScreen()` follow the pattern established by `ROOM_MARKERS` / `WARNING_MARKERS` in PRs #726/#728/#729.

## Tests (9 new, 76 total)
- Each marker individually → true (4 tests)
- No markers → false
- Empty dump → false
- Substring false-positive guarded
- Bare resource-id → true
- Persona name ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)