### PR TITLE
feat(driver/android): androidNavigatesToRoomScreen (Wake 99)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -426,6 +426,25 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return isOnProfileScreen(dump);
   };
 
+  // Wake 99 — `<Name>'s Android UI navigates to the room screen
+  // <suffix>`. j09 — 2 corpus rows with descriptive suffixes:
+  //   - "with host seat occupied"
+  //   - "as a non-seated participant"
+  // The suffix is scenario-reader METADATA, not UI text. It would
+  // never appear in a `text=`/`content-desc=` attribute, so attempting
+  // to substring-match it into the dump would false-fail every call.
+  // Driver asserts ROOM_MARKERS presence only and ignores the suffix.
+  //
+  // FUTURE: a follow-up PR can layer suffix-aware refinement on top
+  // (e.g. for "with host seat occupied", additionally inspect the
+  // seat-1 subtree for a non-empty avatar element). Done as a layer,
+  // not a replacement, so the foundation assertion stays sound.
+  driver.androidNavigatesToRoomScreen = async (_name, _suffix) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    return isInRoomScreen(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -1458,4 +1458,47 @@ describe('android-adb-driver — androidNavigatesToRoomScreen', () => {
     const driver = await createAndroidDriver();
     expect(await driver.androidNavigatesToRoomScreen('Theo', '')).toBe(true);
   });
+
+  test('package-qualified left-boundary guarded — :id/pre_room_seatGrid does NOT match', async () => {
+    // Round 1 I-2: the bare-form left-boundary case is pinned above
+    // (`pre_room_seatGrid_x`). This pins the package-qualified
+    // analogue — `com.shyden.shytalk.local:id/pre_room_seatGrid` —
+    // which exercises a different code path through the regex: the
+    // optional `(?:[^"]*:id/)?` group consumes the package prefix
+    // up through `:id/`, leaving `pre_room_seatGrid` to be matched
+    // against the marker literal `room_seatGrid`. That match must
+    // fail (it does — the marker is not a prefix-substring match;
+    // it must be the FIRST chars after `:id/`).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_room_seatGrid" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToRoomScreen('Theo', 'with host seat occupied')).toBe(
+      false,
+    );
+  });
+
+  test('uiautomator dump throws → false (not undefined)', async () => {
+    // Round 1 I-1: `androidUiDump` wraps the `uiautomator dump` and
+    // `cat /sdcard/dump.xml` adb shell calls in a try/catch that
+    // returns `''` on rejection. The driver method's `if (!dump)
+    // return false` guard then fires. Without this test, if the
+    // catch is ever refactored to re-throw or to return null, the
+    // method silently returns `undefined` — and `executeStep` would
+    // treat that as falsy-truthy ambiguously. Pin the contract:
+    // a thrown adb call still yields a clean `false`.
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToRoomScreen('Theo', 'with host seat occupied')).toBe(
+      false,
+    );
+  });
 });

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -1300,3 +1300,162 @@ describe('android-adb-driver — androidNavigatesToProfileScreen', () => {
     expect(okB).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidNavigatesToRoomScreen', () => {
+  // Wake 99 matcher — `<Name>'s Android UI navigates to the room
+  // screen <suffix>`. j09 — 2 corpus rows with descriptive suffixes:
+  //   - "with host seat occupied"
+  //   - "as a non-seated participant"
+  // The suffix is scenario-reader metadata, NOT UI text — substring-
+  // matching it into the dump would always fail (it never appears in
+  // text=/content-desc= attributes). Driver asserts ROOM_MARKERS
+  // presence only; suffix is accepted-and-ignored. Same 3 markers as
+  // androidIsStillInRoom: room_seatGrid (RoomScreen.kt:718),
+  // room_roomName (RoomToolbar.kt:60), room_backButton
+  // (RoomToolbar.kt:84).
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('room_seatGrid present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToRoomScreen('Theo', 'with host seat occupied')).toBe(true);
+  });
+
+  test('room_roomName present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_roomName" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToRoomScreen('Theo', 'with host seat occupied')).toBe(true);
+  });
+
+  test('room_backButton present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_backButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToRoomScreen('Theo', 'with host seat occupied')).toBe(true);
+  });
+
+  test('no room markers → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToRoomScreen('Theo', 'with host seat occupied')).toBe(
+      false,
+    );
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToRoomScreen('Theo', 'with host seat occupied')).toBe(
+      false,
+    );
+  });
+
+  test('left-boundary false-positive guarded — pre_room_seatGrid_x does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_room_seatGrid_x" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToRoomScreen('Theo', 'with host seat occupied')).toBe(
+      false,
+    );
+  });
+
+  test('right-boundary false-positive guarded — room_seatGrid_extra does NOT match', async () => {
+    // Pins that the closing-quote anchor alone (no left-prefix help)
+    // correctly rejects suffix-padded tags. Package-qualified form is
+    // exercised here too — the `[^"]*:id/` optional group must not
+    // swallow the boundary.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid_extra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToRoomScreen('Theo', 'with host seat occupied')).toBe(
+      false,
+    );
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="room_seatGrid" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToRoomScreen('Theo', 'with host seat occupied')).toBe(true);
+  });
+
+  test('non-seated-participant suffix also accepted with same marker', async () => {
+    // Pins that the suffix is ignored for assertion purposes — both
+    // j09 corpus suffixes return identical results given the same
+    // dump. If a future PR adds suffix-aware refinement (e.g. assert
+    // host seat is occupied only when suffix says so), this test will
+    // need updating to reflect the new contract.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToRoomScreen('Alice', 'as a non-seated participant')).toBe(
+      true,
+    );
+  });
+
+  test('persona name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />',
+    });
+    const driver = await createAndroidDriver();
+    const okTheo = await driver.androidNavigatesToRoomScreen('Theo', 'with host seat occupied');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okAlice = await driver2.androidNavigatesToRoomScreen('Alice', 'with host seat occupied');
+
+    expect(okTheo).toBe(true);
+    expect(okAlice).toBe(true);
+  });
+
+  test('empty suffix tolerated — does not throw, marker-only assertion holds', async () => {
+    // Defensive: even though the runner regex requires a non-empty
+    // suffix (`(.+)$`), pin that an accidentally-empty suffix doesn't
+    // crash the driver. Matches the foundation policy that the suffix
+    // is ignored for assertion.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToRoomScreen('Theo', '')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `androidNavigatesToRoomScreen(name, suffix)` for the Wake 99 matcher: `<Name>'s Android UI navigates to the room screen <suffix>` (j09, 2 corpus rows).
- Reuses the existing `isInRoomScreen` helper — same ROOM_MARKERS as `androidIsStillInRoom` (`room_seatGrid`, `room_roomName`, `room_backButton`).
- The Gherkin **suffix** is scenario-reader metadata ("with host seat occupied", "as a non-seated participant"), not UI text. Accepted-and-ignored at this foundation layer — substring-matching it into the dump would false-fail every call.
- 11 new tests, 88 total in the driver suite, all passing.

## Phase context
Phase 4 sequential driver-method PR #10 of ~30. Following PR #731 (`androidNavigatesToProfileScreen`). One method per PR, continuous review-loop until ZERO findings → auto-merge.

## Foundation policy
The suffix arg shape is preserved (runner calls `driver[methodName](name, suffix)`), but the foundation impl asserts ROOM_MARKERS presence only. A future PR can LAYER suffix-aware refinement (e.g. for "with host seat occupied" additionally check seat-1 has a non-empty avatar element) on top — done as a layer, not a replacement, so the foundation assertion stays sound.

## Test plan
- [x] `npx jest tests/scripts/drivers/android-adb-driver.test.js` — 88 passed
- [x] `npm run lint` — 0 errors (only inherited warnings)
- [x] `npx prettier --check scripts/drivers/android-adb-driver.js tests/scripts/drivers/android-adb-driver.test.js` — clean
- [x] Both j09 corpus suffixes pinned in test ("with host seat occupied" + "as a non-seated participant")
- [x] Boundary false-positives pinned both sides (`pre_*_x` + `*_extra`) to preempt Round-1 findings seen on PRs #730/#731
- [x] Bare resource-id (no package prefix) case pinned
- [x] Persona-name ignored across personas
- [x] Empty-suffix defensive case pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)