### PR TITLE
feat(driver/android): androidShowsMicIconAs (Wake 103)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -467,6 +467,47 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return isInRoomScreen(dump);
   };
 
+  // Wake 103 — `<Name>'s Android UI shows mic icon as "<X>"` (j09
+  // host mic on/off, j10 warning auto-mutes, j15 MC unmutes between
+  // sets). Inspects the `room_micToggleButton` IconButton's
+  // contentDescription (ChatPanel.kt:325-332) to determine state.
+  //
+  // The Compose contentDescription is the action a user would take
+  // on tap, so the displayed STATE is the inverse:
+  //   - contentDescription "Mute"              → mic is currently OPEN
+  //   - contentDescription "Unmute"            → mic is currently MUTED
+  //   - contentDescription "Voice unavailable" → mic is CLOSED
+  //
+  // Foundation policy: English (en-US) `local` flavor only.
+  // Locale-aware expansion belongs in this map (driver-side), not
+  // the runner — the Gherkin `state` arg is a stable literal.
+  //
+  // Attribute-order tolerance: uiautomator dump's attribute ordering
+  // is not contractually fixed. The impl uses a TWO-STEP extraction:
+  // first capture the full <node ...> tag containing the testTag,
+  // then look for content-desc within that captured tag string.
+  // This is order-independent and survives uiautomator version drift.
+  const MIC_STATE_HINTS = {
+    open: ['Mute'],
+    muted: ['Unmute'],
+    closed: ['Voice unavailable'],
+  };
+  driver.androidShowsMicIconAs = async (_name, state) => {
+    if (!state) return false;
+    const hints = MIC_STATE_HINTS[state.toLowerCase()];
+    if (!hints) return false;
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?room_micToggleButton"[^>]*\/?>/;
+    const tagMatch = dump.match(tagRx);
+    if (!tagMatch) return false;
+    const descMatch = tagMatch[0].match(/content-desc="([^"]*)"/);
+    if (!descMatch) return false;
+    const contentDesc = descMatch[1];
+    return hints.some((h) => contentDesc.includes(h));
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -505,7 +505,22 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     const descMatch = tagMatch[0].match(/content-desc="([^"]*)"/);
     if (!descMatch) return false;
     const contentDesc = descMatch[1];
-    return hints.some((h) => contentDesc.includes(h));
+    // Round 1 I-1 fix: word-boundary match instead of bare
+    // `.includes()`. Plain substring match was vulnerable to prefix
+    // collisions — e.g. `"Auto-Unmute".includes("Unmute")` is true.
+    // Negative lookbehind `(?<![\w-])` blocks preceding word chars
+    // and hyphens (matches the boundary shape used in
+    // androidShowsBanner). Negative lookahead `(?!\w)` blocks
+    // suffix word chars (so `"MuteAll"` doesn't match `"Mute"`).
+    // Spaces and punctuation around the hint remain valid —
+    // padded forms like "Mute mic" and "Currently: Mute" still
+    // match. Hints are escaped for regex safety in case future
+    // localisations contain dot/paren/etc.
+    return hints.some((h) => {
+      const escH = h.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      // eslint-disable-next-line sonarjs/slow-regex
+      return new RegExp(`(?<![\\w-])${escH}(?!\\w)`).test(contentDesc);
+    });
   };
 
   // Open named screen — launches the local-build app via MainActivity.

--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -508,15 +508,23 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     // Round 1 I-1 fix: word-boundary match instead of bare
     // `.includes()`. Plain substring match was vulnerable to prefix
     // collisions — e.g. `"Auto-Unmute".includes("Unmute")` is true.
-    // Negative lookbehind `(?<![\w-])` blocks preceding word chars
-    // and hyphens (matches the boundary shape used in
-    // androidShowsBanner). Negative lookahead `(?!\w)` blocks
-    // suffix word chars (so `"MuteAll"` doesn't match `"Mute"`).
-    // Spaces and punctuation around the hint remain valid —
-    // padded forms like "Mute mic" and "Currently: Mute" still
-    // match. Hints are escaped for regex safety in case future
-    // localisations contain dot/paren/etc.
+    //
+    // Round 2 I-1 fix: conditional rule for multi-word hints. The
+    // word-boundary regex `(?<![\w-])${h}(?!\w)` only anchors at
+    // the OUTER edges of the hint string — so for a multi-word hint
+    // like "Voice unavailable", a content-desc value of
+    // "Enable Voice unavailable mode" matches (leading space passes
+    // the left lookbehind, trailing space passes the right lookahead).
+    // For multi-word hints, switch to exact (case-insensitive)
+    // match: Compose emits stable literal strings, and any padded
+    // form would be a regression in Compose, not an accessibility
+    // tool's padding. Single-word hints retain the word-boundary
+    // substring tolerance so accessibility-padded forms like
+    // "Mute mic" / "Currently: Mute" still match.
     return hints.some((h) => {
+      if (h.includes(' ')) {
+        return contentDesc.toLowerCase() === h.toLowerCase();
+      }
       const escH = h.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       // eslint-disable-next-line sonarjs/slow-regex
       return new RegExp(`(?<![\\w-])${escH}(?!\\w)`).test(contentDesc);

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -1775,3 +1775,261 @@ describe('android-adb-driver — androidContinuesNormallyInRoom', () => {
     expect(await driver.androidContinuesNormallyInRoom('Theo')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsMicIconAs', () => {
+  // Wake 103 matcher — `<Name>'s Android UI shows mic icon as "<X>"`
+  // (j09 host mic on/off, j10 warning auto-mutes, j15 MC unmutes
+  // between sets). Inspects the `room_micToggleButton` IconButton's
+  // contentDescription, which Compose (ChatPanel.kt:325-332) sets
+  // from one of three string resources:
+  //   - Res.string.mute              = "Mute"              ← mic OPEN
+  //   - Res.string.unmute            = "Unmute"            ← mic MUTED
+  //   - Res.string.voice_unavailable = "Voice unavailable" ← mic CLOSED
+  // The button TEXT reflects the action a user would take on tap;
+  // the STATE is therefore the inverse — "Mute" label means the
+  // mic is currently open (clicking would mute it).
+  //
+  // Foundation policy: English (en-US) `local` flavor only. Locale
+  // expansion is a future layer — the matcher's `state` arg is a
+  // Gherkin literal, not a localised string, so the en→i18n map
+  // belongs in the driver, not the runner.
+  //
+  // Attribute-order tolerance: uiautomator dump attribute ordering is
+  // not contractually fixed. The impl uses a TWO-STEP extraction
+  // (find the full <node ...> tag containing the testTag, then look
+  // up content-desc within that captured tag string), so the test
+  // pins both attribute orders.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('"open" state with Mute contentDescription → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Mute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(true);
+  });
+
+  test('"muted" state with Unmute contentDescription → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Unmute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'muted')).toBe(true);
+  });
+
+  test('"closed" state with Voice unavailable contentDescription → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Voice unavailable" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'closed')).toBe(true);
+  });
+
+  test('state/contentDescription mismatch — open expected but Unmute present → false', async () => {
+    // Pins that asking for "open" when the mic is actually muted is
+    // correctly rejected (the journey scenario is failing — assertion
+    // should NOT silently pass).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Unmute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(false);
+  });
+
+  test('state/contentDescription mismatch — muted expected but Mute present → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Mute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'muted')).toBe(false);
+  });
+
+  test('state/contentDescription mismatch — closed expected but Mute present → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Mute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'closed')).toBe(false);
+  });
+
+  test('attribute-order tolerance — content-desc before resource-id → true', async () => {
+    // uiautomator dump's attribute order is not contractually fixed.
+    // Verifying with `node -e` against the live regex before adding
+    // this test confirmed the two-step extraction tolerates both
+    // orderings. Pin both directions.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node content-desc="Mute" resource-id="com.shyden.shytalk.local:id/room_micToggleButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(true);
+  });
+
+  test('mic toggle node missing entirely → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_chatInput" content-desc="Mute" />',
+    });
+    const driver = await createAndroidDriver();
+    // The "Mute" contentDescription is on a non-mic node — must not
+    // false-positive from a stray attribute elsewhere in the dump.
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(false);
+  });
+
+  test('mic toggle present but no content-desc attribute → false', async () => {
+    // Defensive: if a future Compose refactor removes the
+    // contentDescription, the driver should return false (the
+    // contract is "we can detect the state", and without
+    // content-desc we cannot).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(false);
+  });
+
+  test('empty state arg → false', async () => {
+    // Defensive: even though the runner regex requires a non-empty
+    // state (`"([^"]+)"`), pin that an empty arg returns false
+    // rather than throwing or matching arbitrarily.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Mute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', '')).toBe(false);
+  });
+
+  test('unknown state ("speaking") → false', async () => {
+    // Pins that arbitrary states outside the {open, muted, closed}
+    // alphabet return false rather than throwing or short-circuiting
+    // any inner predicate. Critical because the Gherkin author could
+    // typo "open" → "openn" — the assertion must fail loudly.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Mute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'speaking')).toBe(false);
+  });
+
+  test('state arg is case-insensitive — "OPEN" maps to open', async () => {
+    // Defensive against authoring style — the corpus uses lowercase
+    // per the matcher comment, but a Gherkin author writing "OPEN"
+    // or "Open" shouldn't silently fail. Documented behaviour:
+    // lowercase the state before map lookup.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Mute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'OPEN')).toBe(true);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="room_micToggleButton" content-desc="Mute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(true);
+  });
+
+  test('left-boundary false-positive guarded — pre_room_micToggleButton_x does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="pre_room_micToggleButton_x" content-desc="Mute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(false);
+  });
+
+  test('right-boundary false-positive guarded — room_micToggleButton_extra does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton_extra" content-desc="Mute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false (not undefined)', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(false);
+  });
+
+  test('persona name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Mute" />',
+    });
+    const driver = await createAndroidDriver();
+    const okTheo = await driver.androidShowsMicIconAs('Theo', 'open');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Mute" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okAlice = await driver2.androidShowsMicIconAs('Alice', 'open');
+
+    expect(okTheo).toBe(true);
+    expect(okAlice).toBe(true);
+  });
+
+  test('content-desc contains hint as substring (e.g., "Mute mic") → true', async () => {
+    // Pins substring-match semantics: contentDescription doesn't have
+    // to equal the hint exactly. Some accessibility libraries pad
+    // descriptions ("Mute mic", "Currently: Mute"). Substring match
+    // tolerates this without false-failing.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Mute mic" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -2092,4 +2092,54 @@ describe('android-adb-driver — androidShowsMicIconAs', () => {
     const driver = await createAndroidDriver();
     expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(false);
   });
+
+  test('multi-word hint embedded in sentence — "Enable Voice unavailable mode" does NOT match', async () => {
+    // Round 2 I-1: the word-boundary regex `(?<![\w-])${h}(?!\w)`
+    // only anchors at the OUTER edges of the hint. For multi-word
+    // hints like "Voice unavailable", `"Enable Voice unavailable mode"`
+    // satisfies both anchors (leading space passes `(?<![\w-])`,
+    // trailing space passes `(?!\w)`). Fixed by switching multi-word
+    // hints to exact (case-insensitive) match — Compose emits
+    // verbatim string-resource values, so embedded forms would be
+    // a Compose regression, not legitimate UI state.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Enable Voice unavailable mode" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'closed')).toBe(false);
+  });
+
+  test('multi-word hint exact (case-insensitive) match — "voice unavailable" → true', async () => {
+    // Round 2 I-1 corollary: multi-word path uses case-insensitive
+    // exact match. Pin that case variation is still tolerated for
+    // multi-word hints (the prior single-word case-insensitivity
+    // test at "OPEN" exercises the state arg, this exercises the
+    // contentDesc value being case-insensitively equal).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="voice unavailable" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'closed')).toBe(true);
+  });
+
+  test('suffix-padded muted hint — "Unmute mic" → true (symmetric with "Mute mic")', async () => {
+    // Round 2 Minor: symmetric coverage with the suffix-padded
+    // "Mute mic" test for the "open" state. The single-word path
+    // (used for "Unmute") preserves the word-boundary substring
+    // tolerance — "Unmute" is preceded by start-of-string and
+    // followed by a space, so both anchors pass. Important to pin
+    // both single-word hints exercise the same accessibility
+    // padding contract.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Unmute mic" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'muted')).toBe(true);
+  });
 });

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -2020,10 +2020,11 @@ describe('android-adb-driver — androidShowsMicIconAs', () => {
   });
 
   test('content-desc contains hint as substring (e.g., "Mute mic") → true', async () => {
-    // Pins substring-match semantics: contentDescription doesn't have
+    // Pins suffix-padded match semantics: contentDescription doesn't have
     // to equal the hint exactly. Some accessibility libraries pad
-    // descriptions ("Mute mic", "Currently: Mute"). Substring match
-    // tolerates this without false-failing.
+    // descriptions ("Mute mic", "Currently: Mute"). The word-boundary
+    // match (Round 1 I-1 fix) tolerates this without false-failing —
+    // "Mute" is preceded by start-of-string and followed by a space.
     mockExec({
       "'uiautomator' 'dump'": '',
       "'cat' '/sdcard/dump.xml'":
@@ -2031,5 +2032,64 @@ describe('android-adb-driver — androidShowsMicIconAs', () => {
     });
     const driver = await createAndroidDriver();
     expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(true);
+  });
+
+  test('prefix collision guard — "Auto-Unmute" does NOT match state "muted"', async () => {
+    // Round 1 I-1 fix: bare `.includes("Unmute")` would have returned
+    // true for `"Auto-Unmute"` (substring true). The word-boundary
+    // match blocks this — the `-` before "Unmute" is matched by the
+    // negative lookbehind `(?<![\w-])`. Pins the boundary rule so a
+    // future Compose feature adding a label like "Auto-Unmute" or
+    // "Smart-Unmute" doesn't silently false-positive the assertion.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Auto-Unmute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'muted')).toBe(false);
+  });
+
+  test('prefix collision guard — "Pre-Mute" does NOT match state "open"', async () => {
+    // Round 1 I-1: same boundary rule applied to the "open" hint.
+    // Symmetric coverage with the "Auto-Unmute" pin above.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="Pre-Mute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(false);
+  });
+
+  test('suffix collision guard — "MuteAll" does NOT match state "open"', async () => {
+    // Round 1 I-1: the right-side word-boundary `(?!\w)` blocks the
+    // hint from being a prefix of a longer word. "MuteAll" contains
+    // "Mute" but the following `A` is a word char — match blocked.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_micToggleButton" content-desc="MuteAll" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(false);
+  });
+
+  test('package-qualified left-boundary false-positive guarded — :id/pre_room_micToggleButton does NOT match', async () => {
+    // Round 1 I-2: the bare-form left-boundary case is already pinned
+    // (`pre_room_micToggleButton_x`). This pins the analogous
+    // package-qualified form. The optional `(?:[^"]*:id/)?` group
+    // would consume `com.shyden.shytalk.local:id/`, leaving
+    // `pre_room_micToggleButton` to match against the literal
+    // `room_micToggleButton` — that fails because `pre_` precedes
+    // `room_`. The pin makes the regex contract explicit for this
+    // method's distinct (non-dumpHasAnyMarker) regex shape.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_room_micToggleButton" content-desc="Mute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsMicIconAs('Theo', 'open')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Implements `androidShowsMicIconAs(name, state)` for the Wake 103 matcher: `<Name>'s Android UI shows mic icon as "<X>"` (j09/j10/j15).
- Inspects the `room_micToggleButton` IconButton's `contentDescription` attribute (set by `ChatPanel.kt:325-332`).
- Maps Gherkin states to **inverse** of the on-tap action label: `"open"`→`"Mute"`, `"muted"`→`"Unmute"`, `"closed"`→`"Voice unavailable"`. The button text reflects the action a user would take; the state is therefore the inverse.
- 19 new tests, 127 total in the driver suite, all passing.

## Two-step regex extraction
uiautomator dump's attribute ordering is not contractually fixed (this is the **first driver method that depends on a per-node attribute**, vs. the prior presence-only checks). The impl uses a **two-step** extraction:
1. Capture the entire `<node ...>` tag containing the `room_micToggleButton` testTag
2. Look for `content-desc="..."` within the captured tag string

Order-independent — survives uiautomator version drift. Pre-verified with `node -e` against 5 attribute-order variations before writing the test fixture.

## Foundation policy
- English (en-US) `local` flavor only — Compose `stringResource()` resolves to "Mute"/"Unmute"/"Voice unavailable" in en-US. Locale-aware expansion belongs in the `MIC_STATE_HINTS` map (driver-side), not the runner.
- Substring match against contentDescription — some accessibility libraries pad descriptions ("Mute mic", "Currently: Mute"); strict equality would false-fail.
- Case-insensitive state lookup — `OPEN`/`Open`/`open` all resolve. Defensive against authoring style.

## Phase context
Phase 4 sequential driver-method PR #12 of ~30. Following PR #733. One method per PR, continuous review-loop until ZERO findings → auto-merge.

## Test plan
- [x] 19 new tests added, all 127 in suite pass
- [x] 3 happy-path state→hint mappings (open/muted/closed)
- [x] 3 mismatched-state false cases (open expected, Unmute present, etc.)
- [x] Attribute-order tolerance pinned (content-desc before resource-id)
- [x] Mic node missing → false; mic node present but no content-desc → false
- [x] Empty dump → false; empty state arg → false; unknown state → false
- [x] Case-insensitive state ("OPEN" → resolves)
- [x] Bare resource-id (no package prefix) → true
- [x] Left + right boundary false-positive guards
- [x] uiautomator dump throws → false (defensive)
- [x] Persona name ignored
- [x] Substring-match semantics ("Mute mic" → still open)
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)