### PR TITLE
feat(driver/android): androidShowsBalanceViaListener (Wake 100)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -531,6 +531,42 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     });
   };
 
+  // Wake 100 — `<Name>'s Android UI shows the new "<X>" balance via
+  // Firestore listener` (j06 — wallet refresh via real-time listener).
+  // Inspects the `wallet_balance` node's `text=` and `content-desc=`
+  // attributes for the balance string.
+  //
+  // Balance shape: user-facing decimal with optional digit separators
+  // ("5,000"), currency prefix ("$5,000"), and label padding
+  // ("Balance: 5,000 coins"). Word-boundary regex prevents numeric-
+  // prefix collisions ("45,000" must NOT match "5,000") and numeric-
+  // suffix collisions ("5,0000" must NOT match "5,000"). Same boundary
+  // shape as androidShowsMicIconAs (PR #734) but applied across
+  // text= AND content-desc= since either can carry the value.
+  //
+  // Balance arg is regex-escaped — a "." in "1,234.56" matches a
+  // literal dot, not "any char" (decimal-point variant of the
+  // numeric-collision concern).
+  //
+  // Two-step extraction (PR #734 pattern): capture the wallet_balance
+  // node tag first, then scan its attributes. Attribute-order
+  // independent.
+  driver.androidShowsBalanceViaListener = async (_name, balance) => {
+    if (!balance || !balance.trim()) return false;
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?wallet_balance"[^>]*\/?>/;
+    const tagMatch = dump.match(tagRx);
+    if (!tagMatch) return false;
+    const escBalance = balance.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // Scan within the captured tag for either text= or content-desc=
+    // carrying the balance value with digit-boundary protection.
+    // eslint-disable-next-line sonarjs/slow-regex
+    const valueRx = new RegExp(`(?:text|content-desc)="[^"]*(?<![\\w-])${escBalance}(?!\\w)[^"]*"`);
+    return valueRx.test(tagMatch[0]);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -2494,4 +2494,29 @@ describe('android-adb-driver — androidShowsBalanceViaListener', () => {
     const driver = await createAndroidDriver();
     expect(await driver.androidShowsBalanceViaListener('Theo', '1,234.56')).toBe(false);
   });
+
+  test('first-match contract pinned — two wallet_balance nodes, first wins', async () => {
+    // Round 2 Minor: `dump.match(tagRx)` returns the first match
+    // only. If uiautomator emits two `wallet_balance` nodes (rare
+    // in Compose — one wallet UI on screen at a time — but
+    // theoretically possible with modal stacks or recycled views),
+    // the driver inspects whichever node appears first in the dump.
+    //
+    // Pin this as the deliberate contract. A future swap to
+    // `matchAll`/multi-node scanning would change behaviour
+    // silently without this pin — the breakage of this test would
+    // force an explicit decision.
+    //
+    // Setup: first node has "1,234", second has "5,000". Assertion
+    // for "5,000" must return false because the first (winning)
+    // match doesn't carry that value.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="1,234" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(false);
+  });
 });

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -2208,12 +2208,85 @@ describe('android-adb-driver — androidShowsBalanceViaListener', () => {
 
   test('balance with currency prefix — "$5,000" → true', async () => {
     // The `$` is not a word char, so the left lookbehind passes.
-    // Pins that future locale changes adding `$`, `€`, `£`, or `¥`
-    // prefix don't break the assertion.
+    // Round 1 I-3: `€`, `£`, `¥` prefix variants are pinned in
+    // separate tests below (the comment previously claimed coverage
+    // here that was actually absent).
     mockExec({
       "'uiautomator' 'dump'": '',
       "'cat' '/sdcard/dump.xml'":
         '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="$5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(true);
+  });
+
+  test('balance with euro prefix — "€5,000" → true', async () => {
+    // Round 1 I-3: `€` (U+20AC) is non-ASCII, non-word. Under
+    // JavaScript regex semantics without the `u` flag, `\w` matches
+    // only `[A-Za-z0-9_]` — so `€` is NOT a word char and the left
+    // lookbehind `(?<![\w-])` passes. Pin the contract.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="€5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(true);
+  });
+
+  test('balance with pound prefix — "£5,000" → true', async () => {
+    // Round 1 I-3: same as euro pin but for `£` (U+00A3).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="£5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(true);
+  });
+
+  test('balance with yen prefix — "¥5,000" → true', async () => {
+    // Round 1 I-3: same as euro pin but for `¥` (U+00A5).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="¥5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(true);
+  });
+
+  test('hyphen-prefix balance — "-5,000" does NOT match "5,000" (negative is a distinct value)', async () => {
+    // Round 1 I-1: a Compose locale that formats negative balances
+    // as "-5,000" would mean the user's balance is NOT 5,000 (it's
+    // negative 5,000). Asserting "5,000" against a "-5,000" display
+    // must return false. The lookbehind class `[\w-]` blocks the
+    // hyphen specifically (it's the same class used in
+    // androidShowsBanner's text= attribute guard). Pin the
+    // contract so a future relaxation of the class doesn't silently
+    // accept negative balances as matches for positive assertions.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="-5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(false);
+  });
+
+  test('node with &gt;-escaped angle bracket before resource-id → tag still located', async () => {
+    // Round 1 I-2: uiautomator XML-encodes `>` as `&gt;` in
+    // attribute values, so `[^>]*` in the tag regex doesn't truncate
+    // (none of `&`, `g`, `t`, `;` is a literal `>`). Pin that the
+    // tag-capture step works when another attribute value contains
+    // an HTML-escaped angle bracket positioned before resource-id.
+    // Low probability in practice (uiautomator always escapes), but
+    // explicit defends against future regex changes that might use
+    // `[^>]+?` non-greedy or otherwise alter the boundary.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node text="5,000 &gt; 0" resource-id="com.shyden.shytalk.local:id/wallet_balance" content-desc="5,000" />',
     });
     const driver = await createAndroidDriver();
     expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(true);

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -2143,3 +2143,282 @@ describe('android-adb-driver — androidShowsMicIconAs', () => {
     expect(await driver.androidShowsMicIconAs('Theo', 'muted')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsBalanceViaListener', () => {
+  // Wake 100 matcher — `<Name>'s Android UI shows the new "<X>"
+  // balance via Firestore listener` (j06 wallet refresh via real-time
+  // listener). Inspects the `wallet_balance` node's `text=` and
+  // `content-desc=` attributes for the balance string.
+  //
+  // Balance shape is user-facing — can include digit separators
+  // ("5,000"), currency prefix ("$5,000"), and padded labels
+  // ("Balance: 5,000 coins"). Substring match with digit-boundary
+  // protection — same word-boundary pattern as the mic-icon impl
+  // (PR #734).
+  //
+  // The matcher's pattern accepts `"([^"]+)"` so the balance string
+  // is regex-escaped before insertion into the boundary regex.
+  // Compose's text= and content-desc= can appear in either order;
+  // the two-step extraction handles attribute-order tolerance.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('balance in text attribute → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(true);
+  });
+
+  test('balance in content-desc attribute → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" content-desc="5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(true);
+  });
+
+  test('balance with padded label prefix — "Balance: 5,000" → true', async () => {
+    // Accessibility labels often pad the value with a descriptive
+    // prefix. The word-boundary match accepts the surrounding space.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="Balance: 5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(true);
+  });
+
+  test('balance with trailing unit — "5,000 coins" → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="5,000 coins" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(true);
+  });
+
+  test('balance with currency prefix — "$5,000" → true', async () => {
+    // The `$` is not a word char, so the left lookbehind passes.
+    // Pins that future locale changes adding `$`, `€`, `£`, or `¥`
+    // prefix don't break the assertion.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="$5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(true);
+  });
+
+  test('numeric-prefix collision guarded — "45,000" does NOT match "5,000"', async () => {
+    // Pins the digit-boundary protection on the LEFT side. Without
+    // word-boundary, "45,000" would match the hint "5,000" via
+    // naive substring scan, silently confirming an INCORRECT
+    // balance assertion.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="45,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(false);
+  });
+
+  test('numeric-suffix collision guarded — "5,0000" does NOT match "5,000"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="5,0000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(false);
+  });
+
+  test('different balance present → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="1,234" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(false);
+  });
+
+  test('wallet_balance node missing → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" text="5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    // The "5,000" text is on a non-wallet node — must not false-positive
+    // from a stray attribute elsewhere in the dump.
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(false);
+  });
+
+  test('wallet_balance present but neither text nor content-desc has balance → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(false);
+  });
+
+  test('empty balance arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '')).toBe(false);
+  });
+
+  test('whitespace-only balance arg → false', async () => {
+    // Defensive against accidentally-blank Gherkin: even though the
+    // runner regex requires `([^"]+)` (one or more non-quote chars),
+    // an author could write `" "` and it would slip through. Pin
+    // that the driver rejects whitespace-only input.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '   ')).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="wallet_balance" text="5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(true);
+  });
+
+  test('left-boundary false-positive guarded — pre_wallet_balance_x does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_wallet_balance_x" text="5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(false);
+  });
+
+  test('right-boundary false-positive guarded — wallet_balance_extra does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance_extra" text="5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(false);
+  });
+
+  test('package-qualified left-boundary guarded — :id/pre_wallet_balance does NOT match', async () => {
+    // Same pattern as PR #734's I-2 fix. The optional `(?:[^"]*:id/)?`
+    // group consumes the package prefix, leaving `pre_wallet_balance`
+    // to match against `wallet_balance` literal — that fails because
+    // `pre_` precedes `wallet_`. Pin the contract explicit.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_wallet_balance" text="5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(false);
+  });
+
+  test('attribute-order tolerance — content-desc before resource-id → true', async () => {
+    // uiautomator dump attribute ordering is not contractually fixed
+    // (see PR #734 mic-icon impl). The two-step extraction must
+    // tolerate both orderings.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node content-desc="5,000" resource-id="com.shyden.shytalk.local:id/wallet_balance" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(true);
+  });
+
+  test('uiautomator dump throws → false (not undefined)', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(false);
+  });
+
+  test('persona name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    const okTheo = await driver.androidShowsBalanceViaListener('Theo', '5,000');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="5,000" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okAlice = await driver2.androidShowsBalanceViaListener('Alice', '5,000');
+
+    expect(okTheo).toBe(true);
+    expect(okAlice).toBe(true);
+  });
+
+  test('balance with regex-significant chars — "1,234.56" matches literally', async () => {
+    // The balance arg is regex-escaped before insertion into the
+    // boundary regex. Pins that `.` in "1,234.56" matches a LITERAL
+    // dot, not "any char" — `1,2345/6` would otherwise false-match
+    // (decimal-point variant of the prefix-collision concern).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="1,234.56" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '1,234.56')).toBe(true);
+  });
+
+  test('balance with regex-significant chars — "1,234.56" does NOT match "1,234/56"', async () => {
+    // Verifies the literal-dot escape via the negative case.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="1,234/56" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBalanceViaListener('Theo', '1,234.56')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `androidShowsBalanceViaListener(name, balance)` for the Wake 100 matcher: `<Name>'s Android UI shows the new "<X>" balance via Firestore listener` (j06 wallet refresh).
- Inspects the `wallet_balance` testTag node's `text=` AND `content-desc=` attributes for the balance string.
- 22 new tests, 156 total in the driver suite, all passing.

## Balance shape handling
User-facing decimal with optional digit separators (`5,000`), currency prefix (`$5,000`), and label padding (`Balance: 5,000 coins`). Word-boundary regex `(?<![\w-])${balance}(?!\w)` prevents numeric collisions:
- `"45,000"` does NOT match `"5,000"` (left digit boundary)
- `"5,0000"` does NOT match `"5,000"` (right digit boundary)

Balance arg is **regex-escaped** before insertion — `"."` in `"1,234.56"` matches a literal dot (decimal-point variant of the collision concern). Negative test pins this: `"1,234/56"` does NOT match `"1,234.56"`.

## Two-step extraction
Same pattern as PR #734's mic-icon impl: (1) capture the `wallet_balance` node tag, (2) scan its attributes. Attribute-order independent.

## Phase context
Phase 4 sequential driver-method PR #13 of ~30. Following PR #734. One method per PR, continuous review-loop until ZERO findings → auto-merge.

## Test plan
- [x] 22 new tests added, all 156 in suite pass
- [x] Balance in both text= and content-desc= happy paths
- [x] All 3 padding variants pinned (label prefix, trailing unit, currency prefix)
- [x] Digit-boundary collisions both sides ("45,000" / "5,0000")
- [x] Regex-significant char escape pinned (positive + negative)
- [x] Boundary false-positives all 3 forms (bare-left, bare-right, package-qualified-left)
- [x] Attribute-order tolerance pinned
- [x] Empty-dump / empty-balance / whitespace-only / unknown / missing-attribute branches
- [x] uiautomator dump throws → false
- [x] Persona name ignored
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)