### PR TITLE
feat(driver/android): androidReplacesFollowButton (Wake 102)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -567,6 +567,43 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return valueRx.test(tagMatch[0]);
   };
 
+  // Wake 102 — `<Name>'s Android UI replaces follow button with
+  // "<X>"` (j07 — UI element swap after follow action completes).
+  // Inspects the `profile_followButton` testTag node's text= AND
+  // content-desc= attributes for the buttonId string.
+  //
+  // The buttonId is one of the four follow-state Compose strings
+  // (ProfileScreen.kt:1183, 1192): "Follow", "Unfollow", "Following",
+  // "Follow back". These have OVERLAPPING PREFIXES — "Follow" is a
+  // prefix of "Follow back" and "Following". Substring or word-
+  // boundary substring matching would false-positive across them
+  // (asserting "Follow" against a "Follow back" button would pass
+  // under word-boundary substring tolerance because of the space
+  // delimiter).
+  //
+  // Foundation design: EXACT (case-insensitive) match across either
+  // text= or content-desc= within the captured tag. The mic-icon's
+  // substring tolerance (PR #734) was for hypothetical accessibility
+  // padding; here the four states are mutually-exclusive labels and
+  // exact match is the safer foundation. If a future surface
+  // legitimately pads ("Follow • Alice"), this method's contract
+  // needs an explicit revision, not silent drift.
+  driver.androidReplacesFollowButton = async (_name, buttonId) => {
+    if (!buttonId || !buttonId.trim()) return false;
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?profile_followButton"[^>]*\/?>/;
+    const tagMatch = dump.match(tagRx);
+    if (!tagMatch) return false;
+    const target = buttonId.toLowerCase();
+    const attrRx = /(?:text|content-desc)="([^"]*)"/g;
+    for (const m of tagMatch[0].matchAll(attrRx)) {
+      if (m[1].toLowerCase() === target) return true;
+    }
+    return false;
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -2822,4 +2822,78 @@ describe('android-adb-driver — androidReplacesFollowButton', () => {
     const driver = await createAndroidDriver();
     expect(await driver.androidReplacesFollowButton('Theo', 'Unfollow')).toBe(false);
   });
+
+  test('non-self-closing open-tag form with value on outer node → true', async () => {
+    // Round 1 I-1: real uiautomator XML for Compose Button often uses
+    // the open-tag form `<node ...>...</node>` rather than self-closing
+    // `<node ... />`. The `\/?>` part of tagRx correctly matches both
+    // forms. With Compose's `Modifier.semantics(mergeDescendants = true)`
+    // (the default for Button), the merged contentDescription lands on
+    // the OUTER node. tagRx captures just the opening tag (no children),
+    // and the matchAll scan finds the value there.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Follow"><node text="ignored-child-text" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(true);
+  });
+
+  test('non-self-closing form with value ONLY on a child node → false (contract limitation)', async () => {
+    // Round 1 I-1: pin the deliberate contract limitation — values
+    // that appear ONLY on a child node are NOT detected. tagRx
+    // captures just the opening tag, so matchAll scans only the
+    // outer node's attributes. This is the correct foundation
+    // because Compose's Button merges descendants into the outer
+    // node by default. Scanning children would risk cross-button
+    // false-positives (a different Compose surface might nest
+    // arbitrary text inside the button container).
+    //
+    // If a future Compose change ever leaves the value only on a
+    // child, this test breaks loudly and the contract is revisited
+    // intentionally rather than silently expanded.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" class="Button"><node text="Follow" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(false);
+  });
+
+  test('matchAll iterates BOTH text and content-desc — divergent values both findable', async () => {
+    // Round 1 I-2: pin that `matchAll` actually iterates rather than
+    // stopping at the first attribute. With `text="Follow"` AND
+    // `content-desc="Unfollow"` on the same node, both buttonIds
+    // should independently match. Defends against a future refactor
+    // that swaps matchAll for `.match()` (first-only) without
+    // updating tests.
+    //
+    // Realistic? Compose's accessibility merge usually keeps text and
+    // contentDescription aligned, but uiautomator can surface
+    // divergent values when text is the rendered label and
+    // content-desc is the role hint. The pin doesn't assume
+    // divergence is common — just that the iteration semantics
+    // hold when it occurs.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" text="Follow" content-desc="Unfollow" />',
+    });
+    const driver = await createAndroidDriver();
+    // First attribute (text="Follow")
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(true);
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" text="Follow" content-desc="Unfollow" />',
+    });
+    const driver2 = await createAndroidDriver();
+    // Second attribute (content-desc="Unfollow") — only reachable if
+    // matchAll iterates past the first hit when it doesn't match.
+    expect(await driver2.androidReplacesFollowButton('Theo', 'Unfollow')).toBe(true);
+  });
 });

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -2520,3 +2520,306 @@ describe('android-adb-driver — androidShowsBalanceViaListener', () => {
     expect(await driver.androidShowsBalanceViaListener('Theo', '5,000')).toBe(false);
   });
 });
+
+describe('android-adb-driver — androidReplacesFollowButton', () => {
+  // Wake 102 matcher — `<Name>'s Android UI replaces follow button
+  // with "<X>"` (j07 — UI element swap after follow action completes).
+  // Inspects the `profile_followButton` testTag node's text= AND
+  // content-desc= attributes for the buttonId string.
+  //
+  // The buttonId is one of the four follow-state Compose strings
+  // (ProfileScreen.kt:1183, 1192): "Follow", "Unfollow", "Following",
+  // "Follow back". These have OVERLAPPING PREFIXES — "Follow" is a
+  // prefix of "Follow back" and "Following". Substring or word-
+  // boundary substring matching would false-positive across them
+  // (asserting "Follow" against a "Follow back" button would pass
+  // under word-boundary substring tolerance because of the space
+  // delimiter).
+  //
+  // Foundation design: EXACT (case-insensitive) match across either
+  // text= or content-desc= within the captured tag. The mic-icon's
+  // substring tolerance (PR #734) was for hypothetical accessibility
+  // padding; here the four states are mutually-exclusive labels
+  // and exact match is the safer foundation.
+  //
+  // Two-step extraction (PR #734 pattern): capture the
+  // profile_followButton node tag first, then scan its attributes.
+  // Attribute-order independent.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('buttonId "Follow" matches contentDescription "Follow" → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Follow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(true);
+  });
+
+  test('buttonId "Unfollow" matches text="Unfollow" → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" text="Unfollow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Unfollow')).toBe(true);
+  });
+
+  test('buttonId "Following" matches contentDescription "Following" → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Following" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Following')).toBe(true);
+  });
+
+  test('buttonId "Follow back" matches contentDescription "Follow back" → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Follow back" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow back')).toBe(true);
+  });
+
+  test('overlap rejection — buttonId "Follow" does NOT match "Follow back"', async () => {
+    // Critical overlap pin: the corpus has 4 follow states with
+    // overlapping prefixes. Word-boundary substring match would
+    // false-positive here (space delimiter between "Follow" and
+    // "back"). Exact match correctly rejects.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Follow back" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(false);
+  });
+
+  test('overlap rejection — buttonId "Follow" does NOT match "Following"', async () => {
+    // Word-boundary substring match would correctly reject this
+    // (word-char suffix), but the test pins it explicitly for the
+    // exact-match contract too.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Following" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(false);
+  });
+
+  test('overlap rejection — buttonId "Follow back" does NOT match "Follow" (shorter hint, longer button label is the inverse)', async () => {
+    // Inverse direction: button shows shorter "Follow", assertion
+    // asks for longer "Follow back". Exact match rejects (longer
+    // hint cannot equal shorter label).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Follow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow back')).toBe(false);
+  });
+
+  test('case-insensitive match — "follow" matches "Follow"', async () => {
+    // Defensive against authoring style — the corpus uses
+    // canonical-case strings ("Follow"), but a Gherkin author
+    // writing "follow" (lowercase) shouldn't silently fail.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Follow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'follow')).toBe(true);
+  });
+
+  test('case-insensitive multi-word — "follow back" matches "Follow back"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Follow back" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'follow back')).toBe(true);
+  });
+
+  test('profile_followButton node missing → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_messageButton" content-desc="Follow" />',
+    });
+    const driver = await createAndroidDriver();
+    // The "Follow" contentDescription is on a non-follow node —
+    // must not false-positive from a stray attribute elsewhere.
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(false);
+  });
+
+  test('profile_followButton present but no text or content-desc → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(false);
+  });
+
+  test('empty buttonId arg → false', async () => {
+    // Defensive: the runner regex requires `([^"]+)` so an empty
+    // string is not reachable from valid Gherkin, but pin that the
+    // driver rejects whitespace-only input rather than silently
+    // matching any node with an empty attribute.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Follow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', '')).toBe(false);
+  });
+
+  test('whitespace-only buttonId arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Follow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', '   ')).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="profile_followButton" content-desc="Follow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(true);
+  });
+
+  test('left-boundary false-positive guarded — pre_profile_followButton_x does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="pre_profile_followButton_x" content-desc="Follow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(false);
+  });
+
+  test('right-boundary false-positive guarded — profile_followButton_extra does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton_extra" content-desc="Follow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(false);
+  });
+
+  test('package-qualified left-boundary guarded — :id/pre_profile_followButton does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_profile_followButton" content-desc="Follow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(false);
+  });
+
+  test('attribute-order tolerance — content-desc before resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node content-desc="Follow" resource-id="com.shyden.shytalk.local:id/profile_followButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(true);
+  });
+
+  test('uiautomator dump throws → false (not undefined)', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(false);
+  });
+
+  test('persona name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Follow" />',
+    });
+    const driver = await createAndroidDriver();
+    const okTheo = await driver.androidReplacesFollowButton('Theo', 'Follow');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Follow" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okAlice = await driver2.androidReplacesFollowButton('Alice', 'Follow');
+
+    expect(okTheo).toBe(true);
+    expect(okAlice).toBe(true);
+  });
+
+  test('first-match contract pinned — two profile_followButton nodes, first wins', async () => {
+    // Same contract as androidShowsBalanceViaListener (PR #735 R2).
+    // First node has "Follow", second has "Unfollow". Assertion for
+    // "Unfollow" must return false because the first (winning)
+    // match doesn't carry that value. A future swap to
+    // `matchAll`/multi-node scanning would silently change
+    // behaviour without this pin.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Follow" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Unfollow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Unfollow')).toBe(false);
+  });
+
+  test('partial match within a longer attribute value rejected — "Unfollow Alice" does NOT match "Unfollow"', async () => {
+    // Exact-match (not substring) — pin that even where the
+    // buttonId IS a prefix of a longer attribute value, the
+    // assertion fails. Defends against future drift toward
+    // substring tolerance that would re-introduce the overlap
+    // false-positives.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_followButton" content-desc="Unfollow Alice" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Unfollow')).toBe(false);
+  });
+});

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -2896,4 +2896,28 @@ describe('android-adb-driver — androidReplacesFollowButton', () => {
     // matchAll iterates past the first hit when it doesn't match.
     expect(await driver2.androidReplacesFollowButton('Theo', 'Unfollow')).toBe(true);
   });
+
+  test('bare left-boundary without suffix — pre_profile_followButton does NOT match', async () => {
+    // Round 2 I-1: explicit pin that a bare resource-id of
+    // `pre_profile_followButton` (no `_x` suffix, no package prefix)
+    // is correctly rejected. The reviewer's regex-trace reasoning
+    // initially suggested this could be a left-boundary bug because
+    // `profile_followButton"` is a suffix of `pre_profile_followButton"`.
+    //
+    // Verified false alarm — the production regex anchors
+    // `profile_followButton"` to the position IMMEDIATELY after
+    // `resource-id="` (modulo the optional `(?:[^"]*:id/)?` prefix
+    // group). The literal cannot "slide" within the attribute value
+    // because `resource-id="` is a fixed anchor.
+    //
+    // Pin here so future reviewers don't need to mentally simulate
+    // the regex anchoring — the test makes the contract self-evident.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="pre_profile_followButton" content-desc="Follow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidReplacesFollowButton('Theo', 'Follow')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Implements `androidReplacesFollowButton(name, buttonId)` for the Wake 102 matcher: `<Name>'s Android UI replaces follow button with "<X>"` (j07 — UI element swap after follow action completes).
- Inspects the `profile_followButton` testTag node's `text=` AND `content-desc=` attributes for the buttonId string.
- 23 new tests, 185 total in the driver suite, all passing.

## Critical design departure from PR #734
The four follow-state Compose strings ("Follow", "Unfollow", "Following", "Follow back") have **overlapping prefixes** — `"Follow"` is a prefix of `"Follow back"` AND `"Following"`. Word-boundary substring matching (used in PR #734's mic-icon impl) would produce false positives across them:
- Asserting `"Follow"` against a `"Follow back"` button: word-boundary substring → MATCH (space delimiter passes the lookahead). Wrong!

**Foundation design:** EXACT (case-insensitive) match across either `text=` or `content-desc=` within the captured tag. The four buttonIds are mutually-exclusive enumerated labels, not free-form descriptors — strict equality is the semantically correct foundation.

If a future surface legitimately pads the label ("Follow • Alice"), this method's contract needs an **explicit revision**, not silent drift toward substring tolerance.

## Critical overlap-rejection pins
Three tests explicitly pin the overlap-rejection contract:
- `"Follow"` does NOT match `"Follow back"`
- `"Follow"` does NOT match `"Following"`
- `"Follow back"` does NOT match `"Follow"` (inverse direction)

Plus a `"Unfollow Alice"` partial-match rejection pin to defend against future substring drift.

## Phase context
Phase 4 sequential driver-method PR #14 of ~30. Following PR #735. One method per PR, continuous review-loop until ZERO findings → auto-merge.

## Test plan
- [x] 23 new tests added, all 185 in suite pass
- [x] 4 happy-path matches (each follow-state across text= and content-desc=)
- [x] 3 critical overlap-rejection pins (semantic-correctness)
- [x] Case-insensitive single-word and multi-word
- [x] All standard rejection branches (missing tag, no attributes, empty dump, empty/whitespace arg)
- [x] Bare + left + right + package-qualified boundary guards
- [x] Attribute-order tolerance
- [x] uiautomator dump throws → false
- [x] Persona name ignored
- [x] First-match contract pin (two profile_followButton nodes)
- [x] Partial-match rejection ("Unfollow Alice" does NOT match "Unfollow")
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)