### PR TITLE
feat(driver/android): androidShowsFrozenBanner (Wake 99)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -640,6 +640,28 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return /(?<![\w-])enabled="false"/.test(tagMatch[0]);
   };
 
+  // Wake 99 — `<Name>'s Android UI[ opens conversation "<X>"] shows
+  // the frozen-banner element <suffix>` (j08, 4 corpus rows). Driver
+  // receives `(viewer, convId, suffix)` where convId is optional
+  // (null when no "opens conversation X" prefix in the Gherkin) and
+  // suffix is descriptive ("with text-from-key X" or "with locale
+  // string Y").
+  //
+  // Foundation policy: presence-check `privateChat_frozenBanner`
+  // testTag (PrivateChatScreen.kt:440) only. All three args are
+  // accepted-and-ignored at this layer — the assertion is "the
+  // frozen banner is currently visible". A future PR can layer
+  // text-from-key / locale-string verification once those contracts
+  // are clearer. Same shape as androidNavigatesToRoomScreen's
+  // suffix-ignore foundation (PR #732).
+  driver.androidShowsFrozenBanner = async (_viewer, _convId, _suffix) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?privateChat_frozenBanner"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -3282,3 +3282,192 @@ describe('android-adb-driver — androidDisablesInput', () => {
     expect(await driver.androidDisablesInput('Theo', undefined)).toBe(false);
   });
 });
+
+describe('android-adb-driver — androidShowsFrozenBanner', () => {
+  // Wake 99 matcher — `<Name>'s <Plat> UI[ opens conversation "<X>"]
+  // shows the frozen-banner element <suffix>` (j08, 4 corpus rows).
+  // Driver receives `(viewer, convId, suffix)`. `convId` is optional
+  // (null when no "opens conversation X" prefix in Gherkin). `suffix`
+  // is descriptive — could be "with text-from-key X" or "with locale
+  // string Y".
+  //
+  // Foundation policy: presence-check `privateChat_frozenBanner`
+  // testTag (PrivateChatScreen.kt:440) only. All three args are
+  // accepted-and-ignored at this layer — the assertion is "the
+  // frozen banner is currently visible". A future PR can layer
+  // text-from-key / locale-string verification on top once those
+  // contracts are clearer.
+  //
+  // Same shape as androidNavigatesToRoomScreen's suffix-ignore
+  // foundation (PR #732).
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('privateChat_frozenBanner present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_frozenBanner" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X')).toBe(true);
+  });
+
+  test('privateChat_frozenBanner absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_messageInput" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X')).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="privateChat_frozenBanner" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    // PR #736+ established that uiautomator can emit both
+    // self-closing and open-tag forms. The tagRx's `\/?>` handles
+    // both — pin the open-tag form.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_frozenBanner"><node text="Conversation frozen" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X')).toBe(true);
+  });
+
+  test('convId-specified call (non-null) — also passes', async () => {
+    // Pins that the optional convId arg is correctly accepted-and-
+    // ignored when it carries a real value (the "opens conversation
+    // X" Gherkin variant).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_frozenBanner" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidShowsFrozenBanner('Theo', 'conv_abc123', 'with text-from-key X'),
+    ).toBe(true);
+  });
+
+  test('different suffix variant — "with locale string Y" also passes', async () => {
+    // Pins that the suffix is ignored at the foundation layer — all
+    // 4 j08 corpus rows return identical results given the same
+    // dump. A future PR layering suffix-aware refinement (e.g.
+    // text-from-key inspection of the banner's inner text node)
+    // would update this test.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_frozenBanner" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsFrozenBanner('Theo', null, 'with locale string Y')).toBe(true);
+  });
+
+  test('left-boundary false-positive guarded — pre_privateChat_frozenBanner_x does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_privateChat_frozenBanner_x" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X')).toBe(false);
+  });
+
+  test('right-boundary false-positive guarded — privateChat_frozenBanner_extra does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_frozenBanner_extra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X')).toBe(false);
+  });
+
+  test('package-qualified left-boundary guarded — :id/pre_privateChat_frozenBanner does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_privateChat_frozenBanner" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X')).toBe(false);
+  });
+
+  test('bare left-boundary without suffix — pre_privateChat_frozenBanner does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_privateChat_frozenBanner" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false (not undefined)', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X')).toBe(false);
+  });
+
+  test('viewer name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_frozenBanner" />',
+    });
+    const driver = await createAndroidDriver();
+    const okTheo = await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_frozenBanner" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okAlice = await driver2.androidShowsFrozenBanner('Alice', null, 'with text-from-key X');
+
+    expect(okTheo).toBe(true);
+    expect(okAlice).toBe(true);
+  });
+
+  test('first-match contract pinned — two privateChat_frozenBanner nodes, first wins', async () => {
+    // Same first-match contract as prior method PRs. Presence-check
+    // semantics: as long as the first match exists, return true.
+    // The second one's existence doesn't change the answer.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_frozenBanner" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_frozenBanner" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -3470,4 +3470,28 @@ describe('android-adb-driver — androidShowsFrozenBanner', () => {
     const driver = await createAndroidDriver();
     expect(await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X')).toBe(true);
   });
+
+  test('foundation-layer contract pinned — child text content is IGNORED (not consulted)', async () => {
+    // Round 1 I-1: this method's foundation is a pure presence-check
+    // — the banner's INNER text (a child node) is deliberately not
+    // consulted. Pin the contract by showing that a dump whose child
+    // text differs from any plausible expected value STILL returns
+    // true.
+    //
+    // Future layering: a suffix-aware refinement PR will extract the
+    // child node's text= attribute and verify it against either a
+    // string-resource key ("with text-from-key X") or a literal
+    // locale value ("with locale string Y"). When that PR lands, it
+    // must UPDATE this test to reflect the new (stricter) contract.
+    // Without this pin, the layering author might mistakenly assume
+    // the foundation already validated inner text and skip adding
+    // the new assertion.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_frozenBanner"><node text="Something else entirely" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsFrozenBanner('Theo', null, 'with text-from-key X')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Implements `androidShowsFrozenBanner(viewer, convId, suffix)` for the Wake 99 matcher: `<Name>'s Android UI[ opens conversation "<X>"] shows the frozen-banner element <suffix>` (j08, 4 corpus rows).
- Foundation policy: **presence-check `privateChat_frozenBanner` testTag only** (PrivateChatScreen.kt:440). All three args are accepted-and-ignored at this layer — same shape as PR #732's suffix-ignore foundation for `androidNavigatesToRoomScreen`.
- 14 new tests, 228 total in the driver suite, all passing.

## Foundation policy rationale
The corpus has 4 variants of the matcher (with/without `convId`, plus 2 suffix forms — "text-from-key X" / "locale string Y"). Suffix-aware refinement requires inspecting the banner's inner text node against either a stringResource key or a literal locale string — non-trivial contract that benefits from layering once it's actually needed by a real journey test. Foundation just asserts the banner is visible.

## Phase context
Phase 4 sequential driver-method PR #16 of ~30. Following PR #737. One method per PR, continuous review-loop until ZERO findings → auto-merge.

## Test plan
- [x] 14 new tests added, all 228 in suite pass
- [x] Banner present/absent/empty-dump branches
- [x] Bare resource-id (no package prefix) → true
- [x] Non-self-closing tag form → true
- [x] convId variants (null + non-null) both work
- [x] Different suffix variants ("text-from-key" + "locale string") both pass (foundation ignores)
- [x] All 4 boundary guards (bare-left, right, package-qualified-left, bare-left-no-suffix)
- [x] uiautomator dump throws → false
- [x] Viewer name ignored
- [x] First-match contract pin
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)