### PR TITLE
feat(driver/android): androidAdminShowsTableOf (Wake 92)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -690,6 +690,35 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return !emptyRx.test(dump);
   };
 
+  // Wake 92 — `<Name>'s Android Admin UI shows a table of recent
+  // <X>` (j12:24). Generic admin-table presence assertion. The noun
+  // arg can be 1-3 words per the matcher's `(\w+(?:\s+\w+){0,2})`
+  // capture (e.g. "reports", "user reports", "active user reports").
+  //
+  // Foundation strategy: a TABLE_TAGS map from canonical noun to
+  // Compose testTag. Currently only one entry exists:
+  //   - "reports" → reportReview_list (the admin queue list)
+  //
+  // Unmapped nouns return false — same FAIL-loud contract as
+  // INPUT_TAGS in androidDisablesInput (PR #737). Future Compose
+  // work would add testTags for transactions/audits/users/etc.
+  //
+  // Returns boolean. The runner contract also accepts an array of
+  // entries for richer assertion chains, but the foundation just
+  // asserts visibility — a future PR can extract entries when
+  // needed (e.g. for "each entry shows <fields>" follow-up steps).
+  const TABLE_TAGS = { reports: 'reportReview_list' };
+  driver.androidAdminShowsTableOf = async (_viewer, noun) => {
+    if (!noun || !noun.trim()) return false;
+    const tag = TABLE_TAGS[noun.trim().toLowerCase()];
+    if (!tag) return false;
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = new RegExp(`<node[^>]*resource-id="(?:[^"]*:id\\/)?${tag}"[^>]*\\/?>`);
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -707,6 +707,13 @@ async function createAndroidDriver({ serial: preferred } = {}) {
   // entries for richer assertion chains, but the foundation just
   // asserts visibility — a future PR can extract entries when
   // needed (e.g. for "each entry shows <fields>" follow-up steps).
+  // TABLE_TAGS values are expected to be alphanumeric + underscore
+  // only (Compose testTag convention). The defensive escape on `tag`
+  // before regex interpolation defends against future entries that
+  // might contain regex metacharacters (e.g. a hypothetical
+  // "user-reports" with a hyphen, or worse, "report_list+" with a
+  // `+`). Without the escape, the next entry could be a latent
+  // regex-injection point.
   const TABLE_TAGS = { reports: 'reportReview_list' };
   driver.androidAdminShowsTableOf = async (_viewer, noun) => {
     if (!noun || !noun.trim()) return false;
@@ -714,8 +721,9 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     if (!tag) return false;
     const dump = await driver.androidUiDump();
     if (!dump) return false;
+    const escTag = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     // eslint-disable-next-line sonarjs/slow-regex
-    const tagRx = new RegExp(`<node[^>]*resource-id="(?:[^"]*:id\\/)?${tag}"[^>]*\\/?>`);
+    const tagRx = new RegExp(`<node[^>]*resource-id="(?:[^"]*:id\\/)?${escTag}"[^>]*\\/?>`);
     return tagRx.test(dump);
   };
 

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -3759,3 +3759,249 @@ describe('android-adb-driver — androidAdminShowsNewReportInQueue', () => {
     expect(await driver.androidAdminShowsNewReportInQueue('Gary')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidAdminShowsTableOf', () => {
+  // Wake 92 matcher — `<Name>'s Android Admin UI shows a table of
+  // recent <X>` (j12:24). Generic admin-table presence assertion.
+  // Driver receives `(viewer, noun)` where noun is 1-3 words
+  // (e.g. "reports", "user reports", "active user reports").
+  //
+  // Foundation strategy: a TABLE_TAGS map from canonical noun to
+  // Compose testTag. Currently only one entry exists:
+  //   - "reports" → reportReview_list (verified in PR #739)
+  //
+  // Unmapped nouns return false until the corresponding Compose
+  // testTag is added — same FAIL-loud contract as INPUT_TAGS in
+  // PR #737. Returns boolean (truthy = visible). The matcher
+  // protocol also supports returning an array of entries for richer
+  // assertion chains, but the foundation just asserts visibility —
+  // a future PR can extract entries when needed.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('"reports" noun with reportReview_list present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'reports')).toBe(true);
+  });
+
+  test('"reports" noun with table tag absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'reports')).toBe(false);
+  });
+
+  test('unmapped noun "transactions" → false (FAIL-loud contract)', async () => {
+    // Only "reports" is mapped today. An unmapped noun returns false
+    // even if the dump contains a similar-looking table. Protects
+    // journey-test authors from silently asserting against an
+    // unrelated node — they get a clear FAIL until the testTag
+    // mapping lands.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'transactions')).toBe(false);
+  });
+
+  test('case-insensitive noun — "REPORTS" maps to reports', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'REPORTS')).toBe(true);
+  });
+
+  test('noun with surrounding whitespace — "  reports  " maps to reports', async () => {
+    // Defensive against Gherkin authoring artifacts. The matcher
+    // regex `(\w+(?:\s+\w+){0,2})` shouldn't introduce leading/
+    // trailing whitespace, but the .trim() in the lookup defends
+    // against future regex tweaks.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', '  reports  ')).toBe(true);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'reports')).toBe(false);
+  });
+
+  test('empty noun arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', '')).toBe(false);
+  });
+
+  test('whitespace-only noun arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', '   ')).toBe(false);
+  });
+
+  test('null noun arg → false', async () => {
+    // Memory rule: pin null/undefined alongside empty + whitespace
+    // (see PR #737 R2 and the null-undefined-pins memory).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', null)).toBe(false);
+  });
+
+  test('undefined noun arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', undefined)).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'reports')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list"><node text="row 1" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'reports')).toBe(true);
+  });
+
+  test('left-boundary false-positive — pre_reportReview_list_x does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_reportReview_list_x" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'reports')).toBe(false);
+  });
+
+  test('right-boundary false-positive — reportReview_list_extra does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list_extra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'reports')).toBe(false);
+  });
+
+  test('package-qualified left-boundary — :id/pre_reportReview_list does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'reports')).toBe(false);
+  });
+
+  test('bare left-boundary without suffix — pre_reportReview_list does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'reports')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false (not undefined)', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'reports')).toBe(false);
+  });
+
+  test('viewer name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    const okGary = await driver.androidAdminShowsTableOf('Gary', 'reports');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okAlice = await driver2.androidAdminShowsTableOf('Alice', 'reports');
+
+    expect(okGary).toBe(true);
+    expect(okAlice).toBe(true);
+  });
+
+  test('first-match contract pinned — two reportReview_list nodes, presence holds', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'reports')).toBe(true);
+  });
+
+  test('multi-word noun "user reports" → false (no testTag mapping)', async () => {
+    // Pins that compound nouns from the matcher's `(\w+(?:\s+\w+){0,2})`
+    // pattern are accepted by the matcher but return false from the
+    // driver until a TABLE_TAGS entry is added.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsTableOf('Gary', 'user reports')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `androidAdminShowsTableOf(viewer, noun)` for the Wake 92 matcher: `<Name>'s Android Admin UI shows a table of recent <X>` (j12:24). Generic admin-table presence assertion.
- Uses a **TABLE_TAGS map** to translate Gherkin nouns to Compose testTags — same scaffold-then-expand pattern as PR #737's `INPUT_TAGS` for `androidDisablesInput`.
- 20 new tests, 268 total in the driver suite, all passing.

## TABLE_TAGS map
Currently one entry:
- `"reports"` → `reportReview_list`

Future Compose work would add entries for transactions/audits/users/etc. The pin that **unmapped nouns return false** protects journey-test authors from silently asserting against an unrelated node — they get a clear FAIL until the testTag mapping lands.

## Foundation policy
Returns boolean (truthy = visible). The runner contract also accepts an array of entries for richer assertion chains (`ctx.lastTableEntries` populated for follow-up "each entry shows <fields>" steps), but the foundation just asserts visibility — a future PR can extract entries when needed.

## Phase context
Phase 4 sequential driver-method PR #18 of ~30. Following PR #739. One method per PR, continuous review-loop until ZERO findings → auto-merge.

## Test plan
- [x] 20 new tests added, all 268 in suite pass
- [x] Mapped noun ("reports") + tag present → true
- [x] Unmapped noun → false (FAIL-loud contract)
- [x] Case-insensitive noun + whitespace-padded noun → resolved
- [x] All 4 null-safety pins (empty/whitespace/null/undefined) — per memory rule
- [x] Empty dump, bare resource-id, non-self-closing, dump-throws, viewer-ignored
- [x] All 4 boundary guards on the table tag (bare-left, right, package-qualified-left, bare-left-no-suffix)
- [x] First-match contract pin
- [x] Multi-word unmapped noun ("user reports") → false
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)