### PR TITLE
feat(driver/android): androidSearchIn (Wake 32)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -765,7 +765,28 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     const tapped = await driver.androidTapByTag(tag);
     if (!tapped) return false;
     try {
-      adb(['shell', 'input', 'text', text.replace(/ /g, '%s')]);
+      // Round 1 C-1: text is the first USER-CONTROLLED free-form
+      // string reaching adb() in the cluster. Prior methods passed
+      // only known-safe values (numeric coords, alphanumeric tags).
+      // adb() wraps each arg in single quotes; a single quote in
+      // `text` (e.g. "O'Brien", "can't") would produce unbalanced
+      // quotes and shell misparse.
+      //
+      // POSIX escape: replace ' with '\'' (close quote + escaped
+      // literal quote + reopen quote). Inside the surrounding
+      // single quotes that adb() adds, this round-trips correctly —
+      // the device receives the literal text.
+      //
+      // KNOWN LIMITATION (Round 1 I-1): the literal sequence `%s` in
+      // `text` is indistinguishable from an encoded space on the
+      // device side — adb's `input text` decodes `%s` as a literal
+      // space and has no `%%`-style escape. Searching for a string
+      // containing `%s` will yield spaces at those positions. Not
+      // fixable without a different keyboard-driver primitive
+      // (e.g. uiautomator setText via UI Automator API) — separate PR.
+      const quoteEscaped = text.replace(/'/g, "'\\''");
+      const spaceEncoded = quoteEscaped.replace(/ /g, '%s');
+      adb(['shell', 'input', 'text', spaceEncoded]);
       return true;
     } catch (e) {
       console.error(

--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -727,6 +727,54 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Two matchers (Wake 32-ish) delegate to this method:
+  //   `<P> on Android searches "<X>" in <screen>` → screen-scoped
+  //   `<P> on Android types "<X>" into the search field` → active-screen (null)
+  //
+  // First action method in the cluster — instead of asserting state,
+  // it performs a TAP + INPUT TEXT sequence. The runner doesn't
+  // inspect the return value (always wraps in ok: true), but the
+  // driver returns boolean for direct testability and for future
+  // runner refactors that might surface failures.
+  //
+  // Foundation strategy: SEARCH_FIELD_TAGS map from canonical screen
+  // name to Compose testTag. Currently one entry. Null screen falls
+  // back to the same tag (active-screen typically means "the
+  // currently visible search surface", which today is the new-
+  // message composer).
+  //
+  // Text encoding: adb's `shell input text` splits on spaces by
+  // default (each arg becomes a separate command). The standard
+  // workaround is to encode spaces as `%s`. Non-space chars pass
+  // through literally — no shell interpretation because adb()
+  // single-quotes every arg.
+  const SEARCH_FIELD_TAGS = { messages: 'newMessage_searchField' };
+  const DEFAULT_SEARCH_FIELD_TAG = 'newMessage_searchField';
+  driver.androidSearchIn = async (screen, text) => {
+    // `typeof text !== 'string'` rejects null and undefined too
+    // (typeof null === 'object'; typeof undefined === 'undefined').
+    if (typeof text !== 'string' || !text.trim()) return false;
+    // `!screen` matches null, undefined, and the empty string — all
+    // route to the default field. Empty-string screen is unreachable
+    // from valid Gherkin (matcher requires `\w+`), but the broad
+    // check is defensive.
+    const tag = !screen
+      ? DEFAULT_SEARCH_FIELD_TAG
+      : SEARCH_FIELD_TAGS[String(screen).trim().toLowerCase()];
+    if (!tag) return false;
+    const tapped = await driver.androidTapByTag(tag);
+    if (!tapped) return false;
+    try {
+      adb(['shell', 'input', 'text', text.replace(/ /g, '%s')]);
+      return true;
+    } catch (e) {
+      console.error(
+        `[android-driver] androidSearchIn(${screen}, ${text}) input failed: ${e.message}`,
+      );
+      return false;
+    }
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -4050,9 +4050,13 @@ describe('android-adb-driver — androidSearchIn', () => {
     expect(inputCall).toBeDefined();
   });
 
-  test('null screen → defaults to newMessage_searchField', async () => {
+  test('null screen → defaults to newMessage_searchField (tap target pinned)', async () => {
     // The "types into the search field" matcher passes null.
     // Driver falls back to the default search field tag.
+    // Round 1 I-2: also verify the TAP TARGET — without this pin,
+    // a future change routing null to a wrong (but still-rendered)
+    // tag would silently pass. Confirm the tap coordinates match
+    // the centre of the newMessage_searchField bounds.
     mockExec({
       "'uiautomator' 'dump'": '',
       "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
@@ -4060,6 +4064,11 @@ describe('android-adb-driver — androidSearchIn', () => {
     const driver = await createAndroidDriver();
     const ok = await driver.androidSearchIn(null, 'world');
     expect(ok).toBe(true);
+    // bounds [10,100][1000,200] → centre (505, 150)
+    const tapCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'tap'"));
+    expect(tapCall).toBeDefined();
+    expect(tapCall[0]).toContain("'505'");
+    expect(tapCall[0]).toContain("'150'");
   });
 
   test('text with spaces — "hello world" encoded as "hello%sworld"', async () => {
@@ -4207,5 +4216,77 @@ describe('android-adb-driver — androidSearchIn', () => {
     expect(ok).toBe(true);
     const inputCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'text'"));
     expect(inputCall[0]).toContain('a.b*c');
+  });
+
+  test('single quote in text — POSIX-escaped, no shell misparse', async () => {
+    // Round 1 C-1: text is the first USER-CONTROLLED free-form
+    // string reaching adb() in the cluster. adb() wraps each arg
+    // in single quotes; a literal single quote in text (e.g.
+    // "O'Brien", "can't") would produce unbalanced quotes and
+    // shell misparse.
+    //
+    // Fix: POSIX escape pattern `'\''` (close quote + escaped
+    // literal quote + reopen quote). The result, when wrapped by
+    // adb()'s outer single quotes, round-trips correctly.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    const ok = await driver.androidSearchIn('messages', "O'Brien");
+    expect(ok).toBe(true);
+    const inputCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'text'"));
+    expect(inputCall).toBeDefined();
+    // The full adb command should contain the POSIX-safe pattern.
+    // After adb() wraps in single quotes, "O'Brien" becomes
+    // 'O'\''Brien' — close + escaped quote + reopen.
+    expect(inputCall[0]).toContain(String.raw`'O'\''Brien'`);
+  });
+
+  test('single quote alongside spaces — both encodings applied', async () => {
+    // Round 1 C-1: pin that both encodings (POSIX quote escape
+    // + %s space encoding) compose correctly. "can't stop" should
+    // become "can'\\''t%sstop" inside the shell quote-wrap.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    const ok = await driver.androidSearchIn('messages', "can't stop");
+    expect(ok).toBe(true);
+    const inputCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'text'"));
+    expect(inputCall).toBeDefined();
+    // Space replaced with %s AND quote POSIX-escaped.
+    expect(inputCall[0]).toContain('%s');
+    expect(inputCall[0]).toContain(String.raw`'\''`);
+    // Should NOT contain raw space-separated tokens or unbalanced quote.
+    expect(inputCall[0]).not.toContain("'can't'");
+  });
+
+  test('literal "%s" in text — KNOWN LIMITATION pinned (decodes as space)', async () => {
+    // Round 1 I-1: adb's `input text` decodes `%s` as a literal
+    // space and has no `%%`-style escape. A search for the literal
+    // sequence `%s` would yield spaces on the device.
+    //
+    // The driver passes `%s` through unchanged (no further
+    // transformation). The limitation is documented in production
+    // comments and pinned here. A future PR could swap to a
+    // different keyboard-driver primitive (e.g. UI Automator
+    // setText) that doesn't have this asymmetry.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    const ok = await driver.androidSearchIn('messages', 'find %s placeholder');
+    // The call still completes — the device-side decoding is the
+    // limitation, not the driver-side dispatch.
+    expect(ok).toBe(true);
+    const inputCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'text'"));
+    expect(inputCall).toBeDefined();
+    // The driver's transformation only encodes spaces. The literal
+    // `%s` passes through verbatim (would be decoded as space by
+    // adb on the device side — known limitation).
+    expect(inputCall[0]).toContain('find%s%s%splaceholder');
   });
 });

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -4289,4 +4289,29 @@ describe('android-adb-driver — androidSearchIn', () => {
     // adb on the device side — known limitation).
     expect(inputCall[0]).toContain('find%s%s%splaceholder');
   });
+
+  test("recursive-escape case — text containing POSIX escape literal `\\'` is handled", async () => {
+    // Round 2 Minor: the POSIX escape replacement
+    // `text.replace(/'/g, "'\\''")` fires on every `'` in the input
+    // independently. A pathological text like "a'b'c" produces a
+    // string where each ' is independently escaped — verified with
+    // `node -e` to produce structurally valid POSIX-quoted output.
+    //
+    // Unreachable from valid Gherkin (no user searches for POSIX
+    // escape syntax), but pinning the recursive case defends
+    // against a future refactor that might use a non-global replace.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    const ok = await driver.androidSearchIn('messages', "a'b'c");
+    expect(ok).toBe(true);
+    const inputCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'text'"));
+    expect(inputCall).toBeDefined();
+    // After POSIX escape: each ' becomes '\\''. After adb()'s outer
+    // wrap, we should see 'a'\''b'\''c' — every embedded ' properly
+    // closed and reopened.
+    expect(inputCall[0]).toContain(String.raw`'a'\''b'\''c'`);
+  });
 });

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -4005,3 +4005,207 @@ describe('android-adb-driver — androidAdminShowsTableOf', () => {
     expect(await driver.androidAdminShowsTableOf('Gary', 'user reports')).toBe(false);
   });
 });
+
+describe('android-adb-driver — androidSearchIn', () => {
+  // Two matchers delegate to this method:
+  //   `<P> on Android searches "<X>" in <screen>` → screen-scoped
+  //   `<P> on Android types "<X>" into the search field` → active-screen (null)
+  //
+  // Driver signature: `androidSearchIn(screen, text)` — `screen` may
+  // be null (= active-screen / default field).
+  //
+  // Foundation strategy: a SEARCH_FIELD_TAGS map from canonical screen
+  // name to Compose testTag. Currently one entry:
+  //   - "messages" → newMessage_searchField
+  // And the active-screen (null) default routes to the same tag.
+  //
+  // Sequence: tap the search field → type the text (`adb shell input
+  // text`, with spaces encoded as `%s` per Android's standard
+  // convention). No explicit submit — most Compose search fields
+  // auto-search as you type.
+  //
+  // The runner never inspects the return value (always wraps in
+  // `ok: true`), but the driver still returns boolean for direct
+  // testability and for future runner refactors that might want to
+  // surface failures.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('screen "messages" + text "hello" → tap + input text', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    const ok = await driver.androidSearchIn('messages', 'hello');
+    expect(ok).toBe(true);
+    // Verify the tap was at the centre of the bounds
+    const tapCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'tap'"));
+    expect(tapCall).toBeDefined();
+    // Verify input text was called with the literal text
+    const inputCall = execSync.mock.calls.find(
+      (c) => c[0].includes("'input' 'text'") && c[0].includes('hello'),
+    );
+    expect(inputCall).toBeDefined();
+  });
+
+  test('null screen → defaults to newMessage_searchField', async () => {
+    // The "types into the search field" matcher passes null.
+    // Driver falls back to the default search field tag.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    const ok = await driver.androidSearchIn(null, 'world');
+    expect(ok).toBe(true);
+  });
+
+  test('text with spaces — "hello world" encoded as "hello%sworld"', async () => {
+    // adb shell input text uses %s to represent a space (anything
+    // else would be split by the shell). Pin the encoding.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    const ok = await driver.androidSearchIn('messages', 'hello world');
+    expect(ok).toBe(true);
+    const inputCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'text'"));
+    expect(inputCall).toBeDefined();
+    expect(inputCall[0]).toContain('hello%sworld');
+    expect(inputCall[0]).not.toContain("'hello' 'world'");
+  });
+
+  test('unmapped screen "foobar" → false (FAIL-loud contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidSearchIn('foobar', 'hello')).toBe(false);
+  });
+
+  test('search field testTag absent in dump → false', async () => {
+    // Map resolved to a tag, but uiautomator dump doesn't show it
+    // (admin on wrong screen). Tap fails → method returns false.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('main_roomsTab', '[0,1900][270,2100]'),
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidSearchIn('messages', 'hello')).toBe(false);
+  });
+
+  test('empty text arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidSearchIn('messages', '')).toBe(false);
+  });
+
+  test('null text arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidSearchIn('messages', null)).toBe(false);
+  });
+
+  test('undefined text arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidSearchIn('messages', undefined)).toBe(false);
+  });
+
+  test('whitespace-only text arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidSearchIn('messages', '   ')).toBe(false);
+  });
+
+  test('case-insensitive screen name — "MESSAGES" resolves', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidSearchIn('MESSAGES', 'hello')).toBe(true);
+  });
+
+  test('whitespace-padded screen name — "  messages  " resolves after trim', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidSearchIn('  messages  ', 'hello')).toBe(true);
+  });
+
+  test('input text throws → false (defensive)', async () => {
+    // Tap succeeds but the subsequent `input text` call rejects.
+    // The driver catches and returns false rather than propagating.
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) return '';
+      if (cmd.includes("'cat' '/sdcard/dump.xml'")) {
+        return '<node resource-id="com.shyden.shytalk.local:id/newMessage_searchField" bounds="[10,100][1000,200]" />';
+      }
+      if (cmd.includes("'input' 'tap'")) return '';
+      if (cmd.includes("'input' 'text'")) throw new Error('adb: device unauthorised');
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidSearchIn('messages', 'hello')).toBe(false);
+  });
+
+  test('uiautomator dump fails → false (tap fails first)', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) throw new Error('adb: device offline');
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidSearchIn('messages', 'hello')).toBe(false);
+  });
+
+  test('tap and input commands issued in correct order', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    await driver.androidSearchIn('messages', 'query');
+    // Find the indices of tap and input text in the call sequence
+    const tapIdx = execSync.mock.calls.findIndex((c) => c[0].includes("'input' 'tap'"));
+    const inputIdx = execSync.mock.calls.findIndex((c) => c[0].includes("'input' 'text'"));
+    expect(tapIdx).toBeGreaterThanOrEqual(0);
+    expect(inputIdx).toBeGreaterThanOrEqual(0);
+    expect(tapIdx).toBeLessThan(inputIdx);
+  });
+
+  test('text with regex-significant chars — no shell interpretation', async () => {
+    // Pin that the text is passed to `input text` literally — no
+    // shell glob expansion, no regex escape needed. The shell-
+    // quoting of adb() args isolates the value.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('newMessage_searchField', '[10,100][1000,200]'),
+    });
+    const driver = await createAndroidDriver();
+    const ok = await driver.androidSearchIn('messages', 'a.b*c');
+    expect(ok).toBe(true);
+    const inputCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'text'"));
+    expect(inputCall[0]).toContain('a.b*c');
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `androidSearchIn(screen, text)` for the Wake 32 matchers (two phrasings, single driver method):
  - `<P> on Android searches "<X>" in <screen>` → screen-scoped
  - `<P> on Android types "<X>" into the search field` → active-screen (null)
- **First ACTION method in the cluster** (vs. the assertion methods shipped so far).
- 15 new tests, 283 total in the driver suite, all passing.

## Sequence
1. Resolve screen → testTag via `SEARCH_FIELD_TAGS` map (or default for null screen)
2. Tap the search field (via existing `androidTapByTag` primitive)
3. Type the text (via `adb shell input text`, with spaces encoded as `%s`)

## SEARCH_FIELD_TAGS map
Currently one entry:
- `"messages"` → `"newMessage_searchField"`

Null/falsy screen falls back to the same tag as the active-screen default.

## Text encoding
adb's `shell input text` splits on spaces by default — workaround is `%s` encoding. Non-space chars pass through literally because `adb()` single-quotes every arg.

## Null-safety via typeof
Uses `typeof text !== 'string'` instead of `text == null` (ESLint's `eqeqeq` rule blocks loose equality in this codebase). The `typeof` check rejects both null and undefined.

## Phase context
Phase 4 sequential driver-method PR #19 of ~30. Following PR #740. One method per PR, continuous review-loop until ZERO findings → auto-merge.

## Test plan
- [x] 15 new tests added, all 283 in suite pass
- [x] Happy path with both `"messages"` and null screen
- [x] Spaces encoded as `%s`; regex-significant chars pass through literally
- [x] Unmapped screen → false (FAIL-loud); search field absent → false
- [x] All 4 null-safety pins on text (empty/whitespace/null/undefined)
- [x] Case-insensitive + whitespace-padded screen name
- [x] input-text throws → false; dump fails → false
- [x] Command-ordering pin (tap before input-text)
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)