### PR TITLE
feat(driver/android): androidNavigatesToPath (Wake 99)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -880,6 +880,61 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return await driver.androidTap(cx, cy);
   };
 
+  // Wake 99 — `<Name>'s Android UI navigates to "<Path>"` (j03+).
+  // Generic path-based navigation assertion. Path is a web-style
+  // URL like `/`, `/profile/42`, `/messages/abc`.
+  //
+  // Foundation strategy: PATH_TAGS map with prefix-resolver
+  //   1. Exact match (handles `/` — must not greedy-match other paths)
+  //   2. Prefix match: `/profile/42` → `/profile` mapping
+  //
+  // Currently 5 mappings, all grounded in existing Compose testTags:
+  //   - "/"         → main_roomsTab            (root → rooms landing)
+  //   - "/profile"  → profile_displayName       (any profile screen)
+  //   - "/messages" → main_messagesTab          (messages tab)
+  //   - "/wallet"   → wallet_balance            (wallet screen)
+  //   - "/settings" → securitySettingsScreen    (settings landing)
+  //
+  // Unmapped paths return false — FAIL-loud contract (same as
+  // INPUT_TAGS / TABLE_TAGS scaffolds).
+  //
+  // Foundation contract: PRESENCE check only. Tab paths assert the
+  // tab BAR is visible (true on every main screen), so they're
+  // looser than "user is on THIS tab specifically". A future PR
+  // can tighten with `selected="true"` for tab paths.
+  const PATH_TAGS = {
+    '/': 'main_roomsTab',
+    '/profile': 'profile_displayName',
+    '/messages': 'main_messagesTab',
+    '/wallet': 'wallet_balance',
+    '/settings': 'securitySettingsScreen',
+  };
+  function resolvePathTag(path) {
+    if (PATH_TAGS[path]) return PATH_TAGS[path];
+    // Prefix match: longest-matching prefix wins. Exclude '/' from
+    // prefix iteration (it's exact-only — otherwise every path
+    // would prefix-match it).
+    let best = null;
+    for (const prefix of Object.keys(PATH_TAGS)) {
+      if (prefix === '/') continue;
+      if (path === prefix || path.startsWith(prefix + '/')) {
+        if (!best || prefix.length > best.length) best = prefix;
+      }
+    }
+    return best ? PATH_TAGS[best] : null;
+  }
+  driver.androidNavigatesToPath = async (_name, path) => {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    const tag = resolvePathTag(path.trim());
+    if (!tag) return false;
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    const escTag = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = new RegExp(`<node[^>]*resource-id="(?:[^"]*:id\\/)?${escTag}"[^>]*\\/?>`);
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -4798,3 +4798,260 @@ describe('android-adb-driver — androidJoinEventRoom', () => {
     expect(tapCall[0]).toContain("'300'");
   });
 });
+
+describe('android-adb-driver — androidNavigatesToPath', () => {
+  // Wake 99 matcher — `<Name>'s Android UI navigates to "<Path>"`
+  // (j03+). Generic path-based navigation assertion. Driver receives
+  // `(name, path)` where path is a web-style URL: `/`, `/profile/42`,
+  // `/messages/abc`, etc.
+  //
+  // Foundation strategy: a PATH_TAGS map from path prefix to
+  // distinctive Compose testTag. Path resolution:
+  //   1. Exact match (handles `/` specifically)
+  //   2. Prefix match: `/profile/42` → uses `/profile` mapping
+  //
+  // Currently 5 mappings:
+  //   - "/"         → main_roomsTab            (root → rooms landing)
+  //   - "/profile"  → profile_displayName       (any profile screen)
+  //   - "/messages" → main_messagesTab          (messages tab)
+  //   - "/wallet"   → wallet_balance            (wallet screen)
+  //   - "/settings" → securitySettingsScreen    (settings landing)
+  //
+  // Unmapped paths return false (FAIL-loud contract — journey
+  // author gets a clear FAIL until the path mapping lands).
+  //
+  // Foundation contract: PRESENCE check only. Tab paths like "/" and
+  // "/messages" assert the tab bar is visible, which is true on every
+  // main screen (slightly looser than "user is on THIS tab"). A
+  // future PR can tighten with `selected="true"` for tab paths.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('root "/" → main_roomsTab present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Lena', '/')).toBe(true);
+  });
+
+  test('exact "/profile" → profile_displayName present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_displayName" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/profile')).toBe(true);
+  });
+
+  test('prefix-match "/profile/42" → resolves to /profile mapping', async () => {
+    // Pin the prefix-resolver. A profile URL with a user ID still
+    // routes to the profile screen check.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_displayName" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/profile/42')).toBe(true);
+  });
+
+  test('prefix-match "/messages/abc123" → resolves to /messages mapping', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/messages/abc123')).toBe(true);
+  });
+
+  test('"/wallet" → wallet_balance present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/wallet_balance" text="5,000" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/wallet')).toBe(true);
+  });
+
+  test('"/settings" → securitySettingsScreen present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/securitySettingsScreen" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/settings')).toBe(true);
+  });
+
+  test('expected screen testTag absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    // Asserting profile but on rooms tab → must fail.
+    expect(await driver.androidNavigatesToPath('Adam', '/profile/42')).toBe(false);
+  });
+
+  test('unmapped path "/login.html" → false (FAIL-loud)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/login.html')).toBe(false);
+  });
+
+  test('unmapped path "/unknown" → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/unknown')).toBe(false);
+  });
+
+  test('empty path arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '')).toBe(false);
+  });
+
+  test('whitespace-only path arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '   ')).toBe(false);
+  });
+
+  test('null path arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', null)).toBe(false);
+  });
+
+  test('undefined path arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', undefined)).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/profile')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/profile')).toBe(false);
+  });
+
+  test('persona name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    const okAdam = await driver.androidNavigatesToPath('Adam', '/');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okLena = await driver2.androidNavigatesToPath('Lena', '/');
+
+    expect(okAdam).toBe(true);
+    expect(okLena).toBe(true);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="profile_displayName" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/profile')).toBe(true);
+  });
+
+  test('"/profile" exact-match is distinct from "/profile-extras" non-prefix', async () => {
+    // Defensive: the prefix-resolver requires either exact match
+    // OR the prefix followed by `/`. A path like "/profile-extras"
+    // is NOT a prefix of "/profile" — must return null (FAIL-loud).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_displayName" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/profile-extras')).toBe(false);
+  });
+
+  test('longest-prefix wins: a path matching multiple prefixes resolves to the most specific', async () => {
+    // Currently no path overlaps exist (all prefixes are disjoint),
+    // but pin the contract via the resolver behaviour. If future
+    // mappings add e.g. "/profile/edit", the resolver should
+    // prefer "/profile/edit" over "/profile" for "/profile/edit/photo".
+    //
+    // Today's pin: "/profile/42" resolves to "/profile" (the only
+    // matching prefix), not to "/" (which is exact-only).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_displayName" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/profile/42')).toBe(true);
+    // Sanity: "/" does NOT prefix-match "/profile/42" because the
+    // "/" → main_roomsTab mapping is exact-only.
+  });
+
+  test('path with extra trailing segments — "/profile/42/edit" still resolves to /profile', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_displayName" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/profile/42/edit')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -5054,4 +5054,52 @@ describe('android-adb-driver — androidNavigatesToPath', () => {
     const driver = await createAndroidDriver();
     expect(await driver.androidNavigatesToPath('Adam', '/profile/42/edit')).toBe(true);
   });
+
+  test('path with query string "/profile?userId=42" → false (no query-string routing)', async () => {
+    // Round 1 I-1: the path-resolver does NOT strip query strings.
+    // `/profile?userId=42` is neither an exact match nor a prefix
+    // match (the literal string starts with `/profile?`, not
+    // `/profile/`). FAIL-loud contract: Gherkin steps must supply
+    // clean path segments without query strings.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_displayName" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/profile?userId=42')).toBe(false);
+  });
+
+  test('path with fragment "/profile#bio" → false (no fragment routing)', async () => {
+    // Round 1 I-2: same contract as query strings — fragments are
+    // not stripped by the path-resolver. `/profile#bio` is neither
+    // exact nor prefix match. FAIL-loud.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/profile_displayName" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/profile#bio')).toBe(false);
+  });
+
+  test('"/" exclusion from prefix-iteration is directly pinned — /profile/42 does NOT resolve via /', async () => {
+    // Round 1 M-1: the previous longest-prefix test implies `/` is
+    // exact-only via the dump-content selection, but doesn't pin
+    // it directly. This test makes the exclusion unambiguous:
+    // the dump contains ONLY main_roomsTab (the `/` mapping
+    // target). If `/` were treated as a prefix, `/profile/42`
+    // would route to main_roomsTab and the dump-presence check
+    // would PASS — which would be wrong (the user is asserting
+    // they're on /profile/42, not at /). The correct behaviour:
+    // `/profile/42` routes to profile_displayName, which is ABSENT
+    // here → result must be false.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidNavigatesToPath('Adam', '/profile/42')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Implements `androidNavigatesToPath(name, path)` for the Wake 99 matcher: `<Name>'s Android UI navigates to "<Path>"` (j03+).
- Path is a web-style URL: `/`, `/profile/42`, `/messages/abc`, etc.
- 20 new tests, 336 total in the driver suite, all passing.

## Foundation: PATH_TAGS with prefix-resolver
Two-step resolution:
1. **Exact match** first (handles `/` — must not greedy-match every path)
2. **Prefix match** with longest-wins (handles `/profile/42` → `/profile`)

Currently 5 mappings, all grounded in existing Compose testTags:
- `"/"` → `main_roomsTab`
- `"/profile"` → `profile_displayName`
- `"/messages"` → `main_messagesTab`
- `"/wallet"` → `wallet_balance`
- `"/settings"` → `securitySettingsScreen`

Unmapped paths return `false` — FAIL-loud contract (same as `INPUT_TAGS`/`TABLE_TAGS` from PRs #737/#740).

## Foundation contract
PRESENCE check only. Tab paths assert the tab BAR is visible (true on every main screen), so they're looser than "user is on THIS tab specifically". A future PR can tighten with `selected="true"` for tab paths.

## Phase context
Phase 4 sequential driver-method PR #22 of ~30. Following PR #743. One method per PR, continuous review-loop until ZERO findings → auto-merge.

## Test plan
- [x] All 5 path mappings (exact match) → true; 3 prefix-match cases
- [x] Expected screen absent → false; unmapped paths → false
- [x] All 4 null-safety pins on path
- [x] Empty dump → false; dump throws → false
- [x] Persona name ignored; bare resource-id → true
- [x] `/profile-extras` does NOT prefix-match `/profile` (FAIL-loud)
- [x] Longest-prefix-wins contract pinned
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)