### PR TITLE
feat(driver/android): androidShowsNewGiftEntry (Wake 100)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -935,6 +935,44 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 100 — `<Name>'s Android UI shows the new "<X>" gift entry`
+  // (j05 — gift-log entry on recipient view). Driver receives
+  // `(name, giftId)` where giftId is the friendly name ("crown",
+  // "rose", etc.) per the j05 corpus.
+  //
+  // Foundation strategy: two-step COMPOSITION (mirrors
+  // androidAdminShowsNewReportInQueue from PR #739):
+  //   1. giftWall_grid testTag must be PRESENT (user is on the
+  //      gift-wall surface).
+  //   2. giftId text appears anywhere in the dump with word-boundary
+  //      protection — same regex shape as androidShowsBanner.
+  //
+  // The "new" semantic is journey-orchestrated — the test runs
+  // RIGHT AFTER a gift is sent, so the latest entry IS the new one.
+  // A future PR could layer per-row inspection (e.g.
+  // `giftWall_entry_${giftId}` parameterised testTag) to verify
+  // the specific entry rather than any text occurrence.
+  driver.androidShowsNewGiftEntry = async (_name, giftId) => {
+    if (typeof giftId !== 'string' || !giftId.trim()) return false;
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // Step 1: gift wall must be visible
+    // eslint-disable-next-line sonarjs/slow-regex
+    const wallRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?giftWall_grid"[^>]*\/?>/;
+    if (!wallRx.test(dump)) return false;
+    // Step 2: giftId text appears with word-boundary protection
+    // (same boundary shape as androidShowsBanner — blocks prefix
+    // collisions like "Crowning" / "primrose" matching "crown" /
+    // "rose"). Hint is regex-escaped for future gift IDs that
+    // might contain dots, plus signs, etc.
+    const escGift = giftId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const giftRx = new RegExp(
+      `(?<![\\w-])(?:text|content-desc)="[^"]*(?<![\\w-])${escGift}(?!\\w)[^"]*"`,
+    );
+    return giftRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -966,9 +966,19 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     // "rose"). Hint is regex-escaped for future gift IDs that
     // might contain dots, plus signs, etc.
     const escGift = giftId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // Round 1 I-1 fix: SYMMETRIC inner boundaries. Original was
+    // `(?<![\w-])...(?!\w)` — left blocks word + hyphen, right only
+    // blocks word. Asymmetric: `text="crown-shaped"` false-matches
+    // `crown` because hyphen passes the right lookahead.
+    //
+    // Fixed to `(?![\w-])` on the right — symmetric with the left
+    // lookbehind. Now `crown-shaped` correctly does NOT match
+    // `crown`, while `Adam sent crown today` (space-padded) still
+    // does. Defends against compound gift labels like "rose-gold
+    // pendant" false-matching the "rose" hint.
     // eslint-disable-next-line sonarjs/slow-regex
     const giftRx = new RegExp(
-      `(?<![\\w-])(?:text|content-desc)="[^"]*(?<![\\w-])${escGift}(?!\\w)[^"]*"`,
+      `(?<![\\w-])(?:text|content-desc)="[^"]*(?<![\\w-])${escGift}(?![\\w-])[^"]*"`,
     );
     return giftRx.test(dump);
   };

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -5103,3 +5103,264 @@ describe('android-adb-driver — androidNavigatesToPath', () => {
     expect(await driver.androidNavigatesToPath('Adam', '/profile/42')).toBe(false);
   });
 });
+
+describe('android-adb-driver — androidShowsNewGiftEntry', () => {
+  // Wake 100 matcher — `<Name>'s Android UI shows the new "<X>"
+  // gift entry` (j05 — gift-log entry on recipient view). Driver
+  // receives `(name, giftId)` where giftId is the friendly name
+  // ("crown", "rose", etc.) per the j05 corpus.
+  //
+  // Foundation strategy: two-step composition (mirrors PR #739's
+  // androidAdminShowsNewReportInQueue pattern):
+  //   1. giftWall_grid testTag must be PRESENT (user is on the
+  //      gift-wall surface — profile screen typically).
+  //   2. giftId text appears anywhere in the dump with word-boundary
+  //      protection (prevents prefix-collision: "crown" hint must
+  //      not match "Crowning Achievement").
+  //
+  // The "new" semantic is journey-orchestrated — the test runs
+  // RIGHT AFTER a gift is sent, so the latest entry IS the new one.
+  // A future PR could layer per-row inspection (e.g.
+  // giftWall_entry_${giftId}) to verify the specific entry rather
+  // than any text occurrence.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('giftWall_grid present + giftId in text → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'crown')).toBe(true);
+  });
+
+  test('giftWall_grid present + giftId in content-desc → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node content-desc="rose" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'rose')).toBe(true);
+  });
+
+  test('giftWall_grid absent (user on wrong screen) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />' +
+        '<node text="crown" />',
+    });
+    const driver = await createAndroidDriver();
+    // The "crown" text exists but on a non-gift-wall screen → must
+    // not false-positive. Pin the FIRST guard (giftWall_grid required).
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'crown')).toBe(false);
+  });
+
+  test('giftWall_grid present but giftId not in any text → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="other-gift" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'crown')).toBe(false);
+  });
+
+  test('giftWall_grid present + giftId padded in surrounding text → true', async () => {
+    // Real gift-log entries often have padded labels like
+    // "Adam sent crown ×5" — substring match should accept.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown today" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'crown')).toBe(true);
+  });
+
+  test('prefix-collision blocked — "crown" hint does NOT match "Crowning Achievement"', async () => {
+    // Word-boundary protection. "Crowning" starts with "Crown" but
+    // the `(?!\w)` lookahead blocks suffix word chars. Also blocks
+    // the case-sensitive concern (English: "crown" lowercase vs
+    // "Crowning" capital C — the regex is case-sensitive so this
+    // wouldn't match anyway, but pin both forms).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Crowning Achievement Unlocked" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'crown')).toBe(false);
+  });
+
+  test('suffix-collision blocked — "rose" hint does NOT match "roseate"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="roseate hue" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'rose')).toBe(false);
+  });
+
+  test('prefix-collision blocked — "rose" hint does NOT match "primrose"', async () => {
+    // Word-prefix collision the OTHER direction.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="primrose path" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'rose')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'crown')).toBe(false);
+  });
+
+  test('empty giftId arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', '')).toBe(false);
+  });
+
+  test('whitespace-only giftId arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', '   ')).toBe(false);
+  });
+
+  test('null giftId arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', null)).toBe(false);
+  });
+
+  test('undefined giftId arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', undefined)).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="giftWall_grid" /><node text="crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'crown')).toBe(true);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'crown')).toBe(false);
+  });
+
+  test('persona name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="crown" />',
+    });
+    const driver = await createAndroidDriver();
+    const okSelma = await driver.androidShowsNewGiftEntry('Selma', 'crown');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="crown" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okAlice = await driver2.androidShowsNewGiftEntry('Alice', 'crown');
+
+    expect(okSelma).toBe(true);
+    expect(okAlice).toBe(true);
+  });
+
+  test('giftId with regex-significant chars — escaped before insertion', async () => {
+    // Defensive: gift IDs in the j05 corpus are plain words, but
+    // a future "gift_2.0" or "rose+1" would have regex metacharacters.
+    // The escape ensures literal matching.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="gift_2.0" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'gift_2.0')).toBe(true);
+  });
+
+  test('giftId with regex-significant chars — negative case proves literal-dot escape', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="gift_2X0" />',
+    });
+    const driver = await createAndroidDriver();
+    // Without the literal-dot escape, "2.0" would match "2X0" (. = any char).
+    // With escape, "2.0" requires a literal dot → no match.
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'gift_2.0')).toBe(false);
+  });
+
+  test('compound attribute names (hint-text=) NOT consulted for giftId match', async () => {
+    // Same lookbehind concern as PR #742 (scan-all-strings). The
+    // outer attribute-name guard `(?<![\w-])(?:text|content-desc)=`
+    // prevents `hint-text="crown"` from triggering a false match.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node hint-text="crown" sub-text="more text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'crown')).toBe(false);
+  });
+});

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -5187,11 +5187,16 @@ describe('android-adb-driver — androidShowsNewGiftEntry', () => {
   });
 
   test('prefix-collision blocked — "crown" hint does NOT match "Crowning Achievement"', async () => {
-    // Word-boundary protection. "Crowning" starts with "Crown" but
-    // the `(?!\w)` lookahead blocks suffix word chars. Also blocks
-    // the case-sensitive concern (English: "crown" lowercase vs
-    // "Crowning" capital C — the regex is case-sensitive so this
-    // wouldn't match anyway, but pin both forms).
+    // Word-boundary protection: the inner right lookahead
+    // `(?![\w-])` blocks suffix word chars. "Crowning" — the `i`
+    // after `Crown` is a word char → blocked.
+    //
+    // Round 1 I-2 fix: comment corrected. The case-sensitivity is
+    // a side effect (the regex is case-sensitive so `crown` ≠
+    // `Crown`), but the ACTUAL blocking mechanism here is the
+    // right-side word-boundary, not case rules. A future-reader
+    // asking "what if giftId were `Crown` (capital C)?" needs to
+    // know it's the word-boundary doing the work.
     mockExec({
       "'uiautomator' 'dump'": '',
       "'cat' '/sdcard/dump.xml'":
@@ -5362,5 +5367,36 @@ describe('android-adb-driver — androidShowsNewGiftEntry', () => {
     });
     const driver = await createAndroidDriver();
     expect(await driver.androidShowsNewGiftEntry('Selma', 'crown')).toBe(false);
+  });
+
+  test('suffix-hyphen blocked — "crown" hint does NOT match "crown-shaped"', async () => {
+    // Round 1 I-1 fix: the original inner right lookahead was
+    // `(?!\w)` (blocks word chars only). A hyphen is not `\w`, so
+    // `text="crown-shaped"` false-matched `crown`. Fixed to
+    // `(?![\w-])` — symmetric with the inner left lookbehind
+    // `(?<![\w-])`. Defends against compound gift labels.
+    //
+    // Verified with `node -e` against the new regex.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="crown-shaped" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'crown')).toBe(false);
+  });
+
+  test('suffix-hyphen symmetric — "rose" hint does NOT match "rose-gold pendant"', async () => {
+    // Round 1 I-1 fix: same boundary applied to "rose". Compound
+    // labels with hyphen-prefixed suffixes are blocked.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="rose-gold pendant" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewGiftEntry('Selma', 'rose')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Implements `androidShowsNewGiftEntry(name, giftId)` for the Wake 100 matcher: `<Name>'s Android UI shows the new "<X>" gift entry` (j05).
- 19 new tests, 358 total in the driver suite, all passing.

## Foundation: two-step composition
Mirrors PR #739's `androidAdminShowsNewReportInQueue` pattern:
1. `giftWall_grid` testTag must be PRESENT (user is on the gift-wall surface)
2. `giftId` text appears anywhere in the dump with word-boundary protection

## "New" semantic
Journey-orchestrated — test runs RIGHT AFTER a gift is sent, so the latest entry IS the new one. A future PR could layer per-row inspection via a `giftWall_entry_${giftId}` parameterised testTag for stricter verification.

## Reused patterns
- Same boundary shape as `androidShowsBanner` (`text=` guard against `hint-text=` collisions)
- Same word-boundary substring as `androidShowsBalanceViaListener`
- Same two-step compose as `androidAdminShowsNewReportInQueue`
- Same regex-significant char escape as PRs #735, #740

## Phase context
Phase 4 sequential driver-method PR #23 of ~30. Following PR #744. One method per PR, continuous review-loop until ZERO findings → auto-merge.

## Test plan
- [x] 19 new tests, all 358 in suite pass
- [x] giftWall_grid + giftId positive paths (text + content-desc)
- [x] First-guard pin: giftWall_grid absent → false
- [x] Padded text ("Adam sent crown today") → true
- [x] 3 collision pins: "crown" ≠ "Crowning"; "rose" ≠ "roseate" / "primrose"
- [x] All 4 null-safety pins; empty dump; dump throws; persona ignored
- [x] Bare resource-id; regex-significant char escape (both directions)
- [x] Compound attribute names (hint-text=) NOT consulted
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)