### PR TITLE
feat(driver/android): androidShowsInSeatGrid (Wake 102)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -983,6 +983,38 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return giftRx.test(dump);
   };
 
+  // Wake 102 — `<Name>'s Android UI shows <Other> in seat N of the
+  // seat grid` (j09). Driver receives `(viewer, target, seatNum)`.
+  //
+  // Foundation strategy: two-step composition (mirrors PR #745's
+  // androidShowsNewGiftEntry):
+  //   1. room_seatGrid testTag PRESENT (user is on the room screen).
+  //   2. target's name appears in any text= or content-desc= with
+  //      SYMMETRIC word-boundary protection (`(?<![\w-])` +
+  //      `(?![\w-])` — same shape as PR #745 R1 fix).
+  //
+  // The seat-position semantic is journey-orchestrated until per-
+  // seat testTags exist (Compose currently only tags the container
+  // `room_seatGrid`, not individual seats). A future PR could
+  // layer this with e.g. `room_seat_${seatNum}_displayName` for
+  // stricter per-position verification.
+  driver.androidShowsInSeatGrid = async (_viewer, target, _seatNum) => {
+    if (typeof target !== 'string' || !target.trim()) return false;
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // Step 1: seat-grid must be visible
+    // eslint-disable-next-line sonarjs/slow-regex
+    const gridRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?room_seatGrid"[^>]*\/?>/;
+    if (!gridRx.test(dump)) return false;
+    // Step 2: target name appears with symmetric word-boundary
+    const escTarget = target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const targetRx = new RegExp(
+      `(?<![\\w-])(?:text|content-desc)="[^"]*(?<![\\w-])${escTarget}(?![\\w-])[^"]*"`,
+    );
+    return targetRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -5400,3 +5400,290 @@ describe('android-adb-driver — androidShowsNewGiftEntry', () => {
     expect(await driver.androidShowsNewGiftEntry('Selma', 'rose')).toBe(false);
   });
 });
+
+describe('android-adb-driver — androidShowsInSeatGrid', () => {
+  // Wake 102 matcher — `<Name>'s Android UI shows <Other> in seat N
+  // of the seat grid` (j09). Driver receives `(viewer, target,
+  // seatNum)`. The seat-position aspect requires per-seat testTags
+  // which don't exist yet (Compose attaches `room_seatGrid` to the
+  // container only). Foundation policy: ignore seatNum, assert
+  // target's name is visible somewhere in the seat-grid surface.
+  //
+  // Two-step composition (same pattern as PR #745
+  // androidShowsNewGiftEntry):
+  //   1. room_seatGrid testTag must be PRESENT (user is on the
+  //      room screen).
+  //   2. target's name appears in any text=/content-desc= with
+  //      SYMMETRIC word-boundary protection (`(?<![\w-])` +
+  //      `(?![\w-])` — same boundary fix as PR #745 R1).
+  //
+  // The seat-position semantic is journey-orchestrated until per-
+  // seat testTags exist. A future PR could layer this with e.g.
+  // `room_seat_${seatNum}_displayName` for stricter verification.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('room_seatGrid + target name in text → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' + '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Adam', 1)).toBe(true);
+  });
+
+  test('room_seatGrid + target name in content-desc → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node content-desc="Bea" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Bea', 2)).toBe(true);
+  });
+
+  test('room_seatGrid absent (user not in room) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />' + '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    // "Adam" text exists but on a non-seat-grid screen → must NOT
+    // false-positive. Pin the FIRST guard.
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Adam', 1)).toBe(false);
+  });
+
+  test('room_seatGrid present + target not in any text → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Different" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Adam', 1)).toBe(false);
+  });
+
+  test('seatNum is ignored at foundation layer — N=1 and N=5 both pass when target visible', async () => {
+    // Foundation contract pin: the seat-number arg is accepted but
+    // ignored. Both N=1 and N=5 return the same result given the
+    // same dump. A future PR layering per-seat verification will
+    // need to update this pin.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' + '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    const ok1 = await driver.androidShowsInSeatGrid('Selma', 'Adam', 1);
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' + '<node text="Adam" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const ok5 = await driver2.androidShowsInSeatGrid('Selma', 'Adam', 5);
+
+    expect(ok1).toBe(true);
+    expect(ok5).toBe(true);
+  });
+
+  test('padded target name — "speaker: Adam" still matches Adam', async () => {
+    // Realistic seat-grid labels often pad with role prefix
+    // ("speaker: Adam", "host • Adam"). Substring match with
+    // word-boundary protection accepts.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="speaker: Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Adam', 1)).toBe(true);
+  });
+
+  test('prefix-collision blocked — "Adam" hint does NOT match "AdamSmith"', async () => {
+    // Word-boundary protection (same as PR #745 fix). "AdamSmith"
+    // — the `S` after `Adam` is a word char → blocked.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="AdamSmith" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Adam', 1)).toBe(false);
+  });
+
+  test('suffix-collision blocked — "Bea" hint does NOT match "Beatrix"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Beatrix the great" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Bea', 1)).toBe(false);
+  });
+
+  test('hyphen-suffix blocked — "Adam" hint does NOT match "Adam-jr"', async () => {
+    // Round 1 boundary inherited from PR #745 — symmetric
+    // `(?<![\w-])...(?![\w-])` blocks hyphen-suffix compounds.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam-jr" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Adam', 1)).toBe(false);
+  });
+
+  test('hyphen-prefix blocked — "Adam" hint does NOT match "pre-Adam"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="pre-Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Adam', 1)).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Adam', 1)).toBe(false);
+  });
+
+  test('empty target arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' + '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', '', 1)).toBe(false);
+  });
+
+  test('whitespace-only target → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' + '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', '   ', 1)).toBe(false);
+  });
+
+  test('null target → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' + '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', null, 1)).toBe(false);
+  });
+
+  test('undefined target → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' + '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', undefined, 1)).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="room_seatGrid" /><node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Adam', 1)).toBe(true);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Adam', 1)).toBe(false);
+  });
+
+  test('viewer name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' + '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    const okSelma = await driver.androidShowsInSeatGrid('Selma', 'Adam', 1);
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' + '<node text="Adam" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okBea = await driver2.androidShowsInSeatGrid('Bea', 'Adam', 1);
+
+    expect(okSelma).toBe(true);
+    expect(okBea).toBe(true);
+  });
+
+  test('target with regex-significant chars — escaped before insertion', async () => {
+    // Defensive — persona names are simple, but a future scenario
+    // could use a target like "User.42" or "Bob+1". Regex-escape
+    // ensures literal matching.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="User.42" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'User.42', 1)).toBe(true);
+  });
+
+  test('target with regex-significant chars — negative pins literal-dot escape', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="UserX42" />',
+    });
+    const driver = await createAndroidDriver();
+    // Without escape, "User.42" would match "UserX42" (. = any char).
+    // With escape, "User.42" requires literal dot → no match.
+    expect(await driver.androidShowsInSeatGrid('Selma', 'User.42', 1)).toBe(false);
+  });
+
+  test('compound attribute names (hint-text=) NOT consulted', async () => {
+    // Same outer-attribute-name guard as PRs #742 and #745.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node hint-text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Adam', 1)).toBe(false);
+  });
+});

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -5494,6 +5494,21 @@ describe('android-adb-driver — androidShowsInSeatGrid', () => {
     expect(ok5).toBe(true);
   });
 
+  test('seatNum=0 (off-by-one sentinel) also accept-and-ignored', async () => {
+    // Round 1 I-1 pin: while real seat positions start at 1, an
+    // off-by-one journey authoring error could pass 0. The
+    // foundation accept-and-ignore contract extends across the full
+    // integer domain — `_seatNum` is never read, so 0 yields the
+    // same result as 1/5/etc. when target is visible.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' + '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInSeatGrid('Selma', 'Adam', 0)).toBe(true);
+  });
+
   test('padded target name — "speaker: Adam" still matches Adam', async () => {
     // Realistic seat-grid labels often pad with role prefix
     // ("speaker: Adam", "host • Adam"). Substring match with


### PR DESCRIPTION
## Summary
- Implements `androidShowsInSeatGrid(viewer, target, seatNum)` for the Wake 102 matcher: `<Name>'s Android UI shows <Other> in seat N of the seat grid` (j09).
- 21 new tests, 381 total in the driver suite, all passing.

## Foundation: two-step composition
Mirrors PR #745's `androidShowsNewGiftEntry`:
1. `room_seatGrid` testTag PRESENT (user is on the room screen)
2. Target's name appears in `text=` or `content-desc=` with symmetric word-boundary `(?<![\w-])...(?![\w-])`

## The seat-number gap
Compose currently only tags the container `room_seatGrid`, not individual seats. The seatNum arg is accepted-and-ignored at this layer — journey-orchestrated. A future PR could layer per-seat verification with e.g. `room_seat_${seatNum}_displayName`.

## Reused patterns
- Outer attribute-name guard from `androidShowsBanner` (`text=` not `hint-text=`)
- Symmetric word-boundary inner anchors from PR #745 R1 fix (hyphen-aware)
- Compound-attribute lookbehind from PR #742

## Phase context
Phase 4 sequential driver-method PR #24 of ~30. Following PR #745. One method per PR, continuous review-loop until ZERO findings → auto-merge.

## Test plan
- [x] 21 new tests, all 381 in suite pass
- [x] room_seatGrid + target name (text + content-desc) → true
- [x] First-guard pin: room_seatGrid absent → false
- [x] Padded target ("speaker: Adam") → true
- [x] 4 boundary collisions blocked: AdamSmith, Beatrix, Adam-jr, pre-Adam
- [x] seatNum ignored at foundation (N=1 vs N=5 same result)
- [x] All 4 null-safety pins; empty dump; dump throws; viewer ignored
- [x] Bare resource-id; regex-significant char escape (both directions)
- [x] Compound attribute names (hint-text=) NOT consulted
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)