### PR TITLE
feat(driver/android): androidShowsGiftFromSender (Wake 99)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1015,6 +1015,46 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return targetRx.test(dump);
   };
 
+  // Wake 99 — `<Name>'s Android UI shows a "<X>" gift from <Other>`
+  // (j01). Driver receives `(recipient, giftId, sender)`.
+  //
+  // Foundation strategy: TRIPLE composition (extends the double
+  // composition from PR #745):
+  //   1. giftWall_grid testTag PRESENT (recipient is on gift-wall).
+  //   2. giftId text appears with symmetric word-boundary.
+  //   3. sender text appears with symmetric word-boundary.
+  //
+  // Both substring scans run over the whole dump independently.
+  // The journey orchestrator ensures only one gift entry is shown
+  // at the time of the assertion, so cross-entry "match in
+  // different entries" false positives aren't reachable. A future
+  // PR could layer per-entry verification once Compose ships per-
+  // entry testTags.
+  driver.androidShowsGiftFromSender = async (_recipient, giftId, sender) => {
+    if (typeof giftId !== 'string' || !giftId.trim()) return false;
+    if (typeof sender !== 'string' || !sender.trim()) return false;
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // Step 1: gift wall must be visible
+    // eslint-disable-next-line sonarjs/slow-regex
+    const wallRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?giftWall_grid"[^>]*\/?>/;
+    if (!wallRx.test(dump)) return false;
+    // Step 2: giftId appears with symmetric word-boundary
+    const escGift = giftId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const giftRx = new RegExp(
+      `(?<![\\w-])(?:text|content-desc)="[^"]*(?<![\\w-])${escGift}(?![\\w-])[^"]*"`,
+    );
+    if (!giftRx.test(dump)) return false;
+    // Step 3: sender appears with symmetric word-boundary
+    const escSender = sender.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const senderRx = new RegExp(
+      `(?<![\\w-])(?:text|content-desc)="[^"]*(?<![\\w-])${escSender}(?![\\w-])[^"]*"`,
+    );
+    return senderRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -6009,4 +6009,63 @@ describe('android-adb-driver — androidShowsGiftFromSender', () => {
     const driver = await createAndroidDriver();
     expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(false);
   });
+
+  test('hyphen-suffix blocked on sender — "Adam" hint ≠ "Adam-Lee"', async () => {
+    // Round 1 I-1: symmetric coverage with the giftId hyphen-suffix
+    // pin above. The symmetric `(?<![\w-])...(?![\w-])` boundary
+    // blocks compound name suffixes for the sender arg too.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam-Lee sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(false);
+  });
+
+  test('hyphen-prefix blocked on sender — "Adam" hint ≠ "pre-Adam"', async () => {
+    // Round 1 I-1: symmetric prefix variant for sender. The
+    // boundary lookbehind blocks hyphen-prefixed forms equally.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="crown from pre-Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(false);
+  });
+
+  test('cross-entry: giftId and sender from different entries both appear → true (known; orchestrator enforces single-entry invariant)', async () => {
+    // Round 1 I-2: documents the foundation contract gap. The two
+    // substring scans run independently over the WHOLE dump — if
+    // multiple gift entries are visible, the assertion can pass
+    // even when no single entry matches both giftId AND sender
+    // (cross-entry false positive).
+    //
+    // This is a KNOWN limitation. The production comment at the
+    // driver method documents that "the journey orchestrator
+    // ensures only one gift entry is shown at the time of the
+    // assertion, so cross-entry false positives aren't reachable."
+    // This test pins that behaviour explicitly — without it, the
+    // contract gap was undocumented in the test record.
+    //
+    // Setup: entry-1 has "crown from Alice", entry-2 has "rose
+    // from Adam". Assertion "crown from Adam" passes because crown
+    // matches entry-1 AND Adam matches entry-2.
+    //
+    // A future PR layering per-entry verification (via per-entry
+    // testTags) would tighten this — this pin would then be
+    // updated to `expect(...).toBe(false)`.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="crown from Alice" />' +
+        '<node text="rose from Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(true);
+  });
 });

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -5702,3 +5702,311 @@ describe('android-adb-driver — androidShowsInSeatGrid', () => {
     expect(await driver.androidShowsInSeatGrid('Selma', 'Adam', 1)).toBe(false);
   });
 });
+
+describe('android-adb-driver — androidShowsGiftFromSender', () => {
+  // Wake 99 matcher — `<Name>'s Android UI shows a "<X>" gift from
+  // <Other>` (j01 — gift-receipt notification on recipient view).
+  // Driver receives `(recipient, giftId, sender)`.
+  //
+  // Foundation strategy: TRIPLE composition (extends PR #745's
+  // double composition):
+  //   1. giftWall_grid testTag PRESENT (recipient is on gift-wall
+  //      surface).
+  //   2. giftId text appears with symmetric word-boundary.
+  //   3. sender text appears with symmetric word-boundary.
+  //
+  // Both substring scans run over the whole dump independently —
+  // the journey orchestrator ensures only one gift entry is shown
+  // at the time of the assertion, so cross-entry "match in
+  // different entries" false positives aren't reachable. A future
+  // PR could layer per-entry verification once Compose ships per-
+  // entry testTags.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('giftWall_grid + giftId + sender all present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(true);
+  });
+
+  test('giftId in text, sender in content-desc → true', async () => {
+    // Realistic uiautomator output often splits role across nodes.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="crown" /><node content-desc="from Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(true);
+  });
+
+  test('giftWall_grid absent (wrong screen) → false', async () => {
+    // First guard pins: even when both giftId and sender are in
+    // the dump, the assertion fails if the gift-wall surface
+    // isn't visible.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />' +
+        '<node text="Adam sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(false);
+  });
+
+  test('giftId present but sender absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(false);
+  });
+
+  test('sender present but giftId absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent something" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(false);
+  });
+
+  test('both giftId and sender in same node text → true', async () => {
+    // Pin the same-node case explicitly (the realistic gift-log
+    // entry shape: "Adam sent crown ×5"). Both regexes find their
+    // hit in the same text= attribute.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown today" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(true);
+  });
+
+  test('prefix collision blocked on giftId — "crown" hint ≠ "Crowning"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam earned Crowning Achievement" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(false);
+  });
+
+  test('prefix collision blocked on sender — "Adam" hint ≠ "AdamSmith"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="AdamSmith sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(false);
+  });
+
+  test('hyphen-suffix blocked on giftId — "crown" hint ≠ "crown-shaped"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown-shaped trophy" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(false);
+  });
+
+  test('empty giftId → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', '', 'Adam')).toBe(false);
+  });
+
+  test('empty sender → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', '')).toBe(false);
+  });
+
+  test('null giftId → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', null, 'Adam')).toBe(false);
+  });
+
+  test('null sender → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', null)).toBe(false);
+  });
+
+  test('undefined giftId → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', undefined, 'Adam')).toBe(false);
+  });
+
+  test('undefined sender → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', undefined)).toBe(false);
+  });
+
+  test('whitespace-only giftId → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', '   ', 'Adam')).toBe(false);
+  });
+
+  test('whitespace-only sender → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', '   ')).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="giftWall_grid" /><node text="Adam sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(true);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(false);
+  });
+
+  test('recipient name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    const okSelma = await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="Adam sent crown" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okBea = await driver2.androidShowsGiftFromSender('Bea', 'crown', 'Adam');
+
+    expect(okSelma).toBe(true);
+    expect(okBea).toBe(true);
+  });
+
+  test('giftId AND sender with regex-significant chars — both escaped', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="User.42 sent gift_2.0" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'gift_2.0', 'User.42')).toBe(true);
+  });
+
+  test('regex-escape — literal dot does not match arbitrary char', async () => {
+    // Without escape, "gift_2.0" would match "gift_2X0". With
+    // escape, it requires a literal dot.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node text="UserX42 sent gift_2X0" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'gift_2.0', 'User.42')).toBe(false);
+  });
+
+  test('compound attribute names (hint-text=) NOT consulted', async () => {
+    // Outer attribute-name guard from PR #742 + #745.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node hint-text="Adam sent crown" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsGiftFromSender('Selma', 'crown', 'Adam')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `androidShowsGiftFromSender(recipient, giftId, sender)` for the Wake 99 matcher: `<Name>'s Android UI shows a "<X>" gift from <Other>` (j01).
- 24 new tests, 406 total in the driver suite, all passing.

## Foundation: TRIPLE composition
Extends PR #745's double composition with a second substring scan:
1. `giftWall_grid` testTag PRESENT (recipient is on gift-wall)
2. `giftId` text appears with symmetric word-boundary
3. `sender` text appears with symmetric word-boundary

Both substring scans run over the whole dump independently — the journey orchestrator ensures only one gift entry is shown at the time of the assertion, so cross-entry false positives aren't reachable. A future PR could layer per-entry verification once Compose ships per-entry testTags.

## Reused patterns
- Outer compound-attr lookbehind (PR #742)
- Symmetric inner word-boundary (PR #745 R1)
- Regex-escape on both args (PRs #735/#740/#745)
- First-guard discipline (PR #739)

## Phase context
Phase 4 sequential driver-method PR #25 of ~30. Following PR #746.

## Test plan
- [x] 24 new tests, all 406 in suite pass
- [x] Both substrings present → true (same-node, different-attrs, padded variants)
- [x] First-guard pin: giftWall_grid absent → false
- [x] Each substring absent → false (giftId only / sender only)
- [x] Boundary collisions on BOTH args (Crowning, AdamSmith, crown-shaped)
- [x] All 4 null-safety pins x 2 args
- [x] Empty dump; dump throws; recipient ignored
- [x] Bare resource-id; regex-significant char escape (both directions, both args)
- [x] Compound attribute names (hint-text=) NOT consulted
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)