### PR TITLE
feat(driver/android): androidShowsNewUnreadConversation (Wake 102)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1078,6 +1078,37 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 102 — `<Name>'s Android UI shows a new conversation with
+  // <Other> highlighted as unread` (j07 — recipient's inbox shows
+  // new unread conversation from sender). Driver receives
+  // `(viewer, other)`.
+  //
+  // Foundation strategy: two-step composition (mirrors PR #745):
+  //   1. main_messagesTab testTag PRESENT (viewer is in messages
+  //      area — this assertion can't be made from anywhere else).
+  //   2. other's name appears in text/content-desc with symmetric
+  //      word-boundary protection.
+  //
+  // The "highlighted as unread" semantic is journey-orchestrated.
+  // No per-row testTag exists for unread state today; a future PR
+  // could layer this with e.g. `conversation_row_${id}_unread`.
+  driver.androidShowsNewUnreadConversation = async (_viewer, other) => {
+    if (typeof other !== 'string' || !other.trim()) return false;
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // Step 1: messages tab visible
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tabRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?main_messagesTab"[^>]*\/?>/;
+    if (!tabRx.test(dump)) return false;
+    // Step 2: other name appears with symmetric word-boundary
+    const escOther = other.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const otherRx = new RegExp(
+      `(?<![\\w-])(?:text|content-desc)="[^"]*(?<![\\w-])${escOther}(?![\\w-])[^"]*"`,
+    );
+    return otherRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -6471,4 +6471,42 @@ describe('android-adb-driver — androidShowsNewUnreadConversation', () => {
     const driver = await createAndroidDriver();
     expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(false);
   });
+
+  test('first-guard right-boundary — main_messagesTabExtra does NOT count', async () => {
+    // Round 1 I-2: symmetric with the left-boundary pin above.
+    // The closing `"` in the regex is a hard right anchor, but the
+    // pin documents the contract.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTabExtra" />' +
+        '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(false);
+  });
+
+  test('chat-thread-screen disambiguation — privateChat_messageInput alone (no messages tab) → false', async () => {
+    // Round 1 I-1: PrivateChatScreen replaces MainScreen entirely
+    // in the nav graph (NavGraph.kt:496-497) — its Scaffold has no
+    // NavigationBar. So `main_messagesTab` is ABSENT when inside a
+    // chat thread. This pin documents the screen distinction
+    // explicitly: even when the chat input is visible (which would
+    // be reachable from a sibling test like
+    // `androidShowsMessageInConversationThread`), the conversation
+    // LIST is NOT in the dump → must return false.
+    //
+    // Regression-proof against a future navigation refactor that
+    // embeds the chat screen inside MainScreen (which would
+    // suddenly make main_messagesTab present + privateChat_messageInput
+    // present simultaneously; the assertion would falsely pass).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_messageInput" />' +
+        '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(false);
+  });
 });

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -6225,3 +6225,250 @@ describe('android-adb-driver — androidShowsMessageInConversationThread', () =>
     expect(await driver.androidShowsMessageInConversationThread('Selma')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsNewUnreadConversation', () => {
+  // Wake 102 matcher — `<Name>'s Android UI shows a new conversation
+  // with <Other> highlighted as unread` (j07 — recipient's inbox
+  // shows new unread conversation from sender). Driver receives
+  // `(viewer, other)`.
+  //
+  // Foundation strategy: two-step composition (mirrors PR #745):
+  //   1. main_messagesTab testTag PRESENT (viewer is in messages
+  //      area).
+  //   2. other's name appears in text/content-desc with symmetric
+  //      word-boundary protection.
+  //
+  // The "highlighted as unread" semantic is journey-orchestrated.
+  // No per-row testTag exists for unread state today; a future PR
+  // could layer this with e.g. `conversation_row_${id}_unread`.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('main_messagesTab + other in text → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(true);
+  });
+
+  test('main_messagesTab + other in content-desc → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node content-desc="Bea" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Bea')).toBe(true);
+  });
+
+  test('main_messagesTab absent (wrong screen) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />' + '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(false);
+  });
+
+  test('main_messagesTab present but other absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="Different" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(false);
+  });
+
+  test('prefix-collision blocked — "Adam" hint ≠ "AdamSmith"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="AdamSmith" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(false);
+  });
+
+  test('hyphen-suffix blocked — "Adam" hint ≠ "Adam-Lee"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="Adam-Lee" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(false);
+  });
+
+  test('hyphen-prefix blocked — "Adam" hint ≠ "pre-Adam"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="pre-Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(false);
+  });
+
+  test('padded other name — "Adam · just now" still matches', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="Adam · just now" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(true);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(false);
+  });
+
+  test('empty other arg → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', '')).toBe(false);
+  });
+
+  test('whitespace-only other → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', '   ')).toBe(false);
+  });
+
+  test('null other → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', null)).toBe(false);
+  });
+
+  test('undefined other → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', undefined)).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="main_messagesTab" /><node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(true);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(false);
+  });
+
+  test('viewer name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    const okSelma = await driver.androidShowsNewUnreadConversation('Selma', 'Adam');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="Adam" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okBea = await driver2.androidShowsNewUnreadConversation('Bea', 'Adam');
+
+    expect(okSelma).toBe(true);
+    expect(okBea).toBe(true);
+  });
+
+  test('other with regex-significant chars — positive case (literal dot)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="User.42" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'User.42')).toBe(true);
+  });
+
+  test('other with regex-significant chars — negative pins literal-dot escape', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node text="UserX42" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'User.42')).toBe(false);
+  });
+
+  test('compound attribute names (hint-text=) NOT consulted', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_messagesTab" />' +
+        '<node hint-text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(false);
+  });
+
+  test('first-guard left-boundary — pre_main_messagesTab does NOT count', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_main_messagesTab" /><node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `androidShowsNewUnreadConversation(viewer, other)` for the Wake 102 matcher: `<Name>'s Android UI shows a new conversation with <Other> highlighted as unread` (j07).
- 20 new tests, 441 total in the driver suite, all passing.

## Foundation: two-step composition
Mirrors PR #745:
1. `main_messagesTab` testTag PRESENT (viewer in messages area)
2. `other` name appears in text/content-desc with symmetric word-boundary protection

## Known limitation: "highlighted as unread"
Journey-orchestrated. No per-row testTag exists for unread state today; a future PR could layer this with e.g. `conversation_row_${id}_unread`.

## Phase context
Phase 4 sequential driver-method PR #27 of ~30. Following PR #748.

## Test plan
- [x] 20 new tests, all 441 in suite pass
- [x] Both attribute types; first-guard pin; other-absent pin
- [x] 3 boundary collisions blocked (AdamSmith, Adam-Lee, pre-Adam)
- [x] Padded other ("Adam · just now") → true
- [x] All 4 null-safety pins; empty dump; dump throws; viewer ignored
- [x] Bare resource-id; regex-significant char escape (both directions)
- [x] Compound attribute names (hint-text=) NOT consulted
- [x] First-guard boundary: pre_main_messagesTab does NOT count
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)