### PR TITLE
feat(driver/android): androidAdminShowsRowForWithStatus (Wake 98)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1109,6 +1109,50 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return otherRx.test(dump);
   };
 
+  // Wake 98 — `<Name>'s Android Admin UI shows N row for "<X>" with
+  // status "<Y>"` (j01/j04 admin-queue row presence). Driver
+  // receives `(viewer, count, targetId, status)`.
+  //
+  // Foundation strategy: TRIPLE composition (mirrors PR #747's
+  // androidShowsGiftFromSender):
+  //   1. reportReview_list testTag PRESENT (admin queue visible)
+  //   2. targetId text appears with symmetric word-boundary
+  //   3. status text appears with symmetric word-boundary
+  //
+  // The COUNT (typically 1) is journey-orchestrated and ignored
+  // at foundation — no per-row testTag exists for counting matching
+  // rows. A future PR could layer this with `reportReview_row_${id}`
+  // parameterised testTags.
+  //
+  // Cross-row pass-through (same as PR #747): if multiple rows
+  // are visible with targetId in row-A and status in row-B, the
+  // assertion passes. Journey orchestrator's responsibility to
+  // ensure single-row context.
+  driver.androidAdminShowsRowForWithStatus = async (_viewer, _count, targetId, status) => {
+    if (typeof targetId !== 'string' || !targetId.trim()) return false;
+    if (typeof status !== 'string' || !status.trim()) return false;
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // Step 1: admin queue visible
+    // eslint-disable-next-line sonarjs/slow-regex
+    const listRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?reportReview_list"[^>]*\/?>/;
+    if (!listRx.test(dump)) return false;
+    // Step 2: targetId appears with symmetric word-boundary
+    const escTarget = targetId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const targetRx = new RegExp(
+      `(?<![\\w-])(?:text|content-desc)="[^"]*(?<![\\w-])${escTarget}(?![\\w-])[^"]*"`,
+    );
+    if (!targetRx.test(dump)) return false;
+    // Step 3: status appears with symmetric word-boundary
+    const escStatus = status.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const statusRx = new RegExp(
+      `(?<![\\w-])(?:text|content-desc)="[^"]*(?<![\\w-])${escStatus}(?![\\w-])[^"]*"`,
+    );
+    return statusRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -6889,4 +6889,54 @@ describe('android-adb-driver — androidAdminShowsRowForWithStatus', () => {
       await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
     ).toBe(true);
   });
+
+  test('hyphen-suffix blocked on targetId — "riley-abc123" hint ≠ "riley-abc123-extra"', async () => {
+    // Round 1 I-1: symmetric coverage with the status hyphen-suffix
+    // pin. The `(?![\w-])` right boundary blocks trailing hyphens
+    // for the targetId arg too.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123-extra pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(false);
+  });
+
+  test('compound-attribute guard isolated per arg — targetId in hint-text= (only) → false', async () => {
+    // Round 1 I-2: isolate Step 2's compound-attribute guard.
+    // status appears in legitimate text=, but targetId is only in
+    // hint-text=. Should return false (Step 2 fails because
+    // targetId is not in a real text/content-desc attribute).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node hint-text="riley-abc123" /><node text="pending review" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(false);
+  });
+
+  test('compound-attribute guard isolated per arg — status in hint-text= (only) → false', async () => {
+    // Round 1 I-2: isolate Step 3's compound-attribute guard.
+    // targetId appears in legitimate text=, but status is only in
+    // hint-text=. Should return false (Step 3 fails because status
+    // is not in a real text/content-desc attribute).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 row" /><node hint-text="pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(false);
+  });
 });

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -6510,3 +6510,383 @@ describe('android-adb-driver — androidShowsNewUnreadConversation', () => {
     expect(await driver.androidShowsNewUnreadConversation('Selma', 'Adam')).toBe(false);
   });
 });
+
+describe('android-adb-driver — androidAdminShowsRowForWithStatus', () => {
+  // Wake 98 matcher — `<Name>'s Android Admin UI shows N row for
+  // "<X>" with status "<Y>"` (j01/j04 admin-queue row presence).
+  // Driver receives `(viewer, count, targetId, status)`.
+  //
+  // Foundation strategy: TRIPLE composition (mirrors PR #747's
+  // androidShowsGiftFromSender):
+  //   1. reportReview_list testTag PRESENT (admin queue visible)
+  //   2. targetId text appears with symmetric word-boundary
+  //   3. status text appears with symmetric word-boundary
+  //
+  // The COUNT (typically 1) is journey-orchestrated and ignored
+  // at foundation — no per-row testTag exists for counting matching
+  // rows. A future PR could layer per-row inspection once
+  // `reportReview_row_${id}` parameterised testTags ship.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('reportReview_list + targetId + status all present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 [pending review]" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(true);
+  });
+
+  test('targetId in text, status in content-desc → true', async () => {
+    // Realistic admin rows split target + status across attrs.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123" /><node content-desc="status: pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(true);
+  });
+
+  test('reportReview_list absent (wrong screen) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />' +
+        '<node text="riley-abc123 pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(false);
+  });
+
+  test('targetId present + status absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 resolved" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(false);
+  });
+
+  test('status present + targetId absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="someone-else pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(false);
+  });
+
+  test('count is ignored — N=1 and N=3 both return same result', async () => {
+    // Foundation contract pin: count is accepted but ignored. The
+    // journey orchestrator is responsible for verifying the number
+    // of matching rows — a future PR could layer this.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 pending" />',
+    });
+    const driver = await createAndroidDriver();
+    const ok1 = await driver.androidAdminShowsRowForWithStatus(
+      'Greta',
+      1,
+      'riley-abc123',
+      'pending',
+    );
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 pending" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const ok3 = await driver2.androidAdminShowsRowForWithStatus(
+      'Greta',
+      3,
+      'riley-abc123',
+      'pending',
+    );
+
+    expect(ok1).toBe(true);
+    expect(ok3).toBe(true);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(false);
+  });
+
+  test('empty targetId → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowForWithStatus('Greta', 1, '', 'pending')).toBe(false);
+  });
+
+  test('empty status → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', '')).toBe(
+      false,
+    );
+  });
+
+  test('null targetId → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowForWithStatus('Greta', 1, null, 'pending')).toBe(false);
+  });
+
+  test('null status → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', null)).toBe(
+      false,
+    );
+  });
+
+  test('undefined targetId → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowForWithStatus('Greta', 1, undefined, 'pending')).toBe(
+      false,
+    );
+  });
+
+  test('undefined status → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', undefined),
+    ).toBe(false);
+  });
+
+  test('whitespace-only targetId → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowForWithStatus('Greta', 1, '   ', 'pending')).toBe(
+      false,
+    );
+  });
+
+  test('whitespace-only status → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', '   ')).toBe(
+      false,
+    );
+  });
+
+  test('prefix-collision blocked on targetId — "riley" hint ≠ "rileyford"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="rileyford pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley', 'pending')).toBe(
+      false,
+    );
+  });
+
+  test('hyphen-suffix blocked on status — "pending" hint ≠ "pending-review"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 pending-review" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="reportReview_list" /><node text="riley-abc123 pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(true);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(false);
+  });
+
+  test('viewer name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 pending" />',
+    });
+    const driver = await createAndroidDriver();
+    const okGreta = await driver.androidAdminShowsRowForWithStatus(
+      'Greta',
+      1,
+      'riley-abc123',
+      'pending',
+    );
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 pending" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okAlice = await driver2.androidAdminShowsRowForWithStatus(
+      'Alice',
+      1,
+      'riley-abc123',
+      'pending',
+    );
+
+    expect(okGreta).toBe(true);
+    expect(okAlice).toBe(true);
+  });
+
+  test('regex-significant chars on both args — escaped properly', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="user.42 status:in.review" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'user.42', 'in.review')).toBe(
+      true,
+    );
+  });
+
+  test('regex-significant chars — negative pins literal-dot escape', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="userX42 statusXin/review" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'user.42', 'in.review')).toBe(
+      false,
+    );
+  });
+
+  test('compound attribute names (hint-text=) NOT consulted for either arg', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node hint-text="riley-abc123 pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(false);
+  });
+
+  test('cross-row pass-through documented — targetId in row-1, status in row-2 → true (orchestrator invariant)', async () => {
+    // Round 1 contract pin (mirrors PR #747's cross-entry pin):
+    // the two substring scans run INDEPENDENTLY over the whole
+    // dump. If multiple rows are visible with target and status
+    // split across them, the assertion can pass even though no
+    // single row matches both. This is a KNOWN limitation —
+    // documented in production. A future per-row testTag layer
+    // would tighten this.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />' +
+        '<node text="riley-abc123 resolved" />' +
+        '<node text="other-user pending" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsRowForWithStatus('Greta', 1, 'riley-abc123', 'pending'),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `androidAdminShowsRowForWithStatus(viewer, count, targetId, status)` for the Wake 98 matcher: `<Name>'s Android Admin UI shows N row for "<X>" with status "<Y>"` (j01/j04 admin-queue row presence).
- 24 new tests, 467 total in the driver suite, all passing.

## Foundation: TRIPLE composition
Mirrors PR #747's `androidShowsGiftFromSender`:
1. `reportReview_list` testTag PRESENT (admin queue visible)
2. `targetId` text appears with symmetric word-boundary
3. `status` text appears with symmetric word-boundary

## Foundation policy
- **Count ignored** (journey-orchestrated; typically 1). A future PR could layer per-row counting once `reportReview_row_${id}` parameterised testTags ship.
- **Cross-row pass-through documented** (same as PR #747): if multiple rows are visible with target in row-A and status in row-B, the assertion passes. Journey orchestrator's responsibility.

## Phase context
Phase 4 sequential driver-method PR #28 of ~30. Following PR #749.

## Test plan
- [x] 24 new tests, all 467 in suite pass
- [x] All 3 substrings present (same-row, split-attr)
- [x] First-guard pin; each substring absent → false
- [x] Count ignored (N=1 vs N=3)
- [x] All 4 null-safety pins x 2 args
- [x] Empty dump; dump throws; viewer ignored
- [x] Bare resource-id; regex-escape both directions both args
- [x] Compound attribute names (hint-text=) NOT consulted
- [x] Prefix-collision on targetId; hyphen-suffix on status
- [x] Cross-row pass-through contract pinned explicitly
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)