### PR TITLE
feat(driver/android): androidAdminShowsRowCountInTable (Wake 104)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1153,6 +1153,37 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return statusRx.test(dump);
   };
 
+  // Wake 104 — `<Name>'s Android Admin UI shows N rows in the <X>
+  // table` (j12 — generic admin table row-count assertion). Driver
+  // receives `(viewer, count, tableName)`.
+  //
+  // Foundation strategy: same TABLE_TAGS lookup as PR #740's
+  // androidAdminShowsTableOf. Same TABLE_TAGS constant is
+  // intentionally redeclared in this closure for symmetry and
+  // future independent evolution. Currently one entry:
+  //   - "reports" → reportReview_list
+  //
+  // The COUNT is journey-orchestrated and ignored at foundation —
+  // no per-row testTag exists for counting matching rows. A future
+  // PR could layer this with `reportReview_row_${id}` parameterised
+  // testTags + a counter scan.
+  //
+  // Unmapped tableNames return false (FAIL-loud) — same scaffold-
+  // then-expand discipline as INPUT_TAGS (PR #737), TABLE_TAGS
+  // (PR #740), SEARCH_FIELD_TAGS (PR #741), PATH_TAGS (PR #744).
+  const ROW_COUNT_TABLE_TAGS = { reports: 'reportReview_list' };
+  driver.androidAdminShowsRowCountInTable = async (_viewer, _count, tableName) => {
+    if (typeof tableName !== 'string' || !tableName.trim()) return false;
+    const tag = ROW_COUNT_TABLE_TAGS[tableName.trim().toLowerCase()];
+    if (!tag) return false;
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    const escTag = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = new RegExp(`<node[^>]*resource-id="(?:[^"]*:id\\/)?${escTag}"[^>]*\\/?>`);
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -7096,6 +7096,23 @@ describe('android-adb-driver — androidAdminShowsRowCountInTable', () => {
     expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, undefined)).toBe(false);
   });
 
+  test('numeric tableName (e.g., 42) → false (typeof guard pinned)', async () => {
+    // Round 1 I-1: extends the null/undefined null-safety matrix
+    // to numeric types. The `typeof tableName !== 'string'` guard
+    // rejects ANY non-string (number, boolean, object) — pin the
+    // numeric case explicitly so a future refactor changing the
+    // guard to `!tableName` (which would still reject 0 but accept
+    // non-zero numbers as truthy and crash on `.trim()`) is
+    // caught immediately.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, 42)).toBe(false);
+  });
+
   test('bare resource-id (no package prefix) → true', async () => {
     mockExec({
       "'uiautomator' 'dump'": '',

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -6940,3 +6940,243 @@ describe('android-adb-driver — androidAdminShowsRowForWithStatus', () => {
     ).toBe(false);
   });
 });
+
+describe('android-adb-driver — androidAdminShowsRowCountInTable', () => {
+  // Wake 104 matcher — `<Name>'s Android Admin UI shows N rows in
+  // the <X> table` (j12 — generic admin table row-count assertion).
+  // Driver receives `(viewer, count, tableName)`.
+  //
+  // Foundation strategy: same TABLE_TAGS lookup as PR #740's
+  // androidAdminShowsTableOf. Currently one entry:
+  //   - "reports" → reportReview_list
+  //
+  // The COUNT is journey-orchestrated and ignored at foundation —
+  // no per-row testTag exists for counting matching rows. A future
+  // PR could layer this with `reportReview_row_${id}` parameterised
+  // testTags + a counter scan.
+  //
+  // Unmapped tableNames return false (FAIL-loud) — same contract
+  // as PR #740.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('"reports" table + tag present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, 'reports')).toBe(true);
+  });
+
+  test('"reports" table absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, 'reports')).toBe(false);
+  });
+
+  test('unmapped tableName "transactions" → false (FAIL-loud)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, 'transactions')).toBe(false);
+  });
+
+  test('count is ignored — N=1 and N=42 both pass when table visible', async () => {
+    // Foundation contract pin: count is accepted but not verified.
+    // Without per-row testTags, counting matching rows isn't
+    // possible. The journey orchestrator is responsible for
+    // verifying actual row count.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    const ok1 = await driver.androidAdminShowsRowCountInTable('Greta', 1, 'reports');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const ok42 = await driver2.androidAdminShowsRowCountInTable('Greta', 42, 'reports');
+
+    expect(ok1).toBe(true);
+    expect(ok42).toBe(true);
+  });
+
+  test('count=0 (empty assertion) — still returns true if table visible (foundation contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 0, 'reports')).toBe(true);
+  });
+
+  test('case-insensitive tableName — "REPORTS" resolves', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, 'REPORTS')).toBe(true);
+  });
+
+  test('whitespace-padded tableName resolves after trim', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, '  reports  ')).toBe(true);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, 'reports')).toBe(false);
+  });
+
+  test('empty tableName → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, '')).toBe(false);
+  });
+
+  test('whitespace-only tableName → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, '   ')).toBe(false);
+  });
+
+  test('null tableName → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, null)).toBe(false);
+  });
+
+  test('undefined tableName → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, undefined)).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, 'reports')).toBe(true);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, 'reports')).toBe(false);
+  });
+
+  test('viewer name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    const okGreta = await driver.androidAdminShowsRowCountInTable('Greta', 1, 'reports');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okAlice = await driver2.androidAdminShowsRowCountInTable('Alice', 1, 'reports');
+
+    expect(okGreta).toBe(true);
+    expect(okAlice).toBe(true);
+  });
+
+  test('left-boundary inherited from regex — pre_reportReview_list_x does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_reportReview_list_x" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, 'reports')).toBe(false);
+  });
+
+  test('right-boundary — reportReview_list_extra does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list_extra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, 'reports')).toBe(false);
+  });
+
+  test('multi-word tableName "user reports" → false (not in TABLE_TAGS)', async () => {
+    // Matcher regex allows `\w+(?:[ -]\w+)?` — both "user reports"
+    // and "user-reports" are reachable. Both unmapped → false.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, 'user reports')).toBe(false);
+  });
+
+  test('hyphenated tableName "user-reports" → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/reportReview_list" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, 'user-reports')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `androidAdminShowsRowCountInTable(viewer, count, tableName)` for the Wake 104 matcher: `<Name>'s Android Admin UI shows N rows in the <X> table` (j12).
- 19 new tests, 489 total in the driver suite, all passing.

## Foundation: TABLE_TAGS lookup
Same shape as PR #740's `androidAdminShowsTableOf`. One entry:
- `"reports"` → `"reportReview_list"`

## Foundation policy
- **Count ignored** (journey-orchestrated). Without per-row testTags, counting matching rows isn't possible. A future PR could layer with `reportReview_row_${id}` parameterised testTags + counter scan.
- **Unmapped tableNames → false** (FAIL-loud) — consistent with INPUT_TAGS/TABLE_TAGS/SEARCH_FIELD_TAGS/PATH_TAGS discipline.

## Phase context
Phase 4 sequential driver-method PR #29 of ~30. Following PR #750.

## Test plan
- [x] 19 new tests, all 489 in suite pass
- [x] Table present/absent; unmapped tableName → false
- [x] Count ignored (N=1, N=42, N=0)
- [x] Case-insensitive + whitespace-padded tableName
- [x] All 4 null-safety pins on tableName
- [x] Empty dump; dump throws; viewer ignored
- [x] Bare resource-id; left + right boundary guards
- [x] Multi-word + hyphenated tableName variants (both unmapped → false)
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)