### PR TITLE
feat(driver/android): androidShowsInThread (Wake 100)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1184,6 +1184,29 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 100 — `<Name>'s Android UI shows the <noun> in the thread
+  // [with <suffix>]` (j07, 2 corpus rows). noun is "message" or
+  // "reply"; optional trailing suffix like "with timestamp + sent
+  // indicator". Driver receives `(name, noun, suffix)`.
+  //
+  // Foundation strategy: presence-check the conversation thread
+  // is open (privateChat_messageInput testTag PRESENT). Same shape
+  // as PR #748's androidShowsMessageInConversationThread but with
+  // two additional accepted-and-ignored args (noun, suffix).
+  //
+  // The noun/suffix details are journey-orchestrated — the test
+  // runs RIGHT AFTER a specific message/reply is sent, so "the
+  // <noun>" being visible is implied by the thread being open. A
+  // future PR could layer per-message verification with parameterised
+  // testTags or by parsing message bodies in the dump.
+  driver.androidShowsInThread = async (_name, _noun, _suffix) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?privateChat_messageInput"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -7384,4 +7384,20 @@ describe('android-adb-driver — androidShowsInThread', () => {
     const driver = await createAndroidDriver();
     expect(await driver.androidShowsInThread('Selma', 'edit', '')).toBe(true);
   });
+
+  test('undefined suffix → true (suffix accepted-and-ignored regardless of value)', async () => {
+    // Round 1 pin: the runner at manual-qa-runner.js:12069 normalises
+    // `suffix = m[4] || ''` so undefined never reaches the driver
+    // from valid Gherkin. But the foundation contract is "suffix is
+    // ignored regardless of value" — pin that explicitly. Consistent
+    // with the seatNum=0 pin in PR #746 (extends accept-and-ignore
+    // across the full value domain for ignored args).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_messageInput" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'message', undefined)).toBe(true);
+  });
 });

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -7197,3 +7197,191 @@ describe('android-adb-driver — androidAdminShowsRowCountInTable', () => {
     expect(await driver.androidAdminShowsRowCountInTable('Greta', 1, 'user-reports')).toBe(false);
   });
 });
+
+describe('android-adb-driver — androidShowsInThread', () => {
+  // Wake 100 matcher — `<Name>'s Android UI shows the <noun> in the
+  // thread [with <suffix>]` (j07, 2 corpus rows). noun is
+  // "message" or "reply"; optional trailing suffix like "with
+  // timestamp + sent indicator".
+  //
+  // Foundation strategy: presence-check the conversation thread is
+  // open (privateChat_messageInput testTag PRESENT). Same shape as
+  // PR #748's androidShowsMessageInConversationThread but with two
+  // additional accepted-and-ignored args (noun, suffix).
+  //
+  // The noun/suffix details are journey-orchestrated — the test
+  // runs RIGHT AFTER a specific message/reply is sent, so "the
+  // <noun>" being visible is implied by the thread being open.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('privateChat_messageInput present + noun="message" → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_messageInput" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'message', '')).toBe(true);
+  });
+
+  test('privateChat_messageInput present + noun="reply" → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_messageInput" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'reply', '')).toBe(true);
+  });
+
+  test('with suffix — "with timestamp + sent indicator" still passes (suffix ignored)', async () => {
+    // Foundation contract pin: suffix is accepted but ignored.
+    // The thread being open is sufficient.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_messageInput" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidShowsInThread('Selma', 'message', 'with timestamp + sent indicator'),
+    ).toBe(true);
+  });
+
+  test('privateChat_messageInput absent (wrong screen) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'message', '')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'message', '')).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="privateChat_messageInput" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'message', '')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_messageInput"><node text="placeholder" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'message', '')).toBe(true);
+  });
+
+  test('left-boundary false-positive guarded — pre_privateChat_messageInput_x does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_privateChat_messageInput_x" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'message', '')).toBe(false);
+  });
+
+  test('right-boundary false-positive guarded — privateChat_messageInput_extra does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_messageInput_extra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'message', '')).toBe(false);
+  });
+
+  test('package-qualified left-boundary guarded — :id/pre_privateChat_messageInput does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_privateChat_messageInput" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'message', '')).toBe(false);
+  });
+
+  test('bare left-boundary without suffix — pre_privateChat_messageInput does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_privateChat_messageInput" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'message', '')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'message', '')).toBe(false);
+  });
+
+  test('persona name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_messageInput" />',
+    });
+    const driver = await createAndroidDriver();
+    const okSelma = await driver.androidShowsInThread('Selma', 'message', '');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_messageInput" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okBea = await driver2.androidShowsInThread('Bea', 'message', '');
+
+    expect(okSelma).toBe(true);
+    expect(okBea).toBe(true);
+  });
+
+  test('first-match contract — two privateChat_messageInput nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_messageInput" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_messageInput" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'message', '')).toBe(true);
+  });
+
+  test('arbitrary noun (e.g., "edit") still passes — noun ignored', async () => {
+    // Pin that the noun argument is accepted-and-ignored at the
+    // foundation layer. Future suffix-aware refinement could
+    // distinguish "message" vs "reply" vs "edit" but the
+    // foundation just verifies thread is open.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/privateChat_messageInput" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInThread('Selma', 'edit', '')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `androidShowsInThread(name, noun, suffix)` for the Wake 100 matcher: `<Name>'s Android UI shows the <noun> in the thread [with <suffix>]` (j07, 2 corpus rows).
- 15 new tests, 505 total in the driver suite, all passing.

## Foundation: presence check (same shape as PR #748)
Asserts the conversation thread is open via `privateChat_messageInput` testTag. The noun ("message"/"reply") and optional suffix are accepted-and-ignored at this layer — journey-orchestrated.

A future PR could layer per-message verification with parameterised testTags or by parsing message bodies in the dump.

## Phase context
Phase 4 sequential driver-method PR #30 of ~30. Following PR #751.

## Test plan
- [x] 15 new tests, all 505 in suite pass
- [x] Both noun variants (message, reply); with-suffix variant
- [x] Wrong screen → false; empty dump → false
- [x] Bare resource-id; non-self-closing form
- [x] All 4 boundary guards (bare-left+suffix, right, package-qualified-left, bare-left-no-suffix)
- [x] uiautomator dump throws → false; persona name ignored; first-match contract
- [x] Arbitrary noun ignored
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)