### PR TITLE
feat(driver/android): androidShowsSeatWithIndicator (Wake 101)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1207,6 +1207,51 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 101 — `<Name>'s Android UI shows <Other>'s seat with <X>
+  // indicator` (j09 mic-on / j10 mic-off). Generic per-seat
+  // indicator assertion. Driver receives `(viewer, target,
+  // indicator)`.
+  //
+  // Foundation strategy: TRIPLE composition (mirrors PR #747's
+  // androidShowsGiftFromSender):
+  //   1. room_seatGrid testTag PRESENT (viewer on room screen)
+  //   2. target's name appears with symmetric word-boundary
+  //   3. indicator text appears with symmetric word-boundary
+  //
+  // Per-seat indicator scoping is journey-orchestrated — no per-
+  // seat testTag exists yet. The journey ensures only the
+  // relevant seat is in view at assertion time. A future PR could
+  // layer per-seat per-indicator testTags (e.g.
+  // `room_seat_${n}_micOn`).
+  //
+  // Cross-seat pass-through (same as PR #747's cross-entry): two
+  // independent scans over the whole dump. Journey orchestrator's
+  // responsibility to ensure single-seat context.
+  driver.androidShowsSeatWithIndicator = async (_viewer, target, indicator) => {
+    if (typeof target !== 'string' || !target.trim()) return false;
+    if (typeof indicator !== 'string' || !indicator.trim()) return false;
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // Step 1: seat grid visible
+    // eslint-disable-next-line sonarjs/slow-regex
+    const gridRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?room_seatGrid"[^>]*\/?>/;
+    if (!gridRx.test(dump)) return false;
+    // Step 2: target appears with symmetric word-boundary
+    const escTarget = target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const targetRx = new RegExp(
+      `(?<![\\w-])(?:text|content-desc)="[^"]*(?<![\\w-])${escTarget}(?![\\w-])[^"]*"`,
+    );
+    if (!targetRx.test(dump)) return false;
+    // Step 3: indicator appears with symmetric word-boundary
+    const escIndicator = indicator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const indicatorRx = new RegExp(
+      `(?<![\\w-])(?:text|content-desc)="[^"]*(?<![\\w-])${escIndicator}(?![\\w-])[^"]*"`,
+    );
+    return indicatorRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -7526,6 +7526,21 @@ describe('android-adb-driver — androidShowsSeatWithIndicator', () => {
     expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(false);
   });
 
+  test('prefix-collision blocked on indicator — "mic-on" ≠ "notmic-on"', async () => {
+    // Round 1 pin: symmetric LEFT-boundary guard for indicator
+    // (matching the existing right-boundary pin above). The inner
+    // `(?<![\w-])` blocks word-char and hyphen prefixes equally for
+    // both target AND indicator args.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam notmic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(false);
+  });
+
   test('empty dump → false', async () => {
     mockExec({
       "'uiautomator' 'dump'": '',

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -7401,3 +7401,323 @@ describe('android-adb-driver — androidShowsInThread', () => {
     expect(await driver.androidShowsInThread('Selma', 'message', undefined)).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsSeatWithIndicator', () => {
+  // Wake 101 matcher — `<Name>'s Android UI shows <Other>'s seat
+  // with <X> indicator` (j09 mic-on / j10 mic-off). Generic
+  // per-seat indicator assertion. Driver receives `(viewer, target,
+  // indicator)`.
+  //
+  // Foundation strategy: TRIPLE composition (mirrors PR #747's
+  // androidShowsGiftFromSender):
+  //   1. room_seatGrid testTag PRESENT (viewer is on room screen)
+  //   2. target's name appears with symmetric word-boundary
+  //   3. indicator text appears with symmetric word-boundary
+  //
+  // Per-seat indicator scoping is journey-orchestrated — no per-
+  // seat testTag exists yet. The journey ensures only the
+  // relevant seat is in view at assertion time. A future PR could
+  // layer per-seat per-indicator testTags (e.g. `room_seat_${n}_micOn`).
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('room_seatGrid + target + indicator all present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam" /><node content-desc="mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(true);
+  });
+
+  test('target + indicator on same node → true', async () => {
+    // Realistic seat overlay: "Adam mic-on" or similar.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(true);
+  });
+
+  test('room_seatGrid absent (wrong screen) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />' +
+        '<node text="Adam mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(false);
+  });
+
+  test('target present + indicator absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' + '<node text="Adam" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(false);
+  });
+
+  test('indicator present + target absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="someone-else mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(false);
+  });
+
+  test('multiple indicators — "mic-off" requested, "mic-on" in dump → false', async () => {
+    // Pin that indicator distinction matters: asking for mic-off
+    // shouldn't false-positive against mic-on.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam" /><node content-desc="mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-off')).toBe(false);
+  });
+
+  test('prefix-collision blocked on target — "Adam" ≠ "AdamSmith"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="AdamSmith mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(false);
+  });
+
+  test('hyphen-suffix blocked on target — "Adam" ≠ "Adam-jr"', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam-jr mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(false);
+  });
+
+  test('hyphen-suffix blocked on indicator — "mic-on" ≠ "mic-on-pulse"', async () => {
+    // The indicator itself contains a hyphen ("mic-on"). The
+    // symmetric word-boundary `(?![\w-])` blocks a trailing hyphen
+    // even when the literal contains internal hyphens.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam mic-on-pulse" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(false);
+  });
+
+  test('empty target → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', '', 'mic-on')).toBe(false);
+  });
+
+  test('empty indicator → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', '')).toBe(false);
+  });
+
+  test('null target → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', null, 'mic-on')).toBe(false);
+  });
+
+  test('null indicator → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', null)).toBe(false);
+  });
+
+  test('undefined target → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', undefined, 'mic-on')).toBe(false);
+  });
+
+  test('undefined indicator → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', undefined)).toBe(false);
+  });
+
+  test('whitespace-only target → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', '   ', 'mic-on')).toBe(false);
+  });
+
+  test('whitespace-only indicator → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', '   ')).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="room_seatGrid" /><node text="Adam mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(true);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(false);
+  });
+
+  test('viewer name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    const okSelma = await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam mic-on" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okBea = await driver2.androidShowsSeatWithIndicator('Bea', 'Adam', 'mic-on');
+
+    expect(okSelma).toBe(true);
+    expect(okBea).toBe(true);
+  });
+
+  test('regex-significant chars on both args — escaped properly', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="User.42 status.online" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'User.42', 'status.online')).toBe(
+      true,
+    );
+  });
+
+  test('regex-escape negative — literal dot escaped', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="UserX42 statusXonline" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'User.42', 'status.online')).toBe(
+      false,
+    );
+  });
+
+  test('compound attribute names (hint-text=) NOT consulted', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node hint-text="Adam mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(false);
+  });
+
+  test('cross-seat pass-through documented — target in seat-A, indicator in seat-B → true (orchestrator invariant)', async () => {
+    // Same contract as PR #747's cross-entry pin and PR #750's
+    // cross-row pin. Two independent scans over the whole dump.
+    // Documented limitation: per-seat scoping requires per-seat
+    // testTags (don't exist yet).
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_seatGrid" />' +
+        '<node text="Adam mic-off" />' +
+        '<node text="someone-else mic-on" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatWithIndicator('Selma', 'Adam', 'mic-on')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `androidShowsSeatWithIndicator(viewer, target, indicator)` for the Wake 101 matcher: `<Name>'s Android UI shows <Other>'s seat with <X> indicator` (j09/j10).
- 25 new tests, 531 total in the driver suite, all passing.

## Foundation: TRIPLE composition (mirrors PR #747)
1. `room_seatGrid` testTag PRESENT (viewer on room screen)
2. `target` name appears with symmetric word-boundary
3. `indicator` text appears with symmetric word-boundary

## Known limitations (journey-orchestrated)
- **Per-seat scoping**: no per-seat testTag yet. A future PR could layer `room_seat_${n}_micOn` style tags.
- **Cross-seat pass-through**: two independent scans over the whole dump. Documented + pinned. Journey orchestrator's responsibility.

## Phase context
Phase 4 sequential driver-method PR #31 (extends past the original ~30 estimate). Following PR #752.

## Test plan
- [x] 25 new tests, all 531 in suite pass
- [x] Both attribute types; same-node case
- [x] First-guard pin; each substring absent → false
- [x] Indicator distinction (mic-off requested vs mic-on present)
- [x] 3 boundary collisions blocked: AdamSmith, Adam-jr, mic-on-pulse
- [x] All 4 null-safety pins x 2 args
- [x] Empty dump; dump throws; viewer ignored
- [x] Bare resource-id; regex-escape both directions both args
- [x] Compound attribute names (hint-text=) NOT consulted
- [x] Cross-seat pass-through pinned explicitly
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)