### PR TITLE
feat(driver/android): androidShowsContributorsList (Wake 92)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1273,6 +1273,26 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 92 — `<Name>'s Android UI shows the list of contributors
+  // with amounts` (j15:35). Single-arg.
+  //
+  // Foundation strategy: presence-check the gift-wall surface
+  // (giftWall_grid testTag PRESENT). The "amounts" semantic is
+  // journey-orchestrated — without per-row testTags for contributor
+  // amounts, the foundation can't verify the per-row amount
+  // structure. The journey ensures this matcher only fires when
+  // the gift wall is showing contributor entries.
+  //
+  // A future PR could layer per-contributor verification via
+  // testTags like `giftWall_contributor_${id}_amount`.
+  driver.androidShowsContributorsList = async (_name) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?giftWall_grid"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -7887,3 +7887,152 @@ describe('android-adb-driver — androidShowsSecondOffensiveMessage', () => {
     expect(await driver.androidShowsSecondOffensiveMessage('Selma')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsContributorsList', () => {
+  // Wake 92 matcher — `<Name>'s Android UI shows the list of
+  // contributors with amounts` (j15:35). Single-arg.
+  //
+  // Foundation strategy: presence-check the gift-wall surface
+  // (giftWall_grid testTag PRESENT). The "amounts" semantic is
+  // journey-orchestrated — without per-row testTags for contributor
+  // amounts, the foundation can't verify the per-row amount
+  // structure. The journey ensures this matcher only fires when
+  // the gift wall is showing contributor entries.
+  //
+  // A future PR could layer per-contributor verification via
+  // testTags like `giftWall_contributor_${id}_amount`.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('giftWall_grid present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsContributorsList('Selma')).toBe(true);
+  });
+
+  test('giftWall_grid absent (wrong screen) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsContributorsList('Selma')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsContributorsList('Selma')).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="giftWall_grid" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsContributorsList('Selma')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid"><node text="contributor 1" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsContributorsList('Selma')).toBe(true);
+  });
+
+  test('left-boundary false-positive — pre_giftWall_grid_x does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_giftWall_grid_x" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsContributorsList('Selma')).toBe(false);
+  });
+
+  test('right-boundary false-positive — giftWall_grid_extra does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid_extra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsContributorsList('Selma')).toBe(false);
+  });
+
+  test('package-qualified left-boundary — :id/pre_giftWall_grid does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_giftWall_grid" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsContributorsList('Selma')).toBe(false);
+  });
+
+  test('bare left-boundary no suffix — pre_giftWall_grid does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_giftWall_grid" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsContributorsList('Selma')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsContributorsList('Selma')).toBe(false);
+  });
+
+  test('persona name ignored', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />',
+    });
+    const driver = await createAndroidDriver();
+    const okSelma = await driver.androidShowsContributorsList('Selma');
+
+    jest.clearAllMocks();
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />',
+    });
+    const driver2 = await createAndroidDriver();
+    const okBea = await driver2.androidShowsContributorsList('Bea');
+
+    expect(okSelma).toBe(true);
+    expect(okBea).toBe(true);
+  });
+
+  test('first-match contract — two giftWall_grid nodes still pass', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/giftWall_grid" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsContributorsList('Selma')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `androidShowsContributorsList(name)` for the Wake 92 matcher (j15:35).
- 12 new tests, 556 total in the driver suite, all passing.

## Foundation: gift-wall presence check
The "amounts" semantic is journey-orchestrated. No per-row testTag for contributor amounts; a future PR could layer per-contributor verification.

## Phase context
Phase 4 sequential driver-method PR #33 (cluster extending past the original ~30 estimate). Following PR #754.

## Test plan
- [x] 12 tests, all 556 in suite pass
- [x] Thread present → true; absent → false; empty dump → false
- [x] Bare resource-id; non-self-closing form
- [x] All 4 boundary guards
- [x] uiautomator dump throws → false; persona name ignored; first-match contract
- [x] `cd express-api && npm run lint` — 0 errors
- [x] `cd express-api && npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)