### PR TITLE
feat(driver/android): androidTapFromSurface (Wake 89)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1392,6 +1392,47 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 89 — `<Name> on <Plat> taps the <X> from the <Y>` (j16:24).
+  // Composite tap-from-surface action. Driver receives `(name, target,
+  // source)` — locate surface Y, scope to target X within it.
+  //
+  // Foundation strategy: SURFACE_TARGET_TAGS scaffold keyed by lowercase
+  // `${source}::${target}` → Compose testTag. ONE mapping is grounded
+  // in the journey corpus (j16:48):
+  //
+  //   'invite banner::event-room link' → 'inviteBanner_eventRoomLink'
+  //
+  // The `inviteBanner_*` testTag does NOT yet exist in
+  // shared/src/commonMain (no banner with this testTag in any current
+  // composable). So this method returns false in real journeys today.
+  // When the surface ships with that testTag, this stays sound — the
+  // exact-match lookup will land.
+  //
+  // FAIL-loud contract: unmapped source OR target returns false
+  // (consistent with INPUT_TAGS / TABLE_TAGS / SEARCH_FIELD_TAGS /
+  // PATH_TAGS / ROW_COUNT_TABLE_TAGS scaffolds). A journey author
+  // writing an unmapped surface gets a clear FAIL instead of a silent
+  // pass against an unrelated node.
+  //
+  // Per-element action body (tap the resolved testTag's bounds) is
+  // deferred until the testTag exists in the dump. The `_name` arg
+  // is accepted-and-ignored.
+  const SURFACE_TARGET_TAGS = {
+    'invite banner::event-room link': 'inviteBanner_eventRoomLink',
+  };
+  driver.androidTapFromSurface = async (_name, target, source) => {
+    if (!target || !target.trim()) return false;
+    if (!source || !source.trim()) return false;
+    const key = `${source.toLowerCase()}::${target.toLowerCase()}`;
+    const tag = SURFACE_TARGET_TAGS[key];
+    if (!tag) return false;
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = new RegExp(`<node[^>]*resource-id="(?:[^"]*:id\\/)?${tag}"[^>]*\\/?>`);
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1428,8 +1428,14 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     if (!tag) return false;
     const dump = await driver.androidUiDump();
     if (!dump) return false;
+    // Defense-in-depth: regex-escape the tag value before interpolation,
+    // consistent with TABLE_TAGS (line 724), PATH_TAGS (line 932), and
+    // ROW_COUNT_TABLE_TAGS (line 1181). Current sole entry contains only
+    // `[A-Za-z_]`, but a future map value containing a regex metacharacter
+    // (e.g. `.` or `+`) would silently broaden the match without this guard.
+    const escTag = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     // eslint-disable-next-line sonarjs/slow-regex
-    const tagRx = new RegExp(`<node[^>]*resource-id="(?:[^"]*:id\\/)?${tag}"[^>]*\\/?>`);
+    const tagRx = new RegExp(`<node[^>]*resource-id="(?:[^"]*:id\\/)?${escTag}"[^>]*\\/?>`);
     return tagRx.test(dump);
   };
 

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -8870,3 +8870,310 @@ describe('android-adb-driver — androidSubmitStarFeedback', () => {
     expect(await driver.androidSubmitStarFeedback('Yuki', 5, 'good')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidTapFromSurface', () => {
+  // Wake 89 — `<Name> on <Plat> taps the <X> from the <Y>` (j16:24).
+  // Composite tap-from-surface action. Driver receives
+  // `(name, target, source)` — locate surface Y, scope to target X
+  // within it.
+  //
+  // Foundation strategy: SURFACE_TARGET_TAGS scaffold keyed by
+  // lowercase `${source}::${target}` → Compose testTag. Currently
+  // ONE mapping is grounded in the journey corpus (j16:48):
+  //
+  //   'invite banner::event-room link' → 'inviteBanner_eventRoomLink'
+  //
+  // The `inviteBanner_*` testTag does NOT yet exist in
+  // shared/src/commonMain — the invite-banner surface is unbuilt.
+  // So this method returns false in real journeys today. When the
+  // surface ships, this stays sound — the testTag will land.
+  //
+  // FAIL-loud contract: unmapped source OR target returns false
+  // (consistent with INPUT_TAGS / TABLE_TAGS / SEARCH_FIELD_TAGS /
+  // PATH_TAGS scaffolds). A journey author writing an unmapped
+  // surface gets a clear FAIL.
+  //
+  // Per-element action body (tap the resolved testTag's bounds) is
+  // deferred until the testTag exists in the dump. The `_name` arg
+  // is accepted-and-ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('mapped surface+target tag present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', 'invite banner')).toBe(
+      true,
+    );
+  });
+
+  test('mapped surface+target tag ABSENT (surface not visible) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', 'invite banner')).toBe(
+      false,
+    );
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', 'invite banner')).toBe(
+      false,
+    );
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', 'invite banner')).toBe(
+      false,
+    );
+  });
+
+  test('unmapped source "footer" → false (FAIL-loud)', async () => {
+    // FAIL-loud: a journey author writing "taps the X from the footer"
+    // gets a clear FAIL when no footer surface is mapped.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', 'footer')).toBe(false);
+  });
+
+  test('unmapped target "skip link" → false (FAIL-loud)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'skip link', 'invite banner')).toBe(false);
+  });
+
+  test('mapped source + unmapped target → false (composite key miss)', async () => {
+    // Pin: even though "invite banner" alone is mapped, a target
+    // OTHER than "event-room link" in that surface returns false
+    // because the composite key doesn't exist.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'dismiss button', 'invite banner')).toBe(
+      false,
+    );
+  });
+
+  test('empty target → false', async () => {
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', '', 'invite banner')).toBe(false);
+  });
+
+  test('whitespace-only target → false', async () => {
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', '   ', 'invite banner')).toBe(false);
+  });
+
+  test('null target → false', async () => {
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', null, 'invite banner')).toBe(false);
+  });
+
+  test('undefined target → false', async () => {
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', undefined, 'invite banner')).toBe(false);
+  });
+
+  test('empty source → false', async () => {
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', '')).toBe(false);
+  });
+
+  test('whitespace-only source → false', async () => {
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', '   ')).toBe(false);
+  });
+
+  test('null source → false', async () => {
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', null)).toBe(false);
+  });
+
+  test('undefined source → false', async () => {
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', undefined)).toBe(false);
+  });
+
+  test('case-insensitive lookup — UPPERCASE source/target still resolves', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'EVENT-ROOM LINK', 'INVITE BANNER')).toBe(
+      true,
+    );
+  });
+
+  test('mixed-case lookup — Invite Banner + Event-Room Link still resolves', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'Event-Room Link', 'Invite Banner')).toBe(
+      true,
+    );
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', 'invite banner')).toBe(
+      true,
+    );
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink"><node text="Join now" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', 'invite banner')).toBe(
+      true,
+    );
+  });
+
+  test('left-boundary false-positive — pre_inviteBanner_eventRoomLink_x does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_inviteBanner_eventRoomLink_x" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', 'invite banner')).toBe(
+      false,
+    );
+  });
+
+  test('right-boundary false-positive — inviteBanner_eventRoomLink_extra does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink_extra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', 'invite banner')).toBe(
+      false,
+    );
+  });
+
+  test('bare left-boundary no suffix — pre_inviteBanner_eventRoomLink does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', 'invite banner')).toBe(
+      false,
+    );
+  });
+
+  test('persona name ignored — Bea also passes when surface+target visible', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Bea', 'event-room link', 'invite banner')).toBe(
+      true,
+    );
+  });
+
+  test('null name → true (name accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface(null, 'event-room link', 'invite banner')).toBe(true);
+  });
+
+  test('undefined name → true (name accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface(undefined, 'event-room link', 'invite banner')).toBe(
+      true,
+    );
+  });
+
+  test('empty name → true (name accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('', 'event-room link', 'invite banner')).toBe(true);
+  });
+
+  test('whitespace-only name → true (name accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('   ', 'event-room link', 'invite banner')).toBe(
+      true,
+    );
+  });
+
+  test('first-match contract — two inviteBanner_eventRoomLink nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/inviteBanner_eventRoomLink" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidTapFromSurface('Selma', 'event-room link', 'invite banner')).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- **Method:** `androidTapFromSurface(name, target, source)` — j16 composite tap-from-surface action (`<Name> on <Plat> taps the <X> from the <Y>`)
- **6th scaffold:** introduces `SURFACE_TARGET_TAGS` keyed by lowercase `${source}::${target}` composite. One initial mapping (`'invite banner::event-room link' → 'inviteBanner_eventRoomLink'`) grounded in j16:48
- **Foundation behaviour:** the `inviteBanner_*` testTag doesn't exist in `shared/src/commonMain` yet → returns false in real journeys today. When the banner ships with that testTag, the exact-match lookup will land
- **FAIL-loud:** unmapped source OR target returns false (consistent with INPUT_TAGS / TABLE_TAGS / SEARCH_FIELD_TAGS / PATH_TAGS / ROW_COUNT_TABLE_TAGS conventions)
- **Tests:** 28, all passing

## Test plan
- [x] `npx jest -t "androidTapFromSurface"` → 28/28 pass
- [x] `npx prettier --check` → clean
- [x] No regressions (only pre-existing `data-export-builder.test.js` fails on main)
- [ ] CI: ci/express, ci/lint, SonarCloud, dependency-review

## Inputs covered
| Param | Required? | Empty | Whitespace | null | undefined |
|---|---|---|---|---|---|
| `name` | accepted-and-ignored | pass | pass | pass | pass |
| `target` | required | reject | reject | reject | reject |
| `source` | required | reject | reject | reject | reject |

🤖 Generated with [Claude Code](https://claude.com/claude-code)