### PR TITLE
feat(driver/android): androidAdminShowsAppealText (Wake 89)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1439,6 +1439,29 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 89 — `<Name>'s <Plat> Admin UI shows <Other>'s appeal with the
+  // text` (j11:73). Admin moderation UI assertion. Driver verifies an
+  // appeal section is visible for <Other> with non-empty body text.
+  //
+  // Foundation strategy: presence-check on the `adminAppeal_*` testTag
+  // PREFIX. The current app has NO admin moderation surface in
+  // shared/src/commonMain — only the USER-side flow exists
+  // (`suspension_appealField` / `suspension_submitAppealButton` in
+  // SuspensionScreen.kt). The admin reviewer side is web-only today.
+  //
+  // Returns false in real journeys today. When/if an Android admin app
+  // ships with `adminAppeal_*` testTags, this stays sound — the wildcard
+  // prefix match will land.
+  //
+  // Both args (`_viewer`, `_target`) are accepted-and-ignored.
+  driver.androidAdminShowsAppealText = async (_viewer, _target) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?adminAppeal_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -9177,3 +9177,236 @@ describe('android-adb-driver — androidTapFromSurface', () => {
     );
   });
 });
+
+describe('android-adb-driver — androidAdminShowsAppealText', () => {
+  // Wake 89 — `<Name>'s <Plat> Admin UI shows <Other>'s appeal with the
+  // text` (j11:73). Admin moderation UI assertion. Driver verifies an
+  // appeal section is visible for <Other> with non-empty body text.
+  //
+  // Foundation strategy: presence-check on `adminAppeal_appealText`
+  // testTag. The current app has NO admin moderation surface in
+  // shared/src/commonMain — only the USER-side suspension/appeal flow
+  // exists (suspension_appealField / suspension_submitAppealButton in
+  // SuspensionScreen.kt). The admin reviewer side is web-only today.
+  //
+  // So this method returns false in real journeys today. When/if an
+  // Android admin app ships with `adminAppeal_*` testTags, this stays
+  // sound — the wildcard prefix match will land.
+  //
+  // Both args (`_viewer`, `_target`) are accepted-and-ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('adminAppeal_appealText present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', 'Selma')).toBe(true);
+  });
+
+  test('adminAppeal_panel present → true (any adminAppeal_* matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_panel" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', 'Selma')).toBe(true);
+  });
+
+  test('absent (no admin surface visible) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', 'Selma')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', 'Selma')).toBe(false);
+  });
+
+  test('bare resource-id (no package prefix) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', 'Selma')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_appealText"><node text="I would like to appeal" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', 'Selma')).toBe(true);
+  });
+
+  test('left-boundary false-positive — pre_adminAppeal_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', 'Selma')).toBe(false);
+  });
+
+  test('bare left-boundary — pre_adminAppeal_appealText does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', 'Selma')).toBe(false);
+  });
+
+  test('similar but distinct prefix — suspension_appealField does NOT match', async () => {
+    // The user-side suspension appeal field is distinct from the
+    // admin-side review panel. Pin that they don't conflate.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/suspension_appealField" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', 'Selma')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', 'Selma')).toBe(false);
+  });
+
+  test('viewer name accepted-and-ignored — Bea also passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Bea', 'Selma')).toBe(true);
+  });
+
+  test('target name accepted-and-ignored — different target passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', 'Theo')).toBe(true);
+  });
+
+  test('null viewer → true (viewer accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText(null, 'Selma')).toBe(true);
+  });
+
+  test('undefined viewer → true (viewer accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText(undefined, 'Selma')).toBe(true);
+  });
+
+  test('empty viewer → true (viewer accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('', 'Selma')).toBe(true);
+  });
+
+  test('whitespace viewer → true (viewer accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('   ', 'Selma')).toBe(true);
+  });
+
+  test('null target → true (target accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', null)).toBe(true);
+  });
+
+  test('undefined target → true (target accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', undefined)).toBe(true);
+  });
+
+  test('empty target → true (target accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', '')).toBe(true);
+  });
+
+  test('whitespace target → true (target accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_appealText" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', '   ')).toBe(true);
+  });
+
+  test('first-match contract — two adminAppeal_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_appealText" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/adminAppeal_panel" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsAppealText('Mod', 'Selma')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -17529,6 +17529,72 @@ describe('Wake 89 — "<Name>\'s <Plat> Admin UI shows <Other>\'s appeal with th
     expect(r.ok).toBe(false);
     expect(r.error).toMatch(/webAdminShowsAppealText/);
   });
+
+  // Android branch — routes to ctx.uiDriver.androidAdminShowsAppealText
+  test('Android matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { androidAdminShowsAppealText: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Greta's Android Admin UI shows Raul's appeal with the text" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Greta', 'Raul');
+  });
+
+  test('Android no appeal → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidAdminShowsAppealText: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Greta's Android Admin UI shows Raul's appeal with the text" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Raul|appeal/);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Greta's Android Admin UI shows Raul's appeal with the text" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/androidAdminShowsAppealText/);
+  });
+
+  // iOS Sim branch — routes to ctx.uiDriver.iosAdminShowsAppealText
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosAdminShowsAppealText: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Greta's iOS Sim Admin UI shows Raul's appeal with the text" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Greta', 'Raul');
+  });
+
+  test('iOS Sim no appeal → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosAdminShowsAppealText: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Greta's iOS Sim Admin UI shows Raul's appeal with the text" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Raul|appeal/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Greta's iOS Sim Admin UI shows Raul's appeal with the text" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/iosAdminShowsAppealText/);
+  });
 });
 
 describe('Wake 89 — "a conversation "<X>" exists ... created before the OSA migration" (state-seed)', () => {


### PR DESCRIPTION
## Summary
- **Method:** `androidAdminShowsAppealText(viewer, target)` — j11 admin moderation UI assertion (`<Name>'s <Plat> Admin UI shows <Other>'s appeal with the text`)
- **Foundation strategy:** presence-check on the `adminAppeal_*` testTag PREFIX. No admin moderation surface exists in `shared/src/commonMain` yet — only the USER-side suspension flow does (`suspension_appealField` in `SuspensionScreen.kt`). The admin reviewer side is web-only today.
- **Returns false in real journeys today.** When/if an Android admin app ships with `adminAppeal_*` testTags, this stays sound — the wildcard prefix match will land.
- **Tests:** 21, all passing — including a distinct-prefix guard ensuring `suspension_appealField` (user-side) does NOT match `adminAppeal_*` (admin-side).

## Inputs covered
| Param | Required? | Empty | Whitespace | null | undefined |
|---|---|---|---|---|---|
| `viewer` | accepted-and-ignored | pass | pass | pass | pass |
| `target` | accepted-and-ignored | pass | pass | pass | pass |

## Test plan
- [x] `npx jest -t "androidAdminShowsAppealText"` → 21/21 pass
- [x] `npx prettier --check` → clean
- [x] No regressions (only pre-existing `data-export-builder.test.js` fails on main)
- [ ] CI: ci/express, ci/lint, SonarCloud, dependency-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)