### PR TITLE
feat(driver/android): androidAdminShowsDashboardCounters (Wake 105)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1462,6 +1462,31 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 105 — `<Name>'s <Plat> Admin UI shows the dashboard with
+  // counters: N reports, N verifications, N appeals` (j12). Admin
+  // landing page counters. Driver receives
+  // `(viewer, { reports, verifications, appeals })`.
+  //
+  // Foundation strategy: presence-check on `adminDashboard_*` testTag
+  // PREFIX. No admin moderation surface in shared/src/commonMain yet
+  // (web-only admin reviewer side) — see sibling matcher
+  // androidAdminShowsAppealText for context. Returns false in real
+  // journeys today; when adminDashboard_* testTags ship (e.g.
+  // adminDashboard_reportsCounter / verificationsCounter / appealsCounter),
+  // the wildcard prefix match will land.
+  //
+  // Both args (_viewer, _counters) accepted-and-ignored. The
+  // foundation does not validate that the displayed counter values
+  // match the expected object — that needs per-counter testTags + a
+  // text-extraction inspection mechanism.
+  driver.androidAdminShowsDashboardCounters = async (_viewer, _counters) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?adminDashboard_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -9410,3 +9410,349 @@ describe('android-adb-driver — androidAdminShowsAppealText', () => {
     expect(await driver.androidAdminShowsAppealText('Mod', 'Selma')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidAdminShowsDashboardCounters', () => {
+  // Wake 105 — `<Name>'s <Plat> Admin UI shows the dashboard with
+  // counters: N reports, N verifications, N appeals` (j12). Admin
+  // landing page counters. Driver receives
+  // `(viewer, { reports, verifications, appeals })`.
+  //
+  // Foundation strategy: presence-check on the `adminDashboard_*`
+  // testTag PREFIX. The current app has NO admin moderation surface
+  // in shared/src/commonMain — see the sibling matcher
+  // androidAdminShowsAppealText for context. The admin reviewer side
+  // is web-only today.
+  //
+  // Returns false in real journeys today. When/if an Android admin
+  // app ships with `adminDashboard_*` testTags (e.g.
+  // adminDashboard_reportsCounter, adminDashboard_verificationsCounter,
+  // adminDashboard_appealsCounter), this stays sound — the wildcard
+  // prefix match will land.
+  //
+  // Both args (`_viewer`, `_counters`) accepted-and-ignored. The
+  // foundation does not validate that the displayed counter values
+  // match the expected object — that needs per-counter testTags + a
+  // text-extraction inspection mechanism.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('adminDashboard_reportsCounter present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 5,
+        verifications: 2,
+        appeals: 1,
+      }),
+    ).toBe(true);
+  });
+
+  test('adminDashboard_verificationsCounter present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_verificationsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 0,
+        verifications: 0,
+        appeals: 0,
+      }),
+    ).toBe(true);
+  });
+
+  test('adminDashboard_appealsCounter present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_appealsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 100,
+        verifications: 50,
+        appeals: 10,
+      }),
+    ).toBe(true);
+  });
+
+  test('absent (no admin surface) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 0,
+        verifications: 0,
+        appeals: 0,
+      }),
+    ).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 0,
+        verifications: 0,
+        appeals: 0,
+      }),
+    ).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 1,
+        verifications: 1,
+        appeals: 1,
+      }),
+    ).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounter"><node text="5" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 5,
+        verifications: 0,
+        appeals: 0,
+      }),
+    ).toBe(true);
+  });
+
+  test('left-boundary — pre_adminDashboard_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 0,
+        verifications: 0,
+        appeals: 0,
+      }),
+    ).toBe(false);
+  });
+
+  test('bare left-boundary — pre_adminDashboard_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 0,
+        verifications: 0,
+        appeals: 0,
+      }),
+    ).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 0,
+        verifications: 0,
+        appeals: 0,
+      }),
+    ).toBe(false);
+  });
+
+  test('viewer name accepted-and-ignored — Bea passes too', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Bea', {
+        reports: 1,
+        verifications: 1,
+        appeals: 1,
+      }),
+    ).toBe(true);
+  });
+
+  test('null viewer → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters(null, {
+        reports: 0,
+        verifications: 0,
+        appeals: 0,
+      }),
+    ).toBe(true);
+  });
+
+  test('undefined viewer → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters(undefined, {
+        reports: 0,
+        verifications: 0,
+        appeals: 0,
+      }),
+    ).toBe(true);
+  });
+
+  test('empty viewer → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('', {
+        reports: 0,
+        verifications: 0,
+        appeals: 0,
+      }),
+    ).toBe(true);
+  });
+
+  test('whitespace viewer → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('   ', {
+        reports: 0,
+        verifications: 0,
+        appeals: 0,
+      }),
+    ).toBe(true);
+  });
+
+  test('null counters → true (counters accepted-and-ignored)', async () => {
+    // The foundation does not destructure or validate counters — pin that
+    // a null object doesn't crash the method and still returns based on
+    // the testTag presence-check.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsDashboardCounters('Mod', null)).toBe(true);
+  });
+
+  test('undefined counters → true (counters accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsDashboardCounters('Mod', undefined)).toBe(true);
+  });
+
+  test('empty object counters → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsDashboardCounters('Mod', {})).toBe(true);
+  });
+
+  test('partial counters (missing verifications) → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsDashboardCounters('Mod', { reports: 5, appeals: 1 })).toBe(
+      true,
+    );
+  });
+
+  test('high-value counters (large numbers) → true', async () => {
+    // Pin that NaN/Infinity/very-large numbers don't crash. Counters are
+    // accepted-and-ignored, so the value shouldn't matter at all.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 9999999,
+        verifications: 0,
+        appeals: -1,
+      }),
+    ).toBe(true);
+  });
+
+  test('first-match contract — two adminDashboard_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounter" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_appealsCounter" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 1,
+        verifications: 1,
+        appeals: 1,
+      }),
+    ).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -9578,6 +9578,46 @@ describe('android-adb-driver — androidAdminShowsDashboardCounters', () => {
     ).toBe(false);
   });
 
+  test('right-boundary — adminDashboard_reportsCounterExtra still matches (prefix contract)', async () => {
+    // Pin: the prefix-wildcard form `adminDashboard_[^"]*` accepts ANY
+    // suffix up to the closing quote. `_reportsCounterExtra` is therefore
+    // a valid match — the foundation matches any `adminDashboard_*` tag.
+    // If a future change tightened the suffix (e.g. required word-boundary
+    // or an enumerated suffix list), this test would catch the change.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminDashboard_reportsCounterExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 0,
+        verifications: 0,
+        appeals: 0,
+      }),
+    ).toBe(true);
+  });
+
+  test('confusable non-dashboard prefix — admin_dashboardSummary does NOT match', async () => {
+    // Pin: the left anchor is `adminDashboard_` literally, NOT `admin_`.
+    // A hypothetical `admin_*` family of testTags must not false-match an
+    // adminDashboard_* assertion. Documents the prefix specificity.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/admin_dashboardSummary" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(
+      await driver.androidAdminShowsDashboardCounters('Mod', {
+        reports: 0,
+        verifications: 0,
+        appeals: 0,
+      }),
+    ).toBe(false);
+  });
+
   test('uiautomator dump throws → false', async () => {
     execSync.mockImplementation((cmd) => {
       if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -20845,7 +20845,11 @@ describe('Wake 105 — "<Name>\'s <Plat> Admin UI shows the dashboard with count
       ctx,
     );
     expect(r.ok).toBe(false);
-    expect(r.error).toMatch(/Greta|dashboard|counters/);
+    // Tighter than the Web sibling's loose `/Greta|dashboard|counters/` —
+    // pin that the error message includes the structural "dashboard ...
+    // counters" phrasing so a future refactor cannot drop both terms
+    // without breaking this test.
+    expect(r.error).toMatch(/dashboard.*counters/i);
   });
 
   test('Android driver missing → fail', async () => {
@@ -20887,7 +20891,7 @@ describe('Wake 105 — "<Name>\'s <Plat> Admin UI shows the dashboard with count
       ctx,
     );
     expect(r.ok).toBe(false);
-    expect(r.error).toMatch(/Greta|dashboard|counters/);
+    expect(r.error).toMatch(/dashboard.*counters/i);
   });
 
   test('iOS Sim driver missing → fail', async () => {

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -20818,6 +20818,90 @@ describe('Wake 105 — "<Name>\'s <Plat> Admin UI shows the dashboard with count
     expect(r.ok).toBe(false);
     expect(r.error).toMatch(/Greta|dashboard|counters/);
   });
+
+  // Android branch — routes to ctx.uiDriver.androidAdminShowsDashboardCounters
+  test('Android matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { androidAdminShowsDashboardCounters: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Greta's Android Admin UI shows the dashboard with counters: 3 reports, 5 verifications, 2 appeals",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Greta', { reports: 3, verifications: 5, appeals: 2 });
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidAdminShowsDashboardCounters: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Greta's Android Admin UI shows the dashboard with counters: 1 reports, 2 verifications, 3 appeals",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Greta|dashboard|counters/);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Greta's Android Admin UI shows the dashboard with counters: 0 reports, 0 verifications, 0 appeals",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/androidAdminShowsDashboardCounters/);
+  });
+
+  // iOS Sim branch — routes to ctx.uiDriver.iosAdminShowsDashboardCounters
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosAdminShowsDashboardCounters: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Greta's iOS Sim Admin UI shows the dashboard with counters: 4 reports, 1 verifications, 7 appeals",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Greta', { reports: 4, verifications: 1, appeals: 7 });
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosAdminShowsDashboardCounters: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Greta's iOS Sim Admin UI shows the dashboard with counters: 1 reports, 0 verifications, 0 appeals",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Greta|dashboard|counters/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Greta's iOS Sim Admin UI shows the dashboard with counters: 0 reports, 0 verifications, 0 appeals",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/iosAdminShowsDashboardCounters/);
+  });
 });
 
 // ── Wake 106 — j12 admin daily routine ─────────────────────────────


### PR DESCRIPTION
## Summary
- **Method:** `androidAdminShowsDashboardCounters(viewer, { reports, verifications, appeals })` — j12 admin landing-page counters
- **Foundation strategy:** presence-check `adminDashboard_*` testTag PREFIX. No Android admin surface exists in `shared/src/commonMain` yet — web-only today (same as PR #762's `androidAdminShowsAppealText`)
- **Returns false** in real journeys today; lands true when `adminDashboard_reportsCounter` / `_verificationsCounter` / `_appealsCounter` testTags ship
- **Counter VALUE validation deferred** — needs per-counter testTags + text-extraction inspection mechanism
- **Tests:** 21 driver + 6 runner-branch (Android/iOS Sim dispatch) per cluster convention

## Inputs covered
| Param | Required? | Empty/whitespace | null/undefined |
|---|---|---|---|
| `viewer` | accepted-and-ignored | pass | pass |
| `counters` (object) | accepted-and-ignored | pass (partial/empty obj) | pass |

## Test plan
- [x] `npx jest -t "androidAdminShowsDashboardCounters"` → 21/21 driver tests pass
- [x] `npx jest -t "dashboard with counters"` → 8/8 runner tests pass (2 prior Web + 6 new Android/iOS Sim)
- [x] `npx prettier --check` → clean
- [ ] CI: ci/express, ci/lint, SonarCloud, dependency-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)