### PR TITLE
feat(driver/android): androidAdminShowsStat (Wake 106)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1487,6 +1487,29 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 106 — `<Name>'s <Plat> Admin UI shows the "<X>" stat` (j12).
+  // Named-stat visibility on the admin dashboard. Driver receives
+  // `(viewer, statName)` where statName is a free-form display label.
+  //
+  // Foundation strategy: presence-check on the `adminStat_*` testTag
+  // PREFIX. No admin moderation surface in shared/src/commonMain yet
+  // (web-only admin) — see siblings androidAdminShowsAppealText (#762)
+  // and androidAdminShowsDashboardCounters (#763). Returns false in
+  // real journeys today; lands true when `adminStat_*` testTags ship.
+  //
+  // Both args (_viewer, _statName) accepted-and-ignored. The foundation
+  // does NOT verify that the specific named stat is displayed — it
+  // only verifies that ANY adminStat_* element is visible. Per-stat
+  // verification would need a stat-name → testTag map (similar to the
+  // SURFACE_TARGET_TAGS scaffold in #760).
+  driver.androidAdminShowsStat = async (_viewer, _statName) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?adminStat_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -9796,3 +9796,252 @@ describe('android-adb-driver — androidAdminShowsDashboardCounters', () => {
     ).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidAdminShowsStat', () => {
+  // Wake 106 — `<Name>'s <Plat> Admin UI shows the "<X>" stat` (j12).
+  // Named-stat visibility on the admin dashboard. Driver receives
+  // `(viewer, statName)` where statName is a free-form display label
+  // ("Daily Active Users", "Reports Resolved Today", etc.).
+  //
+  // Foundation strategy: presence-check on the `adminStat_*` testTag
+  // PREFIX. No admin moderation surface in shared/src/commonMain yet
+  // (web-only admin) — see siblings androidAdminShowsAppealText (#762)
+  // and androidAdminShowsDashboardCounters (#763). Returns false in
+  // real journeys today; lands true when `adminStat_*` testTags ship.
+  //
+  // Both args (`_viewer`, `_statName`) are accepted-and-ignored. The
+  // foundation does NOT verify that the specific named stat is
+  // displayed — it only verifies that ANY adminStat_* element is
+  // visible. Per-stat verification would need a stat-name → testTag
+  // map (similar to the SURFACE_TARGET_TAGS scaffold).
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('adminStat_dailyActiveUsers present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', 'Daily Active Users')).toBe(true);
+  });
+
+  test('adminStat_reportsResolved present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_reportsResolved" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', 'Reports Resolved Today')).toBe(true);
+  });
+
+  test('absent (no admin surface) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', 'Daily Active Users')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', 'Daily Active Users')).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', 'Daily Active Users')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsers"><node text="1,234" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', 'Daily Active Users')).toBe(true);
+  });
+
+  test('left-boundary — pre_adminStat_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', 'Daily Active Users')).toBe(false);
+  });
+
+  test('bare left-boundary — pre_adminStat_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', 'Daily Active Users')).toBe(false);
+  });
+
+  test('right-boundary — adminStat_dailyActiveUsersExtra still matches (prefix contract)', async () => {
+    // Pin: the wildcard suffix `[^"]*` accepts ANY chars up to the
+    // closing quote, so a longer suffix is acceptable. If a future
+    // tightening required word-boundary, this test would catch it.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsersExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', 'Daily Active Users')).toBe(true);
+  });
+
+  test('confusable prefix — admin_statSummary does NOT match', async () => {
+    // Pin: the left anchor is `adminStat_` literally. A hypothetical
+    // `admin_*` family must not false-match.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/admin_statSummary" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', 'Daily Active Users')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', 'Daily Active Users')).toBe(false);
+  });
+
+  test('viewer name accepted-and-ignored — Bea passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Bea', 'Daily Active Users')).toBe(true);
+  });
+
+  test('null viewer → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat(null, 'Daily Active Users')).toBe(true);
+  });
+
+  test('undefined viewer → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat(undefined, 'Daily Active Users')).toBe(true);
+  });
+
+  test('empty viewer → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('', 'Daily Active Users')).toBe(true);
+  });
+
+  test('whitespace viewer → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('   ', 'Daily Active Users')).toBe(true);
+  });
+
+  test('null statName → true (accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', null)).toBe(true);
+  });
+
+  test('undefined statName → true (accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', undefined)).toBe(true);
+  });
+
+  test('empty statName → true (accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', '')).toBe(true);
+  });
+
+  test('whitespace statName → true (accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', '   ')).toBe(true);
+  });
+
+  test('different statName still passes (foundation does not match specific stat)', async () => {
+    // The foundation contract: ANY adminStat_* tag satisfies ANY stat
+    // name query. Per-stat verification needs a stat-name → testTag map.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsers" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', 'Reports Resolved Today')).toBe(true);
+  });
+
+  test('first-match contract — two adminStat_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_dailyActiveUsers" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/adminStat_reportsResolved" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidAdminShowsStat('Mod', 'Daily Active Users')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -21059,4 +21059,91 @@ describe('Wake 106 — `<Name>\'s <Plat> Admin UI shows the "<X>" stat`', () => 
     expect(r.ok).toBe(true);
     expect(spy).toHaveBeenCalledWith('Greta', 'Blocked cross-cohort attempts (24h)');
   });
+
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webAdminShowsStat: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Greta\'s Web Admin UI shows the "Daily Active Users" stat' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Daily Active Users|stat/i);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Greta\'s Web Admin UI shows the "Daily Active Users" stat' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/webAdminShowsStat/);
+  });
+
+  // Android branch — routes to ctx.uiDriver.androidAdminShowsStat
+  test('Android matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { androidAdminShowsStat: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Greta\'s Android Admin UI shows the "Daily Active Users" stat' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Greta', 'Daily Active Users');
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidAdminShowsStat: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Greta\'s Android Admin UI shows the "Daily Active Users" stat' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Daily Active Users|stat/i);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Greta\'s Android Admin UI shows the "Daily Active Users" stat' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/androidAdminShowsStat/);
+  });
+
+  // iOS Sim branch — routes to ctx.uiDriver.iosAdminShowsStat
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosAdminShowsStat: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Greta\'s iOS Sim Admin UI shows the "Daily Active Users" stat' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Greta', 'Daily Active Users');
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosAdminShowsStat: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Greta\'s iOS Sim Admin UI shows the "Daily Active Users" stat' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Daily Active Users|stat/i);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Greta\'s iOS Sim Admin UI shows the "Daily Active Users" stat' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/iosAdminShowsStat/);
+  });
 });


### PR DESCRIPTION
## Summary
- **Method:** `androidAdminShowsStat(viewer, statName)` — j12 named-stat visibility on admin dashboard
- **Foundation strategy:** presence-check `adminStat_*` testTag PREFIX. No admin moderation surface in `shared/src/commonMain` yet (web-only) — siblings #762, #763 in same boat
- **Per-stat verification deferred:** foundation matches ANY `adminStat_*` element, NOT the specific named stat. A future stat-name → testTag map (SURFACE_TARGET_TAGS-style) is needed for per-stat assertion
- **Tests:** 22 driver + 9 runner — includes the right-boundary, confusable-prefix, and tightened-error pins added in PR #763 R1

## Inputs covered
| Param | Required? | Empty/whitespace | null/undefined |
|---|---|---|---|
| `viewer` | accepted-and-ignored | pass | pass |
| `statName` | accepted-and-ignored | pass | pass |

## Test plan
- [x] `npx jest -t "androidAdminShowsStat"` → 22/22 driver tests pass
- [x] `npx jest -t "Admin UI shows the .* stat"` → 9/9 runner tests pass (3 per platform + the original 1)
- [x] `npx prettier --check` → clean
- [ ] CI: ci/express, ci/lint, SonarCloud, dependency-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)