### PR TITLE
feat(driver/android): androidApproveSeatRequest (Wake 86)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1533,6 +1533,33 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 86 — `<Name> on <Plat> approves <Other>'s seat request` (j17:51).
+  // Voice-room host action — host approves a pending seat request from
+  // <Other>. Driver receives `(host, requester)`.
+  //
+  // Foundation strategy: presence-check on the `seatRequest_*` testTag
+  // PREFIX. No `seatRequest_*` testTag exists in shared/src/commonMain
+  // yet — seat-request backend exists (SeatRequestRepository in
+  // core/room), but no UI testTag exposes the pending-requests panel
+  // or per-request Approve button. SeatItem.kt exposes only
+  // room_requestSeatButton (requester-side) and room_seatGrid (host
+  // view).
+  //
+  // Returns false in real journeys today; lands true when seatRequest_*
+  // testTags ship (e.g. seatRequest_pendingPanel /
+  // seatRequest_approveButton_<requesterId>).
+  //
+  // Both args (_host, _requester) accepted-and-ignored. Per-requester
+  // approval (tapping THIS specific approve button) needs a
+  // requester-id → testTag map.
+  driver.androidApproveSeatRequest = async (_host, _requester) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?seatRequest_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -6097,13 +6097,17 @@ const matchers = [
   {
     // Approve seat request composite (j09 host). Driver locates the
     // seat-request notification for the named user and taps approve.
+    // Driver contract is `(host, requester)` — matches Wake 86's
+    // canonical "approves" phrasing at line 9753 to keep both step
+    // forms consistent under the same driver method.
     pattern: /^([A-Z][a-z]+)\s+on Android\s+taps approve on ([A-Z][a-z]+)'s seat request$/,
     async handler(m, ctx) {
+      const host = m[1];
       const requester = m[2];
       if (!ctx.uiDriver?.androidApproveSeatRequest) {
         return { ok: false, error: 'ctx.uiDriver.androidApproveSeatRequest not configured' };
       }
-      await ctx.uiDriver.androidApproveSeatRequest(requester);
+      await ctx.uiDriver.androidApproveSeatRequest(host, requester);
       return { ok: true };
     },
   },

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -10291,3 +10291,264 @@ describe('android-adb-driver — androidAlsoShowsInParticipantsList', () => {
     expect(await driver.androidAlsoShowsInParticipantsList('Alice', 'Bao')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidApproveSeatRequest', () => {
+  // Wake 86 — `<Name> on <Plat> approves <Other>'s seat request` (j17:51).
+  // Voice-room host action — host approves a pending seat request from
+  // <Other>. Driver receives `(host, requester)`.
+  //
+  // Foundation strategy: presence-check on the `seatRequest_*` testTag
+  // PREFIX. No `seatRequest_*` testTag exists in shared/src/commonMain
+  // yet — seat-request backend exists (SeatRequestRepository in core/room),
+  // but no UI testTag exposes the pending-requests panel or per-request
+  // Approve button to uiautomator. SeatItem.kt exposes only
+  // room_requestSeatButton (requester-side) and room_seatGrid (host view).
+  //
+  // Returns false in real journeys today; lands true when seatRequest_*
+  // testTags ship (e.g. seatRequest_pendingPanel /
+  // seatRequest_approveButton_<requesterId>).
+  //
+  // Both args (_host, _requester) accepted-and-ignored. Per-requester
+  // approval (tapping THIS specific approve button) needs a requester-id
+  // → testTag map.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('seatRequest_approveButton present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'Bao')).toBe(true);
+  });
+
+  test('seatRequest_pendingPanel present → true (any suffix matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_pendingPanel" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'Bao')).toBe(true);
+  });
+
+  test('absent (no seat-request surface) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'Bao')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'Bao')).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'Bao')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton"><node text="Approve" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'Bao')).toBe(true);
+  });
+
+  test('left-boundary — pre_seatRequest_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'Bao')).toBe(false);
+  });
+
+  test('bare left-boundary — pre_seatRequest_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'Bao')).toBe(false);
+  });
+
+  test('right-boundary — seatRequest_approveButtonExtra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButtonExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'Bao')).toBe(true);
+  });
+
+  test('confusable prefix — seat_requestApprove does NOT match', async () => {
+    // Pin: left anchor is `seatRequest_` literally. A hypothetical
+    // `seat_*` family must not false-match.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seat_requestApprove" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'Bao')).toBe(false);
+  });
+
+  test('similar-but-distinct — room_requestSeatButton does NOT match', async () => {
+    // The requester-side button (SeatItem.kt:142) must not satisfy a
+    // HOST approval matcher. They serve different roles in the j17
+    // sequence.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_requestSeatButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'Bao')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'Bao')).toBe(false);
+  });
+
+  test('host name accepted-and-ignored — Ines passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Ines', 'Bao')).toBe(true);
+  });
+
+  test('null host → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest(null, 'Bao')).toBe(true);
+  });
+
+  test('undefined host → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest(undefined, 'Bao')).toBe(true);
+  });
+
+  test('empty host → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('', 'Bao')).toBe(true);
+  });
+
+  test('whitespace host → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('   ', 'Bao')).toBe(true);
+  });
+
+  test('null requester → true (accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', null)).toBe(true);
+  });
+
+  test('undefined requester → true (accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', undefined)).toBe(true);
+  });
+
+  test('empty requester → true (accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', '')).toBe(true);
+  });
+
+  test('whitespace requester → true (accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', '   ')).toBe(true);
+  });
+
+  test('different requester still passes (foundation does not match specific request)', async () => {
+    // Per-requester approval needs a requester-id → testTag map.
+    // Today the foundation matches ANY seatRequest_* element.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'NotInRequest')).toBe(true);
+  });
+
+  test('first-match contract — two seatRequest_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_pendingPanel" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidApproveSeatRequest('Alice', 'Bao')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -16738,6 +16738,73 @@ describe('Wake 86 — "<Name> on <Plat> approves <Other>\'s seat request"', () =
     expect(r.ok).toBe(false);
     expect(r.error).toMatch(/androidApproveSeatRequest/);
   });
+
+  // Android driver returns false → fail
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidApproveSeatRequest: spy } });
+    const r = await executeStep(
+      { kind: 'When', text: "Bao on Android approves Yuki's seat request" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Yuki|seat request/i);
+  });
+
+  // iOS Sim driver returns false → fail + no-driver → fail
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosApproveSeatRequest: spy } });
+    const r = await executeStep(
+      { kind: 'When', text: "Selma on iOS Sim approves Alice's seat request" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|seat request/i);
+  });
+
+  test('iOS Sim no driver → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'When', text: "Selma on iOS Sim approves Alice's seat request" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/iosApproveSeatRequest/);
+  });
+
+  // Web branch — routes to ctx.webDriver.webApproveSeatRequest
+  test('Web matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webApproveSeatRequest: spy } });
+    const r = await executeStep(
+      { kind: 'When', text: "Bao on Web approves Yuki's seat request" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Bao', 'Yuki');
+  });
+
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webApproveSeatRequest: spy } });
+    const r = await executeStep(
+      { kind: 'When', text: "Bao on Web approves Yuki's seat request" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Yuki|seat request/i);
+  });
+
+  test('Web no driver → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'When', text: "Bao on Web approves Yuki's seat request" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/webApproveSeatRequest/);
+  });
 });
 
 describe('Wake 86 — "<Name>\'s locale is <X>" (bare state-seed)', () => {

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -9871,7 +9871,12 @@ describe('Approve seat request composite', () => {
       ctx,
     );
     expect(r.ok).toBe(true);
-    expect(spy).toHaveBeenCalledWith('Ines');
+    // Updated PR #766: driver contract is now `(host, requester)` to
+    // match Wake 86's canonical "approves" phrasing. Previously
+    // asserted the requester only — the host was dropped on the
+    // floor, which would mask a regression when per-requester
+    // approval lands.
+    expect(spy).toHaveBeenCalledWith('Theo', 'Ines');
   });
 });
 


### PR DESCRIPTION
## Summary
- **Method:** `androidApproveSeatRequest(host, requester)` — j17 voice-room host action
- **Foundation:** presence-check `seatRequest_*` testTag PREFIX. Backend exists (SeatRequestRepository); no UI testTag for host-side approval yet
- **Per-requester deferred** — needs requester-id → testTag map for per-button targeting
- **Tests:** 23 driver + 9 runner — full preemptive checklist applied, including similar-but-distinct guard (room_requestSeatButton — requester-side — does NOT satisfy host approval matcher)

## Test plan
- [x] `npx jest -t "androidApproveSeatRequest"` → 23/23 driver tests pass
- [x] `npx jest -t "approves.*seat request"` → 9/9 runner tests pass (3 per platform)
- [x] `npx prettier --check` → clean
- [ ] CI: ci/express, ci/lint, SonarCloud, dependency-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)