### PR TITLE
feat(driver/android): androidRefreshLanguageRail (Wake 87)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1615,6 +1615,28 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 87 — `<Name> on <Plat> refreshes the language rail` (j17:78).
+  // Pull-to-refresh / refresh-button on the language-filter rail.
+  // Driver receives `(name)`.
+  //
+  // Foundation strategy: presence-check on the `languageRail_*` testTag
+  // PREFIX. No `languageRail_*` testTag exists in
+  // shared/src/commonMain yet — the language-filter rail UI is unbuilt.
+  // Returns false in real journeys today; lands true when the rail
+  // ships with `languageRail_*` testTags (e.g. languageRail_container,
+  // languageRail_refreshButton).
+  //
+  // Action body (perform the pull-to-refresh gesture or tap the
+  // refresh button) is deferred until per-element testTags exist.
+  // The `_name` arg is accepted-and-ignored.
+  driver.androidRefreshLanguageRail = async (_name) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?languageRail_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -9896,8 +9896,9 @@ const matchers = [
           ? 'androidRefreshLanguageRail'
           : 'iosRefreshLanguageRail';
       const driver = platform.startsWith('Web') ? ctx.webDriver : ctx.uiDriver;
+      const driverName = platform.startsWith('Web') ? 'ctx.webDriver' : 'ctx.uiDriver';
       if (!driver?.[methodName]) {
-        return { ok: false, error: `ctx.uiDriver.${methodName} not configured` };
+        return { ok: false, error: `${driverName}.${methodName} not configured` };
       }
       const ok = await driver[methodName](name);
       if (!ok) {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -11152,3 +11152,202 @@ describe('android-adb-driver — androidOpenProfileFrom', () => {
     expect(await driver.androidOpenProfileFrom('Yuki', 'Bao', 'room')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidRefreshLanguageRail', () => {
+  // Wake 87 — `<Name> on <Plat> refreshes the language rail` (j17:78).
+  // Pull-to-refresh / refresh-button on the language-filter rail.
+  // Driver receives `(name)`.
+  //
+  // Foundation strategy: presence-check on the `languageRail_*` testTag
+  // PREFIX. No `languageRail_*` testTag exists in
+  // shared/src/commonMain yet — the language-filter rail UI is unbuilt.
+  // Returns false in real journeys today; lands true when the rail
+  // ships with `languageRail_*` testTags (e.g. languageRail_container,
+  // languageRail_refreshButton).
+  //
+  // Action body (perform the pull-to-refresh gesture or tap the refresh
+  // button) is deferred until per-element testTags exist. The `_name`
+  // arg is accepted-and-ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('languageRail_container present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/languageRail_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(true);
+  });
+
+  test('languageRail_refreshButton present → true (any suffix matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/languageRail_refreshButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(true);
+  });
+
+  test('absent (no language rail) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="languageRail_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/languageRail_container"><node text="EN" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(true);
+  });
+
+  test('left-boundary — pre_languageRail_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_languageRail_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(false);
+  });
+
+  test('bare left-boundary — pre_languageRail_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_languageRail_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(false);
+  });
+
+  test('right-boundary — languageRail_containerExtra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/languageRail_containerExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(true);
+  });
+
+  test('confusable prefix — language_railOption does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/language_railOption" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(false);
+  });
+
+  test('bare confusable prefix — language_railOption does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="language_railOption" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(false);
+  });
+
+  test('name accepted-and-ignored — Bao passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/languageRail_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Bao')).toBe(true);
+  });
+
+  test('null name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/languageRail_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail(null)).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/languageRail_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail(undefined)).toBe(true);
+  });
+
+  test('empty name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/languageRail_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('')).toBe(true);
+  });
+
+  test('whitespace name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/languageRail_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('   ')).toBe(true);
+  });
+
+  test('first-match contract — two languageRail_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/languageRail_container" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/languageRail_refreshButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -17067,6 +17067,53 @@ describe('Wake 87 — "<Name> on <Plat> refreshes the language rail"', () => {
     expect(spy).toHaveBeenCalledWith('Alice');
   });
 
+  // Each Web variant gets its own 3-test set per cluster checklist:
+  // matching/returns-false/driver-missing. The Web/Web Chromium/Web Safari
+  // tokens share the same `startsWith('Web')` dispatch branch, but pinning
+  // each variant individually catches a future regression that special-
+  // cases one token (e.g. browser-specific routing override).
+  test('Web Chromium driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webRefreshLanguageRail: spy } });
+    const r = await executeStep(
+      { kind: 'When', text: 'Alice on Web Chromium refreshes the language rail' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|language rail/);
+  });
+
+  test('Web Chromium driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'When', text: 'Alice on Web Chromium refreshes the language rail' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webRefreshLanguageRail/);
+  });
+
+  test('Web Safari driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webRefreshLanguageRail: spy } });
+    const r = await executeStep(
+      { kind: 'When', text: 'Alice on Web Safari refreshes the language rail' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|language rail/);
+  });
+
+  test('Web Safari driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'When', text: 'Alice on Web Safari refreshes the language rail' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webRefreshLanguageRail/);
+  });
+
   test('Web driver returns false → fail', async () => {
     const spy = jest.fn(async () => false);
     const ctx = makeCtx({ webDriver: { webRefreshLanguageRail: spy } });

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -16998,7 +16998,94 @@ describe('Wake 87 — "<Name> on <Plat> refreshes the language rail"', () => {
       ctx,
     );
     expect(r.ok).toBe(false);
-    expect(r.error).toMatch(/androidRefreshLanguageRail/);
+    expect(r.error).toMatch(/ctx\.uiDriver\.androidRefreshLanguageRail/);
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidRefreshLanguageRail: spy } });
+    const r = await executeStep(
+      { kind: 'When', text: 'Marcus on Android refreshes the language rail' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Marcus|language rail/);
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosRefreshLanguageRail: spy } });
+    const r = await executeStep(
+      { kind: 'When', text: 'Yuki on iOS Sim refreshes the language rail' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Yuki|language rail/);
+  });
+
+  test('iOS Sim no driver → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'When', text: 'Yuki on iOS Sim refreshes the language rail' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.iosRefreshLanguageRail/);
+  });
+
+  // Web branch — routes to ctx.webDriver.webRefreshLanguageRail
+  test('Web matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webRefreshLanguageRail: spy } });
+    const r = await executeStep(
+      { kind: 'When', text: 'Alice on Web refreshes the language rail' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice');
+  });
+
+  test('Web Chromium matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webRefreshLanguageRail: spy } });
+    const r = await executeStep(
+      { kind: 'When', text: 'Alice on Web Chromium refreshes the language rail' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice');
+  });
+
+  test('Web Safari matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webRefreshLanguageRail: spy } });
+    const r = await executeStep(
+      { kind: 'When', text: 'Alice on Web Safari refreshes the language rail' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice');
+  });
+
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webRefreshLanguageRail: spy } });
+    const r = await executeStep(
+      { kind: 'When', text: 'Alice on Web refreshes the language rail' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|language rail/);
+  });
+
+  test('Web driver missing → fail (driver-object name correctly identifies webDriver)', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'When', text: 'Alice on Web refreshes the language rail' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webRefreshLanguageRail/);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Method:** `androidRefreshLanguageRail(name)` — j17 pull-to-refresh action
- **Foundation:** presence-check `languageRail_*` testTag PREFIX. No such testTag yet — rail UI unbuilt
- **Tests:** 18 driver + 11 runner — full preemptive checklist + Web Chromium/Safari coverage + driver-object name fix in runner handler

## Notable PR #769 items
- **Runtime fix** (per PR #768 R1): runner handler at line 9899-9901 corrected to use dynamic `driverName` instead of hardcoded `ctx.uiDriver`
- **All "driver missing" runner assertions tightened** to `/ctx\.<correctDriver>\.<methodName>/`
- **All 3 Web tokens covered** (`Web` + `Web Chromium` + `Web Safari`)

## Test plan
- [x] `npx jest -t "androidRefreshLanguageRail"` → 18/18 driver tests pass
- [x] `npx jest -t "refreshes the language rail"` → 11/11 runner tests pass
- [x] `npx prettier --check` → clean
- [ ] CI: ci/express, ci/lint, SonarCloud, dependency-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)