### PR TITLE
feat(driver/android): androidShowsBeansPerWeekChart (Wake 87)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1637,6 +1637,27 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 87 — `<Name>'s <Plat> UI shows a chart of beans earned per
+  // week` (j17:74). Bare chart-presence assertion. Driver receives
+  // `(name)`.
+  //
+  // Foundation strategy: presence-check on the `beansChart_*` testTag
+  // PREFIX. No `beansChart_*` testTag exists in shared/src/commonMain
+  // yet — the beans-earnings chart UI is unbuilt. Returns false in
+  // real journeys today; lands true when the chart ships with
+  // `beansChart_*` testTags (e.g. beansChart_container,
+  // beansChart_weekBar).
+  //
+  // Bin-level value verification is out of scope (matcher contract is
+  // "bare chart-presence assertion"). `_name` accepted-and-ignored.
+  driver.androidShowsBeansPerWeekChart = async (_name) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?beansChart_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -9846,8 +9846,9 @@ const matchers = [
           ? 'androidShowsBeansPerWeekChart'
           : 'iosShowsBeansPerWeekChart';
       const driver = platform.startsWith('Web') ? ctx.webDriver : ctx.uiDriver;
+      const driverName = platform.startsWith('Web') ? 'ctx.webDriver' : 'ctx.uiDriver';
       if (!driver?.[methodName]) {
-        return { ok: false, error: `ctx.uiDriver.${methodName} not configured` };
+        return { ok: false, error: `${driverName}.${methodName} not configured` };
       }
       const shown = await driver[methodName](name);
       if (!shown) {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -11351,3 +11351,201 @@ describe('android-adb-driver — androidRefreshLanguageRail', () => {
     expect(await driver.androidRefreshLanguageRail('Yuki')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsBeansPerWeekChart', () => {
+  // Wake 87 — `<Name>'s <Plat> UI shows a chart of beans earned per
+  // week` (j17:74). Bare chart-presence assertion. Driver receives
+  // `(name)`.
+  //
+  // Foundation strategy: presence-check on the `beansChart_*` testTag
+  // PREFIX. No `beansChart_*` testTag exists in shared/src/commonMain
+  // yet — the beans-earnings chart UI is unbuilt. Returns false in
+  // real journeys today; lands true when the chart ships with
+  // `beansChart_*` testTags (e.g. beansChart_container,
+  // beansChart_weekBar).
+  //
+  // Bin-level value verification is out of scope (matcher contract:
+  // "bare chart-presence assertion"). `_name` accepted-and-ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('beansChart_container present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/beansChart_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(true);
+  });
+
+  test('beansChart_weekBar present → true (any suffix matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/beansChart_weekBar" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(true);
+  });
+
+  test('absent (no chart) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="beansChart_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/beansChart_container"><node text="W1" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(true);
+  });
+
+  test('left-boundary — pre_beansChart_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_beansChart_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(false);
+  });
+
+  test('bare left-boundary — pre_beansChart_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_beansChart_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(false);
+  });
+
+  test('right-boundary — beansChart_containerExtra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/beansChart_containerExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(true);
+  });
+
+  test('confusable prefix — beans_chartPanel does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/beans_chartPanel" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(false);
+  });
+
+  test('bare confusable prefix — beans_chartPanel does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="beans_chartPanel" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(false);
+  });
+
+  test('name accepted-and-ignored — Bao passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/beansChart_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Bao')).toBe(true);
+  });
+
+  test('null name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/beansChart_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart(null)).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/beansChart_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart(undefined)).toBe(true);
+  });
+
+  test('empty name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/beansChart_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('')).toBe(true);
+  });
+
+  test('whitespace name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/beansChart_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('   ')).toBe(true);
+  });
+
+  test('first-match contract — two beansChart_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/beansChart_container" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/beansChart_weekBar" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -16923,7 +16923,139 @@ describe('Wake 87 — "<Name>\'s <Plat> UI shows a chart of beans earned per wee
       ctx,
     );
     expect(r.ok).toBe(false);
-    expect(r.error).toMatch(/webShowsBeansPerWeekChart/);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsBeansPerWeekChart/);
+  });
+
+  // Web Chromium variant — full 3-test set per cluster checklist
+  test('Web Chromium matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsBeansPerWeekChart: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Bao's Web Chromium UI shows a chart of beans earned per week" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Bao');
+  });
+
+  test('Web Chromium driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsBeansPerWeekChart: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Bao's Web Chromium UI shows a chart of beans earned per week" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/chart|beans/);
+  });
+
+  test('Web Chromium driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Bao's Web Chromium UI shows a chart of beans earned per week" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsBeansPerWeekChart/);
+  });
+
+  // Web Safari variant — full 3-test set
+  test('Web Safari matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsBeansPerWeekChart: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Bao's Web Safari UI shows a chart of beans earned per week" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Bao');
+  });
+
+  test('Web Safari driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsBeansPerWeekChart: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Bao's Web Safari UI shows a chart of beans earned per week" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/chart|beans/);
+  });
+
+  test('Web Safari driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Bao's Web Safari UI shows a chart of beans earned per week" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsBeansPerWeekChart/);
+  });
+
+  // Android branch — routes to ctx.uiDriver.androidShowsBeansPerWeekChart
+  test('Android matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { androidShowsBeansPerWeekChart: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Bao's Android UI shows a chart of beans earned per week" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Bao');
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidShowsBeansPerWeekChart: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Bao's Android UI shows a chart of beans earned per week" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/chart|beans/);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Bao's Android UI shows a chart of beans earned per week" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.androidShowsBeansPerWeekChart/);
+  });
+
+  // iOS Sim branch — routes to ctx.uiDriver.iosShowsBeansPerWeekChart
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosShowsBeansPerWeekChart: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Bao's iOS Sim UI shows a chart of beans earned per week" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Bao');
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsBeansPerWeekChart: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Bao's iOS Sim UI shows a chart of beans earned per week" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/chart|beans/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Bao's iOS Sim UI shows a chart of beans earned per week" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.iosShowsBeansPerWeekChart/);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Method:** `androidShowsBeansPerWeekChart(name)` — j17 chart-presence assertion
- **Foundation:** presence-check `beansChart_*` testTag PREFIX. No such testTag yet
- **Tests:** 18 driver + 15 runner — full preemptive checklist + 3-per-Web-variant rule (5 platform arms × 3 tests = 15)
- **Runner driver-object name fix** applied to line 9849

## Test plan
- [x] `npx jest -t "androidShowsBeansPerWeekChart"` → 18/18 driver tests pass
- [x] `npx jest -t "beans earned per week"` → 15/15 runner tests pass
- [x] `npx prettier --check` → clean
- [ ] CI: ci/express, ci/lint, SonarCloud, dependency-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)