### PR TITLE
feat(driver/android): androidShowsCountBadge (Wake 98)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1658,6 +1658,28 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 98 — `<Name>'s <Plat> UI shows a +N in the "<X>" count`
+  // (j01/j02/j07). Generic delta-badge assertion. Driver receives
+  // `(name, delta, label)`.
+  //
+  // Foundation strategy: presence-check on the `countBadge_*` testTag
+  // PREFIX. No `countBadge_*` testTag exists in shared/src/commonMain
+  // yet — delta-badge UI is unbuilt. Returns false in real journeys
+  // today; lands true when ships with countBadge_followersDelta /
+  // countBadge_likesDelta testTags.
+  //
+  // Per-label verification (Followers vs Likes) needs a label →
+  // testTag map. Per-delta verification (matching the actual displayed
+  // +N) needs text-extraction. Both deferred. All 3 args
+  // (_name, _delta, _label) accepted-and-ignored.
+  driver.androidShowsCountBadge = async (_name, _delta, _label) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?countBadge_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -11713,8 +11713,9 @@ const matchers = [
           ? 'androidShowsCountBadge'
           : 'iosShowsCountBadge';
       const driver = platform.startsWith('Web') ? ctx.webDriver : ctx.uiDriver;
+      const driverName = platform.startsWith('Web') ? 'ctx.webDriver' : 'ctx.uiDriver';
       if (!driver?.[methodName]) {
-        return { ok: false, error: `ctx.uiDriver.${methodName} not configured` };
+        return { ok: false, error: `${driverName}.${methodName} not configured` };
       }
       const ok = await driver[methodName](name, delta, label);
       if (!ok) {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -11549,3 +11549,284 @@ describe('android-adb-driver — androidShowsBeansPerWeekChart', () => {
     expect(await driver.androidShowsBeansPerWeekChart('Yuki')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsCountBadge', () => {
+  // Wake 98 — `<Name>'s <Plat> UI shows a +N in the "<X>" count`
+  // (j01/j02/j07). Generic delta-badge assertion: a numeric counter
+  // (Followers, Likes, etc.) shows a +N increment. Driver receives
+  // `(name, delta, label)`.
+  //
+  // Foundation strategy: presence-check on the `countBadge_*` testTag
+  // PREFIX. No `countBadge_*` testTag exists in shared/src/commonMain
+  // yet — delta-badge UI is unbuilt. Returns false in real journeys
+  // today; lands true when ships with countBadge_followersDelta,
+  // countBadge_likesDelta, etc.
+  //
+  // Per-label verification (`Followers` vs `Likes`) needs a label →
+  // testTag map. Per-delta verification (matching the actual displayed
+  // +N) needs text-extraction. Both deferred. All 3 args
+  // (_name, _delta, _label) accepted-and-ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('countBadge_followersDelta present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, 'Followers')).toBe(true);
+  });
+
+  test('countBadge_likesDelta present → true (any suffix matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_likesDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 5, 'Likes')).toBe(true);
+  });
+
+  test('absent (no badge) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, 'Followers')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, 'Followers')).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, 'Followers')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta"><node text="+1" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, 'Followers')).toBe(true);
+  });
+
+  test('left-boundary — pre_countBadge_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, 'Followers')).toBe(false);
+  });
+
+  test('bare left-boundary — pre_countBadge_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, 'Followers')).toBe(false);
+  });
+
+  test('right-boundary — countBadge_followersDeltaExtra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDeltaExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, 'Followers')).toBe(true);
+  });
+
+  test('confusable prefix — count_badgeSummary does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/count_badgeSummary" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, 'Followers')).toBe(false);
+  });
+
+  test('bare confusable prefix — count_badgeSummary does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="count_badgeSummary" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, 'Followers')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, 'Followers')).toBe(false);
+  });
+
+  test('name accepted-and-ignored — Bao passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Bao', 1, 'Followers')).toBe(true);
+  });
+
+  test('null name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge(null, 1, 'Followers')).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge(undefined, 1, 'Followers')).toBe(true);
+  });
+
+  test('empty name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('', 1, 'Followers')).toBe(true);
+  });
+
+  test('whitespace name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('   ', 1, 'Followers')).toBe(true);
+  });
+
+  test('null delta → true (accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', null, 'Followers')).toBe(true);
+  });
+
+  test('undefined delta → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', undefined, 'Followers')).toBe(true);
+  });
+
+  test('0 delta → true (delta accepted-and-ignored regardless of value)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 0, 'Followers')).toBe(true);
+  });
+
+  test('null label → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, null)).toBe(true);
+  });
+
+  test('undefined label → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, undefined)).toBe(true);
+  });
+
+  test('empty label → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, '')).toBe(true);
+  });
+
+  test('whitespace label → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, '   ')).toBe(true);
+  });
+
+  test('different label still passes (foundation does not match specific label)', async () => {
+    // Per-label verification needs a label → testTag map.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, 'Likes')).toBe(true);
+  });
+
+  test('first-match contract — two countBadge_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_followersDelta" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/countBadge_likesDelta" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsCountBadge('Selma', 1, 'Followers')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -20140,6 +20140,137 @@ describe('Wake 98 — `<Name>\'s <Plat> UI shows a +N in the "<X>" count`', () =
     expect(r.ok).toBe(false);
     expect(r.error).toMatch(/Alice|Likes/);
   });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web UI shows a +1 in the "Followers" count' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsCountBadge/);
+  });
+
+  // Web Chromium variant — full 3-test set
+  test('Web Chromium matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsCountBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web Chromium UI shows a +1 in the "Followers" count' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 1, 'Followers');
+  });
+
+  test('Web Chromium driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsCountBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web Chromium UI shows a +1 in the "Followers" count' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|Followers/);
+  });
+
+  test('Web Chromium driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web Chromium UI shows a +1 in the "Followers" count' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsCountBadge/);
+  });
+
+  // Web Safari variant — full 3-test set
+  test('Web Safari matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsCountBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web Safari UI shows a +1 in the "Followers" count' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 1, 'Followers');
+  });
+
+  test('Web Safari driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsCountBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web Safari UI shows a +1 in the "Followers" count' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|Followers/);
+  });
+
+  test('Web Safari driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web Safari UI shows a +1 in the "Followers" count' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsCountBadge/);
+  });
+
+  // Android branch — completing 3-test set
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidShowsCountBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Marcus\'s Android UI shows a +1 in the "Followers" count' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Marcus|Followers/);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Marcus\'s Android UI shows a +1 in the "Followers" count' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.androidShowsCountBadge/);
+  });
+
+  // iOS Sim branch — full 3-test set
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosShowsCountBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Marcus\'s iOS Sim UI shows a +1 in the "Followers" count' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Marcus', 1, 'Followers');
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsCountBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Marcus\'s iOS Sim UI shows a +1 in the "Followers" count' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Marcus|Followers/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Marcus\'s iOS Sim UI shows a +1 in the "Followers" count' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.iosShowsCountBadge/);
+  });
 });
 
 describe('Wake 98 — `<Name>\'s <Plat> Admin UI shows N row for "<X>" with status "<Y>"`', () => {


### PR DESCRIPTION
## Summary
- **Method:** `androidShowsCountBadge(name, delta, label)` — j01/j02/j07 delta-badge assertion
- **Foundation:** presence-check `countBadge_*` testTag PREFIX. No such testTag yet
- **Tests:** 26 driver + 16 runner total (Wake 98) — full preemptive checklist + 3-per-Web-variant rule

## Test plan
- [x] `npx jest -t "androidShowsCountBadge"` → 26/26 driver tests pass
- [x] `npx jest -t "in the .* count"` → 16/16 runner tests pass
- [x] `npx prettier --check` → clean
- [ ] CI: ci/express, ci/lint, SonarCloud, dependency-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)