### PR TITLE
feat(driver/android): androidShowsEditedBodyWithTag (Wake 103)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1680,6 +1680,30 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 103 — `<Name>'s <Plat> UI shows the edited body "<X>" with an
+  // "<Y>" tag` (j07). Message-edit indicator on the recipient view.
+  // Driver receives `(name, body, tag)`.
+  //
+  // Foundation strategy: presence-check on the `editedBody_*` testTag
+  // PREFIX. No `editedBody_*` testTag exists in shared/src/commonMain
+  // yet — only the source-side `room_msg_editTarget_<id>` testTag
+  // exists (MessageBubble.kt:241), which marks the message being
+  // edited (NOT the post-edit "(edited)" badge on the recipient view
+  // — distinct concerns).
+  //
+  // Returns false in real journeys today; lands true when ships with
+  // editedBody_<msgId> / editedBody_badge testTags.
+  //
+  // Per-body and per-tag verification need text-extraction. Deferred.
+  // All 3 args (_name, _body, _tag) accepted-and-ignored.
+  driver.androidShowsEditedBodyWithTag = async (_name, _body, _tag) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?editedBody_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -12644,8 +12644,9 @@ const matchers = [
           ? 'androidShowsEditedBodyWithTag'
           : 'iosShowsEditedBodyWithTag';
       const driver = platform.startsWith('Web') ? ctx.webDriver : ctx.uiDriver;
+      const driverName = platform.startsWith('Web') ? 'ctx.webDriver' : 'ctx.uiDriver';
       if (!driver?.[methodName]) {
-        return { ok: false, error: `ctx.uiDriver.${methodName} not configured` };
+        return { ok: false, error: `${driverName}.${methodName} not configured` };
       }
       const ok = await driver[methodName](name, body, tag);
       if (!ok) {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -11830,3 +11830,310 @@ describe('android-adb-driver — androidShowsCountBadge', () => {
     expect(await driver.androidShowsCountBadge('Selma', 1, 'Followers')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsEditedBodyWithTag', () => {
+  // Wake 103 — `<Name>'s <Plat> UI shows the edited body "<X>" with an
+  // "<Y>" tag` (j07). Message-edit indicator on the recipient view.
+  // Driver receives `(name, body, tag)`.
+  //
+  // Foundation strategy: presence-check on the `editedBody_*` testTag
+  // PREFIX. No `editedBody_*` testTag exists in shared/src/commonMain
+  // yet — only the source-side `room_msg_editTarget_<id>` testTag
+  // exists (MessageBubble.kt:241), which marks the message being
+  // edited, not the post-edit "(edited)" badge on the recipient view.
+  //
+  // Returns false in real journeys today; lands true when ships with
+  // editedBody_<msgId> / editedBody_badge / etc.
+  //
+  // Per-body text verification (matching the displayed string) and
+  // per-tag verification (matching the "(edited)" label exactly) are
+  // deferred — both need text-extraction. All 3 args (_name, _body,
+  // _tag) accepted-and-ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('editedBody_badge present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated body', 'edited')).toBe(
+      true,
+    );
+  });
+
+  test('editedBody_msg42 present → true (any suffix matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_msg42" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(true);
+  });
+
+  test('absent (no edited badge) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge"><node text="(edited)" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(true);
+  });
+
+  test('left-boundary — pre_editedBody_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(false);
+  });
+
+  test('bare left-boundary — pre_editedBody_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(false);
+  });
+
+  test('right-boundary — editedBody_badgeExtra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badgeExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(true);
+  });
+
+  test('confusable prefix — edited_bodyOther does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/edited_bodyOther" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(false);
+  });
+
+  test('bare confusable prefix — edited_bodyOther does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="edited_bodyOther" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(false);
+  });
+
+  test('similar-but-distinct — room_msg_editTarget_42 does NOT match', async () => {
+    // The source-side edit-target testTag (MessageBubble.kt:241) marks
+    // the message being edited, NOT the post-edit indicator. Pin that
+    // these don't conflate.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/room_msg_editTarget_42" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(false);
+  });
+
+  test('name accepted-and-ignored — Bao passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Bao', 'Updated', 'edited')).toBe(true);
+  });
+
+  test('null name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag(null, 'Updated', 'edited')).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag(undefined, 'Updated', 'edited')).toBe(true);
+  });
+
+  test('empty name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('', 'Updated', 'edited')).toBe(true);
+  });
+
+  test('whitespace name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('   ', 'Updated', 'edited')).toBe(true);
+  });
+
+  test('null body → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', null, 'edited')).toBe(true);
+  });
+
+  test('undefined body → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', undefined, 'edited')).toBe(true);
+  });
+
+  test('empty body → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', '', 'edited')).toBe(true);
+  });
+
+  test('whitespace body → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', '   ', 'edited')).toBe(true);
+  });
+
+  test('null tag → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', null)).toBe(true);
+  });
+
+  test('undefined tag → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', undefined)).toBe(true);
+  });
+
+  test('empty tag → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', '')).toBe(true);
+  });
+
+  test('whitespace tag → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', '   ')).toBe(true);
+  });
+
+  test('different body/tag still passes (foundation does not match specifics)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'AnyBody', 'AnyTag')).toBe(true);
+  });
+
+  test('first-match contract — two editedBody_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_badge" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/editedBody_msg42" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -21176,6 +21176,201 @@ describe('Wake 103 — `<Name>\'s <Plat> UI shows the edited body "<X>" with an 
     expect(r.ok).toBe(true);
     expect(spy).toHaveBeenCalledWith('Alice', 'typo here', 'edited');
   });
+
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsEditedBodyWithTag: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Web UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|edited|tag/);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Web UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsEditedBodyWithTag/);
+  });
+
+  // Web Chromium variant — full 3-test set
+  test('Web Chromium matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsEditedBodyWithTag: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Web Chromium UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'typo here', 'edited');
+  });
+
+  test('Web Chromium driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsEditedBodyWithTag: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Web Chromium UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|edited|tag/);
+  });
+
+  test('Web Chromium driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Web Chromium UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsEditedBodyWithTag/);
+  });
+
+  // Web Safari variant — full 3-test set
+  test('Web Safari matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsEditedBodyWithTag: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Web Safari UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'typo here', 'edited');
+  });
+
+  test('Web Safari driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsEditedBodyWithTag: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Web Safari UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|edited|tag/);
+  });
+
+  test('Web Safari driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Web Safari UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsEditedBodyWithTag/);
+  });
+
+  // Android branch — full 3-test set
+  test('Android matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { androidShowsEditedBodyWithTag: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Android UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'typo here', 'edited');
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidShowsEditedBodyWithTag: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Android UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|edited|tag/);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Android UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.androidShowsEditedBodyWithTag/);
+  });
+
+  // iOS Sim branch — full 3-test set
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosShowsEditedBodyWithTag: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s iOS Sim UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'typo here', 'edited');
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsEditedBodyWithTag: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s iOS Sim UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|edited|tag/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s iOS Sim UI shows the edited body "typo here" with an "edited" tag',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.iosShowsEditedBodyWithTag/);
+  });
 });
 
 describe('Wake 103 — "<Name>\'s <Plat> UI also shows <Other> in the participants list"', () => {


### PR DESCRIPTION
## Summary
- **Method:** `androidShowsEditedBodyWithTag(name, body, tag)` — j07 recipient-view edit indicator
- **Foundation:** presence-check `editedBody_*` testTag PREFIX. Distinct from source-side `room_msg_editTarget_<id>` (similar-but-distinct guard pinned).
- **Tests:** 28 driver + 15 runner

## Test plan
- [x] `npx jest -t "androidShowsEditedBodyWithTag"` → 28/28 driver tests pass
- [x] `npx jest -t "edited body"` → 15/15 runner tests pass
- [x] `npx prettier --check` → clean
- [ ] CI: ci/express, ci/lint, SonarCloud, dependency-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)