### PR TITLE
feat(driver/android): androidShowsInAppGiftNotification (Wake 100)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1704,6 +1704,28 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 100 — `<Name>'s <Plat> UI shows the in-app gift notification
+  // with sender "<X>" and gift "<Y>"` (j05). Toast/banner when a gift
+  // is received in real time. Driver receives
+  // `(recipient, sender, giftId)`.
+  //
+  // Foundation strategy: presence-check on the `giftNotification_*`
+  // testTag PREFIX. No `giftNotification_*` testTag exists in
+  // shared/src/commonMain yet — the real-time gift notification toast
+  // is unbuilt. Returns false in real journeys today; lands true when
+  // ships with giftNotification_toast / giftNotification_giftIcon.
+  //
+  // Per-sender and per-gift verification need text/image extraction.
+  // Deferred. All 3 args (_recipient, _sender, _giftId) accepted-and-
+  // ignored.
+  driver.androidShowsInAppGiftNotification = async (_recipient, _sender, _giftId) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?giftNotification_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -12139,8 +12139,9 @@ const matchers = [
           ? 'androidShowsInAppGiftNotification'
           : 'iosShowsInAppGiftNotification';
       const driver = platform.startsWith('Web') ? ctx.webDriver : ctx.uiDriver;
+      const driverName = platform.startsWith('Web') ? 'ctx.webDriver' : 'ctx.uiDriver';
       if (!driver?.[methodName]) {
-        return { ok: false, error: `ctx.uiDriver.${methodName} not configured` };
+        return { ok: false, error: `${driverName}.${methodName} not configured` };
       }
       const ok = await driver[methodName](recipient, sender, giftId);
       if (!ok) {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -12137,3 +12137,294 @@ describe('android-adb-driver — androidShowsEditedBodyWithTag', () => {
     expect(await driver.androidShowsEditedBodyWithTag('Alice', 'Updated', 'edited')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsInAppGiftNotification', () => {
+  // Wake 100 — `<Name>'s <Plat> UI shows the in-app gift notification
+  // with sender "<X>" and gift "<Y>"` (j05). Toast/banner when a gift
+  // is received in real time. Driver receives
+  // `(recipient, sender, giftId)`.
+  //
+  // Foundation strategy: presence-check on the `giftNotification_*`
+  // testTag PREFIX. No `giftNotification_*` testTag exists in
+  // shared/src/commonMain yet — the real-time gift notification toast
+  // is unbuilt. Returns false in real journeys today; lands true when
+  // ships with giftNotification_toast / giftNotification_giftIcon.
+  //
+  // Per-sender and per-gift verification need text/image extraction.
+  // Deferred. All 3 args (_recipient, _sender, _giftId) accepted-and-
+  // ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('giftNotification_toast present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(true);
+  });
+
+  test('giftNotification_giftIcon present → true (any suffix matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_giftIcon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(true);
+  });
+
+  test('absent (no notification) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast"><node text="Alice sent you a rose" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(true);
+  });
+
+  test('left-boundary — pre_giftNotification_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(false);
+  });
+
+  test('bare left-boundary — pre_giftNotification_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(false);
+  });
+
+  test('right-boundary — giftNotification_toastExtra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toastExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(true);
+  });
+
+  test('confusable prefix — gift_notificationPanel does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/gift_notificationPanel" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(false);
+  });
+
+  test('bare confusable prefix — gift_notificationPanel does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="gift_notificationPanel" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(false);
+  });
+
+  test('recipient accepted-and-ignored — Bao passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Bao', 'Alice', 'rose')).toBe(true);
+  });
+
+  test('null recipient → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification(null, 'Alice', 'rose')).toBe(true);
+  });
+
+  test('undefined recipient → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification(undefined, 'Alice', 'rose')).toBe(true);
+  });
+
+  test('empty recipient → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('', 'Alice', 'rose')).toBe(true);
+  });
+
+  test('whitespace recipient → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('   ', 'Alice', 'rose')).toBe(true);
+  });
+
+  test('null sender → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', null, 'rose')).toBe(true);
+  });
+
+  test('undefined sender → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', undefined, 'rose')).toBe(true);
+  });
+
+  test('empty sender → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', '', 'rose')).toBe(true);
+  });
+
+  test('whitespace sender → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', '   ', 'rose')).toBe(true);
+  });
+
+  test('null giftId → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', null)).toBe(true);
+  });
+
+  test('undefined giftId → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', undefined)).toBe(true);
+  });
+
+  test('empty giftId → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', '')).toBe(true);
+  });
+
+  test('whitespace giftId → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', '   ')).toBe(true);
+  });
+
+  test('different sender/giftId still passes (foundation does not match specifics)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Different', 'AnyGift')).toBe(
+      true,
+    );
+  });
+
+  test('first-match contract — two giftNotification_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_toast" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/giftNotification_giftIcon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -20782,18 +20782,127 @@ describe('Wake 100 — `<Name>\'s <Plat> UI shows the new "<X>" gift entry`', ()
 });
 
 describe('Wake 100 — `<Name>\'s <Plat> UI shows the in-app gift notification with sender "<X>" and gift "<Y>"`', () => {
+  // Helper for terser tests in this block
+  const giftText = (platform) =>
+    `Selma's ${platform} UI shows the in-app gift notification with sender "Alice" and gift "crown"`;
+
   test('matching → ok', async () => {
     const spy = jest.fn(async () => true);
     const ctx = makeCtx({ uiDriver: { androidShowsInAppGiftNotification: spy } });
-    const r = await executeStep(
-      {
-        kind: 'Then',
-        text: 'Selma\'s Android UI shows the in-app gift notification with sender "Alice" and gift "crown"',
-      },
-      ctx,
-    );
+    const r = await executeStep({ kind: 'Then', text: giftText('Android') }, ctx);
     expect(r.ok).toBe(true);
     expect(spy).toHaveBeenCalledWith('Selma', 'Alice', 'crown');
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidShowsInAppGiftNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: giftText('Android') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Selma|gift notification/i);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: giftText('Android') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.androidShowsInAppGiftNotification/);
+  });
+
+  // iOS Sim — full 3-test set
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosShowsInAppGiftNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: giftText('iOS Sim') }, ctx);
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Selma', 'Alice', 'crown');
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsInAppGiftNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: giftText('iOS Sim') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Selma|gift notification/i);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: giftText('iOS Sim') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.iosShowsInAppGiftNotification/);
+  });
+
+  // Web — full 3-test set
+  test('Web matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsInAppGiftNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: giftText('Web') }, ctx);
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Selma', 'Alice', 'crown');
+  });
+
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsInAppGiftNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: giftText('Web') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Selma|gift notification/i);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: giftText('Web') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsInAppGiftNotification/);
+  });
+
+  // Web Chromium — full 3-test set
+  test('Web Chromium matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsInAppGiftNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: giftText('Web Chromium') }, ctx);
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Selma', 'Alice', 'crown');
+  });
+
+  test('Web Chromium driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsInAppGiftNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: giftText('Web Chromium') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Selma|gift notification/i);
+  });
+
+  test('Web Chromium driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: giftText('Web Chromium') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsInAppGiftNotification/);
+  });
+
+  // Web Safari — full 3-test set
+  test('Web Safari matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsInAppGiftNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: giftText('Web Safari') }, ctx);
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Selma', 'Alice', 'crown');
+  });
+
+  test('Web Safari driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsInAppGiftNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: giftText('Web Safari') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Selma|gift notification/i);
+  });
+
+  test('Web Safari driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: giftText('Web Safari') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsInAppGiftNotification/);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Method:** `androidShowsInAppGiftNotification(recipient, sender, giftId)` — j05 real-time gift toast
- **Foundation:** `giftNotification_*` testTag PREFIX — no such testTag yet
- **Tests:** 27 driver + 15 runner — full preemptive checklist

## Test plan
- [x] `npx jest -t "androidShowsInAppGiftNotification"` → 27/27
- [x] `npx jest -t "in-app gift notification"` → 15/15
- [x] `npx prettier --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)