### PR TITLE
feat(driver/android): androidShowsInResults (Wake 98)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1726,6 +1726,31 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 98 — `<Name>'s <Plat> UI shows <Other> in the results[ with
+  // displayName "<X>"]` (j01/j02). Discovery list result visibility.
+  // Optional displayName suffix. Driver receives
+  // `(viewer, target, displayName)` — displayName may be `null` (no
+  // `with displayName` suffix in step).
+  //
+  // Foundation strategy: presence-check on the `searchResults_*`
+  // testTag PREFIX. No `searchResults_*` testTag exists in
+  // shared/src/commonMain yet — NewMessageScreen.kt exposes only
+  // `newMessage_searchField` for the input box, not per-result tiles.
+  //
+  // Returns false in real journeys today; lands true when ships with
+  // searchResults_userTile / searchResults_container.
+  //
+  // Per-user verification needs user-id → testTag map. Per-displayName
+  // verification needs text-extraction. Both deferred. All 3 args
+  // (_viewer, _target, _displayName) accepted-and-ignored.
+  driver.androidShowsInResults = async (_viewer, _target, _displayName) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?searchResults_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   // Open named screen — launches the local-build app via MainActivity.
   // The app's AndroidManifest does NOT declare a `shytalk://` scheme
   // (only HTTPS auth deep-links per app/src/main/AndroidManifest.xml).

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -11863,8 +11863,9 @@ const matchers = [
           ? 'androidShowsInResults'
           : 'iosShowsInResults';
       const driver = platform.startsWith('Web') ? ctx.webDriver : ctx.uiDriver;
+      const driverName = platform.startsWith('Web') ? 'ctx.webDriver' : 'ctx.uiDriver';
       if (!driver?.[methodName]) {
-        return { ok: false, error: `ctx.uiDriver.${methodName} not configured` };
+        return { ok: false, error: `${driverName}.${methodName} not configured` };
       }
       const ok = await driver[methodName](viewer, target, displayName);
       if (!ok) {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -12428,3 +12428,296 @@ describe('android-adb-driver — androidShowsInAppGiftNotification', () => {
     expect(await driver.androidShowsInAppGiftNotification('Selma', 'Alice', 'rose')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsInResults', () => {
+  // Wake 98 — `<Name>'s <Plat> UI shows <Other> in the results[ with
+  // displayName "<X>"]` (j01/j02). Discovery list result visibility.
+  // Optional displayName suffix lets the driver also verify rendered
+  // string. Driver receives `(viewer, target, displayName)` —
+  // displayName may be `null` (no `with displayName` suffix in step).
+  //
+  // Foundation strategy: presence-check on the `searchResults_*`
+  // testTag PREFIX. No `searchResults_*` testTag exists in
+  // shared/src/commonMain yet — NewMessageScreen.kt exposes only
+  // `newMessage_searchField` for the input box, not per-result tiles.
+  //
+  // Returns false in real journeys today; lands true when ships with
+  // searchResults_userTile / searchResults_container etc.
+  //
+  // Per-user verification (asserting <Other> specifically, not any
+  // result) needs user-id → testTag map. Per-displayName verification
+  // needs text-extraction. Both deferred. All 3 args (_viewer,
+  // _target, _displayName) accepted-and-ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('searchResults_userTile present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', null)).toBe(true);
+  });
+
+  test('searchResults_container present → true (any suffix matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', 'Bob Smith')).toBe(true);
+  });
+
+  test('absent (no results) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', null)).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', null)).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', null)).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile"><node text="Bob" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', null)).toBe(true);
+  });
+
+  test('left-boundary — pre_searchResults_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', null)).toBe(false);
+  });
+
+  test('bare left-boundary — pre_searchResults_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', null)).toBe(false);
+  });
+
+  test('right-boundary — searchResults_userTileExtra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTileExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', null)).toBe(true);
+  });
+
+  test('confusable prefix — search_resultsItem does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/search_resultsItem" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', null)).toBe(false);
+  });
+
+  test('bare confusable prefix — search_resultsItem does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="search_resultsItem" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', null)).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', null)).toBe(false);
+  });
+
+  test('viewer accepted-and-ignored — Bao passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Bao', 'Bob', null)).toBe(true);
+  });
+
+  test('null viewer → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults(null, 'Bob', null)).toBe(true);
+  });
+
+  test('undefined viewer → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults(undefined, 'Bob', null)).toBe(true);
+  });
+
+  test('empty viewer → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('', 'Bob', null)).toBe(true);
+  });
+
+  test('whitespace viewer → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('   ', 'Bob', null)).toBe(true);
+  });
+
+  test('null target → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', null, null)).toBe(true);
+  });
+
+  test('undefined target → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', undefined, null)).toBe(true);
+  });
+
+  test('empty target → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', '', null)).toBe(true);
+  });
+
+  test('whitespace target → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', '   ', null)).toBe(true);
+  });
+
+  test('null displayName → true (suffix absent in step)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', null)).toBe(true);
+  });
+
+  test('undefined displayName → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', undefined)).toBe(true);
+  });
+
+  test('empty displayName → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', '')).toBe(true);
+  });
+
+  test('whitespace displayName → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', '   ')).toBe(true);
+  });
+
+  test('different target still passes (foundation does not match specific user)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'NotInList', 'Any Name')).toBe(true);
+  });
+
+  test('first-match contract — two searchResults_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_userTile" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/searchResults_container" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsInResults('Alice', 'Bob', null)).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -20457,7 +20457,141 @@ describe('Wake 98 — `<Name>\'s <Plat> UI shows <Other> in the results[ with di
       ctx,
     );
     expect(r.ok).toBe(false);
-    expect(r.error).toMatch(/iosShowsInResults/);
+    expect(r.error).toMatch(/ctx\.uiDriver\.iosShowsInResults/);
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsInResults: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Mia's iOS Sim UI shows Marcus in the results" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Marcus|results/i);
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidShowsInResults: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Adam\'s Android UI shows Alice in the results with displayName "Alice"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|results/i);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Adam's Android UI shows Alice in the results" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.androidShowsInResults/);
+  });
+
+  // Web — full 3-test set
+  test('Web matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsInResults: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web UI shows Bob in the results" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'Bob', null);
+  });
+
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsInResults: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web UI shows Bob in the results" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Bob|results/i);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web UI shows Bob in the results" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsInResults/);
+  });
+
+  // Web Chromium variant
+  test('Web Chromium matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsInResults: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web Chromium UI shows Bob in the results" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'Bob', null);
+  });
+
+  test('Web Chromium driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsInResults: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web Chromium UI shows Bob in the results" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Bob|results/i);
+  });
+
+  test('Web Chromium driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web Chromium UI shows Bob in the results" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsInResults/);
+  });
+
+  // Web Safari variant
+  test('Web Safari matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsInResults: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web Safari UI shows Bob in the results" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'Bob', null);
+  });
+
+  test('Web Safari driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsInResults: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web Safari UI shows Bob in the results" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Bob|results/i);
+  });
+
+  test('Web Safari driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web Safari UI shows Bob in the results" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsInResults/);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Method:** `androidShowsInResults(viewer, target, displayName)` — j01/j02 discovery list
- **Foundation:** `searchResults_*` testTag PREFIX — not yet built
- **Tests:** 27 driver + 15 runner — full preemptive checklist (`displayName` nullable per matcher spec)

## Test plan
- [x] `npx jest -t "androidShowsInResults"` → 27/27
- [x] `npx jest -t "in the results"` → 15/15
- [x] `npx prettier --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)