### PR TITLE
feat(driver/android): androidShowsNonEmptyLocaleText (Wake 89)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1768,6 +1768,28 @@ async function createAndroidDriver({ serial: preferred } = {}) {
   //
   // The `_name` arg is accepted-and-ignored; `noun` and `kind` are
   // REQUIRED (input rejection on empty/whitespace/null/undefined).
+  // Wake 89 — `<Name>'s <Plat> UI shows non-empty <Language> text for
+  // section N` (j13:36). Locale section assertion. Driver receives
+  // `(name, code, section)`.
+  //
+  // Foundation strategy: presence-check on the `localeText_*` testTag
+  // PREFIX. No `localeText_*` testTag exists in shared/src/commonMain
+  // yet — per-section locale-text testTags are unbuilt. Returns false
+  // in real journeys today; lands true when ships with
+  // localeText_section1 / localeText_section2 etc.
+  //
+  // Per-section verification needs a section-number → testTag map.
+  // Per-language verification needs text-extraction + script-category
+  // detection. Both deferred. All 3 args (_name, _code, _section)
+  // accepted-and-ignored.
+  driver.androidShowsNonEmptyLocaleText = async (_name, _code, _section) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?localeText_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   const NOUN_KIND_TAGS = {
     'appeal::button': 'suspension_submitAppealButton',
   };

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -10255,8 +10255,9 @@ const matchers = [
           ? 'androidShowsNonEmptyLocaleText'
           : 'iosShowsNonEmptyLocaleText';
       const driver = platform.startsWith('Web') ? ctx.webDriver : ctx.uiDriver;
+      const driverName = platform.startsWith('Web') ? 'ctx.webDriver' : 'ctx.uiDriver';
       if (!driver?.[methodName]) {
-        return { ok: false, error: `ctx.uiDriver.${methodName} not configured` };
+        return { ok: false, error: `${driverName}.${methodName} not configured` };
       }
       const ok = await driver[methodName](name, code, section);
       if (!ok) {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -12995,3 +12995,284 @@ describe('android-adb-driver — androidShowsNamedKind', () => {
     expect(await driver.androidShowsNamedKind('Raul', 'appeal', 'button')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsNonEmptyLocaleText', () => {
+  // Wake 89 — `<Name>'s <Plat> UI shows non-empty <Language> text for
+  // section N` (j13:36). Locale section assertion. Driver checks that
+  // section N of the current screen contains non-empty text in the
+  // named language. Driver receives `(name, code, section)` — code is
+  // a BCP-47 locale code (en, ja, ar, etc.), section is a number.
+  //
+  // Foundation strategy: presence-check on the `localeText_*` testTag
+  // PREFIX. No `localeText_*` testTag exists in shared/src/commonMain
+  // yet — per-section locale-text testTags are unbuilt. Returns false
+  // in real journeys today; lands true when ships with
+  // localeText_section1 / localeText_section2 etc.
+  //
+  // Per-section verification needs a section-number → testTag map.
+  // Per-language verification needs text-extraction + script-category
+  // detection. Both deferred. All 3 args (_name, _code, _section)
+  // accepted-and-ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('localeText_section1 present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 1)).toBe(true);
+  });
+
+  test('localeText_section2 present → true (any suffix matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section2" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ar', 2)).toBe(true);
+  });
+
+  test('absent (no locale-text element) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 1)).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 1)).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 1)).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1"><node text="こんにちは" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 1)).toBe(true);
+  });
+
+  test('left-boundary — pre_localeText_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 1)).toBe(false);
+  });
+
+  test('bare left-boundary — pre_localeText_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 1)).toBe(false);
+  });
+
+  test('right-boundary — localeText_section1Extra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1Extra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 1)).toBe(true);
+  });
+
+  test('confusable prefix — locale_textSection1 does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/locale_textSection1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 1)).toBe(false);
+  });
+
+  test('bare confusable prefix — locale_textSection1 does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="locale_textSection1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 1)).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 1)).toBe(false);
+  });
+
+  test('name accepted-and-ignored — Selma passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Selma', 'ja', 1)).toBe(true);
+  });
+
+  test('null name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText(null, 'ja', 1)).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText(undefined, 'ja', 1)).toBe(true);
+  });
+
+  test('empty name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('', 'ja', 1)).toBe(true);
+  });
+
+  test('whitespace name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('   ', 'ja', 1)).toBe(true);
+  });
+
+  test('null code → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', null, 1)).toBe(true);
+  });
+
+  test('undefined code → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', undefined, 1)).toBe(true);
+  });
+
+  test('empty code → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', '', 1)).toBe(true);
+  });
+
+  test('whitespace code → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', '   ', 1)).toBe(true);
+  });
+
+  test('null section → true (accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', null)).toBe(true);
+  });
+
+  test('undefined section → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', undefined)).toBe(true);
+  });
+
+  test('0 section → true (section accepted-and-ignored regardless of value)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 0)).toBe(true);
+  });
+
+  test('different code/section still passes (foundation does not match specifics)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ar', 99)).toBe(true);
+  });
+
+  test('first-match contract — two localeText_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section1" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/localeText_section2" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 1)).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -18202,6 +18202,160 @@ describe('Wake 89 — "<Name>\'s <Plat> UI shows non-empty <Language> text for s
     expect(r.ok).toBe(false);
     expect(r.error).toMatch(/Klingonese|language/);
   });
+
+  // Web driver returns false → fail / driver missing → fail
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsNonEmptyLocaleText: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web UI shows non-empty Arabic text for section 11" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/section|Arabic/);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web UI shows non-empty Arabic text for section 11" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsNonEmptyLocaleText/);
+  });
+
+  // Web Chromium variant
+  test('Web Chromium matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsNonEmptyLocaleText: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web Chromium UI shows non-empty Arabic text for section 11" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Layla', 'ar', 11);
+  });
+
+  test('Web Chromium driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsNonEmptyLocaleText: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web Chromium UI shows non-empty Arabic text for section 11" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/section|Arabic/);
+  });
+
+  test('Web Chromium driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web Chromium UI shows non-empty Arabic text for section 11" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsNonEmptyLocaleText/);
+  });
+
+  // Web Safari variant
+  test('Web Safari matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsNonEmptyLocaleText: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web Safari UI shows non-empty Arabic text for section 11" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Layla', 'ar', 11);
+  });
+
+  test('Web Safari driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsNonEmptyLocaleText: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web Safari UI shows non-empty Arabic text for section 11" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/section|Arabic/);
+  });
+
+  test('Web Safari driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web Safari UI shows non-empty Arabic text for section 11" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsNonEmptyLocaleText/);
+  });
+
+  // Android — full 3-test set
+  test('Android matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { androidShowsNonEmptyLocaleText: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Hayato's Android UI shows non-empty Japanese text for section 3" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Hayato', 'ja', 3);
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidShowsNonEmptyLocaleText: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Hayato's Android UI shows non-empty Japanese text for section 3" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/section|Japanese/);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Hayato's Android UI shows non-empty Japanese text for section 3" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.androidShowsNonEmptyLocaleText/);
+  });
+
+  // iOS Sim — full 3-test set
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosShowsNonEmptyLocaleText: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Yuki's iOS Sim UI shows non-empty Japanese text for section 3" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Yuki', 'ja', 3);
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsNonEmptyLocaleText: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Yuki's iOS Sim UI shows non-empty Japanese text for section 3" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/section|Japanese/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Yuki's iOS Sim UI shows non-empty Japanese text for section 3" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.iosShowsNonEmptyLocaleText/);
+  });
 });
 
 describe('Wake 89 — "<Name>\'s <Plat> UI disables the <X> input"', () => {


### PR DESCRIPTION
## Summary
- **Method:** `androidShowsNonEmptyLocaleText(name, code, section)` — j13 locale section assertion
- **Foundation:** `localeText_*` testTag PREFIX — no such testTag yet
- **Tests:** 26 driver + 17 runner (Wake 89 full 5-arm × 3-test + 2 pre-existing)

## Test plan
- [x] `npx jest -t "androidShowsNonEmptyLocaleText"` → 26/26
- [x] `npx jest -t "non-empty .* text for section"` → 17/17

🤖 Generated with [Claude Code](https://claude.com/claude-code)