### PR TITLE
feat(driver/android): androidShowsOfficialBadge (Wake 88)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1790,6 +1790,27 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 88 — `<Name>'s <Plat> UI shows the official badge[ <suffix>]`
+  // (j13/j18). Bare and suffixed forms; the optional trailing fragment
+  // is passed verbatim so the driver can dispatch to the right slot
+  // ("on the sender avatar", "with Arabic label", etc.).
+  //
+  // Foundation strategy: presence-check on the `officialBadge_*`
+  // testTag PREFIX. No `officialBadge_*` testTag exists in
+  // shared/src/commonMain yet — Official-user badge UI is unbuilt.
+  // Returns false in real journeys today; lands true when ships with
+  // officialBadge_icon / officialBadge_label.
+  //
+  // Per-suffix dispatch (avatar vs label, language variant) deferred.
+  // Both args (_name, _suffix) accepted-and-ignored.
+  driver.androidShowsOfficialBadge = async (_name, _suffix) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?officialBadge_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   const NOUN_KIND_TAGS = {
     'appeal::button': 'suspension_submitAppealButton',
   };

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -10057,8 +10057,9 @@ const matchers = [
           ? 'androidShowsOfficialBadge'
           : 'iosShowsOfficialBadge';
       const driver = platform.startsWith('Web') ? ctx.webDriver : ctx.uiDriver;
+      const driverName = platform.startsWith('Web') ? 'ctx.webDriver' : 'ctx.uiDriver';
       if (!driver?.[methodName]) {
-        return { ok: false, error: `ctx.uiDriver.${methodName} not configured` };
+        return { ok: false, error: `${driverName}.${methodName} not configured` };
       }
       const shown = await driver[methodName](name, suffix);
       if (!shown) {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -13276,3 +13276,243 @@ describe('android-adb-driver — androidShowsNonEmptyLocaleText', () => {
     expect(await driver.androidShowsNonEmptyLocaleText('Hayato', 'ja', 1)).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsOfficialBadge', () => {
+  // Wake 88 — `<Name>'s <Plat> UI shows the official badge[ <suffix>]`
+  // (j13/j18). Bare and suffixed forms; the optional trailing fragment
+  // is passed to the driver verbatim so it can dispatch to the right
+  // slot ("on the sender avatar", "with Arabic label", etc.).
+  //
+  // Foundation strategy: presence-check on the `officialBadge_*`
+  // testTag PREFIX. No `officialBadge_*` testTag exists in
+  // shared/src/commonMain yet — Official-user badge UI is unbuilt.
+  // Returns false in real journeys today; lands true when ships with
+  // officialBadge_icon / officialBadge_label.
+  //
+  // Per-suffix dispatch (avatar vs label, language variant) deferred.
+  // All 2 args (_name, _suffix) accepted-and-ignored. Note: runner
+  // coerces a missing suffix to `''`, never null/undefined — pin both
+  // forms defensively anyway.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('officialBadge_icon present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_icon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', '')).toBe(true);
+  });
+
+  test('officialBadge_label present + suffix passed → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_label" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', 'on the sender avatar')).toBe(true);
+  });
+
+  test('absent (no badge) → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', '')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', '')).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="officialBadge_icon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', '')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_icon"><node text="Official" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', '')).toBe(true);
+  });
+
+  test('left-boundary — pre_officialBadge_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_officialBadge_icon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', '')).toBe(false);
+  });
+
+  test('bare left-boundary — pre_officialBadge_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_officialBadge_icon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', '')).toBe(false);
+  });
+
+  test('right-boundary — officialBadge_iconExtra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_iconExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', '')).toBe(true);
+  });
+
+  test('confusable prefix — official_badgeRoot does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/official_badgeRoot" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', '')).toBe(false);
+  });
+
+  test('bare confusable prefix — official_badgeRoot does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="official_badgeRoot" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', '')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', '')).toBe(false);
+  });
+
+  test('name accepted-and-ignored — Layla passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_icon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Layla', '')).toBe(true);
+  });
+
+  test('null name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_icon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge(null, '')).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_icon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge(undefined, '')).toBe(true);
+  });
+
+  test('empty name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_icon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('', '')).toBe(true);
+  });
+
+  test('whitespace name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_icon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('   ', '')).toBe(true);
+  });
+
+  test('null suffix → true (defensive — runner passes empty string)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_icon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', null)).toBe(true);
+  });
+
+  test('undefined suffix → true (defensive — runner passes empty string)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_icon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', undefined)).toBe(true);
+  });
+
+  test('whitespace suffix → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_icon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', '   ')).toBe(true);
+  });
+
+  test('different suffix still passes (foundation does not dispatch on suffix)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_icon" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', 'with Arabic label')).toBe(true);
+  });
+
+  test('first-match contract — two officialBadge_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_icon" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/officialBadge_label" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOfficialBadge('Officia', '')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -17784,6 +17784,137 @@ describe('Wake 88 — "<Name>\'s <Plat> UI shows the official badge[ <suffix>]"'
     expect(r.ok).toBe(false);
     expect(r.error).toMatch(/Hayato|badge/);
   });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Hayato's Android UI shows the official badge" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.androidShowsOfficialBadge/);
+  });
+
+  // iOS Sim — full 3-test set
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosShowsOfficialBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Yuki's iOS Sim UI shows the official badge" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Yuki', '');
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsOfficialBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Yuki's iOS Sim UI shows the official badge" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Yuki|badge/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Yuki's iOS Sim UI shows the official badge" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.iosShowsOfficialBadge/);
+  });
+
+  // Web — full 3-test set (Web ok already covered above by arabic-label test)
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsOfficialBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web UI shows the official badge" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Layla|badge/);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web UI shows the official badge" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsOfficialBadge/);
+  });
+
+  // Web Chromium variant
+  test('Web Chromium matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsOfficialBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web Chromium UI shows the official badge" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Layla', '');
+  });
+
+  test('Web Chromium driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsOfficialBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web Chromium UI shows the official badge" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Layla|badge/);
+  });
+
+  test('Web Chromium driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web Chromium UI shows the official badge" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsOfficialBadge/);
+  });
+
+  // Web Safari variant
+  test('Web Safari matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsOfficialBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web Safari UI shows the official badge" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Layla', '');
+  });
+
+  test('Web Safari driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsOfficialBadge: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web Safari UI shows the official badge" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Layla|badge/);
+  });
+
+  test('Web Safari driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Layla's Web Safari UI shows the official badge" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsOfficialBadge/);
+  });
 });
 
 describe('Wake 88 — "<Name> on <Plat> opens <Other>\'s profile and taps "<X>""', () => {


### PR DESCRIPTION
## Summary
- **Method:** `androidShowsOfficialBadge(name, suffix)` — j13/j18 official badge
- **Foundation:** `officialBadge_*` testTag PREFIX
- **Tests:** 22 driver + 16 runner

## Test plan
- [x] driver: 22/22
- [x] runner: 16/16

🤖 Generated with [Claude Code](https://claude.com/claude-code)