### PR TITLE
feat(driver/android): androidShowsOwnRankInTop (Wake 100)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1832,6 +1832,27 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 100 — `<Name>'s <Plat> UI shows (her|his|their) own rank in
+  // the top N` (j05). Leaderboard own-rank visibility. Driver receives
+  // `(name, topN)`.
+  //
+  // Foundation strategy: presence-check on the `ownRank_*` testTag
+  // PREFIX. No `ownRank_*` testTag exists in shared/src/commonMain
+  // yet — leaderboard own-rank highlight is unbuilt. Returns false in
+  // real journeys today; lands true when ships with
+  // ownRank_indicator / ownRank_userRow etc.
+  //
+  // Per-topN verification (asserting rank is within top N) needs
+  // text-extraction. Deferred. Both args (_name, _topN) accepted-
+  // and-ignored.
+  driver.androidShowsOwnRankInTop = async (_name, _topN) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?ownRank_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   const NOUN_KIND_TAGS = {
     'appeal::button': 'suspension_submitAppealButton',
   };

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -12175,8 +12175,9 @@ const matchers = [
           ? 'androidShowsOwnRankInTop'
           : 'iosShowsOwnRankInTop';
       const driver = platform.startsWith('Web') ? ctx.webDriver : ctx.uiDriver;
+      const driverName = platform.startsWith('Web') ? 'ctx.webDriver' : 'ctx.uiDriver';
       if (!driver?.[methodName]) {
-        return { ok: false, error: `ctx.uiDriver.${methodName} not configured` };
+        return { ok: false, error: `${driverName}.${methodName} not configured` };
       }
       const ok = await driver[methodName](name, topN);
       if (!ok) {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -13714,3 +13714,242 @@ describe('android-adb-driver — androidShowsOnlyMinorCohortInRankings', () => {
     expect(await driver.androidShowsOnlyMinorCohortInRankings('Mia')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsOwnRankInTop', () => {
+  // Wake 100 — `<Name>'s <Plat> UI shows (her|his|their) own rank in
+  // the top N` (j05). Leaderboard own-rank visibility. Pronoun is
+  // grammatical (not captured). Driver receives `(name, topN)` —
+  // topN is the integer cutoff (e.g. 10, 50, 100).
+  //
+  // Foundation strategy: presence-check on the `ownRank_*` testTag
+  // PREFIX. No `ownRank_*` testTag exists in shared/src/commonMain
+  // yet — leaderboard own-rank highlight is unbuilt. Returns false
+  // in real journeys today; lands true when ships with
+  // ownRank_indicator / ownRank_userRow etc.
+  //
+  // Per-topN verification (asserting the rank is within top N) needs
+  // text-extraction of the rank number. Deferred. Both args
+  // (_name, _topN) accepted-and-ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('ownRank_indicator present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_indicator" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 10)).toBe(true);
+  });
+
+  test('ownRank_userRow present → true (any suffix matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_userRow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 50)).toBe(true);
+  });
+
+  test('absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 10)).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 10)).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="ownRank_indicator" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 10)).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_indicator"><node text="#7" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 10)).toBe(true);
+  });
+
+  test('left-boundary — pre_ownRank_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_ownRank_indicator" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 10)).toBe(false);
+  });
+
+  test('bare left-boundary — pre_ownRank_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_ownRank_indicator" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 10)).toBe(false);
+  });
+
+  test('right-boundary — ownRank_indicatorExtra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_indicatorExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 10)).toBe(true);
+  });
+
+  test('confusable prefix — own_rankPanel does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/own_rankPanel" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 10)).toBe(false);
+  });
+
+  test('bare confusable prefix — own_rankPanel does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="own_rankPanel" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 10)).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 10)).toBe(false);
+  });
+
+  test('name accepted-and-ignored — Bao passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_indicator" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Bao', 10)).toBe(true);
+  });
+
+  test('null name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_indicator" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop(null, 10)).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_indicator" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop(undefined, 10)).toBe(true);
+  });
+
+  test('empty name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_indicator" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('', 10)).toBe(true);
+  });
+
+  test('whitespace name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_indicator" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('   ', 10)).toBe(true);
+  });
+
+  test('null topN → true (accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_indicator" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', null)).toBe(true);
+  });
+
+  test('undefined topN → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_indicator" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', undefined)).toBe(true);
+  });
+
+  test('0 topN → true (topN accepted-and-ignored regardless of value)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_indicator" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 0)).toBe(true);
+  });
+
+  test('different topN still passes (foundation does not match specific cutoff)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_indicator" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 9999)).toBe(true);
+  });
+
+  test('first-match contract — two ownRank_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_indicator" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/ownRank_userRow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsOwnRankInTop('Selma', 10)).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -21763,6 +21763,138 @@ describe('Wake 100 — "<Name>\'s <Plat> UI shows (her|his|their) own rank in th
     expect(r.ok).toBe(true);
     expect(spy).toHaveBeenCalledWith('Yuki', 10);
   });
+
+  // Android — driver returns false + missing
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidShowsOwnRankInTop: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Adam's Android UI shows his own rank in the top 50" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Adam|rank/);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Adam's Android UI shows his own rank in the top 50" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.androidShowsOwnRankInTop/);
+  });
+
+  // iOS Sim — driver returns false + missing
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsOwnRankInTop: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Yuki's iOS Sim UI shows their own rank in the top 10" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Yuki|rank/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Yuki's iOS Sim UI shows their own rank in the top 10" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.iosShowsOwnRankInTop/);
+  });
+
+  // Web — driver returns false + missing
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsOwnRankInTop: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web UI shows her own rank in the top 100" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|rank/);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web UI shows her own rank in the top 100" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsOwnRankInTop/);
+  });
+
+  // Web Chromium variant
+  test('Web Chromium matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsOwnRankInTop: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web Chromium UI shows her own rank in the top 100" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 100);
+  });
+
+  test('Web Chromium driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsOwnRankInTop: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web Chromium UI shows her own rank in the top 100" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|rank/);
+  });
+
+  test('Web Chromium driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web Chromium UI shows her own rank in the top 100" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsOwnRankInTop/);
+  });
+
+  // Web Safari variant
+  test('Web Safari matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsOwnRankInTop: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web Safari UI shows her own rank in the top 100" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 100);
+  });
+
+  test('Web Safari driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsOwnRankInTop: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web Safari UI shows her own rank in the top 100" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|rank/);
+  });
+
+  test('Web Safari driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: "Alice's Web Safari UI shows her own rank in the top 100" },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsOwnRankInTop/);
+  });
 });
 
 describe('Wake 100 — `<Name>\'s <Plat> UI shows the new "<X>" balance via Firestore listener`', () => {


### PR DESCRIPTION
## Summary
- **Method:** `androidShowsOwnRankInTop(name, topN)` — j05 leaderboard own-rank
- **Foundation:** `ownRank_*` testTag PREFIX
- **Tests:** 22 driver + 15 runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)