### PR TITLE
feat(driver/android): androidShowsRoomWarningBanner (Wake 97)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1872,6 +1872,27 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 97 — `<Name>'s <Plat> UI shows the warning banner overlay on
+  // top of the room` (j10). Cohort-warning overlay assertion. Driver
+  // receives `(name)`.
+  //
+  // Foundation strategy: presence-check on the `roomWarningBanner_*`
+  // testTag PREFIX. No `roomWarningBanner_*` testTag exists in
+  // shared/src/commonMain yet — the in-room overlay variant is unbuilt
+  // (the full-screen `warning_*` family in WarningScreen.kt:82+ is a
+  // distinct concern — different journey trigger). Returns false in
+  // real journeys today; lands true when ships with
+  // roomWarningBanner_overlay / _title etc.
+  //
+  // The `_name` arg is accepted-and-ignored.
+  driver.androidShowsRoomWarningBanner = async (_name) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?roomWarningBanner_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   const NOUN_KIND_TAGS = {
     'appeal::button': 'suspension_submitAppealButton',
   };

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -11574,8 +11574,9 @@ const matchers = [
           ? 'androidShowsRoomWarningBanner'
           : 'iosShowsRoomWarningBanner';
       const driver = platform.startsWith('Web') ? ctx.webDriver : ctx.uiDriver;
+      const driverName = platform.startsWith('Web') ? 'ctx.webDriver' : 'ctx.uiDriver';
       if (!driver?.[methodName]) {
-        return { ok: false, error: `ctx.uiDriver.${methodName} not configured` };
+        return { ok: false, error: `${driverName}.${methodName} not configured` };
       }
       const ok = await driver[methodName](name);
       if (!ok) {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -14150,3 +14150,214 @@ describe('android-adb-driver — androidShowsRoomClosedSummary', () => {
     expect(await driver.androidShowsRoomClosedSummary('Selma')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsRoomWarningBanner', () => {
+  // Wake 97 — `<Name>'s <Plat> UI shows the warning banner overlay on
+  // top of the room` (j10). Cohort-warning overlay assertion. Driver
+  // receives `(name)`.
+  //
+  // Foundation strategy: presence-check on the `roomWarningBanner_*`
+  // testTag PREFIX. No `roomWarningBanner_*` testTag exists in
+  // shared/src/commonMain yet — the in-room warning overlay is unbuilt
+  // (the full-screen WarningScreen.kt is distinct; the overlay variant
+  // is the j10 concern). Returns false in real journeys today; lands
+  // true when ships with roomWarningBanner_overlay / _title etc.
+  //
+  // Distinct-from `warning_*` (WarningScreen.kt's full-screen tags):
+  // similar-but-distinct guard pinned. `_name` accepted-and-ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('roomWarningBanner_overlay present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomWarningBanner_overlay" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(true);
+  });
+
+  test('roomWarningBanner_title present → true (any suffix matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomWarningBanner_title" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(true);
+  });
+
+  test('absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="roomWarningBanner_overlay" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomWarningBanner_overlay"><node text="Warning" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(true);
+  });
+
+  test('left-boundary — pre_roomWarningBanner_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_roomWarningBanner_overlay" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(false);
+  });
+
+  test('bare left-boundary — pre_roomWarningBanner_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_roomWarningBanner_overlay" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(false);
+  });
+
+  test('right-boundary — roomWarningBanner_overlayExtra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomWarningBanner_overlayExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(true);
+  });
+
+  test('confusable prefix — roomWarning_bannerOther does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomWarning_bannerOther" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(false);
+  });
+
+  test('bare confusable prefix — roomWarning_bannerOther does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="roomWarning_bannerOther" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(false);
+  });
+
+  test('similar-but-distinct — warning_title (WarningScreen full-screen tag) does NOT match', async () => {
+    // WarningScreen.kt:82 exposes warning_title for the FULL-SCREEN
+    // warning, distinct from the j10 in-room overlay. Pin that they
+    // don't conflate — different journey concerns.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/warning_title" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(false);
+  });
+
+  test('name accepted-and-ignored — Bao passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomWarningBanner_overlay" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Bao')).toBe(true);
+  });
+
+  test('null name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomWarningBanner_overlay" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner(null)).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomWarningBanner_overlay" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner(undefined)).toBe(true);
+  });
+
+  test('empty name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomWarningBanner_overlay" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('')).toBe(true);
+  });
+
+  test('whitespace name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomWarningBanner_overlay" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('   ')).toBe(true);
+  });
+
+  test('first-match contract — two roomWarningBanner_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomWarningBanner_overlay" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/roomWarningBanner_title" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -20512,7 +20512,189 @@ describe('Wake 97 — "<Name>\'s <Plat> UI shows the warning banner overlay on t
       ctx,
     );
     expect(r.ok).toBe(false);
-    expect(r.error).toMatch(/androidShowsRoomWarningBanner/);
+    expect(r.error).toMatch(/ctx\.uiDriver\.androidShowsRoomWarningBanner/);
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidShowsRoomWarningBanner: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Theo's Android UI shows the warning banner overlay on top of the room",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Theo|warning|banner/);
+  });
+
+  // iOS Sim
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosShowsRoomWarningBanner: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Theo's iOS Sim UI shows the warning banner overlay on top of the room",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Theo');
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsRoomWarningBanner: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Theo's iOS Sim UI shows the warning banner overlay on top of the room",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Theo|warning|banner/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Theo's iOS Sim UI shows the warning banner overlay on top of the room",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.iosShowsRoomWarningBanner/);
+  });
+
+  // Web
+  test('Web matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsRoomWarningBanner: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Theo's Web UI shows the warning banner overlay on top of the room",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Theo');
+  });
+
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsRoomWarningBanner: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Theo's Web UI shows the warning banner overlay on top of the room",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Theo|warning|banner/);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Theo's Web UI shows the warning banner overlay on top of the room",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsRoomWarningBanner/);
+  });
+
+  // Web Chromium
+  test('Web Chromium matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsRoomWarningBanner: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Theo's Web Chromium UI shows the warning banner overlay on top of the room",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Theo');
+  });
+
+  test('Web Chromium driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsRoomWarningBanner: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Theo's Web Chromium UI shows the warning banner overlay on top of the room",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Theo|warning|banner/);
+  });
+
+  test('Web Chromium driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Theo's Web Chromium UI shows the warning banner overlay on top of the room",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsRoomWarningBanner/);
+  });
+
+  // Web Safari
+  test('Web Safari matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsRoomWarningBanner: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Theo's Web Safari UI shows the warning banner overlay on top of the room",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Theo');
+  });
+
+  test('Web Safari driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsRoomWarningBanner: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Theo's Web Safari UI shows the warning banner overlay on top of the room",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Theo|warning|banner/);
+  });
+
+  test('Web Safari driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: "Theo's Web Safari UI shows the warning banner overlay on top of the room",
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsRoomWarningBanner/);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Method:** `androidShowsRoomWarningBanner(name)` — j10 cohort warning overlay
- **Foundation:** `roomWarningBanner_*` testTag PREFIX (distinct from WarningScreen's full-screen `warning_*`)
- **Tests:** 19 driver + 15 runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)