### PR TITLE
feat(driver/android): androidShowsSeatRequestNotification (Wake 101)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1893,6 +1893,27 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 101 — `<Name>'s <Plat> UI shows a seat-request notification
+  // with "<X>" + approve/deny` (j09). Host receives notification when
+  // a participant requests a seat. Driver receives `(host, requester)`.
+  //
+  // Foundation strategy: presence-check on the
+  // `seatRequestNotification_*` testTag PREFIX. No
+  // `seatRequestNotification_*` testTag exists in shared/src/commonMain
+  // yet — host-side notification UI is unbuilt. Returns false in real
+  // journeys today; lands true when ships with
+  // seatRequestNotification_toast / _actionRow etc.
+  //
+  // Distinct-from `seatRequest_*` (#766 — the host approval button
+  // family). Both args (_host, _requester) accepted-and-ignored.
+  driver.androidShowsSeatRequestNotification = async (_host, _requester) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?seatRequestNotification_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   const NOUN_KIND_TAGS = {
     'appeal::button': 'suspension_submitAppealButton',
   };

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -12352,8 +12352,9 @@ const matchers = [
           ? 'androidShowsSeatRequestNotification'
           : 'iosShowsSeatRequestNotification';
       const driver = platform.startsWith('Web') ? ctx.webDriver : ctx.uiDriver;
+      const driverName = platform.startsWith('Web') ? 'ctx.webDriver' : 'ctx.uiDriver';
       if (!driver?.[methodName]) {
-        return { ok: false, error: `ctx.uiDriver.${methodName} not configured` };
+        return { ok: false, error: `${driverName}.${methodName} not configured` };
       }
       const ok = await driver[methodName](host, requester);
       if (!ok) {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -14361,3 +14361,266 @@ describe('android-adb-driver — androidShowsRoomWarningBanner', () => {
     expect(await driver.androidShowsRoomWarningBanner('Theo')).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsSeatRequestNotification', () => {
+  // Wake 101 — `<Name>'s <Plat> UI shows a seat-request notification
+  // with "<X>" + approve/deny` (j09). Host receives notification when
+  // a participant requests a seat. Driver receives `(host, requester)`.
+  //
+  // Foundation strategy: presence-check on the
+  // `seatRequestNotification_*` testTag PREFIX. No
+  // `seatRequestNotification_*` testTag exists in
+  // shared/src/commonMain yet — host-side notification UI is unbuilt.
+  // Returns false in real journeys today; lands true when ships with
+  // seatRequestNotification_toast / seatRequestNotification_actionRow
+  // etc.
+  //
+  // Distinct-from `seatRequest_*` (#766 — the host approval button
+  // family); similar-but-distinct guard pinned. Both args (_host,
+  // _requester) accepted-and-ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('seatRequestNotification_toast present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(true);
+  });
+
+  test('seatRequestNotification_actionRow present → true (any suffix matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_actionRow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(true);
+  });
+
+  test('absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toast"><node text="Bao requests" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(true);
+  });
+
+  test('left-boundary — pre_seatRequestNotification_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(false);
+  });
+
+  test('bare left-boundary — pre_seatRequestNotification_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(false);
+  });
+
+  test('right-boundary — seatRequestNotification_toastExtra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toastExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(true);
+  });
+
+  test('confusable prefix — seatRequest_Notification does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_Notification" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(false);
+  });
+
+  test('bare confusable prefix — seatRequest_Notification does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="seatRequest_Notification" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(false);
+  });
+
+  test('similar-but-distinct — seatRequest_approveButton (host action) does NOT match', async () => {
+    // PR #766 shipped seatRequest_* for the host APPROVAL button.
+    // Distinct from the host-side seatRequestNotification_* for the
+    // incoming-request toast. Pin that they don't conflate.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequest_approveButton" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(false);
+  });
+
+  test('host accepted-and-ignored — Ines passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Ines', 'Bao')).toBe(true);
+  });
+
+  test('null host → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification(null, 'Bao')).toBe(true);
+  });
+
+  test('undefined host → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification(undefined, 'Bao')).toBe(true);
+  });
+
+  test('empty host → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('', 'Bao')).toBe(true);
+  });
+
+  test('whitespace host → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('   ', 'Bao')).toBe(true);
+  });
+
+  test('null requester → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', null)).toBe(true);
+  });
+
+  test('undefined requester → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', undefined)).toBe(true);
+  });
+
+  test('empty requester → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', '')).toBe(true);
+  });
+
+  test('whitespace requester → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', '   ')).toBe(true);
+  });
+
+  test('different requester still passes (foundation does not match specific user)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toast" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'NotInRequest')).toBe(true);
+  });
+
+  test('first-match contract — two seatRequestNotification_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_toast" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/seatRequestNotification_actionRow" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsSeatRequestNotification('Alice', 'Bao')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -22184,18 +22184,122 @@ describe('Wake 101 — "(either )?<Name>\'s <Plat> UI is still in the room <suff
 });
 
 describe('Wake 101 — `<Name>\'s <Plat> UI shows a seat-request notification with "<X>" + approve/deny`', () => {
+  const seatReqText = (platform) =>
+    `Theo's ${platform} UI shows a seat-request notification with "Ines" + approve/deny`;
+
   test('matching → ok', async () => {
     const spy = jest.fn(async () => true);
     const ctx = makeCtx({ uiDriver: { androidShowsSeatRequestNotification: spy } });
-    const r = await executeStep(
-      {
-        kind: 'Then',
-        text: 'Theo\'s Android UI shows a seat-request notification with "Ines" + approve/deny',
-      },
-      ctx,
-    );
+    const r = await executeStep({ kind: 'Then', text: seatReqText('Android') }, ctx);
     expect(r.ok).toBe(true);
     expect(spy).toHaveBeenCalledWith('Theo', 'Ines');
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidShowsSeatRequestNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: seatReqText('Android') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Theo|seat-request/);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: seatReqText('Android') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.androidShowsSeatRequestNotification/);
+  });
+
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosShowsSeatRequestNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: seatReqText('iOS Sim') }, ctx);
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Theo', 'Ines');
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsSeatRequestNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: seatReqText('iOS Sim') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Theo|seat-request/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: seatReqText('iOS Sim') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.iosShowsSeatRequestNotification/);
+  });
+
+  test('Web matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsSeatRequestNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: seatReqText('Web') }, ctx);
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Theo', 'Ines');
+  });
+
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsSeatRequestNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: seatReqText('Web') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Theo|seat-request/);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: seatReqText('Web') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsSeatRequestNotification/);
+  });
+
+  test('Web Chromium matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsSeatRequestNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: seatReqText('Web Chromium') }, ctx);
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Theo', 'Ines');
+  });
+
+  test('Web Chromium driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsSeatRequestNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: seatReqText('Web Chromium') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Theo|seat-request/);
+  });
+
+  test('Web Chromium driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: seatReqText('Web Chromium') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsSeatRequestNotification/);
+  });
+
+  test('Web Safari matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsSeatRequestNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: seatReqText('Web Safari') }, ctx);
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Theo', 'Ines');
+  });
+
+  test('Web Safari driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsSeatRequestNotification: spy } });
+    const r = await executeStep({ kind: 'Then', text: seatReqText('Web Safari') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Theo|seat-request/);
+  });
+
+  test('Web Safari driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: seatReqText('Web Safari') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsSeatRequestNotification/);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Method:** `androidShowsSeatRequestNotification(host, requester)` — j09 host-side notification
- **Foundation:** `seatRequestNotification_*` testTag PREFIX (distinct from #766's `seatRequest_*`)
- **Tests:** 24 driver + 15 runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)