### PR TITLE
feat(driver/android): androidShowsToastAndNavigates (Wake 93)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1935,6 +1935,26 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 93 — `OR within Nms <Name>'s <Plat> UI shows a "<X>" toast
+  // and navigates back to "<Y>"` (j10:36). Alternate-outcome step.
+  // Driver receives `(name, toast, route, timeout)`.
+  //
+  // Foundation strategy: presence-check on the `toastWithRoute_*`
+  // testTag PREFIX. No `toastWithRoute_*` testTag exists in
+  // shared/src/commonMain yet — toast-with-navigation combination is
+  // unbuilt. Returns false in real journeys today; lands true when
+  // ships with toastWithRoute_text / toastWithRoute_destination etc.
+  //
+  // Per-toast / per-route / timeout verification deferred. All 4 args
+  // (_name, _toast, _route, _timeout) accepted-and-ignored.
+  driver.androidShowsToastAndNavigates = async (_name, _toast, _route, _timeout) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?toastWithRoute_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   const NOUN_KIND_TAGS = {
     'appeal::button': 'suspension_submitAppealButton',
   };

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -10940,8 +10940,9 @@ const matchers = [
           ? 'androidShowsToastAndNavigates'
           : 'iosShowsToastAndNavigates';
       const driver = platform.startsWith('Web') ? ctx.webDriver : ctx.uiDriver;
+      const driverName = platform.startsWith('Web') ? 'ctx.webDriver' : 'ctx.uiDriver';
       if (!driver?.[methodName]) {
-        return { ok: false, error: `ctx.uiDriver.${methodName} not configured` };
+        return { ok: false, error: `${driverName}.${methodName} not configured` };
       }
       const ok = await driver[methodName](name, toast, route, timeout);
       if (!ok) {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -14862,3 +14862,324 @@ describe('android-adb-driver — androidShowsStalkersDelta', () => {
     expect(await driver.androidShowsStalkersDelta('Alice', 1)).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsToastAndNavigates', () => {
+  // Wake 93 — `OR within Nms <Name>'s <Plat> UI shows a "<X>" toast
+  // and navigates back to "<Y>"` (j10:36). Alternate-outcome step
+  // (runner treats `OR within` as a normal Then; if THIS condition
+  // holds within timeout, the alternate is satisfied). Driver
+  // receives `(name, toast, route, timeout)`.
+  //
+  // Foundation strategy: presence-check on the `toastWithRoute_*`
+  // testTag PREFIX. No `toastWithRoute_*` testTag exists in
+  // shared/src/commonMain yet — toast-with-navigation combination is
+  // unbuilt. Returns false in real journeys today; lands true when
+  // ships with toastWithRoute_text / toastWithRoute_destination etc.
+  //
+  // Per-toast / per-route / timeout verification deferred. All 4 args
+  // (_name, _toast, _route, _timeout) accepted-and-ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('toastWithRoute_text present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'Room closed', '/rooms', 5000)).toBe(
+      true,
+    );
+  });
+
+  test('toastWithRoute_destination present → true (any suffix matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_destination" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 1000)).toBe(true);
+  });
+
+  test('absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 1000)).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 1000)).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 1000)).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text"><node text="Room closed" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 1000)).toBe(true);
+  });
+
+  test('left-boundary — pre_toastWithRoute_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 1000)).toBe(false);
+  });
+
+  test('bare left-boundary — pre_toastWithRoute_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 1000)).toBe(false);
+  });
+
+  test('right-boundary — toastWithRoute_textExtra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_textExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 1000)).toBe(true);
+  });
+
+  test('confusable prefix — toast_withRoute does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toast_withRoute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 1000)).toBe(false);
+  });
+
+  test('bare confusable prefix — toast_withRoute does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="toast_withRoute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 1000)).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 1000)).toBe(false);
+  });
+
+  test('name accepted-and-ignored — Bao passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Bao', 'X', '/y', 1000)).toBe(true);
+  });
+
+  test('null name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates(null, 'X', '/y', 1000)).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates(undefined, 'X', '/y', 1000)).toBe(true);
+  });
+
+  test('empty name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('', 'X', '/y', 1000)).toBe(true);
+  });
+
+  test('whitespace name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('   ', 'X', '/y', 1000)).toBe(true);
+  });
+
+  test('null toast → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', null, '/y', 1000)).toBe(true);
+  });
+
+  test('undefined toast → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', undefined, '/y', 1000)).toBe(true);
+  });
+
+  test('empty toast → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', '', '/y', 1000)).toBe(true);
+  });
+
+  test('whitespace toast → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', '   ', '/y', 1000)).toBe(true);
+  });
+
+  test('null route → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', null, 1000)).toBe(true);
+  });
+
+  test('undefined route → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', undefined, 1000)).toBe(true);
+  });
+
+  test('empty route → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '', 1000)).toBe(true);
+  });
+
+  test('whitespace route → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '   ', 1000)).toBe(true);
+  });
+
+  test('null timeout → true (timeout accepted-and-ignored)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', null)).toBe(true);
+  });
+
+  test('undefined timeout → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', undefined)).toBe(true);
+  });
+
+  test('0 timeout → true (timeout accepted-and-ignored regardless of value)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 0)).toBe(true);
+  });
+
+  test('different toast/route still passes (foundation does not match specifics)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'AnyToast', '/any', 9999)).toBe(true);
+  });
+
+  test('first-match contract — two toastWithRoute_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_destination" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 1000)).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -19652,6 +19652,187 @@ describe('Wake 93 — `OR within Nms <Name>\'s <Plat> UI shows a "<X>" toast and
     expect(r.ok).toBe(false);
     expect(r.error).toMatch(/toast|nav/);
   });
+
+  test('iOS Sim no driver → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'OR within 3000ms Bao\'s iOS Sim UI shows a "X" toast and navigates back to "/y"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.iosShowsToastAndNavigates/);
+  });
+
+  // Android — full 3-test set
+  test('Android matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { androidShowsToastAndNavigates: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'OR within 3000ms Theo\'s Android UI shows a "Closed" toast and navigates back to "/rooms"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Theo', 'Closed', '/rooms', 3000);
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidShowsToastAndNavigates: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'OR within 3000ms Theo\'s Android UI shows a "Closed" toast and navigates back to "/rooms"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/toast|nav/);
+  });
+
+  test('Android no driver → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'OR within 3000ms Theo\'s Android UI shows a "Closed" toast and navigates back to "/rooms"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.androidShowsToastAndNavigates/);
+  });
+
+  // Web — full 3-test set
+  test('Web matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsToastAndNavigates: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'OR within 3000ms Alice\'s Web UI shows a "Closed" toast and navigates back to "/rooms"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'Closed', '/rooms', 3000);
+  });
+
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsToastAndNavigates: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'OR within 3000ms Alice\'s Web UI shows a "Closed" toast and navigates back to "/rooms"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/toast|nav/);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'OR within 3000ms Alice\'s Web UI shows a "Closed" toast and navigates back to "/rooms"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsToastAndNavigates/);
+  });
+
+  // Web Chromium variant
+  test('Web Chromium matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsToastAndNavigates: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'OR within 3000ms Alice\'s Web Chromium UI shows a "Closed" toast and navigates back to "/rooms"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'Closed', '/rooms', 3000);
+  });
+
+  test('Web Chromium driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsToastAndNavigates: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'OR within 3000ms Alice\'s Web Chromium UI shows a "Closed" toast and navigates back to "/rooms"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/toast|nav/);
+  });
+
+  test('Web Chromium driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'OR within 3000ms Alice\'s Web Chromium UI shows a "Closed" toast and navigates back to "/rooms"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsToastAndNavigates/);
+  });
+
+  // Web Safari variant
+  test('Web Safari matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsToastAndNavigates: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'OR within 3000ms Alice\'s Web Safari UI shows a "Closed" toast and navigates back to "/rooms"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'Closed', '/rooms', 3000);
+  });
+
+  test('Web Safari driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsToastAndNavigates: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'OR within 3000ms Alice\'s Web Safari UI shows a "Closed" toast and navigates back to "/rooms"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/toast|nav/);
+  });
+
+  test('Web Safari driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'OR within 3000ms Alice\'s Web Safari UI shows a "Closed" toast and navigates back to "/rooms"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsToastAndNavigates/);
+  });
 });
 
 describe('Wake 93 — "the PM does NOT render in English even if <Sender>\'s locale is en"', () => {


### PR DESCRIPTION
## Summary
- **Method:** `androidShowsToastAndNavigates(name, toast, route, timeout)` — j10 alternate-outcome toast+nav
- **Foundation:** `toastWithRoute_*` testTag PREFIX
- **Tests:** 22 driver + 16 runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)