### PR TITLE
feat(driver/android): androidShowsToastAndNavigatesBack (Wake 104)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -1955,6 +1955,26 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 104 — `<Name>'s <Plat> UI shows a "<X>" toast and navigates
+  // back to "<Y>"` (j10). Toast + nav (no timeout prefix; distinct
+  // from Wake 93's `OR within Nms` variant — both share the same
+  // toast+route surface). Driver receives `(name, toast, route)`.
+  //
+  // Foundation strategy: presence-check on the `toastWithRoute_*`
+  // testTag PREFIX — same family as #784's `androidShowsToastAndNavigates`
+  // (j10 toast+nav surface is shared between OR-variant and direct
+  // variant). Returns false in real journeys today.
+  //
+  // Per-toast / per-route verification deferred. All 3 args (_name,
+  // _toast, _route) accepted-and-ignored.
+  driver.androidShowsToastAndNavigatesBack = async (_name, _toast, _route) => {
+    const dump = await driver.androidUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<node[^>]*resource-id="(?:[^"]*:id\/)?toastWithRoute_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   const NOUN_KIND_TAGS = {
     'appeal::button': 'suspension_submitAppealButton',
   };

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -12772,8 +12772,9 @@ const matchers = [
           ? 'androidShowsToastAndNavigatesBack'
           : 'iosShowsToastAndNavigatesBack';
       const driver = platform.startsWith('Web') ? ctx.webDriver : ctx.uiDriver;
+      const driverName = platform.startsWith('Web') ? 'ctx.webDriver' : 'ctx.uiDriver';
       if (!driver?.[methodName]) {
-        return { ok: false, error: `ctx.uiDriver.${methodName} not configured` };
+        return { ok: false, error: `${driverName}.${methodName} not configured` };
       }
       const ok = await driver[methodName](name, toast, route);
       if (!ok) {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -15183,3 +15183,294 @@ describe('android-adb-driver — androidShowsToastAndNavigates', () => {
     expect(await driver.androidShowsToastAndNavigates('Theo', 'X', '/y', 1000)).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidShowsToastAndNavigatesBack', () => {
+  // Wake 104 — `<Name>'s <Plat> UI shows a "<X>" toast and navigates
+  // back to "<Y>"` (j10). Toast + nav (no timeout prefix; distinct
+  // from Wake 93's `OR within Nms` variant — both share the same
+  // toast+route surface). Driver receives `(name, toast, route)`.
+  //
+  // Foundation strategy: presence-check on the `toastWithRoute_*`
+  // testTag PREFIX — same family as #784's `androidShowsToastAndNavigates`
+  // (j10 toast+nav surface is shared between the OR-variant and the
+  // direct variant). Returns false in real journeys today; lands true
+  // when ships with toastWithRoute_text / toastWithRoute_destination
+  // etc.
+  //
+  // Per-toast / per-route verification deferred. All 3 args (_name,
+  // _toast, _route) accepted-and-ignored.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('toastWithRoute_text present → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'Room closed', '/rooms')).toBe(
+      true,
+    );
+  });
+
+  test('toastWithRoute_destination present → true (any suffix matches)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_destination" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '/y')).toBe(true);
+  });
+
+  test('absent → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '/y')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '/y')).toBe(false);
+  });
+
+  test('bare resource-id → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '/y')).toBe(true);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text"><node text="Room closed" /></node>',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '/y')).toBe(true);
+  });
+
+  test('left-boundary — pre_toastWithRoute_X does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/pre_toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '/y')).toBe(false);
+  });
+
+  test('bare left-boundary — pre_toastWithRoute_X does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="pre_toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '/y')).toBe(false);
+  });
+
+  test('right-boundary — toastWithRoute_textExtra still matches (prefix contract)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_textExtra" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '/y')).toBe(true);
+  });
+
+  test('confusable prefix — toast_withRoute does NOT match (package-qualified)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toast_withRoute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '/y')).toBe(false);
+  });
+
+  test('bare confusable prefix — toast_withRoute does NOT match', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="toast_withRoute" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '/y')).toBe(false);
+  });
+
+  test('uiautomator dump throws → false', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'uiautomator' 'dump'")) {
+        throw new Error('adb: device offline');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '/y')).toBe(false);
+  });
+
+  test('name accepted-and-ignored — Bao passes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Bao', 'X', '/y')).toBe(true);
+  });
+
+  test('null name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack(null, 'X', '/y')).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack(undefined, 'X', '/y')).toBe(true);
+  });
+
+  test('empty name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('', 'X', '/y')).toBe(true);
+  });
+
+  test('whitespace name → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('   ', 'X', '/y')).toBe(true);
+  });
+
+  test('null toast → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', null, '/y')).toBe(true);
+  });
+
+  test('undefined toast → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', undefined, '/y')).toBe(true);
+  });
+
+  test('empty toast → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', '', '/y')).toBe(true);
+  });
+
+  test('whitespace toast → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', '   ', '/y')).toBe(true);
+  });
+
+  test('null route → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', null)).toBe(true);
+  });
+
+  test('undefined route → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', undefined)).toBe(true);
+  });
+
+  test('empty route → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '')).toBe(true);
+  });
+
+  test('whitespace route → true', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '   ')).toBe(true);
+  });
+
+  test('different toast/route still passes (foundation does not match specifics)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'AnyToast', '/any')).toBe(true);
+  });
+
+  test('first-match contract — two toastWithRoute_* nodes', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_text" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/toastWithRoute_destination" />',
+    });
+    const driver = await createAndroidDriver();
+    expect(await driver.androidShowsToastAndNavigatesBack('Theo', 'X', '/y')).toBe(true);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -23291,18 +23291,122 @@ describe('Wake 103 — "<Name>\'s <Plat> UI shows the room-closed summary panel"
 // ── Wake 104 — j10/j11/j12 narrows ──────────────────────────────────
 
 describe('Wake 104 — `<Name>\'s <Plat> UI shows a "<X>" toast and navigates back to "<Y>"`', () => {
+  const tnbText = (platform) =>
+    `Ines's ${platform} UI shows a "Room closed by host warning" toast and navigates back to "/rooms"`;
+
   test('matching → ok', async () => {
     const spy = jest.fn(async () => true);
     const ctx = makeCtx({ uiDriver: { iosShowsToastAndNavigatesBack: spy } });
-    const r = await executeStep(
-      {
-        kind: 'Then',
-        text: 'Ines\'s iOS Sim UI shows a "Room closed by host warning" toast and navigates back to "/rooms"',
-      },
-      ctx,
-    );
+    const r = await executeStep({ kind: 'Then', text: tnbText('iOS Sim') }, ctx);
     expect(r.ok).toBe(true);
     expect(spy).toHaveBeenCalledWith('Ines', 'Room closed by host warning', '/rooms');
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsToastAndNavigatesBack: spy } });
+    const r = await executeStep({ kind: 'Then', text: tnbText('iOS Sim') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Ines|toast|nav/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: tnbText('iOS Sim') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.iosShowsToastAndNavigatesBack/);
+  });
+
+  test('Android matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { androidShowsToastAndNavigatesBack: spy } });
+    const r = await executeStep({ kind: 'Then', text: tnbText('Android') }, ctx);
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Ines', 'Room closed by host warning', '/rooms');
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidShowsToastAndNavigatesBack: spy } });
+    const r = await executeStep({ kind: 'Then', text: tnbText('Android') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Ines|toast|nav/);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: tnbText('Android') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.uiDriver\.androidShowsToastAndNavigatesBack/);
+  });
+
+  test('Web matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsToastAndNavigatesBack: spy } });
+    const r = await executeStep({ kind: 'Then', text: tnbText('Web') }, ctx);
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Ines', 'Room closed by host warning', '/rooms');
+  });
+
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsToastAndNavigatesBack: spy } });
+    const r = await executeStep({ kind: 'Then', text: tnbText('Web') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Ines|toast|nav/);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: tnbText('Web') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsToastAndNavigatesBack/);
+  });
+
+  test('Web Chromium matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsToastAndNavigatesBack: spy } });
+    const r = await executeStep({ kind: 'Then', text: tnbText('Web Chromium') }, ctx);
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Ines', 'Room closed by host warning', '/rooms');
+  });
+
+  test('Web Chromium driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsToastAndNavigatesBack: spy } });
+    const r = await executeStep({ kind: 'Then', text: tnbText('Web Chromium') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Ines|toast|nav/);
+  });
+
+  test('Web Chromium driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: tnbText('Web Chromium') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsToastAndNavigatesBack/);
+  });
+
+  test('Web Safari matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsToastAndNavigatesBack: spy } });
+    const r = await executeStep({ kind: 'Then', text: tnbText('Web Safari') }, ctx);
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Ines', 'Room closed by host warning', '/rooms');
+  });
+
+  test('Web Safari driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsToastAndNavigatesBack: spy } });
+    const r = await executeStep({ kind: 'Then', text: tnbText('Web Safari') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Ines|toast|nav/);
+  });
+
+  test('Web Safari driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Then', text: tnbText('Web Safari') }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.webDriver\.webShowsToastAndNavigatesBack/);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Method:** `androidShowsToastAndNavigatesBack(name, toast, route)` — j10 direct toast+nav (no `OR within` prefix)
- **Foundation:** `toastWithRoute_*` testTag PREFIX (shared with #784)
- **Tests:** 27 driver + 15 runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)