### PR TITLE
feat(driver/ios): Phase 5 scaffold — ios-devicectl-driver.js

### DIFF
--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -48,12 +48,26 @@ function selectUdid(preferredUdid) {
     const raw = execSync('xcrun devicectl list devices 2>/dev/null', {
       encoding: 'utf8',
     });
-    // devicectl output format (varies by version):
-    //   Name           Hostname    Identifier  State    Model
-    //   iPhone (Yuki)  iPhone.local 00008110-... connected iPhone16,2
-    // Extract the first connected device's UDID (40-char hex with dashes).
-    const m = raw.match(/([0-9A-F]{8}-[0-9A-F]{16})\s+connected/i);
-    return m ? m[1] : null;
+    // devicectl output (Xcode 15+ / macOS 14+) emits the device list as
+    // a fixed-width table:
+    //   Name            Hostname                        Identifier                             State                Model
+    //   -------------   -----------------------------   ------------------------------------   ------------------   ----
+    //   Sean's iPhone   Seans-iPhone.coredevice.local   74563FF8-D1FC-567D-A6C1-7C8C3CEFE0C6   available (paired)   iPhone Air (iPhone18,4)
+    //
+    // The Identifier is an RFC-4122 UUID (8-4-4-4-12 hex with dashes,
+    // total 36 chars). The State literal is `available` (with optional
+    // `(paired)` / `(connected)` parenthetical) — NOT just `connected`
+    // as earlier devicectl versions used. Accept both forms.
+    //
+    // We also tolerate the older 8-16 single-dash UDID format (e.g.
+    // `00008110-001A2B3C4D5E6F70`) that some older devices still emit.
+    const uuidRx =
+      /([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})\s+(?:available|connected)/i;
+    const legacyRx = /([0-9A-F]{8}-[0-9A-F]{16})\s+(?:available|connected)/i;
+    const uuidMatch = raw.match(uuidRx);
+    if (uuidMatch) return uuidMatch[1];
+    const legacyMatch = raw.match(legacyRx);
+    return legacyMatch ? legacyMatch[1] : null;
   } catch (_e) {
     return null;
   }

--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -1,0 +1,173 @@
+/**
+ * iOS driver backed by `xcrun devicectl` — physical iPhone target.
+ *
+ * Replaces `ios-simctl-driver.js` (simulator-only) per the policy
+ * shift: journey tests run on a real device over wireless, not on a
+ * simulator (see feedback-ios-also-journey-tested.md). The simctl
+ * driver is preserved in-tree for reference but the runner now
+ * imports from this file.
+ *
+ * SCAFFOLD STATE: this is the Phase 5 root PR. The factory + method
+ * name registry + stub methods are in place; real UI inspection
+ * (devicectl + WDA / XCTest harness) lands in subsequent PRs that
+ * convert each stub into a foundation presence-check method, mirror-
+ * ing the Android cluster's pattern.
+ *
+ * Wiring contract:
+ *   - `createIosDriver({ udid })` picks the first connected physical
+ *     iPhone via `xcrun devicectl list devices` (defaults to the
+ *     first device). If no device is connected, returns a driver with
+ *     `_udid = null` rather than throwing — every method then returns
+ *     false (consistent with the foundation contract).
+ *   - Methods accept the persona name as their first arg (matcher
+ *     convention).
+ *
+ * Tooling notes (`xcrun devicectl ...`):
+ *   - `device list`                     — list connected devices
+ *   - `device install app <bundleId>`   — install app
+ *   - `device process launch <bundleId>`— launch app
+ *   - `device info details`             — device metadata
+ *   - For UI inspection on physical devices, devicectl alone is
+ *     insufficient; this scaffold uses WebDriverAgent / XCTest as a
+ *     future integration. Until that lands, `iosUiDump()` returns ''
+ *     and every presence-check method returns false in real journeys.
+ *
+ * Foundation parity with android-adb-driver.js:
+ *   - `iosUiDump()` is the rough equivalent of `androidUiDump()` —
+ *     returns the current screen's XML tree (or '' if unavailable).
+ *   - Each `iosShows*` / `iosTap*` method matches its Android sibling's
+ *     arg list (1:1 with the runner-side dispatch).
+ *   - Foundation methods will land via subsequent PRs as
+ *     `<feature>_*` testTag presence-checks against `iosUiDump()`.
+ */
+const { execSync } = require('child_process');
+
+function selectUdid(preferredUdid) {
+  if (preferredUdid) return preferredUdid;
+  try {
+    const raw = execSync('xcrun devicectl list devices 2>/dev/null', {
+      encoding: 'utf8',
+    });
+    // devicectl output format (varies by version):
+    //   Name           Hostname    Identifier  State    Model
+    //   iPhone (Yuki)  iPhone.local 00008110-... connected iPhone16,2
+    // Extract the first connected device's UDID (40-char hex with dashes).
+    const m = raw.match(/([0-9A-F]{8}-[0-9A-F]{16})\s+connected/i);
+    return m ? m[1] : null;
+  } catch (_e) {
+    return null;
+  }
+}
+
+// Copied from ios-simctl-driver.js — the runner dispatches these names
+// for iOS scenarios. Each subsequent PR will replace the stub for one
+// of these names with a foundation presence-check.
+const IOS_METHOD_NAMES = [
+  'iosAdminShowsAppealText',
+  'iosAdminShowsDashboardCounters',
+  'iosAdminShowsNewReportInQueue',
+  'iosAdminShowsRowCountInTable',
+  'iosAdminShowsRowForWithStatus',
+  'iosAdminShowsStat',
+  'iosAdminShowsTableOf',
+  'iosAlsoShowsInParticipantsList',
+  'iosApproveSeatRequest',
+  'iosContinuesNormallyInRoom',
+  'iosDisablesInput',
+  'iosIsNoLongerInVoiceRoom',
+  'iosIsStillInRoom',
+  'iosJoinEventRoom',
+  'iosNavigatesBackToTab',
+  'iosNavigatesToPath',
+  'iosNavigatesToProfileScreen',
+  'iosNavigatesToRoomScreen',
+  'iosNavigatesToWarningScreen',
+  'iosOpenProfileAndTap',
+  'iosOpenProfileFrom',
+  'iosOpensTab',
+  'iosRefreshLanguageRail',
+  'iosReplacesFollowButton',
+  'iosShowsBalanceViaListener',
+  'iosShowsBanner',
+  'iosShowsBeansPerWeekChart',
+  'iosShowsContributorsList',
+  'iosShowsCountBadge',
+  'iosShowsEditedBodyWithTag',
+  'iosShowsFrozenBanner',
+  'iosShowsGiftFromSender',
+  'iosShowsInAppGiftNotification',
+  'iosShowsInResults',
+  'iosShowsInSeatGrid',
+  'iosShowsInThread',
+  'iosShowsMessageInConversationThread',
+  'iosShowsMicIconAs',
+  'iosShowsNamedKind',
+  'iosShowsNewGiftEntry',
+  'iosShowsNewUnreadConversation',
+  'iosShowsNonEmptyLocaleText',
+  'iosShowsOfficialBadge',
+  'iosShowsOnlyMinorCohortInRankings',
+  'iosShowsOwnRankInTop',
+  'iosShowsPmThreadDirection',
+  'iosShowsRoomClosedSummary',
+  'iosShowsRoomWarningBanner',
+  'iosShowsSecondOffensiveMessage',
+  'iosShowsSeatRequestNotification',
+  'iosShowsSeatWithIndicator',
+  'iosShowsStalkersDelta',
+  'iosShowsSystemPmFromOfficia',
+  'iosShowsToastAndNavigates',
+  'iosShowsToastAndNavigatesBack',
+  'iosShowsUserCard',
+  'iosShowsUserCardSkeletons',
+  'iosShowsWarningScreenOnRelaunch',
+  'iosShowsWarningScreenWithReason',
+  'iosShowsWelcomePmInLanguage',
+  'iosSubmitStarFeedback',
+  'iosTapFromSurface',
+  'iosOpenScreen',
+  'iosTapByTag',
+  'iosSearchIn',
+  'iosScanAllRenderedStrings',
+];
+
+function listMethods() {
+  return [...new Set(IOS_METHOD_NAMES)].sort();
+}
+
+async function createIosDriver({ udid: preferred } = {}) {
+  const udid = selectUdid(preferred);
+  const driver = { _udid: udid };
+
+  // Dump the current screen's view hierarchy. Foundation parity with
+  // androidUiDump() — returns the raw XML string. Real implementation
+  // is deferred until WebDriverAgent / XCTest harness is wired up;
+  // until then, returns '' so every presence-check method below
+  // returns false.
+  driver.iosUiDump = async () => {
+    // Future: spawn WDA, query /source endpoint, return XML.
+    // For now: empty string ⇒ all presence-checks return false.
+    return '';
+  };
+
+  // Stub registration loop. Each subsequent PR overrides one name
+  // with a foundation presence-check (e.g.
+  //   driver.iosShowsUserCard = async (_viewer, _target) => {
+  //     const dump = await driver.iosUiDump();
+  //     if (!dump) return false;
+  //     const tagRx = /<XCUIElementTypeAny[^>]*identifier="(?:[^"]*:id\/)?userCard_[^"]*"[^>]*\/?>/;
+  //     return tagRx.test(dump);
+  //   };
+  // until all names have foundation implementations.
+  for (const methodName of listMethods()) {
+    driver[methodName] = async (..._args) => false;
+  }
+
+  driver.close = async () => {
+    /* devicectl is stateless; nothing to release */
+  };
+
+  return driver;
+}
+
+module.exports = { createIosDriver, listMethods, selectUdid, IOS_METHOD_NAMES };

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -14076,7 +14076,13 @@ async function main() {
       console.error(`[runner] Android driver init failed: ${e.message}`);
     }
   }
-  if (opts.driver === 'simctl' || opts.driver === 'all') {
+  if (opts.driver === 'devicectl' || opts.driver === 'simctl' || opts.driver === 'all') {
+    // Accept both 'devicectl' (canonical, physical-device target) and
+    // 'simctl' (legacy alias from the simulator era). Both route to
+    // ios-devicectl-driver per the Phase 5 migration; 'simctl' is kept
+    // as a transitional alias so existing tooling/scripts that pass
+    // --driver simctl continue to work. A future PR can remove the
+    // alias once all journey runners are migrated.
     try {
       const { createIosDriver } = require('./drivers/ios-devicectl-driver');
       const iosDriver = await createIosDriver({});

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -14078,7 +14078,7 @@ async function main() {
   }
   if (opts.driver === 'simctl' || opts.driver === 'all') {
     try {
-      const { createIosDriver } = require('./drivers/ios-simctl-driver');
+      const { createIosDriver } = require('./drivers/ios-devicectl-driver');
       const iosDriver = await createIosDriver({});
       if (!uiDriver) {
         uiDriver = iosDriver;

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -19,12 +19,42 @@ describe('ios-devicectl-driver — selectUdid', () => {
     expect(execSync).not.toHaveBeenCalled();
   });
 
-  test('extracts UDID from devicectl output when no preferred', () => {
+  test('extracts UDID — legacy 8-16 format with "connected" state', () => {
     execSync.mockReturnValueOnce(
       'Name           Hostname     Identifier                          State      Model\n' +
         'iPhone (Yuki)  iPhone.local 00008110-001A2B3C4D5E6F70           connected  iPhone16,2\n',
     );
     expect(selectUdid()).toBe('00008110-001A2B3C4D5E6F70');
+  });
+
+  test('extracts UDID — RFC-4122 8-4-4-4-12 UUID with "available (paired)" state (Xcode 15+)', () => {
+    // This is the REAL devicectl output on macOS 14 / Xcode 15+ —
+    // verified empirically against `xcrun devicectl list devices`
+    // on a paired iPhone. PR #787 R0 reviewer flagged this format
+    // gap; this test pins the production case.
+    execSync.mockReturnValueOnce(
+      'Name            Hostname                        Identifier                             State                Model\n' +
+        '-------------   -----------------------------   ------------------------------------   ------------------   ----\n' +
+        "Sean's iPhone   Seans-iPhone.coredevice.local   74563FF8-D1FC-567D-A6C1-7C8C3CEFE0C6   available (paired)   iPhone Air (iPhone18,4)\n",
+    );
+    expect(selectUdid()).toBe('74563FF8-D1FC-567D-A6C1-7C8C3CEFE0C6');
+  });
+
+  test('extracts UDID — RFC-4122 with "available (connected)" parenthetical', () => {
+    execSync.mockReturnValueOnce(
+      'Name   Hostname   Identifier                             State                  Model\n' +
+        'Phone  Phone.local 11111111-2222-3333-4444-555555555555  available (connected)  iPhone16,1\n',
+    );
+    expect(selectUdid()).toBe('11111111-2222-3333-4444-555555555555');
+  });
+
+  test('extracts UDID — picks FIRST device when multiple are listed', () => {
+    execSync.mockReturnValueOnce(
+      'Name    Hostname     Identifier                             State                Model\n' +
+        'iPhoneA host1.local 11111111-1111-1111-1111-111111111111  available (paired)   iPhone16,1\n' +
+        'iPhoneB host2.local 22222222-2222-2222-2222-222222222222  available (paired)   iPhone16,2\n',
+    );
+    expect(selectUdid()).toBe('11111111-1111-1111-1111-111111111111');
   });
 
   test('returns null when devicectl shows no connected device', () => {
@@ -36,6 +66,14 @@ describe('ios-devicectl-driver — selectUdid', () => {
     execSync.mockImplementationOnce(() => {
       throw new Error('xcrun: command not found');
     });
+    expect(selectUdid()).toBe(null);
+  });
+
+  test('returns null when devicectl emits headers only (empty device list)', () => {
+    execSync.mockReturnValueOnce(
+      'Name   Hostname   Identifier   State   Model\n' +
+        '----   --------   ----------   -----   -----\n',
+    );
     expect(selectUdid()).toBe(null);
   });
 });
@@ -86,6 +124,30 @@ describe('ios-devicectl-driver — createIosDriver factory', () => {
   test('exposes a close() that resolves cleanly', async () => {
     const driver = await createIosDriver({ udid: 'X' });
     await expect(driver.close()).resolves.toBeUndefined();
+  });
+
+  test('no-arg invocation works (factory default `{}`)', async () => {
+    // The factory's `{ udid: preferred } = {}` default must accept
+    // bare `createIosDriver()`. The runner calls `createIosDriver({})`
+    // but the public API surface also supports no-arg.
+    execSync.mockImplementationOnce(() => {
+      throw new Error('xcrun: command not found');
+    });
+    const driver = await createIosDriver();
+    expect(driver).toBeDefined();
+    expect(driver._udid).toBe(null);
+  });
+
+  test('factory: devicectl succeeds but returns no devices → _udid = null', async () => {
+    // The "no device matched" path through createIosDriver — distinct
+    // from the throw path. Pin that the factory tolerates a clean
+    // empty-device-list response.
+    execSync.mockReturnValueOnce(
+      'Name   Hostname   Identifier   State   Model\n' +
+        '----   --------   ----------   -----   -----\n',
+    );
+    const driver = await createIosDriver({});
+    expect(driver._udid).toBe(null);
   });
 });
 

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -1,0 +1,133 @@
+jest.mock('child_process');
+const { execSync } = require('child_process');
+
+const {
+  createIosDriver,
+  listMethods,
+  selectUdid,
+  IOS_METHOD_NAMES,
+} = require('../../../scripts/drivers/ios-devicectl-driver');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ios-devicectl-driver — selectUdid', () => {
+  test('honours preferred UDID without invoking devicectl', () => {
+    const result = selectUdid('00008110-001A2B3C4D5E6F70');
+    expect(result).toBe('00008110-001A2B3C4D5E6F70');
+    expect(execSync).not.toHaveBeenCalled();
+  });
+
+  test('extracts UDID from devicectl output when no preferred', () => {
+    execSync.mockReturnValueOnce(
+      'Name           Hostname     Identifier                          State      Model\n' +
+        'iPhone (Yuki)  iPhone.local 00008110-001A2B3C4D5E6F70           connected  iPhone16,2\n',
+    );
+    expect(selectUdid()).toBe('00008110-001A2B3C4D5E6F70');
+  });
+
+  test('returns null when devicectl shows no connected device', () => {
+    execSync.mockReturnValueOnce('Name  Hostname  Identifier  State  Model\n' + '(no devices)\n');
+    expect(selectUdid()).toBe(null);
+  });
+
+  test('returns null when devicectl throws', () => {
+    execSync.mockImplementationOnce(() => {
+      throw new Error('xcrun: command not found');
+    });
+    expect(selectUdid()).toBe(null);
+  });
+});
+
+describe('ios-devicectl-driver — listMethods', () => {
+  test('returns the IOS_METHOD_NAMES sorted + deduped', () => {
+    const methods = listMethods();
+    expect(methods).toEqual([...new Set(IOS_METHOD_NAMES)].sort());
+  });
+
+  test('every name starts with "ios"', () => {
+    for (const name of listMethods()) {
+      expect(name.startsWith('ios')).toBe(true);
+    }
+  });
+
+  test('matches the simctl driver method-name surface (1:1 contract)', () => {
+    const { listMethods: simctlList } = require('../../../scripts/drivers/ios-simctl-driver');
+    expect(listMethods()).toEqual(simctlList());
+  });
+});
+
+describe('ios-devicectl-driver — createIosDriver factory', () => {
+  test('returns driver object when no device connected (does not throw)', async () => {
+    execSync.mockImplementationOnce(() => {
+      throw new Error('xcrun: command not found');
+    });
+    const driver = await createIosDriver({});
+    expect(driver).toBeDefined();
+    expect(driver._udid).toBe(null);
+  });
+
+  test('honours preferred UDID without listing devices', async () => {
+    const driver = await createIosDriver({ udid: 'PREFERRED-UDID-123' });
+    expect(driver._udid).toBe('PREFERRED-UDID-123');
+    expect(execSync).not.toHaveBeenCalled();
+  });
+
+  test('uses first connected device when no UDID preferred', async () => {
+    execSync.mockReturnValueOnce(
+      'Name           Hostname     Identifier                          State      Model\n' +
+        'iPhone (Yuki)  iPhone.local 00008110-001A2B3C4D5E6F70           connected  iPhone16,2\n',
+    );
+    const driver = await createIosDriver({});
+    expect(driver._udid).toBe('00008110-001A2B3C4D5E6F70');
+  });
+
+  test('exposes a close() that resolves cleanly', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    await expect(driver.close()).resolves.toBeUndefined();
+  });
+});
+
+describe('ios-devicectl-driver — iosUiDump', () => {
+  test('returns empty string in scaffold state (WDA not yet wired)', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    const dump = await driver.iosUiDump();
+    expect(dump).toBe('');
+  });
+});
+
+describe('ios-devicectl-driver — every IOS_METHOD_NAMES entry resolves to a function', () => {
+  // This contract test guards against typos in the method-name array
+  // (e.g. a name in IOS_METHOD_NAMES that doesn't get registered on
+  // the driver instance) and pins that every stub returns false in
+  // the scaffold state.
+  test.each(listMethods())('driver.%s is a function returning false', async (methodName) => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(typeof driver[methodName]).toBe('function');
+    // All stubs return false until subsequent PRs replace them with
+    // foundation presence-check implementations.
+    const result = await driver[methodName]('arg1', 'arg2', 'arg3');
+    expect(result).toBe(false);
+  });
+});
+
+describe('ios-devicectl-driver — stub call-arity tolerance', () => {
+  // Stubs accept any number of args (0, 1, 2, 3, 4). Pin this so a
+  // future refactor that adds arg-validation to the stub loop doesn't
+  // accidentally break callers that pass varying arg counts.
+  test('iosShowsUserCard accepts 0 args', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(await driver.iosShowsUserCard()).toBe(false);
+  });
+
+  test('iosShowsToastAndNavigates accepts 4 args', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(await driver.iosShowsToastAndNavigates('a', 'b', 'c', 100)).toBe(false);
+  });
+
+  test('iosShowsCountBadge accepts null/undefined args', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(await driver.iosShowsCountBadge(null, undefined, '')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- **Phase 5 root PR.** Creates `scripts/drivers/ios-devicectl-driver.js` replacing `ios-simctl-driver.js` (simulator-only) per the physical-device-only policy
- **Scaffold state:** factory + 65 method-name stubs (returning false) + `iosUiDump()` placeholder. Subsequent PRs convert each stub to a foundation presence-check (mirroring the Android cluster's pattern from Phase 4)
- **Runner import updated** to the new driver
- **Tests:** 81 passing (4 selectUdid + 3 listMethods + 4 factory + 1 iosUiDump + 65 parameterised name-contract + 3 stub-arity + 1 close)
- **Backwards-compat:** the simctl driver file is preserved in-tree for reference; runner now imports from devicectl

## Per-method foundation pattern (subsequent PRs)
Each `iosShows*` / `iosTap*` PR will follow the Android cluster's
preemptive checklist: presence-check against `iosUiDump()` (currently
returns ''), full 5-arm × 3-test runner coverage, all input-rejection
pins, both confusable-prefix forms, etc.

## Test plan
- [x] `npx jest tests/scripts/drivers/ios-devicectl-driver.test.js` → 81/81 pass
- [x] `npx jest tests/scripts/manual-qa-runner.test.js` → 1757/1757 (no regression at matcher layer)
- [x] `npx prettier --check` → clean
- [ ] CI: ci/express, ci/lint, SonarCloud, dependency-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)