### PR TITLE
feat(driver/ios): iosAdminShowsAppealText (Wake 89)

### DIFF
--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -165,17 +165,40 @@ async function createIosDriver({ udid: preferred } = {}) {
   };
 
   // Stub registration loop. Each subsequent PR overrides one name
-  // with a foundation presence-check (e.g.
-  //   driver.iosShowsUserCard = async (_viewer, _target) => {
-  //     const dump = await driver.iosUiDump();
-  //     if (!dump) return false;
-  //     const tagRx = /<XCUIElementTypeAny[^>]*identifier="(?:[^"]*:id\/)?userCard_[^"]*"[^>]*\/?>/;
-  //     return tagRx.test(dump);
-  //   };
-  // until all names have foundation implementations.
+  // with a foundation presence-check (XCUITest dump format) that
+  // mirrors the Android cluster's pattern but adapted to iOS's
+  // identifier attribute. Until all names have foundation
+  // implementations, every unimplemented stub returns false.
   for (const methodName of listMethods()) {
     driver[methodName] = async (..._args) => false;
   }
+
+  // ── Foundation presence-check methods ─────────────────────────────
+  //
+  // Each iOS foundation method follows the Android cluster's pattern:
+  // presence-check against `iosUiDump()` for a `<feature>_*` testTag
+  // PREFIX. iOS-specific differences from Android:
+  //   - XCUITest emits `<XCUIElementType... identifier="X" />` (no
+  //     `resource-id` attribute, no `:id/` package qualifier).
+  //   - The XML element tag varies (XCUIElementTypeButton,
+  //     XCUIElementTypeOther, etc.) so the regex matches any
+  //     `XCUIElementType\w+`.
+  //
+  // While `iosUiDump()` returns '' in the scaffold state, every
+  // presence-check returns false in real journeys. When WDA / XCTest
+  // integration lands, both `iosUiDump()` and these regexes start
+  // doing real work.
+  //
+  // Wake 89 — `<Name>'s <Plat> Admin UI shows <Other>'s appeal with
+  // the text` (j11:73). Same matcher as Android #762; iOS variant.
+  // Returns false today (no admin UI on iOS, same as Android).
+  driver.iosAdminShowsAppealText = async (_viewer, _target) => {
+    const dump = await driver.iosUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<XCUIElementType\w+[^>]*\bidentifier="adminAppeal_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
 
   driver.close = async () => {
     /* devicectl is stateless; nothing to release */

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -174,6 +174,171 @@ describe('ios-devicectl-driver — every IOS_METHOD_NAMES entry resolves to a fu
   });
 });
 
+describe('ios-devicectl-driver — iosAdminShowsAppealText', () => {
+  // Wake 89 — `<Name>'s <Plat> Admin UI shows <Other>'s appeal with
+  // the text` (j11:73). Same matcher as Android PR #762; iOS variant.
+  //
+  // Foundation strategy: presence-check on `adminAppeal_*` XCUITest
+  // identifier PREFIX. No iOS admin surface exists today; returns
+  // false in real journeys. Tests use injected mock iosUiDump.
+  //
+  // XCUITest dump format (when WDA lands):
+  //   <XCUIElementTypeOther identifier="adminAppeal_appealText" name="..." />
+  // The regex matches any XCUIElementType\w+ with identifier prefix.
+  //
+  // Both args (_viewer, _target) accepted-and-ignored.
+  function driverWithDump(xml) {
+    return createIosDriver({ udid: 'X' }).then((d) => {
+      d.iosUiDump = async () => xml;
+      return d;
+    });
+  }
+
+  test('adminAppeal_appealText present → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealText" />',
+    );
+    expect(await driver.iosAdminShowsAppealText('Mod', 'Selma')).toBe(true);
+  });
+
+  test('adminAppeal_panel present → true (any suffix matches prefix)', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeButton identifier="adminAppeal_panel" />');
+    expect(await driver.iosAdminShowsAppealText('Mod', 'Selma')).toBe(true);
+  });
+
+  test('absent (no admin surface) → false', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosAdminShowsAppealText('Mod', 'Selma')).toBe(false);
+  });
+
+  test('empty dump → false (default scaffold state)', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    // Default iosUiDump returns '' — every presence-check returns false.
+    expect(await driver.iosAdminShowsAppealText('Mod', 'Selma')).toBe(false);
+  });
+
+  test('non-self-closing tag form → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealText"><XCUIElementTypeStaticText name="Text" /></XCUIElementTypeOther>',
+    );
+    expect(await driver.iosAdminShowsAppealText('Mod', 'Selma')).toBe(true);
+  });
+
+  test('left-boundary — pre_adminAppeal_X does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="pre_adminAppeal_appealText" />',
+    );
+    expect(await driver.iosAdminShowsAppealText('Mod', 'Selma')).toBe(false);
+  });
+
+  test('right-boundary — adminAppeal_appealTextExtra still matches (prefix contract)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealTextExtra" />',
+    );
+    expect(await driver.iosAdminShowsAppealText('Mod', 'Selma')).toBe(true);
+  });
+
+  test('confusable prefix — admin_appeal does NOT match (no underscore-after-prefix)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="admin_appealSummary" />',
+    );
+    expect(await driver.iosAdminShowsAppealText('Mod', 'Selma')).toBe(false);
+  });
+
+  test('different-attribute (name= instead of identifier=) does NOT match', async () => {
+    // Pin: the regex requires `identifier=`, not `name=`. Android's
+    // resource-id sibling has a similar attribute-specificity guard.
+    const driver = await driverWithDump('<XCUIElementTypeOther name="adminAppeal_appealText" />');
+    expect(await driver.iosAdminShowsAppealText('Mod', 'Selma')).toBe(false);
+  });
+
+  test('iosUiDump throws → false', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('WDA: connection lost');
+    };
+    await expect(driver.iosAdminShowsAppealText('Mod', 'Selma')).rejects.toThrow();
+  });
+
+  test('viewer accepted-and-ignored — Bea passes', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealText" />',
+    );
+    expect(await driver.iosAdminShowsAppealText('Bea', 'Selma')).toBe(true);
+  });
+
+  test('null viewer → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealText" />',
+    );
+    expect(await driver.iosAdminShowsAppealText(null, 'Selma')).toBe(true);
+  });
+
+  test('undefined viewer → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealText" />',
+    );
+    expect(await driver.iosAdminShowsAppealText(undefined, 'Selma')).toBe(true);
+  });
+
+  test('empty viewer → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealText" />',
+    );
+    expect(await driver.iosAdminShowsAppealText('', 'Selma')).toBe(true);
+  });
+
+  test('whitespace viewer → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealText" />',
+    );
+    expect(await driver.iosAdminShowsAppealText('   ', 'Selma')).toBe(true);
+  });
+
+  test('null target → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealText" />',
+    );
+    expect(await driver.iosAdminShowsAppealText('Mod', null)).toBe(true);
+  });
+
+  test('undefined target → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealText" />',
+    );
+    expect(await driver.iosAdminShowsAppealText('Mod', undefined)).toBe(true);
+  });
+
+  test('empty target → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealText" />',
+    );
+    expect(await driver.iosAdminShowsAppealText('Mod', '')).toBe(true);
+  });
+
+  test('whitespace target → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealText" />',
+    );
+    expect(await driver.iosAdminShowsAppealText('Mod', '   ')).toBe(true);
+  });
+
+  test('different target still passes (foundation does not match specific user)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealText" />',
+    );
+    expect(await driver.iosAdminShowsAppealText('Mod', 'Theo')).toBe(true);
+  });
+
+  test('first-match contract — two adminAppeal_* nodes', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="adminAppeal_appealText" />' +
+        '<XCUIElementTypeOther identifier="adminAppeal_panel" />',
+    );
+    expect(await driver.iosAdminShowsAppealText('Mod', 'Selma')).toBe(true);
+  });
+});
+
 describe('ios-devicectl-driver — stub call-arity tolerance', () => {
   // Stubs accept any number of args (0, 1, 2, 3, 4). Pin this so a
   // future refactor that adds arg-validation to the stub loop doesn't

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -252,7 +252,12 @@ describe('ios-devicectl-driver — iosAdminShowsAppealText', () => {
     expect(await driver.iosAdminShowsAppealText('Mod', 'Selma')).toBe(false);
   });
 
-  test('iosUiDump throws → false', async () => {
+  test('iosUiDump throws → rejects (propagates; no try/catch in foundation)', async () => {
+    // iOS foundation methods do NOT swallow iosUiDump errors — propagation
+    // is the chosen contract. This differs from the Android sibling which
+    // wraps androidUiDump in try/catch and returns false. Documented as a
+    // driver-level decision: WDA / XCTest errors should surface to the
+    // runner so journey authors can see real connectivity failures.
     const driver = await createIosDriver({ udid: 'X' });
     driver.iosUiDump = async () => {
       throw new Error('WDA: connection lost');


### PR DESCRIPTION
## Summary
- **First iOS foundation method** — mirrors Android PR #762's pattern, adapted to XCUITest XML format
- **Implementation:** `/<XCUIElementType\w+[^>]*\bidentifier="adminAppeal_[^"]*"[^>]*\/?>/`
- **Foundation contract:** returns false in real journeys (iosUiDump() returns '' in scaffold state, no admin UI on iOS — same as Android)
- **Tests:** 21 new (driver) + 0 runner (Wake 89's iOS branch already covered by Android PR #762's full 3-per-platform pattern)

## Notable iOS-specific differences from Android pattern
- `identifier="X"` instead of `resource-id="..."`
- No package qualifier (`:id/` prefix) — XCUITest uses single namespace
- Element tag is `XCUIElementType\w+` (any subtype: Other / Button / StaticText / etc.)
- Attribute-specificity guard: `name="..."` does NOT trigger (only `identifier="..."` matches)

## Test plan
- [x] `npx jest tests/scripts/drivers/ios-devicectl-driver.test.js` → 108/108
- [x] `npx prettier --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)