### PR TITLE
feat(driver/ios): iosNavigatesToPath (Wake 99)

### DIFF
--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -333,6 +333,54 @@ async function createIosDriver({ udid: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 99 — `<Name>'s <Plat> UI navigates to "<Path>"`. Generic
+  // path-based navigation assertion. Mirrors Android sibling.
+  //
+  // Foundation strategy: IOS_PATH_TAGS map with prefix-resolver
+  //   1. Exact match (handles `/` — must not greedy-match other paths)
+  //   2. Longest-prefix match: `/profile/42` → `/profile` mapping
+  //
+  // 5 mappings, grounded in expected iOS testTag naming (mirroring
+  // Android sibling PATH_TAGS):
+  //   - "/"         → main_roomsTab
+  //   - "/profile"  → profile_displayName
+  //   - "/messages" → main_messagesTab
+  //   - "/wallet"   → wallet_balance
+  //   - "/settings" → securitySettingsScreen
+  //
+  // Unmapped paths return false — FAIL-loud (consistent with other
+  // *_TAGS scaffolds). Both args (_name, path) — name accepted-and-
+  // ignored; path REQUIRED and used in lookup.
+  const IOS_PATH_TAGS = {
+    '/': 'main_roomsTab',
+    '/profile': 'profile_displayName',
+    '/messages': 'main_messagesTab',
+    '/wallet': 'wallet_balance',
+    '/settings': 'securitySettingsScreen',
+  };
+  function resolveIosPathTag(path) {
+    if (IOS_PATH_TAGS[path]) return IOS_PATH_TAGS[path];
+    let best = null;
+    for (const prefix of Object.keys(IOS_PATH_TAGS)) {
+      if (prefix === '/') continue;
+      if (path === prefix || path.startsWith(prefix + '/')) {
+        if (!best || prefix.length > best.length) best = prefix;
+      }
+    }
+    return best ? IOS_PATH_TAGS[best] : null;
+  }
+  driver.iosNavigatesToPath = async (_name, path) => {
+    if (typeof path !== 'string' || !path.trim()) return false;
+    const tag = resolveIosPathTag(path.trim());
+    if (!tag) return false;
+    const dump = await driver.iosUiDump();
+    if (!dump) return false;
+    const escTag = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = new RegExp(`<XCUIElementType\\w+[^>]*\\bidentifier="${escTag}"[^>]*\\/?>`);
+    return tagRx.test(dump);
+  };
+
   const IOS_INPUT_TAGS = { chat: 'room_chatInput' };
   driver.iosDisablesInput = async (_name, inputName) => {
     if (!inputName || !inputName.trim()) return false;

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -1707,6 +1707,145 @@ describe('ios-devicectl-driver — iosNavigatesBackToTab', () => {
   });
 });
 
+describe('ios-devicectl-driver — iosNavigatesToPath', () => {
+  // Wake 99 — `<Name>'s <Plat> UI navigates to "<Path>"`. Generic
+  // path-based navigation. PATH_TAGS scaffold with prefix-resolver.
+  function driverWithDump(xml) {
+    return createIosDriver({ udid: 'X' }).then((d) => {
+      d.iosUiDump = async () => xml;
+      return d;
+    });
+  }
+
+  test('"/" exact match → main_roomsTab present → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosNavigatesToPath('Alice', '/')).toBe(true);
+  });
+
+  test('"/profile" exact match → profile_displayName present → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="profile_displayName" />',
+    );
+    expect(await driver.iosNavigatesToPath('Alice', '/profile')).toBe(true);
+  });
+
+  test('"/profile/42" longest-prefix → profile_displayName present → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="profile_displayName" />',
+    );
+    expect(await driver.iosNavigatesToPath('Alice', '/profile/42')).toBe(true);
+  });
+
+  test('"/messages" exact → main_messagesTab present → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_messagesTab" />');
+    expect(await driver.iosNavigatesToPath('Alice', '/messages')).toBe(true);
+  });
+
+  test('"/wallet" exact → wallet_balance present → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="wallet_balance" />');
+    expect(await driver.iosNavigatesToPath('Alice', '/wallet')).toBe(true);
+  });
+
+  test('"/settings" exact → securitySettingsScreen present → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="securitySettingsScreen" />',
+    );
+    expect(await driver.iosNavigatesToPath('Alice', '/settings')).toBe(true);
+  });
+
+  test('"/" exact does NOT prefix-match other paths', async () => {
+    // CRITICAL pin: "/" must be exact-match-only. If "/" were treated
+    // as a prefix, every path would match. Use a dump WITHOUT
+    // main_roomsTab to verify the path-resolver returns null for
+    // unmapped paths even when "/" could greedily prefix them.
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="profile_displayName" />',
+    );
+    // "/unknown" should NOT resolve to "/" → main_roomsTab.
+    expect(await driver.iosNavigatesToPath('Alice', '/unknown')).toBe(false);
+  });
+
+  test('unmapped path returns false (FAIL-loud)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="profile_displayName" />',
+    );
+    expect(await driver.iosNavigatesToPath('Alice', '/unmapped/path')).toBe(false);
+  });
+
+  test('mapped path + tag absent → false', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosNavigatesToPath('Alice', '/profile')).toBe(false);
+  });
+
+  test('empty dump → false (mapped path)', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(await driver.iosNavigatesToPath('Alice', '/profile')).toBe(false);
+  });
+
+  test('empty path → false', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosNavigatesToPath('Alice', '')).toBe(false);
+  });
+
+  test('whitespace path → false', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosNavigatesToPath('Alice', '   ')).toBe(false);
+  });
+
+  test('null path → false', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosNavigatesToPath('Alice', null)).toBe(false);
+  });
+
+  test('undefined path → false', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosNavigatesToPath('Alice', undefined)).toBe(false);
+  });
+
+  test('non-string path (number) → false', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosNavigatesToPath('Alice', 123)).toBe(false);
+  });
+
+  test('iosUiDump throws → rejects', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('WDA lost');
+    };
+    await expect(driver.iosNavigatesToPath('Alice', '/')).rejects.toThrow();
+  });
+
+  test('name accepted-and-ignored — Bao passes', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosNavigatesToPath('Bao', '/')).toBe(true);
+  });
+
+  test('null name → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosNavigatesToPath(null, '/')).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosNavigatesToPath(undefined, '/')).toBe(true);
+  });
+
+  test('left-boundary — pre_main_roomsTab does NOT match', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="pre_main_roomsTab" />');
+    expect(await driver.iosNavigatesToPath('Alice', '/')).toBe(false);
+  });
+
+  test('attribute-specificity — name= does NOT trigger', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther name="main_roomsTab" />');
+    expect(await driver.iosNavigatesToPath('Alice', '/')).toBe(false);
+  });
+
+  test('path trimmed before resolve — leading/trailing whitespace', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosNavigatesToPath('Alice', '  /  ')).toBe(true);
+  });
+});
+
 describe('ios-devicectl-driver — stub call-arity tolerance', () => {
   // Stubs accept any number of args (0, 1, 2, 3, 4). Pin this so a
   // future refactor that adds arg-validation to the stub loop doesn't


### PR DESCRIPTION
iOS mirror of Android sibling. IOS_PATH_TAGS + prefix-resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)