### PR TITLE
feat(driver/ios): iosRefreshLanguageRail (Wake 87)

### DIFF
--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -462,6 +462,27 @@ async function createIosDriver({ udid: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 87 — `<Name> on <Plat> refreshes the language rail` (j17:78).
+  // Pull-to-refresh / refresh-button on the language-filter rail.
+  // Mirrors Android sibling. Driver receives `(name)`.
+  //
+  // Foundation strategy: presence-check on `languageRail_*` identifier
+  // PREFIX. No `languageRail_*` identifier exists in commonMain yet —
+  // the language-filter rail UI is unbuilt. Returns false in real
+  // journeys today; lands true when the rail ships with `languageRail_*`
+  // identifiers (e.g. languageRail_container, languageRail_refreshButton).
+  //
+  // Action body (pull-to-refresh gesture or tap the refresh button) is
+  // deferred until per-element identifiers exist. `_name` accepted-and-
+  // ignored.
+  driver.iosRefreshLanguageRail = async (_name) => {
+    const dump = await driver.iosUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<XCUIElementType\w+[^>]*\bidentifier="languageRail_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   const IOS_INPUT_TAGS = { chat: 'room_chatInput' };
   driver.iosDisablesInput = async (_name, inputName) => {
     if (!inputName || !inputName.trim()) return false;

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -2691,6 +2691,126 @@ describe('ios-devicectl-driver — iosOpensTab', () => {
   });
 });
 
+describe('ios-devicectl-driver — iosRefreshLanguageRail', () => {
+  // Wake 87 — `<Name> on <Plat> refreshes the language rail` (j17:78).
+  // Foundation: presence-check on `languageRail_*` identifier PREFIX.
+  // No such identifier exists in commonMain yet — returns false today.
+  function driverWithDump(xml) {
+    return createIosDriver({ udid: 'X' }).then((d) => {
+      d.iosUiDump = async () => xml;
+      return d;
+    });
+  }
+
+  test('languageRail_container present → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="languageRail_container" />',
+    );
+    expect(await driver.iosRefreshLanguageRail('Marcus')).toBe(true);
+  });
+
+  test('languageRail_refreshButton present → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="languageRail_refreshButton" />',
+    );
+    expect(await driver.iosRefreshLanguageRail('Marcus')).toBe(true);
+  });
+
+  test('absent (rail not built) → false', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosRefreshLanguageRail('Marcus')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(await driver.iosRefreshLanguageRail('Marcus')).toBe(false);
+  });
+
+  test('non-self-closing form → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="languageRail_container"><XCUIElementTypeStaticText name="EN" /></XCUIElementTypeOther>',
+    );
+    expect(await driver.iosRefreshLanguageRail('Marcus')).toBe(true);
+  });
+
+  test('left-boundary — pre_languageRail_X does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="pre_languageRail_container" />',
+    );
+    expect(await driver.iosRefreshLanguageRail('Marcus')).toBe(false);
+  });
+
+  test('right-boundary — languageRail_containerExtra still matches', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="languageRail_containerExtra" />',
+    );
+    expect(await driver.iosRefreshLanguageRail('Marcus')).toBe(true);
+  });
+
+  test('confusable prefix — languageRailExtras_panel does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="languageRailExtras_panel" />',
+    );
+    expect(await driver.iosRefreshLanguageRail('Marcus')).toBe(false);
+  });
+
+  test('attribute-specificity — name= does NOT trigger', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther name="languageRail_container" />');
+    expect(await driver.iosRefreshLanguageRail('Marcus')).toBe(false);
+  });
+
+  test('iosUiDump throws → rejects', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('WDA lost');
+    };
+    await expect(driver.iosRefreshLanguageRail('Marcus')).rejects.toThrow();
+  });
+
+  test('name accepted-and-ignored — Bao passes', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="languageRail_container" />',
+    );
+    expect(await driver.iosRefreshLanguageRail('Bao')).toBe(true);
+  });
+
+  test('null name → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="languageRail_container" />',
+    );
+    expect(await driver.iosRefreshLanguageRail(null)).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="languageRail_container" />',
+    );
+    expect(await driver.iosRefreshLanguageRail(undefined)).toBe(true);
+  });
+
+  test('empty name → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="languageRail_container" />',
+    );
+    expect(await driver.iosRefreshLanguageRail('')).toBe(true);
+  });
+
+  test('whitespace name → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="languageRail_container" />',
+    );
+    expect(await driver.iosRefreshLanguageRail('   ')).toBe(true);
+  });
+
+  test('first-match contract — two languageRail_* nodes', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="languageRail_container" />' +
+        '<XCUIElementTypeButton identifier="languageRail_refreshButton" />',
+    );
+    expect(await driver.iosRefreshLanguageRail('Marcus')).toBe(true);
+  });
+});
+
 describe('ios-devicectl-driver — stub call-arity tolerance', () => {
   // Stubs accept any number of args (0, 1, 2, 3, 4). Pin this so a
   // future refactor that adds arg-validation to the stub loop doesn't


### PR DESCRIPTION
iOS mirror of Android sibling. Presence-check languageRail_* identifier (rail UI unbuilt; lands true when identifiers ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)