### PR TITLE
feat(driver/ios): iosReplacesFollowButton (Wake 102)

### DIFF
--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -483,6 +483,37 @@ async function createIosDriver({ udid: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 102 — `<Name>'s <Plat> UI replaces follow button with "<X>"`
+  // (j07 — UI element swap after follow action completes). iOS mirror
+  // of Android sibling. Inspects the `profile_followButton` identifier
+  // node's XCUITest attributes for the buttonId string.
+  //
+  // The buttonId is one of the four follow-state strings: "Follow",
+  // "Unfollow", "Following", "Follow back". These have OVERLAPPING
+  // PREFIXES — "Follow" is a prefix of "Follow back" and "Following".
+  // Substring matching would false-positive across them, so the
+  // foundation uses EXACT (case-insensitive) match per attribute value.
+  //
+  // iOS divergence from Android: XCUITest emits `label=`, `name=`, and
+  // optionally `value=` for button labels (vs Android's `text=` /
+  // `content-desc=`). The identifier itself is captured separately and
+  // is not considered as a label candidate.
+  driver.iosReplacesFollowButton = async (_name, buttonId) => {
+    if (!buttonId || !buttonId.trim()) return false;
+    const dump = await driver.iosUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<XCUIElementType\w+[^>]*\bidentifier="profile_followButton"[^>]*\/?>/;
+    const tagMatch = dump.match(tagRx);
+    if (!tagMatch) return false;
+    const target = buttonId.toLowerCase();
+    const attrRx = /\b(?:label|name|value)="([^"]*)"/g;
+    for (const m of tagMatch[0].matchAll(attrRx)) {
+      if (m[1].toLowerCase() === target) return true;
+    }
+    return false;
+  };
+
   const IOS_INPUT_TAGS = { chat: 'room_chatInput' };
   driver.iosDisablesInput = async (_name, inputName) => {
     if (!inputName || !inputName.trim()) return false;

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -2885,6 +2885,20 @@ describe('ios-devicectl-driver — iosReplacesFollowButton', () => {
     expect(await driver.iosReplacesFollowButton('Alice', 'Follow back')).toBe(false);
   });
 
+  test('value="Following" does NOT match "Follow" (overlap-prefix via value attr)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" value="Following" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(false);
+  });
+
+  test('attr-scan continues past mismatched name to match value', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" name="Unrelated" value="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(true);
+  });
+
   test('profile_followButton absent → false', async () => {
     const driver = await driverWithDump(
       '<XCUIElementTypeButton identifier="profile_otherButton" label="Follow" />',
@@ -2925,31 +2939,39 @@ describe('ios-devicectl-driver — iosReplacesFollowButton', () => {
     expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(true);
   });
 
-  test('null buttonId → false', async () => {
-    const driver = await driverWithDump(
-      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
-    );
+  // Input-rejection tests use a throwing iosUiDump to PROVE the
+  // buttonId guard early-returns before any dump fetch — a future
+  // reorder that pulls the dump before validating buttonId would
+  // surface the throw and fail these tests.
+  test('null buttonId → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
     expect(await driver.iosReplacesFollowButton('Alice', null)).toBe(false);
   });
 
-  test('undefined buttonId → false', async () => {
-    const driver = await driverWithDump(
-      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
-    );
+  test('undefined buttonId → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
     expect(await driver.iosReplacesFollowButton('Alice', undefined)).toBe(false);
   });
 
-  test('empty buttonId → false', async () => {
-    const driver = await driverWithDump(
-      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
-    );
+  test('empty buttonId → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
     expect(await driver.iosReplacesFollowButton('Alice', '')).toBe(false);
   });
 
-  test('whitespace buttonId → false', async () => {
-    const driver = await driverWithDump(
-      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
-    );
+  test('whitespace buttonId → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
     expect(await driver.iosReplacesFollowButton('Alice', '   ')).toBe(false);
   });
 

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -2811,6 +2811,206 @@ describe('ios-devicectl-driver — iosRefreshLanguageRail', () => {
   });
 });
 
+describe('ios-devicectl-driver — iosReplacesFollowButton', () => {
+  // Wake 102 — `<Name>'s <Plat> UI replaces follow button with "<X>"`.
+  // Foundation: capture profile_followButton tag, scan label/name/value
+  // attrs for case-insensitive exact match against buttonId.
+  function driverWithDump(xml) {
+    return createIosDriver({ udid: 'X' }).then((d) => {
+      d.iosUiDump = async () => xml;
+      return d;
+    });
+  }
+
+  test('label="Follow" matches "Follow" → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(true);
+  });
+
+  test('name="Following" matches "Following" → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" name="Following" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Following')).toBe(true);
+  });
+
+  test('value="Unfollow" matches "Unfollow" → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" value="Unfollow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Unfollow')).toBe(true);
+  });
+
+  test('label="Follow back" matches "Follow back" → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow back" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow back')).toBe(true);
+  });
+
+  test('label="Follow" matches "follow" (lowercase) → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'follow')).toBe(true);
+  });
+
+  test('label="follow" matches "FOLLOW" (uppercase) → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'FOLLOW')).toBe(true);
+  });
+
+  test('label="Follow back" does NOT match "Follow" (overlap-prefix discipline)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow back" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(false);
+  });
+
+  test('label="Following" does NOT match "Follow" (overlap-prefix discipline)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Following" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(false);
+  });
+
+  test('label="Follow" does NOT match "Follow back" (overlap-prefix discipline)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow back')).toBe(false);
+  });
+
+  test('profile_followButton absent → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_otherButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(false);
+  });
+
+  test('tag present without any label attr → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(false);
+  });
+
+  test('tag present with non-matching label → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Unrelated" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(false);
+  });
+
+  test('identifier value itself is NOT taken as a label candidate', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'profile_followButton')).toBe(false);
+  });
+
+  test('label mismatches but name matches → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Unrelated" name="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(true);
+  });
+
+  test('null buttonId → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', null)).toBe(false);
+  });
+
+  test('undefined buttonId → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', undefined)).toBe(false);
+  });
+
+  test('empty buttonId → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', '')).toBe(false);
+  });
+
+  test('whitespace buttonId → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', '   ')).toBe(false);
+  });
+
+  test('null name → still evaluates buttonId', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton(null, 'Follow')).toBe(true);
+  });
+
+  test('undefined name → still evaluates buttonId', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton(undefined, 'Follow')).toBe(true);
+  });
+
+  test('empty name → still evaluates buttonId', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('', 'Follow')).toBe(true);
+  });
+
+  test('whitespace name → still evaluates buttonId', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('   ', 'Follow')).toBe(true);
+  });
+
+  test('label="Follow" on a DIFFERENT tag (no profile_followButton) → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="profile_otherButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(false);
+  });
+
+  test('left-boundary — pre_profile_followButton does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="pre_profile_followButton" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(false);
+  });
+
+  test('right-boundary — profile_followButtonExtra does NOT match (closing quote anchors)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeButton identifier="profile_followButtonExtra" label="Follow" />',
+    );
+    expect(await driver.iosReplacesFollowButton('Alice', 'Follow')).toBe(false);
+  });
+
+  test('iosUiDump throws → rejects', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('WDA lost');
+    };
+    await expect(driver.iosReplacesFollowButton('Alice', 'Follow')).rejects.toThrow();
+  });
+});
+
 describe('ios-devicectl-driver — stub call-arity tolerance', () => {
   // Stubs accept any number of args (0, 1, 2, 3, 4). Pin this so a
   // future refactor that adds arg-validation to the stub loop doesn't

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -22822,7 +22822,7 @@ describe('Wake 101 — "<Name>\'s LiveKit publish for that room is <enabled|disa
 // ── Wake 102 — j07/j09/j11 singletons ────────────────────────────────
 
 describe('Wake 102 — `<Name>\'s <Plat> UI replaces follow button with "<X>"`', () => {
-  test('matching → ok', async () => {
+  test('Android matching → ok', async () => {
     const spy = jest.fn(async () => true);
     const ctx = makeCtx({ uiDriver: { androidReplacesFollowButton: spy } });
     const r = await executeStep(
@@ -22834,6 +22834,91 @@ describe('Wake 102 — `<Name>\'s <Plat> UI replaces follow button with "<X>"`',
     );
     expect(r.ok).toBe(true);
     expect(spy).toHaveBeenCalledWith('Adam', 'profile_unfollowButton');
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidReplacesFollowButton: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Adam\'s Android UI replaces follow button with "Follow"' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Adam.*Android.*Follow/);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Adam\'s Android UI replaces follow button with "Follow"' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/androidReplacesFollowButton/);
+  });
+
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosReplacesFollowButton: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Nora\'s iOS Sim UI replaces follow button with "Following"' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Nora', 'Following');
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosReplacesFollowButton: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Nora\'s iOS Sim UI replaces follow button with "Follow"' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Nora.*iOS Sim.*Follow/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Nora\'s iOS Sim UI replaces follow button with "Follow"' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/iosReplacesFollowButton/);
+  });
+
+  test('Web matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webReplacesFollowButton: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web UI replaces follow button with "Follow back"' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'Follow back');
+  });
+
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webReplacesFollowButton: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web UI replaces follow button with "Follow"' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice.*Web.*Follow/);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web UI replaces follow button with "Follow"' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/webReplacesFollowButton/);
   });
 });
 


### PR DESCRIPTION
iOS mirror of Android sibling. Captures profile_followButton tag, scans label/name/value XCUITest attrs for case-insensitive exact match. Overlap-prefix discipline (Follow vs Follow back vs Following) pinned by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)