### PR TITLE
feat(driver/ios): iosShowsBalanceViaListener (Wake 100)

### DIFF
--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -514,6 +514,40 @@ async function createIosDriver({ udid: preferred } = {}) {
     return false;
   };
 
+  // Wake 100 — `<Name>'s <Plat> UI shows the new "<X>" balance via
+  // Firestore listener` (j06 — wallet refresh via real-time listener).
+  // iOS mirror of Android sibling. Inspects the `wallet_balance`
+  // identifier node's label/name/value XCUITest attrs for the balance
+  // string.
+  //
+  // Balance shape: user-facing decimal with optional digit separators
+  // ("5,000"), currency prefix ("$5,000"), and label padding
+  // ("Balance: 5,000 coins"). Word-boundary regex prevents numeric-
+  // prefix collisions ("45,000" must NOT match "5,000") and numeric-
+  // suffix collisions ("5,0000" must NOT match "5,000"). Balance arg
+  // is regex-escaped so "." matches a literal dot.
+  //
+  // Two-step extraction (Phase-5 pattern, same as iosReplacesFollowButton):
+  // capture the wallet_balance tag, then scan its attributes — order
+  // independent across label/name/value.
+  driver.iosShowsBalanceViaListener = async (_name, balance) => {
+    if (!balance || !balance.trim()) return false;
+    const dump = await driver.iosUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<XCUIElementType\w+[^>]*\bidentifier="wallet_balance"[^>]*\/?>/;
+    const tagMatch = dump.match(tagRx);
+    if (!tagMatch) return false;
+    const escBalance = balance.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // Scan within the captured tag for label=, name=, or value=
+    // carrying the balance value with digit-boundary protection.
+    // eslint-disable-next-line sonarjs/slow-regex
+    const valueRx = new RegExp(
+      `\\b(?:label|name|value)="[^"]*(?<![\\w-])${escBalance}(?!\\w)[^"]*"`,
+    );
+    return valueRx.test(tagMatch[0]);
+  };
+
   const IOS_INPUT_TAGS = { chat: 'room_chatInput' };
   driver.iosDisablesInput = async (_name, inputName) => {
     if (!inputName || !inputName.trim()) return false;

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -3033,6 +3033,250 @@ describe('ios-devicectl-driver — iosReplacesFollowButton', () => {
   });
 });
 
+describe('ios-devicectl-driver — iosShowsBalanceViaListener', () => {
+  // Wake 100 — `<Name>'s <Plat> UI shows the new "<X>" balance via
+  // Firestore listener`. Foundation: capture wallet_balance tag, scan
+  // label/name/value attrs for balance with word-boundary protection.
+  function driverWithDump(xml) {
+    return createIosDriver({ udid: 'X' }).then((d) => {
+      d.iosUiDump = async () => xml;
+      return d;
+    });
+  }
+
+  // Happy paths across each label-bearing attribute.
+  test('label="5,000" matches "5,000" → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(true);
+  });
+
+  test('name="$5,000" matches "$5,000" → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" name="$5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '$5,000')).toBe(true);
+  });
+
+  test('value="5,000" matches "5,000" → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" value="5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(true);
+  });
+
+  // Substring tolerance with padding (label-style and currency-prefix).
+  test('label="Balance: 5,000 coins" matches "5,000" → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="Balance: 5,000 coins" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(true);
+  });
+
+  test('value="$5,000" matches "5,000" (currency prefix tolerated)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" value="$5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(true);
+  });
+
+  // Numeric-prefix collision: "45,000" must NOT match "5,000".
+  test('label="45,000" does NOT match "5,000" (prefix collision)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="45,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(false);
+  });
+
+  // Numeric-suffix collision: "5,0000" must NOT match "5,000".
+  test('label="5,0000" does NOT match "5,000" (suffix collision)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="5,0000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(false);
+  });
+
+  // Decimal point literal protection.
+  test('balance "1,234.56" matches "1,234.56" exactly', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="1,234.56" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '1,234.56')).toBe(true);
+  });
+
+  test('balance "1,234.56" does NOT match label "1,234X56" (regex-escape protects .)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="1,234X56" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '1,234.56')).toBe(false);
+  });
+
+  // Asymmetric boundary discipline (mirrors Android sibling): the LEFT
+  // boundary excludes both \w and hyphen, but the RIGHT boundary only
+  // excludes \w. Hyphen-suffix is therefore tolerated as a label
+  // separator ("5,000-coin minimum" still matches "5,000"). Underscore-
+  // suffix is REJECTED because underscore IS a word char.
+  test('label="5,000-coin" still matches "5,000" (hyphen tolerated on right)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="5,000-coin" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(true);
+  });
+
+  test('label="5,000_extra" does NOT match "5,000" (underscore is \\w)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="5,000_extra" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(false);
+  });
+
+  test('label="extra-5,000" does NOT match "5,000" (hyphen blocked on LEFT only)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="extra-5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(false);
+  });
+
+  // Tag absence.
+  test('wallet_balance absent → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="profile_displayName" label="5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(false);
+  });
+
+  test('tag present but no label/name/value attrs → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(false);
+  });
+
+  test('tag present with non-matching label → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="0" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(false);
+  });
+
+  // identifier value itself never leaks as a label candidate (\bidentifier=
+  // is excluded from attrRx alternation).
+  test('balance "wallet_balance" does NOT match identifier value itself', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', 'wallet_balance')).toBe(false);
+  });
+
+  // Cross-tag scan-confinement.
+  test('label="5,000" on a DIFFERENT tag → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="other_widget" label="5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(false);
+  });
+
+  // Boundary checks on identifier.
+  test('left-boundary — pre_wallet_balance does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="pre_wallet_balance" label="5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(false);
+  });
+
+  test('right-boundary — wallet_balanceExtra does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balanceExtra" label="5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(false);
+  });
+
+  // attr-scan continues past mismatched name to match value.
+  test('label mismatches but value matches → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="Wallet" value="5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(true);
+  });
+
+  // Input-rejection isolation: throwing iosUiDump proves guard short-
+  // circuits before any dump fetch.
+  test('null balance → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsBalanceViaListener('Alice', null)).toBe(false);
+  });
+
+  test('undefined balance → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsBalanceViaListener('Alice', undefined)).toBe(false);
+  });
+
+  test('empty balance → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsBalanceViaListener('Alice', '')).toBe(false);
+  });
+
+  test('whitespace balance → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsBalanceViaListener('Alice', '   ')).toBe(false);
+  });
+
+  // name (first arg) accepted-and-ignored.
+  test('null name → still evaluates balance', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener(null, '5,000')).toBe(true);
+  });
+
+  test('undefined name → still evaluates balance', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener(undefined, '5,000')).toBe(true);
+  });
+
+  test('empty name → still evaluates balance', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('', '5,000')).toBe(true);
+  });
+
+  test('whitespace name → still evaluates balance', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('   ', '5,000')).toBe(true);
+  });
+
+  test('iosUiDump throws → rejects', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('WDA lost');
+    };
+    await expect(driver.iosShowsBalanceViaListener('Alice', '5,000')).rejects.toThrow();
+  });
+});
+
 describe('ios-devicectl-driver — stub call-arity tolerance', () => {
   // Stubs accept any number of args (0, 1, 2, 3, 4). Pin this so a
   // future refactor that adds arg-validation to the stub loop doesn't

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -3275,6 +3275,28 @@ describe('ios-devicectl-driver — iosShowsBalanceViaListener', () => {
     };
     await expect(driver.iosShowsBalanceViaListener('Alice', '5,000')).rejects.toThrow();
   });
+
+  // Contract pins (R1 from review):
+  // - Padded balance is NOT trimmed before regex construction. ' 5,000'
+  //   passes the !balance.trim() guard but the regex then looks for
+  //   the literal ' 5,000' substring, which won't match label="5,000".
+  //   Mirrors Android sibling behavior.
+  test('padded balance " 5,000" does not match trimmed label "5,000" (no trim before regex)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" label="5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', ' 5,000')).toBe(false);
+  });
+
+  // - The \b on \b(?:label|name|value)= guards against compound attribute
+  //   names like accessibilityLabel=. iOS XCUITest WDA dumps use plain
+  //   label= but the guard is defence-in-depth.
+  test('accessibilityLabel="5,000" does NOT match (\\b guards compound attr name)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="wallet_balance" accessibilityLabel="5,000" />',
+    );
+    expect(await driver.iosShowsBalanceViaListener('Alice', '5,000')).toBe(false);
+  });
 });
 
 describe('ios-devicectl-driver — stub call-arity tolerance', () => {

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -22572,6 +22572,101 @@ describe('Wake 100 — `<Name>\'s <Plat> UI shows the new "<X>" balance via Fire
     expect(r.ok).toBe(false);
     expect(r.error).toMatch(/Alice|balance|1,234/);
   });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Android UI shows the new "5,000" balance via Firestore listener',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/androidShowsBalanceViaListener/);
+  });
+
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosShowsBalanceViaListener: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Nora\'s iOS Sim UI shows the new "5,000" balance via Firestore listener',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Nora', '5,000');
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsBalanceViaListener: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Nora\'s iOS Sim UI shows the new "1,234" balance via Firestore listener',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Nora|balance|1,234/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Nora\'s iOS Sim UI shows the new "5,000" balance via Firestore listener',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/iosShowsBalanceViaListener/);
+  });
+
+  test('Web matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsBalanceViaListener: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Web UI shows the new "$5,000" balance via Firestore listener',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', '$5,000');
+  });
+
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsBalanceViaListener: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Web UI shows the new "1,234" balance via Firestore listener',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|balance|1,234/);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Alice\'s Web UI shows the new "5,000" balance via Firestore listener',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/webShowsBalanceViaListener/);
+  });
 });
 
 // ── Wake 101 — j09/j10 voice-room cluster ───────────────────────────


### PR DESCRIPTION
iOS mirror of Android sibling. Captures wallet_balance tag, scans label/name/value with word-boundary protection (45,000 doesn't false-match 5,000). Pinned asymmetric LEFT-vs-RIGHT boundary: hyphen tolerated on right as label separator, blocked on left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)