### PR TITLE
feat(driver/ios): iosShowsBanner (Wake 97)

### DIFF
--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -548,6 +548,29 @@ async function createIosDriver({ udid: preferred } = {}) {
     return valueRx.test(tagMatch[0]);
   };
 
+  // Wake 97 — `<Name>'s <Plat> UI shows a "<X>" banner`. Mirrors Android
+  // sibling. Banners persist on-screen until dismissed (unlike toasts),
+  // so a single dump scan is sufficient.
+  //
+  // Implementation: dump the UI tree, look for the banner text as any
+  // of label=, name=, or value= XCUITest attribute values across ANY
+  // node (no tag anchoring). Substring match — banners frequently
+  // contain dynamic suffixes ("...in 5 minutes", "(retry)"), so an
+  // exact-match would be too strict. Banner is regex-escaped.
+  //
+  // The \b before (?:label|name|value)= prevents compound attribute
+  // names like accessibilityLabel= from false-matching. Whitespace-only
+  // banner returns false defensively (runner Gherkin requires [^"]+
+  // so unreachable in practice).
+  driver.iosShowsBanner = async (_name, banner) => {
+    if (!banner || !banner.trim()) return false;
+    const dump = await driver.iosUiDump();
+    if (!dump) return false;
+    const escBanner = banner.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    return new RegExp(`\\b(?:label|name|value)="[^"]*${escBanner}[^"]*"`).test(dump);
+  };
+
   const IOS_INPUT_TAGS = { chat: 'room_chatInput' };
   driver.iosDisablesInput = async (_name, inputName) => {
     if (!inputName || !inputName.trim()) return false;

--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -558,10 +558,16 @@ async function createIosDriver({ udid: preferred } = {}) {
   // contain dynamic suffixes ("...in 5 minutes", "(retry)"), so an
   // exact-match would be too strict. Banner is regex-escaped.
   //
-  // The \b before (?:label|name|value)= prevents compound attribute
-  // names like accessibilityLabel= from false-matching. Whitespace-only
-  // banner returns false defensively (runner Gherkin requires [^"]+
-  // so unreachable in practice).
+  // The \b before (?:label|name|value)= guards against compound
+  // attribute names. For name= and value= it blocks typename=,
+  // filename=, somevalue= via the word-boundary check. For label=,
+  // accessibilityLabel= is ALSO blocked but by case-sensitivity
+  // (lowercase label vs capital L) — if a future refactor adds the
+  // `i` flag, the \b alone would NOT protect against accessibilityLabel=
+  // (capital L immediately after `y` is a valid word boundary), so the
+  // case-sensitivity decision matters. Whitespace-only banner returns
+  // false defensively (runner Gherkin requires [^"]+ so unreachable
+  // in practice).
   driver.iosShowsBanner = async (_name, banner) => {
     if (!banner || !banner.trim()) return false;
     const dump = await driver.iosUiDump();

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -3299,6 +3299,177 @@ describe('ios-devicectl-driver — iosShowsBalanceViaListener', () => {
   });
 });
 
+describe('ios-devicectl-driver — iosShowsBanner', () => {
+  // Wake 97 — `<Name>'s <Plat> UI shows a "<X>" banner`. Foundation:
+  // substring scan across any node's label/name/value attr.
+  function driverWithDump(xml) {
+    return createIosDriver({ udid: 'X' }).then((d) => {
+      d.iosUiDump = async () => xml;
+      return d;
+    });
+  }
+
+  // Happy paths — each label-bearing attribute.
+  test('label= carries banner → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText label="Connection lost — retrying" />',
+    );
+    expect(await driver.iosShowsBanner('Adam', 'Connection lost')).toBe(true);
+  });
+
+  test('name= carries banner → true (icon-only banner)', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther name="You are offline" />');
+    expect(await driver.iosShowsBanner('Adam', 'You are offline')).toBe(true);
+  });
+
+  test('value= carries banner → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther value="Reconnecting in 5 seconds" />',
+    );
+    expect(await driver.iosShowsBanner('Adam', 'Reconnecting')).toBe(true);
+  });
+
+  // Substring tolerance — banner with dynamic suffix.
+  test('substring match — banner with dynamic suffix → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText label="Connection lost — retrying in 5 minutes" />',
+    );
+    expect(await driver.iosShowsBanner('Adam', 'Connection lost')).toBe(true);
+  });
+
+  // Regex-meta chars in banner must be treated literally.
+  test('banner with parens "(retry)" matches literally', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeStaticText label="Failed (retry)" />');
+    expect(await driver.iosShowsBanner('Adam', '(retry)')).toBe(true);
+  });
+
+  test('banner with dot "v1.2" matches literal dot (not any-char)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText label="Update to v1.2 available" />',
+    );
+    expect(await driver.iosShowsBanner('Adam', 'v1.2')).toBe(true);
+  });
+
+  test('banner "v1.2" does NOT match label "v1X2" (regex-escape protects dot)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText label="Update to v1X2 available" />',
+    );
+    expect(await driver.iosShowsBanner('Adam', 'v1.2')).toBe(false);
+  });
+
+  // Compound-attribute name protection (the \b guard).
+  test('accessibilityLabel= does NOT trigger (\\b guards compound attr names)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText accessibilityLabel="Connection lost" />',
+    );
+    expect(await driver.iosShowsBanner('Adam', 'Connection lost')).toBe(false);
+  });
+
+  test('hint= does NOT trigger (only label/name/value scanned)', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeStaticText hint="Connection lost" />');
+    expect(await driver.iosShowsBanner('Adam', 'Connection lost')).toBe(false);
+  });
+
+  // identifier= specifically must not be scanned (different attribute).
+  test('identifier="Connection lost" does NOT match (not in attr alternation)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText identifier="Connection lost" />',
+    );
+    expect(await driver.iosShowsBanner('Adam', 'Connection lost')).toBe(false);
+  });
+
+  // Cross-tag scan — banner can be on any element type.
+  test('banner on XCUIElementTypeButton element → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeButton label="Update available" />');
+    expect(await driver.iosShowsBanner('Adam', 'Update available')).toBe(true);
+  });
+
+  test('banner on XCUIElementTypeImage element with name → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeImage name="Connection lost" />');
+    expect(await driver.iosShowsBanner('Adam', 'Connection lost')).toBe(true);
+  });
+
+  // Tag absence / empty dump.
+  test('banner not present → false', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther label="Something else" />');
+    expect(await driver.iosShowsBanner('Adam', 'Connection lost')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(await driver.iosShowsBanner('Adam', 'Connection lost')).toBe(false);
+  });
+
+  // Case sensitivity — banner is a substring match, not case-insensitive.
+  test('case mismatch — "connection lost" lowercase does NOT match "Connection lost"', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeStaticText label="Connection lost" />');
+    expect(await driver.iosShowsBanner('Adam', 'connection lost')).toBe(false);
+  });
+
+  // Input-rejection isolation: throwing iosUiDump proves guard short-
+  // circuits before any dump fetch.
+  test('null banner → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsBanner('Adam', null)).toBe(false);
+  });
+
+  test('undefined banner → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsBanner('Adam', undefined)).toBe(false);
+  });
+
+  test('empty banner → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsBanner('Adam', '')).toBe(false);
+  });
+
+  test('whitespace banner → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsBanner('Adam', '   ')).toBe(false);
+  });
+
+  // name (first arg) accepted-and-ignored.
+  test('null name → still evaluates banner', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeStaticText label="Connection lost" />');
+    expect(await driver.iosShowsBanner(null, 'Connection lost')).toBe(true);
+  });
+
+  test('undefined name → still evaluates banner', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeStaticText label="Connection lost" />');
+    expect(await driver.iosShowsBanner(undefined, 'Connection lost')).toBe(true);
+  });
+
+  test('empty name → still evaluates banner', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeStaticText label="Connection lost" />');
+    expect(await driver.iosShowsBanner('', 'Connection lost')).toBe(true);
+  });
+
+  test('whitespace name → still evaluates banner', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeStaticText label="Connection lost" />');
+    expect(await driver.iosShowsBanner('   ', 'Connection lost')).toBe(true);
+  });
+
+  test('iosUiDump throws → rejects', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('WDA lost');
+    };
+    await expect(driver.iosShowsBanner('Adam', 'Connection lost')).rejects.toThrow();
+  });
+});
+
 describe('ios-devicectl-driver — stub call-arity tolerance', () => {
   // Stubs accept any number of args (0, 1, 2, 3, 4). Pin this so a
   // future refactor that adds arg-validation to the stub loop doesn't

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -3378,6 +3378,19 @@ describe('ios-devicectl-driver — iosShowsBanner', () => {
     expect(await driver.iosShowsBanner('Adam', 'Connection lost')).toBe(false);
   });
 
+  // Direct \b pin for name= against compound attrs (typename=, filename=).
+  test('typename="Connection lost" does NOT match (\\b blocks compound)', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeStaticText typename="Connection lost" />');
+    expect(await driver.iosShowsBanner('Adam', 'Connection lost')).toBe(false);
+  });
+
+  test('somevalue="Connection lost" does NOT match (\\b blocks compound)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText somevalue="Connection lost" />',
+    );
+    expect(await driver.iosShowsBanner('Adam', 'Connection lost')).toBe(false);
+  });
+
   // Cross-tag scan — banner can be on any element type.
   test('banner on XCUIElementTypeButton element → true', async () => {
     const driver = await driverWithDump('<XCUIElementTypeButton label="Update available" />');

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -21263,6 +21263,80 @@ describe('Wake 97 — `<Name>\'s <Plat> UI shows a "<X>" banner`', () => {
     expect(r.ok).toBe(true);
     expect(spy).toHaveBeenCalledWith('Theo', 'Hold on');
   });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsBanner: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Ines\'s iOS Sim UI shows a "Reconnecting" banner' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Ines.*iOS Sim.*Reconnecting/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Ines\'s iOS Sim UI shows a "Reconnecting" banner' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/iosShowsBanner/);
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidShowsBanner: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Theo\'s Android UI shows a "Hold on" banner' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Theo.*Android.*Hold on/);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Theo\'s Android UI shows a "Hold on" banner' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/androidShowsBanner/);
+  });
+
+  test('Web matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsBanner: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web UI shows a "Update available" banner' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'Update available');
+  });
+
+  test('Web driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ webDriver: { webShowsBanner: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web UI shows a "Update available" banner' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice.*Web.*Update available/);
+  });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web UI shows a "Update available" banner' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/webShowsBanner/);
+  });
 });
 
 describe('Wake 97 — "<Name>\'s LiveKit track is not disconnected"', () => {

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -21337,6 +21337,28 @@ describe('Wake 97 — `<Name>\'s <Plat> UI shows a "<X>" banner`', () => {
     expect(r.ok).toBe(false);
     expect(r.error).toMatch(/webShowsBanner/);
   });
+
+  test('Web Chromium platform token → routes to webShowsBanner', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsBanner: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web Chromium UI shows a "Update available" banner' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'Update available');
+  });
+
+  test('Web Safari platform token → routes to webShowsBanner', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ webDriver: { webShowsBanner: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web Safari UI shows a "Update available" banner' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'Update available');
+  });
 });
 
 describe('Wake 97 — "<Name>\'s LiveKit track is not disconnected"', () => {


### PR DESCRIPTION
iOS mirror of Android sibling. Substring scan across label/name/value attrs on any node. accessibilityLabel= guarded via \b on the attr-name alternation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)