### PR TITLE
feat(driver/ios): iosShowsBeansPerWeekChart (Wake 87)

### DIFF
--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -577,6 +577,26 @@ async function createIosDriver({ udid: preferred } = {}) {
     return new RegExp(`\\b(?:label|name|value)="[^"]*${escBanner}[^"]*"`).test(dump);
   };
 
+  // Wake 87 — `<Name>'s <Plat> UI shows a chart of beans earned per
+  // week` (j17:74). Mirrors Android sibling. Bare chart-presence
+  // assertion. Driver receives `(name)`.
+  //
+  // Foundation strategy: presence-check on `beansChart_*` identifier
+  // PREFIX. No such identifier exists in commonMain yet — chart UI is
+  // unbuilt. Returns false in real journeys today; lands true when
+  // the chart ships with `beansChart_*` identifiers (e.g.
+  // beansChart_container, beansChart_weekBar).
+  //
+  // Bin-level value verification is out of scope. `_name` accepted-
+  // and-ignored.
+  driver.iosShowsBeansPerWeekChart = async (_name) => {
+    const dump = await driver.iosUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<XCUIElementType\w+[^>]*\bidentifier="beansChart_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   const IOS_INPUT_TAGS = { chat: 'room_chatInput' };
   driver.iosDisablesInput = async (_name, inputName) => {
     if (!inputName || !inputName.trim()) return false;

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -3483,6 +3483,123 @@ describe('ios-devicectl-driver — iosShowsBanner', () => {
   });
 });
 
+describe('ios-devicectl-driver — iosShowsBeansPerWeekChart', () => {
+  // Wake 87 — `<Name>'s <Plat> UI shows a chart of beans earned per
+  // week`. Foundation: presence-check on `beansChart_*` identifier.
+  function driverWithDump(xml) {
+    return createIosDriver({ udid: 'X' }).then((d) => {
+      d.iosUiDump = async () => xml;
+      return d;
+    });
+  }
+
+  test('beansChart_container present → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="beansChart_container" />',
+    );
+    expect(await driver.iosShowsBeansPerWeekChart('Marcus')).toBe(true);
+  });
+
+  test('beansChart_weekBar present → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="beansChart_weekBar" />');
+    expect(await driver.iosShowsBeansPerWeekChart('Marcus')).toBe(true);
+  });
+
+  test('absent → false', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosShowsBeansPerWeekChart('Marcus')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(await driver.iosShowsBeansPerWeekChart('Marcus')).toBe(false);
+  });
+
+  test('non-self-closing form → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="beansChart_container"><XCUIElementTypeStaticText name="Mon: 12" /></XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsBeansPerWeekChart('Marcus')).toBe(true);
+  });
+
+  test('left-boundary — pre_beansChart_X does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="pre_beansChart_container" />',
+    );
+    expect(await driver.iosShowsBeansPerWeekChart('Marcus')).toBe(false);
+  });
+
+  test('right-boundary — beansChart_containerExtra still matches', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="beansChart_containerExtra" />',
+    );
+    expect(await driver.iosShowsBeansPerWeekChart('Marcus')).toBe(true);
+  });
+
+  test('confusable prefix — beansChartExtras_panel does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="beansChartExtras_panel" />',
+    );
+    expect(await driver.iosShowsBeansPerWeekChart('Marcus')).toBe(false);
+  });
+
+  test('attribute-specificity — name= does NOT trigger', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther name="beansChart_container" />');
+    expect(await driver.iosShowsBeansPerWeekChart('Marcus')).toBe(false);
+  });
+
+  test('iosUiDump throws → rejects', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('WDA lost');
+    };
+    await expect(driver.iosShowsBeansPerWeekChart('Marcus')).rejects.toThrow();
+  });
+
+  test('name accepted-and-ignored — Bao passes', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="beansChart_container" />',
+    );
+    expect(await driver.iosShowsBeansPerWeekChart('Bao')).toBe(true);
+  });
+
+  test('null name → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="beansChart_container" />',
+    );
+    expect(await driver.iosShowsBeansPerWeekChart(null)).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="beansChart_container" />',
+    );
+    expect(await driver.iosShowsBeansPerWeekChart(undefined)).toBe(true);
+  });
+
+  test('empty name → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="beansChart_container" />',
+    );
+    expect(await driver.iosShowsBeansPerWeekChart('')).toBe(true);
+  });
+
+  test('whitespace name → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="beansChart_container" />',
+    );
+    expect(await driver.iosShowsBeansPerWeekChart('   ')).toBe(true);
+  });
+
+  test('first-match contract — two beansChart_* nodes', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="beansChart_container" />' +
+        '<XCUIElementTypeOther identifier="beansChart_weekBar" />',
+    );
+    expect(await driver.iosShowsBeansPerWeekChart('Marcus')).toBe(true);
+  });
+});
+
 describe('ios-devicectl-driver — stub call-arity tolerance', () => {
   // Stubs accept any number of args (0, 1, 2, 3, 4). Pin this so a
   // future refactor that adds arg-validation to the stub loop doesn't


### PR DESCRIPTION
iOS mirror of Android sibling. Presence-check beansChart_* identifier (chart UI unbuilt; foundation returns false until identifiers ship). Runner-routing pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)