### PR TITLE
fix(ci): lint runs on workflow-only PRs + #813 R2 follow-ups

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -99,7 +99,14 @@ jobs:
 
   lint:
     needs: [detect-changes]
-    if: needs.detect-changes.outputs.workflow_only != 'true'
+    # No workflow_only short-circuit: lint.yml's unconditional steps
+    # (actionlint, check-no-paid-runners, check-workflow-concurrency-
+    # scoping, check-orphan-i18n-keys, check-release-trigger) MUST run
+    # on workflow-only PRs — that's the case where they matter most,
+    # since those PRs are the ones changing workflows. The heavyweight
+    # steps inside lint.yml (ktlint, Express lint, Gherkin lint) are
+    # already gated on app_changed / backend_changed, so the cost on
+    # workflow-only PRs is ~30s of cheap shellcheck/script invocations.
     uses: ./.github/workflows/lint.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
               if gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$branch" 2>/tmp/delete-err; then
                 echo "Auto-deleted orphan release branch: $branch"
               else
-                echo "::warning::Could not auto-delete orphan branch '$branch' (likely ruleset-blocked). Proceeding — this run uses a unique per-run-id branch name and won't collide. To clean up the orphan later, delete via GitHub UI (Settings > Branches > $branch > Delete) or add the Release app to the no-force-push-anywhere ruleset's bypass list."
+                echo "::warning::Could not auto-delete orphan branch '$branch' (likely ruleset-blocked). Proceeding — this run uses a unique per-run-id branch name and won't collide. To clean up the orphan later, delete via GitHub UI (Branches page (github.com/${{ github.repository }}/branches) > find $branch > trash icon) or add the Release app to the no-force-push-anywhere ruleset's bypass list."
                 echo "API error output (informational):"
                 cat /tmp/delete-err
               fi
@@ -382,12 +382,17 @@ jobs:
           # of this same run created the branch), accept it and move
           # on. If it exists at a DIFFERENT sha, error out — that's
           # unexpected state that the operator should investigate.
-          EXISTING_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/${BRANCH}" --jq '.object.sha' 2>/dev/null || true)
+          # jq's `// empty` converts a missing key (returns `null`) to no
+          # output, so EXISTING_SHA stays empty when the API returns a
+          # 200 with a body that lacks `.object.sha` (e.g. a malformed
+          # response or a future API contract drift). The `|| true` on
+          # the outer pipeline already handles 404 exit codes.
+          EXISTING_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/${BRANCH}" --jq '.object.sha // empty' 2>/dev/null || true)
           if [ -n "${EXISTING_SHA:-}" ]; then
             if [ "${EXISTING_SHA}" = "${PARENT_SHA}" ]; then
               echo "Branch ${BRANCH} already exists at ${PARENT_SHA} (idempotent re-run); skipping creation."
             else
-              echo "::error::Branch ${BRANCH} already exists but points at ${EXISTING_SHA} (expected ${PARENT_SHA}). This usually means a prior attempt of this run advanced the branch before failing. Delete the branch via GitHub UI (Settings > Branches > ${BRANCH} > Delete) and re-trigger."
+              echo "::error::Branch ${BRANCH} already exists but points at ${EXISTING_SHA} (expected ${PARENT_SHA}). This usually means a prior attempt of this run advanced the branch before failing. Delete the branch via the Branches page (github.com/${{ github.repository }}/branches > find ${BRANCH} > trash icon) and re-trigger."
               exit 1
             fi
           else
@@ -503,7 +508,11 @@ jobs:
             echo "----- PR body (from $PR_BODY_FILE) -----"
             cat "$PR_BODY_FILE"
             echo "----------------------------------------"
-            echo "Recovery command: gh pr create --base main --head ${BRANCH} --title 'chore: release v${VERSION}' --body \"<paste body above>\""
+            # Recovery via --body-file rather than --body to avoid the
+            # quoting trap (the body contains literal " in markdown
+            # footnotes, which would break a shell --body argument).
+            echo "Recovery: save the body above to /tmp/pr-body.md, then run:"
+            echo "  gh pr create --base main --head ${BRANCH} --title 'chore: release v${VERSION}' --body-file /tmp/pr-body.md"
             exit 1
           fi
           PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')


### PR DESCRIPTION
## Summary
Two intertwined fixes per the hard rule `fix pre-existing same as new`:

### Lint gating
Discovered when PR #813's `lint` step was reported `skipping` on its own workflow-only PR — the very case where `check-release-trigger.sh` matters most. The Lint job was gated on `workflow_only != 'true'`, so changes to `.github/workflows/release.yml` would never run the script that validates the release.yml contract.

Removed the gate; `lint.yml`'s internal steps already gate heavyweight tools on `app_changed`/`backend_changed`, so workflow-only PRs only pay ~30s for the always-on script invocations.

### #813 R2 review findings
- **I-1**: jq filter `.object.sha // empty` so a malformed 200 (missing key) leaves `EXISTING_SHA` empty instead of the literal `null`, preventing a confusing 'unexpected state' error
- **M-1**: recovery instruction now points to `--body-file` (markdown footnotes contain literal ` " ` that would break shell `--body`)
- **M-2**: 'Settings > Branches' UI path corrected to the actual Branches page (github.com/<owner>/<repo>/branches > trash icon) in BOTH the orphan-cleanup warning AND the new idempotent-branch-mismatch error
- **I-2** (fork compatibility) accepted as-is: consistent with 4 existing check-*.sh patterns

## Test plan
- [x] `bash scripts/check-release-trigger.sh` exits 0
- [x] All 3 modified YAMLs parse cleanly
- [ ] CI passes — and lint runs (not skipped) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)