### PR TITLE
fix(release): handle 404 correctly in idempotent branch-existence check [CRITICAL]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,13 +382,20 @@ jobs:
           # of this same run created the branch), accept it and move
           # on. If it exists at a DIFFERENT sha, error out — that's
           # unexpected state that the operator should investigate.
-          # jq's `// empty` converts a missing key (returns `null`) to no
-          # output, so EXISTING_SHA stays empty when the API returns a
-          # 200 with a body that lacks `.object.sha` (e.g. a malformed
-          # response or a future API contract drift). The `|| true` on
-          # the outer pipeline already handles 404 exit codes.
-          EXISTING_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/${BRANCH}" --jq '.object.sha // empty' 2>/dev/null || true)
-          if [ -n "${EXISTING_SHA:-}" ]; then
+          #
+          # IMPORTANT: gh api with `--jq` on a 404 response prints the
+          # raw error JSON body to stdout (the --jq filter is bypassed
+          # when gh detects an HTTP error). That's why we split the
+          # exit-code check from the body parse — checking the exit
+          # code via `if gh api ...` is the only reliable way to
+          # distinguish "branch exists (200)" from "branch missing
+          # (404)". Both write to stdout; only the exit code is
+          # diagnostic.
+          if gh api "repos/${{ github.repository }}/git/ref/heads/${BRANCH}" \
+                > /tmp/ref-response.json 2>/dev/null; then
+            # 200 — branch exists. Parse sha from the response body.
+            # `// empty` covers a hypothetical 200-but-missing-key case.
+            EXISTING_SHA=$(jq -r '.object.sha // empty' /tmp/ref-response.json)
             if [ "${EXISTING_SHA}" = "${PARENT_SHA}" ]; then
               echo "Branch ${BRANCH} already exists at ${PARENT_SHA} (idempotent re-run); skipping creation."
             else
@@ -396,6 +403,7 @@ jobs:
               exit 1
             fi
           else
+            # 404 — branch doesn't exist. Create it.
             if ! gh api -X POST "repos/${{ github.repository }}/git/refs" \
                   -f "ref=refs/heads/${BRANCH}" \
                   -f "sha=${PARENT_SHA}" > /tmp/refs-response.json 2>&1; then


### PR DESCRIPTION
## Summary
PR #813's idempotency check had a fatal bug: `gh api --jq` on a 404 response prints the raw error JSON body to stdout (the `--jq` filter is bypassed when gh detects an HTTP error). `EXISTING_SHA` therefore captured the literal `{"message":"Not Found",...}` on a 404 instead of being empty, and the wrong-sha-error arm fired.

## Empirical failure
Release run [26364457651](https://github.com/ShydenMcM/ShyTalk/actions/runs/26364457651) failed with:
```
Branch release/v0.97.6-r26364457651 already exists but points at
{"message":"Not Found","documentation_url":"...","status":"404"}
(expected f511467e158d04...)
```
The branch didn't exist; the workflow should have created it.

## Fix
Split exit-code check from body parse: `if gh api ...` returns 0 on 200 and non-zero on 404. Parse jq only on the 200 path.

## Test plan
- [x] `scripts/check-release-trigger.sh` exits 0
- [x] Ruby YAML parse OK
- [ ] CI passes
- [ ] After merge, re-trigger Release workflow — should succeed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)