### PR TITLE
feat(driver/ios): iosShowsEditedBodyWithTag (Wake 103)

### DIFF
--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -634,6 +634,28 @@ async function createIosDriver({ udid: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 103 — `<Name>'s <Plat> UI shows the edited body "<X>" with
+  // an "<Y>" tag` (j07). iOS mirror of Android sibling. Message-edit
+  // indicator on the recipient view. Driver receives (name, body, tag).
+  //
+  // Foundation strategy: presence-check on `editedBody_*` identifier
+  // PREFIX. No such identifier exists in commonMain yet — only the
+  // source-side `room_msg_editTarget_<id>` identifier exists, which
+  // marks the message being edited (NOT the post-edit "(edited)"
+  // badge on the recipient view — distinct concerns).
+  //
+  // Returns false in real journeys today; lands true when commonMain
+  // ships editedBody_<msgId> / editedBody_badge identifiers. Per-body
+  // and per-tag verification need attribute extraction; deferred. All
+  // 3 args accepted-and-ignored.
+  driver.iosShowsEditedBodyWithTag = async (_name, _body, _tag) => {
+    const dump = await driver.iosUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<XCUIElementType\w+[^>]*\bidentifier="editedBody_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   const IOS_INPUT_TAGS = { chat: 'room_chatInput' };
   driver.iosDisablesInput = async (_name, inputName) => {
     if (!inputName || !inputName.trim()) return false;

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -3852,6 +3852,146 @@ describe('ios-devicectl-driver — iosShowsCountBadge', () => {
   });
 });
 
+describe('ios-devicectl-driver — iosShowsEditedBodyWithTag', () => {
+  // Wake 103 — `<Name>'s <Plat> UI shows the edited body "<X>" with
+  // an "<Y>" tag`. Foundation: presence-check editedBody_* identifier.
+  function driverWithDump(xml) {
+    return createIosDriver({ udid: 'X' }).then((d) => {
+      d.iosUiDump = async () => xml;
+      return d;
+    });
+  }
+
+  test('editedBody_msg123 present → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', 'edited')).toBe(true);
+  });
+
+  test('editedBody_badge present → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_badge" />');
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', 'edited')).toBe(true);
+  });
+
+  test('absent → false', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', 'edited')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', 'edited')).toBe(false);
+  });
+
+  test('non-self-closing form → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="editedBody_msg123"><XCUIElementTypeStaticText name="hi (edited)" /></XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', 'edited')).toBe(true);
+  });
+
+  test('left-boundary — pre_editedBody_X does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="pre_editedBody_msg123" />',
+    );
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', 'edited')).toBe(false);
+  });
+
+  test('right-boundary — editedBody_msg123Extra still matches', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="editedBody_msg123Extra" />',
+    );
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', 'edited')).toBe(true);
+  });
+
+  test('confusable prefix — editedBodyExtras_panel does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="editedBodyExtras_panel" />',
+    );
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', 'edited')).toBe(false);
+  });
+
+  test('attribute-specificity — name= does NOT trigger', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther name="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', 'edited')).toBe(false);
+  });
+
+  test('iosUiDump throws → rejects', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('WDA lost');
+    };
+    await expect(driver.iosShowsEditedBodyWithTag('Greta', 'hi', 'edited')).rejects.toThrow();
+  });
+
+  test('null name → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag(null, 'hi', 'edited')).toBe(true);
+  });
+
+  test('undefined name → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag(undefined, 'hi', 'edited')).toBe(true);
+  });
+
+  test('empty name → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag('', 'hi', 'edited')).toBe(true);
+  });
+
+  test('whitespace name → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag('   ', 'hi', 'edited')).toBe(true);
+  });
+
+  test('null body → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', null, 'edited')).toBe(true);
+  });
+
+  test('undefined body → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', undefined, 'edited')).toBe(true);
+  });
+
+  test('empty body → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', '', 'edited')).toBe(true);
+  });
+
+  test('whitespace body → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', '   ', 'edited')).toBe(true);
+  });
+
+  test('null tag → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', null)).toBe(true);
+  });
+
+  test('undefined tag → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', undefined)).toBe(true);
+  });
+
+  test('empty tag → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', '')).toBe(true);
+  });
+
+  test('whitespace tag → true', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="editedBody_msg123" />');
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', '   ')).toBe(true);
+  });
+
+  test('first-match contract — two editedBody_* nodes', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="editedBody_msg123" />' +
+        '<XCUIElementTypeOther identifier="editedBody_badge" />',
+    );
+    expect(await driver.iosShowsEditedBodyWithTag('Greta', 'hi', 'edited')).toBe(true);
+  });
+});
+
 describe('ios-devicectl-driver — stub call-arity tolerance', () => {
   // Stubs accept any number of args (0, 1, 2, 3, 4). Pin this so a
   // future refactor that adds arg-validation to the stub loop doesn't


### PR DESCRIPTION
iOS mirror of Android sibling. Presence-check editedBody_* identifier (UI unbuilt; lands true when identifiers ship). Runner-routing pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)