### PR TITLE
feat(driver/ios): iosShowsFrozenBanner (Wake 99)

### DIFF
--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -656,6 +656,24 @@ async function createIosDriver({ udid: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 99 — `<Name>'s <Plat> UI[ opens conversation "<X>"] shows the
+  // frozen-banner element <suffix>` (j08). iOS mirror of Android sibling.
+  // Driver receives (viewer, convId, suffix) where convId is optional
+  // (null when no "opens conversation X" prefix) and suffix is
+  // descriptive ("with text-from-key X" or "with locale string Y").
+  //
+  // Foundation strategy: presence-check the EXACT `privateChat_frozenBanner`
+  // identifier. All 3 args accepted-and-ignored — the assertion is
+  // "frozen banner currently visible". Per-text and per-locale
+  // verification can layer on later via attribute extraction.
+  driver.iosShowsFrozenBanner = async (_viewer, _convId, _suffix) => {
+    const dump = await driver.iosUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<XCUIElementType\w+[^>]*\bidentifier="privateChat_frozenBanner"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   const IOS_INPUT_TAGS = { chat: 'room_chatInput' };
   driver.iosDisablesInput = async (_name, inputName) => {
     if (!inputName || !inputName.trim()) return false;

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -3992,6 +3992,155 @@ describe('ios-devicectl-driver — iosShowsEditedBodyWithTag', () => {
   });
 });
 
+describe('ios-devicectl-driver — iosShowsFrozenBanner', () => {
+  // Wake 99 — `<Name>'s <Plat> UI[ opens conversation "<X>"] shows the
+  // frozen-banner element <suffix>`. Foundation: presence-check exact
+  // privateChat_frozenBanner identifier.
+  function driverWithDump(xml) {
+    return createIosDriver({ udid: 'X' }).then((d) => {
+      d.iosUiDump = async () => xml;
+      return d;
+    });
+  }
+
+  test('privateChat_frozenBanner present → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner('Greta', 'conv1', 'with text "frozen"')).toBe(true);
+  });
+
+  test('absent → false', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosShowsFrozenBanner('Greta', null, 'with text "frozen"')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(await driver.iosShowsFrozenBanner('Greta', null, 'with text "frozen"')).toBe(false);
+  });
+
+  test('non-self-closing form → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBanner"><XCUIElementTypeStaticText name="Conversation frozen" /></XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsFrozenBanner('Greta', null, 'with text "frozen"')).toBe(true);
+  });
+
+  test('left-boundary — pre_privateChat_frozenBanner does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="pre_privateChat_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner('Greta', null, 'X')).toBe(false);
+  });
+
+  test('right-boundary — privateChat_frozenBannerExtra does NOT match (exact-match anchor)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBannerExtra" />',
+    );
+    expect(await driver.iosShowsFrozenBanner('Greta', null, 'X')).toBe(false);
+  });
+
+  test('confusable — privateChatExtras_frozenBanner does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChatExtras_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner('Greta', null, 'X')).toBe(false);
+  });
+
+  test('attribute-specificity — name= does NOT trigger', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther name="privateChat_frozenBanner" />');
+    expect(await driver.iosShowsFrozenBanner('Greta', null, 'X')).toBe(false);
+  });
+
+  test('iosUiDump throws → rejects', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('WDA lost');
+    };
+    await expect(
+      driver.iosShowsFrozenBanner('Greta', null, 'with text "frozen"'),
+    ).rejects.toThrow();
+  });
+
+  test('null viewer → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner(null, null, 'X')).toBe(true);
+  });
+
+  test('undefined viewer → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner(undefined, null, 'X')).toBe(true);
+  });
+
+  test('empty viewer → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner('', null, 'X')).toBe(true);
+  });
+
+  test('whitespace viewer → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner('   ', null, 'X')).toBe(true);
+  });
+
+  test('null convId → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner('Greta', null, 'X')).toBe(true);
+  });
+
+  test('undefined convId → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner('Greta', undefined, 'X')).toBe(true);
+  });
+
+  test('non-empty convId still passes', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner('Greta', 'conv-id-99', 'X')).toBe(true);
+  });
+
+  test('null suffix → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner('Greta', null, null)).toBe(true);
+  });
+
+  test('undefined suffix → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner('Greta', null, undefined)).toBe(true);
+  });
+
+  test('empty suffix → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner('Greta', null, '')).toBe(true);
+  });
+
+  test('whitespace suffix → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="privateChat_frozenBanner" />',
+    );
+    expect(await driver.iosShowsFrozenBanner('Greta', null, '   ')).toBe(true);
+  });
+});
+
 describe('ios-devicectl-driver — stub call-arity tolerance', () => {
   // Stubs accept any number of args (0, 1, 2, 3, 4). Pin this so a
   // future refactor that adds arg-validation to the stub loop doesn't

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -22022,6 +22022,51 @@ describe('Wake 99 — `<Name>\'s <Plat> UI[ opens conversation "<X>"] shows the 
     expect(r.ok).toBe(false);
     expect(r.error).toMatch(/Vexa|frozen-banner/);
   });
+
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosShowsFrozenBanner: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Greta\'s iOS Sim UI shows the frozen-banner element with text from key "age_seg_frozen_conversation_banner"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith(
+      'Greta',
+      null,
+      'with text from key "age_seg_frozen_conversation_banner"',
+    );
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsFrozenBanner: spy } });
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Greta\'s iOS Sim UI shows the frozen-banner element with text from key "X"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Greta|frozen-banner/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'Greta\'s iOS Sim UI shows the frozen-banner element with text from key "X"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/iosShowsFrozenBanner/);
+  });
 });
 
 describe("Wake 99 — `<Name>'s <Plat> UI navigates to the room screen <suffix>`", () => {


### PR DESCRIPTION
iOS mirror of Android sibling. Presence-check exact privateChat_frozenBanner identifier. Runner-routing pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)