### PR TITLE
feat(driver/ios): iosShowsGiftFromSender (Wake 99)

### DIFF
--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -674,6 +674,49 @@ async function createIosDriver({ udid: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 99 — `<Name>'s <Plat> UI shows a "<X>" gift from <Other>`
+  // (j01). iOS mirror of Android sibling. Driver receives
+  // (recipient, giftId, sender).
+  //
+  // Foundation strategy: TRIPLE composition:
+  //   1. giftWall_grid identifier PRESENT (recipient is on gift-wall).
+  //   2. giftId substring appears in any label/name/value with
+  //      symmetric word-boundary protection.
+  //   3. sender substring appears in any label/name/value with
+  //      symmetric word-boundary protection.
+  //
+  // Both substring scans run over the whole dump independently. The
+  // journey orchestrator ensures only one gift entry is shown at the
+  // time of the assertion, so cross-entry false positives aren't
+  // reachable. _recipient is accepted-and-ignored.
+  driver.iosShowsGiftFromSender = async (_recipient, giftId, sender) => {
+    if (typeof giftId !== 'string' || !giftId.trim()) return false;
+    if (typeof sender !== 'string' || !sender.trim()) return false;
+    const dump = await driver.iosUiDump();
+    if (!dump) return false;
+    // Step 1: gift wall must be visible.
+    // eslint-disable-next-line sonarjs/slow-regex
+    const wallRx = /<XCUIElementType\w+[^>]*\bidentifier="giftWall_grid"[^>]*\/?>/;
+    if (!wallRx.test(dump)) return false;
+    // Step 2: giftId appears with symmetric word-boundary across
+    // label/name/value attrs. The \b on the attr-name alternation
+    // guards compound attrs (accessibilityLabel, typename) per the
+    // same pattern as iosShowsBanner.
+    const escGift = giftId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const giftRx = new RegExp(
+      `\\b(?:label|name|value)="[^"]*(?<![\\w-])${escGift}(?![\\w-])[^"]*"`,
+    );
+    if (!giftRx.test(dump)) return false;
+    // Step 3: sender appears with symmetric word-boundary.
+    const escSender = sender.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line sonarjs/slow-regex
+    const senderRx = new RegExp(
+      `\\b(?:label|name|value)="[^"]*(?<![\\w-])${escSender}(?![\\w-])[^"]*"`,
+    );
+    return senderRx.test(dump);
+  };
+
   const IOS_INPUT_TAGS = { chat: 'room_chatInput' };
   driver.iosDisablesInput = async (_name, inputName) => {
     if (!inputName || !inputName.trim()) return false;

--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -699,9 +699,14 @@ async function createIosDriver({ udid: preferred } = {}) {
     const wallRx = /<XCUIElementType\w+[^>]*\bidentifier="giftWall_grid"[^>]*\/?>/;
     if (!wallRx.test(dump)) return false;
     // Step 2: giftId appears with symmetric word-boundary across
-    // label/name/value attrs. The \b on the attr-name alternation
-    // guards compound attrs (accessibilityLabel, typename) per the
-    // same pattern as iosShowsBanner.
+    // label/name/value attrs. The \b before (?:label|name|value)=
+    // requires a word boundary IMMEDIATELY BEFORE the attr name —
+    // because \b only fires at \W→\w transitions, compound attrs
+    // like accessibilityLabel= are blocked (the `y` preceding `L`
+    // is a word-char, so no boundary fires there). The symmetric
+    // (?<![\w-]) / (?![\w-]) lookaround around ${escGift} blocks
+    // both word-char AND hyphen on either side, so "roses"/
+    // "wildrose"/"rose-gold" are all rejected for giftId="rose".
     const escGift = giftId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     // eslint-disable-next-line sonarjs/slow-regex
     const giftRx = new RegExp(

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -4141,6 +4141,214 @@ describe('ios-devicectl-driver — iosShowsFrozenBanner', () => {
   });
 });
 
+describe('ios-devicectl-driver — iosShowsGiftFromSender', () => {
+  // Wake 99 — `<Name>'s <Plat> UI shows a "<X>" gift from <Other>`.
+  // Triple composition: giftWall_grid + giftId + sender, both with
+  // symmetric word-boundary protection across label/name/value attrs.
+  function driverWithDump(xml) {
+    return createIosDriver({ udid: 'X' }).then((d) => {
+      d.iosUiDump = async () => xml;
+      return d;
+    });
+  }
+
+  const FULL_DUMP =
+    '<XCUIElementTypeOther identifier="giftWall_grid">' +
+    '<XCUIElementTypeStaticText label="rose" name="rose" />' +
+    '<XCUIElementTypeStaticText label="Adam" name="Adam" />' +
+    '</XCUIElementTypeOther>';
+
+  test('all 3 conditions met → true', async () => {
+    const driver = await driverWithDump(FULL_DUMP);
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(true);
+  });
+
+  test('wall absent → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeStaticText label="rose" /><XCUIElementTypeStaticText label="Adam" />',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(false);
+  });
+
+  test('giftId absent → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid"><XCUIElementTypeStaticText label="Adam" /></XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(false);
+  });
+
+  test('sender absent → false', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid"><XCUIElementTypeStaticText label="rose" /></XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(false);
+  });
+
+  test('giftId "rose" does NOT match "roses" (suffix collision)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText label="roses" /><XCUIElementTypeStaticText label="Adam" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(false);
+  });
+
+  test('giftId "rose" does NOT match "wildrose" (prefix collision)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText label="wildrose" /><XCUIElementTypeStaticText label="Adam" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(false);
+  });
+
+  test('sender "Adam" does NOT match "Adams" (suffix collision)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText label="rose" /><XCUIElementTypeStaticText label="Adams" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(false);
+  });
+
+  test('giftId "v1.2" matches literal dot in label', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText label="v1.2 special" />' +
+        '<XCUIElementTypeStaticText label="Adam" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'v1.2', 'Adam')).toBe(true);
+  });
+
+  test('giftId "v1.2" does NOT match label "v1X2" (regex-escape protects dot)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText label="v1X2" /><XCUIElementTypeStaticText label="Adam" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'v1.2', 'Adam')).toBe(false);
+  });
+
+  test('accessibilityLabel= does NOT contribute (compound attr guard)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText accessibilityLabel="rose" />' +
+        '<XCUIElementTypeStaticText accessibilityLabel="Adam" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(false);
+  });
+
+  test('giftId on label + sender on name → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText label="rose" />' +
+        '<XCUIElementTypeStaticText name="Adam" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(true);
+  });
+
+  // Input rejection with isolation.
+  test('null giftId → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsGiftFromSender('Alice', null, 'Adam')).toBe(false);
+  });
+
+  test('undefined giftId → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsGiftFromSender('Alice', undefined, 'Adam')).toBe(false);
+  });
+
+  test('empty giftId → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsGiftFromSender('Alice', '', 'Adam')).toBe(false);
+  });
+
+  test('whitespace giftId → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsGiftFromSender('Alice', '   ', 'Adam')).toBe(false);
+  });
+
+  test('null sender → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', null)).toBe(false);
+  });
+
+  test('undefined sender → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', undefined)).toBe(false);
+  });
+
+  test('empty sender → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', '')).toBe(false);
+  });
+
+  test('whitespace sender → false, iosUiDump not called', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('must not be called');
+    };
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', '   ')).toBe(false);
+  });
+
+  test('null recipient → still evaluates', async () => {
+    const driver = await driverWithDump(FULL_DUMP);
+    expect(await driver.iosShowsGiftFromSender(null, 'rose', 'Adam')).toBe(true);
+  });
+
+  test('undefined recipient → still evaluates', async () => {
+    const driver = await driverWithDump(FULL_DUMP);
+    expect(await driver.iosShowsGiftFromSender(undefined, 'rose', 'Adam')).toBe(true);
+  });
+
+  test('empty recipient → still evaluates', async () => {
+    const driver = await driverWithDump(FULL_DUMP);
+    expect(await driver.iosShowsGiftFromSender('', 'rose', 'Adam')).toBe(true);
+  });
+
+  test('whitespace recipient → still evaluates', async () => {
+    const driver = await driverWithDump(FULL_DUMP);
+    expect(await driver.iosShowsGiftFromSender('   ', 'rose', 'Adam')).toBe(true);
+  });
+
+  test('iosUiDump throws → rejects', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('WDA lost');
+    };
+    await expect(driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).rejects.toThrow();
+  });
+});
+
 describe('ios-devicectl-driver — stub call-arity tolerance', () => {
   // Stubs accept any number of args (0, 1, 2, 3, 4). Pin this so a
   // future refactor that adds arg-validation to the stub loop doesn't

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -4216,6 +4216,37 @@ describe('ios-devicectl-driver — iosShowsGiftFromSender', () => {
     expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(false);
   });
 
+  test('sender "Adam" does NOT match "AdamSmith" (prefix collision)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText label="rose" />' +
+        '<XCUIElementTypeStaticText label="AdamSmith" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(false);
+  });
+
+  // Hyphen-boundary discipline (the `-` in `[\w-]` lookaround).
+  test('giftId "rose" does NOT match "rose-gold" (hyphen suffix collision)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText label="rose-gold" />' +
+        '<XCUIElementTypeStaticText label="Adam" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(false);
+  });
+
+  test('sender "Adam" does NOT match "Adam-Berg" (hyphen suffix collision)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText label="rose" />' +
+        '<XCUIElementTypeStaticText label="Adam-Berg" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(false);
+  });
+
   test('giftId "v1.2" matches literal dot in label', async () => {
     const driver = await driverWithDump(
       '<XCUIElementTypeOther identifier="giftWall_grid">' +
@@ -4253,6 +4284,59 @@ describe('ios-devicectl-driver — iosShowsGiftFromSender', () => {
         '</XCUIElementTypeOther>',
     );
     expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(true);
+  });
+
+  // value= attribute branch (XCUITest emits value= for controls like
+  // text fields and steppers; the alternation must cover it).
+  test('giftId on value= → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText value="rose" />' +
+        '<XCUIElementTypeStaticText label="Adam" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(true);
+  });
+
+  test('sender on value= → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText label="rose" />' +
+        '<XCUIElementTypeStaticText value="Adam" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(true);
+  });
+
+  // Same-node case: both in one label.
+  test('giftId and sender both in same label → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText label="Adam sent rose today" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'Adam')).toBe(true);
+  });
+
+  // Sender regex-escape (parity with giftId v1.2 coverage).
+  test('sender "User.42" matches literal dot in label', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText label="rose" />' +
+        '<XCUIElementTypeStaticText label="User.42" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'User.42')).toBe(true);
+  });
+
+  test('sender "User.42" does NOT match "UserX42" (escape protects dot)', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="giftWall_grid">' +
+        '<XCUIElementTypeStaticText label="rose" />' +
+        '<XCUIElementTypeStaticText label="UserX42" />' +
+        '</XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsGiftFromSender('Alice', 'rose', 'User.42')).toBe(false);
   });
 
   // Input rejection with isolation.

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -22121,7 +22121,11 @@ describe('Wake 99 — `<Name>\'s <Plat> UI shows a "<X>" gift from <Other>`', ()
       ctx,
     );
     expect(r.ok).toBe(false);
-    expect(r.error).toMatch(/Alice|crown|Bob/);
+    // Tightened (PR #823 R1): require both gift + sender names in
+    // the error so a degraded message that mentions only one would
+    // fail the test.
+    expect(r.error).toMatch(/crown/);
+    expect(r.error).toMatch(/Bob/);
   });
 
   test('Web driver missing → fail', async () => {
@@ -22153,7 +22157,8 @@ describe('Wake 99 — `<Name>\'s <Plat> UI shows a "<X>" gift from <Other>`', ()
       ctx,
     );
     expect(r.ok).toBe(false);
-    expect(r.error).toMatch(/Alice|crown|Bob/);
+    expect(r.error).toMatch(/crown/);
+    expect(r.error).toMatch(/Bob/);
   });
 
   test('Android driver missing → fail', async () => {
@@ -22185,7 +22190,8 @@ describe('Wake 99 — `<Name>\'s <Plat> UI shows a "<X>" gift from <Other>`', ()
       ctx,
     );
     expect(r.ok).toBe(false);
-    expect(r.error).toMatch(/Nora|crown|Bob/);
+    expect(r.error).toMatch(/crown/);
+    expect(r.error).toMatch(/Bob/);
   });
 
   test('iOS Sim driver missing → fail', async () => {

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -22123,6 +22123,80 @@ describe('Wake 99 — `<Name>\'s <Plat> UI shows a "<X>" gift from <Other>`', ()
     expect(r.ok).toBe(false);
     expect(r.error).toMatch(/Alice|crown|Bob/);
   });
+
+  test('Web driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Web UI shows a "rose" gift from Adam' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/webShowsGiftFromSender/);
+  });
+
+  test('Android matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { androidShowsGiftFromSender: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Android UI shows a "rose" gift from Adam' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Alice', 'rose', 'Adam');
+  });
+
+  test('Android driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { androidShowsGiftFromSender: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Android UI shows a "crown" gift from Bob' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Alice|crown|Bob/);
+  });
+
+  test('Android driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Alice\'s Android UI shows a "rose" gift from Adam' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/androidShowsGiftFromSender/);
+  });
+
+  test('iOS Sim matching → ok', async () => {
+    const spy = jest.fn(async () => true);
+    const ctx = makeCtx({ uiDriver: { iosShowsGiftFromSender: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Nora\'s iOS Sim UI shows a "rose" gift from Adam' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith('Nora', 'rose', 'Adam');
+  });
+
+  test('iOS Sim driver returns false → fail', async () => {
+    const spy = jest.fn(async () => false);
+    const ctx = makeCtx({ uiDriver: { iosShowsGiftFromSender: spy } });
+    const r = await executeStep(
+      { kind: 'Then', text: 'Nora\'s iOS Sim UI shows a "crown" gift from Bob' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Nora|crown|Bob/);
+  });
+
+  test('iOS Sim driver missing → fail', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Then', text: 'Nora\'s iOS Sim UI shows a "rose" gift from Adam' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/iosShowsGiftFromSender/);
+  });
 });
 
 describe('Wake 99 — "<Name>\'s <Plat> UI shows only minor-cohort users in the rankings"', () => {


### PR DESCRIPTION
iOS mirror of Android sibling. Triple composition: giftWall_grid presence + giftId + sender, both with symmetric word-boundary protection across label/name/value attrs. Added Android + iOS Sim runner-branch tests per verify-runner-routing-per-platform rule (Wake 99 gift block previously had Web-only coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)