### PR TITLE
feat(driver/ios): iosShowsInResults (Wake 101)

### DIFF
--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -742,6 +742,28 @@ async function createIosDriver({ udid: preferred } = {}) {
     return tagRx.test(dump);
   };
 
+  // Wake 101 — `<Name>'s <Plat> UI shows <Other> in results[ with
+  // displayName "<X>"]` (j01/j02). iOS mirror of Android sibling.
+  // Discovery list result visibility with optional displayName
+  // suffix. Driver receives (viewer, target, displayName) — displayName
+  // may be `null` (no "with displayName" suffix in step).
+  //
+  // Foundation strategy: presence-check `searchResults_*` identifier
+  // PREFIX. No such identifier exists in commonMain yet —
+  // NewMessageScreen exposes only `newMessage_searchField` for the
+  // input box, not per-result tiles. Returns false in real journeys
+  // today; lands true when commonMain ships searchResults_userTile
+  // / searchResults_container. Per-user and per-displayName checks
+  // need attribute extraction; deferred. All 3 args accepted-and-
+  // ignored.
+  driver.iosShowsInResults = async (_viewer, _target, _displayName) => {
+    const dump = await driver.iosUiDump();
+    if (!dump) return false;
+    // eslint-disable-next-line sonarjs/slow-regex
+    const tagRx = /<XCUIElementType\w+[^>]*\bidentifier="searchResults_[^"]*"[^>]*\/?>/;
+    return tagRx.test(dump);
+  };
+
   const IOS_INPUT_TAGS = { chat: 'room_chatInput' };
   driver.iosDisablesInput = async (_name, inputName) => {
     if (!inputName || !inputName.trim()) return false;

--- a/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
+++ b/express-api/tests/scripts/drivers/ios-devicectl-driver.test.js
@@ -4606,6 +4606,182 @@ describe('ios-devicectl-driver — iosShowsInAppGiftNotification', () => {
   });
 });
 
+describe('ios-devicectl-driver — iosShowsInResults', () => {
+  // Wake 101 — `<Name>'s <Plat> UI shows <Other> in results[ with
+  // displayName "<X>"]`. Foundation: presence-check searchResults_*
+  // identifier PREFIX.
+  function driverWithDump(xml) {
+    return createIosDriver({ udid: 'X' }).then((d) => {
+      d.iosUiDump = async () => xml;
+      return d;
+    });
+  }
+
+  test('searchResults_userTile present → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', 'Raul', 'Raul Z.')).toBe(true);
+  });
+
+  test('searchResults_container present → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_container" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', 'Raul', null)).toBe(true);
+  });
+
+  test('absent → false', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther identifier="main_roomsTab" />');
+    expect(await driver.iosShowsInResults('Greta', 'Raul', null)).toBe(false);
+  });
+
+  test('empty dump → false', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    expect(await driver.iosShowsInResults('Greta', 'Raul', null)).toBe(false);
+  });
+
+  test('non-self-closing form → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile"><XCUIElementTypeStaticText name="Raul" /></XCUIElementTypeOther>',
+    );
+    expect(await driver.iosShowsInResults('Greta', 'Raul', null)).toBe(true);
+  });
+
+  test('left-boundary — pre_searchResults_X does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="pre_searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', 'Raul', null)).toBe(false);
+  });
+
+  test('right-boundary — searchResults_userTileExtra still matches', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTileExtra" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', 'Raul', null)).toBe(true);
+  });
+
+  test('confusable — searchResultsExtras_panel does NOT match', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResultsExtras_panel" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', 'Raul', null)).toBe(false);
+  });
+
+  test('attribute-specificity — name= does NOT trigger', async () => {
+    const driver = await driverWithDump('<XCUIElementTypeOther name="searchResults_userTile" />');
+    expect(await driver.iosShowsInResults('Greta', 'Raul', null)).toBe(false);
+  });
+
+  test('iosUiDump throws → rejects', async () => {
+    const driver = await createIosDriver({ udid: 'X' });
+    driver.iosUiDump = async () => {
+      throw new Error('WDA lost');
+    };
+    await expect(driver.iosShowsInResults('Greta', 'Raul', null)).rejects.toThrow();
+  });
+
+  test('null viewer → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults(null, 'Raul', null)).toBe(true);
+  });
+
+  test('undefined viewer → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults(undefined, 'Raul', null)).toBe(true);
+  });
+
+  test('empty viewer → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults('', 'Raul', null)).toBe(true);
+  });
+
+  test('whitespace viewer → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults('   ', 'Raul', null)).toBe(true);
+  });
+
+  test('null target → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', null, null)).toBe(true);
+  });
+
+  test('undefined target → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', undefined, null)).toBe(true);
+  });
+
+  test('empty target → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', '', null)).toBe(true);
+  });
+
+  test('whitespace target → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', '   ', null)).toBe(true);
+  });
+
+  test('non-null displayName → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', 'Raul', 'Raul Z.')).toBe(true);
+  });
+
+  test('null displayName → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', 'Raul', null)).toBe(true);
+  });
+
+  test('undefined displayName → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', 'Raul', undefined)).toBe(true);
+  });
+
+  test('empty displayName → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', 'Raul', '')).toBe(true);
+  });
+
+  test('whitespace displayName → true', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', 'Raul', '   ')).toBe(true);
+  });
+
+  test('first-match contract — two searchResults_* nodes', async () => {
+    const driver = await driverWithDump(
+      '<XCUIElementTypeOther identifier="searchResults_userTile" />' +
+        '<XCUIElementTypeOther identifier="searchResults_container" />',
+    );
+    expect(await driver.iosShowsInResults('Greta', 'Raul', null)).toBe(true);
+  });
+});
+
 describe('ios-devicectl-driver — stub call-arity tolerance', () => {
   // Stubs accept any number of args (0, 1, 2, 3, 4). Pin this so a
   // future refactor that adds arg-validation to the stub loop doesn't


### PR DESCRIPTION
iOS mirror of Android sibling. Presence-check searchResults_* identifier. Runner-routing pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)