### PR TITLE
chore(deps): defer compose-mp minor bumps pending nav-compose alignment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,8 +25,14 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "org.jetbrains.kotlin.plugin.compose"
         update-types: ["version-update:semver-major"]
+      # Minor bumps gated on the navigation-compose ecosystem: compose 1.11.0+
+      # needs a navigation-compose whose Skiko aligns, but stable nav tops out
+      # at 2.9.2 (compose 1.10.x) and the next (2.10.0-alpha01) targets compose
+      # 1.12.0-alpha01 + the JetBrains EAP repo. Ignoring minor (and major)
+      # until a stable compose + stable nav 2.10 align — patches on 1.10.x still
+      # flow. Deferred #705 on 2026-05-26; remove the minor entry to revisit.
       - dependency-name: "org.jetbrains.compose"
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "androidx.compose:compose-bom"
         update-types: ["version-update:semver-major"]
       - dependency-name: "io.livekit:livekit-android"


### PR DESCRIPTION
## What
Adds `version-update:semver-minor` to the existing `org.jetbrains.compose` dependabot ignore (major was already ignored).

## Why
Compose Multiplatform **1.11.0+ has no compatible stable navigation-compose**:
- stable `jetbrains-navigation-compose` 2.9.2 is built for compose 1.10.x → Skiko clash with 1.11.0 (fails `checkIosSimulatorArm64MainComposeLibrariesCompatibility`)
- the next nav, 2.10.0-alpha01, targets compose **1.12.0-alpha01** whose klibs are EAP-only (not on Maven Central)

Adopting 1.11.0 would require wiring the JetBrains compose-dev EAP repo and running the compose framework on alphas in a production iOS app. Deferred per the #705 decision. Patches on 1.10.x still flow; remove the semver-minor entry to revisit once a stable compose + stable nav 2.10 align.

Closes the loop on **#705** (being closed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)