### PR TITLE
fix(android): drop redundant trailing Unit in refreshIdToken (Kotlin warning)

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/AuthRepositoryImpl.kt
@@ -166,6 +166,5 @@ class AuthRepositoryImpl(
             // Firebase's local cache.
             val user = auth.currentUser ?: throw IllegalStateException("No signed-in user")
             user.getIdToken(true).await()
-            Unit
         }
 }


### PR DESCRIPTION
## What
Removes the redundant trailing `Unit` literal from `refreshIdToken()`'s `firebaseCall { … }` block.

## Why
`AuthRepositoryImpl.kt:169 Expression is unused` (Kotlin compiler warning). Since `refreshIdToken(): Resource<Unit>` already pins `firebaseCall`'s `T = Unit`, the lambda is effectively `() -> Unit` — `getIdToken(true).await()` is coerced-to-Unit, so the explicit trailing `Unit` was a redundant standalone statement. Matches the sibling `sendSignInLink()` idiom (ends on `.await()`, no explicit `Unit`). Surfaced during #705's iOS build; fixed per the warnings-are-failures / fix-pre-existing policy.

## Verification
- `:app:compileDevDebugKotlin --rerun-tasks` → BUILD SUCCESSFUL, **no "Expression is unused"** (and no other warnings)
- `:app:testDevDebugUnitTest` → BUILD SUCCESSFUL, tests pass
- Behaviorally inert (removes a no-op `Unit` literal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)