### PR TITLE
chore(ios): enforce Kotlin allWarningsAsErrors on shared (#24c finale)

### DIFF
--- a/express-api/tests/scripts/ios-shared-warnings-as-errors.test.js
+++ b/express-api/tests/scripts/ios-shared-warnings-as-errors.test.js
@@ -1,0 +1,31 @@
+/**
+ * Kotlin warnings-as-errors enforced on the shared module (#24c finale).
+ *
+ * shared/ holds the bulk of our code (commonMain: models, repos, ViewModels,
+ * UI). `allWarningsAsErrors = true` makes ANY Kotlin compiler warning across
+ * shared (commonMain / jvm / android / iOS) fail the build — the enforcement
+ * end of the iOS-warnings arc. Verified: shared compiles green under the flag
+ * on all targets (compileKotlinIosArm64 / compileKotlinJvm / compileAndroidMain).
+ *
+ * NOT enforced (upstream/environment debt — see
+ * .project/ios-build-warnings-debt.md): pod deprecations, the gitlive cinterop
+ * import warning, the Xcode-26.3 Metal `ld:` quirk, and Swift app-target
+ * -warnings-as-errors (blocked by the cinterop diagnostic at the shared.h
+ * import boundary). None are Kotlin-compiler warnings, so this gate is the
+ * right scope for "enforce our code".
+ *
+ * Pins the flag so a future "build cleanup" can't silently drop it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SHARED_BUILD_GRADLE = path.join(__dirname, '../../../shared/build.gradle.kts');
+
+describe('shared Kotlin warnings-as-errors enforcement', () => {
+  test('shared/build.gradle.kts sets allWarningsAsErrors = true', () => {
+    const src = fs.readFileSync(SHARED_BUILD_GRADLE, 'utf8');
+    // The Kotlin Gradle DSL: compilerOptions { allWarningsAsErrors = true }.
+    expect(src).toMatch(/allWarningsAsErrors\s*=\s*true/);
+  });
+});

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -8,6 +8,14 @@ plugins {
 kotlin {
     compilerOptions {
         freeCompilerArgs.add("-Xexpect-actual-classes")
+        // Enforce our-code warnings-as-errors (#24c finale): any Kotlin
+        // compiler warning across shared (commonMain / jvm / android / iOS)
+        // now fails the build. Our Kotlin is warning-clean. The remaining iOS
+        // build warnings (pod deprecations, the gitlive cinterop import, the
+        // Xcode-26.3 Metal-toolchain ld: quirk) are upstream/environment and
+        // are NOT Kotlin-compiler warnings, so this gate does not touch them —
+        // they are tracked as upstream debt instead.
+        allWarningsAsErrors = true
     }
 
     // JVM target exists solely to run commonTest on Windows/Linux/CI

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/auth/GoogleSignInHelperTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/feature/auth/GoogleSignInHelperTest.kt
@@ -2,6 +2,7 @@ package com.shyden.shytalk.feature.auth
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -85,12 +86,17 @@ class GoogleSignInHelperTest {
         val cancelled: Throwable = GoogleSignInCancelledException()
         assertIs<GoogleSignInNoAccountException>(noAccount)
         assertIs<GoogleSignInCancelledException>(cancelled)
-        assertTrue(
-            noAccount !is GoogleSignInCancelledException,
+        // Runtime distinctness via reflection: KClass.isInstance is not folded
+        // to a constant the way `!is` is (which trips allWarningsAsErrors as
+        // "Check for instance is always 'true'"), so these survive -Werror while
+        // still catching a future refactor that makes either exception inherit
+        // from the other and breaks SignInScreen's catch-order branching.
+        assertFalse(
+            GoogleSignInCancelledException::class.isInstance(noAccount),
             "no-account must NOT match the cancelled catch arm",
         )
-        assertTrue(
-            cancelled !is GoogleSignInNoAccountException,
+        assertFalse(
+            GoogleSignInNoAccountException::class.isInstance(cancelled),
             "cancelled must NOT match the no-account catch arm",
         )
     }


### PR DESCRIPTION
The achievable end of the iOS-warnings arc: **Kotlin `allWarningsAsErrors` on the `shared` module** (commonMain / jvm / android / iOS + test source sets) — any Kotlin compiler warning in our shared code now fails the build.

## Verified clean under the flag
`compileKotlinIosArm64`, `compileKotlinJvm`, `compileAndroidMain`, `compileTestKotlinJvm` + `jvmTest` all green. Surfaced + fixed 2 redundant-instance warnings in `GoogleSignInHelperTest` (the `!is` future-guards were statically folded after `assertIs` smart-cast → switched to reflection `KClass.isInstance`, which isn't folded, preserving the runtime guard). Pinned by `ios-shared-warnings-as-errors.test.js`.

## NOT enforced — upstream / environment debt (none are Kotlin-compiler warnings)
Tracked in `.project/ios-build-warnings-debt.md` (local) — recorded here for durability:
- **Cinterop** (gitlive `SharedFirebase_databaseChildEventType` import) — gitlive 2.4.0 + K/N 2.4.0-RC are maxed; also blocks Swift app-target `-warnings-as-errors` at the `shared.h` boundary.
- **Pod/SDK deprecations** (Firebase/GoogleSignIn vs iOS 26, zlib, abseil) — no iOS-26-clean pod releases yet.
- **Metal `ld:` quirk** (×6) — Xcode 26.3 searches a non-existent toolchain subpath; `-downloadComponent` install **verified ineffective**; it's a linker warning `-Werror` wouldn't catch anyway.

## Related (separate, parked for operator)
- **iOS deploy archive broken** (#8 in session notes): SwiftPM targets get the manual provisioning profile (from #841 SPM migration). Release-critical signing; blocks all iOS deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)