### PR TITLE
chore(android): enforce Kotlin allWarningsAsErrors on the app module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -267,6 +267,18 @@ android {
     }
 }
 
+// Enforce our-code warnings-as-errors on the Android app module — the sibling
+// of shared's allWarningsAsErrors (#852). The app module is verified
+// warning-clean across its main, unit-test, and androidTest Kotlin
+// compilations; this gate keeps it that way: any Kotlin compiler warning in
+// app/ now fails the build. Android-SDK / library deprecations that surface
+// here must be fixed (or the dependency upgraded), never suppressed.
+kotlin {
+    compilerOptions {
+        allWarningsAsErrors.set(true)
+    }
+}
+
 // Workaround: Copy compose resources with the correct package-prefixed path for Android assets
 val copyComposeResources =
     tasks.register<Copy>("copySharedComposeResourcesToAssets") {

--- a/express-api/tests/scripts/android-app-warnings-as-errors.test.js
+++ b/express-api/tests/scripts/android-app-warnings-as-errors.test.js
@@ -1,0 +1,35 @@
+/**
+ * Kotlin warnings-as-errors enforced on the Android `app` module.
+ *
+ * Sibling of the shared-module gate (#852, ios-shared-warnings-as-errors).
+ * The app module (Android UI, services, navigation, the instrumented BDD
+ * suite) compiles clean under allWarningsAsErrors across its main / unit-test
+ * / androidTest source sets — this pins the flag so a future "build cleanup"
+ * can't silently drop it.
+ *
+ * IMPORTANT — this pins the `.set(true)` form, NOT `= true`. The app module
+ * uses AGP 9.x's built-in kotlinc (not the kotlin-multiplatform plugin that
+ * `shared` uses). On built-in kotlinc the Kotlin-DSL property assignment
+ * `allWarningsAsErrors = true` binds as a SILENT NO-OP — verified empirically:
+ * a deliberate deprecation-usage probe compiled clean with `= true`, but
+ * FAILED the build (`e: warnings found and -Werror specified`) with
+ * `.set(true)`. So the `.set(...)` form is load-bearing here; a regression to
+ * `= true` would re-disable enforcement while looking correct, so we fail on it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const APP_BUILD_GRADLE = path.join(__dirname, '../../../app/build.gradle.kts');
+
+describe('Android app Kotlin warnings-as-errors enforcement', () => {
+  test('app/build.gradle.kts enforces allWarningsAsErrors via the .set(true) form', () => {
+    const src = fs.readFileSync(APP_BUILD_GRADLE, 'utf8');
+    expect(src).toMatch(/allWarningsAsErrors\.set\(\s*true\s*\)/);
+  });
+
+  test('app/build.gradle.kts does NOT use the no-op `allWarningsAsErrors = true` form (built-in kotlinc)', () => {
+    const src = fs.readFileSync(APP_BUILD_GRADLE, 'utf8');
+    expect(src).not.toMatch(/allWarningsAsErrors\s*=\s*true/);
+  });
+});


### PR DESCRIPTION
Extends #852 (shared enforce) to the Android `app` module — Kotlin `allWarningsAsErrors` now enforced across `app`'s main / unit-test / androidTest source sets, closing out warnings-as-errors on all our Kotlin.

## The `.set(true)` gotcha (why the pin test is strict)
`app` uses **AGP 9.2.1's built-in kotlinc** (not the kotlin-multiplatform plugin `shared` uses). On built-in kotlinc, the Kotlin-DSL property **assignment** `allWarningsAsErrors = true` binds as a **silent no-op** — verified: a deliberate `@Deprecated`-usage probe compiled *clean* with `=`, but FAILED (`e: warnings found and -Werror specified`) with `.set(true)`. So the gate uses `.set(true)`, and the pin test (`android-app-warnings-as-errors`) both asserts the working form **and** rejects the no-op `= true` form, so enforcement can't silently regress.

## Verified
`:app:compileDevDebugKotlin`, `:app:compileDevDebugUnitTestKotlin`, `:app:compileDevDebugAndroidTestKotlin` all BUILD SUCCESSFUL under the enforcing flag (`--rerun-tasks --no-build-cache`). Pin test green; prettier/eslint/ktlint clean.

## Discovered — pre-existing Gradle warnings (NOT in scope here)
Two Gradle-level warnings surface on the app build; neither is a Kotlin compiler warning so `-Werror` doesn't catch them, and both predate this PR:
- KMP `withHostTest {}` notice (shared's commonTest android host tests not enabled)
- a Gradle-10 deprecation notice (needs `--warning-mode all` to source)

Tracked for focused follow-ups rather than bundled into this enforce PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)