### PR TITLE
fix(ios): per-target distribution signing in pbxproj so the deploy archive succeeds (#8)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -671,13 +671,15 @@ jobs:
           fi
           echo "Exported IPA: ${ipas[0]} ($(du -h "${ipas[0]}" | cut -f1))"
 
-      # Surface the IPA as a workflow artifact so an AFK operator can
-      # pull it via `gh run download <run-id> -n dev-ios-ipa` and
-      # install on a physical iPhone via
-      # `xcrun devicectl device install app --device <UDID> path/to/*.ipa`
-      # without needing a TestFlight tester invite + waiting for App
-      # Store Connect processing. TestFlight upload still happens in
-      # the next step for the normal tester-distribution flow.
+      # Surface the exported IPA as a workflow artifact — a downloadable record
+      # of exactly what shipped, useful for inspection / App Store Connect
+      # troubleshooting. NOTE: this IPA is App Store-signed (ExportOptions
+      # method: app-store-connect), so it CANNOT be sideloaded onto a device via
+      # `xcrun devicectl device install app` — that fails with "Attempted to
+      # install a Beta profile without the proper entitlement". On-device
+      # testing goes through TestFlight (uploaded in the next step); sideloading
+      # would need a separate ad-hoc-signed export whose profile lists the
+      # target device UDIDs.
       - name: Upload IPA as workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -621,8 +621,18 @@ jobs:
           # — both fine for non-distributed local builds.
           echo "Setting CFBundleVersion=${BUILD_NUMBER} MARKETING_VERSION=${VERSION_NAME}"
           cd iosApp
-          # Archive — pass build settings so we don't have to mutate
-          # Info.plist or the .pbxproj on disk.
+          # Archive with AUTOMATIC signing, then re-sign for distribution at
+          # export (ExportOptions.plist maps the profile per-bundle-ID). We do
+          # NOT pass CODE_SIGN_STYLE=Manual / PROVISIONING_PROFILE_SPECIFIER as
+          # global build settings — those apply to EVERY target, including the
+          # SwiftPM resource bundles (SwiftProtobuf_SwiftProtobuf,
+          # LiveKit_LiveKit) pulled in by the #841 SPM migration, which "do not
+          # support provisioning profiles" and fail the archive with exit 65.
+          # Automatic signing lets every target sign cleanly; -exportArchive
+          # then applies the distribution profile only to com.shyden.shytalk.
+          # -allowProvisioningUpdates + the ASC API key let Xcode resolve the
+          # app target's profile headlessly in CI. Build settings (not Info.plist
+          # / .pbxproj mutation) still carry the version numbers.
           xcodebuild \
             -workspace iosApp.xcworkspace \
             -scheme iosApp \
@@ -631,9 +641,10 @@ jobs:
             -archivePath $RUNNER_TEMP/iosApp.xcarchive \
             -clonedSourcePackagesDirPath ../build/ios-spm-packages \
             -parallelizeTargets \
-            CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
-            PROVISIONING_PROFILE_SPECIFIER="ShyTalk App Store Distribution" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" \
+            -authenticationKeyID "$APP_STORE_CONNECT_KEY_ID" \
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
             DEVELOPMENT_TEAM=F3XX4PM3MF \
             CURRENT_PROJECT_VERSION="${BUILD_NUMBER}" \
             MARKETING_VERSION="${VERSION_NAME}" \
@@ -644,7 +655,7 @@ jobs:
             -archivePath $RUNNER_TEMP/iosApp.xcarchive \
             -exportOptionsPlist ExportOptions.plist \
             -exportPath $RUNNER_TEMP/export \
-            -authenticationKeyPath $RUNNER_TEMP/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8 \
+            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" \
             -authenticationKeyID $APP_STORE_CONNECT_KEY_ID \
             -authenticationKeyIssuerID $APP_STORE_CONNECT_ISSUER_ID
           # Verify a single IPA was produced (catches `destination: upload` regressions

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -621,18 +621,19 @@ jobs:
           # — both fine for non-distributed local builds.
           echo "Setting CFBundleVersion=${BUILD_NUMBER} MARKETING_VERSION=${VERSION_NAME}"
           cd iosApp
-          # Archive with AUTOMATIC signing, then re-sign for distribution at
-          # export (ExportOptions.plist maps the profile per-bundle-ID). We do
-          # NOT pass CODE_SIGN_STYLE=Manual / PROVISIONING_PROFILE_SPECIFIER as
-          # global build settings — those apply to EVERY target, including the
-          # SwiftPM resource bundles (SwiftProtobuf_SwiftProtobuf,
-          # LiveKit_LiveKit) pulled in by the #841 SPM migration, which "do not
-          # support provisioning profiles" and fail the archive with exit 65.
-          # Automatic signing lets every target sign cleanly; -exportArchive
-          # then applies the distribution profile only to com.shyden.shytalk.
-          # -allowProvisioningUpdates + the ASC API key let Xcode resolve the
-          # app target's profile headlessly in CI. Build settings (not Info.plist
-          # / .pbxproj mutation) still carry the version numbers.
+          # The app's Release config is manual-signed for App Store distribution
+          # PER-TARGET in project.pbxproj (CODE_SIGN_STYLE=Manual + "Apple
+          # Distribution" identity + "ShyTalk App Store Distribution" profile).
+          # That's the crux: signing passed as GLOBAL xcodebuild build settings
+          # hits every target, including the SwiftPM resource bundles
+          # (SwiftProtobuf_SwiftProtobuf / LiveKit_LiveKit, from the #841 SPM
+          # migration) which can't hold a profile → exit 65; a per-target pbxproj
+          # setting reaches only the app. An App Store profile needs no registered
+          # devices, so this avoids the automatic "team has no devices" failure,
+          # and a real archive sign preserves the app's entitlements (Push, etc).
+          # DEVELOPMENT_TEAM is the only global signing setting (lets the SPM
+          # bundles sign with the team identity, no profile). -exportArchive then
+          # exports for App Store via ExportOptions.plist.
           xcodebuild \
             -workspace iosApp.xcworkspace \
             -scheme iosApp \
@@ -641,10 +642,6 @@ jobs:
             -archivePath $RUNNER_TEMP/iosApp.xcarchive \
             -clonedSourcePackagesDirPath ../build/ios-spm-packages \
             -parallelizeTargets \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" \
-            -authenticationKeyID "$APP_STORE_CONNECT_KEY_ID" \
-            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
             DEVELOPMENT_TEAM=F3XX4PM3MF \
             CURRENT_PROJECT_VERSION="${BUILD_NUMBER}" \
             MARKETING_VERSION="${VERSION_NAME}" \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -468,9 +468,6 @@ jobs:
       # the rationale. 50-min cap catches recurrence cheaply.
       - name: Build and archive iOS app
         timeout-minutes: 50
-        env:
-          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
           set -euo pipefail
           # Read the bumped versionCode/versionName from app/build.gradle.kts

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -493,23 +493,20 @@ jobs:
           fi
           echo "Archiving iOS as v${VERSION_NAME} (build ${VERSION_CODE}) — matches Android"
           cd iosApp
-          # Archive with AUTOMATIC signing; -exportArchive re-signs for
-          # distribution (ExportOptions.plist, per-bundle-ID). A global manual
-          # PROVISIONING_PROFILE_SPECIFIER breaks the SwiftPM resource bundles
-          # (SwiftProtobuf_SwiftProtobuf / LiveKit_LiveKit "do not support
-          # provisioning profiles" → exit 65). See deploy-dev.yml for the full
-          # rationale. -allowProvisioningUpdates + the ASC key resolve the app
-          # target's profile headlessly in CI.
+          # The app's Release config is manual-signed for App Store distribution
+          # PER-TARGET in project.pbxproj, NOT via global xcodebuild build
+          # settings — those would hit the SwiftPM resource bundles
+          # (SwiftProtobuf_SwiftProtobuf / LiveKit_LiveKit) which can't hold a
+          # profile → exit 65. An App Store profile needs no devices (avoids the
+          # automatic "team has no devices" failure). DEVELOPMENT_TEAM lets the
+          # SPM bundles sign with the team identity. See deploy-dev.yml for the
+          # full rationale. -exportArchive exports via ExportOptions.plist.
           xcodebuild \
             -workspace iosApp.xcworkspace \
             -scheme iosApp \
             -sdk iphoneos \
             -configuration Release \
             -archivePath $RUNNER_TEMP/iosApp.xcarchive \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" \
-            -authenticationKeyID "$APP_STORE_CONNECT_KEY_ID" \
-            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
             DEVELOPMENT_TEAM=F3XX4PM3MF \
             CURRENT_PROJECT_VERSION="${VERSION_CODE}" \
             MARKETING_VERSION="${VERSION_NAME}" \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -468,6 +468,9 @@ jobs:
       # the rationale. 50-min cap catches recurrence cheaply.
       - name: Build and archive iOS app
         timeout-minutes: 50
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
           set -euo pipefail
           # Read the bumped versionCode/versionName from app/build.gradle.kts
@@ -490,15 +493,23 @@ jobs:
           fi
           echo "Archiving iOS as v${VERSION_NAME} (build ${VERSION_CODE}) — matches Android"
           cd iosApp
+          # Archive with AUTOMATIC signing; -exportArchive re-signs for
+          # distribution (ExportOptions.plist, per-bundle-ID). A global manual
+          # PROVISIONING_PROFILE_SPECIFIER breaks the SwiftPM resource bundles
+          # (SwiftProtobuf_SwiftProtobuf / LiveKit_LiveKit "do not support
+          # provisioning profiles" → exit 65). See deploy-dev.yml for the full
+          # rationale. -allowProvisioningUpdates + the ASC key resolve the app
+          # target's profile headlessly in CI.
           xcodebuild \
             -workspace iosApp.xcworkspace \
             -scheme iosApp \
             -sdk iphoneos \
             -configuration Release \
             -archivePath $RUNNER_TEMP/iosApp.xcarchive \
-            CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
-            PROVISIONING_PROFILE_SPECIFIER="ShyTalk App Store Distribution" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" \
+            -authenticationKeyID "$APP_STORE_CONNECT_KEY_ID" \
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
             DEVELOPMENT_TEAM=F3XX4PM3MF \
             CURRENT_PROJECT_VERSION="${VERSION_CODE}" \
             MARKETING_VERSION="${VERSION_NAME}" \
@@ -516,9 +527,9 @@ jobs:
             -archivePath $RUNNER_TEMP/iosApp.xcarchive \
             -exportOptionsPlist ExportOptions.plist \
             -exportPath $RUNNER_TEMP/export \
-            -authenticationKeyPath $RUNNER_TEMP/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8 \
-            -authenticationKeyID $APP_STORE_CONNECT_KEY_ID \
-            -authenticationKeyIssuerID $APP_STORE_CONNECT_ISSUER_ID
+            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" \
+            -authenticationKeyID "$APP_STORE_CONNECT_KEY_ID" \
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID"
           # Verify a single IPA was produced (catches `destination: upload` regressions
           # that uploaded silently and left no local artifact, breaking the next step)
           shopt -s nullglob

--- a/express-api/tests/scripts/ios-deploy-archive-signing.test.js
+++ b/express-api/tests/scripts/ios-deploy-archive-signing.test.js
@@ -1,0 +1,53 @@
+/**
+ * iOS deploy archive must NOT force a global manual provisioning profile (#8).
+ *
+ * The #841 LiveKit CocoaPods→SPM migration added SwiftPM resource-bundle
+ * targets (SwiftProtobuf_SwiftProtobuf, LiveKit_LiveKit) that "do not support
+ * provisioning profiles". Passing PROVISIONING_PROFILE_SPECIFIER /
+ * CODE_SIGN_STYLE=Manual as GLOBAL xcodebuild build settings at archive time
+ * applied the distribution profile to those targets too and failed the archive
+ * (`** ARCHIVE FAILED **`, exit 65) — blocking all iOS dev + prod deploys.
+ *
+ * The fix archives with AUTOMATIC signing (-allowProvisioningUpdates + the ASC
+ * API key so Xcode resolves the app target's profile headlessly), then
+ * -exportArchive re-signs for distribution via ExportOptions.plist, which maps
+ * the profile per-bundle-ID (com.shyden.shytalk only). This test locks that in
+ * so a future edit can't reintroduce the global manual override that breaks the
+ * SPM targets.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOWS = ['deploy-dev.yml', 'deploy-prod.yml'];
+const workflowPath = (name) => path.join(__dirname, '../../../.github/workflows', name);
+const EXPORT_OPTIONS = path.join(__dirname, '../../../iosApp/ExportOptions.plist');
+
+// Strip comment lines so the explanatory comments — which intentionally name
+// the very tokens we forbid, to document why — don't cause false matches. We
+// assert against the actual xcodebuild commands only.
+const stripComments = (yaml) =>
+  yaml
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+
+describe('iOS deploy archive signing (#8 regression guard)', () => {
+  test.each(WORKFLOWS)('%s archives with automatic signing, no global manual profile', (name) => {
+    const src = stripComments(fs.readFileSync(workflowPath(name), 'utf8'));
+    // The global manual override (build settings, `TOKEN=value`) is exactly
+    // what broke the SPM resource bundles.
+    expect(src).not.toMatch(/PROVISIONING_PROFILE_SPECIFIER=/);
+    expect(src).not.toMatch(/CODE_SIGN_STYLE=Manual/);
+    // Automatic signing + ASC key so Xcode resolves the app's profile in CI.
+    expect(src).toMatch(/-allowProvisioningUpdates/);
+  });
+
+  test('ExportOptions.plist still re-signs for distribution, scoped per-bundle-ID', () => {
+    const src = fs.readFileSync(EXPORT_OPTIONS, 'utf8');
+    // Distribution signing now happens ONLY at export, mapped to the app bundle.
+    expect(src).toMatch(/<key>signingStyle<\/key>\s*<string>manual<\/string>/);
+    expect(src).toMatch(/com\.shyden\.shytalk/);
+    expect(src).toMatch(/ShyTalk App Store Distribution/);
+  });
+});

--- a/express-api/tests/scripts/ios-deploy-archive-signing.test.js
+++ b/express-api/tests/scripts/ios-deploy-archive-signing.test.js
@@ -1,19 +1,27 @@
 /**
- * iOS deploy archive must NOT force a global manual provisioning profile (#8).
+ * iOS deploy archive signing (#8 regression guard).
  *
- * The #841 LiveKit CocoaPods→SPM migration added SwiftPM resource-bundle
- * targets (SwiftProtobuf_SwiftProtobuf, LiveKit_LiveKit) that "do not support
- * provisioning profiles". Passing PROVISIONING_PROFILE_SPECIFIER /
- * CODE_SIGN_STYLE=Manual as GLOBAL xcodebuild build settings at archive time
- * applied the distribution profile to those targets too and failed the archive
- * (`** ARCHIVE FAILED **`, exit 65) — blocking all iOS dev + prod deploys.
+ * The #841 LiveKit CocoaPods→SPM migration broke the deploy archive. Three
+ * CLI-global signing approaches all fail, because xcodebuild build settings are
+ * GLOBAL (they hit every target, including the SwiftPM resource bundles
+ * SwiftProtobuf_SwiftProtobuf / LiveKit_LiveKit):
+ *   - manual-global (CODE_SIGN_STYLE=Manual + PROVISIONING_PROFILE_SPECIFIER)
+ *     forces a profile onto those bundles, which "do not support provisioning
+ *     profiles" → ** ARCHIVE FAILED ** (exit 65);
+ *   - automatic (-allowProvisioningUpdates) tries to mint an iOS *Development*
+ *     profile, which needs registered devices the runner lacks (exit 65);
+ *   - unsigned archive + export-resign risks dropping Push entitlements.
  *
- * The fix archives with AUTOMATIC signing (-allowProvisioningUpdates + the ASC
- * API key so Xcode resolves the app target's profile headlessly), then
- * -exportArchive re-signs for distribution via ExportOptions.plist, which maps
- * the profile per-bundle-ID (com.shyden.shytalk only). This test locks that in
- * so a future edit can't reintroduce the global manual override that breaks the
- * SPM targets.
+ * The fix signs the app PER-TARGET in project.pbxproj (the iosApp Release
+ * config: CODE_SIGN_STYLE=Manual + "Apple Distribution" identity + "ShyTalk App
+ * Store Distribution" profile). Per-target reaches only the app, so the SPM
+ * bundles keep their defaults; the App Store profile needs no devices; and the
+ * entitlements (CODE_SIGN_ENTITLEMENTS) are preserved by a real archive sign.
+ * -exportArchive then exports for App Store via ExportOptions.plist.
+ *
+ * Pins: (a) the workflows pass NO global signing override on the archive;
+ * (b) the pbxproj app Release config carries the manual distribution signing;
+ * (c) ExportOptions still does manual per-bundle-ID distribution.
  */
 
 const fs = require('fs');
@@ -22,10 +30,10 @@ const path = require('path');
 const WORKFLOWS = ['deploy-dev.yml', 'deploy-prod.yml'];
 const workflowPath = (name) => path.join(__dirname, '../../../.github/workflows', name);
 const EXPORT_OPTIONS = path.join(__dirname, '../../../iosApp/ExportOptions.plist');
+const PBXPROJ = path.join(__dirname, '../../../iosApp/iosApp.xcodeproj/project.pbxproj');
 
 // Strip comment lines so the explanatory comments — which intentionally name
-// the very tokens we forbid, to document why — don't cause false matches. We
-// assert against the actual xcodebuild commands only.
+// the forbidden tokens to document why — don't cause false matches.
 const stripComments = (yaml) =>
   yaml
     .split('\n')
@@ -33,19 +41,26 @@ const stripComments = (yaml) =>
     .join('\n');
 
 describe('iOS deploy archive signing (#8 regression guard)', () => {
-  test.each(WORKFLOWS)('%s archives with automatic signing, no global manual profile', (name) => {
+  test.each(WORKFLOWS)('%s passes no global signing override on the archive', (name) => {
     const src = stripComments(fs.readFileSync(workflowPath(name), 'utf8'));
-    // The global manual override (build settings, `TOKEN=value`) is exactly
-    // what broke the SPM resource bundles.
+    // Global build settings hit every target incl. the SPM resource bundles —
+    // signing belongs in the pbxproj (per-target), not on the CLI.
     expect(src).not.toMatch(/PROVISIONING_PROFILE_SPECIFIER=/);
     expect(src).not.toMatch(/CODE_SIGN_STYLE=Manual/);
-    // Automatic signing + ASC key so Xcode resolves the app's profile in CI.
-    expect(src).toMatch(/-allowProvisioningUpdates/);
+    expect(src).not.toMatch(/CODE_SIGN_IDENTITY=/);
+    // -allowProvisioningUpdates is the automatic path that needs devices.
+    expect(src).not.toMatch(/-allowProvisioningUpdates/);
   });
 
-  test('ExportOptions.plist still re-signs for distribution, scoped per-bundle-ID', () => {
+  test('iosApp Release config is manual-signed for distribution in pbxproj', () => {
+    const src = fs.readFileSync(PBXPROJ, 'utf8');
+    expect(src).toMatch(/CODE_SIGN_STYLE = Manual;/);
+    expect(src).toMatch(/PROVISIONING_PROFILE_SPECIFIER = "ShyTalk App Store Distribution";/);
+    expect(src).toMatch(/CODE_SIGN_IDENTITY = "Apple Distribution";/);
+  });
+
+  test('ExportOptions.plist exports for distribution, scoped per-bundle-ID', () => {
     const src = fs.readFileSync(EXPORT_OPTIONS, 'utf8');
-    // Distribution signing now happens ONLY at export, mapped to the app bundle.
     expect(src).toMatch(/<key>signingStyle<\/key>\s*<string>manual<\/string>/);
     expect(src).toMatch(/com\.shyden\.shytalk/);
     expect(src).toMatch(/ShyTalk App Store Distribution/);

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -731,9 +731,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = F3XX4PM3MF;
+				PROVISIONING_PROFILE_SPECIFIER = "ShyTalk App Store Distribution";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;


### PR DESCRIPTION
Fixes the iOS deploy archive (task #8), broken by the #841 LiveKit CocoaPods→SPM migration. **Validated end-to-end** (below). **Held for your review** — it touches release signing, so I did not auto-merge.

## Root cause
`xcodebuild` build settings are GLOBAL — signing passed on the archive CLI hits *every* target, including the SwiftPM resource bundles `SwiftProtobuf_SwiftProtobuf` / `LiveKit_LiveKit`. All three CLI approaches fail:
| approach | result |
|---|---|
| manual-global (`CODE_SIGN_STYLE=Manual` + `PROVISIONING_PROFILE_SPECIFIER`) | forces a profile onto the SPM bundles → `ARCHIVE FAILED` (exit 65) |
| automatic (`-allowProvisioningUpdates`) | mints an iOS *Development* profile → needs registered devices CI lacks ("team has no devices", exit 65) |
| unsigned archive + export-resign | documented risk of dropping Push entitlements (this app uses Firebase Messaging) |

## Fix — per-target signing in project.pbxproj
The **iosApp Release config** → `CODE_SIGN_STYLE=Manual` + `CODE_SIGN_IDENTITY="Apple Distribution"` + `PROVISIONING_PROFILE_SPECIFIER="ShyTalk App Store Distribution"`. Per-target reaches only the app; the SPM bundles keep their defaults; the App Store profile needs no devices; the real archive sign preserves entitlements. Debug/Debug-Local/Release-Local configs are untouched (local dev unaffected). The archive commands now pass only `DEVELOPMENT_TEAM` (+ version build settings); `-exportArchive` is unchanged. Applied to deploy-dev.yml + deploy-prod.yml; pin test guards the regression.

## Validated
iOS-only deploy-dev run **[26482090289](https://github.com/ShydenMcM/ShyTalk/actions/runs/26482090289)** → `distribute-ios = success`: archive ✓ · export ✓ · **TestFlight upload ✓**. A code review + an on-device install-smoke are finishing; I'll comment with both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)