### PR TITLE
chore(shared): run commonTest on the android host (#10)

### DIFF
--- a/express-api/tests/scripts/shared-android-host-tests.test.js
+++ b/express-api/tests/scripts/shared-android-host-tests.test.js
@@ -1,0 +1,27 @@
+/**
+ * shared module runs commonTest on the android host (#10).
+ *
+ * The KMP android library plugin emitted "commonTest source directory exists,
+ * but android host tests are not enabled. add withHostTest {}". Enabling it
+ * runs the shared suite against the androidMain actuals (Logger.android.kt,
+ * etc.) — coverage jvm() never exercises — and clears the notice.
+ *
+ * isReturnDefaultValues=true is load-bearing: without it, android.jar stubs
+ * (android.util.Log) throw "Method ... not mocked" and 39 tests cascade-fail.
+ * It mirrors app/build.gradle.kts's testOptions so the suite runs without
+ * Robolectric. This pins both so the android-host coverage can't be silently
+ * dropped or quietly broken.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SHARED_BUILD_GRADLE = path.join(__dirname, '../../../shared/build.gradle.kts');
+
+describe('shared android host tests (#10)', () => {
+  test('shared/build.gradle.kts enables withHostTest with returnDefaultValues', () => {
+    const src = fs.readFileSync(SHARED_BUILD_GRADLE, 'utf8');
+    expect(src).toMatch(/withHostTest\s*\{/);
+    expect(src).toMatch(/isReturnDefaultValues\s*=\s*true/);
+  });
+});

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -34,6 +34,17 @@ kotlin {
         compilerOptions {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
         }
+
+        // Run commonTest on the android target's host (local JVM) as well —
+        // clears the KMP "commonTest source directory exists, but android host
+        // tests are not enabled" notice AND adds real coverage of the androidMain
+        // actuals (e.g. Logger.android.kt), which jvm() never exercises.
+        // isReturnDefaultValues stubs android.jar calls (android.util.Log) the
+        // same way app/build.gradle.kts does, so the suite runs without
+        // Robolectric.
+        withHostTest {
+            isReturnDefaultValues = true
+        }
     }
 
     listOf(


### PR DESCRIPTION
Clears the KMP Gradle notice *"commonTest source directory exists, but android host tests are not enabled"* (task #10) by enabling `withHostTest {}` on the shared module's android target.

## Why it's more than silencing a notice
The android host run exercises the **androidMain actuals** (e.g. `Logger.android.kt`) that `jvm()` never touches — genuine added coverage of the shared suite on the android platform impls.

## The returnDefaultValues catch
Enabling host tests alone surfaced **39 failures**, all tracing to `android.util.Log not mocked` (`Logger.android.kt:32`) cascading into auth-state assertions. `isReturnDefaultValues = true` (mirroring `app/build.gradle.kts`) stubs the android.jar calls so the suite runs without Robolectric. Verified locally: `:shared:testAndroidHostTest` → **443 pass**. Pinned by `shared-android-host-tests.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)