### PR TITLE
ci(shared): run :shared:testAndroidHostTest in pr-checks (#12)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -181,7 +181,7 @@ jobs:
           # isPersonaPickerAvailable returns false). See app/build.gradle.kts
           # line 105 for the buildConfigField wiring.
           DEV_QA_PERSONAS_PASSWORD: ${{ secrets.DEV_QA_PERSONAS_PASSWORD }}
-        run: ./gradlew testDevDebugUnitTest :shared:jvmTest detekt assembleDevRelease jacocoDevDebugUnitTestReport --parallel
+        run: ./gradlew testDevDebugUnitTest :shared:jvmTest :shared:testAndroidHostTest detekt assembleDevRelease jacocoDevDebugUnitTestReport --parallel
 
       # Also build the local-flavor APK so AFK operators / automation
       # can install it on test devices without needing a local Firebase

--- a/express-api/tests/scripts/shared-android-host-tests.test.js
+++ b/express-api/tests/scripts/shared-android-host-tests.test.js
@@ -17,11 +17,20 @@ const fs = require('fs');
 const path = require('path');
 
 const SHARED_BUILD_GRADLE = path.join(__dirname, '../../../shared/build.gradle.kts');
+const PR_CHECKS = path.join(__dirname, '../../../.github/workflows/pr-checks.yml');
 
 describe('shared android host tests (#10)', () => {
   test('shared/build.gradle.kts enables withHostTest with returnDefaultValues', () => {
     const src = fs.readFileSync(SHARED_BUILD_GRADLE, 'utf8');
     expect(src).toMatch(/withHostTest\s*\{/);
     expect(src).toMatch(/isReturnDefaultValues\s*=\s*true/);
+  });
+
+  test('pr-checks.yml runs :shared:testAndroidHostTest in CI (#12)', () => {
+    // Enabling host tests is only meaningful if CI runs them — otherwise the
+    // androidMain-actual coverage rots (it never reaches the pipeline). Pin
+    // the CI invocation so the coverage stays live.
+    const src = fs.readFileSync(PR_CHECKS, 'utf8');
+    expect(src).toMatch(/:shared:testAndroidHostTest/);
   });
 });


### PR DESCRIPTION
Implements the follow-up the #855 (#10) reviewer identified (Observation A): `withHostTest` cleared the Gradle notice, but CI only ran `:shared:jvmTest` — never `testAndroidHostTest` — so the androidMain-actual coverage (`Logger.android.kt` etc.) never reached the pipeline and a regression there would slip through.

Adds `:shared:testAndroidHostTest` to the pr-checks unit-test gradle invocation (line 184). 443 host tests, green locally; **this PR's own CI run exercises them in the pipeline**. Pin test extended to assert the CI invocation so it can't be silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)