### PR TITLE
feat(rooms): server-authoritative room mutations + client cutover (P1+P2)

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
@@ -1,10 +1,8 @@
 package com.shyden.shytalk.data.repository
 
 import android.util.Log
-import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.shyden.shytalk.core.model.ChatRoom
-import com.shyden.shytalk.core.model.Seat
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.core.util.firebaseCall
 import com.shyden.shytalk.data.remote.WorkerApiClient
@@ -137,13 +135,8 @@ class RoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to join room") {
-            firestore
-                .document("rooms/$roomId")
-                .update(
-                    mapOf(
-                        "participantIds" to FieldValue.arrayUnion(userId),
-                    ),
-                ).await()
+            api.post("/api/rooms/$roomId/join")
+            // currentRoomId is the caller's own user doc (allowed by rules); stays client-side.
             firestore.document("users/$userId").update("currentRoomId", roomId).await()
         }
 
@@ -152,38 +145,10 @@ class RoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to leave room") {
-            // Atomic: read seats + clear-by-user in one transaction so a
-            // concurrent moveSeat (also transactional) can't swap the seat
-            // mid-flight, which would otherwise leave us writing the
-            // pre-move user's seat clear (stale data) or missing the
-            // target's actual seat. moveSeat at line 219 uses the same
-            // pattern; this brings leaveRoom's read-then-write to parity.
-            val roomRef = firestore.document("rooms/$roomId")
-            firestore
-                .runTransaction { transaction ->
-                    val doc = transaction.get(roomRef)
-                    val data = doc.data
-                    val updates =
-                        mutableMapOf<String, Any?>(
-                            "participantIds" to FieldValue.arrayRemove(userId),
-                        )
-                    if (data != null) {
-                        val seatsRaw = data["seats"] as? Map<*, *>
-                        seatsRaw?.forEach { (index, seatData) ->
-                            val seat = seatData as? Map<*, *>
-                            if (seat?.get("userId") == userId) {
-                                updates["seats.$index.userId"] = null
-                                updates["seats.$index.state"] = "EMPTY"
-                                updates["seats.$index.isMuted"] = false
-                            }
-                        }
-                    }
-                    transaction.update(roomRef, updates)
-                }.await()
-            // user-doc update is intentionally outside the transaction —
-            // Firestore transactions can't span unrelated docs without a
-            // multi-doc read; if the user-doc write fails, the user has a
-            // stale currentRoomId but the room is correctly cleared.
+            // Server-authoritative: participant removal + own-seat clear happen
+            // transactionally inside the /leave endpoint.
+            api.post("/api/rooms/$roomId/leave")
+            // currentRoomId is the caller's own user doc; stays client-side.
             firestore.document("users/$userId").update("currentRoomId", null).await()
         }
 
@@ -193,16 +158,7 @@ class RoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to take seat") {
-            firestore
-                .document("rooms/$roomId")
-                .update(
-                    mapOf(
-                        "seats.$seatIndex.userId" to userId,
-                        "seats.$seatIndex.state" to "OCCUPIED",
-                        "seats.$seatIndex.isMuted" to false,
-                        "allTimeSeatUserIds" to FieldValue.arrayUnion(userId),
-                    ),
-                ).await()
+            api.post("/api/rooms/$roomId/seats/$seatIndex/claim")
         }
 
     override suspend fun leaveSeat(
@@ -210,21 +166,16 @@ class RoomRepositoryImpl(
         seatIndex: Int,
     ): Resource<Unit> =
         firebaseCall("Failed to leave seat") {
-            firestore
-                .document("rooms/$roomId")
-                .update(
-                    mapOf(
-                        "seats.$seatIndex.userId" to null,
-                        "seats.$seatIndex.state" to "EMPTY",
-                        "seats.$seatIndex.isMuted" to false,
-                    ),
-                ).await()
+            api.post("/api/rooms/$roomId/seats/$seatIndex/leave")
         }
 
     override suspend fun removeFromSeat(
         roomId: String,
         seatIndex: Int,
-    ): Resource<Unit> = leaveSeat(roomId, seatIndex)
+    ): Resource<Unit> =
+        firebaseCall("Failed to remove from seat") {
+            api.post("/api/rooms/$roomId/seats/$seatIndex/remove")
+        }
 
     override suspend fun moveSeat(
         roomId: String,
@@ -233,33 +184,7 @@ class RoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to move seat") {
-            val roomRef = firestore.document("rooms/$roomId")
-            firestore
-                .runTransaction { transaction ->
-                    val doc = transaction.get(roomRef)
-                    val data = doc.data ?: throw Exception("Room not found")
-                    val seatsRaw = data["seats"] as? Map<*, *> ?: throw Exception("No seats data")
-                    val fromSeat =
-                        (seatsRaw[fromIndex.toString()] as? Map<*, *>)?.let { raw ->
-                            raw.entries.associate { (k, v) -> k.toString() to v }
-                        } ?: Seat.EMPTY_MAP
-                    val toSeat =
-                        (seatsRaw[toIndex.toString()] as? Map<*, *>)?.let { raw ->
-                            raw.entries.associate { (k, v) -> k.toString() to v }
-                        } ?: Seat.EMPTY_MAP
-
-                    transaction.update(
-                        roomRef,
-                        mapOf(
-                            "seats.$fromIndex.userId" to toSeat["userId"],
-                            "seats.$fromIndex.state" to (toSeat["state"] ?: "EMPTY"),
-                            "seats.$fromIndex.isMuted" to (toSeat["isMuted"] ?: false),
-                            "seats.$toIndex.userId" to fromSeat["userId"],
-                            "seats.$toIndex.state" to (fromSeat["state"] ?: "EMPTY"),
-                            "seats.$toIndex.isMuted" to (fromSeat["isMuted"] ?: false),
-                        ),
-                    )
-                }.await()
+            api.post("/api/rooms/$roomId/seats/$fromIndex/move", JSONObject().put("toIndex", toIndex))
         }
 
     override suspend fun kickUser(
@@ -270,44 +195,16 @@ class RoomRepositoryImpl(
         reason: String,
     ): Resource<Unit> =
         firebaseCall("Failed to kick user") {
-            val effectiveReason = reason.ifBlank { "No reason given" }
-            val roomRef = firestore.document("rooms/$roomId")
-            // Atomic: when seatIndex is unknown we MUST read seats inside
-            // the same transaction as the clear, otherwise a concurrent
-            // moveSeat can shuffle the target's seat between our read and
-            // write, leaving us blanking the wrong seat.
-            firestore
-                .runTransaction { transaction ->
-                    val updates =
-                        mutableMapOf<String, Any?>(
-                            "participantIds" to FieldValue.arrayRemove(userId),
-                            "bannedUserIds" to FieldValue.arrayUnion(userId),
-                            "kickInfo.$userId" to
-                                mapOf(
-                                    "kickerName" to kickerName,
-                                    "reason" to effectiveReason,
-                                ),
-                        )
-                    if (seatIndex != null) {
-                        updates["seats.$seatIndex.userId"] = null
-                        updates["seats.$seatIndex.state"] = "EMPTY"
-                        updates["seats.$seatIndex.isMuted"] = false
-                    } else {
-                        val doc = transaction.get(roomRef)
-                        val data = doc.data
-                        val seatsRaw = data?.get("seats") as? Map<*, *>
-                        seatsRaw?.forEach { (index, seatData) ->
-                            val seat = seatData as? Map<*, *>
-                            if (seat?.get("userId") == userId) {
-                                updates["seats.$index.userId"] = null
-                                updates["seats.$index.state"] = "EMPTY"
-                                updates["seats.$index.isMuted"] = false
-                            }
-                        }
-                    }
-                    transaction.update(roomRef, updates)
-                }.await()
-            firestore.document("users/$userId").update("currentRoomId", null).await()
+            // Server derives the target's seat + clears it transactionally; the
+            // kicked user self-clears their own currentRoomId on observing the ban.
+            api.post(
+                "/api/rooms/$roomId/kick",
+                JSONObject().apply {
+                    put("userId", userId)
+                    put("reason", reason.ifBlank { "No reason given" })
+                    put("kickerName", kickerName)
+                },
+            )
         }
 
     override suspend fun toggleMute(
@@ -316,12 +213,7 @@ class RoomRepositoryImpl(
         isMuted: Boolean,
     ): Resource<Unit> =
         firebaseCall("Failed to toggle mute") {
-            firestore
-                .document("rooms/$roomId")
-                .update(
-                    "seats.$seatIndex.isMuted",
-                    isMuted,
-                ).await()
+            api.patch("/api/rooms/$roomId/seats/$seatIndex/mute", JSONObject().put("isMuted", isMuted))
         }
 
     override suspend fun addHost(
@@ -329,14 +221,7 @@ class RoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to add host") {
-            firestore
-                .document("rooms/$roomId")
-                .update(
-                    mapOf(
-                        "hostIds" to FieldValue.arrayUnion(userId),
-                        "allTimeHostIds" to FieldValue.arrayUnion(userId),
-                    ),
-                ).await()
+            api.post("/api/rooms/$roomId/hosts", JSONObject().put("userId", userId))
         }
 
     override suspend fun removeHost(
@@ -344,12 +229,7 @@ class RoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to remove host") {
-            firestore
-                .document("rooms/$roomId")
-                .update(
-                    "hostIds",
-                    FieldValue.arrayRemove(userId),
-                ).await()
+            api.delete("/api/rooms/$roomId/hosts/$userId")
         }
 
     override suspend fun updateRoomName(
@@ -357,7 +237,7 @@ class RoomRepositoryImpl(
         newName: String,
     ): Resource<Unit> =
         firebaseCall("Failed to update room name") {
-            firestore.document("rooms/$roomId").update("name", newName).await()
+            api.patch("/api/rooms/$roomId/name", JSONObject().put("name", newName))
         }
 
     override suspend fun setRequireApproval(
@@ -365,19 +245,15 @@ class RoomRepositoryImpl(
         requireApproval: Boolean,
     ): Resource<Unit> =
         firebaseCall("Failed to update approval setting") {
-            firestore.document("rooms/$roomId").update("requireApproval", requireApproval).await()
+            api.patch(
+                "/api/rooms/$roomId/require-approval",
+                JSONObject().put("requireApproval", requireApproval),
+            )
         }
 
     override suspend fun setOwnerAway(roomId: String): Resource<Unit> =
         firebaseCall("Failed to set owner away") {
-            firestore
-                .document("rooms/$roomId")
-                .update(
-                    mapOf(
-                        "state" to "OWNER_AWAY",
-                        "ownerLeftAt" to System.currentTimeMillis(),
-                    ),
-                ).await()
+            api.post("/api/rooms/$roomId/owner-away")
         }
 
     override suspend fun setOwnerReturned(
@@ -385,14 +261,7 @@ class RoomRepositoryImpl(
         ownerId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to set owner returned") {
-            firestore
-                .document("rooms/$roomId")
-                .update(
-                    mapOf(
-                        "state" to "ACTIVE",
-                        "ownerLeftAt" to null,
-                    ),
-                ).await()
+            api.post("/api/rooms/$roomId/owner-returned")
         }
 
     // Keep as Worker API — needs FCM push notification
@@ -415,12 +284,8 @@ class RoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to cancel invite") {
-            firestore
-                .document("rooms/$roomId")
-                .update(
-                    "pendingInvites.$userId",
-                    FieldValue.delete(),
-                ).await()
+            // Self-scoped on the server (deletes the caller's own pending invite).
+            api.post("/api/rooms/$roomId/decline-invite")
         }
 
     override suspend fun acceptInvite(
@@ -429,52 +294,15 @@ class RoomRepositoryImpl(
         seatIndex: Int,
     ): Resource<Unit> =
         firebaseCall("Failed to accept invite") {
-            firestore
-                .document("rooms/$roomId")
-                .update(
-                    mapOf(
-                        "pendingInvites.$userId" to FieldValue.delete(),
-                        "participantIds" to FieldValue.arrayUnion(userId),
-                        "seats.$seatIndex.userId" to userId,
-                        "seats.$seatIndex.state" to "OCCUPIED",
-                        "seats.$seatIndex.isMuted" to false,
-                        "allTimeSeatUserIds" to FieldValue.arrayUnion(userId),
-                    ),
-                ).await()
+            api.post("/api/rooms/$roomId/seats/$seatIndex/accept-invite")
+            // currentRoomId is the caller's own user doc; stays client-side.
             firestore.document("users/$userId").update("currentRoomId", roomId).await()
         }
 
     override suspend fun closeRoom(roomId: String): Resource<Unit> =
         firebaseCall("Failed to close room") {
-            // Read current room to get participant list
-            val doc = firestore.document("rooms/$roomId").get().await()
-            val data = doc.data ?: throw Exception("Room not found")
-            val participantIds = (data["participantIds"] as? List<*>)?.filterIsInstance<String>() ?: emptyList()
-
-            val emptySeat = mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false)
-            val emptySeats = (0..7).associate { it.toString() to emptySeat }
-
-            firestore
-                .document("rooms/$roomId")
-                .update(
-                    mapOf(
-                        "state" to "CLOSED",
-                        "closedAt" to System.currentTimeMillis(),
-                        "participantIds" to emptyList<String>(),
-                        "seats" to emptySeats,
-                    ),
-                ).await()
-
-            // Clear currentRoomId for all participants
-            for (uid in participantIds) {
-                try {
-                    firestore.document("users/$uid").update("currentRoomId", null).await()
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    Log.w(TAG, "Room operation failed", e)
-                }
-            }
+            // Server empties the room + clears every participant's currentRoomId.
+            api.post("/api/rooms/$roomId/close")
         }
 
     override suspend fun findActiveRoomByOwner(ownerId: String): String? =
@@ -499,12 +327,7 @@ class RoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to record first join timestamp") {
-            firestore
-                .document("rooms/$roomId")
-                .update(
-                    "firstJoinTimestamps.$userId",
-                    System.currentTimeMillis(),
-                ).await()
+            api.post("/api/rooms/$roomId/first-join")
         }
 
     override suspend fun leaveAllRooms(
@@ -512,6 +335,8 @@ class RoomRepositoryImpl(
         exceptRoomId: String?,
     ): Resource<Unit> =
         firebaseCall("Failed to leave all rooms") {
+            // Query stays client-side (reads allowed); each room's mutation
+            // routes through the server-authoritative /leave endpoint.
             val snapshot =
                 firestore
                     .collection("rooms")
@@ -521,31 +346,8 @@ class RoomRepositoryImpl(
                     .await()
             for (doc in snapshot.documents) {
                 if (doc.id == exceptRoomId) continue
-                // Atomic per-room: read seats + clear under one transaction
-                // so a concurrent moveSeat can't shuffle this user's seat
-                // between our read and write. Each room is independent so
-                // a per-room transaction (not multi-doc) is sufficient.
-                val roomRef = firestore.document("rooms/${doc.id}")
                 try {
-                    firestore
-                        .runTransaction { transaction ->
-                            val freshDoc = transaction.get(roomRef)
-                            val data = freshDoc.data ?: return@runTransaction
-                            val updates =
-                                mutableMapOf<String, Any?>(
-                                    "participantIds" to FieldValue.arrayRemove(userId),
-                                )
-                            val seatsRaw = data["seats"] as? Map<*, *>
-                            seatsRaw?.forEach { (index, seatData) ->
-                                val seat = seatData as? Map<*, *>
-                                if (seat?.get("userId") == userId) {
-                                    updates["seats.$index.userId"] = null
-                                    updates["seats.$index.state"] = "EMPTY"
-                                    updates["seats.$index.isMuted"] = false
-                                }
-                            }
-                            transaction.update(roomRef, updates)
-                        }.await()
+                    api.post("/api/rooms/${doc.id}/leave")
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -557,6 +359,8 @@ class RoomRepositoryImpl(
 
     override suspend fun closeAllRoomsByOwner(ownerId: String): Resource<Unit> =
         firebaseCall("Failed to close rooms") {
+            // Query stays client-side; each close routes through /close (which
+            // also clears participants' currentRoomId server-side).
             val snapshot =
                 firestore
                     .collection("rooms")
@@ -565,32 +369,8 @@ class RoomRepositoryImpl(
                     .get()
                     .await()
             for (doc in snapshot.documents) {
-                val data = doc.data ?: continue
-                val participantIds = (data["participantIds"] as? List<*>)?.filterIsInstance<String>() ?: emptyList()
-
-                val emptySeat = mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false)
-                val emptySeats = (0..7).associate { it.toString() to emptySeat }
-
                 try {
-                    firestore
-                        .document("rooms/${doc.id}")
-                        .update(
-                            mapOf(
-                                "state" to "CLOSED",
-                                "closedAt" to System.currentTimeMillis(),
-                                "participantIds" to emptyList<String>(),
-                                "seats" to emptySeats,
-                            ),
-                        ).await()
-                    for (uid in participantIds) {
-                        try {
-                            firestore.document("users/$uid").update("currentRoomId", null).await()
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            Log.w(TAG, "Room operation failed", e)
-                        }
-                    }
+                    api.post("/api/rooms/${doc.id}/close")
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -604,29 +384,8 @@ class RoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to remove disconnected user") {
-            // Same race-safety logic as leaveRoom.
-            val roomRef = firestore.document("rooms/$roomId")
-            firestore
-                .runTransaction { transaction ->
-                    val doc = transaction.get(roomRef)
-                    val data = doc.data
-                    val updates =
-                        mutableMapOf<String, Any?>(
-                            "participantIds" to FieldValue.arrayRemove(userId),
-                        )
-                    if (data != null) {
-                        val seatsRaw = data["seats"] as? Map<*, *>
-                        seatsRaw?.forEach { (index, seatData) ->
-                            val seat = seatData as? Map<*, *>
-                            if (seat?.get("userId") == userId) {
-                                updates["seats.$index.userId"] = null
-                                updates["seats.$index.state"] = "EMPTY"
-                                updates["seats.$index.isMuted"] = false
-                            }
-                        }
-                    }
-                    transaction.update(roomRef, updates)
-                }.await()
-            firestore.document("users/$userId").update("currentRoomId", null).await()
+            // Server verifies the target is actually absent (RTDB presence) and
+            // clears their seat + currentRoomId.
+            api.post("/api/rooms/$roomId/disconnect-user", JSONObject().put("userId", userId))
         }
 }

--- a/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
@@ -11,6 +11,7 @@ import com.google.firebase.firestore.Transaction
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.data.remote.WorkerApiClient
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -164,8 +165,10 @@ class RoomRepositoryImplTest {
     @Test
     fun `leaveRoom returns Error on exception`() =
         runTest {
-            // leaveRoom now routes participant removal through the /leave endpoint.
-            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
+            // Pin: must be the /leave api call that throws (not the subsequent
+            // currentRoomId firestore write) — guards against a refactor that
+            // accidentally moved the failure-mode to the wrong call.
+            coEvery { api.post(eq("/api/rooms/room-1/leave"), any()) } throws RuntimeException("Fail")
 
             val result = repo.leaveRoom("room-1", "user-1")
             assertTrue(result is Resource.Error)
@@ -185,7 +188,7 @@ class RoomRepositoryImplTest {
     @Test
     fun `takeSeat returns Error on exception`() =
         runTest {
-            coEvery { api.post(any(), any()) } throws RuntimeException("No seats")
+            coEvery { api.post(eq("/api/rooms/room-1/seats/2/claim"), any()) } throws RuntimeException("No seats")
 
             val result = repo.takeSeat("room-1", 2, "user-1")
             assertTrue(result is Resource.Error)
@@ -227,7 +230,7 @@ class RoomRepositoryImplTest {
     @Test
     fun `moveSeat returns Error on exception`() =
         runTest {
-            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
+            coEvery { api.post(eq("/api/rooms/room-1/seats/2/move"), any()) } throws RuntimeException("Fail")
 
             val result = repo.moveSeat("room-1", 2, 5, "user-a")
             assertTrue(result is Resource.Error)
@@ -480,6 +483,116 @@ class RoomRepositoryImplTest {
             coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
 
             val result = repo.removeDisconnectedUser("room-1", "user-1")
+            assertTrue(result is Resource.Error)
+        }
+
+    // endregion
+
+    // region migration error-injection coverage (PR #858 reviewer I3 + I4)
+    //
+    // Each migrated method's failure path changed from a Firestore
+    // Tasks.forException to an api.* throw. The Success tests pass via relaxed
+    // mocks (any api call returns a relaxed JSONObject → Resource.Success), but
+    // the error path needs a dedicated stub to confirm ApiException → firebaseCall
+    // → Resource.Error still holds.
+
+    @Test
+    fun `leaveSeat returns Error on exception`() =
+        runTest {
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
+            val result = repo.leaveSeat("room-1", 3)
+            assertTrue(result is Resource.Error)
+        }
+
+    @Test
+    fun `removeFromSeat returns Error on exception`() =
+        runTest {
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
+            val result = repo.removeFromSeat("room-1", 3)
+            assertTrue(result is Resource.Error)
+        }
+
+    @Test
+    fun `toggleMute returns Error on exception`() =
+        runTest {
+            coEvery { api.patch(any(), any()) } throws RuntimeException("Fail")
+            val result = repo.toggleMute("room-1", 2, true)
+            assertTrue(result is Resource.Error)
+        }
+
+    @Test
+    fun `addHost returns Error on exception`() =
+        runTest {
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
+            val result = repo.addHost("room-1", "user-1")
+            assertTrue(result is Resource.Error)
+        }
+
+    @Test
+    fun `removeHost returns Error on exception`() =
+        runTest {
+            coEvery { api.delete(any<String>()) } throws RuntimeException("Fail")
+            val result = repo.removeHost("room-1", "user-1")
+            assertTrue(result is Resource.Error)
+        }
+
+    @Test
+    fun `setRequireApproval returns Error on exception`() =
+        runTest {
+            coEvery { api.patch(any(), any()) } throws RuntimeException("Fail")
+            val result = repo.setRequireApproval("room-1", true)
+            assertTrue(result is Resource.Error)
+        }
+
+    @Test
+    fun `setOwnerAway returns Error on exception`() =
+        runTest {
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
+            val result = repo.setOwnerAway("room-1")
+            assertTrue(result is Resource.Error)
+        }
+
+    @Test
+    fun `setOwnerReturned returns Error on exception`() =
+        runTest {
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
+            val result = repo.setOwnerReturned("room-1", "owner-1")
+            assertTrue(result is Resource.Error)
+        }
+
+    @Test
+    fun `cancelInvite returns Error on exception`() =
+        runTest {
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
+            val result = repo.cancelInvite("room-1", "user-1")
+            assertTrue(result is Resource.Error)
+        }
+
+    // Reviewer I4: pin that cancelInvite routes to /decline-invite (not a path
+    // derived from the user-supplied userId arg) — the interface accepts a
+    // userId param but the migrated impl ignores it and is self-scoped
+    // server-side via req.auth. Without this pin, a refactor that started
+    // honouring the param could silently regress to a foreign-invite cancel.
+    @Test
+    fun `cancelInvite posts to decline-invite endpoint regardless of userId arg`() =
+        runTest {
+            repo.cancelInvite("room-1", "user-1")
+            coVerify { api.post(eq("/api/rooms/room-1/decline-invite"), any()) }
+        }
+
+    @Test
+    fun `acceptInvite returns Error on exception`() =
+        runTest {
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
+            val result = repo.acceptInvite("room-1", "user-1", 2)
+            assertTrue(result is Resource.Error)
+        }
+
+    @Test
+    fun `recordFirstJoinTimestamp returns Error on exception`() =
+        runTest {
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
+            val result = repo.recordFirstJoinTimestamp("room-1", "user-1")
             assertTrue(result is Resource.Error)
         }
 

--- a/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
@@ -144,7 +144,7 @@ class RoomRepositoryImplTest {
     @Test
     fun `joinRoom returns Error on exception`() =
         runTest {
-            every { mockDocRef.update(any<Map<String, Any>>()) } returns Tasks.forException(RuntimeException("Fail"))
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
 
             val result = repo.joinRoom("room-1", "user-1")
             assertTrue(result is Resource.Error)
@@ -164,10 +164,8 @@ class RoomRepositoryImplTest {
     @Test
     fun `leaveRoom returns Error on exception`() =
         runTest {
-            // leaveRoom now reads + writes inside a transaction (race-safety
-            // fix for the seat-clear path), so failures surface via
-            // runTransaction rather than the standalone get/update calls.
-            every { firestore.runTransaction<Unit>(any()) } returns Tasks.forException(RuntimeException("Fail"))
+            // leaveRoom now routes participant removal through the /leave endpoint.
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
 
             val result = repo.leaveRoom("room-1", "user-1")
             assertTrue(result is Resource.Error)
@@ -187,7 +185,7 @@ class RoomRepositoryImplTest {
     @Test
     fun `takeSeat returns Error on exception`() =
         runTest {
-            every { mockDocRef.update(any<Map<String, Any>>()) } returns Tasks.forException(RuntimeException("No seats"))
+            coEvery { api.post(any(), any()) } throws RuntimeException("No seats")
 
             val result = repo.takeSeat("room-1", 2, "user-1")
             assertTrue(result is Resource.Error)
@@ -209,7 +207,7 @@ class RoomRepositoryImplTest {
     // region removeFromSeat
 
     @Test
-    fun `removeFromSeat delegates to leaveSeat`() =
+    fun `removeFromSeat returns Success`() =
         runTest {
             val result = repo.removeFromSeat("room-1", 3)
             assertTrue(result is Resource.Success)
@@ -229,7 +227,7 @@ class RoomRepositoryImplTest {
     @Test
     fun `moveSeat returns Error on exception`() =
         runTest {
-            every { firestore.runTransaction<Unit>(any()) } returns Tasks.forException(RuntimeException("Fail"))
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
 
             val result = repo.moveSeat("room-1", 2, 5, "user-a")
             assertTrue(result is Resource.Error)
@@ -249,9 +247,7 @@ class RoomRepositoryImplTest {
     @Test
     fun `kickUser returns Error on exception`() =
         runTest {
-            // kickUser now reads + writes inside a transaction; failure
-            // surfaces via runTransaction.
-            every { firestore.runTransaction<Unit>(any()) } returns Tasks.forException(RuntimeException("Fail"))
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
 
             val result = repo.kickUser("room-1", "bad-user", 2)
             assertTrue(result is Resource.Error)
@@ -300,7 +296,7 @@ class RoomRepositoryImplTest {
     @Test
     fun `updateRoomName returns Error on exception`() =
         runTest {
-            every { mockDocRef.update(any<String>(), any()) } returns Tasks.forException(RuntimeException("Fail"))
+            coEvery { api.patch(any(), any()) } throws RuntimeException("Fail")
 
             val result = repo.updateRoomName("room-1", "New Name")
             assertTrue(result is Resource.Error)
@@ -379,7 +375,7 @@ class RoomRepositoryImplTest {
     @Test
     fun `closeRoom returns Error on exception`() =
         runTest {
-            every { mockDocRef.get() } returns Tasks.forException(RuntimeException("Fail"))
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
 
             val result = repo.closeRoom("room-1")
             assertTrue(result is Resource.Error)
@@ -481,9 +477,7 @@ class RoomRepositoryImplTest {
     @Test
     fun `removeDisconnectedUser returns Error on exception`() =
         runTest {
-            // removeDisconnectedUser now reads + writes inside a transaction;
-            // failure surfaces via runTransaction.
-            every { firestore.runTransaction<Unit>(any()) } returns Tasks.forException(RuntimeException("Fail"))
+            coEvery { api.post(any(), any()) } throws RuntimeException("Fail")
 
             val result = repo.removeDisconnectedUser("room-1", "user-1")
             assertTrue(result is Resource.Error)

--- a/express-api/src/index.js
+++ b/express-api/src/index.js
@@ -212,6 +212,7 @@ app.use('/api', require('./routes/livekit'));
 app.use('/api', require('./routes/reports'));
 app.use('/api', require('./routes/notifications'));
 app.use('/api', require('./routes/rooms'));
+app.use('/api', require('./routes/room-mutations'));
 app.use('/api', require('./routes/data-export'));
 app.use('/api', require('./routes/age-verification'));
 app.use('/api', require('./routes/pm-lock-check'));

--- a/express-api/src/routes/room-mutations.js
+++ b/express-api/src/routes/room-mutations.js
@@ -1,0 +1,168 @@
+/**
+ * Server-authoritative room mutations (anti-grief + race-safety hardening).
+ *
+ * Previously the client RoomRepository wrote the room doc directly, and
+ * firestore.rules let any same-cohort participant write any field — so all
+ * role/seat gates were CLIENT-ONLY (a hand-crafted write could self-promote
+ * to host, kick anyone, or seize a seat), and seat claims were non-atomic
+ * (`update()` with no precondition => concurrent claims last-write-wins, or a
+ * user seated twice).
+ *
+ * These endpoints enforce the ChatRoom gates SERVER-SIDE via the Admin SDK
+ * (bypasses rules) with TRANSACTIONAL seat claims: a seat has <=1 occupant and
+ * a user occupies <=1 seat. firestore.rules is tightened in a later phase to
+ * forbid direct client room-doc writes.
+ *
+ * Phase 1 — seat lifecycle (claim / accept-invite / leave). Moderation +
+ * owner/settings ops follow in subsequent chunks.
+ */
+
+const router = require('express').Router();
+const { db, rtdb, FieldValue } = require('../utils/firebase');
+const { cohortFromClaim } = require('../utils/firebase-claims');
+const {
+  canTakeSeatDirectly,
+  userSeatIndex,
+  MAX_SEATS,
+  OWNER_SEAT_INDEX,
+} = require('../utils/room-auth');
+const log = require('../utils/log');
+
+/** Supplementary RTDB nudge (the Firestore room-doc listener is the primary propagation). */
+async function broadcastRoomUpdated(roomId) {
+  try {
+    await rtdb
+      .ref(`rooms/${roomId}/events/lastEvent`)
+      .set({ type: 'room_updated', ts: Date.now() });
+  } catch (err) {
+    log.error('room-mutations', 'RTDB broadcast failed', { roomId, error: err.message });
+  }
+}
+
+/** Parse + bounds-check a seat index from the path; null if invalid. */
+function parseSeatIndex(raw) {
+  const idx = Number(raw);
+  if (!Number.isInteger(idx) || idx < 0 || idx >= MAX_SEATS) return null;
+  return idx;
+}
+
+/**
+ * Load the room + apply the cohort gate inside a transaction, then delegate
+ * to `mutate(room, t, roomRef) -> { status, body }`. The room is cohort-
+ * stamped at create; a cohort mismatch is hidden as 404 (OSA existence-hide).
+ */
+async function inRoomTransaction(req, roomId, mutate) {
+  const roomRef = db.doc(`rooms/${roomId}`);
+  return db.runTransaction(async (t) => {
+    const snap = await t.get(roomRef);
+    if (!snap.exists) return { status: 404, body: { error: 'Room not found' } };
+    const room = snap.data();
+    if (cohortFromClaim(req) !== (room.cohort ?? 'minor')) {
+      return { status: 404, body: { error: 'Not found' } };
+    }
+    return mutate(room, t, roomRef);
+  });
+}
+
+// POST /rooms/:roomId/seats/:seatIndex/claim — caller seats THEMSELVES.
+router.post('/rooms/:roomId/seats/:seatIndex/claim', async (req, res) => {
+  const { roomId } = req.params;
+  const seatIndex = parseSeatIndex(req.params.seatIndex);
+  if (seatIndex === null) return res.status(400).json({ error: 'Invalid seat index' });
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+      const seat = (room.seats || {})[String(seatIndex)] || {};
+      if (seat.userId || seat.state === 'OCCUPIED') {
+        return { status: 409, body: { error: 'Seat is already taken', code: 'SEAT_TAKEN' } };
+      }
+      if (!canTakeSeatDirectly(room, callerId, seatIndex)) {
+        return { status: 403, body: { error: 'Not allowed to take this seat' } };
+      }
+      if (userSeatIndex(room, callerId) !== -1) {
+        return { status: 409, body: { error: 'Already seated', code: 'ALREADY_SEATED' } };
+      }
+      t.update(roomRef, {
+        [`seats.${seatIndex}.userId`]: callerId,
+        [`seats.${seatIndex}.state`]: 'OCCUPIED',
+        [`seats.${seatIndex}.isMuted`]: false,
+        participantIds: FieldValue.arrayUnion(callerId),
+        allTimeSeatUserIds: FieldValue.arrayUnion(callerId),
+      });
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Seat claim failed', { roomId, seatIndex, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/seats/:seatIndex/accept-invite — invited caller seats SELF.
+router.post('/rooms/:roomId/seats/:seatIndex/accept-invite', async (req, res) => {
+  const { roomId } = req.params;
+  const seatIndex = parseSeatIndex(req.params.seatIndex);
+  if (seatIndex === null) return res.status(400).json({ error: 'Invalid seat index' });
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+      const invited = Object.prototype.hasOwnProperty.call(room.pendingInvites || {}, callerId);
+      if (!invited) return { status: 403, body: { error: 'No pending invite' } };
+      if (seatIndex === OWNER_SEAT_INDEX)
+        return { status: 403, body: { error: 'Seat 0 is owner-only' } };
+      const seat = (room.seats || {})[String(seatIndex)] || {};
+      if (seat.userId || seat.state === 'OCCUPIED') {
+        return { status: 409, body: { error: 'Seat is already taken', code: 'SEAT_TAKEN' } };
+      }
+      if (userSeatIndex(room, callerId) !== -1) {
+        return { status: 409, body: { error: 'Already seated', code: 'ALREADY_SEATED' } };
+      }
+      t.update(roomRef, {
+        [`pendingInvites.${callerId}`]: FieldValue.delete(),
+        [`seats.${seatIndex}.userId`]: callerId,
+        [`seats.${seatIndex}.state`]: 'OCCUPIED',
+        [`seats.${seatIndex}.isMuted`]: false,
+        participantIds: FieldValue.arrayUnion(callerId),
+        allTimeSeatUserIds: FieldValue.arrayUnion(callerId),
+      });
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Accept invite failed', { roomId, seatIndex, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/seats/:seatIndex/leave — caller leaves their OWN seat.
+router.post('/rooms/:roomId/seats/:seatIndex/leave', async (req, res) => {
+  const { roomId } = req.params;
+  const seatIndex = parseSeatIndex(req.params.seatIndex);
+  if (seatIndex === null) return res.status(400).json({ error: 'Invalid seat index' });
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      const seat = (room.seats || {})[String(seatIndex)] || {};
+      if (String(seat.userId) !== callerId) {
+        return { status: 403, body: { error: 'Not your seat' } };
+      }
+      t.update(roomRef, {
+        [`seats.${seatIndex}.userId`]: null,
+        [`seats.${seatIndex}.state`]: 'EMPTY',
+        [`seats.${seatIndex}.isMuted`]: false,
+      });
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Leave seat failed', { roomId, seatIndex, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/express-api/src/routes/room-mutations.js
+++ b/express-api/src/routes/room-mutations.js
@@ -14,8 +14,9 @@
  * forbid direct client room-doc writes.
  *
  * Phase 1 — the full server-authoritative room-mutation surface: seat lifecycle
- * (claim / accept-invite / leave / move), moderation (kick / remove / mute /
- * add+remove host), join (with ban enforcement), invite-decline, room settings
+ * (claim / accept-invite / leave-seat / move), participant lifecycle (join with
+ * ban enforcement / leave-room / disconnect-eviction / first-join), moderation
+ * (kick / remove / mute / add+remove host), invite-decline, room settings
  * (rename / require-approval) and room lifecycle (owner-away / owner-returned /
  * close). firestore.rules is tightened in a later phase to forbid direct client
  * room-doc writes.
@@ -33,6 +34,7 @@ const {
   canMoveSeat,
   canCloseRoom,
   canSetOwnerAway,
+  canRemoveDisconnected,
   resolveRole,
   MAX_SEATS,
   OWNER_SEAT_INDEX,
@@ -54,19 +56,19 @@ async function broadcastRoomUpdated(roomId) {
 }
 
 /**
- * Owner-presence check for the non-owner setOwnerAway safety-net path. Reads
- * RTDB presence at rooms/<roomId>/presence/<ownerId>. FAIL-SAFE to "present"
- * on any read error so a presence outage can never let a non-owner forge an
- * owner-away transition while the owner is actually connected.
+ * RTDB presence check for the presence-gated endpoints (owner-away safety net,
+ * disconnect-user eviction). Reads rooms/<roomId>/presence/<userId>. FAIL-SAFE
+ * to "present" on any read error so a presence outage can never let a caller
+ * forge an owner-away transition or evict a still-connected user.
  */
-async function isOwnerPresent(roomId, ownerId) {
+async function isUserPresent(roomId, userId) {
   try {
-    const snap = await rtdb.ref(`rooms/${roomId}/presence/${ownerId}`).get();
+    const snap = await rtdb.ref(`rooms/${roomId}/presence/${userId}`).get();
     return snap.exists();
   } catch (err) {
-    log.error('room-mutations', 'Owner presence read failed', {
+    log.error('room-mutations', 'Presence read failed', {
       roomId,
-      ownerId,
+      userId,
       error: err.message,
     });
     return true;
@@ -440,7 +442,7 @@ router.post('/rooms/:roomId/owner-away', async (req, res) => {
     // owner-returned. This mirrors the client presence monitor and is strictly
     // safer than the prior client-only write. (Fully closing it needs a
     // Firestore-visible presence token — tracked for the rules-lockdown phase.)
-    const ownerPresent = callerIsOwner ? false : await isOwnerPresent(roomId, preRoom.ownerId);
+    const ownerPresent = callerIsOwner ? false : await isUserPresent(roomId, preRoom.ownerId);
 
     const result = await db.runTransaction(async (t) => {
       const snap = await t.get(roomRef);
@@ -604,6 +606,115 @@ router.post('/rooms/:roomId/decline-invite', async (req, res) => {
     return res.status(result.status).json(result.body);
   } catch (err) {
     log.error('room-mutations', 'Decline invite failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/leave — caller removes THEMSELVES from the room
+// (participant list + their own seat, if seated). currentRoomId stays a client
+// self-write. Idempotent: a no-op arrayRemove if the caller isn't a member.
+router.post('/rooms/:roomId/leave', async (req, res) => {
+  const { roomId } = req.params;
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      const update = { participantIds: FieldValue.arrayRemove(callerId) };
+      const seatIdx = userSeatIndex(room, callerId);
+      if (seatIdx !== -1) {
+        update[`seats.${seatIdx}.userId`] = null;
+        update[`seats.${seatIdx}.state`] = 'EMPTY';
+        update[`seats.${seatIdx}.isMuted`] = false;
+      }
+      t.update(roomRef, update);
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Leave room failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/disconnect-user — remove a DISCONNECTED non-owner
+// (presence-timeout eviction triggered by a participant's presence monitor).
+// The target's absence is verified against RTDB presence BEFORE the txn
+// (fail-safe to present). Also clears the removed user's currentRoomId — a
+// foreign user-doc write that only the server may perform once rules lock down.
+router.post('/rooms/:roomId/disconnect-user', async (req, res) => {
+  const { roomId } = req.params;
+  const targetId = String(req.body?.userId ?? '') || null;
+  if (!targetId) return res.status(400).json({ error: 'userId required' });
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const roomRef = db.doc(`rooms/${roomId}`);
+    const preSnap = await roomRef.get();
+    if (!preSnap.exists) return res.status(404).json({ error: 'Room not found' });
+    const preRoom = preSnap.data();
+    if (cohortFromClaim(req) !== (preRoom.cohort ?? 'minor')) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+    const targetPresent = await isUserPresent(roomId, targetId);
+
+    const result = await db.runTransaction(async (t) => {
+      const snap = await t.get(roomRef);
+      if (!snap.exists) return { status: 404, body: { error: 'Room not found' } };
+      const room = snap.data();
+      if (cohortFromClaim(req) !== (room.cohort ?? 'minor')) {
+        return { status: 404, body: { error: 'Not found' } };
+      }
+      if (!canRemoveDisconnected(room, callerId, targetId, targetPresent)) {
+        return { status: 403, body: { error: 'Not allowed to remove this user' } };
+      }
+      const update = { participantIds: FieldValue.arrayRemove(targetId) };
+      const seatIdx = userSeatIndex(room, targetId);
+      if (seatIdx !== -1) {
+        update[`seats.${seatIdx}.userId`] = null;
+        update[`seats.${seatIdx}.state`] = 'EMPTY';
+        update[`seats.${seatIdx}.isMuted`] = false;
+      }
+      t.update(roomRef, update);
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) {
+      try {
+        await db.doc(`users/${targetId}`).set({ currentRoomId: null }, { merge: true });
+      } catch (err) {
+        log.error('room-mutations', 'disconnect-user currentRoomId clear failed', {
+          roomId,
+          targetId,
+          error: err.message,
+        });
+      }
+      await broadcastRoomUpdated(roomId);
+    }
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Disconnect user failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/first-join — caller records THEIR OWN first-join time.
+// Self-scoped + set-once: writes firstJoinTimestamps[caller] only if absent, so
+// re-entry never overwrites the original timestamp.
+router.post('/rooms/:roomId/first-join', async (req, res) => {
+  const { roomId } = req.params;
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      const already = Object.prototype.hasOwnProperty.call(
+        room.firstJoinTimestamps || {},
+        callerId,
+      );
+      if (already) return { status: 200, body: { success: true } };
+      t.update(roomRef, { [`firstJoinTimestamps.${callerId}`]: Date.now() });
+      return { status: 200, body: { success: true }, mutated: true };
+    });
+    if (result.status === 200 && result.mutated) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Record first join failed', { roomId, error: err.message });
     return res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/express-api/src/routes/room-mutations.js
+++ b/express-api/src/routes/room-mutations.js
@@ -13,8 +13,12 @@
  * a user occupies <=1 seat. firestore.rules is tightened in a later phase to
  * forbid direct client room-doc writes.
  *
- * Phase 1 — seat lifecycle (claim / accept-invite / leave). Moderation +
- * owner/settings ops follow in subsequent chunks.
+ * Phase 1 — the full server-authoritative room-mutation surface: seat lifecycle
+ * (claim / accept-invite / leave / move), moderation (kick / remove / mute /
+ * add+remove host), join (with ban enforcement), invite-decline, room settings
+ * (rename / require-approval) and room lifecycle (owner-away / owner-returned /
+ * close). firestore.rules is tightened in a later phase to forbid direct client
+ * room-doc writes.
  */
 
 const router = require('express').Router();
@@ -26,11 +30,17 @@ const {
   canKickUser,
   canRemoveFromSeat,
   canForceMute,
+  canMoveSeat,
+  canCloseRoom,
+  canSetOwnerAway,
   resolveRole,
   MAX_SEATS,
   OWNER_SEAT_INDEX,
 } = require('../utils/room-auth');
 const log = require('../utils/log');
+
+// Mirrors the client room-name input cap (CreateRoomDialog: length <= 50).
+const MAX_ROOM_NAME_LENGTH = 50;
 
 /** Supplementary RTDB nudge (the Firestore room-doc listener is the primary propagation). */
 async function broadcastRoomUpdated(roomId) {
@@ -40,6 +50,26 @@ async function broadcastRoomUpdated(roomId) {
       .set({ type: 'room_updated', ts: Date.now() });
   } catch (err) {
     log.error('room-mutations', 'RTDB broadcast failed', { roomId, error: err.message });
+  }
+}
+
+/**
+ * Owner-presence check for the non-owner setOwnerAway safety-net path. Reads
+ * RTDB presence at rooms/<roomId>/presence/<ownerId>. FAIL-SAFE to "present"
+ * on any read error so a presence outage can never let a non-owner forge an
+ * owner-away transition while the owner is actually connected.
+ */
+async function isOwnerPresent(roomId, ownerId) {
+  try {
+    const snap = await rtdb.ref(`rooms/${roomId}/presence/${ownerId}`).get();
+    return snap.exists();
+  } catch (err) {
+    log.error('room-mutations', 'Owner presence read failed', {
+      roomId,
+      ownerId,
+      error: err.message,
+    });
+    return true;
   }
 }
 
@@ -309,6 +339,271 @@ router.delete('/rooms/:roomId/hosts/:userId', async (req, res) => {
     return res.status(result.status).json(result.body);
   } catch (err) {
     log.error('room-mutations', 'Remove host failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// PATCH /rooms/:roomId/name — OWNER renames the room.
+router.patch('/rooms/:roomId/name', async (req, res) => {
+  const { roomId } = req.params;
+  const name = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
+  if (!name) return res.status(400).json({ error: 'name required' });
+  if (name.length > MAX_ROOM_NAME_LENGTH) {
+    return res.status(400).json({ error: 'name too long' });
+  }
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      if (resolveRole(room, callerId) !== 'OWNER') {
+        return { status: 403, body: { error: 'Only the owner can rename the room' } };
+      }
+      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+      t.update(roomRef, { name });
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Rename failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// PATCH /rooms/:roomId/require-approval — OWNER toggles the seat-approval policy.
+router.patch('/rooms/:roomId/require-approval', async (req, res) => {
+  const { roomId } = req.params;
+  if (typeof req.body?.requireApproval !== 'boolean') {
+    return res.status(400).json({ error: 'requireApproval (boolean) required' });
+  }
+  const { requireApproval } = req.body;
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      if (resolveRole(room, callerId) !== 'OWNER') {
+        return { status: 403, body: { error: 'Only the owner can change approval settings' } };
+      }
+      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+      t.update(roomRef, { requireApproval });
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Set requireApproval failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/owner-returned — OWNER returns from OWNER_AWAY.
+router.post('/rooms/:roomId/owner-returned', async (req, res) => {
+  const { roomId } = req.params;
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      if (resolveRole(room, callerId) !== 'OWNER') {
+        return { status: 403, body: { error: 'Only the owner can return to the room' } };
+      }
+      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+      // Idempotent: already active — no write, no spurious broadcast.
+      if (room.state === 'ACTIVE') return { status: 200, body: { success: true } };
+      t.update(roomRef, { state: 'ACTIVE', ownerLeftAt: null });
+      return { status: 200, body: { success: true }, mutated: true };
+    });
+    if (result.status === 200 && result.mutated) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Owner returned failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/owner-away — OWNER (or a participant when the owner is
+// verifiably absent) transitions the room to OWNER_AWAY. Presence is read
+// BEFORE the transaction (RTDB reads can't run inside a Firestore txn); the
+// txn re-validates state/role atomically.
+router.post('/rooms/:roomId/owner-away', async (req, res) => {
+  const { roomId } = req.params;
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const roomRef = db.doc(`rooms/${roomId}`);
+    const preSnap = await roomRef.get();
+    if (!preSnap.exists) return res.status(404).json({ error: 'Room not found' });
+    const preRoom = preSnap.data();
+    if (cohortFromClaim(req) !== (preRoom.cohort ?? 'minor')) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+    const callerIsOwner = resolveRole(preRoom, callerId) === 'OWNER';
+    // Presence is read here, immediately before the txn, to keep the window
+    // between read and commit minimal. A residual TOCTOU window is unavoidable
+    // (RTDB can't be read inside a Firestore txn): if the owner reconnects
+    // within it the room may briefly flip to OWNER_AWAY — self-healing via
+    // owner-returned. This mirrors the client presence monitor and is strictly
+    // safer than the prior client-only write. (Fully closing it needs a
+    // Firestore-visible presence token — tracked for the rules-lockdown phase.)
+    const ownerPresent = callerIsOwner ? false : await isOwnerPresent(roomId, preRoom.ownerId);
+
+    const result = await db.runTransaction(async (t) => {
+      const snap = await t.get(roomRef);
+      if (!snap.exists) return { status: 404, body: { error: 'Room not found' } };
+      const room = snap.data();
+      if (cohortFromClaim(req) !== (room.cohort ?? 'minor')) {
+        return { status: 404, body: { error: 'Not found' } };
+      }
+      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+      if (!canSetOwnerAway(room, callerId, ownerPresent)) {
+        return { status: 403, body: { error: 'Not allowed to set owner away' } };
+      }
+      // Idempotent: already away (e.g. owner re-triggers). Placed AFTER the auth
+      // gate so a non-participant can't probe room state via a 200.
+      if (room.state === 'OWNER_AWAY') return { status: 200, body: { success: true } };
+      t.update(roomRef, { state: 'OWNER_AWAY', ownerLeftAt: Date.now() });
+      return { status: 200, body: { success: true }, mutated: true };
+    });
+    if (result.status === 200 && result.mutated) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Owner away failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/close — OWNER (or a participant under the OWNER_AWAY
+// close preconditions) ends the room: empties seats + participants and clears
+// every participant's currentRoomId (foreign user-doc writes that only the
+// server may perform once firestore.rules is locked down).
+router.post('/rooms/:roomId/close', async (req, res) => {
+  const { roomId } = req.params;
+  const callerId = String(req.auth.uniqueId);
+  const now = Date.now();
+  let participantsToClear = [];
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      if (!canCloseRoom(room, callerId, now)) {
+        return { status: 403, body: { error: 'Not allowed to close this room' } };
+      }
+      if (room.state === 'CLOSED') return { status: 200, body: { success: true } }; // idempotent
+      participantsToClear = (room.participantIds || []).map(String);
+      const emptySeats = {};
+      for (let i = 0; i < MAX_SEATS; i += 1) {
+        emptySeats[String(i)] = { userId: null, state: 'EMPTY', isMuted: false };
+      }
+      t.update(roomRef, {
+        state: 'CLOSED',
+        closedAt: now,
+        ownerLeftAt: null,
+        seats: emptySeats,
+        participantIds: [],
+      });
+      return { status: 200, body: { success: true }, closed: true };
+    });
+    if (result.status === 200 && result.closed) {
+      // Best-effort: a failure here must NOT undo the already-committed close;
+      // clients also self-clear their own currentRoomId on observing the close.
+      try {
+        if (participantsToClear.length) {
+          const batch = db.batch();
+          for (const pid of participantsToClear) {
+            batch.set(db.doc(`users/${pid}`), { currentRoomId: null }, { merge: true });
+          }
+          await batch.commit();
+        }
+      } catch (err) {
+        log.error('room-mutations', 'closeRoom currentRoomId clear failed', {
+          roomId,
+          error: err.message,
+        });
+      }
+      await broadcastRoomUpdated(roomId);
+    }
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Close room failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/seats/:seatIndex/move — owner/host moves a seat occupant
+// to another seat, swapping with the target seat's contents. seatIndex is the
+// SOURCE; the destination is `toIndex` in the body. Mirrors
+// ActiveRoomManager.moveSeat: neither seat may be the owner seat, and a host
+// may not move the owner or another host.
+router.post('/rooms/:roomId/seats/:seatIndex/move', async (req, res) => {
+  const { roomId } = req.params;
+  const fromIndex = parseSeatIndex(req.params.seatIndex);
+  if (fromIndex === null) return res.status(400).json({ error: 'Invalid seat index' });
+  const toIndex = parseSeatIndex(req.body?.toIndex);
+  if (toIndex === null) return res.status(400).json({ error: 'Invalid target seat index' });
+  if (fromIndex === toIndex) {
+    return res.status(400).json({ error: 'Source and target seats are the same' });
+  }
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+      if (!canMoveSeat(room, callerId, fromIndex, toIndex)) {
+        return { status: 403, body: { error: 'Not allowed to move this seat' } };
+      }
+      const seats = room.seats || {};
+      const fromSeat = seats[String(fromIndex)] || {};
+      const toSeat = seats[String(toIndex)] || {};
+      t.update(roomRef, {
+        [`seats.${fromIndex}.userId`]: toSeat.userId ?? null,
+        [`seats.${fromIndex}.state`]: toSeat.state ?? 'EMPTY',
+        [`seats.${fromIndex}.isMuted`]: toSeat.isMuted ?? false,
+        [`seats.${toIndex}.userId`]: fromSeat.userId ?? null,
+        [`seats.${toIndex}.state`]: fromSeat.state ?? 'EMPTY',
+        [`seats.${toIndex}.isMuted`]: fromSeat.isMuted ?? false,
+      });
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Move seat failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/join — caller joins the room's participant list. The ban
+// list is enforced server-side here. currentRoomId is the caller's own user-doc
+// field and remains a client write.
+router.post('/rooms/:roomId/join', async (req, res) => {
+  const { roomId } = req.params;
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+      if ((room.bannedUserIds || []).map(String).includes(callerId)) {
+        return { status: 403, body: { error: 'You are banned from this room', code: 'BANNED' } };
+      }
+      t.update(roomRef, { participantIds: FieldValue.arrayUnion(callerId) });
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Join room failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/decline-invite — caller declines THEIR OWN pending invite.
+// Self-scoped by auth: a caller can only ever remove their own pendingInvites
+// entry. No-op (still 200) when there is no pending invite.
+router.post('/rooms/:roomId/decline-invite', async (req, res) => {
+  const { roomId } = req.params;
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      const hasInvite = Object.prototype.hasOwnProperty.call(room.pendingInvites || {}, callerId);
+      if (!hasInvite) return { status: 200, body: { success: true } };
+      t.update(roomRef, { [`pendingInvites.${callerId}`]: FieldValue.delete() });
+      return { status: 200, body: { success: true }, mutated: true };
+    });
+    if (result.status === 200 && result.mutated) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Decline invite failed', { roomId, error: err.message });
     return res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/express-api/src/routes/room-mutations.js
+++ b/express-api/src/routes/room-mutations.js
@@ -515,8 +515,15 @@ router.post('/rooms/:roomId/decline-invite', async (req, res) =>
 // self-write. Idempotent: a no-op arrayRemove if the caller isn't a member.
 router.post('/rooms/:roomId/leave', async (req, res) =>
   executeRoomMutation(req, res, 'Leave room', ({ room, t, roomRef, callerId }) => {
-    const update = { participantIds: FieldValue.arrayRemove(callerId) };
+    const isMember = (room.participantIds || []).map(String).includes(callerId);
     const seatIdx = userSeatIndex(room, callerId);
+    // Idempotent no-op: caller isn't a member and isn't seated. Skip the
+    // unnecessary t.update + RTDB broadcast (the arrayRemove was a no-op
+    // anyway). Common on a client retrying after a disconnect.
+    if (!isMember && seatIdx === -1) {
+      return { status: 200, body: { success: true }, noop: true };
+    }
+    const update = { participantIds: FieldValue.arrayRemove(callerId) };
     if (seatIdx !== -1) {
       update[`seats.${seatIdx}.userId`] = null;
       update[`seats.${seatIdx}.state`] = 'EMPTY';

--- a/express-api/src/routes/room-mutations.js
+++ b/express-api/src/routes/room-mutations.js
@@ -23,6 +23,10 @@ const { cohortFromClaim } = require('../utils/firebase-claims');
 const {
   canTakeSeatDirectly,
   userSeatIndex,
+  canKickUser,
+  canRemoveFromSeat,
+  canForceMute,
+  resolveRole,
   MAX_SEATS,
   OWNER_SEAT_INDEX,
 } = require('../utils/room-auth');
@@ -161,6 +165,150 @@ router.post('/rooms/:roomId/seats/:seatIndex/leave', async (req, res) => {
     return res.status(result.status).json(result.body);
   } catch (err) {
     log.error('room-mutations', 'Leave seat failed', { roomId, seatIndex, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/kick — owner/host bans + removes a target user.
+router.post('/rooms/:roomId/kick', async (req, res) => {
+  const { roomId } = req.params;
+  const targetId = String(req.body?.userId ?? '') || null;
+  const reason = typeof req.body?.reason === 'string' ? req.body.reason : '';
+  const kickerName = typeof req.body?.kickerName === 'string' ? req.body.kickerName : '';
+  if (!targetId) return res.status(400).json({ error: 'userId required' });
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      if (!canKickUser(room, callerId, targetId)) {
+        return { status: 403, body: { error: 'Not allowed to kick this user' } };
+      }
+      const update = {
+        bannedUserIds: FieldValue.arrayUnion(targetId),
+        participantIds: FieldValue.arrayRemove(targetId),
+        [`kickInfo.${targetId}`]: { kickerName, reason },
+      };
+      const seatIdx = userSeatIndex(room, targetId);
+      if (seatIdx !== -1) {
+        update[`seats.${seatIdx}.userId`] = null;
+        update[`seats.${seatIdx}.state`] = 'EMPTY';
+        update[`seats.${seatIdx}.isMuted`] = false;
+      }
+      t.update(roomRef, update);
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Kick failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/seats/:seatIndex/remove — owner/host vacates a seat (no ban).
+router.post('/rooms/:roomId/seats/:seatIndex/remove', async (req, res) => {
+  const { roomId } = req.params;
+  const seatIndex = parseSeatIndex(req.params.seatIndex);
+  if (seatIndex === null) return res.status(400).json({ error: 'Invalid seat index' });
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      if (!canRemoveFromSeat(room, callerId, seatIndex)) {
+        return { status: 403, body: { error: 'Not allowed to remove this occupant' } };
+      }
+      t.update(roomRef, {
+        [`seats.${seatIndex}.userId`]: null,
+        [`seats.${seatIndex}.state`]: 'EMPTY',
+        [`seats.${seatIndex}.isMuted`]: false,
+      });
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Remove from seat failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// PATCH /rooms/:roomId/seats/:seatIndex/mute — force-mute (owner/host) or self-unmute.
+router.patch('/rooms/:roomId/seats/:seatIndex/mute', async (req, res) => {
+  const { roomId } = req.params;
+  const seatIndex = parseSeatIndex(req.params.seatIndex);
+  if (seatIndex === null) return res.status(400).json({ error: 'Invalid seat index' });
+  if (typeof req.body?.isMuted !== 'boolean') {
+    return res.status(400).json({ error: 'isMuted (boolean) required' });
+  }
+  const { isMuted } = req.body;
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      const seat = (room.seats || {})[String(seatIndex)] || {};
+      if (!seat.userId) return { status: 409, body: { error: 'Seat is empty' } };
+      if (isMuted) {
+        // Force-mute: moderator gate (owner/host, not owner/other-host, not already muted).
+        if (!canForceMute(room, callerId, seatIndex)) {
+          return { status: 403, body: { error: 'Not allowed to mute this seat' } };
+        }
+      } else if (String(seat.userId) !== callerId) {
+        // Unmute: only the seat's own occupant may unmute themselves.
+        return { status: 403, body: { error: 'Only the occupant can unmute' } };
+      }
+      t.update(roomRef, { [`seats.${seatIndex}.isMuted`]: isMuted });
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Mute toggle failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /rooms/:roomId/hosts — OWNER promotes a participant to host.
+router.post('/rooms/:roomId/hosts', async (req, res) => {
+  const { roomId } = req.params;
+  const targetId = String(req.body?.userId ?? '') || null;
+  if (!targetId) return res.status(400).json({ error: 'userId required' });
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      if (resolveRole(room, callerId) !== 'OWNER') {
+        return { status: 403, body: { error: 'Only the owner can add hosts' } };
+      }
+      if (String(targetId) === String(room.ownerId)) {
+        return { status: 400, body: { error: 'Owner is not a host' } };
+      }
+      t.update(roomRef, {
+        hostIds: FieldValue.arrayUnion(targetId),
+        allTimeHostIds: FieldValue.arrayUnion(targetId),
+      });
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Add host failed', { roomId, error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// DELETE /rooms/:roomId/hosts/:userId — OWNER demotes a host.
+router.delete('/rooms/:roomId/hosts/:userId', async (req, res) => {
+  const { roomId } = req.params;
+  const targetId = String(req.params.userId);
+  const callerId = String(req.auth.uniqueId);
+  try {
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
+      if (resolveRole(room, callerId) !== 'OWNER') {
+        return { status: 403, body: { error: 'Only the owner can remove hosts' } };
+      }
+      t.update(roomRef, { hostIds: FieldValue.arrayRemove(targetId) });
+      return { status: 200, body: { success: true } };
+    });
+    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    log.error('room-mutations', 'Remove host failed', { roomId, error: err.message });
     return res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/express-api/src/routes/room-mutations.js
+++ b/express-api/src/routes/room-mutations.js
@@ -100,324 +100,251 @@ async function inRoomTransaction(req, roomId, mutate) {
   });
 }
 
-// POST /rooms/:roomId/seats/:seatIndex/claim — caller seats THEMSELVES.
-router.post('/rooms/:roomId/seats/:seatIndex/claim', async (req, res) => {
+/**
+ * Standard wrapper for mutation endpoints: routes the request + cohort gate
+ * through `inRoomTransaction`, broadcasts the RTDB nudge on a real mutation
+ * (return `{ noop: true }` from the inner `mutate` to opt out — used by
+ * idempotent set-once / already-in-target-state branches), and converts an
+ * unexpected throw into a logged 500. Reserved for endpoints whose shape is
+ * "validate → load+gate→update → respond"; specialised flows (`owner-away`
+ * pre-reads RTDB presence; `close` does a post-txn batch user-doc clear;
+ * `disconnect-user` does both) hand-roll their try/catch.
+ */
+async function executeRoomMutation(req, res, errorContext, mutate) {
   const { roomId } = req.params;
-  const seatIndex = parseSeatIndex(req.params.seatIndex);
-  if (seatIndex === null) return res.status(400).json({ error: 'Invalid seat index' });
   const callerId = String(req.auth.uniqueId);
   try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
-      const seat = (room.seats || {})[String(seatIndex)] || {};
-      if (seat.userId || seat.state === 'OCCUPIED') {
-        return { status: 409, body: { error: 'Seat is already taken', code: 'SEAT_TAKEN' } };
-      }
-      if (!canTakeSeatDirectly(room, callerId, seatIndex)) {
-        return { status: 403, body: { error: 'Not allowed to take this seat' } };
-      }
-      if (userSeatIndex(room, callerId) !== -1) {
-        return { status: 409, body: { error: 'Already seated', code: 'ALREADY_SEATED' } };
-      }
-      t.update(roomRef, {
-        [`seats.${seatIndex}.userId`]: callerId,
-        [`seats.${seatIndex}.state`]: 'OCCUPIED',
-        [`seats.${seatIndex}.isMuted`]: false,
-        participantIds: FieldValue.arrayUnion(callerId),
-        allTimeSeatUserIds: FieldValue.arrayUnion(callerId),
-      });
-      return { status: 200, body: { success: true } };
-    });
-    if (result.status === 200) await broadcastRoomUpdated(roomId);
+    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) =>
+      mutate({ room, t, roomRef, callerId, req }),
+    );
+    if (result.status === 200 && !result.noop) {
+      await broadcastRoomUpdated(roomId);
+    }
     return res.status(result.status).json(result.body);
   } catch (err) {
-    log.error('room-mutations', 'Seat claim failed', { roomId, seatIndex, error: err.message });
+    log.error('room-mutations', `${errorContext} failed`, { roomId, error: err.message });
     return res.status(500).json({ error: 'Internal server error' });
   }
+}
+
+// POST /rooms/:roomId/seats/:seatIndex/claim — caller seats THEMSELVES.
+router.post('/rooms/:roomId/seats/:seatIndex/claim', async (req, res) => {
+  const seatIndex = parseSeatIndex(req.params.seatIndex);
+  if (seatIndex === null) return res.status(400).json({ error: 'Invalid seat index' });
+  return executeRoomMutation(req, res, 'Seat claim', ({ room, t, roomRef, callerId }) => {
+    if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+    const seat = (room.seats || {})[String(seatIndex)] || {};
+    if (seat.userId || seat.state === 'OCCUPIED') {
+      return { status: 409, body: { error: 'Seat is already taken', code: 'SEAT_TAKEN' } };
+    }
+    if (!canTakeSeatDirectly(room, callerId, seatIndex)) {
+      return { status: 403, body: { error: 'Not allowed to take this seat' } };
+    }
+    if (userSeatIndex(room, callerId) !== -1) {
+      return { status: 409, body: { error: 'Already seated', code: 'ALREADY_SEATED' } };
+    }
+    t.update(roomRef, {
+      [`seats.${seatIndex}.userId`]: callerId,
+      [`seats.${seatIndex}.state`]: 'OCCUPIED',
+      [`seats.${seatIndex}.isMuted`]: false,
+      participantIds: FieldValue.arrayUnion(callerId),
+      allTimeSeatUserIds: FieldValue.arrayUnion(callerId),
+    });
+    return { status: 200, body: { success: true } };
+  });
 });
 
 // POST /rooms/:roomId/seats/:seatIndex/accept-invite — invited caller seats SELF.
 router.post('/rooms/:roomId/seats/:seatIndex/accept-invite', async (req, res) => {
-  const { roomId } = req.params;
   const seatIndex = parseSeatIndex(req.params.seatIndex);
   if (seatIndex === null) return res.status(400).json({ error: 'Invalid seat index' });
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
-      const invited = Object.prototype.hasOwnProperty.call(room.pendingInvites || {}, callerId);
-      if (!invited) return { status: 403, body: { error: 'No pending invite' } };
-      if (seatIndex === OWNER_SEAT_INDEX)
-        return { status: 403, body: { error: 'Seat 0 is owner-only' } };
-      const seat = (room.seats || {})[String(seatIndex)] || {};
-      if (seat.userId || seat.state === 'OCCUPIED') {
-        return { status: 409, body: { error: 'Seat is already taken', code: 'SEAT_TAKEN' } };
-      }
-      if (userSeatIndex(room, callerId) !== -1) {
-        return { status: 409, body: { error: 'Already seated', code: 'ALREADY_SEATED' } };
-      }
-      t.update(roomRef, {
-        [`pendingInvites.${callerId}`]: FieldValue.delete(),
-        [`seats.${seatIndex}.userId`]: callerId,
-        [`seats.${seatIndex}.state`]: 'OCCUPIED',
-        [`seats.${seatIndex}.isMuted`]: false,
-        participantIds: FieldValue.arrayUnion(callerId),
-        allTimeSeatUserIds: FieldValue.arrayUnion(callerId),
-      });
-      return { status: 200, body: { success: true } };
+  return executeRoomMutation(req, res, 'Accept invite', ({ room, t, roomRef, callerId }) => {
+    if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+    const invited = Object.prototype.hasOwnProperty.call(room.pendingInvites || {}, callerId);
+    if (!invited) return { status: 403, body: { error: 'No pending invite' } };
+    if (seatIndex === OWNER_SEAT_INDEX)
+      return { status: 403, body: { error: 'Seat 0 is owner-only' } };
+    const seat = (room.seats || {})[String(seatIndex)] || {};
+    if (seat.userId || seat.state === 'OCCUPIED') {
+      return { status: 409, body: { error: 'Seat is already taken', code: 'SEAT_TAKEN' } };
+    }
+    if (userSeatIndex(room, callerId) !== -1) {
+      return { status: 409, body: { error: 'Already seated', code: 'ALREADY_SEATED' } };
+    }
+    t.update(roomRef, {
+      [`pendingInvites.${callerId}`]: FieldValue.delete(),
+      [`seats.${seatIndex}.userId`]: callerId,
+      [`seats.${seatIndex}.state`]: 'OCCUPIED',
+      [`seats.${seatIndex}.isMuted`]: false,
+      participantIds: FieldValue.arrayUnion(callerId),
+      allTimeSeatUserIds: FieldValue.arrayUnion(callerId),
     });
-    if (result.status === 200) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Accept invite failed', { roomId, seatIndex, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
+    return { status: 200, body: { success: true } };
+  });
 });
 
 // POST /rooms/:roomId/seats/:seatIndex/leave — caller leaves their OWN seat.
 router.post('/rooms/:roomId/seats/:seatIndex/leave', async (req, res) => {
-  const { roomId } = req.params;
   const seatIndex = parseSeatIndex(req.params.seatIndex);
   if (seatIndex === null) return res.status(400).json({ error: 'Invalid seat index' });
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      const seat = (room.seats || {})[String(seatIndex)] || {};
-      if (String(seat.userId) !== callerId) {
-        return { status: 403, body: { error: 'Not your seat' } };
-      }
-      t.update(roomRef, {
-        [`seats.${seatIndex}.userId`]: null,
-        [`seats.${seatIndex}.state`]: 'EMPTY',
-        [`seats.${seatIndex}.isMuted`]: false,
-      });
-      return { status: 200, body: { success: true } };
+  return executeRoomMutation(req, res, 'Leave seat', ({ room, t, roomRef, callerId }) => {
+    const seat = (room.seats || {})[String(seatIndex)] || {};
+    if (String(seat.userId) !== callerId) {
+      return { status: 403, body: { error: 'Not your seat' } };
+    }
+    t.update(roomRef, {
+      [`seats.${seatIndex}.userId`]: null,
+      [`seats.${seatIndex}.state`]: 'EMPTY',
+      [`seats.${seatIndex}.isMuted`]: false,
     });
-    if (result.status === 200) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Leave seat failed', { roomId, seatIndex, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
+    return { status: 200, body: { success: true } };
+  });
 });
 
 // POST /rooms/:roomId/kick — owner/host bans + removes a target user.
 router.post('/rooms/:roomId/kick', async (req, res) => {
-  const { roomId } = req.params;
   const targetId = String(req.body?.userId ?? '') || null;
   const reason = typeof req.body?.reason === 'string' ? req.body.reason : '';
   const kickerName = typeof req.body?.kickerName === 'string' ? req.body.kickerName : '';
   if (!targetId) return res.status(400).json({ error: 'userId required' });
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      if (!canKickUser(room, callerId, targetId)) {
-        return { status: 403, body: { error: 'Not allowed to kick this user' } };
-      }
-      const update = {
-        bannedUserIds: FieldValue.arrayUnion(targetId),
-        participantIds: FieldValue.arrayRemove(targetId),
-        [`kickInfo.${targetId}`]: { kickerName, reason },
-      };
-      const seatIdx = userSeatIndex(room, targetId);
-      if (seatIdx !== -1) {
-        update[`seats.${seatIdx}.userId`] = null;
-        update[`seats.${seatIdx}.state`] = 'EMPTY';
-        update[`seats.${seatIdx}.isMuted`] = false;
-      }
-      t.update(roomRef, update);
-      return { status: 200, body: { success: true } };
-    });
-    if (result.status === 200) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Kick failed', { roomId, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
+  return executeRoomMutation(req, res, 'Kick', ({ room, t, roomRef, callerId }) => {
+    if (!canKickUser(room, callerId, targetId)) {
+      return { status: 403, body: { error: 'Not allowed to kick this user' } };
+    }
+    const update = {
+      bannedUserIds: FieldValue.arrayUnion(targetId),
+      participantIds: FieldValue.arrayRemove(targetId),
+      [`kickInfo.${targetId}`]: { kickerName, reason },
+    };
+    const seatIdx = userSeatIndex(room, targetId);
+    if (seatIdx !== -1) {
+      update[`seats.${seatIdx}.userId`] = null;
+      update[`seats.${seatIdx}.state`] = 'EMPTY';
+      update[`seats.${seatIdx}.isMuted`] = false;
+    }
+    t.update(roomRef, update);
+    return { status: 200, body: { success: true } };
+  });
 });
 
 // POST /rooms/:roomId/seats/:seatIndex/remove — owner/host vacates a seat (no ban).
 router.post('/rooms/:roomId/seats/:seatIndex/remove', async (req, res) => {
-  const { roomId } = req.params;
   const seatIndex = parseSeatIndex(req.params.seatIndex);
   if (seatIndex === null) return res.status(400).json({ error: 'Invalid seat index' });
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      if (!canRemoveFromSeat(room, callerId, seatIndex)) {
-        return { status: 403, body: { error: 'Not allowed to remove this occupant' } };
-      }
-      t.update(roomRef, {
-        [`seats.${seatIndex}.userId`]: null,
-        [`seats.${seatIndex}.state`]: 'EMPTY',
-        [`seats.${seatIndex}.isMuted`]: false,
-      });
-      return { status: 200, body: { success: true } };
+  return executeRoomMutation(req, res, 'Remove from seat', ({ room, t, roomRef, callerId }) => {
+    if (!canRemoveFromSeat(room, callerId, seatIndex)) {
+      return { status: 403, body: { error: 'Not allowed to remove this occupant' } };
+    }
+    t.update(roomRef, {
+      [`seats.${seatIndex}.userId`]: null,
+      [`seats.${seatIndex}.state`]: 'EMPTY',
+      [`seats.${seatIndex}.isMuted`]: false,
     });
-    if (result.status === 200) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Remove from seat failed', { roomId, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
+    return { status: 200, body: { success: true } };
+  });
 });
 
 // PATCH /rooms/:roomId/seats/:seatIndex/mute — force-mute (owner/host) or self-unmute.
 router.patch('/rooms/:roomId/seats/:seatIndex/mute', async (req, res) => {
-  const { roomId } = req.params;
   const seatIndex = parseSeatIndex(req.params.seatIndex);
   if (seatIndex === null) return res.status(400).json({ error: 'Invalid seat index' });
   if (typeof req.body?.isMuted !== 'boolean') {
     return res.status(400).json({ error: 'isMuted (boolean) required' });
   }
   const { isMuted } = req.body;
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      const seat = (room.seats || {})[String(seatIndex)] || {};
-      if (!seat.userId) return { status: 409, body: { error: 'Seat is empty' } };
-      if (isMuted) {
-        // Force-mute: moderator gate (owner/host, not owner/other-host, not already muted).
-        if (!canForceMute(room, callerId, seatIndex)) {
-          return { status: 403, body: { error: 'Not allowed to mute this seat' } };
-        }
-      } else if (String(seat.userId) !== callerId) {
-        // Unmute: only the seat's own occupant may unmute themselves.
-        return { status: 403, body: { error: 'Only the occupant can unmute' } };
+  return executeRoomMutation(req, res, 'Mute toggle', ({ room, t, roomRef, callerId }) => {
+    const seat = (room.seats || {})[String(seatIndex)] || {};
+    if (!seat.userId) return { status: 409, body: { error: 'Seat is empty' } };
+    if (isMuted) {
+      // Force-mute: moderator gate (owner/host, not owner/other-host, not already muted).
+      if (!canForceMute(room, callerId, seatIndex)) {
+        return { status: 403, body: { error: 'Not allowed to mute this seat' } };
       }
-      t.update(roomRef, { [`seats.${seatIndex}.isMuted`]: isMuted });
-      return { status: 200, body: { success: true } };
-    });
-    if (result.status === 200) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Mute toggle failed', { roomId, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
+    } else if (String(seat.userId) !== callerId) {
+      // Unmute: only the seat's own occupant may unmute themselves.
+      return { status: 403, body: { error: 'Only the occupant can unmute' } };
+    }
+    t.update(roomRef, { [`seats.${seatIndex}.isMuted`]: isMuted });
+    return { status: 200, body: { success: true } };
+  });
 });
 
 // POST /rooms/:roomId/hosts — OWNER promotes a participant to host.
 router.post('/rooms/:roomId/hosts', async (req, res) => {
-  const { roomId } = req.params;
   const targetId = String(req.body?.userId ?? '') || null;
   if (!targetId) return res.status(400).json({ error: 'userId required' });
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      if (resolveRole(room, callerId) !== 'OWNER') {
-        return { status: 403, body: { error: 'Only the owner can add hosts' } };
-      }
-      if (String(targetId) === String(room.ownerId)) {
-        return { status: 400, body: { error: 'Owner is not a host' } };
-      }
-      t.update(roomRef, {
-        hostIds: FieldValue.arrayUnion(targetId),
-        allTimeHostIds: FieldValue.arrayUnion(targetId),
-      });
-      return { status: 200, body: { success: true } };
+  return executeRoomMutation(req, res, 'Add host', ({ room, t, roomRef, callerId }) => {
+    if (resolveRole(room, callerId) !== 'OWNER') {
+      return { status: 403, body: { error: 'Only the owner can add hosts' } };
+    }
+    if (String(targetId) === String(room.ownerId)) {
+      return { status: 400, body: { error: 'Owner is not a host' } };
+    }
+    t.update(roomRef, {
+      hostIds: FieldValue.arrayUnion(targetId),
+      allTimeHostIds: FieldValue.arrayUnion(targetId),
     });
-    if (result.status === 200) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Add host failed', { roomId, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
+    return { status: 200, body: { success: true } };
+  });
 });
 
 // DELETE /rooms/:roomId/hosts/:userId — OWNER demotes a host.
 router.delete('/rooms/:roomId/hosts/:userId', async (req, res) => {
-  const { roomId } = req.params;
   const targetId = String(req.params.userId);
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      if (resolveRole(room, callerId) !== 'OWNER') {
-        return { status: 403, body: { error: 'Only the owner can remove hosts' } };
-      }
-      t.update(roomRef, { hostIds: FieldValue.arrayRemove(targetId) });
-      return { status: 200, body: { success: true } };
-    });
-    if (result.status === 200) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Remove host failed', { roomId, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
+  return executeRoomMutation(req, res, 'Remove host', ({ room, t, roomRef, callerId }) => {
+    if (resolveRole(room, callerId) !== 'OWNER') {
+      return { status: 403, body: { error: 'Only the owner can remove hosts' } };
+    }
+    t.update(roomRef, { hostIds: FieldValue.arrayRemove(targetId) });
+    return { status: 200, body: { success: true } };
+  });
 });
 
 // PATCH /rooms/:roomId/name — OWNER renames the room.
 router.patch('/rooms/:roomId/name', async (req, res) => {
-  const { roomId } = req.params;
   const name = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
   if (!name) return res.status(400).json({ error: 'name required' });
   if (name.length > MAX_ROOM_NAME_LENGTH) {
     return res.status(400).json({ error: 'name too long' });
   }
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      if (resolveRole(room, callerId) !== 'OWNER') {
-        return { status: 403, body: { error: 'Only the owner can rename the room' } };
-      }
-      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
-      t.update(roomRef, { name });
-      return { status: 200, body: { success: true } };
-    });
-    if (result.status === 200) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Rename failed', { roomId, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
+  return executeRoomMutation(req, res, 'Rename', ({ room, t, roomRef, callerId }) => {
+    if (resolveRole(room, callerId) !== 'OWNER') {
+      return { status: 403, body: { error: 'Only the owner can rename the room' } };
+    }
+    if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+    t.update(roomRef, { name });
+    return { status: 200, body: { success: true } };
+  });
 });
 
 // PATCH /rooms/:roomId/require-approval — OWNER toggles the seat-approval policy.
 router.patch('/rooms/:roomId/require-approval', async (req, res) => {
-  const { roomId } = req.params;
   if (typeof req.body?.requireApproval !== 'boolean') {
     return res.status(400).json({ error: 'requireApproval (boolean) required' });
   }
   const { requireApproval } = req.body;
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      if (resolveRole(room, callerId) !== 'OWNER') {
-        return { status: 403, body: { error: 'Only the owner can change approval settings' } };
-      }
-      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
-      t.update(roomRef, { requireApproval });
-      return { status: 200, body: { success: true } };
-    });
-    if (result.status === 200) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Set requireApproval failed', { roomId, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
+  return executeRoomMutation(req, res, 'Set requireApproval', ({ room, t, roomRef, callerId }) => {
+    if (resolveRole(room, callerId) !== 'OWNER') {
+      return { status: 403, body: { error: 'Only the owner can change approval settings' } };
+    }
+    if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+    t.update(roomRef, { requireApproval });
+    return { status: 200, body: { success: true } };
+  });
 });
 
-// POST /rooms/:roomId/owner-returned — OWNER returns from OWNER_AWAY.
-router.post('/rooms/:roomId/owner-returned', async (req, res) => {
-  const { roomId } = req.params;
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      if (resolveRole(room, callerId) !== 'OWNER') {
-        return { status: 403, body: { error: 'Only the owner can return to the room' } };
-      }
-      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
-      // Idempotent: already active — no write, no spurious broadcast.
-      if (room.state === 'ACTIVE') return { status: 200, body: { success: true } };
-      t.update(roomRef, { state: 'ACTIVE', ownerLeftAt: null });
-      return { status: 200, body: { success: true }, mutated: true };
-    });
-    if (result.status === 200 && result.mutated) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Owner returned failed', { roomId, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
+// POST /rooms/:roomId/owner-returned — OWNER returns from OWNER_AWAY (idempotent on ACTIVE).
+router.post('/rooms/:roomId/owner-returned', async (req, res) =>
+  executeRoomMutation(req, res, 'Owner returned', ({ room, t, roomRef, callerId }) => {
+    if (resolveRole(room, callerId) !== 'OWNER') {
+      return { status: 403, body: { error: 'Only the owner can return to the room' } };
+    }
+    if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+    if (room.state === 'ACTIVE') return { status: 200, body: { success: true }, noop: true };
+    t.update(roomRef, { state: 'ACTIVE', ownerLeftAt: null });
+    return { status: 200, body: { success: true } };
+  }),
+);
 
 // POST /rooms/:roomId/owner-away — OWNER (or a participant when the owner is
 // verifiably absent) transitions the room to OWNER_AWAY. Presence is read
@@ -530,7 +457,6 @@ router.post('/rooms/:roomId/close', async (req, res) => {
 // ActiveRoomManager.moveSeat: neither seat may be the owner seat, and a host
 // may not move the owner or another host.
 router.post('/rooms/:roomId/seats/:seatIndex/move', async (req, res) => {
-  const { roomId } = req.params;
   const fromIndex = parseSeatIndex(req.params.seatIndex);
   if (fromIndex === null) return res.status(400).json({ error: 'Invalid seat index' });
   const toIndex = parseSeatIndex(req.body?.toIndex);
@@ -538,103 +464,68 @@ router.post('/rooms/:roomId/seats/:seatIndex/move', async (req, res) => {
   if (fromIndex === toIndex) {
     return res.status(400).json({ error: 'Source and target seats are the same' });
   }
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
-      if (!canMoveSeat(room, callerId, fromIndex, toIndex)) {
-        return { status: 403, body: { error: 'Not allowed to move this seat' } };
-      }
-      const seats = room.seats || {};
-      const fromSeat = seats[String(fromIndex)] || {};
-      const toSeat = seats[String(toIndex)] || {};
-      t.update(roomRef, {
-        [`seats.${fromIndex}.userId`]: toSeat.userId ?? null,
-        [`seats.${fromIndex}.state`]: toSeat.state ?? 'EMPTY',
-        [`seats.${fromIndex}.isMuted`]: toSeat.isMuted ?? false,
-        [`seats.${toIndex}.userId`]: fromSeat.userId ?? null,
-        [`seats.${toIndex}.state`]: fromSeat.state ?? 'EMPTY',
-        [`seats.${toIndex}.isMuted`]: fromSeat.isMuted ?? false,
-      });
-      return { status: 200, body: { success: true } };
+  return executeRoomMutation(req, res, 'Move seat', ({ room, t, roomRef, callerId }) => {
+    if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+    if (!canMoveSeat(room, callerId, fromIndex, toIndex)) {
+      return { status: 403, body: { error: 'Not allowed to move this seat' } };
+    }
+    const seats = room.seats || {};
+    const fromSeat = seats[String(fromIndex)] || {};
+    const toSeat = seats[String(toIndex)] || {};
+    t.update(roomRef, {
+      [`seats.${fromIndex}.userId`]: toSeat.userId ?? null,
+      [`seats.${fromIndex}.state`]: toSeat.state ?? 'EMPTY',
+      [`seats.${fromIndex}.isMuted`]: toSeat.isMuted ?? false,
+      [`seats.${toIndex}.userId`]: fromSeat.userId ?? null,
+      [`seats.${toIndex}.state`]: fromSeat.state ?? 'EMPTY',
+      [`seats.${toIndex}.isMuted`]: fromSeat.isMuted ?? false,
     });
-    if (result.status === 200) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Move seat failed', { roomId, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
+    return { status: 200, body: { success: true } };
+  });
 });
 
 // POST /rooms/:roomId/join — caller joins the room's participant list. The ban
 // list is enforced server-side here. currentRoomId is the caller's own user-doc
 // field and remains a client write.
-router.post('/rooms/:roomId/join', async (req, res) => {
-  const { roomId } = req.params;
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
-      if ((room.bannedUserIds || []).map(String).includes(callerId)) {
-        return { status: 403, body: { error: 'You are banned from this room', code: 'BANNED' } };
-      }
-      t.update(roomRef, { participantIds: FieldValue.arrayUnion(callerId) });
-      return { status: 200, body: { success: true } };
-    });
-    if (result.status === 200) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Join room failed', { roomId, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
+router.post('/rooms/:roomId/join', async (req, res) =>
+  executeRoomMutation(req, res, 'Join room', ({ room, t, roomRef, callerId }) => {
+    if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
+    if ((room.bannedUserIds || []).map(String).includes(callerId)) {
+      return { status: 403, body: { error: 'You are banned from this room', code: 'BANNED' } };
+    }
+    t.update(roomRef, { participantIds: FieldValue.arrayUnion(callerId) });
+    return { status: 200, body: { success: true } };
+  }),
+);
 
 // POST /rooms/:roomId/decline-invite — caller declines THEIR OWN pending invite.
 // Self-scoped by auth: a caller can only ever remove their own pendingInvites
 // entry. No-op (still 200) when there is no pending invite.
-router.post('/rooms/:roomId/decline-invite', async (req, res) => {
-  const { roomId } = req.params;
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      const hasInvite = Object.prototype.hasOwnProperty.call(room.pendingInvites || {}, callerId);
-      if (!hasInvite) return { status: 200, body: { success: true } };
-      t.update(roomRef, { [`pendingInvites.${callerId}`]: FieldValue.delete() });
-      return { status: 200, body: { success: true }, mutated: true };
-    });
-    if (result.status === 200 && result.mutated) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Decline invite failed', { roomId, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
+router.post('/rooms/:roomId/decline-invite', async (req, res) =>
+  executeRoomMutation(req, res, 'Decline invite', ({ room, t, roomRef, callerId }) => {
+    const hasInvite = Object.prototype.hasOwnProperty.call(room.pendingInvites || {}, callerId);
+    if (!hasInvite) return { status: 200, body: { success: true }, noop: true };
+    t.update(roomRef, { [`pendingInvites.${callerId}`]: FieldValue.delete() });
+    return { status: 200, body: { success: true } };
+  }),
+);
 
 // POST /rooms/:roomId/leave — caller removes THEMSELVES from the room
 // (participant list + their own seat, if seated). currentRoomId stays a client
 // self-write. Idempotent: a no-op arrayRemove if the caller isn't a member.
-router.post('/rooms/:roomId/leave', async (req, res) => {
-  const { roomId } = req.params;
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      const update = { participantIds: FieldValue.arrayRemove(callerId) };
-      const seatIdx = userSeatIndex(room, callerId);
-      if (seatIdx !== -1) {
-        update[`seats.${seatIdx}.userId`] = null;
-        update[`seats.${seatIdx}.state`] = 'EMPTY';
-        update[`seats.${seatIdx}.isMuted`] = false;
-      }
-      t.update(roomRef, update);
-      return { status: 200, body: { success: true } };
-    });
-    if (result.status === 200) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Leave room failed', { roomId, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
+router.post('/rooms/:roomId/leave', async (req, res) =>
+  executeRoomMutation(req, res, 'Leave room', ({ room, t, roomRef, callerId }) => {
+    const update = { participantIds: FieldValue.arrayRemove(callerId) };
+    const seatIdx = userSeatIndex(room, callerId);
+    if (seatIdx !== -1) {
+      update[`seats.${seatIdx}.userId`] = null;
+      update[`seats.${seatIdx}.state`] = 'EMPTY';
+      update[`seats.${seatIdx}.isMuted`] = false;
+    }
+    t.update(roomRef, update);
+    return { status: 200, body: { success: true } };
+  }),
+);
 
 // POST /rooms/:roomId/disconnect-user — remove a DISCONNECTED non-owner
 // (presence-timeout eviction triggered by a participant's presence monitor).
@@ -698,25 +589,13 @@ router.post('/rooms/:roomId/disconnect-user', async (req, res) => {
 // POST /rooms/:roomId/first-join — caller records THEIR OWN first-join time.
 // Self-scoped + set-once: writes firstJoinTimestamps[caller] only if absent, so
 // re-entry never overwrites the original timestamp.
-router.post('/rooms/:roomId/first-join', async (req, res) => {
-  const { roomId } = req.params;
-  const callerId = String(req.auth.uniqueId);
-  try {
-    const result = await inRoomTransaction(req, roomId, (room, t, roomRef) => {
-      const already = Object.prototype.hasOwnProperty.call(
-        room.firstJoinTimestamps || {},
-        callerId,
-      );
-      if (already) return { status: 200, body: { success: true } };
-      t.update(roomRef, { [`firstJoinTimestamps.${callerId}`]: Date.now() });
-      return { status: 200, body: { success: true }, mutated: true };
-    });
-    if (result.status === 200 && result.mutated) await broadcastRoomUpdated(roomId);
-    return res.status(result.status).json(result.body);
-  } catch (err) {
-    log.error('room-mutations', 'Record first join failed', { roomId, error: err.message });
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
+router.post('/rooms/:roomId/first-join', async (req, res) =>
+  executeRoomMutation(req, res, 'Record first join', ({ room, t, roomRef, callerId }) => {
+    const already = Object.prototype.hasOwnProperty.call(room.firstJoinTimestamps || {}, callerId);
+    if (already) return { status: 200, body: { success: true }, noop: true };
+    t.update(roomRef, { [`firstJoinTimestamps.${callerId}`]: Date.now() });
+    return { status: 200, body: { success: true } };
+  }),
+);
 
 module.exports = router;

--- a/express-api/src/utils/room-auth.js
+++ b/express-api/src/utils/room-auth.js
@@ -59,10 +59,54 @@ function userSeatIndex(room, userId) {
   return -1;
 }
 
+/**
+ * Mirror of ChatRoom.canKickUser: may `actorId` kick/ban `targetId`?
+ * Owners are never kickable; owner may kick anyone; host may kick non-hosts;
+ * attendees may kick no one.
+ */
+function canKickUser(room, actorId, targetId) {
+  if (String(targetId) === String(room.ownerId)) return false;
+  const role = resolveRole(room, actorId);
+  if (role === 'OWNER') return true;
+  if (role === 'HOST') return !asIds(room.hostIds).includes(String(targetId));
+  return false;
+}
+
+/**
+ * Mirror of ChatRoom.canRemoveFromSeat: may `actorId` force-vacate the
+ * occupant of `seatIndex` (without banning)? Seat 0 can never be force-
+ * vacated; otherwise the actor must be able to kick the occupant.
+ */
+function canRemoveFromSeat(room, actorId, seatIndex) {
+  if (Number(seatIndex) === OWNER_SEAT_INDEX) return false;
+  const occupantId = ((room.seats || {})[String(seatIndex)] || {}).userId;
+  if (!occupantId) return false;
+  return canKickUser(room, actorId, occupantId);
+}
+
+/**
+ * Mirror of ChatRoom.canForceMute: may `actorId` force-MUTE the occupant of
+ * `seatIndex`? Never the owner; never an already-muted seat (only the
+ * occupant may unmute themselves); a host may not mute another host.
+ */
+function canForceMute(room, actorId, seatIndex) {
+  const seat = (room.seats || {})[String(seatIndex)];
+  if (!seat || !seat.userId) return false;
+  if (String(seat.userId) === String(room.ownerId)) return false;
+  if (seat.isMuted) return false;
+  const role = resolveRole(room, actorId);
+  if (role === 'OWNER') return true;
+  if (role === 'HOST') return !asIds(room.hostIds).includes(String(seat.userId));
+  return false;
+}
+
 module.exports = {
   OWNER_SEAT_INDEX,
   MAX_SEATS,
   resolveRole,
   canTakeSeatDirectly,
   userSeatIndex,
+  canKickUser,
+  canRemoveFromSeat,
+  canForceMute,
 };

--- a/express-api/src/utils/room-auth.js
+++ b/express-api/src/utils/room-auth.js
@@ -100,13 +100,97 @@ function canForceMute(room, actorId, seatIndex) {
   return false;
 }
 
+// mirrors Constants.OWNER_LEAVE_TIMEOUT_MS (5 minutes) — the owner-away grace
+// window after which any remaining participant may close the room.
+const OWNER_LEAVE_TIMEOUT_MS = 300000;
+
+/**
+ * True if any seat is OCCUPIED by a non-owner, optionally excluding `exceptId`
+ * (e.g. the caller who is in the act of leaving). Mirrors the client's
+ * `hasSeatedNonOwners` + staleRooms.js predicate; used to decide when an
+ * OWNER_AWAY room is empty enough to close.
+ */
+function hasNonOwnerSeated(room, exceptId = null) {
+  const ownerId = String(room.ownerId);
+  const except = exceptId === null ? null : String(exceptId);
+  return Object.values(room.seats || {}).some(
+    (seat) =>
+      seat &&
+      seat.userId &&
+      seat.state === 'OCCUPIED' &&
+      String(seat.userId) !== ownerId &&
+      String(seat.userId) !== except,
+  );
+}
+
+/**
+ * Mirror of ActiveRoomManager.moveSeat: may `actorId` move the occupant of
+ * `fromIndex` to `toIndex`? Owner/host only (attendees never); neither seat may
+ * be the owner seat; the source must be occupied; a host may not move the owner
+ * or another host. The actual swap (and per-user uniqueness, preserved by
+ * construction) is applied transactionally by the caller.
+ */
+function canMoveSeat(room, actorId, fromIndex, toIndex) {
+  if (Number(fromIndex) === OWNER_SEAT_INDEX || Number(toIndex) === OWNER_SEAT_INDEX) return false;
+  const role = resolveRole(room, actorId);
+  if (role === 'ATTENDEE') return false;
+  const occupantId = ((room.seats || {})[String(fromIndex)] || {}).userId;
+  if (!occupantId) return false;
+  if (role === 'HOST') {
+    if (String(occupantId) === String(room.ownerId)) return false;
+    if (asIds(room.hostIds).includes(String(occupantId))) return false;
+  }
+  return true;
+}
+
+/**
+ * May `callerId` close the room (at server time `nowMs`)?
+ *  - the OWNER may always close;
+ *  - otherwise a PARTICIPANT may close only an OWNER_AWAY room, and only once
+ *    either no other non-owner is still seated OR the owner-away grace window
+ *    has elapsed.
+ * Mirrors ActiveRoomManager.leaveRoom (close when no seated non-owners remain)
+ * + handleOwnerAwayCountdown (any participant closes an expired OWNER_AWAY
+ * room). The state/precondition gate is what stops a malicious non-owner from
+ * closing a live room.
+ */
+function canCloseRoom(room, callerId, nowMs) {
+  if (resolveRole(room, callerId) === 'OWNER') return true;
+  if (room.state !== 'OWNER_AWAY') return false;
+  if (!asIds(room.participantIds).includes(String(callerId))) return false;
+  if (!hasNonOwnerSeated(room, callerId)) return true;
+  // `?? NaN` makes a missing/null ownerLeftAt yield NaN, so the comparison is
+  // false (not-yet-expired) without a loose `!= null` check.
+  return nowMs - Number(room.ownerLeftAt ?? NaN) >= OWNER_LEAVE_TIMEOUT_MS;
+}
+
+/**
+ * May `callerId` transition the room to OWNER_AWAY? The OWNER always may
+ * (graceful leave with others present). A non-owner may ONLY as the presence-
+ * monitor safety net: the room must be ACTIVE, the caller a participant, and
+ * the owner verifiably ABSENT (`ownerPresent === false`, read from RTDB
+ * presence by the caller before the transaction). This blocks a forged
+ * owner-away while the owner is actually connected.
+ */
+function canSetOwnerAway(room, callerId, ownerPresent) {
+  if (resolveRole(room, callerId) === 'OWNER') return true;
+  if (room.state !== 'ACTIVE') return false;
+  if (ownerPresent) return false;
+  return asIds(room.participantIds).includes(String(callerId));
+}
+
 module.exports = {
   OWNER_SEAT_INDEX,
   MAX_SEATS,
+  OWNER_LEAVE_TIMEOUT_MS,
   resolveRole,
   canTakeSeatDirectly,
   userSeatIndex,
   canKickUser,
   canRemoveFromSeat,
   canForceMute,
+  hasNonOwnerSeated,
+  canMoveSeat,
+  canCloseRoom,
+  canSetOwnerAway,
 };

--- a/express-api/src/utils/room-auth.js
+++ b/express-api/src/utils/room-auth.js
@@ -191,6 +191,12 @@ function canSetOwnerAway(room, callerId, ownerPresent) {
 function canRemoveDisconnected(room, callerId, targetId, targetPresent) {
   if (String(targetId) === String(room.ownerId)) return false;
   if (targetPresent) return false;
+  // Already-removed guard: a concurrent /leave or another presence-monitor
+  // /disconnect-user may have removed the target between the client deciding
+  // to evict and this request landing. Without this check the gate passes,
+  // the arrayRemove is a no-op, but we still write an unnecessary user-doc
+  // currentRoomId clear and fire a broadcast.
+  if (!asIds(room.participantIds).includes(String(targetId))) return false;
   return asIds(room.participantIds).includes(String(callerId));
 }
 

--- a/express-api/src/utils/room-auth.js
+++ b/express-api/src/utils/room-auth.js
@@ -1,0 +1,68 @@
+/**
+ * Server-side mirror of the client room role/permission gates
+ * (shared/src/commonMain/kotlin/com/shyden/shytalk/core/model/ChatRoom.kt).
+ *
+ * The client checks are UX-only; THESE are the authoritative enforcement,
+ * applied inside the Admin-SDK room-mutation endpoints (which bypass
+ * firestore.rules). uniqueIds are stored as strings in the room doc
+ * (ownerId, participantIds, hostIds, seats.*.userId), so every comparison
+ * is String()-normalised — req.auth.uniqueId arrives as a number.
+ */
+
+const OWNER_SEAT_INDEX = 0;
+const MAX_SEATS = 8;
+
+function asIds(arr) {
+  return (arr || []).map(String);
+}
+
+/** OWNER (room creator) | HOST (in hostIds) | ATTENDEE (everyone else). */
+function resolveRole(room, callerId) {
+  const id = String(callerId);
+  if (String(room.ownerId) === id) return 'OWNER';
+  if (asIds(room.hostIds).includes(id)) return 'HOST';
+  return 'ATTENDEE';
+}
+
+/**
+ * Mirror of ChatRoom.canTakeSeatDirectly: may `actorId` claim `seatIndex`
+ * without going through the seat-request queue?
+ * - seat 0 is owner-only (and the owner may sit ONLY in seat 0)
+ * - hosts may take any non-owner seat unless the room requires approval
+ * - attendees never bypass — they must create a seat request
+ * Occupancy is re-checked by the caller transactionally; this is the
+ * role/seat-policy gate only.
+ */
+function canTakeSeatDirectly(room, actorId, seatIndex) {
+  const idx = Number(seatIndex);
+  const role = resolveRole(room, actorId);
+  if (role === 'OWNER' && idx !== OWNER_SEAT_INDEX) return false;
+  if (idx === OWNER_SEAT_INDEX && role !== 'OWNER') return false;
+  const seat = (room.seats || {})[String(idx)];
+  if (!seat) return false;
+  if (role === 'OWNER') return true;
+  if (role === 'HOST') return !room.requireApproval;
+  return false;
+}
+
+/**
+ * Index of the seat currently occupied by `userId`, or -1 if none.
+ * Per-user seat-uniqueness guard: a user may occupy at most one seat, so
+ * a claim/accept must reject when this returns >= 0.
+ */
+function userSeatIndex(room, userId) {
+  const id = String(userId);
+  const seats = room.seats || {};
+  for (const idx of Object.keys(seats)) {
+    if (seats[idx] && String(seats[idx].userId) === id) return Number(idx);
+  }
+  return -1;
+}
+
+module.exports = {
+  OWNER_SEAT_INDEX,
+  MAX_SEATS,
+  resolveRole,
+  canTakeSeatDirectly,
+  userSeatIndex,
+};

--- a/express-api/src/utils/room-auth.js
+++ b/express-api/src/utils/room-auth.js
@@ -179,6 +179,21 @@ function canSetOwnerAway(room, callerId, ownerPresent) {
   return asIds(room.participantIds).includes(String(callerId));
 }
 
+/**
+ * May `callerId` remove the DISCONNECTED user `targetId` (presence-timeout
+ * eviction by the client presence monitor)? The target must NOT be the owner
+ * (owner disconnect → owner-away, never removal), must be verifiably ABSENT
+ * (`targetPresent === false`, read from RTDB by the caller before the txn), and
+ * the caller must be a participant. Mirrors ActiveRoomManager's presence-monitor
+ * non-owner removal branch; the presence precondition is what stops this being
+ * abused as an "evict any participant" primitive.
+ */
+function canRemoveDisconnected(room, callerId, targetId, targetPresent) {
+  if (String(targetId) === String(room.ownerId)) return false;
+  if (targetPresent) return false;
+  return asIds(room.participantIds).includes(String(callerId));
+}
+
 module.exports = {
   OWNER_SEAT_INDEX,
   MAX_SEATS,
@@ -193,4 +208,5 @@ module.exports = {
   canMoveSeat,
   canCloseRoom,
   canSetOwnerAway,
+  canRemoveDisconnected,
 };

--- a/express-api/tests/routes/room-mutations.test.js
+++ b/express-api/tests/routes/room-mutations.test.js
@@ -4,15 +4,28 @@ const request = require('supertest');
 // ── Firebase Admin mock (db.runTransaction + FieldValue sentinels) ──
 const mockTxnGet = jest.fn();
 const mockTxnUpdate = jest.fn();
-const mockRoomRef = { path: 'rooms/room-1' };
+const mockDocGet = jest.fn(); // non-transactional roomRef.get() — owner-away pre-read
+const mockRoomRef = { path: 'rooms/room-1', get: (...a) => mockDocGet(...a) };
 const mockRtdbSet = jest.fn().mockResolvedValue();
+const mockRtdbGet = jest.fn(); // RTDB owner-presence read (setOwnerAway non-owner path)
+const mockBatchSet = jest.fn();
+const mockBatchCommit = jest.fn().mockResolvedValue();
 
 jest.mock('../../src/utils/firebase', () => ({
   db: {
     doc: jest.fn(() => mockRoomRef),
     runTransaction: jest.fn(async (fn) => fn({ get: mockTxnGet, update: mockTxnUpdate })),
+    batch: jest.fn(() => ({
+      set: (...a) => mockBatchSet(...a),
+      commit: (...a) => mockBatchCommit(...a),
+    })),
   },
-  rtdb: { ref: jest.fn(() => ({ set: (...a) => mockRtdbSet(...a) })) },
+  rtdb: {
+    ref: jest.fn(() => ({
+      set: (...a) => mockRtdbSet(...a),
+      get: (...a) => mockRtdbGet(...a),
+    })),
+  },
   FieldValue: {
     arrayUnion: (...args) => ({ __arrayUnion: args }),
     arrayRemove: (...args) => ({ __arrayRemove: args }),
@@ -74,6 +87,9 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockCohort = 'adult';
   mockRtdbSet.mockResolvedValue();
+  mockBatchCommit.mockResolvedValue();
+  mockRtdbGet.mockResolvedValue({ exists: () => true }); // owner present by default
+  mockDocGet.mockResolvedValue({ exists: false }); // owner-away pre-read; set per test
 });
 
 describe('POST /api/rooms/:roomId/seats/:seatIndex/claim', () => {
@@ -486,5 +502,831 @@ describe('POST /api/rooms/:roomId/hosts (add) + DELETE .../hosts/:userId (remove
       mockRoomRef,
       expect.objectContaining({ hostIds: { __arrayRemove: ['10'] } }),
     );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Chunk C1 — room lifecycle + settings (rename / require-approval /
+// owner-away / owner-returned / close). Settings are owner-only; the two
+// lifecycle ops (close, owner-away) additionally honour the NON-owner
+// safety-net paths the client drives, with state + presence preconditions
+// enforced server-side so a malicious participant can't grief.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('PATCH /api/rooms/:roomId/name', () => {
+  test('400 when name missing — no transaction', async () => {
+    const res = await request(createApp(1)).patch('/api/rooms/room-1/name').send({});
+    expect(res.status).toBe(400);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('400 when name is blank after trim', async () => {
+    const res = await request(createApp(1)).patch('/api/rooms/room-1/name').send({ name: '   ' });
+    expect(res.status).toBe(400);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('400 when name exceeds 50 characters', async () => {
+    const res = await request(createApp(1))
+      .patch('/api/rooms/room-1/name')
+      .send({ name: 'x'.repeat(51) });
+    expect(res.status).toBe(400);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('404 when the room does not exist', async () => {
+    mockTxnGet.mockResolvedValue(snap(null));
+    const res = await request(createApp(1)).patch('/api/rooms/room-1/name').send({ name: 'Hi' });
+    expect(res.status).toBe(404);
+  });
+
+  test('404 (hidden) on cohort mismatch', async () => {
+    mockCohort = 'minor';
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ cohort: 'adult' })));
+    const res = await request(createApp(1)).patch('/api/rooms/room-1/name').send({ name: 'Hi' });
+    expect(res.status).toBe(404);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('403 when a host (non-owner) tries to rename', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(10)).patch('/api/rooms/room-1/name').send({ name: 'Hi' });
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('403 when an attendee tries to rename', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(99)).patch('/api/rooms/room-1/name').send({ name: 'Hi' });
+    expect(res.status).toBe(403);
+  });
+
+  test('409 when the room is CLOSED', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED' })));
+    const res = await request(createApp(1)).patch('/api/rooms/room-1/name').send({ name: 'Hi' });
+    expect(res.status).toBe(409);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('200 owner renames — trims and persists', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(1))
+      .patch('/api/rooms/room-1/name')
+      .send({ name: '  New Name  ' });
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(mockRoomRef, { name: 'New Name' });
+    expect(mockRtdbSet).toHaveBeenCalled(); // broadcast
+  });
+
+  test('500 when the transaction throws', async () => {
+    mockTxnGet.mockRejectedValue(new Error('boom'));
+    const res = await request(createApp(1)).patch('/api/rooms/room-1/name').send({ name: 'Hi' });
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('PATCH /api/rooms/:roomId/require-approval', () => {
+  test('400 when requireApproval is not a boolean — no transaction', async () => {
+    const res = await request(createApp(1))
+      .patch('/api/rooms/room-1/require-approval')
+      .send({ requireApproval: 'yes' });
+    expect(res.status).toBe(400);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('400 when requireApproval is missing', async () => {
+    const res = await request(createApp(1)).patch('/api/rooms/room-1/require-approval').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('404 when the room does not exist', async () => {
+    mockTxnGet.mockResolvedValue(snap(null));
+    const res = await request(createApp(1))
+      .patch('/api/rooms/room-1/require-approval')
+      .send({ requireApproval: true });
+    expect(res.status).toBe(404);
+  });
+
+  test('404 (hidden) on cohort mismatch', async () => {
+    mockCohort = 'minor';
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ cohort: 'adult' })));
+    const res = await request(createApp(1))
+      .patch('/api/rooms/room-1/require-approval')
+      .send({ requireApproval: true });
+    expect(res.status).toBe(404);
+  });
+
+  test('403 when a host (non-owner) toggles approval', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(10))
+      .patch('/api/rooms/room-1/require-approval')
+      .send({ requireApproval: true });
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('409 when the room is CLOSED', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED' })));
+    const res = await request(createApp(1))
+      .patch('/api/rooms/room-1/require-approval')
+      .send({ requireApproval: true });
+    expect(res.status).toBe(409);
+  });
+
+  test('200 owner enables approval', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(1))
+      .patch('/api/rooms/room-1/require-approval')
+      .send({ requireApproval: true });
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(mockRoomRef, { requireApproval: true });
+  });
+
+  test('200 owner disables approval (false is a valid value, not "missing")', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ requireApproval: true })));
+    const res = await request(createApp(1))
+      .patch('/api/rooms/room-1/require-approval')
+      .send({ requireApproval: false });
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(mockRoomRef, { requireApproval: false });
+  });
+
+  test('500 when the transaction throws', async () => {
+    mockTxnGet.mockRejectedValue(new Error('boom'));
+    const res = await request(createApp(1))
+      .patch('/api/rooms/room-1/require-approval')
+      .send({ requireApproval: true });
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /api/rooms/:roomId/owner-returned', () => {
+  test('404 when the room does not exist', async () => {
+    mockTxnGet.mockResolvedValue(snap(null));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/owner-returned').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('404 (hidden) on cohort mismatch', async () => {
+    mockCohort = 'minor';
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ cohort: 'adult' })));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/owner-returned').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('403 when a non-owner tries to mark owner returned', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'OWNER_AWAY' })));
+    const res = await request(createApp(10)).post('/api/rooms/room-1/owner-returned').send({});
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('409 when the room is CLOSED', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED' })));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/owner-returned').send({});
+    expect(res.status).toBe(409);
+  });
+
+  test('200 owner returns — clears away state', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'OWNER_AWAY', ownerLeftAt: 123 })));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/owner-returned').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(mockRoomRef, { state: 'ACTIVE', ownerLeftAt: null });
+    expect(mockRtdbSet).toHaveBeenCalled();
+  });
+
+  test('500 when the transaction throws', async () => {
+    mockTxnGet.mockRejectedValue(new Error('boom'));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/owner-returned').send({});
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /api/rooms/:roomId/owner-away', () => {
+  // owner-away pre-reads the room (non-txn) to resolve owner/role for the
+  // presence decision, then re-validates inside the transaction.
+  function primeOwnerAway(room) {
+    mockDocGet.mockResolvedValue(snap(room));
+    mockTxnGet.mockResolvedValue(snap(room));
+  }
+
+  test('404 when the room does not exist (pre-read)', async () => {
+    mockDocGet.mockResolvedValue(snap(null));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/owner-away').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('404 (hidden) on cohort mismatch (pre-read)', async () => {
+    mockCohort = 'minor';
+    mockDocGet.mockResolvedValue(snap(mkRoom({ cohort: 'adult' })));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/owner-away').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('200 owner marks self away — OWNER_AWAY + numeric ownerLeftAt, no presence read', async () => {
+    primeOwnerAway(mkRoom({ state: 'ACTIVE' }));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/owner-away').send({});
+    expect(res.status).toBe(200);
+    const [, payload] = mockTxnUpdate.mock.calls[0];
+    expect(payload.state).toBe('OWNER_AWAY');
+    expect(typeof payload.ownerLeftAt).toBe('number');
+    expect(mockRtdbGet).not.toHaveBeenCalled(); // owner path skips presence verification
+  });
+
+  test('200 idempotent when already OWNER_AWAY — no write', async () => {
+    primeOwnerAway(mkRoom({ state: 'OWNER_AWAY', ownerLeftAt: 123 }));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/owner-away').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('409 when the room is CLOSED', async () => {
+    primeOwnerAway(mkRoom({ state: 'CLOSED' }));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/owner-away').send({});
+    expect(res.status).toBe(409);
+  });
+
+  test('403 non-owner when the owner IS present', async () => {
+    primeOwnerAway(mkRoom({ state: 'ACTIVE' }));
+    mockRtdbGet.mockResolvedValue({ exists: () => true });
+    const res = await request(createApp(10)).post('/api/rooms/room-1/owner-away').send({});
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+    expect(mockRtdbGet).toHaveBeenCalled();
+  });
+
+  test('200 non-owner participant when the owner is ABSENT and room ACTIVE', async () => {
+    primeOwnerAway(mkRoom({ state: 'ACTIVE' }));
+    mockRtdbGet.mockResolvedValue({ exists: () => false });
+    const res = await request(createApp(10)).post('/api/rooms/room-1/owner-away').send({});
+    expect(res.status).toBe(200);
+    const [, payload] = mockTxnUpdate.mock.calls[0];
+    expect(payload.state).toBe('OWNER_AWAY');
+    expect(typeof payload.ownerLeftAt).toBe('number');
+  });
+
+  test('403 non-owner who is NOT a participant even if owner absent', async () => {
+    primeOwnerAway(mkRoom({ state: 'ACTIVE', participantIds: ['1', '99'] }));
+    mockRtdbGet.mockResolvedValue({ exists: () => false });
+    const res = await request(createApp(10)).post('/api/rooms/room-1/owner-away').send({});
+    expect(res.status).toBe(403);
+  });
+
+  test('403 non-owner falls back to "present" when the presence read throws', async () => {
+    primeOwnerAway(mkRoom({ state: 'ACTIVE' }));
+    mockRtdbGet.mockRejectedValue(new Error('rtdb down'));
+    const res = await request(createApp(10)).post('/api/rooms/room-1/owner-away').send({});
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('500 when the transaction throws', async () => {
+    mockDocGet.mockResolvedValue(snap(mkRoom({ state: 'ACTIVE' })));
+    mockTxnGet.mockRejectedValue(new Error('boom'));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/owner-away').send({});
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /api/rooms/:roomId/close', () => {
+  test('404 when the room does not exist', async () => {
+    mockTxnGet.mockResolvedValue(snap(null));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/close').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('404 (hidden) on cohort mismatch', async () => {
+    mockCohort = 'minor';
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ cohort: 'adult' })));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/close').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('200 owner closes — empties room + clears every participant currentRoomId', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom())); // participants 1, 10, 99
+    const res = await request(createApp(1)).post('/api/rooms/room-1/close').send({});
+    expect(res.status).toBe(200);
+    const [, payload] = mockTxnUpdate.mock.calls[0];
+    expect(payload).toEqual(
+      expect.objectContaining({ state: 'CLOSED', ownerLeftAt: null, participantIds: [] }),
+    );
+    expect(typeof payload.closedAt).toBe('number');
+    expect(payload.seats['0']).toEqual({ userId: null, state: 'EMPTY', isMuted: false });
+    expect(Object.keys(payload.seats)).toHaveLength(8);
+    expect(mockBatchSet).toHaveBeenCalledTimes(3); // one per participant
+    expect(mockBatchCommit).toHaveBeenCalled();
+    expect(mockRtdbSet).toHaveBeenCalled();
+  });
+
+  test('200 idempotent when already CLOSED — no write, no clears', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED' })));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/close').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+    expect(mockBatchSet).not.toHaveBeenCalled();
+  });
+
+  test('403 non-owner cannot close an ACTIVE room', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'ACTIVE' })));
+    const res = await request(createApp(10)).post('/api/rooms/room-1/close').send({});
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('200 non-owner closes OWNER_AWAY room with no other non-owner seated', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          state: 'OWNER_AWAY',
+          ownerLeftAt: Date.now(),
+          seats: {
+            0: { userId: '1', state: 'OCCUPIED', isMuted: false },
+            3: { userId: '10', state: 'OCCUPIED', isMuted: false }, // caller only
+          },
+        }),
+      ),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/close').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalled();
+  });
+
+  test('403 non-owner cannot close OWNER_AWAY room while another non-owner is seated (not expired)', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          state: 'OWNER_AWAY',
+          ownerLeftAt: Date.now(),
+          seats: {
+            0: { userId: '1', state: 'OCCUPIED', isMuted: false },
+            3: { userId: '10', state: 'OCCUPIED', isMuted: false }, // caller
+            4: { userId: '99', state: 'OCCUPIED', isMuted: false }, // other non-owner still seated
+          },
+        }),
+      ),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/close').send({});
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('200 non-owner closes an EXPIRED OWNER_AWAY room even if others seated', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          state: 'OWNER_AWAY',
+          ownerLeftAt: Date.now() - 300000 - 1, // older than OWNER_LEAVE_TIMEOUT_MS (5 min)
+          seats: {
+            0: { userId: '1', state: 'OCCUPIED', isMuted: false },
+            3: { userId: '10', state: 'OCCUPIED', isMuted: false },
+            4: { userId: '99', state: 'OCCUPIED', isMuted: false },
+          },
+        }),
+      ),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/close').send({});
+    expect(res.status).toBe(200);
+  });
+
+  test('403 non-owner who is not a participant cannot close', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ state: 'OWNER_AWAY', ownerLeftAt: Date.now(), participantIds: ['1', '99'] })),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/close').send({});
+    expect(res.status).toBe(403);
+  });
+
+  test('200 close still succeeds when the currentRoomId batch clear fails (best-effort)', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    mockBatchCommit.mockRejectedValue(new Error('batch down'));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/close').send({});
+    expect(res.status).toBe(200); // room already closed in the txn; clearing is best-effort
+  });
+
+  test('500 when the transaction throws', async () => {
+    mockTxnGet.mockRejectedValue(new Error('boom'));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/close').send({});
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Chunk C2 — seat-move, join (ban-check), invite-decline.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/rooms/:roomId/seats/:seatIndex/move', () => {
+  test('400 on out-of-range source seat index', async () => {
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/seats/8/move')
+      .send({ toIndex: 3 });
+    expect(res.status).toBe(400);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('400 when toIndex is missing', async () => {
+    const res = await request(createApp(1)).post('/api/rooms/room-1/seats/3/move').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('400 when toIndex is out of range', async () => {
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 99 });
+    expect(res.status).toBe(400);
+  });
+
+  test('400 when source and target are the same seat', async () => {
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 3 });
+    expect(res.status).toBe(400);
+  });
+
+  test('404 when the room does not exist', async () => {
+    mockTxnGet.mockResolvedValue(snap(null));
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 4 });
+    expect(res.status).toBe(404);
+  });
+
+  test('404 (hidden) on cohort mismatch', async () => {
+    mockCohort = 'minor';
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ cohort: 'adult' })));
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 4 });
+    expect(res.status).toBe(404);
+  });
+
+  test('409 when the room is CLOSED', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED' })));
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 4 });
+    expect(res.status).toBe(409);
+  });
+
+  test('403 when an attendee tries to move a seat', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 3: { userId: '99', state: 'OCCUPIED', isMuted: false } } })),
+    );
+    const res = await request(createApp(99))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 4 });
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('403 when the source seat is the owner seat (0)', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/seats/0/move')
+      .send({ toIndex: 3 });
+    expect(res.status).toBe(403);
+  });
+
+  test('403 when the target seat is the owner seat (0)', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 3: { userId: '10', state: 'OCCUPIED', isMuted: false } } })),
+    );
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 0 });
+    expect(res.status).toBe(403);
+  });
+
+  test('403 when the source seat is empty', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom())); // seat 4 is empty
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/seats/4/move')
+      .send({ toIndex: 3 });
+    expect(res.status).toBe(403);
+  });
+
+  test('403 when a host tries to move another host', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          hostIds: ['10', '20'],
+          seats: {
+            3: { userId: '20', state: 'OCCUPIED', isMuted: false }, // another host
+            4: { userId: null, state: 'EMPTY', isMuted: false },
+          },
+        }),
+      ),
+    );
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 4 });
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('200 owner moves an occupant into an empty seat (preserves mute state)', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          seats: {
+            3: { userId: '99', state: 'OCCUPIED', isMuted: true },
+            4: { userId: null, state: 'EMPTY', isMuted: false },
+          },
+        }),
+      ),
+    );
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 4 });
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({
+        'seats.3.userId': null,
+        'seats.3.state': 'EMPTY',
+        'seats.3.isMuted': false,
+        'seats.4.userId': '99',
+        'seats.4.state': 'OCCUPIED',
+        'seats.4.isMuted': true,
+      }),
+    );
+    expect(mockRtdbSet).toHaveBeenCalled();
+  });
+
+  test('200 swaps two occupied non-owner seats', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          participantIds: ['1', '10', '99', '77'],
+          seats: {
+            3: { userId: '99', state: 'OCCUPIED', isMuted: false },
+            4: { userId: '77', state: 'OCCUPIED', isMuted: true },
+          },
+        }),
+      ),
+    );
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 4 });
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({
+        'seats.3.userId': '77',
+        'seats.3.state': 'OCCUPIED',
+        'seats.3.isMuted': true,
+        'seats.4.userId': '99',
+        'seats.4.state': 'OCCUPIED',
+        'seats.4.isMuted': false,
+      }),
+    );
+  });
+
+  test('500 when the transaction throws', async () => {
+    mockTxnGet.mockRejectedValue(new Error('boom'));
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 4 });
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /api/rooms/:roomId/join', () => {
+  test('404 when the room does not exist', async () => {
+    mockTxnGet.mockResolvedValue(snap(null));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/join').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('404 (hidden) on cohort mismatch', async () => {
+    mockCohort = 'minor';
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ cohort: 'adult' })));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/join').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('409 when the room is CLOSED', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED' })));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/join').send({});
+    expect(res.status).toBe(409);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('403 BANNED when the caller is on the ban list', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ bannedUserIds: ['50'] })));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/join').send({});
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('BANNED');
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('200 joins an ACTIVE room — adds to participants', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/join').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(mockRoomRef, {
+      participantIds: { __arrayUnion: ['50'] },
+    });
+    expect(mockRtdbSet).toHaveBeenCalled();
+  });
+
+  test('200 joins an OWNER_AWAY room (still joinable)', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'OWNER_AWAY', ownerLeftAt: Date.now() })));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/join').send({});
+    expect(res.status).toBe(200);
+  });
+
+  test('500 when the transaction throws', async () => {
+    mockTxnGet.mockRejectedValue(new Error('boom'));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/join').send({});
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /api/rooms/:roomId/decline-invite', () => {
+  test('404 when the room does not exist', async () => {
+    mockTxnGet.mockResolvedValue(snap(null));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/decline-invite').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('404 (hidden) on cohort mismatch', async () => {
+    mockCohort = 'minor';
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ cohort: 'adult' })));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/decline-invite').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test("200 deletes the caller's own pending invite", async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ pendingInvites: { 50: '10' } })));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/decline-invite').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(mockRoomRef, {
+      'pendingInvites.50': { __delete: true },
+    });
+    expect(mockRtdbSet).toHaveBeenCalled();
+  });
+
+  test('200 idempotent no-op when the caller has no pending invite — no write', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ pendingInvites: { 77: '10' } })));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/decline-invite').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('500 when the transaction throws', async () => {
+    mockTxnGet.mockRejectedValue(new Error('boom'));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/decline-invite').send({});
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Chunk C — review-hardening coverage (boundaries, idempotency ORDERING,
+// type-coercion, role×state edges surfaced in code review).
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('Chunk C review-hardening coverage', () => {
+  test('PATCH /name: 200 at exactly 50 characters (boundary)', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(1))
+      .patch('/api/rooms/room-1/name')
+      .send({ name: 'x'.repeat(50) });
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(mockRoomRef, { name: 'x'.repeat(50) });
+  });
+
+  test('PATCH /name: 400 when name is a non-string type (number)', async () => {
+    const res = await request(createApp(1)).patch('/api/rooms/room-1/name').send({ name: 42 });
+    expect(res.status).toBe(400);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('POST /owner-returned: 200 idempotent no-op on an already-ACTIVE room (no write, no broadcast)', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'ACTIVE' })));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/owner-returned').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+    expect(mockRtdbSet).not.toHaveBeenCalled();
+  });
+
+  test('POST /owner-away: 403 for a non-owner on an already-OWNER_AWAY room (auth precedes idempotency)', async () => {
+    const room = mkRoom({ state: 'OWNER_AWAY', ownerLeftAt: 123 });
+    mockDocGet.mockResolvedValue(snap(room));
+    mockTxnGet.mockResolvedValue(snap(room));
+    mockRtdbGet.mockResolvedValue({ exists: () => false }); // even with the owner absent
+    const res = await request(createApp(99)).post('/api/rooms/room-1/owner-away').send({});
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('POST /owner-away: the non-owner path reads presence at the owner RTDB node', async () => {
+    const { rtdb } = require('../../src/utils/firebase');
+    const room = mkRoom({ state: 'ACTIVE' });
+    mockDocGet.mockResolvedValue(snap(room));
+    mockTxnGet.mockResolvedValue(snap(room));
+    mockRtdbGet.mockResolvedValue({ exists: () => false });
+    await request(createApp(10)).post('/api/rooms/room-1/owner-away').send({});
+    expect(rtdb.ref).toHaveBeenCalledWith('rooms/room-1/presence/1');
+  });
+
+  test('POST /seats/:i/move: 403 when a host targets the owner seat (toIndex 0)', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 3: { userId: '99', state: 'OCCUPIED', isMuted: false } } })),
+    );
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 0 });
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('POST /seats/:i/move: 403 when a host tries to move the owner (source occupied by owner)', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 3: { userId: '1', state: 'OCCUPIED', isMuted: false } } })),
+    );
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 4 });
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('POST /seats/:i/move: 400 when toIndex is a non-integer (float)', async () => {
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 3.7 });
+    expect(res.status).toBe(400);
+  });
+
+  test('POST /seats/:i/move: 200 moves are permitted in an OWNER_AWAY room', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          state: 'OWNER_AWAY',
+          ownerLeftAt: Date.now(),
+          seats: {
+            3: { userId: '99', state: 'OCCUPIED', isMuted: false },
+            4: { userId: null, state: 'EMPTY', isMuted: false },
+          },
+        }),
+      ),
+    );
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/seats/3/move')
+      .send({ toIndex: 4 });
+    expect(res.status).toBe(200);
+  });
+
+  test('POST /join: 200 idempotent when the caller is already a participant', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom())); // participant 10 already present
+    const res = await request(createApp(10)).post('/api/rooms/room-1/join').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(mockRoomRef, {
+      participantIds: { __arrayUnion: ['10'] },
+    });
+  });
+
+  test('POST /join: 200 when the room doc has no bannedUserIds field', async () => {
+    const room = mkRoom();
+    delete room.bannedUserIds; // ensure the field is absent
+    mockTxnGet.mockResolvedValue(snap(room));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/join').send({});
+    expect(res.status).toBe(200);
+  });
+
+  test('POST /decline-invite: 200 deletes a pending invite even on a CLOSED room', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED', pendingInvites: { 50: '10' } })));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/decline-invite').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(mockRoomRef, {
+      'pendingInvites.50': { __delete: true },
+    });
+  });
+
+  test('POST /close: 200 with zero participants performs no currentRoomId batch clear', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ participantIds: [] })));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/close').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalled();
+    expect(mockBatchSet).not.toHaveBeenCalled();
+  });
+
+  test('POST /close: 403 non-owner cannot expire-close when ownerLeftAt is missing (NaN guard)', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          state: 'OWNER_AWAY',
+          // ownerLeftAt intentionally absent → expiry comparison must be false
+          seats: {
+            0: { userId: '1', state: 'OCCUPIED', isMuted: false },
+            3: { userId: '10', state: 'OCCUPIED', isMuted: false }, // caller
+            4: { userId: '99', state: 'OCCUPIED', isMuted: false }, // another non-owner seated
+          },
+        }),
+      ),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/close').send({});
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
   });
 });

--- a/express-api/tests/routes/room-mutations.test.js
+++ b/express-api/tests/routes/room-mutations.test.js
@@ -1,0 +1,280 @@
+const express = require('express');
+const request = require('supertest');
+
+// ── Firebase Admin mock (db.runTransaction + FieldValue sentinels) ──
+const mockTxnGet = jest.fn();
+const mockTxnUpdate = jest.fn();
+const mockRoomRef = { path: 'rooms/room-1' };
+const mockRtdbSet = jest.fn().mockResolvedValue();
+
+jest.mock('../../src/utils/firebase', () => ({
+  db: {
+    doc: jest.fn(() => mockRoomRef),
+    runTransaction: jest.fn(async (fn) => fn({ get: mockTxnGet, update: mockTxnUpdate })),
+  },
+  rtdb: { ref: jest.fn(() => ({ set: (...a) => mockRtdbSet(...a) })) },
+  FieldValue: {
+    arrayUnion: (...args) => ({ __arrayUnion: args }),
+    delete: () => ({ __delete: true }),
+  },
+}));
+
+// Caller cohort is controllable per test; the room is cohort-stamped.
+let mockCohort = 'adult';
+jest.mock('../../src/utils/firebase-claims', () => ({
+  cohortFromClaim: () => mockCohort,
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const log = require('../../src/utils/log');
+const router = require('../../src/routes/room-mutations');
+
+function createApp(uniqueId = 10) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.auth = { uid: 'fb-uid', uniqueId };
+    next();
+  });
+  app.use('/api', router);
+  return app;
+}
+
+function snap(room) {
+  return room === null ? { exists: false } : { exists: true, data: () => room };
+}
+
+/** Default room: owner=1 (seat 0), host=10, attendee=99; seats 3 & 4 empty. */
+function mkRoom(overrides = {}) {
+  return {
+    ownerId: '1',
+    cohort: 'adult',
+    state: 'ACTIVE',
+    participantIds: ['1', '10', '99'],
+    hostIds: ['10'],
+    requireApproval: false,
+    pendingInvites: {},
+    seats: {
+      0: { userId: '1', state: 'OCCUPIED', isMuted: false },
+      3: { userId: null, state: 'EMPTY', isMuted: false },
+      4: { userId: null, state: 'EMPTY', isMuted: false },
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCohort = 'adult';
+  mockRtdbSet.mockResolvedValue();
+});
+
+describe('POST /api/rooms/:roomId/seats/:seatIndex/claim', () => {
+  test('400 on out-of-range seat index (>= MAX_SEATS) — no transaction', async () => {
+    const res = await request(createApp()).post('/api/rooms/room-1/seats/8/claim').send({});
+    expect(res.status).toBe(400);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('400 on negative seat index', async () => {
+    const res = await request(createApp()).post('/api/rooms/room-1/seats/-1/claim').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('400 on non-numeric seat index', async () => {
+    const res = await request(createApp()).post('/api/rooms/room-1/seats/abc/claim').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('404 when the room does not exist', async () => {
+    mockTxnGet.mockResolvedValue(snap(null));
+    const res = await request(createApp()).post('/api/rooms/room-1/seats/3/claim').send({});
+    expect(res.status).toBe(404);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('404 (hidden) when the caller cohort differs from the room cohort', async () => {
+    mockCohort = 'minor';
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ cohort: 'adult' })));
+    const res = await request(createApp()).post('/api/rooms/room-1/seats/3/claim').send({});
+    expect(res.status).toBe(404);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('409 when the room is CLOSED', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED' })));
+    const res = await request(createApp()).post('/api/rooms/room-1/seats/3/claim').send({});
+    expect(res.status).toBe(409);
+  });
+
+  test('409 SEAT_TAKEN when the seat is already occupied (race guard)', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 3: { userId: '77', state: 'OCCUPIED', isMuted: false } } })),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/seats/3/claim').send({});
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('SEAT_TAKEN');
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('403 when an attendee tries to take a seat directly (must use the request flow)', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(99)).post('/api/rooms/room-1/seats/3/claim').send({});
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('403 when a non-owner tries to take seat 0 (owner-only)', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 0: { userId: null, state: 'EMPTY', isMuted: false } } })),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/seats/0/claim').send({});
+    expect(res.status).toBe(403);
+  });
+
+  test('409 ALREADY_SEATED when the caller already occupies another seat', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          seats: {
+            3: { userId: null, state: 'EMPTY', isMuted: false },
+            4: { userId: '10', state: 'OCCUPIED', isMuted: false },
+          },
+        }),
+      ),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/seats/3/claim').send({});
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('ALREADY_SEATED');
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('200 seats a host in an empty seat (transactional write + broadcast)', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(10)).post('/api/rooms/room-1/seats/3/claim').send({});
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({
+        'seats.3.userId': '10',
+        'seats.3.state': 'OCCUPIED',
+        'seats.3.isMuted': false,
+        participantIds: { __arrayUnion: ['10'] },
+        allTimeSeatUserIds: { __arrayUnion: ['10'] },
+      }),
+    );
+    expect(mockRtdbSet).toHaveBeenCalled();
+  });
+
+  test('200 lets the owner take seat 0', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 0: { userId: null, state: 'EMPTY', isMuted: false } } })),
+    );
+    const res = await request(createApp(1)).post('/api/rooms/room-1/seats/0/claim').send({});
+    expect(res.status).toBe(200);
+  });
+
+  test('500 when the transaction throws', async () => {
+    mockTxnGet.mockRejectedValue(new Error('Firestore down'));
+    const res = await request(createApp(10)).post('/api/rooms/room-1/seats/3/claim').send({});
+    expect(res.status).toBe(500);
+    expect(log.error).toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/rooms/:roomId/seats/:seatIndex/accept-invite', () => {
+  test('403 when the caller has no pending invite', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ pendingInvites: {} })));
+    const res = await request(createApp(20))
+      .post('/api/rooms/room-1/seats/3/accept-invite')
+      .send({});
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('403 when accepting into seat 0 (owner-only)', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          pendingInvites: { 20: '1' },
+          seats: { 0: { userId: null, state: 'EMPTY', isMuted: false } },
+        }),
+      ),
+    );
+    const res = await request(createApp(20))
+      .post('/api/rooms/room-1/seats/0/accept-invite')
+      .send({});
+    expect(res.status).toBe(403);
+  });
+
+  test('409 SEAT_TAKEN when the invited seat is occupied', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          pendingInvites: { 20: '1' },
+          seats: { 3: { userId: '77', state: 'OCCUPIED', isMuted: false } },
+        }),
+      ),
+    );
+    const res = await request(createApp(20))
+      .post('/api/rooms/room-1/seats/3/accept-invite')
+      .send({});
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('SEAT_TAKEN');
+  });
+
+  test('200 seats the invited user, consumes the invite, adds participant', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          pendingInvites: { 20: '1' },
+          participantIds: ['1', '10'],
+          seats: { 3: { userId: null, state: 'EMPTY', isMuted: false } },
+        }),
+      ),
+    );
+    const res = await request(createApp(20))
+      .post('/api/rooms/room-1/seats/3/accept-invite')
+      .send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({
+        'pendingInvites.20': { __delete: true },
+        'seats.3.userId': '20',
+        'seats.3.state': 'OCCUPIED',
+        participantIds: { __arrayUnion: ['20'] },
+      }),
+    );
+  });
+});
+
+describe('POST /api/rooms/:roomId/seats/:seatIndex/leave', () => {
+  test("200 clears the caller's own seat", async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 3: { userId: '10', state: 'OCCUPIED', isMuted: false } } })),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/seats/3/leave').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({ 'seats.3.userId': null, 'seats.3.state': 'EMPTY' }),
+    );
+  });
+
+  test('403 when the caller does not occupy that seat', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 3: { userId: '77', state: 'OCCUPIED', isMuted: false } } })),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/seats/3/leave').send({});
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/express-api/tests/routes/room-mutations.test.js
+++ b/express-api/tests/routes/room-mutations.test.js
@@ -739,11 +739,12 @@ describe('POST /api/rooms/:roomId/owner-away', () => {
     expect(mockRtdbGet).not.toHaveBeenCalled(); // owner path skips presence verification
   });
 
-  test('200 idempotent when already OWNER_AWAY — no write', async () => {
+  test('200 idempotent when already OWNER_AWAY — no write + no spurious broadcast', async () => {
     primeOwnerAway(mkRoom({ state: 'OWNER_AWAY', ownerLeftAt: 123 }));
     const res = await request(createApp(1)).post('/api/rooms/room-1/owner-away').send({});
     expect(res.status).toBe(200);
     expect(mockTxnUpdate).not.toHaveBeenCalled();
+    expect(mockRtdbSet).not.toHaveBeenCalled();
   });
 
   test('409 when the room is CLOSED', async () => {
@@ -1383,6 +1384,17 @@ describe('POST /api/rooms/:roomId/leave', () => {
     expect(payload).toEqual({ participantIds: { __arrayRemove: ['99'] } });
   });
 
+  test('200 idempotent no-op: no write + no broadcast when caller is neither a participant nor seated', async () => {
+    // Common on a client retrying /leave after a disconnect — the arrayRemove
+    // would be a no-op anyway; the noop branch additionally suppresses the
+    // spurious RTDB nudge that would wake every connected client.
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ participantIds: ['1', '10'] }))); // 99 absent
+    const res = await request(createApp(99)).post('/api/rooms/room-1/leave').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+    expect(mockRtdbSet).not.toHaveBeenCalled();
+  });
+
   test('500 when the transaction throws', async () => {
     mockTxnGet.mockRejectedValue(new Error('boom'));
     const res = await request(createApp(10)).post('/api/rooms/room-1/leave').send({});
@@ -1390,6 +1402,10 @@ describe('POST /api/rooms/:roomId/leave', () => {
   });
 });
 
+// TOCTOU note for the disconnect-user presence gate: a test for the reconnect-
+// between-pre-read-and-txn race is intentionally absent — that window is
+// accepted and documented in isUserPresent(). It cannot be closed without a
+// Firestore-visible presence token (tracked for the rules-lockdown phase).
 describe('POST /api/rooms/:roomId/disconnect-user', () => {
   test('400 when userId is missing', async () => {
     const res = await request(createApp(10)).post('/api/rooms/room-1/disconnect-user').send({});
@@ -1461,6 +1477,7 @@ describe('POST /api/rooms/:roomId/disconnect-user', () => {
   });
 
   test('200 removes an absent non-owner, clears their seat + currentRoomId', async () => {
+    const { db } = require('../../src/utils/firebase');
     const room = mkRoom({ seats: { 3: { userId: '99', state: 'OCCUPIED', isMuted: false } } });
     mockDocGet.mockResolvedValue(snap(room));
     mockTxnGet.mockResolvedValue(snap(room));
@@ -1478,7 +1495,46 @@ describe('POST /api/rooms/:roomId/disconnect-user', () => {
         'seats.3.isMuted': false,
       }),
     );
+    // Pin the foreign-doc address: the currentRoomId clear must target the
+    // EVICTED user's doc (users/99), not the room doc. Without this guard a
+    // refactor could silently write the clear against the wrong path and the
+    // mockDocSet assertion alone would still pass (db.doc returns the same
+    // shared mockRoomRef for any path).
+    expect(db.doc).toHaveBeenCalledWith('users/99');
     expect(mockDocSet).toHaveBeenCalledWith({ currentRoomId: null }, { merge: true });
+  });
+
+  test('403 when the target is already removed (not in participantIds)', async () => {
+    // Race window: a concurrent /leave or another presence-monitor
+    // /disconnect-user may have removed the target between the client deciding
+    // to evict and this request landing. Without the target-membership gate we
+    // would no-op write a clean room + fire a spurious broadcast.
+    const room = mkRoom({ participantIds: ['1', '10'] }); // 99 already removed
+    mockDocGet.mockResolvedValue(snap(room));
+    mockTxnGet.mockResolvedValue(snap(room));
+    mockRtdbGet.mockResolvedValue({ exists: () => false });
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/disconnect-user')
+      .send({ userId: '99' });
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('200 still succeeds when the currentRoomId clear fails (best-effort)', async () => {
+    // The post-txn user-doc clear is wrapped in try/catch (mirrors /close):
+    // the room mutation already committed, the kicked user self-clears on
+    // observing the ban, and the foreign user-doc write must not undo the
+    // already-committed eviction.
+    const room = mkRoom({ seats: { 3: { userId: '99', state: 'OCCUPIED', isMuted: false } } });
+    mockDocGet.mockResolvedValue(snap(room));
+    mockTxnGet.mockResolvedValue(snap(room));
+    mockRtdbGet.mockResolvedValue({ exists: () => false });
+    mockDocSet.mockRejectedValue(new Error('user doc write failed'));
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/disconnect-user')
+      .send({ userId: '99' });
+    expect(res.status).toBe(200);
+    expect(log.error).toHaveBeenCalled();
   });
 
   test('500 when the transaction throws', async () => {

--- a/express-api/tests/routes/room-mutations.test.js
+++ b/express-api/tests/routes/room-mutations.test.js
@@ -4,10 +4,15 @@ const request = require('supertest');
 // ── Firebase Admin mock (db.runTransaction + FieldValue sentinels) ──
 const mockTxnGet = jest.fn();
 const mockTxnUpdate = jest.fn();
-const mockDocGet = jest.fn(); // non-transactional roomRef.get() — owner-away pre-read
-const mockRoomRef = { path: 'rooms/room-1', get: (...a) => mockDocGet(...a) };
+const mockDocGet = jest.fn(); // non-transactional roomRef.get() — owner-away/disconnect pre-read
+const mockDocSet = jest.fn().mockResolvedValue(); // db.doc(...).set() — disconnect-user currentRoomId clear
+const mockRoomRef = {
+  path: 'rooms/room-1',
+  get: (...a) => mockDocGet(...a),
+  set: (...a) => mockDocSet(...a),
+};
 const mockRtdbSet = jest.fn().mockResolvedValue();
-const mockRtdbGet = jest.fn(); // RTDB owner-presence read (setOwnerAway non-owner path)
+const mockRtdbGet = jest.fn(); // RTDB presence read (owner-away / disconnect-user)
 const mockBatchSet = jest.fn();
 const mockBatchCommit = jest.fn().mockResolvedValue();
 
@@ -88,8 +93,9 @@ beforeEach(() => {
   mockCohort = 'adult';
   mockRtdbSet.mockResolvedValue();
   mockBatchCommit.mockResolvedValue();
-  mockRtdbGet.mockResolvedValue({ exists: () => true }); // owner present by default
-  mockDocGet.mockResolvedValue({ exists: false }); // owner-away pre-read; set per test
+  mockRtdbGet.mockResolvedValue({ exists: () => true }); // target present by default
+  mockDocGet.mockResolvedValue({ exists: false }); // pre-read; set per test
+  mockDocSet.mockResolvedValue();
 });
 
 describe('POST /api/rooms/:roomId/seats/:seatIndex/claim', () => {
@@ -1328,5 +1334,196 @@ describe('Chunk C review-hardening coverage', () => {
     const res = await request(createApp(10)).post('/api/rooms/room-1/close').send({});
     expect(res.status).toBe(403);
     expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Chunk D — participant lifecycle: leave-room, disconnect-eviction, first-join.
+// Completes the server-authoritative surface so EVERY client room-doc write has
+// an endpoint (prerequisite for the rules lockdown).
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/rooms/:roomId/leave', () => {
+  test('404 when the room does not exist', async () => {
+    mockTxnGet.mockResolvedValue(snap(null));
+    const res = await request(createApp(99)).post('/api/rooms/room-1/leave').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('404 (hidden) on cohort mismatch', async () => {
+    mockCohort = 'minor';
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ cohort: 'adult' })));
+    const res = await request(createApp(99)).post('/api/rooms/room-1/leave').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('200 removes the caller from participants and clears their seat', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 3: { userId: '10', state: 'OCCUPIED', isMuted: false } } })),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/leave').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({
+        participantIds: { __arrayRemove: ['10'] },
+        'seats.3.userId': null,
+        'seats.3.state': 'EMPTY',
+        'seats.3.isMuted': false,
+      }),
+    );
+    expect(mockRtdbSet).toHaveBeenCalled();
+  });
+
+  test('200 removes from participants with no seat fields when the caller is unseated', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom())); // caller 99 is a participant but not seated
+    const res = await request(createApp(99)).post('/api/rooms/room-1/leave').send({});
+    expect(res.status).toBe(200);
+    const [, payload] = mockTxnUpdate.mock.calls[0];
+    expect(payload).toEqual({ participantIds: { __arrayRemove: ['99'] } });
+  });
+
+  test('500 when the transaction throws', async () => {
+    mockTxnGet.mockRejectedValue(new Error('boom'));
+    const res = await request(createApp(10)).post('/api/rooms/room-1/leave').send({});
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /api/rooms/:roomId/disconnect-user', () => {
+  test('400 when userId is missing', async () => {
+    const res = await request(createApp(10)).post('/api/rooms/room-1/disconnect-user').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('404 when the room does not exist (pre-read)', async () => {
+    mockDocGet.mockResolvedValue(snap(null));
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/disconnect-user')
+      .send({ userId: '99' });
+    expect(res.status).toBe(404);
+  });
+
+  test('404 (hidden) on cohort mismatch (pre-read)', async () => {
+    mockCohort = 'minor';
+    mockDocGet.mockResolvedValue(snap(mkRoom({ cohort: 'adult' })));
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/disconnect-user')
+      .send({ userId: '99' });
+    expect(res.status).toBe(404);
+  });
+
+  test('403 when the target is the owner (owner disconnect uses owner-away, not removal)', async () => {
+    const room = mkRoom();
+    mockDocGet.mockResolvedValue(snap(room));
+    mockTxnGet.mockResolvedValue(snap(room));
+    mockRtdbGet.mockResolvedValue({ exists: () => false });
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/disconnect-user')
+      .send({ userId: '1' });
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('403 when the target is still present', async () => {
+    const room = mkRoom({ seats: { 3: { userId: '99', state: 'OCCUPIED', isMuted: false } } });
+    mockDocGet.mockResolvedValue(snap(room));
+    mockTxnGet.mockResolvedValue(snap(room));
+    mockRtdbGet.mockResolvedValue({ exists: () => true }); // present → cannot evict
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/disconnect-user')
+      .send({ userId: '99' });
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('403 when the caller is not a participant', async () => {
+    const room = mkRoom({ participantIds: ['1', '99'] }); // caller 10 not a participant
+    mockDocGet.mockResolvedValue(snap(room));
+    mockTxnGet.mockResolvedValue(snap(room));
+    mockRtdbGet.mockResolvedValue({ exists: () => false });
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/disconnect-user')
+      .send({ userId: '99' });
+    expect(res.status).toBe(403);
+  });
+
+  test('403 fail-safe to present when the presence read throws', async () => {
+    const room = mkRoom({ seats: { 3: { userId: '99', state: 'OCCUPIED', isMuted: false } } });
+    mockDocGet.mockResolvedValue(snap(room));
+    mockTxnGet.mockResolvedValue(snap(room));
+    mockRtdbGet.mockRejectedValue(new Error('rtdb down'));
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/disconnect-user')
+      .send({ userId: '99' });
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('200 removes an absent non-owner, clears their seat + currentRoomId', async () => {
+    const room = mkRoom({ seats: { 3: { userId: '99', state: 'OCCUPIED', isMuted: false } } });
+    mockDocGet.mockResolvedValue(snap(room));
+    mockTxnGet.mockResolvedValue(snap(room));
+    mockRtdbGet.mockResolvedValue({ exists: () => false }); // absent → evictable
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/disconnect-user')
+      .send({ userId: '99' });
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({
+        participantIds: { __arrayRemove: ['99'] },
+        'seats.3.userId': null,
+        'seats.3.state': 'EMPTY',
+        'seats.3.isMuted': false,
+      }),
+    );
+    expect(mockDocSet).toHaveBeenCalledWith({ currentRoomId: null }, { merge: true });
+  });
+
+  test('500 when the transaction throws', async () => {
+    mockDocGet.mockResolvedValue(snap(mkRoom()));
+    mockRtdbGet.mockResolvedValue({ exists: () => false });
+    mockTxnGet.mockRejectedValue(new Error('boom'));
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/disconnect-user')
+      .send({ userId: '99' });
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /api/rooms/:roomId/first-join', () => {
+  test('404 when the room does not exist', async () => {
+    mockTxnGet.mockResolvedValue(snap(null));
+    const res = await request(createApp(99)).post('/api/rooms/room-1/first-join').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('404 (hidden) on cohort mismatch', async () => {
+    mockCohort = 'minor';
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ cohort: 'adult' })));
+    const res = await request(createApp(99)).post('/api/rooms/room-1/first-join').send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('200 records a numeric first-join timestamp when absent', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(99)).post('/api/rooms/room-1/first-join').send({});
+    expect(res.status).toBe(200);
+    const [, payload] = mockTxnUpdate.mock.calls[0];
+    expect(typeof payload['firstJoinTimestamps.99']).toBe('number');
+  });
+
+  test('200 idempotent set-once: no write when a timestamp already exists', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ firstJoinTimestamps: { 99: 12345 } })));
+    const res = await request(createApp(99)).post('/api/rooms/room-1/first-join').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('500 when the transaction throws', async () => {
+    mockTxnGet.mockRejectedValue(new Error('boom'));
+    const res = await request(createApp(99)).post('/api/rooms/room-1/first-join').send({});
+    expect(res.status).toBe(500);
   });
 });

--- a/express-api/tests/routes/room-mutations.test.js
+++ b/express-api/tests/routes/room-mutations.test.js
@@ -15,6 +15,7 @@ jest.mock('../../src/utils/firebase', () => ({
   rtdb: { ref: jest.fn(() => ({ set: (...a) => mockRtdbSet(...a) })) },
   FieldValue: {
     arrayUnion: (...args) => ({ __arrayUnion: args }),
+    arrayRemove: (...args) => ({ __arrayRemove: args }),
     delete: () => ({ __delete: true }),
   },
 }));
@@ -276,5 +277,214 @@ describe('POST /api/rooms/:roomId/seats/:seatIndex/leave', () => {
     const res = await request(createApp(10)).post('/api/rooms/room-1/seats/3/leave').send({});
     expect(res.status).toBe(403);
     expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/rooms/:roomId/kick', () => {
+  test('400 when userId is missing', async () => {
+    const res = await request(createApp(1)).post('/api/rooms/room-1/kick').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('403 when an attendee tries to kick', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(99)).post('/api/rooms/room-1/kick').send({ userId: '88' });
+    expect(res.status).toBe(403);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
+  test('403 when a host tries to kick the owner', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(10)).post('/api/rooms/room-1/kick').send({ userId: '1' });
+    expect(res.status).toBe(403);
+  });
+
+  test('403 when a host tries to kick another host', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ hostIds: ['10', '55'] })));
+    const res = await request(createApp(10)).post('/api/rooms/room-1/kick').send({ userId: '55' });
+    expect(res.status).toBe(403);
+  });
+
+  test('200 owner bans + removes the target and clears their seat', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 4: { userId: '99', state: 'OCCUPIED', isMuted: false } } })),
+    );
+    const res = await request(createApp(1))
+      .post('/api/rooms/room-1/kick')
+      .send({ userId: '99', reason: 'spam', kickerName: 'Alice' });
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({
+        bannedUserIds: { __arrayUnion: ['99'] },
+        participantIds: { __arrayRemove: ['99'] },
+        'kickInfo.99': { kickerName: 'Alice', reason: 'spam' },
+        'seats.4.userId': null,
+        'seats.4.state': 'EMPTY',
+      }),
+    );
+  });
+
+  test('200 host kicks an attendee who is not seated (no seat fields written)', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ participantIds: ['1', '10', '99'] })));
+    const res = await request(createApp(10)).post('/api/rooms/room-1/kick').send({ userId: '99' });
+    expect(res.status).toBe(200);
+    const update = mockTxnUpdate.mock.calls[0][1];
+    expect(update.bannedUserIds).toEqual({ __arrayUnion: ['99'] });
+    expect(Object.keys(update).some((k) => k.startsWith('seats.'))).toBe(false);
+  });
+});
+
+describe('POST /api/rooms/:roomId/seats/:seatIndex/remove', () => {
+  test('403 when an attendee tries to remove an occupant', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 4: { userId: '88', state: 'OCCUPIED', isMuted: false } } })),
+    );
+    const res = await request(createApp(99)).post('/api/rooms/room-1/seats/4/remove').send({});
+    expect(res.status).toBe(403);
+  });
+
+  test('403 when removing the occupant of seat 0 (owner seat is protected)', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/seats/0/remove').send({});
+    expect(res.status).toBe(403);
+  });
+
+  test('200 host removes an attendee from a seat (no ban)', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 4: { userId: '88', state: 'OCCUPIED', isMuted: false } } })),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/seats/4/remove').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({ 'seats.4.userId': null, 'seats.4.state': 'EMPTY' }),
+    );
+  });
+});
+
+describe('PATCH /api/rooms/:roomId/seats/:seatIndex/mute', () => {
+  test('400 when isMuted is missing', async () => {
+    const res = await request(createApp(1)).patch('/api/rooms/room-1/seats/4/mute').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('409 when the seat is empty', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(1))
+      .patch('/api/rooms/room-1/seats/3/mute')
+      .send({ isMuted: true });
+    expect(res.status).toBe(409);
+  });
+
+  test('403 when an attendee tries to force-mute', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 4: { userId: '88', state: 'OCCUPIED', isMuted: false } } })),
+    );
+    const res = await request(createApp(99))
+      .patch('/api/rooms/room-1/seats/4/mute')
+      .send({ isMuted: true });
+    expect(res.status).toBe(403);
+  });
+
+  test('403 when a host tries to mute another host', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          hostIds: ['10', '55'],
+          seats: { 4: { userId: '55', state: 'OCCUPIED', isMuted: false } },
+        }),
+      ),
+    );
+    const res = await request(createApp(10))
+      .patch('/api/rooms/room-1/seats/4/mute')
+      .send({ isMuted: true });
+    expect(res.status).toBe(403);
+  });
+
+  test('200 owner force-mutes an attendee', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 4: { userId: '88', state: 'OCCUPIED', isMuted: false } } })),
+    );
+    const res = await request(createApp(1))
+      .patch('/api/rooms/room-1/seats/4/mute')
+      .send({ isMuted: true });
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({ 'seats.4.isMuted': true }),
+    );
+  });
+
+  test('403 when a non-occupant tries to unmute someone', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 4: { userId: '88', state: 'OCCUPIED', isMuted: true } } })),
+    );
+    const res = await request(createApp(10))
+      .patch('/api/rooms/room-1/seats/4/mute')
+      .send({ isMuted: false });
+    expect(res.status).toBe(403);
+  });
+
+  test('200 the occupant unmutes themselves', async () => {
+    mockTxnGet.mockResolvedValue(
+      snap(mkRoom({ seats: { 4: { userId: '88', state: 'OCCUPIED', isMuted: true } } })),
+    );
+    const res = await request(createApp(88))
+      .patch('/api/rooms/room-1/seats/4/mute')
+      .send({ isMuted: false });
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({ 'seats.4.isMuted': false }),
+    );
+  });
+});
+
+describe('POST /api/rooms/:roomId/hosts (add) + DELETE .../hosts/:userId (remove)', () => {
+  test('400 when userId is missing on add', async () => {
+    const res = await request(createApp(1)).post('/api/rooms/room-1/hosts').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('403 when a non-owner tries to add a host', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(10)).post('/api/rooms/room-1/hosts').send({ userId: '99' });
+    expect(res.status).toBe(403);
+  });
+
+  test('400 when trying to add the owner as a host', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/hosts').send({ userId: '1' });
+    expect(res.status).toBe(400);
+  });
+
+  test('200 owner promotes a participant to host', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/hosts').send({ userId: '99' });
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({
+        hostIds: { __arrayUnion: ['99'] },
+        allTimeHostIds: { __arrayUnion: ['99'] },
+      }),
+    );
+  });
+
+  test('403 when a non-owner tries to remove a host', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ hostIds: ['10', '55'] })));
+    const res = await request(createApp(10)).delete('/api/rooms/room-1/hosts/55').send({});
+    expect(res.status).toBe(403);
+  });
+
+  test('200 owner demotes a host', async () => {
+    mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(1)).delete('/api/rooms/room-1/hosts/10').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({ hostIds: { __arrayRemove: ['10'] } }),
+    );
   });
 });

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosRoomRepositoryImpl.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosRoomRepositoryImpl.kt
@@ -1,14 +1,12 @@
 package com.shyden.shytalk.data.repository
 
 import com.shyden.shytalk.core.model.ChatRoom
-import com.shyden.shytalk.core.model.Seat
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.core.util.currentTimeMillis
 import com.shyden.shytalk.core.util.firebaseCall
 import com.shyden.shytalk.core.util.logW
 import com.shyden.shytalk.data.firestore.dataMap
 import com.shyden.shytalk.data.remote.IosApiClient
-import dev.gitlive.firebase.firestore.FieldValue
 import dev.gitlive.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
@@ -121,9 +119,8 @@ class IosRoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to join room") {
-            firestore.collection("rooms").document(roomId).updateFields {
-                "participantIds" to FieldValue.arrayUnion(userId)
-            }
+            api.post("/api/rooms/$roomId/join")
+            // currentRoomId is the caller's own user doc (allowed by rules); stays client-side.
             firestore.collection("users").document(userId).updateFields { "currentRoomId" to roomId }
         }
 
@@ -132,31 +129,9 @@ class IosRoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to leave room") {
-            // Atomic: read seats + clear-by-user in one transaction so a
-            // concurrent moveSeat (also transactional, line 165) can't
-            // shuffle the seat between our read and write. Mirrors the
-            // Android fix in PR #518 (RoomRepositoryImpl.kt:143).
-            val roomRef = firestore.collection("rooms").document(roomId)
-            firestore.runTransaction {
-                val doc = get(roomRef)
-                val data = if (doc.exists) doc.dataMap() else null
-                updateFields(roomRef) {
-                    "participantIds" to FieldValue.arrayRemove(userId)
-                }
-                if (data != null) {
-                    val seatsRaw = data["seats"] as? Map<*, *>
-                    seatsRaw?.forEach { (index, seatData) ->
-                        val seat = seatData as? Map<*, *>
-                        if (seat?.get("userId") == userId) {
-                            updateFields(roomRef) {
-                                "seats.$index.userId" to null
-                                "seats.$index.state" to "EMPTY"
-                                "seats.$index.isMuted" to false
-                            }
-                        }
-                    }
-                }
-            }
+            // Server-authoritative: participant removal + own-seat clear happen
+            // transactionally inside the /leave endpoint.
+            api.post("/api/rooms/$roomId/leave")
             firestore.collection("users").document(userId).updateFields { "currentRoomId" to null }
         }
 
@@ -166,12 +141,7 @@ class IosRoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to take seat") {
-            firestore.collection("rooms").document(roomId).updateFields {
-                "seats.$seatIndex.userId" to userId
-                "seats.$seatIndex.state" to "OCCUPIED"
-                "seats.$seatIndex.isMuted" to false
-                "allTimeSeatUserIds" to FieldValue.arrayUnion(userId)
-            }
+            api.post("/api/rooms/$roomId/seats/$seatIndex/claim")
         }
 
     override suspend fun leaveSeat(
@@ -179,17 +149,16 @@ class IosRoomRepositoryImpl(
         seatIndex: Int,
     ): Resource<Unit> =
         firebaseCall("Failed to leave seat") {
-            firestore.collection("rooms").document(roomId).updateFields {
-                "seats.$seatIndex.userId" to null
-                "seats.$seatIndex.state" to "EMPTY"
-                "seats.$seatIndex.isMuted" to false
-            }
+            api.post("/api/rooms/$roomId/seats/$seatIndex/leave")
         }
 
     override suspend fun removeFromSeat(
         roomId: String,
         seatIndex: Int,
-    ): Resource<Unit> = leaveSeat(roomId, seatIndex)
+    ): Resource<Unit> =
+        firebaseCall("Failed to remove from seat") {
+            api.post("/api/rooms/$roomId/seats/$seatIndex/remove")
+        }
 
     override suspend fun moveSeat(
         roomId: String,
@@ -198,29 +167,10 @@ class IosRoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to move seat") {
-            val roomRef = firestore.collection("rooms").document(roomId)
-            firestore.runTransaction {
-                val doc = get(roomRef)
-                val data = doc.dataMap()
-                val seatsRaw = data["seats"] as? Map<*, *> ?: throw Exception("No seats data")
-                val fromSeat =
-                    (seatsRaw[fromIndex.toString()] as? Map<*, *>)
-                        ?.entries
-                        ?.associate { (k, v) -> k.toString() to v } ?: Seat.EMPTY_MAP
-                val toSeat =
-                    (seatsRaw[toIndex.toString()] as? Map<*, *>)
-                        ?.entries
-                        ?.associate { (k, v) -> k.toString() to v } ?: Seat.EMPTY_MAP
-
-                updateFields(roomRef) {
-                    "seats.$fromIndex.userId" to toSeat["userId"]
-                    "seats.$fromIndex.state" to (toSeat["state"] ?: "EMPTY")
-                    "seats.$fromIndex.isMuted" to (toSeat["isMuted"] ?: false)
-                    "seats.$toIndex.userId" to fromSeat["userId"]
-                    "seats.$toIndex.state" to (fromSeat["state"] ?: "EMPTY")
-                    "seats.$toIndex.isMuted" to (fromSeat["isMuted"] ?: false)
-                }
-            }
+            api.post(
+                "/api/rooms/$roomId/seats/$fromIndex/move",
+                JsonObject(mapOf("toIndex" to JsonPrimitive(toIndex))),
+            )
         }
 
     override suspend fun kickUser(
@@ -231,43 +181,18 @@ class IosRoomRepositoryImpl(
         reason: String,
     ): Resource<Unit> =
         firebaseCall("Failed to kick user") {
-            val effectiveReason = reason.ifBlank { "No reason given" }
-            val kickInfoValue: Map<String, String> = mapOf("kickerName" to kickerName, "reason" to effectiveReason)
-            val roomRef = firestore.collection("rooms").document(roomId)
-            // Atomic: when seatIndex is unknown we MUST read seats inside
-            // the same transaction as the clear, otherwise a concurrent
-            // moveSeat can shuffle the target's seat between our read and
-            // write, leaving us blanking the wrong seat. Mirrors Android
-            // fix in PR #518.
-            firestore.runTransaction {
-                updateFields(roomRef) {
-                    "participantIds" to FieldValue.arrayRemove(userId)
-                    "bannedUserIds" to FieldValue.arrayUnion(userId)
-                    "kickInfo.$userId" to kickInfoValue
-                }
-                if (seatIndex != null) {
-                    updateFields(roomRef) {
-                        "seats.$seatIndex.userId" to null
-                        "seats.$seatIndex.state" to "EMPTY"
-                        "seats.$seatIndex.isMuted" to false
-                    }
-                } else {
-                    val doc = get(roomRef)
-                    val data = if (doc.exists) doc.dataMap() else null
-                    val seatsRaw = data?.get("seats") as? Map<*, *>
-                    seatsRaw?.forEach { (index, seatData) ->
-                        val seat = seatData as? Map<*, *>
-                        if (seat?.get("userId") == userId) {
-                            updateFields(roomRef) {
-                                "seats.$index.userId" to null
-                                "seats.$index.state" to "EMPTY"
-                                "seats.$index.isMuted" to false
-                            }
-                        }
-                    }
-                }
-            }
-            firestore.collection("users").document(userId).updateFields { "currentRoomId" to null }
+            // Server derives the target's seat + clears it transactionally; the
+            // kicked user self-clears their own currentRoomId on observing the ban.
+            api.post(
+                "/api/rooms/$roomId/kick",
+                JsonObject(
+                    mapOf(
+                        "userId" to JsonPrimitive(userId),
+                        "reason" to JsonPrimitive(reason.ifBlank { "No reason given" }),
+                        "kickerName" to JsonPrimitive(kickerName),
+                    ),
+                ),
+            )
         }
 
     override suspend fun toggleMute(
@@ -276,9 +201,10 @@ class IosRoomRepositoryImpl(
         isMuted: Boolean,
     ): Resource<Unit> =
         firebaseCall("Failed to toggle mute") {
-            firestore.collection("rooms").document(roomId).updateFields {
-                "seats.$seatIndex.isMuted" to isMuted
-            }
+            api.patch(
+                "/api/rooms/$roomId/seats/$seatIndex/mute",
+                JsonObject(mapOf("isMuted" to JsonPrimitive(isMuted))),
+            )
         }
 
     override suspend fun addHost(
@@ -286,10 +212,7 @@ class IosRoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to add host") {
-            firestore.collection("rooms").document(roomId).updateFields {
-                "hostIds" to FieldValue.arrayUnion(userId)
-                "allTimeHostIds" to FieldValue.arrayUnion(userId)
-            }
+            api.post("/api/rooms/$roomId/hosts", JsonObject(mapOf("userId" to JsonPrimitive(userId))))
         }
 
     override suspend fun removeHost(
@@ -297,9 +220,7 @@ class IosRoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to remove host") {
-            firestore.collection("rooms").document(roomId).updateFields {
-                "hostIds" to FieldValue.arrayRemove(userId)
-            }
+            api.delete("/api/rooms/$roomId/hosts/$userId")
         }
 
     override suspend fun updateRoomName(
@@ -307,7 +228,7 @@ class IosRoomRepositoryImpl(
         newName: String,
     ): Resource<Unit> =
         firebaseCall("Failed to update room name") {
-            firestore.collection("rooms").document(roomId).updateFields { "name" to newName }
+            api.patch("/api/rooms/$roomId/name", JsonObject(mapOf("name" to JsonPrimitive(newName))))
         }
 
     override suspend fun setRequireApproval(
@@ -315,17 +236,15 @@ class IosRoomRepositoryImpl(
         requireApproval: Boolean,
     ): Resource<Unit> =
         firebaseCall("Failed to update approval setting") {
-            firestore.collection("rooms").document(roomId).updateFields {
-                "requireApproval" to requireApproval
-            }
+            api.patch(
+                "/api/rooms/$roomId/require-approval",
+                JsonObject(mapOf("requireApproval" to JsonPrimitive(requireApproval))),
+            )
         }
 
     override suspend fun setOwnerAway(roomId: String): Resource<Unit> =
         firebaseCall("Failed to set owner away") {
-            firestore.collection("rooms").document(roomId).updateFields {
-                "state" to "OWNER_AWAY"
-                "ownerLeftAt" to currentTimeMillis()
-            }
+            api.post("/api/rooms/$roomId/owner-away")
         }
 
     override suspend fun setOwnerReturned(
@@ -333,10 +252,7 @@ class IosRoomRepositoryImpl(
         ownerId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to set owner returned") {
-            firestore.collection("rooms").document(roomId).updateFields {
-                "state" to "ACTIVE"
-                "ownerLeftAt" to null
-            }
+            api.post("/api/rooms/$roomId/owner-returned")
         }
 
     override suspend fun sendInvite(
@@ -361,9 +277,8 @@ class IosRoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to cancel invite") {
-            firestore.collection("rooms").document(roomId).updateFields {
-                "pendingInvites.$userId" to FieldValue.delete
-            }
+            // Self-scoped on the server (deletes the caller's own pending invite).
+            api.post("/api/rooms/$roomId/decline-invite")
         }
 
     override suspend fun acceptInvite(
@@ -372,42 +287,14 @@ class IosRoomRepositoryImpl(
         seatIndex: Int,
     ): Resource<Unit> =
         firebaseCall("Failed to accept invite") {
-            firestore.collection("rooms").document(roomId).updateFields {
-                "pendingInvites.$userId" to FieldValue.delete
-                "participantIds" to FieldValue.arrayUnion(userId)
-                "seats.$seatIndex.userId" to userId
-                "seats.$seatIndex.state" to "OCCUPIED"
-                "seats.$seatIndex.isMuted" to false
-                "allTimeSeatUserIds" to FieldValue.arrayUnion(userId)
-            }
+            api.post("/api/rooms/$roomId/seats/$seatIndex/accept-invite")
             firestore.collection("users").document(userId).updateFields { "currentRoomId" to roomId }
         }
 
     override suspend fun closeRoom(roomId: String): Resource<Unit> =
         firebaseCall("Failed to close room") {
-            val doc = firestore.collection("rooms").document(roomId).get()
-            if (!doc.exists) throw Exception("Room not found")
-            val data = doc.dataMap()
-            val participantIds = (data["participantIds"] as? List<*>)?.filterIsInstance<String>() ?: emptyList()
-
-            val emptySeat = mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false)
-            val emptySeats = (0..7).associate { it.toString() to emptySeat }
-
-            firestore.collection("rooms").document(roomId).updateFields {
-                "state" to "CLOSED"
-                "closedAt" to currentTimeMillis()
-                "participantIds" to emptyList<String>()
-                "seats" to emptySeats
-            }
-            for (uid in participantIds) {
-                try {
-                    firestore.collection("users").document(uid).updateFields { "currentRoomId" to null }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    logW(TAG, "Failed to clear currentRoomId for $uid")
-                }
-            }
+            // Server empties the room + clears every participant's currentRoomId.
+            api.post("/api/rooms/$roomId/close")
         }
 
     override suspend fun findActiveRoomByOwner(ownerId: String): String? =
@@ -434,9 +321,7 @@ class IosRoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to record first join timestamp") {
-            firestore.collection("rooms").document(roomId).updateFields {
-                "firstJoinTimestamps.$userId" to currentTimeMillis()
-            }
+            api.post("/api/rooms/$roomId/first-join")
         }
 
     override suspend fun leaveAllRooms(
@@ -455,31 +340,8 @@ class IosRoomRepositoryImpl(
                     }.get()
             for (doc in snapshot.documents) {
                 if (doc.id == exceptRoomId) continue
-                // Atomic per-room: read seats inside the transaction so a
-                // concurrent moveSeat can't shuffle this user's seat. Each
-                // room is independent so a per-room transaction is enough.
-                // Mirrors Android fix in PR #518.
-                val roomRef = firestore.collection("rooms").document(doc.id)
                 try {
-                    firestore.runTransaction {
-                        val freshDoc = get(roomRef)
-                        if (!freshDoc.exists) return@runTransaction
-                        val freshData = freshDoc.dataMap()
-                        updateFields(roomRef) {
-                            "participantIds" to FieldValue.arrayRemove(userId)
-                        }
-                        val seatsRaw = freshData["seats"] as? Map<*, *>
-                        seatsRaw?.forEach { (index, seatData) ->
-                            val seat = seatData as? Map<*, *>
-                            if (seat?.get("userId") == userId) {
-                                updateFields(roomRef) {
-                                    "seats.$index.userId" to null
-                                    "seats.$index.state" to "EMPTY"
-                                    "seats.$index.isMuted" to false
-                                }
-                            }
-                        }
-                    }
+                    api.post("/api/rooms/${doc.id}/leave")
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -491,6 +353,8 @@ class IosRoomRepositoryImpl(
 
     override suspend fun closeAllRoomsByOwner(ownerId: String): Resource<Unit> =
         firebaseCall("Failed to close rooms") {
+            // Query stays client-side; each close routes through /close (which
+            // also clears participants' currentRoomId server-side).
             val snapshot =
                 firestore
                     .collection("rooms")
@@ -500,29 +364,9 @@ class IosRoomRepositoryImpl(
                             "state" inArray listOf("ACTIVE", "OWNER_AWAY"),
                         )
                     }.get()
-
-            val emptySeat = mapOf("userId" to null, "state" to "EMPTY", "isMuted" to false)
-            val emptySeats = (0..7).associate { it.toString() to emptySeat }
-
             for (doc in snapshot.documents) {
-                val data = doc.dataMap()
-                val participantIds = (data["participantIds"] as? List<*>)?.filterIsInstance<String>() ?: emptyList()
                 try {
-                    firestore.collection("rooms").document(doc.id).updateFields {
-                        "state" to "CLOSED"
-                        "closedAt" to currentTimeMillis()
-                        "participantIds" to emptyList<String>()
-                        "seats" to emptySeats
-                    }
-                    for (uid in participantIds) {
-                        try {
-                            firestore.collection("users").document(uid).updateFields { "currentRoomId" to null }
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            logW(TAG, "Failed to clear currentRoomId for $uid")
-                        }
-                    }
+                    api.post("/api/rooms/${doc.id}/close")
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -536,60 +380,11 @@ class IosRoomRepositoryImpl(
         userId: String,
     ): Resource<Unit> =
         firebaseCall("Failed to remove disconnected user") {
-            // Same race-safety logic as leaveRoom — read seats inside the
-            // transaction. Mirrors Android fix in PR #518.
-            val roomRef = firestore.collection("rooms").document(roomId)
-            firestore.runTransaction {
-                val doc = get(roomRef)
-                val data = if (doc.exists) doc.dataMap() else null
-                updateFields(roomRef) {
-                    "participantIds" to FieldValue.arrayRemove(userId)
-                }
-                if (data != null) {
-                    val seatsRaw = data["seats"] as? Map<*, *>
-                    seatsRaw?.forEach { (index, seatData) ->
-                        val seat = seatData as? Map<*, *>
-                        if (seat?.get("userId") == userId) {
-                            updateFields(roomRef) {
-                                "seats.$index.userId" to null
-                                "seats.$index.state" to "EMPTY"
-                                "seats.$index.isMuted" to false
-                            }
-                        }
-                    }
-                }
-            }
-            firestore.collection("users").document(userId).updateFields { "currentRoomId" to null }
+            // Server verifies the target is actually absent (RTDB presence) and
+            // clears their seat + currentRoomId.
+            api.post(
+                "/api/rooms/$roomId/disconnect-user",
+                JsonObject(mapOf("userId" to JsonPrimitive(userId))),
+            )
         }
-
-    private suspend fun clearUserFromRoom(
-        roomId: String,
-        userId: String,
-        data: Map<String, Any?>?,
-    ) {
-        firestore.collection("rooms").document(roomId).updateFields {
-            "participantIds" to FieldValue.arrayRemove(userId)
-        }
-        if (data != null) {
-            clearUserSeatOnly(roomId, userId, data)
-        }
-    }
-
-    private suspend fun clearUserSeatOnly(
-        roomId: String,
-        userId: String,
-        data: Map<String, Any?>,
-    ) {
-        val seatsRaw = data["seats"] as? Map<*, *> ?: return
-        for ((index, seatData) in seatsRaw) {
-            val seat = seatData as? Map<*, *> ?: continue
-            if (seat["userId"] == userId) {
-                firestore.collection("rooms").document(roomId).updateFields {
-                    "seats.$index.userId" to null
-                    "seats.$index.state" to "EMPTY"
-                    "seats.$index.isMuted" to false
-                }
-            }
-        }
-    }
 }

--- a/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/model/SeatTest.kt
+++ b/shared/src/jvmTest/kotlin/com/shyden/shytalk/core/model/SeatTest.kt
@@ -109,7 +109,7 @@ class SeatTest {
         assertEquals(original, restored)
     }
 
-    // ── isOccupiedBy ───────────────────────────────────────────��────
+    // ── isOccupiedBy ─────────────────────────────────────────────────
 
     @Test
     fun `isOccupiedBy returns true for matching user in OCCUPIED state`() {


### PR DESCRIPTION
## What this ships
Server-authoritative room mutations — closes both verified audit defects:
- **Privilege escalation / IDOR** — `firestore.rules` let any same-cohort participant write any room-doc field; role gates were CLIENT-ONLY. All 19 room-doc mutations now go through Admin-SDK Express endpoints that enforce the `ChatRoom`/`ActiveRoomManager` role gates server-side.
- **Seat-claim race** — `takeSeat`/`acceptInvite` were blind `update()`s. Now transactional with empty-seat + per-user-uniqueness preconditions (`409 SEAT_TAKEN` / `ALREADY_SEATED`).

## Commits (P1 server + P2 client cutover)
- `21d59a08bec` **P1 Chunk A** — seat lifecycle (claim / accept-invite / leave-seat)
- `8e4d7384a63` **P1 Chunk B** — moderation (kick / remove-seat / mute / +/- host)
- `469e896a843` **P1 Chunk C** — settings + lifecycle (name / require-approval / owner-away / owner-returned / close) + seat-move / join(ban-enforced) / decline-invite
- `5ff88312082` **P1 Chunk D** — leave-room / disconnect-user / first-join (closed a P2-scoping gap where these also wrote the room doc with no endpoint)
- `97a1e60ea82` **P2 Android** — `RoomRepositoryImpl` mutations → `api.{post,patch,delete}` via `WorkerApiClient`
- `31b25a2de83` **P2 iOS** — `IosRoomRepositoryImpl` mutations → `IosApiClient`; removed dead `clearUserFromRoom` / `clearUserSeatOnly` helpers

19 endpoints total. **Web is N/A** (no room-mutation code; voice rooms are app-only).

## Verification
- **Express:** 249 suites / 9567 passing (+147 new room-mutation tests, exhaustive `role × state × precondition × edge` + a code-review pass that surfaced & fixed C2 auth-before-idempotency and I1 owner-returned idempotency).
- **Android:** `RoomRepositoryImplTest` green, `compileDevDebugKotlin` (allWarningsAsErrors) clean, detekt clean.
- **iOS:** `compileKotlinIosArm64` + detekt clean (iosMain has no JVM tests; covered by the shared endpoint suite).
- **Live local-stack E2E** (verified on CPH2653 with full Docker stack + emulator):
  - All 19 routes correctly return `401` with no auth (smoke).
  - Auth middleware accepts real Firebase-emulator-signed tokens.
  - **Cohort gate** enforces OSA #17 isolation (`404` hidden on mismatch).
  - **Happy-path `claim`** writes `seats.3.userId/state/isMuted` + `allTimeSeatUserIds` correctly to emulator Firestore.
  - **Authz gate** enforces (host can't close `ACTIVE` → `403`).
  - **Happy-path `close`** (owner) → `state=CLOSED, closedAt, seats emptied, participantIds=[]`, `ownerLeftAt=null`.
- **Sonar quality gate passed** on push.

## Design + per-method migration map
Full brief on disk: `.project/plans/2026-05-28-room-mutations-p2-p3-migration.md`.

Key invariants kept: SELF `currentRoomId` writes stay client-side (own user doc); foreign `currentRoomId` clears moved server-side (`/close` clears all participants; `/disconnect-user` clears the evicted user); the kicked user self-clears via the existing room observer (no new server-side write needed there). `createRoom` stays a client create — `firestore.rules` will keep `allow create` (validated) and add `allow update: if false`.

## Gated — does NOT ship in this PR
- **P3 — `firestore.rules` lockdown** (operator checkpoint, high blast radius). Must deploy the migrated clients FIRST, then rules dev → soak → prod.
- **P4 — prod Express deploy** (operator checkpoint).

## Notes for the reviewer
- Sonar surfaced a pre-existing UTF-8 issue in `shared/src/jvmTest/kotlin/com/shyden/shytalk/core/model/SeatTest.kt:112` (invalid character) — unrelated to this change but worth a follow-up.
- `start.sh` builds the local APK with `localHostAlias=10.0.2.2` by default; physical-device dev needs `installLocalDebug -PlocalHost=localhost`. Worth a `start.sh` follow-up to detect physical devices and pass it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
