### PR TITLE
fix(rooms): /first-join must reject 409 on CLOSED rooms (state-machine gap)

### DIFF
--- a/express-api/src/routes/room-mutations.js
+++ b/express-api/src/routes/room-mutations.js
@@ -595,9 +595,12 @@ router.post('/rooms/:roomId/disconnect-user', async (req, res) => {
 
 // POST /rooms/:roomId/first-join — caller records THEIR OWN first-join time.
 // Self-scoped + set-once: writes firstJoinTimestamps[caller] only if absent, so
-// re-entry never overwrites the original timestamp.
+// re-entry never overwrites the original timestamp. Rejects 409 on CLOSED rooms
+// — the participation-timestamp record is conceptually a lifecycle-write and
+// must follow the same "no writes after CLOSE" invariant as /join, /name, etc.
 router.post('/rooms/:roomId/first-join', async (req, res) =>
   executeRoomMutation(req, res, 'Record first join', ({ room, t, roomRef, callerId }) => {
+    if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
     const already = Object.prototype.hasOwnProperty.call(room.firstJoinTimestamps || {}, callerId);
     if (already) return { status: 200, body: { success: true }, noop: true };
     t.update(roomRef, { [`firstJoinTimestamps.${callerId}`]: Date.now() });

--- a/express-api/tests/routes/room-mutations.test.js
+++ b/express-api/tests/routes/room-mutations.test.js
@@ -1562,6 +1562,18 @@ describe('POST /api/rooms/:roomId/first-join', () => {
     expect(res.status).toBe(404);
   });
 
+  test('409 when the room is CLOSED — no write to firstJoinTimestamps', async () => {
+    // Invariant: CLOSED rooms accept zero client writes. Pre-fix the handler
+    // had no state gate, so a post-CLOSE call would persist a participation
+    // timestamp on a dead room (stale-state leak). Other lifecycle/settings
+    // endpoints (/join, /name, /require-approval, /claim) already reject 409
+    // on CLOSED — this pin extends the same invariant to /first-join.
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED' })));
+    const res = await request(createApp(99)).post('/api/rooms/room-1/first-join').send({});
+    expect(res.status).toBe(409);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
   test('200 records a numeric first-join timestamp when absent', async () => {
     mockTxnGet.mockResolvedValue(snap(mkRoom()));
     const res = await request(createApp(99)).post('/api/rooms/room-1/first-join').send({});


### PR DESCRIPTION
## Problem
`POST /api/rooms/:roomId/first-join` had no `CLOSED`-state gate. Every other state-extending lifecycle endpoint in `room-mutations.js` (`/join`, `/name`, `/require-approval`, `/claim`, `/accept-invite`, `/seats/:i/move`, `/owner-away`, `/owner-returned`) returns `409` when the room is `CLOSED` — but `/first-join` would persist a participation timestamp on a dead room.

**Severity:** low (the room is already `CLOSED`, so the leaked timestamp is never read in production), but the invariant matters: **clients write zero state to a `CLOSED` room, ever**. Pre-fix, an attacker post-`CLOSE` could pollute `firstJoinTimestamps` with arbitrary `participant_id → timestamp` pairs.

## How it was found
QA-matrix audit pass for **Task #8 — "Backlog: deepen tests / QA-matrix pass"**, per the [feedback-zero-gap-qa-mindset-everywhere] memory rule. A `CLOSED × endpoint` cross-cut revealed the gap. Full audit + queued follow-up PRs documented in [`.project/test-plans/exhaustive/2026-05-28-room-mutations-qa-matrix.md`](https://github.com/ShydenMcM/ShyTalk/blob/main/.project/test-plans/exhaustive/2026-05-28-room-mutations-qa-matrix.md) (filed in PR B).

## Fix
- `room-mutations.js`: insert `if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };` at the top of the `/first-join` handler body — before the idempotency check — so a CLOSED-state callback is rejected even when the caller already has a stored timestamp.

## Tests (TDD)
- New test in `room-mutations.test.js`: `'409 when the room is CLOSED — no write to firstJoinTimestamps'`.
- Mirrors the existing CLOSED-pin pattern from `/name`, `/require-approval`, `/claim`, `/join`.
- Asserts both the `409` status AND that `mockTxnUpdate` is never called.
- **Red → green confirmed locally**: pre-fix the new test got `200` (bug confirmed). Post-fix `151/151` pass.

## Follow-ups (queued)
- PR B: exhaustive matrix doc in `.project/test-plans/exhaustive/` (companion to this PR).
- PR C: pin `200`-cleanup behaviour on CLOSED for self-removal endpoints (`/leave`, `/decline-invite`, `/seats/:i/leave`, `/hosts DELETE`).
- PR D: pin existing CLOSED gate of `/accept-invite` (impl already gated, no test pin).
- PR E (operator-gated): add CLOSED gates to `/kick`, `/hosts POST`, `/seats/:i/mute` — semantic design decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)