### PR TITLE
test(rooms): pin 200-cleanup-on-CLOSED for 4 self-targeted endpoints

### DIFF
--- a/express-api/tests/routes/room-mutations.test.js
+++ b/express-api/tests/routes/room-mutations.test.js
@@ -300,6 +300,30 @@ describe('POST /api/rooms/:roomId/seats/:seatIndex/leave', () => {
     expect(res.status).toBe(403);
     expect(mockTxnUpdate).not.toHaveBeenCalled();
   });
+
+  test('200 CLOSED-room cleanup: caller can still vacate their own seat after close', async () => {
+    // CLEANUP-ON-CLOSED invariant: self-targeted vacate endpoints stay
+    // available on CLOSED rooms so a client recovering from a crash/disconnect
+    // can drop its stale seat occupancy. Distinct from state-extending writes
+    // (/join, /name, /first-join, /claim) which 409 on CLOSED. Documenting
+    // INTENTIONAL design — changing /seats/:seatIndex/leave to reject CLOSED
+    // would break crash-recovery flows where the room transitioned to CLOSED
+    // between the client's last state read and its self-vacate retry.
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          state: 'CLOSED',
+          seats: { 3: { userId: '10', state: 'OCCUPIED', isMuted: false } },
+        }),
+      ),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/seats/3/leave').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({ 'seats.3.userId': null, 'seats.3.state': 'EMPTY' }),
+    );
+  });
 });
 
 describe('POST /api/rooms/:roomId/kick', () => {
@@ -502,6 +526,21 @@ describe('POST /api/rooms/:roomId/hosts (add) + DELETE .../hosts/:userId (remove
 
   test('200 owner demotes a host', async () => {
     mockTxnGet.mockResolvedValue(snap(mkRoom()));
+    const res = await request(createApp(1)).delete('/api/rooms/room-1/hosts/10').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({ hostIds: { __arrayRemove: ['10'] } }),
+    );
+  });
+
+  test('200 CLOSED-room cleanup: owner can still demote a host after close', async () => {
+    // CLEANUP-ON-CLOSED invariant: host removal is a role-clearing cleanup
+    // (mirror of /seats/:i/leave for seat occupancy). Documents intentional
+    // design — the inverse `/hosts POST` (promotion) is a state-extending
+    // write and is queued for a separate operator-gated PR to add a CLOSED
+    // gate.
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED' })));
     const res = await request(createApp(1)).delete('/api/rooms/room-1/hosts/10').send({});
     expect(res.status).toBe(200);
     expect(mockTxnUpdate).toHaveBeenCalledWith(
@@ -1180,6 +1219,21 @@ describe('POST /api/rooms/:roomId/decline-invite', () => {
     expect(mockTxnUpdate).not.toHaveBeenCalled();
   });
 
+  test('200 CLOSED-room cleanup: caller can still decline their pending invite after close', async () => {
+    // CLEANUP-ON-CLOSED invariant: declining is a self-targeted cleanup of
+    // the caller's own pendingInvites entry. The /close endpoint does NOT
+    // clear pendingInvites server-side, so a client that received an invite
+    // before the room closed can still cleanly decline post-close. Documents
+    // intentional design — pairs with /seats/:i/leave and /hosts DELETE
+    // pins.
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED', pendingInvites: { 50: '10' } })));
+    const res = await request(createApp(50)).post('/api/rooms/room-1/decline-invite').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(mockRoomRef, {
+      'pendingInvites.50': { __delete: true },
+    });
+  });
+
   test('500 when the transaction throws', async () => {
     mockTxnGet.mockRejectedValue(new Error('boom'));
     const res = await request(createApp(50)).post('/api/rooms/room-1/decline-invite').send({});
@@ -1393,6 +1447,32 @@ describe('POST /api/rooms/:roomId/leave', () => {
     expect(res.status).toBe(200);
     expect(mockTxnUpdate).not.toHaveBeenCalled();
     expect(mockRtdbSet).not.toHaveBeenCalled();
+  });
+
+  test('200 CLOSED-room cleanup: caller can still leave after close', async () => {
+    // CLEANUP-ON-CLOSED invariant: room-leave is a self-targeted cleanup
+    // (caller removing themselves from participantIds + own seat). Mirrors
+    // /seats/:i/leave + /decline-invite + /hosts DELETE pins — the universal
+    // post-CLOSE allowance is "drop your own state, never extend the room's".
+    // Documents intentional design.
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          state: 'CLOSED',
+          seats: { 3: { userId: '10', state: 'OCCUPIED', isMuted: false } },
+        }),
+      ),
+    );
+    const res = await request(createApp(10)).post('/api/rooms/room-1/leave').send({});
+    expect(res.status).toBe(200);
+    expect(mockTxnUpdate).toHaveBeenCalledWith(
+      mockRoomRef,
+      expect.objectContaining({
+        participantIds: { __arrayRemove: ['10'] },
+        'seats.3.userId': null,
+        'seats.3.state': 'EMPTY',
+      }),
+    );
   });
 
   test('500 when the transaction throws', async () => {


### PR DESCRIPTION
## What this pins
4 self-targeted cleanup endpoints intentionally accept writes on a `CLOSED` room but had **no test pinning that behaviour**. Without an explicit pin, a future contributor could mistakenly add a "consistent CLOSED gate" that breaks crash-recovery flows — clients self-removing stale state after the room transitioned to `CLOSED` between their last read and their retry.

## The CLEANUP-ON-CLOSED invariant being documented
- **self-targeted vacate / decline / demote** endpoints stay `200` on `CLOSED`
- this is distinct from state-extending writes (`/join`, `/name`, `/first-join`, `/claim`, `/accept-invite`, `/seats/:i/move`, `/owner-away`, `/owner-returned`) which `409` on `CLOSED` — those gates already had test pins

## Endpoints pinned (4 new tests, no impl change)
| Endpoint | Cleanup semantics | Pin assertion |
| --- | --- | --- |
| `POST /api/rooms/:roomId/seats/:seatIndex/leave` | caller vacates own seat | 200 + `seats.{i}.userId/state=EMPTY` write |
| `POST /api/rooms/:roomId/leave` | caller leaves room | 200 + `participantIds arrayRemove` + seat cleared |
| `POST /api/rooms/:roomId/decline-invite` | caller declines own invite | 200 + `pendingInvites.{caller} delete` |
| `DELETE /api/rooms/:roomId/hosts/:userId` | owner demotes host | 200 + `hostIds arrayRemove` |

Each test mirrors the existing happy-path test's assertion shape (specific Firestore write expectation), so a regression that drops the cleanup write fails the test, not just a status-code change.

## What is intentionally NOT pinned here
The inverse state-extending endpoints (`/hosts POST add`, `/kick`, `/seats/:i/mute`, `/disconnect-user`) are NOT pinned in this PR. Semantically they probably SHOULD reject `CLOSED` but the change is a design decision queued for an **operator-gated PR** (matrix-doc row E, see `.project/test-plans/exhaustive/2026-05-28-room-mutations-qa-matrix.md`).

## Companion to
- PR #860 — `fix(rooms): /first-join 409 on CLOSED` (the real-bug-fix that surfaced this audit). Same QA-matrix pass.
- (Local) `.project/test-plans/exhaustive/2026-05-28-room-mutations-qa-matrix.md` — the matrix doc tracking which gaps remain.

## Tests
Full file: **154/154 pass** (was 150 + 4 new = 154). Branch is off `origin/main` (pre-#860); after #860 merges, both diffs are additive and live in disjoint describe blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)