### PR TITLE
fix(rooms): CLOSED gate on 4 state-extending endpoints (/kick, /hosts POST, /seats/:i/mute, /disconnect-user)

### DIFF
--- a/express-api/src/routes/room-mutations.js
+++ b/express-api/src/routes/room-mutations.js
@@ -211,6 +211,12 @@ router.post('/rooms/:roomId/kick', async (req, res) => {
     if (!canKickUser(room, callerId, targetId)) {
       return { status: 403, body: { error: 'Not allowed to kick this user' } };
     }
+    // CLOSED gate positioned AFTER the role check (info-hiding): unprivileged
+    // callers still see 403 regardless of room state, so an attacker cannot
+    // probe CLOSED state by switching between role-lacking and privileged
+    // accounts. Kicking a user from a dead room is a state-extending write
+    // (the ban persists in bannedUserIds) and must be rejected.
+    if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
     const update = {
       bannedUserIds: FieldValue.arrayUnion(targetId),
       participantIds: FieldValue.arrayRemove(targetId),
@@ -253,6 +259,12 @@ router.patch('/rooms/:roomId/seats/:seatIndex/mute', async (req, res) => {
   }
   const { isMuted } = req.body;
   return executeRoomMutation(req, res, 'Mute toggle', ({ room, t, roomRef, callerId }) => {
+    // CLOSED gate fires FIRST — before the seat-empty probe. Otherwise an
+    // attacker could compare the seat-empty 409 vs seat-occupied 200/403
+    // responses to learn the room's seat state after CLOSE. Muting in a dead
+    // room is also a state-extending write (`seats.{i}.isMuted` persists on
+    // a room nobody can hear).
+    if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
     const seat = (room.seats || {})[String(seatIndex)] || {};
     if (!seat.userId) return { status: 409, body: { error: 'Seat is empty' } };
     if (isMuted) {
@@ -280,6 +292,10 @@ router.post('/rooms/:roomId/hosts', async (req, res) => {
     if (String(targetId) === String(room.ownerId)) {
       return { status: 400, body: { error: 'Owner is not a host' } };
     }
+    // CLOSED gate positioned AFTER role + input checks (info-hiding for the
+    // role probe). Promoting a host of a dead room is a state-extending write
+    // — the host role persists on a room whose lifecycle is over.
+    if (room.state === 'CLOSED') return { status: 409, body: { error: 'Room is closed' } };
     t.update(roomRef, {
       hostIds: FieldValue.arrayUnion(targetId),
       allTimeHostIds: FieldValue.arrayUnion(targetId),
@@ -552,6 +568,12 @@ router.post('/rooms/:roomId/disconnect-user', async (req, res) => {
     if (cohortFromClaim(req) !== (preRoom.cohort ?? 'minor')) {
       return res.status(404).json({ error: 'Not found' });
     }
+    // CLOSED gate fires HERE — after the cohort check, before the RTDB
+    // presence read. Saves a roundtrip on a CLOSED room and avoids leaking
+    // RTDB error behaviour for a state that no longer matters. Disconnecting
+    // from a dead room is a state-extending write (clears the target's
+    // `currentRoomId` on a room nobody can rejoin).
+    if (preRoom.state === 'CLOSED') return res.status(409).json({ error: 'Room is closed' });
     const targetPresent = await isUserPresent(roomId, targetId);
 
     const result = await db.runTransaction(async (t) => {

--- a/express-api/tests/routes/room-mutations.test.js
+++ b/express-api/tests/routes/room-mutations.test.js
@@ -450,6 +450,20 @@ describe('POST /api/rooms/:roomId/kick', () => {
     expect(update.bannedUserIds).toEqual({ __arrayUnion: ['99'] });
     expect(Object.keys(update).some((k) => k.startsWith('seats.'))).toBe(false);
   });
+
+  test('409 when the room is CLOSED — gate fires AFTER role check (info-hiding ordering)', async () => {
+    // The CLOSED gate is positioned AFTER the canKickUser role check so an
+    // unprivileged caller still sees 403 regardless of room state — preventing
+    // a state-probe by switching between role-lacking and privileged accounts.
+    // This test uses the OWNER (uid=1) to clear the role gate and isolate the
+    // CLOSED branch. Kicking a user from a dead room is a state-extending write
+    // (the ban persists in bannedUserIds) so CLOSED rooms must reject it,
+    // matching the universal invariant from the matrix doc.
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED' })));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/kick').send({ userId: '99' });
+    expect(res.status).toBe(409);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
 });
 
 describe('POST /api/rooms/:roomId/seats/:seatIndex/remove', () => {
@@ -556,6 +570,30 @@ describe('PATCH /api/rooms/:roomId/seats/:seatIndex/mute', () => {
       expect.objectContaining({ 'seats.4.isMuted': false }),
     );
   });
+
+  test('409 when the room is CLOSED — gate fires BEFORE seat-empty probe', async () => {
+    // The CLOSED gate sits at the top of the handler — before the seat-empty
+    // 409 branch — so an attacker cannot probe "is seat N still occupied in
+    // that dead room?" by comparing the error message between empty vs
+    // occupied seats. The test uses an OCCUPIED seat (so the write would
+    // otherwise succeed, 200) to prove the CLOSED gate fires before any
+    // state-read or write — masking occupancy state from the caller.
+    // Muting in a dead room is a state-extending write (it persists
+    // `seats.{i}.isMuted` on a room nobody can hear).
+    mockTxnGet.mockResolvedValue(
+      snap(
+        mkRoom({
+          state: 'CLOSED',
+          seats: { 4: { userId: '99', state: 'OCCUPIED', isMuted: false } },
+        }),
+      ),
+    );
+    const res = await request(createApp(1))
+      .patch('/api/rooms/room-1/seats/4/mute')
+      .send({ isMuted: true });
+    expect(res.status).toBe(409);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
 });
 
 describe('POST /api/rooms/:roomId/hosts (add) + DELETE .../hosts/:userId (remove)', () => {
@@ -589,6 +627,19 @@ describe('POST /api/rooms/:roomId/hosts (add) + DELETE .../hosts/:userId (remove
     );
   });
 
+  test('409 when the room is CLOSED on POST add — gate fires AFTER owner-role check', async () => {
+    // The CLOSED gate is positioned AFTER the owner-role 403 check + AFTER the
+    // owner-is-not-a-host 400 sanity, so unprivileged callers still see their
+    // 403 regardless of room state (info-hiding). Owner caller (uid=1) clears
+    // the role gate; target uid=99 is a regular participant, not the owner.
+    // Promoting a host of a dead room is a state-extending write — the host
+    // role persists on a room whose lifecycle is over.
+    mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED' })));
+    const res = await request(createApp(1)).post('/api/rooms/room-1/hosts').send({ userId: '99' });
+    expect(res.status).toBe(409);
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+  });
+
   test('403 when a non-owner tries to remove a host', async () => {
     mockTxnGet.mockResolvedValue(snap(mkRoom({ hostIds: ['10', '55'] })));
     const res = await request(createApp(10)).delete('/api/rooms/room-1/hosts/55').send({});
@@ -609,8 +660,7 @@ describe('POST /api/rooms/:roomId/hosts (add) + DELETE .../hosts/:userId (remove
     // CLEANUP-ON-CLOSED invariant: host removal is a role-clearing cleanup
     // (mirror of /seats/:i/leave for seat occupancy). Documents intentional
     // design — the inverse `/hosts POST` (promotion) is a state-extending
-    // write and is queued for a separate operator-gated PR to add a CLOSED
-    // gate.
+    // write and gets a CLOSED gate in this same PR (test above).
     mockTxnGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED' })));
     const res = await request(createApp(1)).delete('/api/rooms/room-1/hosts/10').send({});
     expect(res.status).toBe(200);
@@ -1696,6 +1746,29 @@ describe('POST /api/rooms/:roomId/disconnect-user', () => {
       .post('/api/rooms/room-1/disconnect-user')
       .send({ userId: '99' });
     expect(res.status).toBe(500);
+  });
+
+  test('409 when the room is CLOSED — pre-read short-circuit (no RTDB, no txn, no user-doc clear)', async () => {
+    // The CLOSED gate sits BETWEEN the cohort gate on preRoom and the
+    // isUserPresent() RTDB roundtrip. Three not-called assertions isolate the
+    // short-circuit:
+    //   - mockRtdbGet not called → the presence read was skipped (saved roundtrip)
+    //   - mockTxnGet not called → the transaction was never entered
+    //   - mockDocSet not called → the post-txn currentRoomId clear didn't fire
+    // The mockDocSet pin specifically guards against a future refactor that
+    // moves the user-doc clear ahead of the txn (which would silently break
+    // the 409 path's "no state writes" invariant). Disconnecting a user from
+    // a dead room is a state-extending write — clearing currentRoomId mutates
+    // the target user's doc based on a room that no longer matters.
+    mockDocGet.mockResolvedValue(snap(mkRoom({ state: 'CLOSED' })));
+    const res = await request(createApp(10))
+      .post('/api/rooms/room-1/disconnect-user')
+      .send({ userId: '99' });
+    expect(res.status).toBe(409);
+    expect(mockRtdbGet).not.toHaveBeenCalled();
+    expect(mockTxnGet).not.toHaveBeenCalled();
+    expect(mockTxnUpdate).not.toHaveBeenCalled();
+    expect(mockDocSet).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## PR E in the QA-matrix sequence

Closes the cleanup-vs-extend CLOSED invariant on the 4 endpoints that previously returned 200 on a CLOSED room. Each is a state-extending write that should match the universal "no client writes after CLOSE" pattern enforced by `/join`, `/name`, `/first-join`, `/claim`, `/accept-invite`, `/seats/:i/move`, `/owner-away`, `/owner-returned`.

| Endpoint | Operation | Why current 200 was wrong |
| --- | --- | --- |
| `POST /rooms/:roomId/kick` | Add to `bannedUserIds`, remove from `participantIds` | Ban persists on a dead room |
| `PATCH /rooms/:roomId/seats/:i/mute` | Set `seats.{i}.isMuted` | Mute state persists on a room nobody can hear |
| `POST /rooms/:roomId/hosts` | Add to `hostIds` | Host role persists on a dead room |
| `POST /rooms/:roomId/disconnect-user` | Remove from `participantIds`, clear seat, clear foreign user-doc `currentRoomId` | State-extending writes against a room nobody can rejoin |

## Architect-validated ordering

Each gate is positioned at a specific point to preserve security invariants:

- **`/kick`** — gate **AFTER** the `canKickUser` 403 check (info-hiding: unprivileged callers still see 403 regardless of room state).
- **`/seats/:i/mute`** — gate **BEFORE** the seat-empty 409 check (prevents attacker probing seat occupancy via differential responses on a dead room).
- **`/hosts POST`** — gate **AFTER** the owner-role 403 + owner-is-not-a-host 400 (same info-hiding rationale).
- **`/disconnect-user`** — gate on `preRoom` **AFTER** the cohort check, **BEFORE** the `isUserPresent()` RTDB roundtrip (saves the network call + avoids leaking RTDB error behaviour for a state that no longer matters).

## Tests (4 new, TDD red → green, file 164/164)

Each new test follows the established CLOSED-test pattern in this file and includes the specific isolation assertions the architect recommended:

- **`/disconnect-user`** test asserts FOUR not-called pins (`mockRtdbGet`, `mockTxnGet`, `mockTxnUpdate`, `mockDocSet`) — the `mockDocSet` pin specifically guards against a future refactor that moves the user-doc clear ahead of the txn (would silently break the no-state-writes-on-409 invariant).
- **`/seats/:i/mute`** test uses an OCCUPIED seat so the write would otherwise succeed — proves the CLOSED gate fires before any state-read.
- Also updates the now-stale "queued for separate PR" comment on the existing `/hosts DELETE` CLOSED-cleanup test (PR #861) to cross-reference this PR's new `/hosts POST` test.

## Quality loop (per operator's "always run the full loop")

- ✅ 3 alternatives explored (A: inline / B: shared helper / C: gate-in-executeRoomMutation-with-opt-out)
- ✅ `feature-dev:code-architect` agent validated Alternative A (matches existing inline pattern; B introduces new abstraction in file using direct guards; C alters well-tested helper for 16 handlers with huge regression surface)
- ✅ TDD red → green confirmed locally (4 tests fail pre-impl, pass post-impl)
- ✅ `code-reviewer` agent: 1 wording fix in `/mute` test comment (corrected inline), 1 pre-existing iOS coverage gap (no `IosRoomRepositoryImpl` tests exist anywhere — system-wide infra gap — scoped to immediate follow-up PR per [feedback-fix-pre-existing-and-new-same] rule)

## What this does NOT do

- **TOCTOU window** (room closes between `/disconnect-user` pre-read and txn) is intentionally NOT closed. The pre-read gate eliminates the routine case; the txn-re-read window remains pre-existing across all hand-rolled handlers. Tracked for a future "state-machine race hardening" PR per architect recommendation.
- **No `code: 'ROOM_CLOSED'` field added** — would require a 9-site sweep with no client-side consumer; defer to a future PR if/when client retry logic needs it.

## Follow-up queued this session (per the matrix doc)

- **PR F** — `IosRoomRepositoryImpl` test scaffolding (closes reviewer's I2 — no iOS repository tests exist anywhere). Needs iosTest source-set setup, 2-4hr scope.
- **PR G** — VM-layer `Resource<Unit>` handling for 409 on kick/mute/host/disconnect (closes reviewer's I3 — pre-existing fire-and-forget pattern). Likely operator-gated since it's a UX design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)