### PR TITLE
test(shared): pin firebaseCall wrapper contract + fix empty-message fallback (closes PR #863 reviewer I2)

### DIFF
--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/FirebaseCall.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/FirebaseCall.kt
@@ -21,5 +21,9 @@ suspend inline fun <T> firebaseCall(
         throw e
     } catch (e: Exception) {
         logE("firebaseCall", errorMessage, e)
-        Resource.Error(e.message ?: errorMessage, e)
+        // Fall back to `errorMessage` when the exception's own message is null OR
+        // empty. A bare `?:` only catches null, but an empty-string message gives
+        // the user no actionable information either — so empty must also fall back
+        // to the call-site's descriptive errorMessage (e.g. "Failed to kick user").
+        Resource.Error(e.message?.takeIf { it.isNotEmpty() } ?: errorMessage, e)
     }

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/FirebaseCallTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/FirebaseCallTest.kt
@@ -14,16 +14,9 @@ import kotlin.test.fail
  * repository uses to convert thrown exceptions into [Resource.Error] and
  * non-throwing results into [Resource.Success].
  *
- * Why test the wrapper rather than each repo method individually: every
- * repository in the codebase (`RoomRepositoryImpl` on Android,
- * `IosRoomRepositoryImpl` on iOS, `IosUserRepositoryImpl`, …) routes through
- * `firebaseCall`, so the error-mapping contract proven here applies
- * uniformly — including the 409 → Resource.Error path that PR E surfaced
- * via the new CLOSED gates on `/kick`, `/seats/:i/mute`, `/hosts POST`,
- * `/disconnect-user`. Per the code-reviewer agent's I2 finding on PR #863:
- * "the iOS client path to surface those errors (via firebaseCall →
- * Resource.Error) is untested on iOS" — closing the systemic gap here is
- * the minimum-viable closure for that finding.
+ * The wrapper is in commonMain and is exercised here from commonTest so the
+ * contract is verified for both Android and iOS targets without requiring
+ * platform-specific test infrastructure.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class FirebaseCallTest {
@@ -55,6 +48,18 @@ class FirebaseCallTest {
             val result = firebaseCall { "room-abc-123" }
             assertTrue(result is Resource.Success, "expected Success, got $result")
             assertEquals("room-abc-123", result.data)
+        }
+
+    @Test
+    fun `success path handles null return for nullable T`() =
+        runTest {
+            // Some repository methods return `Resource<T?>` where the block
+            // legitimately returns null (e.g. "lookup a user that may not exist").
+            // The wrapper must propagate null through Resource.Success(null), NOT
+            // convert it to Resource.Error or short-circuit.
+            val result: Resource<String?> = firebaseCall { null }
+            assertTrue(result is Resource.Success, "expected Success, got $result")
+            assertEquals(null, result.data)
         }
 
     // ── Error path: exception with a message ───────────────────────────
@@ -96,6 +101,22 @@ class FirebaseCallTest {
             assertEquals("Failed to kick user", result.message)
         }
 
+    @Test
+    fun `exception with empty string message also falls back to the errorMessage`() =
+        runTest {
+            // A bare `?:` operator only catches `null`, not empty string.
+            // An empty exception message gives the user no actionable info,
+            // so empty must also fall back to the call-site's descriptive
+            // errorMessage. The production fix uses `?.takeIf { it.isNotEmpty() } ?:`
+            // to handle both null and empty cases uniformly.
+            val result =
+                firebaseCall<Unit>(errorMessage = "Failed to kick user") {
+                    throw RuntimeException("")
+                }
+            assertTrue(result is Resource.Error, "expected Error, got $result")
+            assertEquals("Failed to kick user", result.message)
+        }
+
     // ── Error path: original exception preserved ───────────────────────
 
     @Test
@@ -113,21 +134,38 @@ class FirebaseCallTest {
     // ── Structured concurrency: CancellationException rethrows ─────────
 
     @Test
-    fun `CancellationException is rethrown unchanged (structured concurrency)`() =
+    fun `CancellationException is rethrown as the exact same instance (structured concurrency)`() =
         runTest {
             // Swallowing CancellationException breaks coroutine cancellation
             // propagation — a scope canceller would never get its cancel signal.
-            // The wrapper's contract is to RETHROW it verbatim, NOT convert
-            // to Resource.Error.
+            // The wrapper's contract is to RETHROW it verbatim (same instance,
+            // not a wrapper), NOT convert to Resource.Error.
+            val original = CancellationException("user-cancelled")
             try {
-                firebaseCall<Unit> { throw CancellationException("user-cancelled") }
+                firebaseCall<Unit> { throw original }
                 fail("expected CancellationException to propagate, but firebaseCall returned normally")
             } catch (e: CancellationException) {
-                assertEquals("user-cancelled", e.message)
+                assertSame(original, e, "rethrown exception must be the exact same instance")
             }
         }
 
     // ── Generic exception types ────────────────────────────────────────
+
+    @Test
+    fun `non-Exception Error subtypes (OutOfMemoryError, etc) propagate uncaught — not converted to Resource Error`() =
+        runTest {
+            // The catch on `Exception` is deliberately narrower than `Throwable`:
+            // fatal JVM errors (OOM, stack overflow, etc.) should crash the
+            // coroutine rather than be silently wrapped. This test pins that
+            // intentional catch boundary — a future "let me catch Throwable
+            // instead" change would now be a deliberate, reviewable diff.
+            try {
+                firebaseCall<Unit> { throw OutOfMemoryError("test OOM") }
+                fail("expected OutOfMemoryError to propagate uncaught, but firebaseCall returned normally")
+            } catch (e: OutOfMemoryError) {
+                assertEquals("test OOM", e.message)
+            }
+        }
 
     @Test
     fun `wrapper handles arbitrary Exception subtypes (IllegalStateException, IllegalArgumentException, etc)`() =

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/FirebaseCallTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/FirebaseCallTest.kt
@@ -1,0 +1,151 @@
+package com.shyden.shytalk.core.util
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Tests for [firebaseCall] — the generic suspend-wrapper that every
+ * repository uses to convert thrown exceptions into [Resource.Error] and
+ * non-throwing results into [Resource.Success].
+ *
+ * Why test the wrapper rather than each repo method individually: every
+ * repository in the codebase (`RoomRepositoryImpl` on Android,
+ * `IosRoomRepositoryImpl` on iOS, `IosUserRepositoryImpl`, …) routes through
+ * `firebaseCall`, so the error-mapping contract proven here applies
+ * uniformly — including the 409 → Resource.Error path that PR E surfaced
+ * via the new CLOSED gates on `/kick`, `/seats/:i/mute`, `/hosts POST`,
+ * `/disconnect-user`. Per the code-reviewer agent's I2 finding on PR #863:
+ * "the iOS client path to surface those errors (via firebaseCall →
+ * Resource.Error) is untested on iOS" — closing the systemic gap here is
+ * the minimum-viable closure for that finding.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FirebaseCallTest {
+    // ── Success path ───────────────────────────────────────────────────
+
+    @Test
+    fun `success returns Resource Success with the block's value`() =
+        runTest {
+            val result = firebaseCall { 42 }
+            assertTrue(result is Resource.Success, "expected Success, got $result")
+            assertEquals(42, result.data)
+        }
+
+    @Test
+    fun `success path works for Unit returns (fire-and-forget repository methods)`() =
+        runTest {
+            // Every mutation method in IosRoomRepositoryImpl + RoomRepositoryImpl
+            // returns Resource<Unit>; the wrapper must hand back Resource.Success(Unit).
+            // The lambda body intentionally has no statements — it implicitly returns
+            // Unit, which is what we want to assert is propagated through.
+            val result: Resource<Unit> = firebaseCall { }
+            assertTrue(result is Resource.Success, "expected Success, got $result")
+            assertEquals(Unit, result.data)
+        }
+
+    @Test
+    fun `success path works for String returns (e g  ID-returning create methods)`() =
+        runTest {
+            val result = firebaseCall { "room-abc-123" }
+            assertTrue(result is Resource.Success, "expected Success, got $result")
+            assertEquals("room-abc-123", result.data)
+        }
+
+    // ── Error path: exception with a message ───────────────────────────
+
+    @Test
+    fun `exception with a message converts to Resource Error with that message`() =
+        runTest {
+            val result = firebaseCall<Unit> { throw RuntimeException("Room is closed") }
+            assertTrue(result is Resource.Error, "expected Error, got $result")
+            assertEquals("Room is closed", result.message)
+        }
+
+    // ── Error path: null exception message → default / custom errorMessage ──
+
+    @Test
+    fun `exception with null message falls back to the default errorMessage`() =
+        runTest {
+            // Mirrors the production contract: when an underlying library throws
+            // with a null .message (some Firebase SDKs do this on dropped txns),
+            // the wrapper's default "Operation failed" must surface so the user
+            // sees SOMETHING instead of an empty string.
+            val result = firebaseCall<Unit> { throw RuntimeException() }
+            assertTrue(result is Resource.Error, "expected Error, got $result")
+            assertEquals("Operation failed", result.message)
+        }
+
+    @Test
+    fun `exception with null message uses the custom errorMessage parameter`() =
+        runTest {
+            // Each repository call site passes its own descriptive errorMessage
+            // ("Failed to kick user", "Failed to add host", etc.) so the user-
+            // facing error is actionable even when the underlying exception is
+            // anonymous. This pins that contract.
+            val result =
+                firebaseCall<Unit>(errorMessage = "Failed to kick user") {
+                    throw RuntimeException()
+                }
+            assertTrue(result is Resource.Error, "expected Error, got $result")
+            assertEquals("Failed to kick user", result.message)
+        }
+
+    // ── Error path: original exception preserved ───────────────────────
+
+    @Test
+    fun `the original exception instance is preserved on Resource Error exception field`() =
+        runTest {
+            // Sentry / logcat upstream relies on the original Throwable for
+            // stack-trace symbolication; the wrapper MUST NOT replace it with
+            // a synthetic exception.
+            val original = IllegalStateException("specific cause")
+            val result = firebaseCall<Unit> { throw original }
+            assertTrue(result is Resource.Error, "expected Error, got $result")
+            assertSame(original, result.exception, "wrapper must keep the original throwable")
+        }
+
+    // ── Structured concurrency: CancellationException rethrows ─────────
+
+    @Test
+    fun `CancellationException is rethrown unchanged (structured concurrency)`() =
+        runTest {
+            // Swallowing CancellationException breaks coroutine cancellation
+            // propagation — a scope canceller would never get its cancel signal.
+            // The wrapper's contract is to RETHROW it verbatim, NOT convert
+            // to Resource.Error.
+            try {
+                firebaseCall<Unit> { throw CancellationException("user-cancelled") }
+                fail("expected CancellationException to propagate, but firebaseCall returned normally")
+            } catch (e: CancellationException) {
+                assertEquals("user-cancelled", e.message)
+            }
+        }
+
+    // ── Generic exception types ────────────────────────────────────────
+
+    @Test
+    fun `wrapper handles arbitrary Exception subtypes (IllegalStateException, IllegalArgumentException, etc)`() =
+        runTest {
+            // Mirrors the wide range of exception types Firebase / ApiException
+            // can throw in production — the catch must be on Exception broadly,
+            // not narrowly typed.
+            val cases =
+                listOf(
+                    IllegalStateException("state"),
+                    IllegalArgumentException("arg"),
+                    NoSuchElementException("element"),
+                )
+            for (e in cases) {
+                val result = firebaseCall<Unit> { throw e }
+                assertTrue(result is Resource.Error, "expected Error for $e, got $result")
+                assertEquals(e.message, result.message)
+                assertSame(e, result.exception, "expected same instance for $e")
+            }
+        }
+}


### PR DESCRIPTION
## PR F in the QA-matrix sequence — closes [PR #863](https://github.com/ShydenMcM/ShyTalk/pull/863)'s reviewer I2

PR #863's code-reviewer agent flagged Important finding I2: "the iOS client path to surface those errors (via firebaseCall → Resource.Error) is untested on iOS". Per [feedback-fix-pre-existing-and-new-same.md], pre-existing systemic gaps surfaced in review must be fixed in a follow-up PR THIS session — this is that PR.

## Strategy

The closure tests the generic `firebaseCall` wrapper rather than each iOS repository method:
- `firebaseCall` is in `commonMain` (testable from `commonTest` without iOS-specific infra)
- Every repo (`RoomRepositoryImpl` Android, `IosRoomRepositoryImpl`, `IosUserRepositoryImpl`) routes through it
- Per-iOS-method tests would require a new `iosTest` source-set + KMP test-runner config (2-4 hr scope) — queued for a separate PR

## What changed

**`shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/FirebaseCall.kt`** — 1 production fix (I1 from PR F's own reviewer pass — see "Reviewer findings addressed" below):

```diff
-Resource.Error(e.message ?: errorMessage, e)
+Resource.Error(e.message?.takeIf { it.isNotEmpty() } ?: errorMessage, e)
```

A bare `?:` only catches null, not empty-string. An empty exception message gives the user no actionable info — same as null — so the call-site's descriptive `errorMessage` must also fire on empty.

**`shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/FirebaseCallTest.kt`** — **NEW file, 12 tests** pinning every branch of the wrapper contract.

## Tests (12 total)

| # | Test | Pins |
| --- | --- | --- |
| 1 | success with Int return | wrapper is generic over T |
| 2 | success with Unit return | Resource.Success(Unit) for fire-and-forget repo methods |
| 3 | success with String return | wrapper propagates non-primitive types |
| 4 | success with null T return | `Resource<T?>` supports null block result |
| 5 | error with message | exception.message propagated verbatim |
| 6 | null .message + default errorMessage | `"Operation failed"` fallback |
| 7 | null .message + custom errorMessage | call-site message used |
| 8 | **empty-string .message + custom errorMessage** | I1 production fix pinned |
| 9 | original exception preserved on Resource.Error.exception | Sentry / logcat stack-trace symbolication |
| 10 | CancellationException rethrown — same instance (`assertSame`) | structured concurrency identity-preservation |
| 11 | **OutOfMemoryError propagates uncaught** | deliberate catch-on-Exception boundary pinned |
| 12 | arbitrary Exception subtypes (ISE, IAE, NSEE) | catch is on Exception broadly, not narrowly typed |

## Quality loop (per operator's "always run full loop")

- ✅ Alternatives explored: (A) test wrapper / (B) per-iOS-method tests / (C) both
- ✅ Chose A as minimum-viable closure of reviewer I2; B queued for future iosTest infra PR
- ✅ TDD: tests pass against existing FirebaseCall.kt — no impl change needed for the wrapper contract itself (the I1 production fix was a genuine bug surfaced by testing)
- ✅ `code-reviewer` agent pass 1: 5 findings (I1 / I2 / I3 + M3 + M4)
- ✅ All 5 fixed in second commit on this branch
- ✅ `code-reviewer` agent pass 2: VERDICT: ship (zero findings, all 5 confirmed closed, no new findings introduced by fixes)

## Reviewer findings addressed in 2nd commit

- **I1** (Important — real bug): empty-string exception message passes through `?:` and becomes a useless empty Resource.Error.message. **Fixed in production** with `?.takeIf { it.isNotEmpty() } ?:`, new test pinning the new behaviour.
- **I2** (Important): non-Exception Error subtypes (OOM, SOF) propagation untested. New test pins the intentional catch-on-Exception boundary.
- **I3** (Important): nullable T null-return untested. New test for `Resource<String?>` block returning null.
- **M3** (Minor): CancellationException rethrow assertion tightened from message-equality to instance-equality via `assertSame`.
- **M4** (Minor): class-level KDoc trimmed to remove PR-E-specific references.

## Commits

Two commits — first adds the 9 initial tests, second addresses all 5 reviewer findings. Auto-squashed on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)