### PR TITLE
fix(rooms): VM-layer surface 409 errors on kickUser / forceMuteUser / addHost / removeDisconnectedUser

### DIFF
--- a/app/src/test/java/com/shyden/shytalk/core/room/ActiveRoomManagerTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/core/room/ActiveRoomManagerTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.shyden.shytalk.core.model.RoomRole
 import com.shyden.shytalk.core.model.RoomState
 import com.shyden.shytalk.core.util.Constants
+import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.data.remote.PresenceService
 import com.shyden.shytalk.data.remote.VoiceConnectionState
 import com.shyden.shytalk.data.remote.VoiceService
@@ -805,6 +806,44 @@ class ActiveRoomManagerTest {
             testScheduler.advanceTimeBy(Constants.PRESENCE_TIMEOUT_MS + 100)
 
             coVerify { roomRepository.removeDisconnectedUser("room-1", "user-2") }
+        }
+
+    @Test
+    fun `presence monitor - logs but does not crash when removeDisconnectedUser returns Error`() =
+        runTest {
+            // PR G — pre-fix this was fire-and-forget: a 409 (CLOSED room) from
+            // the presence monitor would silently no-op every grace-window
+            // tick with no diagnostic. Now the Resource.Error branch fires
+            // logW. The test pins: (a) the repo call still fires (server sees
+            // the attempted eviction + can log it), (b) no exception escapes
+            // the coroutine scope, (c) the grace timer is still cleared via
+            // `graceTimers.remove(userId)` so a SECOND presence-monitor cycle
+            // does not re-launch the same grace timer (regression guard for a
+            // future refactor that early-returns on Error before the timer cleanup).
+            coEvery {
+                roomRepository.removeDisconnectedUser("room-1", "user-2")
+            } returns Resource.Error("Room is closed")
+
+            manager.trackRoom("room-1")
+            val room =
+                TestData.createTestRoom(
+                    ownerId = currentUserId,
+                    participantIds = setOf(currentUserId, "user-2"),
+                )
+            manager.updateTrackedRoom(room)
+
+            presenceFlow.value = setOf(currentUserId)
+            testScheduler.advanceTimeBy(Constants.PRESENCE_TIMEOUT_MS + 100)
+
+            // (a) repo call fired despite the error
+            coVerify { roomRepository.removeDisconnectedUser("room-1", "user-2") }
+
+            // (c) second tick must NOT re-launch the grace timer — if the
+            // graceTimers cleanup were skipped on error, the second cycle
+            // would launch a fresh removeDisconnectedUser call. We pin that
+            // exactly ONE call fires across two consecutive presence cycles.
+            testScheduler.advanceTimeBy(Constants.PRESENCE_TIMEOUT_MS + 100)
+            coVerify(exactly = 1) { roomRepository.removeDisconnectedUser("room-1", "user-2") }
         }
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -112,6 +112,10 @@ class RoomViewModelTest {
         coEvery { roomRepository.leaveSeat(any(), any()) } returns Resource.Success(Unit)
         coEvery { roomRepository.toggleMute(any(), any(), any()) } returns Resource.Success(Unit)
         coEvery { roomRepository.acceptInvite(any(), any(), any()) } returns Resource.Success(Unit)
+        // PR G — kickUser + addHost now check Resource<Unit>; default mock to Success
+        // so existing happy-path tests don't fall through the new Error early-return.
+        coEvery { roomRepository.kickUser(any(), any(), any(), any(), any()) } returns Resource.Success(Unit)
+        coEvery { roomRepository.addHost(any(), any()) } returns Resource.Success(Unit)
         coEvery { seatRequestRepository.createRequest(any(), any(), any(), any()) } returns Resource.Success(Unit)
         every { seatRequestRepository.getPendingRequests(any()) } returns pendingRequestsFlow
         every { seatRequestRepository.getRequestsByUser(any(), any()) } returns myRequestsFlow
@@ -751,6 +755,45 @@ class RoomViewModelTest {
 
             coVerify { roomRepository.kickUser("room-1", "attendee-1", null, any(), any()) }
             coVerify { messageRepository.sendSystemMessage("room-1", any()) }
+        }
+
+    @Test
+    fun `kickUser - does NOT send system message when kick returns Error`() =
+        roomTest {
+            // PR G — pre-fix this was fire-and-forget: a failed kick (e.g. 409 on
+            // a CLOSED room) silently no-op'd on the server but STILL posted
+            // '$targetName was kicked' as a system message, confusing every
+            // observer. Now the early-return on Resource.Error guards the
+            // sendSystemMessage call. This pin captures the UX-consistency fix.
+            viewModel = createViewModel()
+            val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
+            seats["3"] = TestData.createTestSeat(userId = "attendee-1")
+            coEvery { userRepository.getUser("attendee-1") } returns
+                Resource.Success(
+                    TestData.createTestUser(uid = "attendee-1", displayName = "Attendee"),
+                )
+            // Override the default Success mock for THIS test to simulate a 409
+            // (room closed) coming back from the server.
+            coEvery {
+                roomRepository.kickUser(any(), any(), any(), any(), any())
+            } returns Resource.Error("Room is closed")
+            emitRoomAsOwner(
+                TestData.createTestRoom(
+                    ownerId = currentUserId,
+                    participantIds = setOf(currentUserId, "attendee-1"),
+                    seats = seats,
+                ),
+            )
+            advanceUntilIdle()
+
+            viewModel.kickUser("attendee-1", 3)
+            advanceUntilIdle()
+
+            // Kick was attempted (we want the repo call to fire, server logs +
+            // sentry know about the failed attempt), but the system message
+            // MUST NOT post — otherwise observers see a fake announcement.
+            coVerify { roomRepository.kickUser("room-1", "attendee-1", 3, any(), any()) }
+            coVerify(exactly = 0) { messageRepository.sendSystemMessage("room-1", any()) }
         }
 
     @Test

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -542,6 +542,36 @@ class RoomViewModelTest {
             coVerify { roomRepository.toggleMute("room-1", 3, true) }
         }
 
+    @Test
+    fun `forceMuteUser - logs but does not crash when toggleMute returns Error`() =
+        roomTest {
+            // PR G — pre-fix this was fire-and-forget: a 409 (CLOSED) or 5xx
+            // silently no-op'd. Now the Resource.Error branch fires logW. The
+            // test pins that (a) the repository was still called (server-side
+            // logs see the attempt), (b) no exception bubbles up to the
+            // coroutine scope, (c) no follow-up state mutation occurs (log-
+            // only contract — UI surfacing is queued for a separate PR).
+            viewModel = createViewModel()
+            val seats = TestData.createSeatsWithOwner(currentUserId).toMutableMap()
+            seats["3"] = TestData.createTestSeat(userId = "attendee-1", isMuted = false)
+            coEvery {
+                roomRepository.toggleMute("room-1", 3, true)
+            } returns Resource.Error("Room is closed")
+            emitRoomAsOwner(
+                TestData.createTestRoom(
+                    ownerId = currentUserId,
+                    participantIds = setOf(currentUserId, "attendee-1"),
+                    seats = seats,
+                ),
+            )
+            advanceUntilIdle()
+
+            viewModel.forceMuteUser(3)
+            advanceUntilIdle()
+
+            coVerify { roomRepository.toggleMute("room-1", 3, true) }
+        }
+
     // ===== moveSeat Tests =====
 
     @Test
@@ -2357,6 +2387,27 @@ class RoomViewModelTest {
     fun `addHost - owner can add a host`() =
         roomTest {
             viewModel = createViewModel()
+            emitRoomAsOwner()
+            advanceUntilIdle()
+
+            viewModel.addHost("user-2")
+            advanceUntilIdle()
+
+            coVerify { roomRepository.addHost("room-1", "user-2") }
+        }
+
+    @Test
+    fun `addHost - logs but does not crash when repository returns Error`() =
+        roomTest {
+            // PR G — pre-fix this was fire-and-forget: a 409 (CLOSED room) or
+            // any 5xx silently no-op'd. Now Resource.Error fires logW. Pin the
+            // contract: repo still called (server logs see the attempt), no
+            // crash, no state mutation occurs (log-only — UI surfacing queued
+            // for a separate PR).
+            viewModel = createViewModel()
+            coEvery {
+                roomRepository.addHost("room-1", "user-2")
+            } returns Resource.Error("Room is closed")
             emitRoomAsOwner()
             advanceUntilIdle()
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/room/ActiveRoomManager.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/room/ActiveRoomManager.kt
@@ -503,7 +503,18 @@ class ActiveRoomManager(
                                         logD(TAG, "presenceMonitor: owner absent → setOwnerAway")
                                         roomRepository.setOwnerAway(roomId)
                                     } else {
-                                        roomRepository.removeDisconnectedUser(roomId, userId)
+                                        val removeResult = roomRepository.removeDisconnectedUser(roomId, userId)
+                                        if (removeResult is Resource.Error) {
+                                            // Surface 409 (CLOSED room) + any server error so it reaches
+                                            // Sentry/logcat. Pre-PR G this was silent fire-and-forget,
+                                            // so the presence monitor would loop on the same disconnected
+                                            // user every grace-window tick with no diagnostic.
+                                            logE(
+                                                TAG,
+                                                "removeDisconnectedUser failed for $userId: ${removeResult.message}",
+                                                removeResult.exception,
+                                            )
+                                        }
                                     }
                                     graceTimers.remove(userId)
                                     emitDisconnectedIds()

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/room/ActiveRoomManager.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/room/ActiveRoomManager.kt
@@ -505,11 +505,13 @@ class ActiveRoomManager(
                                     } else {
                                         val removeResult = roomRepository.removeDisconnectedUser(roomId, userId)
                                         if (removeResult is Resource.Error) {
-                                            // Surface 409 (CLOSED room) + any server error so it reaches
-                                            // Sentry/logcat. Pre-PR G this was silent fire-and-forget,
-                                            // so the presence monitor would loop on the same disconnected
-                                            // user every grace-window tick with no diagnostic.
-                                            logE(
+                                            // 409 (CLOSED room) is a known race: the room closed between
+                                            // the presence-monitor's grace-window tick and this call.
+                                            // logW (not logE) keeps Sentry clean while giving the
+                                            // presence-monitor a diagnostic — pre-PR G this was silent
+                                            // fire-and-forget, so the monitor would loop on the same
+                                            // disconnected user every grace-tick with no signal.
+                                            logW(
                                                 TAG,
                                                 "removeDisconnectedUser failed for $userId: ${removeResult.message}",
                                                 removeResult.exception,

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -1198,10 +1198,11 @@ class RoomViewModel(
             if (seat.isMuted) return@launch
             val result = roomRepository.toggleMute(roomId, seatIndex, true)
             if (result is Resource.Error) {
-                // Surface 409 (CLOSED room), 403 (role mismatch race) + any
-                // network error so they reach Sentry/logcat instead of being
-                // a silent UX no-op. Pre-PR G this was fire-and-forget.
-                logE(TAG, "forceMuteUser failed: ${result.message}", result.exception)
+                // 409 (CLOSED room) + 403 (role mismatch race) are known user-
+                // driven races, not system errors — use logW to keep Sentry
+                // free of false-positive error events. Matches the auto-rejoin
+                // / owner-self-heal logW pattern elsewhere in this file.
+                logW(TAG, "forceMuteUser failed: ${result.message}", result.exception)
             }
         }
     }
@@ -1252,12 +1253,12 @@ class RoomViewModel(
 
             val kickResult = roomRepository.kickUser(roomId, targetUserId, seatIndex, kickerName, displayReason)
             if (kickResult is Resource.Error) {
-                // Surface 409 (CLOSED room) + any server error so it reaches
-                // Sentry/logcat instead of being a silent UX no-op. If the kick
-                // failed, ALSO skip the system message — otherwise we'd post
-                // "$targetName was kicked" against a room where the kick was
-                // rejected, confusing every observer.
-                logE(TAG, "kickUser failed: ${kickResult.message}", kickResult.exception)
+                // 409 (CLOSED room) is a user-driven race, not a system error
+                // — logW keeps Sentry clean. The early return suppresses the
+                // cascading sendSystemMessage call: posting "$targetName was
+                // kicked" against a room where the kick was rejected would
+                // confuse every observer with a fake announcement.
+                logW(TAG, "kickUser failed: ${kickResult.message}", kickResult.exception)
                 return@launch
             }
             messageRepository.sendSystemMessage(roomId, "$targetName was kicked")
@@ -1270,9 +1271,10 @@ class RoomViewModel(
             if (_uiState.value.currentUserId != room.ownerId) return@launch
             val result = roomRepository.addHost(roomId, userId)
             if (result is Resource.Error) {
-                // Surface 409 (CLOSED room) + any server error so it reaches
-                // Sentry/logcat. Pre-PR G this was silent fire-and-forget.
-                logE(TAG, "addHost failed: ${result.message}", result.exception)
+                // 409 (CLOSED room) is a user-driven race, not a system error
+                // — logW keeps Sentry clean while still giving Sentry/logcat
+                // visibility into the failed promotion attempt.
+                logW(TAG, "addHost failed: ${result.message}", result.exception)
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -1196,7 +1196,13 @@ class RoomViewModel(
 
             // Only mute, never unmute — only the user themselves can unmute
             if (seat.isMuted) return@launch
-            roomRepository.toggleMute(roomId, seatIndex, true)
+            val result = roomRepository.toggleMute(roomId, seatIndex, true)
+            if (result is Resource.Error) {
+                // Surface 409 (CLOSED room), 403 (role mismatch race) + any
+                // network error so they reach Sentry/logcat instead of being
+                // a silent UX no-op. Pre-PR G this was fire-and-forget.
+                logE(TAG, "forceMuteUser failed: ${result.message}", result.exception)
+            }
         }
     }
 
@@ -1244,7 +1250,16 @@ class RoomViewModel(
             val targetName = targetUser?.displayName ?: "A user"
             val displayReason = reason.ifBlank { "No reason given" }
 
-            roomRepository.kickUser(roomId, targetUserId, seatIndex, kickerName, displayReason)
+            val kickResult = roomRepository.kickUser(roomId, targetUserId, seatIndex, kickerName, displayReason)
+            if (kickResult is Resource.Error) {
+                // Surface 409 (CLOSED room) + any server error so it reaches
+                // Sentry/logcat instead of being a silent UX no-op. If the kick
+                // failed, ALSO skip the system message — otherwise we'd post
+                // "$targetName was kicked" against a room where the kick was
+                // rejected, confusing every observer.
+                logE(TAG, "kickUser failed: ${kickResult.message}", kickResult.exception)
+                return@launch
+            }
             messageRepository.sendSystemMessage(roomId, "$targetName was kicked")
         }
     }
@@ -1253,7 +1268,12 @@ class RoomViewModel(
         viewModelScope.launch {
             val room = _uiState.value.room ?: return@launch
             if (_uiState.value.currentUserId != room.ownerId) return@launch
-            roomRepository.addHost(roomId, userId)
+            val result = roomRepository.addHost(roomId, userId)
+            if (result is Resource.Error) {
+                // Surface 409 (CLOSED room) + any server error so it reaches
+                // Sentry/logcat. Pre-PR G this was silent fire-and-forget.
+                logE(TAG, "addHost failed: ${result.message}", result.exception)
+            }
         }
     }
 


### PR DESCRIPTION
## PR G — closes PR #863 reviewer I3 (pre-existing fire-and-forget pattern)

PR E (#863) reviewer flagged Important I3: four ViewModel methods discard `Resource<Unit>` from their repository calls, so the new 409 CLOSED-room responses became invisible. Per [feedback-fix-pre-existing-and-new-same.md] HARD rule, pre-existing bugs surfaced in review must be fixed in a follow-up PR THIS session.

## The bug

| File:line | Discarded result | Pre-fix UX | Post-fix |
| --- | --- | --- | --- |
| `RoomViewModel.forceMuteUser:1199` | `roomRepository.toggleMute` | Silent no-op on 409 | `logW` on Error |
| `RoomViewModel.kickUser:1247` | `roomRepository.kickUser` | Silent no-op on 409 + **fake `"$targetName was kicked"` system message posted regardless** | `logW` + early-return suppresses fake announcement |
| `RoomViewModel.addHost:1256` | `roomRepository.addHost` | Silent no-op on 409 | `logW` on Error |
| `ActiveRoomManager.removeDisconnectedUser:506` | `roomRepository.removeDisconnectedUser` | Silent no-op; presence-monitor loop with no diagnostic | `logW` on Error |

The kickUser case had a **compounding bug**: the fake "X was kicked" system message posted even when the server rejected the kick (e.g. 409 on CLOSED room), confusing every observer with a false announcement. The early-return on `Resource.Error` closes that.

## Log severity — `logW`, not `logE`

Per the PR's own reviewer-pass finding: 409 (CLOSED room) is a user-driven race, not a system error. The project's existing convention (RoomViewModel.kt lines 463, 593 — auto-rejoin, owner self-heal) is `logW` for known boundary races, `logE` only for unexpected system errors. Using `logE` here would pollute Sentry with false-positive error events every time a room closes mid-action. All 4 PR G sites use `logW`.

## Tests (4 new — 1 from PR G original, 3 from reviewer pass)

- `kickUser - does NOT send system message when kick returns Error` — pins the cascading-bug fix: kick called, system message NOT called.
- `forceMuteUser - logs but does not crash when toggleMute returns Error` — pins the C2 closure (Error branch covered, no crash).
- `addHost - logs but does not crash when repository returns Error` — pins the C3 closure.
- `presence monitor - logs but does not crash when removeDisconnectedUser returns Error` — pins the C1 closure: repo called, exactly ONE call across two consecutive presence cycles (regression guard for a future refactor that early-returns on Error before the grace-timer cleanup at lines 519-520).

Test setup change: added `coEvery { kickUser/addHost } returns Resource.Success(Unit)` to the `@Before` block of `RoomViewModelTest` alongside the existing Success mocks for `takeSeat/leaveSeat/toggleMute/acceptInvite`. Otherwise the relaxed-MockK default would have triggered the new early-return path on every happy-path test.

## Quality loop (per operator's "always run full loop")

- ✅ `code-reviewer` agent pass 1: 3 Critical (missing Error-branch tests) + 1 Important (logE→logW) + 2 Important (scoped-defer questions)
- ✅ All 3 Critical fixed (3 new tests added across both test classes)
- ✅ I1 fixed (logE→logW across all 4 sites, with rationale in comments)
- ✅ I2 + I3 acknowledged as scoped-defer follow-ups in commit message (closeRoom cascade + joinRoom internal toggleMute — both require operator UX review for the right surfacing strategy)

## Follow-up PRs queued (matrix doc)

- **Systemic fire-and-forget hardening** — 15+ other VM call sites with same pattern (`moveSeat`, `leaveSeat`, `takeSeat`, `sendInvite`, `acceptInvite`, `cancelInvite`, `closeRoom`, `setOwnerAway`, `leaveRoom`, etc.). PR G covers only the 4 reviewer I3 flagged. Operator can decide the right rollout (UX surfacing strategy first).
- **Snackbar / VM-state surfacing of errors** — UX design call. Log-only fix in this PR is minimum-viable; user-visible error surfacing is queued.

Full `:app:testDevDebugUnitTest` + `:shared:jvmTest` green. ktlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)