### PR TITLE
ci(ios): bump build-ios timeout 60 → 90 (PR #865 cancelled at 60:00 exact)

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -97,14 +97,16 @@ jobs:
     needs: [resolve-inputs]
     if: always() && needs.resolve-inputs.result == 'success' && needs.resolve-inputs.outputs.run_ios == 'true'
     runs-on: macos-15
-    # Bumped 2026-05-22 from 30 → 60. PR #714 was the first iOS-touching
-    # PR after PR #708 enabled iOS E2E gating; its build-ios run
-    # cancelled at exactly 30:00. Cold K/N compile alone takes 24-29
-    # min on macos-15; with pod install + xcodebuild build-for-testing
-    # on top, 30 is below the floor. 60 gives ~15 min headroom over the
-    # observed worst case. Pinned by
-    # tests/scripts/ios-tests-build-cache.test.js.
-    timeout-minutes: 60
+    # Bumped 2026-05-22 from 30 → 60 (PR #714 cancelled at 30:00 exactly).
+    # Bumped 2026-05-29 from 60 → 90 (PR #865 cancelled at 60:00 exactly;
+    # iOS Build duration crept from ~50 min on PR #864 (PR F) to the full
+    # 60-min cap on PR #865). Cold K/N compile = 24-29 min on macos-15;
+    # with pod install + Xcode build-for-testing + upload-artifact + cache
+    # post-steps, the worst-case has been creeping up. 90 gives ~30 min
+    # headroom over the most-recent observed worst case, restoring the
+    # PR #714-era safety margin. Pinned by
+    # tests/scripts/ios-tests-build-cache.test.js (asserts ≥60).
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## What

Bumps `timeout-minutes` on the `build-ios` job in `.github/workflows/ios-tests.yml` from **60 → 90**.

## Why

PR #865 (PR G) iOS Build cancelled at the 60-min job-level timeout. iOS Build duration has been creeping up across recent PRs:

| PR | iOS Build duration |
| --- | --- |
| [#862](https://github.com/ShydenMcM/ShyTalk/pull/862) (PR D, trivial test) | ~22 min |
| [#864](https://github.com/ShydenMcM/ShyTalk/pull/864) (PR F, shared/ tests) | ~50 min |
| [#865](https://github.com/ShydenMcM/ShyTalk/pull/865) (PR G, shared/ + app/test) | **60 min → cancelled (exact timeout)** |

The 60-min cap was last set in PR #714 (2026-05-22) when iOS Build started cancelling at the previous 30-min cap. The same wall-creep pattern has now occurred against the 60-min cap. Cold K/N compile alone = 24-29 min; with pod install + Xcode build-for-testing + upload-artifact + cache post-steps, the worst case has crept past 60.

**90 min restores the PR #714-era ~30 min safety margin** above the most-recent observed worst case.

## Pin test

`express-api/tests/scripts/ios-tests-build-cache.test.js` asserts `timeout-minutes ≥ 60`. 90 satisfies this invariant; test stays green (verified locally).

## What this does NOT do

This is the **immediate defensive infra fix** to unblock PR #865 and future `shared/` + `app/test` PRs. It does NOT investigate the root cause of the iOS Build duration creep — plausible causes include Xcode/CocoaPods cache eviction, growing test target, or KMP framework size increase. A separate "iOS Build duration audit" PR can dig into cache-hit rates + per-step timing.

## Verification

Per [feedback-workflow-verify-by-running], this PR's own CI run IS the dispatch verification — the workflow runs with the new 90-min timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)