### PR TITLE
fix(seed-personas): drop `-r dotenv/config` preload — fails in CI (module not resolvable)

### DIFF
--- a/.github/actions/seed-test-personas/action.yml
+++ b/.github/actions/seed-test-personas/action.yml
@@ -44,4 +44,12 @@ runs:
         trap 'rm -f /tmp/firebase-sa-seed.json' EXIT
         export GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa-seed.json
         export FIREBASE_PROJECT_ID="$PROJECT"
-        node -r dotenv/config express-api/scripts/provision-test-personas.js
+        # NB: NO `-r dotenv/config` preload here — the script's docstring
+        # usage example uses dotenv because it assumes a `.env` file on the
+        # dev Express host. In CI the secrets are exported as env vars
+        # directly (PERSONAS_PASSWORD, GOOGLE_APPLICATION_CREDENTIALS,
+        # FIREBASE_PROJECT_ID all set above), so dotenv adds nothing and
+        # the preload fails with `Cannot find module 'dotenv/config'`
+        # because dotenv lives in express-api/node_modules, not the repo-
+        # root node resolution path. Caught in run 26636553597.
+        node express-api/scripts/provision-test-personas.js

--- a/express-api/tests/scripts/deploy-dev-seed-personas.test.js
+++ b/express-api/tests/scripts/deploy-dev-seed-personas.test.js
@@ -157,4 +157,26 @@ describe('seed-test-personas composite action — interface', () => {
       'export GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa-seed.json',
     );
   });
+
+  test('does NOT use the dotenv preload flag on the node invocation (CI exports env directly)', () => {
+    // The script's own usage docstring shows the preload flag because it
+    // assumes a .env file on the dev Express host. In CI dotenv is not on
+    // the node resolution path (lives in express-api/node_modules, not
+    // the repo-root node_modules that the composite action invokes from),
+    // so the preload fails at runtime. Caught in run 26636553597: the
+    // first attempted dev deploy with this action failed at exactly this
+    // point. Pin the absence so it can't regress.
+    //
+    // Slice the actual `node ...` invocation line (not the whole file —
+    // the comment ABOVE the node line literally mentions the flag, so a
+    // whole-file `not.toContain` would match the comment text and pass-
+    // through the actual bug if it returned).
+    const nodeLine = SEED_ACTION.split('\n').find(
+      (l) => /^\s*node\s+/.test(l) && l.includes('provision-test-personas.js'),
+    );
+    expect(nodeLine).toBeDefined();
+    expect(nodeLine).not.toContain('-r dotenv');
+    // Positive form: the bare `node express-api/scripts/...` invocation.
+    expect(nodeLine).toMatch(/node\s+express-api\/scripts\/provision-test-personas\.js/);
+  });
 });


### PR DESCRIPTION
## What went wrong

PR #867's `seed-test-personas` composite action invoked the provision script as `node -r dotenv/config express-api/scripts/provision-test-personas.js`. The flag was copied from the script's docstring usage example (which assumes a `.env` file on the dev Express host). In CI:

1. No `.env` file is involved — secrets are exported as env vars directly (`PERSONAS_PASSWORD`, `GOOGLE_APPLICATION_CREDENTIALS`, `FIREBASE_PROJECT_ID` are set in the action above the node invocation)
2. `dotenv` lives in `express-api/node_modules`, NOT the repo-root `node_modules` that the composite action invokes node from

Result: [run 26636553597](https://github.com/ShydenMcM/ShyTalk/actions/runs/26636553597) — the very first Deploy To Dev with PR #867's action — failed at the seed step with `Cannot find module 'dotenv/config'` (2 min into a 30-60 min deploy).

## Fix

One-line removal of `-r dotenv/config`. The bare `node express-api/scripts/provision-test-personas.js` invocation works because the env vars are already exported.

## Pin test (so this can't regress)

`does NOT use the dotenv preload flag on the node invocation` — slices the actual `node ...` command line out of the action file (NOT a whole-file regex — the explanatory comment above the node line mentions the flag textually and would false-positive a whole-file `not.toContain`). Pins both:

- absence of `-r dotenv` on the node command line
- presence of `node express-api/scripts/provision-test-personas.js` as the positive form

A future maintainer who needs dotenv should install it at the repo root + add a test, NOT silently re-add the flag.

## Verification

`deploy-dev-seed-personas.test.js`: **10/10** (was 9 + 1 new). ESLint clean. Sonar gate passed pre-push.

Per [feedback-workflow-verify-by-running], this PR's own CI run is the dispatch-test verification… though actually the dotenv flag fires in `deploy-backend-dev` only when Deploy To Dev is triggered, NOT on PR CI. The PR's `pr-checks.yml` doesn't exercise the seed action. So the REAL verification is the next Deploy To Dev workflow_dispatch — which I'll trigger immediately after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)