### PR TITLE
fix(seed-personas): cd into express-api before running script (firebase-admin lives there)

### DIFF
--- a/.github/actions/seed-test-personas/action.yml
+++ b/.github/actions/seed-test-personas/action.yml
@@ -44,12 +44,16 @@ runs:
         trap 'rm -f /tmp/firebase-sa-seed.json' EXIT
         export GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa-seed.json
         export FIREBASE_PROJECT_ID="$PROJECT"
-        # NB: NO `-r dotenv/config` preload here — the script's docstring
+        # `cd express-api` so the script's `require('firebase-admin')` etc.
+        # resolves against `express-api/node_modules`. Running with a
+        # `express-api/scripts/...` path from repo root fails because the
+        # repo root has no `node_modules/firebase-admin` (caught in run
+        # 26637428443: `Cannot find module 'firebase-admin'`).
+        #
+        # NB: NO `-r dotenv/config` preload — the script's docstring
         # usage example uses dotenv because it assumes a `.env` file on the
         # dev Express host. In CI the secrets are exported as env vars
         # directly (PERSONAS_PASSWORD, GOOGLE_APPLICATION_CREDENTIALS,
-        # FIREBASE_PROJECT_ID all set above), so dotenv adds nothing and
-        # the preload fails with `Cannot find module 'dotenv/config'`
-        # because dotenv lives in express-api/node_modules, not the repo-
-        # root node resolution path. Caught in run 26636553597.
-        node express-api/scripts/provision-test-personas.js
+        # FIREBASE_PROJECT_ID all set above), so dotenv adds nothing.
+        cd express-api
+        node scripts/provision-test-personas.js

--- a/express-api/tests/scripts/deploy-dev-seed-personas.test.js
+++ b/express-api/tests/scripts/deploy-dev-seed-personas.test.js
@@ -176,7 +176,29 @@ describe('seed-test-personas composite action — interface', () => {
     );
     expect(nodeLine).toBeDefined();
     expect(nodeLine).not.toContain('-r dotenv');
-    // Positive form: the bare `node express-api/scripts/...` invocation.
-    expect(nodeLine).toMatch(/node\s+express-api\/scripts\/provision-test-personas\.js/);
+  });
+
+  test('cd-s into express-api before running node (so require("firebase-admin") resolves)', () => {
+    // The provision script does `require('firebase-admin')` etc. — those
+    // resolve against `express-api/node_modules`, NOT the repo-root.
+    // Running the script with a `express-api/scripts/...` path from repo
+    // root fails because the repo root has no `node_modules/firebase-admin`.
+    // Caught in run 26637428443: `Cannot find module 'firebase-admin'`.
+    //
+    // Pin both: (1) a `cd express-api` precedes the node line, (2) the
+    // node line uses a bare relative path `scripts/provision-test-...`,
+    // NOT the repo-root-prefixed `express-api/scripts/provision-test-...`.
+    const lines = SEED_ACTION.split('\n');
+    const cdIdx = lines.findIndex((l) => /^\s*cd\s+express-api\s*$/.test(l));
+    const nodeIdx = lines.findIndex(
+      (l) => /^\s*node\s+/.test(l) && l.includes('provision-test-personas.js'),
+    );
+    expect(cdIdx).toBeGreaterThan(-1);
+    expect(nodeIdx).toBeGreaterThan(cdIdx);
+    expect(lines[nodeIdx]).toMatch(/^\s*node\s+scripts\/provision-test-personas\.js\s*$/);
+    // Anti-pattern guard: must NOT use repo-root-prefixed path on the
+    // node line (would fail because firebase-admin lives in
+    // express-api/node_modules, not the repo-root resolution path).
+    expect(lines[nodeIdx]).not.toContain('express-api/scripts/');
   });
 });


### PR DESCRIPTION
## Second module-resolution bug in the same line

PR #868 dropped the failing `-r dotenv/config` preload. Next deploy ([run 26637428443](https://github.com/ShydenMcM/ShyTalk/actions/runs/26637428443)) revealed the second bug stacked behind it: `require('firebase-admin')` (and others) resolve against `express-api/node_modules`, but the action was running from the repo root where `node_modules/firebase-admin` doesn't exist.

```
Error: Cannot find module 'firebase-admin'
Require stack:
- /home/runner/work/ShyTalk/ShyTalk/express-api/scripts/provision-test-personas.js
code: 'MODULE_NOT_FOUND'
```

## Fix

Mirror the script's own docstring usage example: `cd express-api && node scripts/provision-test-personas.js`. Puts `express-api/node_modules` on the resolution path, so all `require` calls resolve correctly.

## Pin test (11th in the suite)

`cd-s into express-api before running node (so require("firebase-admin") resolves)`:
- Asserts a `cd express-api` line precedes the node line
- Asserts the node line uses a bare relative path `scripts/provision-...`
- Anti-pattern guard pins the absence of the broken `express-api/scripts/...` path form

## Lesson

Two CWD-dependent bugs were stacked on the same line. The dotenv removal alone wasn't enough — once `-r dotenv/config` was out of the way, `require('firebase-admin')` immediately surfaced as the next failure. The script's docstring usage said:

```
cd /home/ubuntu/express-api
node -r dotenv/config scripts/provision-test-personas.js
```

Both the `cd` AND the `-r dotenv/config` were context-dependent. The right CI adaptation drops the dotenv flag (no `.env` file in CI) but KEEPS the `cd` (require paths depend on it). I had originally kept neither — both context-dependent pieces needed individual evaluation.

11/11 pin tests pass. ESLint clean. Sonar passed pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)