### PR TITLE
fix(seed-personas): npm ci on the GitHub runner so firebase-admin is resolvable

### DIFF
--- a/.github/actions/seed-test-personas/action.yml
+++ b/.github/actions/seed-test-personas/action.yml
@@ -47,13 +47,19 @@ runs:
         # `cd express-api` so the script's `require('firebase-admin')` etc.
         # resolves against `express-api/node_modules`. Running with a
         # `express-api/scripts/...` path from repo root fails because the
-        # repo root has no `node_modules/firebase-admin` (caught in run
-        # 26637428443: `Cannot find module 'firebase-admin'`).
-        #
+        # repo root has no `node_modules/firebase-admin`.
+        cd express-api
+        # `npm ci --omit=dev` installs production deps (firebase-admin,
+        # firebase-admin/firestore, etc.) into express-api/node_modules.
+        # The OUTER deploy-backend-dev workflow only installs deps on the
+        # REMOTE London VM (via ssh), NOT on the GitHub runner — so without
+        # this step the runner's express-api/node_modules is empty and
+        # `require('firebase-admin')` fails. Caught in runs 26637428443 +
+        # 26638445667 (both 'Cannot find module firebase-admin').
+        npm ci --omit=dev --no-audit --no-fund
         # NB: NO `-r dotenv/config` preload — the script's docstring
         # usage example uses dotenv because it assumes a `.env` file on the
         # dev Express host. In CI the secrets are exported as env vars
         # directly (PERSONAS_PASSWORD, GOOGLE_APPLICATION_CREDENTIALS,
         # FIREBASE_PROJECT_ID all set above), so dotenv adds nothing.
-        cd express-api
         node scripts/provision-test-personas.js

--- a/express-api/tests/scripts/deploy-dev-seed-personas.test.js
+++ b/express-api/tests/scripts/deploy-dev-seed-personas.test.js
@@ -201,4 +201,26 @@ describe('seed-test-personas composite action — interface', () => {
     // express-api/node_modules, not the repo-root resolution path).
     expect(lines[nodeIdx]).not.toContain('express-api/scripts/');
   });
+
+  test('runs `npm ci --omit=dev` before node (installs firebase-admin on the runner)', () => {
+    // The outer deploy-backend-dev workflow only npm-installs on the REMOTE
+    // London VM via ssh — the GitHub runner's `express-api/node_modules`
+    // is empty when the seed step starts. Without an install, every
+    // `require('firebase-admin')` etc. in the provision script fails
+    // MODULE_NOT_FOUND. Caught in runs 26637428443 + 26638445667.
+    //
+    // Pin: an `npm ci` line precedes the node line, has `--omit=dev` (we
+    // only need production deps), and is inside the express-api CWD
+    // (after the `cd express-api`).
+    const lines = SEED_ACTION.split('\n');
+    const cdIdx = lines.findIndex((l) => /^\s*cd\s+express-api\s*$/.test(l));
+    const installIdx = lines.findIndex((l) => /^\s*npm ci\b/.test(l));
+    const nodeIdx = lines.findIndex(
+      (l) => /^\s*node\s+/.test(l) && l.includes('provision-test-personas.js'),
+    );
+    expect(cdIdx).toBeGreaterThan(-1);
+    expect(installIdx).toBeGreaterThan(cdIdx);
+    expect(nodeIdx).toBeGreaterThan(installIdx);
+    expect(lines[installIdx]).toContain('--omit=dev');
+  });
 });


### PR DESCRIPTION
## Third failure in the seed-step sequence — root cause

[Run 26638445667](https://github.com/ShydenMcM/ShyTalk/actions/runs/26638445667) — the third dev-deploy attempt with the seed action, after PR #868 (dropped `-r dotenv/config`) and PR #869 (added `cd express-api`) — failed at exactly the same step with **`Cannot find module 'firebase-admin'`** again.

The diagnosis I missed in PR #869: the outer `deploy-backend-dev` workflow only `npm install --omit=dev`s on the REMOTE London VM (via ssh inside the "Deploy Express API to London" step). The GitHub runner where the seed step runs **never** has its own `express-api/node_modules` populated. So `cd express-api` puts the script in the right directory, but the directory has no `node_modules`.

## Fix

Add `npm ci --omit=dev --no-audit --no-fund` between the `cd express-api` and the `node scripts/...` lines. Installs production deps (firebase-admin + its peer modules) on the GitHub runner directly. `--no-audit --no-fund` cuts a few seconds of output noise.

## Pin test added (12th in suite)

`runs npm ci --omit=dev before node (installs firebase-admin on the runner)` — asserts the install precedes node, has `--omit=dev`, and sits inside the express-api CWD.

12/12 pin tests pass. ESLint clean.

## The cascade lesson

| Failure | Fix | What it exposed |
| --- | --- | --- |
| Run 26636553597 | #868 — dropped `-r dotenv/config` | The dotenv preload itself failed first |
| Run 26637428443 | #869 — `cd express-api` | After dotenv was gone, `require('firebase-admin')` was the next line that ran |
| Run 26638445667 | **#870 (this PR)** — `npm ci --omit=dev` | After `cd` set the CWD correctly, firebase-admin STILL wasn't on disk |

Three CWD/module-resolution bugs stacked in sequence. Per [feedback-ci-action-docstring-adaptation] (memory note written just before this PR): "if a fix removes ONE module-not-found error, the next `require()` in the same script is the next failure waiting." I should have run `node express-api/scripts/provision-test-personas.js --dry-run` locally before #869 to surface the npm-install gap. Will retro-fold this lesson into the memory note after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)