### PR TITLE
ci(seed): extract dev-persona seed into reusable workflow + workflow_dispatch entry point

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -157,25 +157,20 @@ jobs:
           service-account-json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DEV }}
           firebase-project: shytalk-dev
 
-      # Refresh the seeded test personas (P-02..P-19) on every dev deploy.
-      # Idempotent: writes only to the hardcoded persona uniqueIds, never
-      # touches manually-created users. Every seeded persona carries
-      # `seedSource: 'automation'` + a `[SEED]` displayName prefix so they're
-      # identifiable as automation accounts in the UI (so testers, mods,
-      # and internal dogfood users don't mistake them for real users).
-      # Opt-out via workflow_dispatch input `seed-personas=false`.
-      - name: Seed test personas (P-02..P-19)
-        if: inputs.seed-personas != false
-        uses: ./.github/actions/seed-test-personas
-        with:
-          service-account-json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DEV }}
-          firebase-project: shytalk-dev
-          personas-password: ${{ secrets.PERSONAS_PASSWORD_DEV }}
-          # Region-specific (europe-west1) — sourced from
-          # app/src/dev/google-services.json (public Firebase config).
-          # Required because the provision script transitively imports
-          # firebase.js which throws if FIREBASE_DATABASE_URL is unset.
-          database-url: https://shytalk-dev-default-rtdb.europe-west1.firebasedatabase.app
+  # Refresh the seeded test personas (P-02..P-19) on every dev deploy.
+  # Factored into a SEPARATE reusable workflow (`seed-dev-personas.yml`)
+  # so it can ALSO be invoked directly via `gh workflow run
+  # seed-dev-personas.yml` to refresh persona state between journey-test
+  # runs WITHOUT a full deploy cycle (~30-60min). Per operator directive
+  # 2026-05-29.
+  #
+  # Opt-out via workflow_dispatch input `seed-personas=false`.
+  seed-dev-personas:
+    name: Seed Dev Personas
+    needs: deploy-backend-dev
+    if: needs.deploy-backend-dev.result == 'success' && inputs.seed-personas != false
+    uses: ./.github/workflows/seed-dev-personas.yml
+    secrets: inherit
 
   deploy-web-dev:
     name: Deploy Web to Dev

--- a/.github/workflows/seed-dev-personas.yml
+++ b/.github/workflows/seed-dev-personas.yml
@@ -1,0 +1,107 @@
+name: Seed Dev Personas
+
+# Reusable workflow + direct dispatch for refreshing the seeded persona cast
+# (P-02..P-19) on a Firebase project. Two invocation paths:
+#
+#   1. workflow_call — invoked from `deploy-dev.yml` after the backend
+#      deploy + rules deploy, so every dev deploy ends with personas in a
+#      known-fresh state.
+#   2. workflow_dispatch — invoked DIRECTLY by the operator (or CI on a
+#      test-rerun job) to refresh seed data WITHOUT a full deploy cycle.
+#      Use case: a journey-runner pass mutated persona state (wallet
+#      balances, follow edges, etc.); to start the next pass clean, run
+#      this workflow rather than the ~30-60min deploy-dev workflow.
+#
+# Implementation lives in `.github/actions/seed-test-personas/action.yml`
+# (a composite action). This file is the workflow-level wrapper that
+# makes the action callable from both paths.
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        description: 'Target environment (dev only — prod-safe by design; the provision script asserts the project ID contains "dev" or "local")'
+        type: string
+        default: dev
+        required: false
+    secrets:
+      # Declared with the EXACT repo-level secret names so `secrets: inherit`
+      # from the caller (deploy-dev.yml) forwards by name, AND actionlint
+      # static-checks the references inside this workflow against the same
+      # declared names. Using camelCase aliases here instead would force a
+      # named-mapping in every caller; the inherit path is simpler.
+      FIREBASE_SERVICE_ACCOUNT_DEV:
+        description: 'Firebase service account JSON for the dev project'
+        required: true
+      PERSONAS_PASSWORD_DEV:
+        description: 'Shared seeded-persona password'
+        required: true
+
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Target environment'
+        type: choice
+        options:
+          - dev
+        default: dev
+
+# Serialize seed runs against the same target — concurrent provisioning
+# would last-write-wins each persona doc (each upsert writes the full doc,
+# so the LAST writer's seedRunAt timestamp wins but no data is lost).
+# Still safer to queue: a re-seed mid-flight while another is running
+# wastes Firebase quota for no observable benefit.
+concurrency:
+  group: seed-dev-personas-${{ inputs.target }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  seed:
+    name: Seed test personas (${{ inputs.target }})
+    runs-on: ubuntu-24.04
+    # Provision touches ~17 personas with create-or-update each — typical
+    # run is 30-60 sec. 10min cap leaves headroom for transient Firebase
+    # Auth quota throttling without letting a stuck run idle forever.
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-node
+
+      - name: Resolve target-specific values
+        id: target-values
+        env:
+          TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+          # Dev is the only supported target (prod is gated by the
+          # provision script's assertSafeProject() check, which refuses
+          # to run unless the project id contains "dev" or "local"; we
+          # also restrict the workflow_dispatch input to `dev` for
+          # belt-and-suspenders).
+          if [ "$TARGET" != "dev" ]; then
+            echo "::error::Unsupported target '$TARGET' — only 'dev' is allowed"
+            exit 1
+          fi
+          # Source the RTDB URL from the public Firebase config committed
+          # to the repo. Region-specific (europe-west1 for dev); cannot
+          # be derived from project ID alone.
+          DATABASE_URL=$(jq -r '.project_info.firebase_url' app/src/dev/google-services.json)
+          echo "firebase-project=shytalk-dev" >> "$GITHUB_OUTPUT"
+          echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Run seed action
+        uses: ./.github/actions/seed-test-personas
+        with:
+          # For workflow_call, secrets are forwarded by the caller via
+          # `secrets:` block; for workflow_dispatch, they resolve from
+          # the repo-level GitHub Actions secrets (PERSONAS_PASSWORD_DEV,
+          # FIREBASE_SERVICE_ACCOUNT_DEV). Both paths land in the same
+          # `secrets.X` references at this scope.
+          service-account-json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DEV }}
+          firebase-project: ${{ steps.target-values.outputs.firebase-project }}
+          personas-password: ${{ secrets.PERSONAS_PASSWORD_DEV }}
+          database-url: ${{ steps.target-values.outputs.database-url }}

--- a/express-api/tests/scripts/deploy-dev-seed-personas.test.js
+++ b/express-api/tests/scripts/deploy-dev-seed-personas.test.js
@@ -1,20 +1,23 @@
 /**
- * Pins the integration that wires `provision-test-personas.js` into
- * `deploy-dev.yml` so every dev deploy refreshes the seeded persona cast
- * (P-02..P-19). Operator directive 2026-05-29:
+ * Pins the auto-seed-dev-personas integration after the 2026-05-29
+ * refactor (operator directive): seed now lives in its own reusable
+ * workflow `seed-dev-personas.yml`, invoked by:
  *
- *   1. Seeding must happen as part of deploy-dev (not a manual side-task).
- *   2. The script must remove ONLY seed data and replace with fresh seed
- *      data — manually-created accounts are never touched.
- *   3. Seed accounts must be easily identifiable so regular users aren't
- *      confused (covered by [SEED] displayName prefix + seedSource field,
- *      pinned in provision-test-personas.test.js).
+ *   1. `deploy-dev.yml` — as a top-level job that `needs: deploy-backend-dev`
+ *      and uses the reusable workflow. Every dev deploy refreshes seed data.
+ *   2. DIRECT `gh workflow run seed-dev-personas.yml` — refreshes seed
+ *      WITHOUT a full deploy. Use case: re-running journey tests after a
+ *      bug fix without burning 30-60min on a redeploy. THIS is the
+ *      contract that drove the refactor.
  *
- * This file pins the workflow-level half of that directive: the
- * `seed-personas` input exists with default true, the deploy-backend-dev
- * job invokes the `seed-test-personas` composite action behind that
- * toggle, and the action declares the inputs it needs to authenticate
- * against shytalk-dev.
+ * Three contracts pinned by this file:
+ *   - deploy-dev.yml has a `seed-dev-personas` job that uses the reusable
+ *     workflow and inherits secrets (instead of an inline composite action).
+ *   - `seed-dev-personas.yml` declares both `workflow_call` and
+ *     `workflow_dispatch` triggers + correct secrets surface.
+ *   - The `seed-test-personas` composite action still encapsulates the
+ *     credential-handling + cd/install/run pipeline (it's invoked from
+ *     the new reusable workflow now, not directly from deploy-dev).
  */
 
 jest.mock('../../src/utils/log', () => ({
@@ -29,91 +32,164 @@ const { join } = require('path');
 
 const REPO_ROOT = join(__dirname, '..', '..', '..');
 const DEPLOY_DEV = readFileSync(join(REPO_ROOT, '.github', 'workflows', 'deploy-dev.yml'), 'utf8');
+const SEED_WORKFLOW = readFileSync(
+  join(REPO_ROOT, '.github', 'workflows', 'seed-dev-personas.yml'),
+  'utf8',
+);
 const SEED_ACTION = readFileSync(
   join(REPO_ROOT, '.github', 'actions', 'seed-test-personas', 'action.yml'),
   'utf8',
 );
 
-describe('deploy-dev.yml — seed-personas integration', () => {
+// ── deploy-dev.yml — invokes the reusable workflow ─────────────────────
+
+describe('deploy-dev.yml — seed-dev-personas job (reusable workflow caller)', () => {
   test('declares a workflow_dispatch input `seed-personas` defaulting to true', () => {
-    // Pin both the input name and the default. A `default: false` would
-    // silently disable seeding on every workflow_dispatch run that didn't
-    // explicitly opt in — exactly the failure mode the operator wants to
-    // prevent by automating the seed step in the first place.
+    // Same toggle as before the refactor; default `true` so seed runs on
+    // every dev deploy unless the operator explicitly opts out via
+    // `gh workflow run deploy-dev.yml -f seed-personas=false`.
     expect(DEPLOY_DEV).toMatch(/^ {6}seed-personas:$/m);
-    // The block following should contain a default: true (within ~5 lines).
     const inputBlock = DEPLOY_DEV.match(/^ {6}seed-personas:[\s\S]{1,300}?default: (true|false)/m);
     expect(inputBlock).not.toBeNull();
     expect(inputBlock[1]).toBe('true');
   });
 
-  test('deploy-backend-dev job invokes the seed-test-personas composite action', () => {
-    // The step lives under `./.github/actions/seed-test-personas` (a
-    // composite action, NOT an inline shell step) so the credential-
-    // handling + trap-cleanup logic is shared with the parallel
-    // deploy-firebase-rules action.
-    expect(DEPLOY_DEV).toContain('uses: ./.github/actions/seed-test-personas');
+  test('seed step is a top-level JOB (not a step inside deploy-backend-dev) — refactored 2026-05-29', () => {
+    // Pre-refactor: seed was an inline `uses: ./.github/actions/...` step
+    // inside the `deploy-backend-dev` job. Post-refactor: it's a top-
+    // level job `seed-dev-personas` that `uses: ./.github/workflows/...`.
+    // The job-level structure makes the seed independently dispatchable
+    // (via the workflow_dispatch on `seed-dev-personas.yml` itself).
+    expect(DEPLOY_DEV).toMatch(/^ {2}seed-dev-personas:$/m);
+    expect(DEPLOY_DEV).toContain('uses: ./.github/workflows/seed-dev-personas.yml');
+    // Anti-pattern guard: the inline action should NOT appear inside
+    // deploy-backend-dev anymore (would indicate someone re-added it
+    // without removing the new job).
+    const backendIdx = DEPLOY_DEV.indexOf('deploy-backend-dev:');
+    const nextJobIdx = DEPLOY_DEV.indexOf('\n  seed-dev-personas:');
+    expect(backendIdx).toBeGreaterThan(-1);
+    expect(nextJobIdx).toBeGreaterThan(backendIdx);
+    const backendBlock = DEPLOY_DEV.slice(backendIdx, nextJobIdx);
+    expect(backendBlock).not.toContain('uses: ./.github/actions/seed-test-personas');
   });
 
-  test('seed step is gated on `inputs.seed-personas != false` (operator opt-out)', () => {
-    // Matching `!= false` (not `== true`) means the seed step ALSO runs on
-    // workflow events that don't supply the input (e.g. if some future
-    // trigger fires without inputs at all). The operator can disable on a
-    // per-run basis via `gh workflow run … -f seed-personas=false`.
-    const stepBlock = DEPLOY_DEV.match(
-      /Seed test personas[\s\S]{0,400}uses: \.\/\.github\/actions\/seed-test-personas/m,
-    );
-    expect(stepBlock).not.toBeNull();
-    expect(stepBlock[0]).toMatch(/if:\s*inputs\.seed-personas\s*!=\s*false/);
+  test('seed-dev-personas job needs deploy-backend-dev (ordering — seed after API + rules)', () => {
+    // Ordering invariant: seed must run AFTER the backend deploy + rules
+    // deploy succeed. Otherwise we'd seed against a half-deployed env.
+    const seedJobIdx = DEPLOY_DEV.indexOf('seed-dev-personas:\n');
+    expect(seedJobIdx).toBeGreaterThan(-1);
+    const jobBlock = DEPLOY_DEV.slice(seedJobIdx, seedJobIdx + 400);
+    expect(jobBlock).toMatch(/needs:\s*deploy-backend-dev/);
   });
 
-  test('seed step passes the FIREBASE_SERVICE_ACCOUNT_DEV + PERSONAS_PASSWORD_DEV secrets + the dev RTDB URL', () => {
-    // Secrets come from GitHub Actions secrets (never appear in workflow
-    // YAML diffs or run logs). PERSONAS_PASSWORD_DEV is a NEW secret the
-    // operator added once (value matches `~/.shytalk/dev-personas.env`).
-    // database-url is the public Firebase RTDB URL (in committed
-    // google-services.json) — required because the provision script
-    // transitively imports firebase.js which throws if FIREBASE_DATABASE_URL
-    // is unset. Region-specific (europe-west1); cannot be derived from
-    // project ID alone.
-    const seedIdx = DEPLOY_DEV.indexOf('uses: ./.github/actions/seed-test-personas');
-    expect(seedIdx).toBeGreaterThan(-1);
-    // Slice forward from the uses: line until the next step or job (top-
-    // level keys / 6-space indent). The seed step's `with:` block is the
-    // immediate target.
-    const stepBlock = DEPLOY_DEV.slice(seedIdx, seedIdx + 1000);
-    expect(stepBlock).toMatch(
-      /service-account-json:\s*\$\{\{\s*secrets\.FIREBASE_SERVICE_ACCOUNT_DEV\s*\}\}/,
-    );
-    expect(stepBlock).toMatch(
-      /personas-password:\s*\$\{\{\s*secrets\.PERSONAS_PASSWORD_DEV\s*\}\}/,
-    );
-    expect(stepBlock).toMatch(/firebase-project:\s*shytalk-dev/);
-    // The URL is committed-public (lives in app/src/dev/google-services.json
-    // too), so it can appear inline in the workflow YAML.
-    expect(stepBlock).toMatch(
-      /database-url:\s*https:\/\/shytalk-dev-default-rtdb\.europe-west1\.firebasedatabase\.app/,
-    );
+  test('seed-dev-personas job is gated on `inputs.seed-personas != false` (operator opt-out)', () => {
+    // The toggle still applies — `gh workflow run deploy-dev.yml -f
+    // seed-personas=false` skips the seed job entirely.
+    const seedJobIdx = DEPLOY_DEV.indexOf('seed-dev-personas:\n');
+    const jobBlock = DEPLOY_DEV.slice(seedJobIdx, seedJobIdx + 400);
+    expect(jobBlock).toMatch(/if:.*inputs\.seed-personas\s*!=\s*false/);
   });
 
-  test('seed step is positioned AFTER the firebase-rules deploy + verify dev API health', () => {
-    // Ordering invariant: seeding before the API is verified live would
-    // mean we could seed against a half-deployed dev. By running the seed
-    // step LAST inside deploy-backend-dev (after API health check + rules
-    // deploy), we guarantee the seed targets a healthy, fully-deployed
-    // shytalk-dev.
-    const rulesIdx = DEPLOY_DEV.indexOf('uses: ./.github/actions/deploy-firebase-rules');
-    const seedIdx = DEPLOY_DEV.indexOf('uses: ./.github/actions/seed-test-personas');
-    expect(rulesIdx).toBeGreaterThan(-1);
-    expect(seedIdx).toBeGreaterThan(-1);
-    expect(seedIdx).toBeGreaterThan(rulesIdx);
+  test('seed-dev-personas job inherits secrets (so the reusable workflow can read FIREBASE_SERVICE_ACCOUNT_DEV / PERSONAS_PASSWORD_DEV)', () => {
+    // `secrets: inherit` is the only path by which the reusable workflow
+    // sees the calling repo's secrets. Without it, the workflow_call
+    // would fail at the secrets validation in seed-dev-personas.yml.
+    const seedJobIdx = DEPLOY_DEV.indexOf('seed-dev-personas:\n');
+    const jobBlock = DEPLOY_DEV.slice(seedJobIdx, seedJobIdx + 400);
+    expect(jobBlock).toMatch(/secrets:\s*inherit/);
   });
 });
 
-describe('seed-test-personas composite action — interface', () => {
+// ── seed-dev-personas.yml — reusable workflow + direct dispatch ────────
+
+describe('seed-dev-personas.yml — reusable workflow + direct dispatch', () => {
+  test('declares both workflow_call AND workflow_dispatch triggers', () => {
+    // workflow_call: invoked from deploy-dev.yml on every dev deploy.
+    // workflow_dispatch: invoked DIRECTLY by operator (or CI rerun job)
+    // to refresh seed WITHOUT a full deploy — the key user-facing
+    // ergonomics improvement of the refactor.
+    expect(SEED_WORKFLOW).toMatch(/^ {2}workflow_call:$/m);
+    expect(SEED_WORKFLOW).toMatch(/^ {2}workflow_dispatch:$/m);
+  });
+
+  test('workflow_call declares the secrets it needs (caller forwards via `secrets: inherit`)', () => {
+    // Declared with the EXACT repo-level secret names so actionlint can
+    // type-check the `secrets.X` references inside the workflow AND so
+    // `secrets: inherit` from the caller forwards by name without needing
+    // an explicit per-secret mapping. Names match the repo's GitHub
+    // Actions secrets settings.
+    expect(SEED_WORKFLOW).toContain('FIREBASE_SERVICE_ACCOUNT_DEV:');
+    expect(SEED_WORKFLOW).toContain('PERSONAS_PASSWORD_DEV:');
+    // Both must be required so a future caller that forgets to forward
+    // them fails at workflow_call validation rather than at runtime.
+    const callIdx = SEED_WORKFLOW.indexOf('workflow_call:');
+    const dispatchIdx = SEED_WORKFLOW.indexOf('workflow_dispatch:');
+    const callBlock = SEED_WORKFLOW.slice(callIdx, dispatchIdx);
+    expect(callBlock).toMatch(/FIREBASE_SERVICE_ACCOUNT_DEV:[\s\S]{1,200}required: true/);
+    expect(callBlock).toMatch(/PERSONAS_PASSWORD_DEV:[\s\S]{1,200}required: true/);
+  });
+
+  test('declares a `target` input on both triggers with `dev` as the only allowed value', () => {
+    // Production-safety: the provision script's assertSafeProject() check
+    // refuses to run unless the project id contains "dev" or "local". The
+    // workflow_dispatch input is a `choice` with only `dev` to prevent
+    // a typo in `gh workflow run seed-dev-personas.yml -f target=prod`
+    // from even reaching the script. Belt + suspenders.
+    expect(SEED_WORKFLOW).toContain('target:');
+    expect(SEED_WORKFLOW).toContain('default: dev');
+    // workflow_dispatch uses `type: choice` with `dev` as the only option.
+    const dispatchIdx = SEED_WORKFLOW.indexOf('workflow_dispatch:');
+    const dispatchBlock = SEED_WORKFLOW.slice(dispatchIdx, dispatchIdx + 500);
+    expect(dispatchBlock).toContain('type: choice');
+    expect(dispatchBlock).toContain('- dev');
+  });
+
+  test('asserts target=dev at runtime (defence-in-depth against a future input addition)', () => {
+    // The script has its own assertSafeProject() but layering a workflow-
+    // level reject too means a typo'd input fails BEFORE the credential
+    // is decoded to /tmp. Cheap belt-and-suspenders.
+    expect(SEED_WORKFLOW).toContain('"$TARGET" != "dev"');
+    expect(SEED_WORKFLOW).toContain('Unsupported target');
+  });
+
+  test('sources FIREBASE_DATABASE_URL from app/src/dev/google-services.json (single source of truth)', () => {
+    // The RTDB URL is region-specific (europe-west1 for dev) — sourcing
+    // it from the committed Firebase config means a future region migration
+    // updates ONE file (the google-services.json) and the seed workflow
+    // automatically picks it up. Pre-refactor, the URL was hardcoded in
+    // deploy-dev.yml.
+    expect(SEED_WORKFLOW).toContain('jq -r');
+    expect(SEED_WORKFLOW).toContain('app/src/dev/google-services.json');
+  });
+
+  test('uses the seed-test-personas composite action', () => {
+    // The implementation hasn't moved — only the invocation layer. The
+    // composite action still does the credential-trap + cd/install/run
+    // pipeline. This pin ensures the workflow stays a thin wrapper.
+    expect(SEED_WORKFLOW).toContain('uses: ./.github/actions/seed-test-personas');
+  });
+
+  test('serializes seed runs against the same target via concurrency.group', () => {
+    // Concurrent seed runs would last-write-wins each persona doc. Queue
+    // them via the concurrency group so a re-seed mid-flight just waits
+    // for the previous one to finish.
+    expect(SEED_WORKFLOW).toContain('concurrency:');
+    expect(SEED_WORKFLOW).toContain('seed-dev-personas-');
+    expect(SEED_WORKFLOW).toContain('cancel-in-progress: false');
+  });
+
+  test('bounded timeout-minutes (10 — leaves room for transient quota throttling)', () => {
+    // Provisioning ~17 personas with create-or-update each is typically
+    // 30-60 sec. 10min cap leaves headroom for transient Firebase Auth
+    // quota throttling without letting a stuck run idle forever.
+    expect(SEED_WORKFLOW).toMatch(/timeout-minutes:\s*10/);
+  });
+});
+
+// ── seed-test-personas composite action — unchanged contracts ──────────
+
+describe('seed-test-personas composite action — interface (unchanged by refactor)', () => {
   test('declares the four required inputs (service-account-json, firebase-project, personas-password, database-url)', () => {
-    // Use indexOf-based slicing instead of `\s*\n\s*` regex — SonarJS flags
-    // the nested whitespace quantifiers as super-linear-backtracking-prone.
     for (const name of [
       'service-account-json:',
       'firebase-project:',
@@ -127,23 +203,7 @@ describe('seed-test-personas composite action — interface', () => {
     }
   });
 
-  test('exports FIREBASE_DATABASE_URL from the database-url input (region-specific RTDB URL)', () => {
-    // The provision script transitively imports `express-api/src/utils/firebase.js`,
-    // which throws `FIREBASE_DATABASE_URL env var is required` at module-load
-    // time if unset. Caught in local dry-run after PR #870's npm-ci fix —
-    // the require chain works, but module-init then fails on the URL check.
-    // Action must wire the input through to the env.
-    expect(SEED_ACTION).toContain('DATABASE_URL: ${{ inputs.database-url }}');
-    expect(SEED_ACTION).toContain('export FIREBASE_DATABASE_URL="$DATABASE_URL"');
-  });
-
   test('all four inputs are required (no defaults that would silently work in CI without secrets)', () => {
-    // Required inputs make the action fail loudly if any secret/value is
-    // missing from the workflow that calls it — the alternative (defaults
-    // to empty string) would let firebase-admin attempt to auth with no
-    // credentials, producing a confusing log line buried in runner output.
-    // Slice the inputs block via string-index (not greedy regex) so SonarJS
-    // doesn't flag a super-linear-backtracking risk on `[\s\S]+?`.
     const inputsIdx = SEED_ACTION.indexOf('inputs:');
     const runsIdx = SEED_ACTION.indexOf('\nruns:');
     expect(inputsIdx).toBeGreaterThan(-1);
@@ -165,36 +225,19 @@ describe('seed-test-personas composite action — interface', () => {
   });
 
   test('wipes the service-account JSON via a trap (credential never leaks across jobs)', () => {
-    // Without the trap, set -e would abort the bash script before the
-    // trailing `rm` runs, leaving /tmp/firebase-sa-seed.json on the
-    // shared runner. Mirrors the safety pattern in
-    // deploy-firebase-rules/action.yml.
     expect(SEED_ACTION).toContain("trap 'rm -f /tmp/firebase-sa-seed.json' EXIT");
     expect(SEED_ACTION).toContain('umask 077');
   });
 
-  test('passes GOOGLE_APPLICATION_CREDENTIALS so firebase-admin auto-auths', () => {
-    // The provision script's `admin.initializeApp()` defaults to
-    // GOOGLE_APPLICATION_CREDENTIALS — if the action didn't export it,
-    // firebase-admin would fall back to gcloud ADC and fail in CI.
+  test('exports GOOGLE_APPLICATION_CREDENTIALS + FIREBASE_PROJECT_ID + FIREBASE_DATABASE_URL', () => {
     expect(SEED_ACTION).toContain(
       'export GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-sa-seed.json',
     );
+    expect(SEED_ACTION).toContain('export FIREBASE_PROJECT_ID="$PROJECT"');
+    expect(SEED_ACTION).toContain('export FIREBASE_DATABASE_URL="$DATABASE_URL"');
   });
 
-  test('does NOT use the dotenv preload flag on the node invocation (CI exports env directly)', () => {
-    // The script's own usage docstring shows the preload flag because it
-    // assumes a .env file on the dev Express host. In CI dotenv is not on
-    // the node resolution path (lives in express-api/node_modules, not
-    // the repo-root node_modules that the composite action invokes from),
-    // so the preload fails at runtime. Caught in run 26636553597: the
-    // first attempted dev deploy with this action failed at exactly this
-    // point. Pin the absence so it can't regress.
-    //
-    // Slice the actual `node ...` invocation line (not the whole file —
-    // the comment ABOVE the node line literally mentions the flag, so a
-    // whole-file `not.toContain` would match the comment text and pass-
-    // through the actual bug if it returned).
+  test('does NOT use the dotenv preload flag on the node invocation', () => {
     const nodeLine = SEED_ACTION.split('\n').find(
       (l) => /^\s*node\s+/.test(l) && l.includes('provision-test-personas.js'),
     );
@@ -202,40 +245,7 @@ describe('seed-test-personas composite action — interface', () => {
     expect(nodeLine).not.toContain('-r dotenv');
   });
 
-  test('cd-s into express-api before running node (so require("firebase-admin") resolves)', () => {
-    // The provision script does `require('firebase-admin')` etc. — those
-    // resolve against `express-api/node_modules`, NOT the repo-root.
-    // Running the script with a `express-api/scripts/...` path from repo
-    // root fails because the repo root has no `node_modules/firebase-admin`.
-    // Caught in run 26637428443: `Cannot find module 'firebase-admin'`.
-    //
-    // Pin both: (1) a `cd express-api` precedes the node line, (2) the
-    // node line uses a bare relative path `scripts/provision-test-...`,
-    // NOT the repo-root-prefixed `express-api/scripts/provision-test-...`.
-    const lines = SEED_ACTION.split('\n');
-    const cdIdx = lines.findIndex((l) => /^\s*cd\s+express-api\s*$/.test(l));
-    const nodeIdx = lines.findIndex(
-      (l) => /^\s*node\s+/.test(l) && l.includes('provision-test-personas.js'),
-    );
-    expect(cdIdx).toBeGreaterThan(-1);
-    expect(nodeIdx).toBeGreaterThan(cdIdx);
-    expect(lines[nodeIdx]).toMatch(/^\s*node\s+scripts\/provision-test-personas\.js\s*$/);
-    // Anti-pattern guard: must NOT use repo-root-prefixed path on the
-    // node line (would fail because firebase-admin lives in
-    // express-api/node_modules, not the repo-root resolution path).
-    expect(lines[nodeIdx]).not.toContain('express-api/scripts/');
-  });
-
-  test('runs `npm ci --omit=dev` before node (installs firebase-admin on the runner)', () => {
-    // The outer deploy-backend-dev workflow only npm-installs on the REMOTE
-    // London VM via ssh — the GitHub runner's `express-api/node_modules`
-    // is empty when the seed step starts. Without an install, every
-    // `require('firebase-admin')` etc. in the provision script fails
-    // MODULE_NOT_FOUND. Caught in runs 26637428443 + 26638445667.
-    //
-    // Pin: an `npm ci` line precedes the node line, has `--omit=dev` (we
-    // only need production deps), and is inside the express-api CWD
-    // (after the `cd express-api`).
+  test('cd-s into express-api + npm-ci-s + runs the script in that order', () => {
     const lines = SEED_ACTION.split('\n');
     const cdIdx = lines.findIndex((l) => /^\s*cd\s+express-api\s*$/.test(l));
     const installIdx = lines.findIndex((l) => /^\s*npm ci\b/.test(l));
@@ -246,5 +256,6 @@ describe('seed-test-personas composite action — interface', () => {
     expect(installIdx).toBeGreaterThan(cdIdx);
     expect(nodeIdx).toBeGreaterThan(installIdx);
     expect(lines[installIdx]).toContain('--omit=dev');
+    expect(lines[nodeIdx]).toMatch(/^\s*node\s+scripts\/provision-test-personas\.js\s*$/);
   });
 });


### PR DESCRIPTION
## Why

Operator directive 2026-05-29:
> the re-seed of dev data should be a separate workflow called by the deployment stage. this way we can re-seed without the need of a whole new deployment. and this is how re-runs of tests should be performed.

Currently the seed step is inline in \`deploy-dev.yml\`'s \`deploy-backend-dev\` job. To re-seed (e.g. between journey-test passes that mutate persona state) you'd have to run the full ~30-60min Deploy To Dev workflow. This refactor extracts the seed into its own reusable workflow with TWO entry points:

1. **\`workflow_call\`** — invoked from \`deploy-dev.yml\` as a downstream job after backend deploy, so every dev deploy still ends with personas in a known-fresh state.
2. **\`workflow_dispatch\`** — invoked DIRECTLY (\`gh workflow run seed-dev-personas.yml\`) to refresh seed data WITHOUT a full deploy. ~30 sec instead of ~30-60 min.

The underlying composite action (\`.github/actions/seed-test-personas/action.yml\`) is unchanged — this PR is purely workflow plumbing.

## Changes

- **New**: \`.github/workflows/seed-dev-personas.yml\` — reusable workflow + manual dispatch entry point. Concurrency group \`seed-dev-personas-\${{ inputs.target }}\` so concurrent runs queue rather than thrash. 10-min timeout. Resolves \`shytalk-dev\` + region-specific RTDB URL (sourced from committed \`google-services.json\`).
- **Modified**: \`.github/workflows/deploy-dev.yml\` — removed inline \`Seed test personas\` step from \`deploy-backend-dev\`; added top-level \`seed-dev-personas\` job that \`uses: ./.github/workflows/seed-dev-personas.yml\` with \`secrets: inherit\`.
- **Rewrote**: \`express-api/tests/scripts/deploy-dev-seed-personas.test.js\` — 19 pin tests across 3 describe blocks covering the new structure. All 19/19 pass; ESLint clean.

## Memory note

Added \`feedback-keep-seed-data-current\` to my persistent memory: when feature work touches user-doc schema / userType enum / cohort / wallet currencies / claims, the persona registry in \`provision-test-personas.js\` MUST be updated in the same PR, and the cheap re-seed path enabled by this refactor should be used to refresh dev.

## Verification

- ✅ \`actionlint\` clean on both files (pre-existing shellcheck warnings on deploy-dev.yml unrelated)
- ✅ 19/19 pin tests pass
- ✅ ESLint clean
- ✅ Pre-push hook (Sonar + lint + actionlint) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)