### PR TITLE
fix(seed-personas): hardcode DATABASE_URL — google-services.json is gitignored

### DIFF
--- a/.github/workflows/seed-dev-personas.yml
+++ b/.github/workflows/seed-dev-personas.yml
@@ -86,12 +86,22 @@ jobs:
             echo "::error::Unsupported target '$TARGET' — only 'dev' is allowed"
             exit 1
           fi
-          # Source the RTDB URL from the public Firebase config committed
-          # to the repo. Region-specific (europe-west1 for dev); cannot
-          # be derived from project ID alone.
-          DATABASE_URL=$(jq -r '.project_info.firebase_url' app/src/dev/google-services.json)
+          # RTDB URL is HARDCODED here, NOT sourced from a JSON file.
+          # The corresponding google-services.json files are gitignored
+          # (they contain the OAuth client IDs, treated as semi-sensitive
+          # client config) and decoded from a base64 secret only when
+          # the Android build needs them. The seed runner doesn't run
+          # the Android build, so requiring it to decode the file just
+          # to read one URL would mean declaring an extra secret on this
+          # reusable workflow and running an extra composite-action step.
+          # Region (europe-west1) + project (shytalk-dev) are stable for
+          # the lifetime of the Firebase project; if either ever changes
+          # this string + the pin test in
+          # express-api/tests/scripts/deploy-dev-seed-personas.test.js
+          # update together. Pre-refactor: same hardcode lived inline in
+          # deploy-dev.yml's seed step (PR #871).
           echo "firebase-project=shytalk-dev" >> "$GITHUB_OUTPUT"
-          echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
+          echo "database-url=https://shytalk-dev-default-rtdb.europe-west1.firebasedatabase.app" >> "$GITHUB_OUTPUT"
 
       - name: Run seed action
         uses: ./.github/actions/seed-test-personas

--- a/express-api/tests/scripts/deploy-dev-seed-personas.test.js
+++ b/express-api/tests/scripts/deploy-dev-seed-personas.test.js
@@ -152,14 +152,68 @@ describe('seed-dev-personas.yml — reusable workflow + direct dispatch', () => 
     expect(SEED_WORKFLOW).toContain('Unsupported target');
   });
 
-  test('sources FIREBASE_DATABASE_URL from app/src/dev/google-services.json (single source of truth)', () => {
-    // The RTDB URL is region-specific (europe-west1 for dev) — sourcing
-    // it from the committed Firebase config means a future region migration
-    // updates ONE file (the google-services.json) and the seed workflow
-    // automatically picks it up. Pre-refactor, the URL was hardcoded in
-    // deploy-dev.yml.
-    expect(SEED_WORKFLOW).toContain('jq -r');
-    expect(SEED_WORKFLOW).toContain('app/src/dev/google-services.json');
+  test('hardcodes FIREBASE_DATABASE_URL to the dev project + region (no JSON lookup)', () => {
+    // The RTDB URL is hardcoded — NOT sourced from a file. The
+    // corresponding google-services.json is gitignored (it carries the
+    // OAuth client ID, treated as semi-sensitive client config) so it's
+    // not on the runner unless the Android-build composite-action step
+    // decodes it from a base64 secret first. The seed runner doesn't
+    // run the Android build; adding a decode step + secret declaration
+    // just to read one stable URL is more cost than the single-source-
+    // of-truth benefit. Region (europe-west1) + project (shytalk-dev)
+    // are stable for the project lifetime.
+    expect(SEED_WORKFLOW).toContain(
+      'https://shytalk-dev-default-rtdb.europe-west1.firebasedatabase.app',
+    );
+  });
+
+  test('shell-command bodies do NOT operationally reference any gitignored google-services.json — regression guard from the 2026-05-29 first-dispatch failure', () => {
+    // Run 26645780661 broke because an earlier draft did
+    //   jq -r '.project_info.firebase_url' app/src/dev/google-services.json
+    // — that file is gitignored, so the jq call failed at the very
+    // first dispatch (caught only because we ran the workflow_dispatch
+    // live; every static gate had passed).
+    //
+    // We strip COMMENT lines from the run blocks before asserting:
+    // commenting the file path is fine (and useful — `git grep
+    // google-services.json` should still find the discussion), but no
+    // shell command may use it. A future maintainer who tries to
+    // factor the URL out of YAML must either commit the source file
+    // or add a decode-from-secret step first.
+    const runBlocks = SEED_WORKFLOW.split(/run:\s*\|/).slice(1);
+    expect(runBlocks.length).toBeGreaterThan(0);
+    runBlocks.forEach((block) => {
+      // Find next-step boundary by searching for both `- name:` and `- uses:`
+      // separately with indexOf — avoids SonarJS's slow-regex false
+      // positive on the `(name|uses)` alternation pattern. Picking the
+      // FIRST occurrence of either marker correctly bounds the run body
+      // before the next step starts.
+      const nameIdx = block.indexOf('\n      - name:');
+      const usesIdx = block.indexOf('\n      - uses:');
+      let stepBoundary = -1;
+      if (nameIdx !== -1 && usesIdx !== -1) {
+        stepBoundary = Math.min(nameIdx, usesIdx);
+      } else if (nameIdx !== -1) {
+        stepBoundary = nameIdx;
+      } else if (usesIdx !== -1) {
+        stepBoundary = usesIdx;
+      }
+      const body = stepBoundary === -1 ? block : block.slice(0, stepBoundary);
+      const code = body
+        .split('\n')
+        .filter((line) => !line.trimStart().startsWith('#'))
+        .join('\n');
+      expect(code).not.toContain('google-services.json');
+      // String-contains checks instead of a regex to avoid SonarJS's
+      // slow-regex false positive on `['"]\.project_info` — that pattern
+      // has no super-linear backtracking risk, but the linter rejects
+      // character-class alternations inside quantified groups. Both
+      // jq + yq are common offenders; cover both.
+      expect(code).not.toContain("jq -r '.project_info");
+      expect(code).not.toContain('jq -r ".project_info');
+      expect(code).not.toContain("yq -r '.project_info");
+      expect(code).not.toContain('yq -r ".project_info');
+    });
   });
 
   test('uses the seed-test-personas composite action', () => {


### PR DESCRIPTION
## Why

PR #872 introduced a regression: my new reusable workflow extracted DATABASE_URL via `jq` from \`app/src/dev/google-services.json\` — which is **gitignored**. The first standalone dispatch ([run 26645780661](https://github.com/ShydenMcM/ShyTalk/actions/runs/26645780661)) failed at the resolve step:

\`\`\`
jq: error: Could not open file app/src/dev/google-services.json: No such file or directory
##[error]Process completed with exit code 2.
\`\`\`

All static gates had passed: actionlint, 19 pin tests, ESLint, reviewer-agent — none could see the missing-file precondition. This is exactly the dynamic-vs-static bug class [\`feedback-workflow-verify-by-running\`] guards against.

## Root cause

I transcribed PR #871's aspirational comment ("sourced from app/src/dev/google-services.json (public Firebase config)") into my refactor without verifying. PR #871 actually hardcoded the URL — the comment described intent, not behavior. Classic "comment lies" failure mode.

The check that would have caught it:

\`\`\`bash
git ls-files app/src/dev/google-services.json   # empty → not tracked
\`\`\`

0.5 seconds. Universal.

## Fix

- **\`.github/workflows/seed-dev-personas.yml\`** — replace the \`jq\` extraction with the hardcoded URL string (matches PR #871's established pattern; the URL is region+project+format-stable for the project's lifetime). Comment explains the choice + points to the pin test so a future maintainer trying to factor it back into JSON finds the discussion.
- **\`express-api/tests/scripts/deploy-dev-seed-personas.test.js\`**:
  - Replace the old assertion (\`expect ... toContain('jq -r')\`) with a pin on the hardcoded URL value.
  - Add a regression-prevention test: shell-command bodies (i.e. \`run:|\` blocks) must NOT reference any gitignored \`google-services.json\` path. Comments are exempted so the explanation can mention the filename for grep-ability.
  - Use \`indexOf\` + \`startsWith\` instead of regex alternations to dodge SonarJS slow-regex false positives.

## Tests

\`\`\`
Tests:       20 passed, 20 total
\`\`\`

ESLint clean (\`--max-warnings=0\`). actionlint clean on the touched workflow.

## Verification post-merge

Per [\`feedback-workflow-verify-by-running\`], after this lands I'll re-dispatch \`seed-dev-personas.yml\` standalone and watch it green before unblocking the j09 smoke test.

## Memory note

Added \`feedback-verify-file-tracked-before-ci-reference\` to codify the \`git ls-files\` pre-check rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)