### PR TITLE
fix(qa-runner+journey-tests): JWT JSON-string traversal + test-corpus contract drift sweep

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -1441,6 +1441,15 @@ const matchers = [
   // Decodes the `token` field of the most-recent response body and asserts on
   // a dotted-path field within the payload. Used for verifying LiveKit access
   // tokens carry the correct cohort / room claims (OSA #17 Fill-2).
+  //
+  // JSON-string intermediate traversal: if a path segment lands on a string
+  // value that JSON.parses to an object, drill INTO the parsed object on the
+  // next segment. This is the canonical shape for LiveKit's `metadata` field —
+  // the SDK stores it verbatim in the JWT as a JSON-serialized string, NOT a
+  // nested object. Without this, `metadata.cohort` would resolve to undefined
+  // even when the metadata claim is correctly set on the token. Pinned by
+  // j09's "LiveKit access token contains cohort claim matching the room"
+  // scenario; surfaced on 2026-05-29 (manual-qa-cycle-1.md).
   {
     pattern: /^the decoded JWT payload has field "([^"]+)" equal to (.+)$/,
     async handler(m, ctx) {
@@ -1456,7 +1465,26 @@ const matchers = [
         };
       }
       const payload = decodeJwtPayload(token);
-      const actual = dottedPath.split('.').reduce((acc, k) => (acc ? acc[k] : undefined), payload);
+      const actual = dottedPath.split('.').reduce((acc, k) => {
+        if (acc === undefined || acc === null) return undefined;
+        // If the current accessor is a string that JSON.parses to an object,
+        // drill INTO the parsed object — supports LiveKit's `metadata` field
+        // (verbatim-JSON-string convention) and any future JSON-encoded
+        // claim payload.
+        if (typeof acc === 'string') {
+          try {
+            const parsed = JSON.parse(acc);
+            if (parsed && typeof parsed === 'object') {
+              return parsed[k];
+            }
+          } catch {
+            // Not JSON — fall through to plain property access below, which
+            // will yield undefined for an object-key on a primitive string
+            // (i.e. preserve old behaviour for non-JSON strings).
+          }
+        }
+        return acc[k];
+      }, payload);
       if (actual !== expected) {
         return {
           ok: false,

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -521,6 +521,53 @@ describe('executeStep', () => {
     expect(r2.ok).toBe(true);
   });
 
+  test('decoded JWT payload — auto-parses JSON-string intermediate (LiveKit metadata convention)', async () => {
+    // LiveKit's AccessToken stores `metadata` verbatim in the JWT as a
+    // JSON-serialized STRING (not a nested object). The matcher must
+    // detect that and drill INTO the parsed object on the next segment.
+    // Pinned by j09's "LiveKit access token contains cohort claim
+    // matching the room" scenario; surfaced when the live JWT carried
+    // a correct metadata claim but the runner reported it as undefined.
+    const payload = Buffer.from(
+      JSON.stringify({
+        video: { room: 'ra1' },
+        // metadata as a string — the real LiveKit wire format
+        metadata: JSON.stringify({ cohort: 'adult' }),
+      }),
+    ).toString('base64url');
+    const token = 'h.' + payload + '.s';
+    const ctx = makeCtx();
+    ctx.lastResponse = { body: { token } };
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the decoded JWT payload has field "metadata.cohort" equal to "adult"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('decoded JWT payload — non-JSON string intermediate preserves old undefined behaviour', async () => {
+    // A string-valued claim that ISN'T JSON must still drill into a
+    // single-character access (which yields undefined for `length`-style
+    // accessors and undefined for any non-numeric key). Pins that the
+    // JSON.parse fallback doesn't accidentally trigger on plain strings.
+    const payload = Buffer.from(JSON.stringify({ subject: 'plain-not-json-string' })).toString(
+      'base64url',
+    );
+    const token = 'h.' + payload + '.s';
+    const ctx = makeCtx();
+    ctx.lastResponse = { body: { token } };
+    const r = await executeStep(
+      { kind: 'Then', text: 'the decoded JWT payload has field "subject.cohort" equal to "x"' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    // Error should mention the missing-field undefined, NOT a JSON-parse crash.
+    expect(r.error).toMatch(/subject\.cohort.*undefined/i);
+  });
+
   test('decoded JWT payload — wrong claim fails with both expected + actual', async () => {
     const payload = Buffer.from(JSON.stringify({ metadata: { cohort: 'minor' } })).toString(
       'base64url',

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -735,7 +735,6 @@
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = F3XX4PM3MF;
-				PROVISIONING_PROFILE_SPECIFIER = "ShyTalk App Store Distribution";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -749,6 +748,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.shyden.shytalk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "ShyTalk App Store Distribution";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/journey-tests/j02-minor-new-restricted.feature
+++ b/journey-tests/j02-minor-new-restricted.feature
@@ -87,7 +87,7 @@ Feature: j02 — Mia's restricted minor experience
     Given Mia has accepted legal as a minor
     When POST /api/users/follow with targetUniqueId=50000010 as Mia
     Then the response status is 404
-    Then the database has 1 entries in "auditLog" matching {action: "blocked", targetId: 50000010, sourceId: {newUniqueId}, reason: "cohort_mismatch"}
+    Then the database has 1 entries in "segregationEvents" matching {action: "blocked", targetUniqueId: 50000010, sourceUniqueId: {newUniqueId}}
     Then Mia's iOS Sim UI does not show Alice anywhere
 
   @blocker @ios-sim
@@ -109,7 +109,7 @@ Feature: j02 — Mia's restricted minor experience
     When POST /api/conversations with targetUniqueId=50000010 as Mia
     Then the response status is 404
     Then no conversation doc is created
-    Then the database has 1 entries in "auditLog" matching {action: "blocked", targetId: 50000010, reason: "cohort_mismatch"}
+    Then the database has 1 entries in "segregationEvents" matching {action: "blocked", targetUniqueId: 50000010}
 
   @ios-sim
   Scenario: Defence-in-depth — stale followingIds entry pointing at an adult is hidden in UI

--- a/journey-tests/j07-discovery-follow-pm.feature
+++ b/journey-tests/j07-discovery-follow-pm.feature
@@ -129,4 +129,4 @@ Feature: j07 — Adam discovers + messages Alice
     When Adam on Android attempts to start a conversation with Marcus via POST /api/conversations
     Then the response status is 404
     Then no conversation doc is created
-    Then the database has 1 entries in "auditLog" matching {action: "blocked", targetId: 60000010, reason: "cohort_mismatch"}
+    Then the database has 1 entries in "segregationEvents" matching {action: "blocked", targetUniqueId: 60000010}

--- a/journey-tests/j08-cross-cohort-wall.feature
+++ b/journey-tests/j08-cross-cohort-wall.feature
@@ -43,7 +43,7 @@ Feature: j08 — Vexa's cross-cohort probing
   Scenario: Vexa's follow attempt via API returns 404 + audit row
     When Vexa on Web POSTs /api/users/follow with targetUniqueId=60000010
     Then the response status is 404
-    Then the database has 1 entries in "auditLog" matching {action: "blocked", sourceId: 50000040, targetId: 60000010, reason: "cohort_mismatch"}
+    Then the database has 1 entries in "segregationEvents" matching {action: "blocked", sourceUniqueId: 50000040, targetUniqueId: 60000010}
 
   @blocker @browser-chromium @cross-cohort
   Scenario: Vexa's PM conversation-creation attempt returns 404 with no conversation doc
@@ -97,7 +97,7 @@ Feature: j08 — Vexa's cross-cohort probing
     Then Vexa's Android UI shows "User not found"
     When Vexa on Android attempts to follow Marcus via the profile screen (via deep-link error path)
     Then the request returns status 404
-    Then the database has 1 entries in "auditLog" matching {action: "blocked", sourceId: 50000040, targetId: 60000010, reason: "cohort_mismatch"}
+    Then the database has 1 entries in "segregationEvents" matching {action: "blocked", sourceUniqueId: 50000040, targetUniqueId: 60000010}
 
   @blocker @cross-cohort
   Scenario: Reverse direction — Marcus (minor) probing Vexa (adult) — same wall
@@ -105,7 +105,7 @@ Feature: j08 — Vexa's cross-cohort probing
     Then Marcus's Android UI shows "No results found"
     When POST /api/users/follow with targetUniqueId=50000040 as Marcus
     Then the response status is 404
-    Then the database has 1 entries in "auditLog" matching {action: "blocked", sourceId: 60000010, targetId: 50000040, reason: "cohort_mismatch"}
+    Then the database has 1 entries in "segregationEvents" matching {action: "blocked", sourceUniqueId: 60000010, targetUniqueId: 50000040}
 
   @cross-cohort @perf-budget:200
   Scenario: Audit row write does not slow the 404 response path noticeably
@@ -125,7 +125,7 @@ Feature: j08 — Vexa's cross-cohort probing
     Then the response status is 404
     Then the database has document "users/50000040" with field "shyCoins" equal to 1000
     Then the database has document "users/60000010" with field "shyCoins" equal to 10
-    Then the database has 1 entries in "auditLog" matching {action: "blocked", sourceId: 50000040, targetId: 60000010, reason: "cohort_mismatch"}
+    Then the database has 1 entries in "segregationEvents" matching {action: "blocked", sourceUniqueId: 50000040, targetUniqueId: 60000010}
     Then no entry is added to "users/50000040/transactions" since "{ts}"
     Then no entry is added to "users/60000010/transactions" since "{ts}"
 

--- a/journey-tests/j09-voice-room-host.feature
+++ b/journey-tests/j09-voice-room-host.feature
@@ -132,6 +132,7 @@ Feature: j09 — Theo hosts a public voice room
   @regression @cross-cohort osa17-pr7-livekit-token-cohort-claim
   Scenario: LiveKit access token contains cohort claim matching the room
     Given Theo on Android created an adult-cohort room "ra1"
+    Given Marcus [P-04] is signed in on Android
     When Alice on Web POSTs /api/livekit/token with roomName="ra1"
     Then the response status is 200
     Then the response body has field "token" of type "string"
@@ -140,4 +141,4 @@ Feature: j09 — Theo hosts a public voice room
     When Marcus on Android POSTs /api/livekit/token with roomName="ra1"
     Then the response status is 404
     Then the response body does not include a token
-    Then the database has 1 entries in "auditLog" matching {action: "blocked", sourceId: 60000010, targetId: "ra1", reason: "cohort_mismatch"}
+    Then the database has 1 entries in "segregationEvents" matching {action: "blocked", sourceUniqueId: 60000010, targetUniqueId: "ra1"}

--- a/journey-tests/j16-event-host-team-leader.feature
+++ b/journey-tests/j16-event-host-team-leader.feature
@@ -107,7 +107,7 @@ Feature: j16 — Tariq's multi-singer event
     When Tariq on Web attempts to add Marcus to his roster via /api/events/roster/add
     Then the response status is 404
     Then Tariq's Web UI shows "User not found"
-    Then the database has 1 entries in "auditLog" matching {action: "blocked", reason: "cohort_mismatch"}
+    Then the database has 1 entries in "segregationEvents" matching {action: "blocked"}
 
   @android-physical
   Scenario: Selma declines the event invite — Tariq sees the decline

--- a/journey-tests/j19-osa-migration-regression.feature
+++ b/journey-tests/j19-osa-migration-regression.feature
@@ -73,4 +73,4 @@ Feature: j19 — OSA migration steady-state regression guards
     Given Officia [P-19] has uniqueId=1, isOfficial=true, isUnblockable=true
     When a query is run for the user doc "users/1"
     Then the doc has entries in "followerIds" with users from BOTH cohort="adult" AND cohort="minor"
-    Then the doc has at most 0 entries in "auditLog" matching {action: "blocked", sourceId: 1}
+    Then the doc has at most 0 entries in "segregationEvents" matching {action: "blocked", sourceUniqueId: 1}


### PR DESCRIPTION
## Why

The 2026-05-29 authenticated j09 dispatches against dev surfaced cascading test-infrastructure drift after PR #875 deployed the LiveKit \`at.metadata = JSON.stringify(...)\` fix. The runner's matcher still reported \`metadata.cohort was undefined\` — but the failure mode was the **runner's path-extract**, not the production code.

## Runner fix

\`express-api/scripts/manual-qa-runner.js\` — the JWT-decode matcher now auto-parses JSON-string intermediate values during dotted-path traversal. LiveKit's AccessToken stores \`metadata\` verbatim in the JWT as a **JSON-serialized string** (NOT a nested object) — without this, \`metadata.cohort\` resolves to undefined even when the claim is set correctly.

Pinned by 2 new tests in \`manual-qa-runner.test.js\`:
- "auto-parses JSON-string intermediate (LiveKit metadata convention)"
- "non-JSON string intermediate preserves old undefined behaviour" (regression guard)

**1808/1808 runner tests pass** (1806 prior + 2 new).

## Feature-corpus drift sweep

After the runner fix unblocked the JWT step, further j09 dispatches surfaced 3 more layers of test-contract drift vs the actual server-side schema:

1. **Collection name**: predicates used \`auditLog\` for cohort-block audit rows, but the server's \`writeSegregationEvent\` writes to **\`segregationEvents\`** (per \`express-api/src/middleware/sameCohort.js:127\` — a separate collection with load-bearing DoS-protective dedup, distinct from the admin-action \`auditLog\`).

2. **Field names**: predicates used \`sourceId\`/\`targetId\`, but the server writes \`sourceUniqueId\`/\`targetUniqueId\` (per livekit.js docstring at lines 87-94: "\`targetUniqueId\` is repurposed here to hold the roomId so the audit schema stays uniform across user-to-user and user-to-room gate hits").

3. **Reason field**: predicates included \`reason: "cohort_mismatch"\`, but the server doesn't write a \`reason\` field — the cohort-block reason is implicit in the collection name + \`action='blocked'\`.

Swept across 10 lines in 7 files (j02, j07, j08, j09, j16, j19).

## j09 cohort-claim — Marcus signed in

The "LiveKit access token contains cohort claim matching the room" scenario uses Marcus [P-04] as the cross-cohort prober but j09's Background only signs in Theo/Alice/Ines. Added scenario-level \`Given Marcus [P-04] is signed in on Android\`. Step count 11/15, well under limit.

## Verification

- 1808/1808 \`manual-qa-runner.test.js\` pass
- 3/3 \`feature-file-endpoint-contracts.test.js\` pass
- ESLint clean (\`--max-warnings=0\`); Prettier clean
- Gherkin quality check clean on all 19 j-files

## What's NOT in this PR (for your review on return)

j09 dispatches still surface other framework gaps that are substantial work-streams needing your direction:

1. **MVP runner UI-driver gaps** (3 findings on j09): the runner's docstring says "UI drivers (adb / simctl / Playwright MCP) are NOT in this MVP — Scenarios that need them are skipped with a STEP_NOT_IMPLEMENTED finding so coverage gaps are visible." Tags like \`main_createRoomFab\` and methods like \`androidNetworkDropFor\` need handler implementations.

2. **STEP_NOT_IMPLEMENTED handlers** for the 8 new setup-style \`Given\` matchers I added during the long-scenario refactor (e.g. "Given Theo's public room is OPEN", "Given Ines has a PENDING seat request in Theo's room"). These need new patterns in the runner's step library that mutate Firestore directly via firebase-admin to bootstrap the test preconditions.

3. **Latest j09 dispatch** also hit a Firebase Auth 400 on Theo's sign-in step — could be rate-limit, password drift, or a side-effect of the latest deploy-dev's seed run. Worth investigating once back.

This PR ships the narrow, ship-ready chunk so the runner can correctly verify the next round of bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)