### PR TITLE
feat(qa-runner): 8 room-state setup-Given handlers (j09 STEP_NOT_IMPLEMENTED unblock)

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -295,6 +295,183 @@ async function clearCrossCohortFollowsForUserDoc(db, uniqueId, newCohort) {
   return cleared;
 }
 
+// ─── Room-state setup primitives (consumed by j09 setup-Given handlers,
+//     and structured to scale to the other journey-tests setup-Givens). ──
+//
+// The long-scenario refactor in PR #874 split each journey's megascenario
+// into phase-focused scenarios sharing the Background. Each later scenario
+// establishes the prior phase's outcome via a setup-style `Given` so it
+// can run in isolation. Those Givens need handlers that mutate Firestore
+// directly via firebase-admin to bootstrap the test precondition — without
+// these, every refactored scenario emits a STEP_NOT_IMPLEMENTED finding.
+//
+// Design principles:
+//
+//   1. Idempotent: re-running a Given against the same scenario state must
+//      not error (handlers are run as setup; rerunning under polling/retry
+//      is legitimate).
+//   2. Stable roomId per title: derive a slug from the title so subsequent
+//      Givens referencing the same title hit the same room doc.
+//   3. ctx-cached host→room map: when a Given says "<host>'s room" without
+//      a title (e.g. "Ines is a non-seated participant in Theo's room"),
+//      resolve the most-recently-touched room owned by that host. Falls
+//      back to creating a default room if no prior reference.
+//   4. Use the persona registry's uniqueId — same indirection as the
+//      sign-in matchers — so a future persona rename doesn't require
+//      updating Givens.
+
+function roomIdFromTitle(title) {
+  // Slug: lowercase, replace non-alphanum with `-`, collapse + trim, cap
+  // at 64 chars (Firestore doc IDs prefer short stable strings + this
+  // keeps logs grep-able). Matches Firestore's auto-ID charset constraints
+  // (ROOM_NAME_PATTERN in express-api/src/routes/livekit.js).
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 64);
+}
+
+async function ensureRoomForHost(ctx, hostName, opts = {}) {
+  const personas = loadPersonas();
+  const host = personas.get(hostName);
+  if (!host?.uniqueId) {
+    throw new Error(`persona "${hostName}" not in registry`);
+  }
+  const title = opts.title || `${hostName}'s test room`;
+  const roomId = opts.roomId || roomIdFromTitle(title);
+  const roomRef = ctx.db.doc(`rooms/${roomId}`);
+  const snap = await roomRef.get();
+  const existing = snap.exists ? snap.data() : null;
+  // Default host seat 0 occupied + unmuted + publishing. The Given may
+  // override via opts.skipHostSeat — used by scenarios that test the
+  // "host's seat is empty" edge case.
+  const defaultSeats = opts.skipHostSeat
+    ? []
+    : [{ userId: host.uniqueId, muted: false, publishAllowed: true }];
+  const doc = {
+    id: roomId,
+    title,
+    hostId: host.uniqueId,
+    state: opts.state || existing?.state || 'OPEN',
+    visibility: opts.visibility || existing?.visibility || 'public',
+    cohort: opts.cohort || existing?.cohort || host.cohort || 'adult',
+    participantIds: existing?.participantIds || [host.uniqueId],
+    seats: existing?.seats || defaultSeats,
+    createdAt: existing?.createdAt || Date.now(),
+  };
+  await roomRef.set(doc);
+  // Cache so subsequent "<host>'s room" Givens resolve to this room.
+  ctx.lastRoomId = roomId;
+  ctx.roomsByHost = ctx.roomsByHost || {};
+  ctx.roomsByHost[hostName] = roomId;
+  return { roomId, doc };
+}
+
+async function resolveRoomForHost(ctx, hostName) {
+  // If a prior Given seeded a room for this host, reuse it. Otherwise
+  // create a default room — keeps Givens like "Ines is a non-seated
+  // participant in Theo's room" working even when Theo's room wasn't
+  // explicitly set up first (the scenario implies the room exists).
+  if (ctx.roomsByHost?.[hostName]) return ctx.roomsByHost[hostName];
+  const { roomId } = await ensureRoomForHost(ctx, hostName);
+  return roomId;
+}
+
+async function ensureParticipantInRoom(ctx, roomId, personaName) {
+  // Read-modify-set (instead of update + FieldValue.arrayUnion). These
+  // helpers are test pre-seeds running single-threaded against either dev
+  // Firestore or the fake-db in unit tests; the atomicity FieldValue would
+  // give doesn't matter, and the read-modify-set form works with both real
+  // Firestore + the existing makeStatefulFakeDb (which doesn't model
+  // FieldValue sentinels). Idempotent: Set.add dedups uniqueIds.
+  const personas = loadPersonas();
+  const persona = personas.get(personaName);
+  if (!persona?.uniqueId) {
+    throw new Error(`persona "${personaName}" not in registry`);
+  }
+  const roomRef = ctx.db.doc(`rooms/${roomId}`);
+  const snap = await roomRef.get();
+  if (!snap.exists) {
+    throw new Error(`room "${roomId}" not found — seed the room before participant Given`);
+  }
+  const data = snap.data() || {};
+  const existing = Array.isArray(data.participantIds) ? data.participantIds : [];
+  const merged = Array.from(new Set([...existing, persona.uniqueId]));
+  await roomRef.set({ participantIds: merged }, { merge: true });
+  return persona.uniqueId;
+}
+
+async function ensureSeatRequest(ctx, roomId, personaName, status = 'PENDING') {
+  // Use doc(generatedId).set() instead of collection().add() — Firestore-add
+  // returns a sentinel ref the test fake-db doesn't model, and the doc-ID
+  // form gives us a stable readable ID (persona+status+timestamp) that
+  // simplifies test assertions.
+  const personas = loadPersonas();
+  const persona = personas.get(personaName);
+  if (!persona?.uniqueId) {
+    throw new Error(`persona "${personaName}" not in registry`);
+  }
+  const docId = `${persona.uniqueId}-${status.toLowerCase()}-${Date.now()}`;
+  await ctx.db.doc(`rooms/${roomId}/seatRequests/${docId}`).set({
+    userId: persona.uniqueId,
+    status,
+    createdAt: Date.now(),
+  });
+}
+
+async function ensureSeatedInRoom(ctx, roomId, personaName, opts = {}) {
+  // Idempotent seat assignment: if the persona is already seated, update
+  // their seat fields in place; otherwise allocate the next empty index.
+  const personas = loadPersonas();
+  const persona = personas.get(personaName);
+  if (!persona?.uniqueId) {
+    throw new Error(`persona "${personaName}" not in registry`);
+  }
+  const roomRef = ctx.db.doc(`rooms/${roomId}`);
+  const snap = await roomRef.get();
+  if (!snap.exists) {
+    throw new Error(`room "${roomId}" not found — seed the room before the seated Given`);
+  }
+  const data = snap.data() || {};
+  const seats = Array.isArray(data.seats) ? data.seats.map((s) => s || null) : [];
+  let seatIndex = seats.findIndex((s) => s?.userId === persona.uniqueId);
+  if (seatIndex === -1) {
+    seatIndex = seats.findIndex((s) => !s || !s.userId);
+    if (seatIndex === -1) seatIndex = seats.length;
+  }
+  seats[seatIndex] = {
+    userId: persona.uniqueId,
+    muted: opts.muted ?? true,
+    publishAllowed: opts.publishAllowed ?? false,
+  };
+  await roomRef.set({ seats }, { merge: true });
+  return seatIndex;
+}
+
+async function ensureKickedFromRoom(ctx, roomId, personaName) {
+  // Read-modify-set (same rationale as ensureParticipantInRoom).
+  const personas = loadPersonas();
+  const persona = personas.get(personaName);
+  if (!persona?.uniqueId) {
+    throw new Error(`persona "${personaName}" not in registry`);
+  }
+  const roomRef = ctx.db.doc(`rooms/${roomId}`);
+  const snap = await roomRef.get();
+  if (!snap.exists) {
+    throw new Error(`room "${roomId}" not found — seed the room before the kicked Given`);
+  }
+  const data = snap.data() || {};
+  const filteredParticipants = (data.participantIds || []).filter((id) => id !== persona.uniqueId);
+  await roomRef.set({ participantIds: filteredParticipants }, { merge: true });
+  const kickDocId = `${persona.uniqueId}-${Date.now()}`;
+  await ctx.db.doc(`rooms/${roomId}/kickedIds/${kickDocId}`).set({
+    userId: persona.uniqueId,
+    kickedAt: Date.now(),
+  });
+}
+
 // ── Step matchers ───────────────────────────────────────────────────
 
 /**
@@ -8828,6 +9005,125 @@ const matchers = [
         };
       }
       return { ok: true };
+    },
+  },
+  // ── Room-state setup Givens (j09 phase-scoped scenarios) ──
+  //
+  // The long-scenario refactor (PR #874) split j09's 47-step megascenario
+  // into 10 phase-focused subscenarios sharing the Background sign-in.
+  // Each subscenario establishes the prior phase's outcome via a
+  // setup-style `Given` so it runs in isolation. These 8 matchers seed
+  // the corresponding Firestore state via the room-state primitives
+  // defined above. Together they unblock the 8 STEP_NOT_IMPLEMENTED
+  // findings on j09 (manual-qa-cycle-1.md, 2026-05-29).
+  //
+  // Composition: each handler routes through the primitives so a future
+  // schema change (seat shape, kickedIds collection name, etc.) needs
+  // one update at the helper level, not 8.
+  {
+    pattern: /^([A-Z][a-z]+)'s public room "([^"]+)" is OPEN$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        await ensureRoomForHost(ctx, m[1], { title: m[2], state: 'OPEN', visibility: 'public' });
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
+    pattern: /^([A-Z][a-z]+)'s room "([^"]+)" has ([A-Z][a-z]+) joined as a participant$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        const { roomId } = await ensureRoomForHost(ctx, m[1], { title: m[2] });
+        await ensureParticipantInRoom(ctx, roomId, m[3]);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
+    pattern: /^([A-Z][a-z]+) is a non-seated participant in ([A-Z][a-z]+)'s room$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        const roomId = await resolveRoomForHost(ctx, m[2]);
+        await ensureParticipantInRoom(ctx, roomId, m[1]);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
+    pattern: /^([A-Z][a-z]+) has a PENDING seat request in ([A-Z][a-z]+)'s room$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        const roomId = await resolveRoomForHost(ctx, m[2]);
+        await ensureParticipantInRoom(ctx, roomId, m[1]);
+        await ensureSeatRequest(ctx, roomId, m[1], 'PENDING');
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
+    pattern: /^([A-Z][a-z]+) is seated in ([A-Z][a-z]+)'s room with publish permission$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        const roomId = await resolveRoomForHost(ctx, m[2]);
+        await ensureParticipantInRoom(ctx, roomId, m[1]);
+        await ensureSeatedInRoom(ctx, roomId, m[1], { muted: true, publishAllowed: true });
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
+    pattern: /^([A-Z][a-z]+) is seated and unmuted in ([A-Z][a-z]+)'s room$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        const roomId = await resolveRoomForHost(ctx, m[2]);
+        await ensureParticipantInRoom(ctx, roomId, m[1]);
+        await ensureSeatedInRoom(ctx, roomId, m[1], { muted: false, publishAllowed: true });
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
+    pattern: /^([A-Z][a-z]+) has been kicked from ([A-Z][a-z]+)'s room$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        const roomId = await resolveRoomForHost(ctx, m[2]);
+        await ensureKickedFromRoom(ctx, roomId, m[1]);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
+    pattern: /^([A-Z][a-z]+)'s room "([^"]+)" is OPEN with ([A-Z][a-z]+) as a participant$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        const { roomId } = await ensureRoomForHost(ctx, m[1], { title: m[2], state: 'OPEN' });
+        await ensureParticipantInRoom(ctx, roomId, m[3]);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
     },
   },
   {

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -9746,6 +9746,213 @@ describe('Voice room composite state-seed (X created a <vis> <cohort>-cohort roo
   });
 });
 
+// ─── Room-state setup Givens (j09 phase-scoped scenarios) ────────────
+//
+// 8 new matchers + 5 composable primitives added to unblock j09's
+// STEP_NOT_IMPLEMENTED findings after the long-scenario refactor (PR #874).
+// These tests pin each handler's Firestore mutations against the existing
+// makeStatefulFakeDb. The handlers use read-modify-set semantics (no
+// FieldValue.arrayUnion/arrayRemove) so the fake-db's plain set() merge
+// behaviour is sufficient.
+describe('Room-state setup Givens (j09 phase-scoped scenario setup)', () => {
+  const { personas: PERSONAS } = require('../../scripts/provision-test-personas');
+  const theo = PERSONAS.find((p) => p.id === 'P-10');
+  const alice = PERSONAS.find((p) => p.id === 'P-02');
+  const ines = PERSONAS.find((p) => p.id === 'P-11');
+
+  test('"<host>\'s public room \\"<title>\\" is OPEN" seeds a room doc with state=OPEN + visibility=public', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Theo\'s public room "Theo\'s Test Room" is OPEN' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const roomDocs = Object.entries(db._docs).filter(([k]) => k.startsWith('rooms/'));
+    expect(roomDocs).toHaveLength(1);
+    const [, room] = roomDocs[0];
+    expect(room.hostId).toBe(theo.uniqueId);
+    expect(room.state).toBe('OPEN');
+    expect(room.visibility).toBe('public');
+    expect(room.title).toBe("Theo's Test Room");
+    // Host is auto-seeded into participantIds + seats[0].
+    expect(room.participantIds).toContain(theo.uniqueId);
+    expect(room.seats[0].userId).toBe(theo.uniqueId);
+    // ctx caches the room for follow-on "<host>'s room" Givens.
+    expect(ctx.roomsByHost.Theo).toBeTruthy();
+    expect(ctx.lastRoomId).toBeTruthy();
+  });
+
+  test('"<host>\'s room \\"<title>\\" has <persona> joined as a participant" creates room + adds persona', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db });
+    const r = await executeStep(
+      {
+        kind: 'Given',
+        text: 'Theo\'s room "Theo\'s Test Room" has Alice joined as a participant',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const [, room] = Object.entries(db._docs).filter(([k]) => k.startsWith('rooms/'))[0];
+    expect(room.participantIds).toContain(theo.uniqueId);
+    expect(room.participantIds).toContain(alice.uniqueId);
+  });
+
+  test('"<persona> is a non-seated participant in <host>\'s room" — auto-resolves host\'s room', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db });
+    // No prior room — handler auto-creates Theo's room with default title.
+    const r = await executeStep(
+      { kind: 'Given', text: "Ines is a non-seated participant in Theo's room" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const [, room] = Object.entries(db._docs).filter(([k]) => k.startsWith('rooms/'))[0];
+    expect(room.participantIds).toContain(ines.uniqueId);
+    // Ines is NOT in seats (just participantIds).
+    const inesSeats = (room.seats || []).filter((s) => s?.userId === ines.uniqueId);
+    expect(inesSeats).toHaveLength(0);
+  });
+
+  test('"<persona> has a PENDING seat request in <host>\'s room" creates participant + seatRequest subdoc', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db });
+    const r = await executeStep(
+      { kind: 'Given', text: "Ines has a PENDING seat request in Theo's room" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    // Participant added.
+    const [, room] = Object.entries(db._docs).filter(([k]) => k.startsWith('rooms/'))[0];
+    expect(room.participantIds).toContain(ines.uniqueId);
+    // seatRequest doc written under rooms/<id>/seatRequests/
+    const seatReqs = Object.entries(db._docs).filter(([k]) => k.includes('/seatRequests/'));
+    expect(seatReqs).toHaveLength(1);
+    expect(seatReqs[0][1].userId).toBe(ines.uniqueId);
+    expect(seatReqs[0][1].status).toBe('PENDING');
+  });
+
+  test('"<persona> is seated in <host>\'s room with publish permission" — adds participant + seats persona unmuted-publishable', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db });
+    const r = await executeStep(
+      { kind: 'Given', text: "Ines is seated in Theo's room with publish permission" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const [, room] = Object.entries(db._docs).filter(([k]) => k.startsWith('rooms/'))[0];
+    const inesSeat = (room.seats || []).find((s) => s?.userId === ines.uniqueId);
+    expect(inesSeat).toBeDefined();
+    expect(inesSeat.publishAllowed).toBe(true);
+    expect(inesSeat.muted).toBe(true); // muted-by-default until unmuted Given fires
+  });
+
+  test('"<persona> is seated and unmuted in <host>\'s room" — seats + mic open', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db });
+    const r = await executeStep(
+      { kind: 'Given', text: "Ines is seated and unmuted in Theo's room" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const [, room] = Object.entries(db._docs).filter(([k]) => k.startsWith('rooms/'))[0];
+    const inesSeat = (room.seats || []).find((s) => s?.userId === ines.uniqueId);
+    expect(inesSeat.muted).toBe(false);
+    expect(inesSeat.publishAllowed).toBe(true);
+  });
+
+  test('"<persona> has been kicked from <host>\'s room" — removes from participantIds + adds kickedIds doc', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db });
+    // First add Ines as participant to prove the removal works.
+    await executeStep(
+      { kind: 'Given', text: "Ines is a non-seated participant in Theo's room" },
+      ctx,
+    );
+    const r = await executeStep(
+      { kind: 'Given', text: "Ines has been kicked from Theo's room" },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const [, room] = Object.entries(db._docs).filter(([k]) => k.startsWith('rooms/'))[0];
+    expect(room.participantIds).not.toContain(ines.uniqueId);
+    const kicks = Object.entries(db._docs).filter(([k]) => k.includes('/kickedIds/'));
+    expect(kicks).toHaveLength(1);
+    expect(kicks[0][1].userId).toBe(ines.uniqueId);
+  });
+
+  test('"<host>\'s room \\"<title>\\" is OPEN with <persona> as a participant" — combined seed', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db });
+    const r = await executeStep(
+      {
+        kind: 'Given',
+        text: 'Theo\'s room "Theo\'s Test Room" is OPEN with Alice as a participant',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const [, room] = Object.entries(db._docs).filter(([k]) => k.startsWith('rooms/'))[0];
+    expect(room.state).toBe('OPEN');
+    expect(room.title).toBe("Theo's Test Room");
+    expect(room.participantIds).toContain(alice.uniqueId);
+  });
+
+  // ── Idempotency + chain pins ──
+
+  test('idempotent: re-running the OPEN-with-participant Given does not duplicate participants', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db });
+    const step = {
+      kind: 'Given',
+      text: 'Theo\'s room "Theo\'s Test Room" is OPEN with Alice as a participant',
+    };
+    await executeStep(step, ctx);
+    await executeStep(step, ctx);
+    const [, room] = Object.entries(db._docs).filter(([k]) => k.startsWith('rooms/'))[0];
+    const aliceCount = (room.participantIds || []).filter((id) => id === alice.uniqueId).length;
+    expect(aliceCount).toBe(1);
+  });
+
+  test('chain: prior Given populates ctx.roomsByHost so subsequent "<host>\'s room" Givens hit the same doc', async () => {
+    // This is the critical pin for j09's scenario flow: each later
+    // scenario establishes prior phase via a setup Given that needs to
+    // resolve "Theo's room" to the same room a prior Given created.
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db });
+    await executeStep(
+      { kind: 'Given', text: 'Theo\'s public room "Theo\'s Test Room" is OPEN' },
+      ctx,
+    );
+    const roomIdAfterFirst = ctx.lastRoomId;
+    await executeStep(
+      { kind: 'Given', text: "Ines is a non-seated participant in Theo's room" },
+      ctx,
+    );
+    // Both Givens hit the same room — total room docs should still be 1.
+    const roomDocs = Object.entries(db._docs).filter(([k]) => k.match(/^rooms\/[^/]+$/));
+    expect(roomDocs).toHaveLength(1);
+    expect(roomDocs[0][0]).toBe(`rooms/${roomIdAfterFirst}`);
+    expect(roomDocs[0][1].participantIds).toContain(ines.uniqueId);
+  });
+
+  test('unknown persona name → error surfaced, not crashed', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db });
+    const r = await executeStep({ kind: 'Given', text: 'Zonk\'s public room "x" is OPEN' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/persona "Zonk" not in registry/);
+  });
+
+  test('ctx.db missing → actionable error, not crash', async () => {
+    const ctx = makeCtx(); // no db
+    const r = await executeStep({ kind: 'Given', text: 'Theo\'s public room "x" is OPEN' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.db not initialised/);
+  });
+});
+
 describe('Dialog confirm action (platform-dispatch)', () => {
   test('"X on Android confirms in the dialog" → driver', async () => {
     const spy = jest.fn(async () => undefined);


### PR DESCRIPTION
## Why

j09's authenticated dispatch on 2026-05-29 emitted 8 STEP_NOT_IMPLEMENTED findings — all on setup-style \`Given\` steps introduced by the long-scenario refactor (PR #874). Those Givens establish prior-phase Firestore state so each phase-scoped scenario can run in isolation. Without runner handlers, the entire post-refactor j09 flow is blocked.

## Approach (composable primitives)

Two-layer design that scales to the other ~120 setup-Givens across j01-j17:

**5 primitive helpers** at module scope:
- \`roomIdFromTitle\` — slug derivation matching Firestore + LiveKit's ROOM_NAME_PATTERN
- \`ensureRoomForHost\` — idempotent room-doc creation
- \`resolveRoomForHost\` — ctx-cached resolution of "<host>'s room"
- \`ensureParticipantInRoom\` — idempotent participantIds add
- \`ensureSeatRequest\` — subcollection write under \`rooms/<id>/seatRequests/\`
- \`ensureSeatedInRoom\` — seat allocation (next-free-index, or update-in-place if already seated)
- \`ensureKickedFromRoom\` — participantIds removal + kickedIds subdoc

**8 matchers** delegating to 1-3 primitives:

| Given | Composition |
|---|---|
| \`<host>'s public room "<title>" is OPEN\` | ensureRoomForHost |
| \`<host>'s room "<title>" has <persona> joined as a participant\` | ensureRoomForHost + ensureParticipantInRoom |
| \`<persona> is a non-seated participant in <host>'s room\` | resolveRoomForHost + ensureParticipantInRoom |
| \`<persona> has a PENDING seat request in <host>'s room\` | resolveRoomForHost + ensureParticipantInRoom + ensureSeatRequest |
| \`<persona> is seated in <host>'s room with publish permission\` | resolveRoomForHost + ensureParticipantInRoom + ensureSeatedInRoom |
| \`<persona> is seated and unmuted in <host>'s room\` | same, muted:false |
| \`<persona> has been kicked from <host>'s room\` | resolveRoomForHost + ensureKickedFromRoom |
| \`<host>'s room "<title>" is OPEN with <persona> as a participant\` | ensureRoomForHost + ensureParticipantInRoom |

## Design decisions

- **\`ctx.roomsByHost\` cache**: Givens like "Ines is a non-seated participant in Theo's room" don't carry the title — resolved via the cache populated by prior Givens in the same scenario, or auto-creation if none.
- **Read-modify-set instead of FieldValue.arrayUnion/arrayRemove**: these handlers are TEST PRE-SEEDS running single-threaded. Atomicity doesn't matter, and read-modify-set works with both real Firestore + the existing \`makeStatefulFakeDb\` (no FieldValue mock needed).
- **\`doc(generatedId).set()\` for subcollection adds** instead of \`collection().add()\` — the test fake-db doesn't model the auto-ref from add(); the doc-ID form gives readable IDs that simplify assertions.

## Tests (12 new)

1 per handler (8) + idempotency pin + chain pin (the j09 flow's critical "later Givens hit the same room as earlier Givens" invariant) + unknown-persona error path + ctx.db-missing error path. **1820/1820** \`manual-qa-runner.test.js\` tests pass (1808 prior + 12 new). ESLint + Prettier clean.

## Out of scope (next PRs)

- Re-dispatching j09 against dev post-merge to confirm the 8 STEP_NOT_IMPLEMENTED are gone
- Extending the primitive layer to the other ~120 setup-Given lines across j01-j17 (per-journey PRs)
- The 3 MVP-runner UI-driver gaps (adb / xcrun devicectl / Playwright) — design alternatives in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)