### PR TITLE
fix(qa-runner+j09): {roomId} interpolation + cohort-claim string coercion

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -366,6 +366,16 @@ async function ensureRoomForHost(ctx, hostName, opts = {}) {
   ctx.lastRoomId = roomId;
   ctx.roomsByHost = ctx.roomsByHost || {};
   ctx.roomsByHost[hostName] = roomId;
+  // Expose as a {roomId} interpolation variable so later Then-steps like
+  // `rooms/{roomId}/seats[1].userId` resolve to the actual doc path. The
+  // runner's interpolateScenarioVars (line ~13693) substitutes {name}
+  // from ctx.scenarioVars — without this set, `{roomId}` survives
+  // verbatim and matchers look up a literal `rooms/{roomId}` doc that
+  // doesn't exist. Pinned by 2 of j09's findings (manual-qa-cycle-1.md
+  // 2026-05-29 dispatch — "document rooms/{roomId} does not exist").
+  if (ctx.scenarioVars && typeof ctx.scenarioVars.set === 'function') {
+    ctx.scenarioVars.set('roomId', roomId);
+  }
   return { roomId, doc };
 }
 

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -1329,6 +1329,67 @@ describe('Firestore bulk-query matcher (entries-matching)', () => {
   });
 });
 
+describe('ensureRoomForHost — exposes roomId as a {roomId} interpolation variable', () => {
+  // The runner's interpolateScenarioVars at line ~13693 substitutes
+  // {name} from ctx.scenarioVars. Setup-Given handlers (e.g. "Theo's
+  // public room is OPEN") that create a room need to register the
+  // generated roomId so later Then-steps like `rooms/{roomId}/...`
+  // resolve to the actual doc path. Pinned by 2 of j09's findings
+  // ("document rooms/{roomId} does not exist") on the 2026-05-29
+  // dispatch.
+
+  test('ensureRoom Given sets ctx.scenarioVars.get("roomId") to the seeded room id', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Theo\'s public room "Theo\'s Test Room" is OPEN' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(ctx.scenarioVars.get('roomId')).toBeTruthy();
+    // The roomId is the slug derived from the title.
+    expect(ctx.scenarioVars.get('roomId')).toMatch(/theo-s-test-room/);
+  });
+
+  test('subsequent step text interpolates {roomId} to the actual room id', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    // Phase 1: seed the room.
+    await executeStep(
+      { kind: 'Given', text: 'Theo\'s public room "Theo\'s Test Room" is OPEN' },
+      ctx,
+    );
+    const seededRoomId = ctx.scenarioVars.get('roomId');
+    // Phase 2: a later Then with `{roomId}` in the path should match the
+    // doc the prior Given wrote (not look up a literal `rooms/{roomId}`
+    // that doesn't exist).
+    const r = await executeStep(
+      {
+        kind: 'Then',
+        text: 'the database has document "rooms/{roomId}" with field "title" equal to "Theo\'s Test Room"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    // Sanity: the doc is at the substituted path, not the literal one.
+    expect(db._docs[`rooms/${seededRoomId}`]).toBeDefined();
+    expect(db._docs[`rooms/{roomId}`]).toBeUndefined();
+  });
+
+  test('Given without ctx.scenarioVars (legacy callers) is a no-op for interpolation, not a crash', async () => {
+    // Defensive: some callers/tests build ctx without scenarioVars.
+    // The handler must gate the scenarioVars.set behind a typeof check
+    // so it doesn't TypeError on `undefined.set` and crash the runner.
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db }); // no scenarioVars
+    const r = await executeStep(
+      { kind: 'Given', text: 'Theo\'s public room "Theo\'s Test Room" is OPEN' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
 describe('Firestore bulk-query end-to-end via runFeatureFile', () => {
   function fetchOk() {
     return jest.fn(async (url) => {

--- a/journey-tests/j09-voice-room-host.feature
+++ b/journey-tests/j09-voice-room-host.feature
@@ -141,4 +141,4 @@ Feature: j09 — Theo hosts a public voice room
     When Marcus on Android POSTs /api/livekit/token with roomName="ra1"
     Then the response status is 404
     Then the response body does not include a token
-    Then the database has 1 entries in "segregationEvents" matching {action: "blocked", sourceUniqueId: 60000010, targetUniqueId: "ra1"}
+    Then the database has 1 entries in "segregationEvents" matching {action: "blocked", sourceUniqueId: "60000010", targetUniqueId: "ra1"}


### PR DESCRIPTION
## Why

j09 dispatch on 2026-05-29 23:06 BST (post-PR #877 + #878 merge) surfaced two related drifts:

### 1. `{roomId}` placeholder not substituted in scenarios

Phase-scoped scenarios from PR #874 use `rooms/{roomId}` in Then-step paths. My PR #877 helpers set `ctx.lastRoomId` + `ctx.roomsByHost` but missed the `scenarioVars` hookup — `{roomId}` survived verbatim. Two j09 findings: "Theo approves Ines's seat" + "Host disconnects unexpectedly".

### 2. Cohort-claim predicate type-mismatch

j09's cohort-claim asserted `sourceUniqueId: 60000010` (number) but `livekit.js` writes `String(req.auth.uniqueId)`. Strict === returned false; "0 entries matching".

## Fixes

- `ensureRoomForHost` now calls `ctx.scenarioVars.set('roomId', roomId)` (typeof-guarded).
- Initially fixed type-mismatch by coercing scalar predicate values to String. But the existing test at line 1297 deliberately designs strict typing to **catch** drift. Reverted; quoted j09 line 144 instead.

## Tests (3 new)

- ensureRoomForHost sets scenarioVars.get('roomId') to the seeded slug
- Chain pin: subsequent Then with {roomId} in path matches the seeded doc
- Defensive: handler tolerates legacy callers without scenarioVars

1823/1823 tests pass. ESLint + Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)