### PR TITLE
feat(android-driver): add 3 missing Android tap methods (j09 unblock)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -135,6 +135,10 @@ const ANDROID_METHOD_NAMES = [
   // Pairs `svc wifi disable` + `svc data disable` to fully drop the
   // device's connectivity, then re-enables both after a sleep.
   'androidNetworkDropFor',
+  // Tap + long-press actions for j09's room-host kick/close/join flows.
+  'androidTapQuotedTarget',
+  'androidTapRoomCard',
+  'androidLongPressSeat',
 ];
 
 function listMethods() {
@@ -2078,6 +2082,96 @@ async function createAndroidDriver({ serial: preferred } = {}) {
       return true;
     } catch (e) {
       console.error(`[android-driver] androidOpenScreen(${screen}) failed: ${e.message}`);
+      return false;
+    }
+  };
+
+  // androidTapQuotedTarget — wrapper around tag-based or owner-card tap.
+  // Runner step "<Name> on Android taps the "<X>"" passes (name, targetId,
+  // isRoomCard=false) — targetId is a testTag, delegate to androidTapByTag.
+  // Runner step "<Name> on Android taps the room "<X>" card" passes
+  // (name, targetId, isRoomCard=true) — targetId is the room owner name,
+  // delegate to androidTapRoomCard.
+  driver.androidTapQuotedTarget = async (name, targetId, isRoomCard) => {
+    try {
+      if (isRoomCard) {
+        return await driver.androidTapRoomCard(targetId);
+      }
+      return await driver.androidTapByTag(targetId);
+    } catch (e) {
+      console.error(
+        `[android-driver] androidTapQuotedTarget(${name}, ${targetId}, ${isRoomCard}) failed: ${e.message}`,
+      );
+      return false;
+    }
+  };
+
+  // androidTapRoomCard — taps a room card by its host's persona name.
+  // Looks for a UI element whose dump text or testTag includes the
+  // owner's name OR a `roomCard_<owner>` testTag. Owner=undefined means
+  // "tap the first room card visible" (Marcus same-cohort-gate scenario:
+  // `taps the room card` with no owner).
+  driver.androidTapRoomCard = async (owner) => {
+    try {
+      const dump = await driver.androidUiDump();
+      // Try testTag-based lookup first (most reliable): `roomCard_<owner>`
+      // OR `roomCard_<idx>` for owner-less variant.
+      if (owner) {
+        const tagged = await driver.androidTapByTag(`roomCard_${owner}`);
+        if (tagged) return true;
+      }
+      // Fallback: find any `roomCard_*` element with the owner's name
+      // appearing in the dump text inside its bounds, OR the first
+      // `roomCard_*` if owner is undefined.
+      const escOwner = (owner || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const tagPattern = owner
+        ? new RegExp(
+            `resource-id="(?:[^"]*:id/)?roomCard_\\w*"[^<]*?bounds="\\[(\\d+),(\\d+)\\]\\[(\\d+),(\\d+)\\]"[^<]*?text="[^"]*${escOwner}[^"]*"`,
+          )
+        : /resource-id="(?:[^"]*:id\/)?roomCard_\w*"[^<]*?bounds="\[(\d+),(\d+)\]\[(\d+),(\d+)\]"/;
+      const match = tagPattern.exec(dump);
+      if (!match) return false;
+      const [, x1, y1, x2, y2] = match.map((v, i) => (i === 0 ? v : Number(v)));
+      const cx = Math.round((x1 + x2) / 2);
+      const cy = Math.round((y1 + y2) / 2);
+      return await driver.androidTap(cx, cy);
+    } catch (e) {
+      console.error(`[android-driver] androidTapRoomCard(${owner}) failed: ${e.message}`);
+      return false;
+    }
+  };
+
+  // androidLongPressSeat — long-press on the seat occupied by `target`.
+  // Implementation: `adb shell input swipe X Y X Y 1000` — swipe with
+  // identical start+end coords over 1000ms registers as a long-press
+  // gesture (standard adb idiom for long-press). Locates the seat by
+  // looking for `seat_<targetName>` testTag OR any `seat_*` element with
+  // the target name in its text content.
+  driver.androidLongPressSeat = async (target) => {
+    try {
+      const dump = await driver.androidUiDump();
+      const escTarget = target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      // Try `seat_<target>` testTag first.
+      let re = new RegExp(
+        `resource-id="(?:[^"]*:id/)?seat_${escTarget}"[^<]*?bounds="\\[(\\d+),(\\d+)\\]\\[(\\d+),(\\d+)\\]"`,
+      );
+      let match = re.exec(dump);
+      if (!match) {
+        // Fallback: any `seat_*` element with target name in its dump text.
+        re = new RegExp(
+          `resource-id="(?:[^"]*:id/)?seat_\\w*"[^<]*?bounds="\\[(\\d+),(\\d+)\\]\\[(\\d+),(\\d+)\\]"[^<]*?text="[^"]*${escTarget}[^"]*"`,
+        );
+        match = re.exec(dump);
+      }
+      if (!match) return false;
+      const [, x1, y1, x2, y2] = match.map((v, i) => (i === 0 ? v : Number(v)));
+      const cx = Math.round((x1 + x2) / 2);
+      const cy = Math.round((y1 + y2) / 2);
+      // Long-press via swipe with same start+end coordinates over 1000ms.
+      adb(['shell', 'input', 'swipe', String(cx), String(cy), String(cx), String(cy), '1000']);
+      return true;
+    } catch (e) {
+      console.error(`[android-driver] androidLongPressSeat(${target}) failed: ${e.message}`);
       return false;
     }
   };

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -16089,3 +16089,179 @@ describe('android-adb-driver — androidNetworkDropFor', () => {
     expect(await promise).toBe(true);
   });
 });
+
+describe('android-adb-driver — androidTapQuotedTarget', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('isRoomCard=false delegates to androidTapByTag with the targetId', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('room_endRoomButton', '[200,1500][500,1700]'),
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidTapQuotedTarget('Theo', 'room_endRoomButton', false);
+    await jest.advanceTimersByTimeAsync(500);
+    const ok = await promise;
+    expect(ok).toBe(true);
+    // Center of [200,1500][500,1700] = (350, 1600).
+    const tapCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'tap'"));
+    expect(tapCall[0]).toContain("'350'");
+    expect(tapCall[0]).toContain("'1600'");
+  });
+
+  test('isRoomCard=true delegates to androidTapRoomCard with the targetId as owner', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('roomCard_Theo', '[100,400][800,700]'),
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidTapQuotedTarget('Marcus', 'Theo', true);
+    await jest.advanceTimersByTimeAsync(500);
+    const ok = await promise;
+    expect(ok).toBe(true);
+    const tapCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'tap'"));
+    // Center of [100,400][800,700] = (450, 550).
+    expect(tapCall[0]).toContain("'450'");
+    expect(tapCall[0]).toContain("'550'");
+  });
+
+  test('returns false when neither delegation finds an element', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="other_unrelated" />',
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidTapQuotedTarget('Theo', 'nonexistent', false);
+    await jest.advanceTimersByTimeAsync(500);
+    expect(await promise).toBe(false);
+  });
+});
+
+describe('android-adb-driver — androidTapRoomCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('owner-keyed roomCard_<owner> testTag → taps that specific card', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('roomCard_Theo', '[100,400][800,700]'),
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidTapRoomCard('Theo');
+    await jest.advanceTimersByTimeAsync(500);
+    expect(await promise).toBe(true);
+    const tapCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'tap'"));
+    expect(tapCall[0]).toContain("'450'");
+    expect(tapCall[0]).toContain("'550'");
+  });
+
+  test('owner=undefined → taps the first roomCard_* element in the dump', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomCard_0" bounds="[0,500][1080,700]" />',
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidTapRoomCard(undefined);
+    await jest.advanceTimersByTimeAsync(500);
+    expect(await promise).toBe(true);
+    const tapCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'tap'"));
+    // Center of [0,500][1080,700] = (540, 600).
+    expect(tapCall[0]).toContain("'540'");
+    expect(tapCall[0]).toContain("'600'");
+  });
+
+  test('owner-not-found in any card → returns false', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/unrelated_element" />',
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidTapRoomCard('Theo');
+    await jest.advanceTimersByTimeAsync(500);
+    expect(await promise).toBe(false);
+  });
+
+  test('owner with regex-special chars is escaped (no regex injection)', async () => {
+    // A future persona renamed to "Adam.Foo" (with a dot) would otherwise
+    // be interpreted as the regex `.` wildcard. Pin the escape behaviour.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/roomCard_AdamXFoo" bounds="[0,0][100,100]" />',
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidTapRoomCard('Adam.Foo');
+    await jest.advanceTimersByTimeAsync(500);
+    // The escaped `.` doesn't match `X` in `AdamXFoo` — owner-specific lookup fails;
+    // fallback finds no roomCard_* with owner text in bounds either → false.
+    expect(await promise).toBe(false);
+  });
+});
+
+describe('android-adb-driver — androidLongPressSeat', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('seat_<target> testTag → issues input swipe with identical start/end coords over 1000ms', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('seat_Ines', '[100,800][400,1100]'),
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidLongPressSeat('Ines');
+    await jest.advanceTimersByTimeAsync(500);
+    expect(await promise).toBe(true);
+    // Center of [100,800][400,1100] = (250, 950).
+    const swipeCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'swipe'"));
+    expect(swipeCall).toBeDefined();
+    // Long-press idiom: identical start + end coords + 1000ms duration.
+    expect(swipeCall[0]).toContain("'250' '950' '250' '950' '1000'");
+  });
+
+  test('target-not-found → returns false (no swipe issued)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="seat_someone-else" />',
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidLongPressSeat('Ines');
+    await jest.advanceTimersByTimeAsync(500);
+    expect(await promise).toBe(false);
+    const swipeCall = execSync.mock.calls.find((c) => c[0].includes("'input' 'swipe'"));
+    expect(swipeCall).toBeUndefined();
+  });
+
+  test('target name with regex-special chars is escaped', async () => {
+    // Defensive — a future persona renamed to "Ines.O" would otherwise
+    // be interpreted as a wildcard. Pin escape.
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'":
+        '<node resource-id="com.shyden.shytalk.local:id/seat_InesXO" bounds="[0,0][100,100]" />',
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidLongPressSeat('Ines.O');
+    await jest.advanceTimersByTimeAsync(500);
+    // Escaped `.` doesn't match `X` → primary lookup fails; fallback path
+    // also won't match (no text content matches Ines.O literal) → false.
+    expect(await promise).toBe(false);
+  });
+});


### PR DESCRIPTION
j09's 2026-05-29 dispatch surfaced 3 missing Android driver methods. Each follows the same template as PR #878.

## Methods

1. `androidLongPressSeat(target)` — long-press via `input swipe X Y X Y 1000` (adb long-press idiom)
2. `androidTapQuotedTarget(name, targetId, isRoomCard)` — composition wrapper (delegates to androidTapByTag or androidTapRoomCard)
3. `androidTapRoomCard(owner)` — owner-keyed roomCard_<owner> lookup with dump-text fallback

## Tests

10 new (3+4+3): delegation pins, regex-escape defensive, not-found returns false. 1278/1278 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)