### PR TITLE
feat(web-driver): add webRefreshRoomsList + bootstrap Playwright test scaffolding

### DIFF
--- a/express-api/scripts/drivers/web-playwright-driver.js
+++ b/express-api/scripts/drivers/web-playwright-driver.js
@@ -125,6 +125,10 @@ const WEB_METHOD_NAMES = [
   'webShowsTranslationOf',
   'webScanAllRenderedStrings',
   'webFallbackEnStrings',
+  // j09 — Alice on Web refreshes the rooms list. Navigates to /rooms
+  // on the persona's tab; the matcher's `within 3000ms` polling
+  // wraps the list population.
+  'webRefreshRoomsList',
   // Append-only — add new method names as new matchers land.
 ];
 
@@ -382,6 +386,29 @@ async function createWebDriver({ baseURL = 'http://localhost:8888', headless = t
       collected.push(...texts);
     }
     return collected;
+  };
+
+  // webRefreshRoomsList — refresh the rooms list on the persona's tab.
+  // Runner step "<Name> on Web refreshes the rooms list" (j09: Alice
+  // joins Theo's public room scenario). The persona-scoped Page is
+  // obtained via pageFor(name); navigates to /rooms (the canonical
+  // rooms-list route) if not already there, else does a soft reload.
+  // The soft reload is preferred over location.reload() because it
+  // preserves the Firebase Auth state — a hard reload triggers Firebase
+  // to re-initialise and may invalidate cached auth tokens.
+  driver.webRefreshRoomsList = async (name) => {
+    try {
+      const page = await pageFor(name);
+      // Soft refresh: navigate to /rooms regardless of current location.
+      // Playwright's Page.goto() defaults to waitUntil:'load' which is
+      // enough for the rooms list to render; the matcher's
+      // `within 3000ms` polling wrapper handles any async list population.
+      await page.goto(`${baseURL.replace(/\/$/, '')}/rooms`);
+      return true;
+    } catch (e) {
+      console.error(`[web-driver] webRefreshRoomsList(${name}) failed: ${e.message}`);
+      return false;
+    }
   };
 
   driver.close = async () => {

--- a/express-api/scripts/drivers/web-playwright-driver.js
+++ b/express-api/scripts/drivers/web-playwright-driver.js
@@ -29,10 +29,20 @@ const path = require('path');
 let _playwright;
 function loadPlaywright() {
   if (_playwright) return _playwright;
-  // Resolve `playwright` from the repo root node_modules (not express-api/).
+  // Try bare specifier first so jest's mock-resolution applies in unit
+  // tests (jest.mock('playwright', ...) only intercepts the bare form,
+  // not absolute-path requires). Falls back to the repo-root path for
+  // production / dev runs from express-api where the bare specifier
+  // can't resolve (playwright lives in the repo-root node_modules, not
+  // express-api/node_modules).
+  try {
+    _playwright = require('playwright');
+    return _playwright;
+  } catch (bareErr) {
+    if (bareErr.code !== 'MODULE_NOT_FOUND') throw bareErr;
+  }
   const repoRoot = path.resolve(__dirname, '../../..');
   const playwrightPath = path.join(repoRoot, 'node_modules', 'playwright');
-
   _playwright = require(playwrightPath);
   return _playwright;
 }

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -2921,12 +2921,15 @@ const matchers = [
     pattern:
       /^([A-Z][a-z]+)(?:\s*\[(P-\d{2})\])?\s+on (Web Chromium|Web Safari|Web|Android|iOS Sim)\s+refreshes the rooms list$/,
     async handler(m, ctx) {
+      const name = m[1];
       const platform = m[3];
       if (platform.startsWith('Web')) {
         if (!ctx.webDriver?.webRefreshRoomsList) {
           return { ok: false, error: 'ctx.webDriver.webRefreshRoomsList not configured' };
         }
-        await ctx.webDriver.webRefreshRoomsList();
+        // Pass persona name — web driver maintains per-persona Page state
+        // (pageFor cache), so the refresh needs to target the right tab.
+        await ctx.webDriver.webRefreshRoomsList(name);
         return { ok: true };
       }
       if (platform === 'Android') {

--- a/express-api/tests/routes/livekit-cohort.test.js
+++ b/express-api/tests/routes/livekit-cohort.test.js
@@ -139,6 +139,23 @@ beforeEach(() => {
   mockAdd.mockResolvedValue({ id: 'evt_abc' });
   mockCollection.mockReturnValue({ add: mockAdd });
   mockToJwt.mockResolvedValue('mock-jwt-token');
+  // CI test-execution-order can pollute the livekit-region mock:
+  // some earlier test file may register a clobbering mockImplementation
+  // on `getRegionConfig` (e.g. for a 503-path-coverage test). When this
+  // file runs after such a test, `getRegionConfig()` returns the
+  // polluted value (often undefined or {}), triggering the 503
+  // "Voice service not available" branch and breaking every test
+  // that expects a 200. Explicitly restore the mockReturnValue here
+  // so this file's tests are deterministic regardless of execution
+  // order. Surfaced as flake on PR #875's metadata.cohort tests
+  // (CI run 26666675170 + 26665942317, 2026-05-29).
+  const livekitRegion = require('../../src/utils/livekit-region');
+  livekitRegion.getRegion.mockReturnValue('asia');
+  livekitRegion.getRegionConfig.mockReturnValue({
+    url: 'wss://livekit.test.com',
+    apiKey: 'test-key',
+    apiSecret: 'test-secret',
+  });
   // Reset the AccessToken-instance ledger between tests so per-test
   // assertions on `mockAccessTokenInstances.at(-1)` see only this
   // test's mint, not a leak from a prior test.

--- a/express-api/tests/scripts/drivers/web-playwright-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-playwright-driver.test.js
@@ -19,13 +19,25 @@
 // jest.mock factory may only reference in-scope built-ins. We can mutate
 // the returned object after require, so the factory itself is minimal +
 // the per-test state lives on the module instance via jest.fn handles.
-jest.mock('playwright', () => {
-  return {
-    chromium: {
-      launch: jest.fn(),
-    },
-  };
-});
+//
+// `virtual: true` so the mock works even when `playwright` isn't a
+// resolvable module in the current Node modules tree. The express-api
+// test-backend CI job doesn't install Playwright (it's a heavy browser
+// dep used only by the local manual-qa-runner path), so without virtual
+// jest's factory resolution throws "Cannot find module 'playwright'"
+// before the mock can take effect. Verified locally: with `virtual: true`
+// the test runs identically whether playwright is installed or not.
+jest.mock(
+  'playwright',
+  () => {
+    return {
+      chromium: {
+        launch: jest.fn(),
+      },
+    };
+  },
+  { virtual: true },
+);
 
 const playwright = require('playwright');
 const path = require('path');

--- a/express-api/tests/scripts/drivers/web-playwright-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-playwright-driver.test.js
@@ -1,0 +1,149 @@
+/**
+ * web-playwright-driver.js — driver-method unit tests
+ *
+ * First web-driver test file. Bootstraps the Playwright mock so that
+ * createWebDriver() returns without a real browser launch, then pins
+ * each method's interaction with the mocked Page surface.
+ *
+ * Pattern (for future web-driver PRs to mirror):
+ *   - jest.mock('playwright') with the minimal stub the driver needs
+ *     (chromium.launch returning a browser whose newContext returns a
+ *     context whose newPage returns a Page).
+ *   - Inject per-test Page behaviour via the `prepareMockPages` helper.
+ *   - Build the driver via `await createWebDriver()` — uses the mock.
+ *
+ * Tests run on CI Linux (no Chromium installed) — playwright is mocked
+ * end-to-end, no browser process ever spawns.
+ */
+
+// jest.mock factory may only reference in-scope built-ins. We can mutate
+// the returned object after require, so the factory itself is minimal +
+// the per-test state lives on the module instance via jest.fn handles.
+jest.mock('playwright', () => {
+  return {
+    chromium: {
+      launch: jest.fn(),
+    },
+  };
+});
+
+const playwright = require('playwright');
+const path = require('path');
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const { createWebDriver } = require(
+  path.join(REPO_ROOT, 'express-api/scripts/drivers/web-playwright-driver'),
+);
+
+// Helpers ─────────────────────────────────────────────────────────────
+
+function makeMockPage(overrides = {}) {
+  return {
+    goto: jest.fn(async (_url, _opts) => {
+      if (overrides.gotoFails) throw new Error(overrides.gotoFails);
+      return null;
+    }),
+    locator: jest.fn(() => ({
+      click: jest.fn(),
+      waitFor: jest.fn(),
+    })),
+    waitForLoadState: jest.fn(),
+    close: jest.fn(),
+    context: () => ({ close: jest.fn() }),
+  };
+}
+
+/**
+ * Prime the playwright mock so the driver's pageFor(name) returns the
+ * supplied per-persona Page (in the order createWebDriver() asks).
+ * `pagesByPersona` is a map { Alice: pageA, Tariq: pageT, ... } — keys
+ * order matches the order of pageFor() invocations.
+ */
+function prepareMockPages(pagesByPersona) {
+  const orderedPages = Object.values(pagesByPersona);
+  let pageIdx = 0;
+  playwright.chromium.launch.mockImplementation(async () => ({
+    newContext: jest.fn(async () => ({
+      newPage: jest.fn(async () => {
+        const p = orderedPages[pageIdx] ?? makeMockPage();
+        pageIdx += 1;
+        return p;
+      }),
+      close: jest.fn(),
+    })),
+    close: jest.fn(),
+  }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('web-playwright-driver — createWebDriver', () => {
+  test('returns a driver object with the expected methods', async () => {
+    prepareMockPages({});
+    const driver = await createWebDriver({ baseURL: 'http://localhost:8888' });
+    expect(typeof driver.webRefreshRoomsList).toBe('function');
+    expect(typeof driver.close).toBe('function');
+  });
+});
+
+describe('web-playwright-driver — webRefreshRoomsList', () => {
+  // j09 step: "Alice on Web refreshes the rooms list" — driver
+  // navigates the persona's tab to /rooms. The persona-scoped Page
+  // is obtained via pageFor(name) so multi-actor scenarios (paired
+  // sessions, multi-persona webs) preserve isolation.
+
+  test("navigates the persona's page to <baseURL>/rooms", async () => {
+    const alicePage = makeMockPage();
+    prepareMockPages({ Alice: alicePage });
+    const driver = await createWebDriver({ baseURL: 'http://localhost:8888' });
+    const ok = await driver.webRefreshRoomsList('Alice');
+    expect(ok).toBe(true);
+    expect(alicePage.goto).toHaveBeenCalledTimes(1);
+    expect(alicePage.goto).toHaveBeenCalledWith('http://localhost:8888/rooms');
+  });
+
+  test('trailing slash on baseURL is collapsed (no `//rooms`)', async () => {
+    const alicePage = makeMockPage();
+    prepareMockPages({ Alice: alicePage });
+    const driver = await createWebDriver({ baseURL: 'http://localhost:8888/' });
+    await driver.webRefreshRoomsList('Alice');
+    expect(alicePage.goto).toHaveBeenCalledWith('http://localhost:8888/rooms');
+  });
+
+  test('uses dev baseURL when provided', async () => {
+    const alicePage = makeMockPage();
+    prepareMockPages({ Alice: alicePage });
+    const driver = await createWebDriver({ baseURL: 'https://dev.shytalk.shyden.co.uk' });
+    await driver.webRefreshRoomsList('Alice');
+    expect(alicePage.goto).toHaveBeenCalledWith('https://dev.shytalk.shyden.co.uk/rooms');
+  });
+
+  test('subsequent calls reuse the same Page (pageFor cache)', async () => {
+    const alicePage = makeMockPage();
+    prepareMockPages({ Alice: alicePage });
+    const driver = await createWebDriver({ baseURL: 'http://localhost:8888' });
+    await driver.webRefreshRoomsList('Alice');
+    await driver.webRefreshRoomsList('Alice');
+    expect(alicePage.goto).toHaveBeenCalledTimes(2);
+  });
+
+  test('different personas get separate Pages (isolation)', async () => {
+    const alicePage = makeMockPage();
+    const tariqPage = makeMockPage();
+    prepareMockPages({ Alice: alicePage, Tariq: tariqPage });
+    const driver = await createWebDriver({ baseURL: 'http://localhost:8888' });
+    await driver.webRefreshRoomsList('Alice');
+    await driver.webRefreshRoomsList('Tariq');
+    expect(alicePage.goto).toHaveBeenCalledTimes(1);
+    expect(tariqPage.goto).toHaveBeenCalledTimes(1);
+  });
+
+  test('page.goto throws → returns false (no unhandled rejection)', async () => {
+    const failingPage = makeMockPage({ gotoFails: 'NS_ERROR_OFFLINE' });
+    prepareMockPages({ Alice: failingPage });
+    const driver = await createWebDriver({ baseURL: 'http://localhost:8888' });
+    const ok = await driver.webRefreshRoomsList('Alice');
+    expect(ok).toBe(false);
+  });
+});


### PR DESCRIPTION
j09 surfaced `ctx.webDriver.webRefreshRoomsList not configured` on Alice's "refreshes the rooms list" step.

## Implementation

- `webRefreshRoomsList(name)` — `pageFor(name)` + `page.goto(<baseURL>/rooms)` (trailing-slash safe)
- Runner step matcher updated to pass m[1] (persona name) through

## Test scaffolding

First web-driver test file. `jest.mock('playwright')` with minimal chromium.launch stub; per-test Page behaviour via `prepareMockPages` helper. Documented in the module-level docstring as the pattern for future web-driver PRs.

Tests (7 new):
- createWebDriver returns driver object
- Navigates to <baseURL>/rooms
- Trailing-slash safe (no //rooms)
- Dev baseURL honoured
- pageFor cache: same persona reuses Page
- Multi-persona: different Pages
- page.goto throws → returns false

**7/7 pass**. ESLint + Prettier clean.

## j09 unblock arithmetic

Unblocks 1 finding ("Alice (Web) discovers and joins Theo's public room"). With PRs #877, #878, #879, #880, #881 combined, j09's remaining gaps are only the iOS driver layer (4 methods + WDA infrastructure) and the Android device-screen precondition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)