### PR TITLE
feat(android-driver): androidOpenScreen actually navigates to the requested tab

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -2076,9 +2076,34 @@ async function createAndroidDriver({ serial: preferred } = {}) {
       // dump/tap calls. The 1.5s value mirrors what the existing
       // android-e2e tests use (see app/src/androidTest fixtures).
       await new Promise((r) => setTimeout(r, 1500));
-      // Stash the requested screen on the driver so a future matcher
-      // can use it as a hint when implementing real in-app navigation.
       driver._requestedScreen = screen;
+      // If the screen identifier maps to a known MainScreen bottom-nav
+      // tab, tap it so subsequent taps on `<feature>_*` testTags in
+      // that tab actually find them. Without this, j09's
+      // "Theo taps main_createRoomFab" finds nothing because the
+      // dump is of whichever startup screen MainActivity landed on
+      // (typically `home`, not `rooms`).
+      //
+      // Tab list grounded in
+      //   shared/src/commonMain/.../feature/main/MainScreen.kt
+      // — main_<lowered>Tab is the existing testTag convention.
+      // Unknown screens fall through to a no-op tap (returns true so
+      // the launch alone counts as success — matches the prior
+      // "stash on driver" semantic).
+      const tabScreens = new Set(['rooms', 'home', 'messages', 'profile']);
+      if (screen && tabScreens.has(String(screen).toLowerCase())) {
+        const tag = `main_${String(screen).toLowerCase()}Tab`;
+        // Don't fail the whole call if the tab tap misses — the launch
+        // succeeded; the tab might already be active, or the app might
+        // be on the sign-in screen (no bottom nav visible). Surface
+        // miss as a log warning, not a return-false.
+        const tapped = await driver.androidTapByTag(tag);
+        if (!tapped) {
+          console.warn(
+            `[android-driver] androidOpenScreen(${screen}): launch ok, but tab "${tag}" not found in dump (likely not signed in or already on that tab)`,
+          );
+        }
+      }
       return true;
     } catch (e) {
       console.error(`[android-driver] androidOpenScreen(${screen}) failed: ${e.message}`);

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -16265,3 +16265,119 @@ describe('android-adb-driver — androidLongPressSeat', () => {
     expect(await promise).toBe(false);
   });
 });
+
+describe('android-adb-driver — androidOpenScreen tab-navigation', () => {
+  // Improvement over the prior launch-only stub: after the activity
+  // start settles, the driver taps `main_<lowered>Tab` for the known
+  // bottom-nav set (rooms / home / messages / profile) so dump+tap
+  // matchers downstream find tags on the right screen. Unknown
+  // screen identifiers preserve the prior no-op-then-true semantic.
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('rooms screen → launches MainActivity then taps main_roomsTab', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('main_roomsTab', '[0,1900][270,2100]'),
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidOpenScreen('rooms');
+    await jest.advanceTimersByTimeAsync(1500); // initial settle
+    await jest.advanceTimersByTimeAsync(500); // tap settle
+    expect(await promise).toBe(true);
+    // The MainActivity start was issued
+    const startCall = execSync.mock.calls.map((c) => c[0]).find((c) => c.includes("'am' 'start'"));
+    expect(startCall).toBeDefined();
+    expect(startCall).toContain('MainActivity');
+    // AND a tap was issued on the rooms tab's centre [0,1900][270,2100] = (135, 2000)
+    const tapCall = execSync.mock.calls.map((c) => c[0]).find((c) => c.includes("'input' 'tap'"));
+    expect(tapCall).toBeDefined();
+    expect(tapCall).toContain("'135'");
+    expect(tapCall).toContain("'2000'");
+  });
+
+  test('home/messages/profile each tap the matching main_<name>Tab', async () => {
+    for (const screen of ['home', 'messages', 'profile']) {
+      jest.clearAllMocks();
+      const tag = `main_${screen}Tab`;
+      mockExec({
+        "'uiautomator' 'dump'": '',
+        "'cat' '/sdcard/dump.xml'": dumpWithId(tag, '[300,1900][600,2100]'),
+      });
+      const driver = await createAndroidDriver();
+      const promise = driver.androidOpenScreen(screen);
+      await jest.advanceTimersByTimeAsync(1500);
+      await jest.advanceTimersByTimeAsync(500);
+      expect(await promise).toBe(true);
+      // Centre of [300,1900][600,2100] = (450, 2000)
+      const tapCall = execSync.mock.calls.map((c) => c[0]).find((c) => c.includes("'input' 'tap'"));
+      expect(tapCall).toBeDefined();
+      expect(tapCall).toContain("'450'");
+      expect(tapCall).toContain("'2000'");
+    }
+  });
+
+  test('unknown screen → launches MainActivity, no tab tap, still returns true', async () => {
+    mockExec({});
+    const driver = await createAndroidDriver();
+    const promise = driver.androidOpenScreen('some-future-screen');
+    await jest.advanceTimersByTimeAsync(1500);
+    expect(await promise).toBe(true);
+    // MainActivity launch was issued
+    const startCall = execSync.mock.calls.map((c) => c[0]).find((c) => c.includes("'am' 'start'"));
+    expect(startCall).toBeDefined();
+    // No input tap was issued
+    const tapCall = execSync.mock.calls.map((c) => c[0]).find((c) => c.includes("'input' 'tap'"));
+    expect(tapCall).toBeUndefined();
+  });
+
+  test('tab tap miss does NOT fail the call (logs warning, still returns true)', async () => {
+    // Sign-in-required screens or already-on-the-tab cases yield no
+    // matching dump. The driver must NOT propagate the miss as a
+    // call-level failure — the launch alone is a useful success.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": '<node resource-id="unrelated_tag" />',
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidOpenScreen('rooms');
+    await jest.advanceTimersByTimeAsync(1500);
+    await jest.advanceTimersByTimeAsync(500);
+    expect(await promise).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/tab "main_roomsTab" not found/i));
+    warnSpy.mockRestore();
+  });
+
+  test('_requestedScreen is still stashed on the driver (backward-compat)', async () => {
+    mockExec({});
+    const driver = await createAndroidDriver();
+    const promise = driver.androidOpenScreen('rooms');
+    await jest.advanceTimersByTimeAsync(2000);
+    await promise;
+    // Existing callers that probe _requestedScreen for the most-recent
+    // request still see the value. Preserved across the navigation change.
+    expect(driver._requestedScreen).toBe('rooms');
+  });
+
+  test('case-insensitive screen mapping (Rooms → main_roomsTab)', async () => {
+    mockExec({
+      "'uiautomator' 'dump'": '',
+      "'cat' '/sdcard/dump.xml'": dumpWithId('main_roomsTab', '[0,1900][270,2100]'),
+    });
+    const driver = await createAndroidDriver();
+    // Feature-file authors might capitalise — accept any case.
+    const promise = driver.androidOpenScreen('Rooms');
+    await jest.advanceTimersByTimeAsync(1500);
+    await jest.advanceTimersByTimeAsync(500);
+    expect(await promise).toBe(true);
+    const tapCall = execSync.mock.calls.map((c) => c[0]).find((c) => c.includes("'input' 'tap'"));
+    expect(tapCall).toBeDefined();
+  });
+});


### PR DESCRIPTION
j09 dispatch surfaced `tag "main_createRoomFab" not found in Android UI dump` — runner correctly invoked androidTapByTag, but the device wasn't on the rooms tab. Prior `androidOpenScreen` only launched MainActivity then stashed `_requestedScreen` on the driver.

## Change

After the activity-start settles, the driver now taps `main_<lowered>Tab` for the known bottom-nav set (rooms / home / messages / profile). Tag list grounded in `shared/src/commonMain/.../feature/main/MainScreen.kt`.

- Unknown screens preserve the prior no-op + return-true semantic
- Tab tap miss (sign-in screen / already-on-tab) logs warning, NOT a return-false — launch alone is a useful success
- `_requestedScreen` still stashed (backward-compat)
- Case-insensitive (`Rooms` → `main_roomsTab`)

## Tests (6 new)

3 happy-path + 3 edge cases (unknown screen, tap miss, backward-compat pin). **1284/1284 pass** (1278 prior + 6 new). ESLint + Prettier clean.

## j09 unblock

Combined with the existing sign-in path arriving on home, calling `androidOpenScreen('rooms')` now lands on the rooms tab and `main_createRoomFab` is in the dump → "Theo creates a public voice room" finding cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)