### PR TITLE
feat(qa-runner): 4 j01 first-day setup-Given handlers (Adam onboarding flow)

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -548,6 +548,78 @@ async function applyAgeDowngrade(ctx, personaName, adminPersonaName) {
   return { auditDocId };
 }
 
+async function seedSignedUpUser(ctx, personaName, opts = {}) {
+  // Mirrors a minor-default signup write: users/<uniqueId> with
+  // cohort='minor', isAgeVerified=false, displayName from registry.
+  // Caller can override cohort via opts.cohort (e.g. for j01's
+  // already-flipped-to-adult state).
+  const personas = loadPersonas();
+  const persona = personas.get(personaName);
+  if (!persona?.uniqueId) {
+    throw new Error(`persona "${personaName}" not in registry`);
+  }
+  const fields = {
+    uniqueId: persona.uniqueId,
+    cohort: opts.cohort || 'minor',
+    isAgeVerified: opts.isAgeVerified ?? false,
+    displayName: persona.displayName,
+    email: persona.email,
+    createdAt: Date.now(),
+    ...(opts.extraFields || {}),
+  };
+  await ctx.db.doc(`users/${persona.uniqueId}`).set(fields, { merge: true });
+  // Expose {newUniqueId} interpolation variable (j01 uses this in
+  // assertions like `database has document "users/{newUniqueId}"`).
+  if (ctx.scenarioVars && typeof ctx.scenarioVars.set === 'function') {
+    ctx.scenarioVars.set('newUniqueId', String(persona.uniqueId));
+  }
+  return { fields };
+}
+
+async function seedAcceptedPolicies(ctx, personaName, opts = {}) {
+  // Writes usersAcceptedPolicies/<uniqueId> with the current accepted
+  // privacy + terms versions. j01 uses this as the "Adam has accepted
+  // legal" precondition.
+  const personas = loadPersonas();
+  const persona = personas.get(personaName);
+  if (!persona?.uniqueId) {
+    throw new Error(`persona "${personaName}" not in registry`);
+  }
+  await ctx.db.doc(`usersAcceptedPolicies/${persona.uniqueId}`).set({
+    privacyVersion: opts.privacyVersion || 4,
+    termsVersion: opts.termsVersion || 4,
+    acceptedAt: Date.now(),
+  });
+  return { uniqueId: persona.uniqueId };
+}
+
+async function applyAgeVerificationApproval(ctx, personaName, adminPersonaName) {
+  // Mirrors the production /api/admin/age-verification/approve handler:
+  //   1. users/<persona>.cohort = 'adult' + isAgeVerified = true
+  //   2. auditLog/<auto> with action='age_verification.approve',
+  //      targetId=String(uniqueId), adminId=String(adminUniqueId)
+  const personas = loadPersonas();
+  const persona = personas.get(personaName);
+  const admin = personas.get(adminPersonaName);
+  if (!persona?.uniqueId) {
+    throw new Error(`persona "${personaName}" not in registry`);
+  }
+  if (!admin?.uniqueId) {
+    throw new Error(`admin persona "${adminPersonaName}" not in registry`);
+  }
+  await ctx.db
+    .doc(`users/${persona.uniqueId}`)
+    .set({ cohort: 'adult', isAgeVerified: true }, { merge: true });
+  const auditDocId = `${persona.uniqueId}-approve-${Date.now()}`;
+  await ctx.db.doc(`auditLog/${auditDocId}`).set({
+    action: 'age_verification.approve',
+    targetId: String(persona.uniqueId),
+    adminId: String(admin.uniqueId),
+    timestamp: Date.now(),
+  });
+  return { auditDocId };
+}
+
 async function seedSystemPmFromOfficia(ctx, recipientPersonaName, key) {
   // Officia is uniqueId 1 (SHYTALK_OFFICIAL). The PM flow writes:
   //   1. conversations/<auto> with participantIds=[1, recipient]
@@ -9369,6 +9441,83 @@ const matchers = [
   //     room precondition is only used by j04's "ejected when downgrade
   //     hits" scenario, which can be left as STEP_NOT_IMPLEMENTED for
   //     now and addressed in a follow-up PR.
+  // ── Adam's first-day setup Givens (j01 phase-scoped scenarios) ──
+  //
+  // j01's 10 phase-scoped scenarios establish prior phases via setup
+  // Givens that walk Adam through: signup (minor default) → legal accept
+  // → age-verification submission → admin approve → adult verified
+  // → daily reward → first gift. Adam is an EPHEMERAL persona
+  // (P-01 in EPHEMERAL_PERSONAS, uniqueId 90000001).
+  {
+    // "Adam has just signed up with a minor-default cohort"
+    pattern: /^([A-Z][a-z]+)\s+has just signed up with a minor-default cohort$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        await seedSignedUpUser(ctx, m[1]);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
+    // "Adam has accepted legal as a minor-default user" — composes
+    // signup state + accepted-policies row.
+    pattern: /^([A-Z][a-z]+)\s+has accepted legal as a minor-default user$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        await seedSignedUpUser(ctx, m[1]);
+        await seedAcceptedPolicies(ctx, m[1]);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
+    // "Adam has just been approved to cohort=adult by Greta"
+    pattern: /^([A-Z][a-z]+)\s+has just been approved to cohort=adult by ([A-Z][a-z]+)$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        // Ensure user-doc exists (idempotent — has user doc with cohort=minor
+        // first, then the admin approve flips it to adult).
+        await seedSignedUpUser(ctx, m[1]);
+        await applyAgeVerificationApproval(ctx, m[1], m[2]);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
+    // "Adam is verified adult with adult features unlocked"
+    pattern: /^([A-Z][a-z]+)\s+is verified adult with adult features unlocked$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        // Final-state seed: cohort=adult, isAgeVerified=true, policies
+        // accepted. No audit entry — the test scenarios that care about
+        // the audit row use the "has just been approved" Given which
+        // does include it.
+        await seedSignedUpUser(ctx, m[1], { cohort: 'adult', isAgeVerified: true });
+        await seedAcceptedPolicies(ctx, m[1]);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  // Note: "<persona> has shyCoins >= 10 after daily reward + a +100
+  // admin top-up" (j01:111) is NOT added here — it collides with the
+  // existing assertion matcher at line ~4620 (`<persona> has <field>
+  // <op> <number>`). j01 line 111 should be rewritten as a compose:
+  //   Given Adam is verified adult with adult features unlocked
+  //   Given Adam has user doc with shyCoins=200
+  // using the existing line ~2066 "has user doc with X=Y" matcher.
+  // Pending j01 feature-file update.
   {
     // Wake 80 — "the response from <path>?<query> includes <Name>".
     // j15:62 — checks ctx.lastResponse.results[] for an entry matching

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -10140,6 +10140,114 @@ describe('Admin-moderation setup Givens (j04 phase-scoped scenario setup)', () =
   });
 });
 
+// ─── Adam's first-day setup Givens (j01 phase-scoped scenarios) ─────
+describe("Adam's first-day setup Givens (j01 phase-scoped scenario setup)", () => {
+  // Adam is an EPHEMERAL persona (P-01 in EPHEMERAL_PERSONAS,
+  // uniqueId 90000001). loadPersonas() merges ephemerals so the
+  // matcher resolves persona via `personas.get('Adam')`.
+  const ADAM_UNIQUE_ID = 90000001;
+  const greta = require('../../scripts/provision-test-personas').personas.find(
+    (p) => p.id === 'P-12',
+  );
+
+  test('"<persona> has just signed up with a minor-default cohort" — seeds users/<uniqueId> with cohort=minor + isAgeVerified=false', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Adam has just signed up with a minor-default cohort' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const user = db._docs[`users/${ADAM_UNIQUE_ID}`];
+    expect(user).toBeDefined();
+    expect(user.cohort).toBe('minor');
+    expect(user.isAgeVerified).toBe(false);
+    expect(user.uniqueId).toBe(ADAM_UNIQUE_ID);
+    // {newUniqueId} interpolation variable is set for downstream
+    // assertions referencing users/{newUniqueId}.
+    expect(ctx.scenarioVars.get('newUniqueId')).toBe(String(ADAM_UNIQUE_ID));
+  });
+
+  test('"<persona> has accepted legal as a minor-default user" — composes signup + accepted-policies', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Adam has accepted legal as a minor-default user' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    // User-doc seeded with minor default
+    const user = db._docs[`users/${ADAM_UNIQUE_ID}`];
+    expect(user.cohort).toBe('minor');
+    // usersAcceptedPolicies entry written with current versions
+    const policies = db._docs[`usersAcceptedPolicies/${ADAM_UNIQUE_ID}`];
+    expect(policies).toBeDefined();
+    expect(policies.privacyVersion).toBeGreaterThan(0);
+    expect(policies.termsVersion).toBeGreaterThan(0);
+  });
+
+  test('"<persona> has just been approved to cohort=adult by <admin>" — flips cohort + writes audit row', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Adam has just been approved to cohort=adult by Greta' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    // User flipped
+    const user = db._docs[`users/${ADAM_UNIQUE_ID}`];
+    expect(user.cohort).toBe('adult');
+    expect(user.isAgeVerified).toBe(true);
+    // Audit row written with String-coerced ids per production convention
+    const audits = Object.entries(db._docs).filter(([k]) => k.startsWith('auditLog/'));
+    expect(audits).toHaveLength(1);
+    const [, audit] = audits[0];
+    expect(audit.action).toBe('age_verification.approve');
+    expect(audit.targetId).toBe(String(ADAM_UNIQUE_ID));
+    expect(audit.adminId).toBe(String(greta.uniqueId));
+  });
+
+  test('"<persona> is verified adult with adult features unlocked" — full final state, NO audit (used as compose precondition)', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Adam is verified adult with adult features unlocked' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const user = db._docs[`users/${ADAM_UNIQUE_ID}`];
+    expect(user.cohort).toBe('adult');
+    expect(user.isAgeVerified).toBe(true);
+    // Policies accepted
+    expect(db._docs[`usersAcceptedPolicies/${ADAM_UNIQUE_ID}`]).toBeDefined();
+    // No audit row — this Given is the COMPOSE form (precondition for
+    // a later scenario that doesn't care about the audit).
+    const audits = Object.entries(db._docs).filter(([k]) => k.startsWith('auditLog/'));
+    expect(audits).toHaveLength(0);
+  });
+
+  test('unknown persona → actionable error', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Zonk has just signed up with a minor-default cohort' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/persona "Zonk" not in registry/);
+  });
+
+  test('ctx.db missing → actionable error, not crash', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Given', text: 'Adam has just signed up with a minor-default cohort' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.db not initialised/);
+  });
+});
+
 describe('Dialog confirm action (platform-dispatch)', () => {
   test('"X on Android confirms in the dialog" → driver', async () => {
     const spy = jest.fn(async () => undefined);

--- a/journey-tests/j01-adult-new-day-one.feature
+++ b/journey-tests/j01-adult-new-day-one.feature
@@ -108,7 +108,8 @@ Feature: j01 — Adam's first day
 
   @blocker @android-emulator
   Scenario: Adam sends his first gift to Alice — coins debit, beans credit, both transactions + gift wall entry
-    Given Adam has shyCoins >= 10 after daily reward + a +100 admin top-up
+    Given Adam is verified adult with adult features unlocked
+    Given Adam has user doc with shyCoins=200
     When Adam on Android opens the "wallet" screen
     When Adam on Android taps "wallet_sendGiftButton"
     When Adam on Android selects gift "rose" and recipient "Alice"


### PR DESCRIPTION
j01's 10 phase-scoped scenarios establish Adam's first-day journey (signup → legal → age-verify → admin approve → adult unlocked). Composable per the PR #877/#884 pattern.

## Primitives (3 new)

- `seedSignedUpUser(persona, opts)` — users/<uniqueId> with cohort/isAgeVerified/displayName/email. Sets `{newUniqueId}` scenarioVar.
- `seedAcceptedPolicies(persona)` — usersAcceptedPolicies/<uniqueId> with current privacy+terms versions.
- `applyAgeVerificationApproval(persona, admin)` — mirrors prod approve route: cohort=adult + isAgeVerified=true + audit row.

## Matchers (4 new)

1. `<persona> has just signed up with a minor-default cohort`
2. `<persona> has accepted legal as a minor-default user` (compose)
3. `<persona> has just been approved to cohort=adult by <admin>` (compose)
4. `<persona> is verified adult with adult features unlocked` (final-state compose, no audit)

## Feature file update

j01 line 111 ("Adam has shyCoins >= 10 after daily reward + +100 admin top-up") collided with the existing assertion matcher at line ~4620 (`<persona> has <field> <op> <number>`). Refactored to two existing primitives:

```
Given Adam is verified adult with adult features unlocked
Given Adam has user doc with shyCoins=200
```

## Tests (6 new)

4 per-handler + unknown-persona + ctx.db-missing. String-coerced expectations per production wire format. **1836/1836 pass** (1830 prior + 6 new). ESLint + Prettier clean; Gherkin quality check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)