### PR TITLE
feat(qa-runner): 2 j05 monetization setup-Given handlers (Alice purchase + gift)

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -548,6 +548,91 @@ async function applyAgeDowngrade(ctx, personaName, adminPersonaName) {
   return { auditDocId };
 }
 
+async function applyGiftSend(ctx, senderName, recipientName, giftId) {
+  // Mirrors the production /api/economy/send-gift writes:
+  //   1. users/<sender>.shyCoins decreased by gift.coinCost
+  //   2. users/<recipient>.beans increased by gift.beanValue
+  //   3. users/<sender>/transactions/<auto> type=GIFT_SENT
+  //   4. users/<recipient>/transactions/<auto> type=GIFT_RECEIVED
+  //   5. giftWalls/<recipient>/gifts/<auto> with senderId + giftId
+  // Gift costs grounded in j05: rose=10/5, crown=500/250, diamond=1000/500.
+  const personas = loadPersonas();
+  const sender = personas.get(senderName);
+  const recipient = personas.get(recipientName);
+  if (!sender?.uniqueId) throw new Error(`sender "${senderName}" not in registry`);
+  if (!recipient?.uniqueId) throw new Error(`recipient "${recipientName}" not in registry`);
+  const giftCosts = { rose: [10, 5], crown: [500, 250], diamond: [1000, 500] };
+  const [coinCost, beanValue] = giftCosts[giftId] || [10, 5];
+  // Read-modify-set per existing convention (handles missing users
+  // gracefully — coins default to 0, but this is a Given so the test
+  // usually establishes coins first).
+  const senderRef = ctx.db.doc(`users/${sender.uniqueId}`);
+  const senderSnap = await senderRef.get();
+  const senderData = senderSnap.exists ? senderSnap.data() : {};
+  const senderCoins = Number(senderData.shyCoins) || 0;
+  await senderRef.set({ shyCoins: senderCoins - coinCost }, { merge: true });
+  const recipientRef = ctx.db.doc(`users/${recipient.uniqueId}`);
+  const recipientSnap = await recipientRef.get();
+  const recipientData = recipientSnap.exists ? recipientSnap.data() : {};
+  const recipientBeans = Number(recipientData.beans) || 0;
+  await recipientRef.set({ beans: recipientBeans + beanValue }, { merge: true });
+  const ts = Date.now();
+  await ctx.db.doc(`users/${sender.uniqueId}/transactions/gift-out-${ts}`).set({
+    type: 'GIFT_SENT',
+    amount: -coinCost,
+    giftId,
+    recipientId: String(recipient.uniqueId),
+    timestamp: ts,
+  });
+  await ctx.db.doc(`users/${recipient.uniqueId}/transactions/gift-in-${ts}`).set({
+    type: 'GIFT_RECEIVED',
+    amount: beanValue,
+    giftId,
+    senderId: String(sender.uniqueId),
+    timestamp: ts,
+  });
+  await ctx.db.doc(`giftWalls/${recipient.uniqueId}/gifts/${sender.uniqueId}-${giftId}-${ts}`).set({
+    giftId,
+    senderId: String(sender.uniqueId),
+    timestamp: ts,
+  });
+  return { coinCost, beanValue };
+}
+
+async function applyPurchase(ctx, personaName, packageId, finalShyCoins) {
+  // Mirrors the production /api/economy/purchase writes:
+  //   1. users/<persona>.shyCoins = finalShyCoins (the test fixes the
+  //      post-state explicitly, not via delta; this preserves intent
+  //      regardless of prior coin balance).
+  //   2. users/<persona>/transactions/<auto> type=PURCHASE with productId.
+  // We deliberately don't write a Stripe/IAP receipt sub-doc — receipt
+  // structure is platform-specific (Apple, Google, sandbox) and the
+  // setup-Given form abstracts over it. Downstream scenarios that need
+  // receipt-shape coverage seed it explicitly via a dedicated matcher.
+  const personas = loadPersonas();
+  const p = personas.get(personaName);
+  if (!p?.uniqueId) throw new Error(`persona "${personaName}" not in registry`);
+  // Coin delta is the trailing-digits suffix on the packageId — i.e.
+  // `coins-1000` → +1000. Falls back to (finalShyCoins - prior) if the
+  // packageId doesn't match, which preserves audit-trail accuracy when
+  // the test calls a non-standard packageId.
+  const pkgMatch = /-(\d+)$/.exec(packageId);
+  const userRef = ctx.db.doc(`users/${p.uniqueId}`);
+  const userSnap = await userRef.get();
+  const userData = userSnap.exists ? userSnap.data() : {};
+  const priorCoins = Number(userData.shyCoins) || 0;
+  const coinDelta = pkgMatch ? Number(pkgMatch[1]) : finalShyCoins - priorCoins;
+  await userRef.set({ shyCoins: finalShyCoins }, { merge: true });
+  const ts = Date.now();
+  await ctx.db.doc(`users/${p.uniqueId}/transactions/purchase-${ts}`).set({
+    type: 'PURCHASE',
+    amount: coinDelta,
+    productId: packageId,
+    timestamp: ts,
+  });
+  return { coinDelta };
+}
+
 async function seedSystemPmFromOfficia(ctx, recipientPersonaName, key) {
   // Officia is uniqueId 1 (SHYTALK_OFFICIAL). The PM flow writes:
   //   1. conversations/<auto> with participantIds=[1, recipient]
@@ -3478,6 +3563,70 @@ const matchers = [
       const awardBeans = parseInt(m[3], 10);
       await ctx.db.doc(`gifts/${id}`).set({ id, costCoins, awardBeans });
       return { ok: true };
+    },
+  },
+  {
+    // j05 purchase setup-Given (line 46): "<persona> has just purchased
+    // <packageId> and has <field>=<value>". Composes:
+    //   - applyPurchase: writes the PURCHASE transaction + sets shyCoins
+    //   - the field=value clause overrides the post-purchase balance
+    //     (the scenario author has authority on the post-state — packageId
+    //     might be experimental and not yet in the catalog)
+    // Distinct from the existing `<persona> purchased "<pkg>" with receipt`
+    // matcher (line 5271) — that flavor writes purchaseReceipts/. This
+    // one is for the compact "just purchased + post-state" form j05 uses.
+    pattern:
+      /^([A-Z][a-z]+)(?:\s*\[(P-\d{2})\])?\s+has just purchased\s+([\w-]+)\s+and has\s+(\w+)=(\d+)$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db (firebase-admin Firestore) not initialised' };
+      const name = m[1];
+      const packageId = m[3];
+      const field = m[4];
+      const value = parseInt(m[5], 10);
+      try {
+        if (field === 'shyCoins') {
+          await applyPurchase(ctx, name, packageId, value);
+          return { ok: true };
+        }
+        // Non-shyCoins post-state — fall through to a single-field merge.
+        // applyPurchase still records the transaction so the row count
+        // matches the purchase flow's audit trail.
+        await applyPurchase(ctx, name, packageId, value);
+        const personas = loadPersonas();
+        const p = personas.get(name);
+        await ctx.db.doc(`users/${p.uniqueId}`).set({ [field]: value }, { merge: true });
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
+    // j05 gift-send setup-Given (lines 69/76/81): "<persona> has just sent
+    // <recipient> a <giftId>". Composes applyGiftSend, which mirrors the
+    // production /api/economy/send-gift writes:
+    //   - sender shyCoins decremented by gift cost
+    //   - recipient beans incremented by gift award
+    //   - users/<sender>/transactions/<auto>  type=GIFT_SENT
+    //   - users/<recipient>/transactions/<auto>  type=GIFT_RECEIVED
+    //   - giftWalls/<recipient>/gifts/<auto>  with senderId + giftId
+    // Gift costs read from the giftCosts table inside applyGiftSend
+    // (rose=10/5, crown=500/250, diamond=1000/500), grounded in the
+    // j05 background catalog. Sender wallet must have the gift cost
+    // available — caller is responsible for setting shyCoins first via
+    // an earlier "has shyCoins=N" setup-Given.
+    pattern: /^([A-Z][a-z]+)(?:\s*\[(P-\d{2})\])?\s+has just sent\s+([A-Z][a-z]+)\s+a\s+(\w+)$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db (firebase-admin Firestore) not initialised' };
+      const sender = m[1];
+      const recipient = m[3];
+      const giftId = m[4];
+      try {
+        await applyGiftSend(ctx, sender, recipient, giftId);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
     },
   },
   {

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -10140,6 +10140,173 @@ describe('Admin-moderation setup Givens (j04 phase-scoped scenario setup)', () =
   });
 });
 
+describe('Monetization setup Givens (j05 phase-scoped scenario setup)', () => {
+  const { personas: PERSONAS } = require('../../scripts/provision-test-personas');
+  const alice = PERSONAS.find((p) => p.id === 'P-02');
+  const selma = PERSONAS.find((p) => p.id === 'P-15');
+
+  test('"<persona> has just purchased <package> and has shyCoins=<N>" — writes PURCHASE transaction + sets coins', async () => {
+    const db = makeStatefulFakeDb({
+      [`users/${alice.uniqueId}`]: { shyCoins: 5000 },
+    });
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Alice has just purchased coins-1000 and has shyCoins=6000' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(db._docs[`users/${alice.uniqueId}`].shyCoins).toBe(6000);
+    // PURCHASE transaction row with productId + delta
+    const txns = Object.entries(db._docs).filter(([k]) =>
+      k.startsWith(`users/${alice.uniqueId}/transactions/`),
+    );
+    expect(txns).toHaveLength(1);
+    const [, txn] = txns[0];
+    expect(txn.type).toBe('PURCHASE');
+    expect(txn.amount).toBe(1000);
+    expect(txn.productId).toBe('coins-1000');
+  });
+
+  test('"<persona> has just sent <recipient> a <gift>" — debits sender, credits recipient, writes both transactions + gift wall', async () => {
+    const db = makeStatefulFakeDb({
+      [`users/${alice.uniqueId}`]: { shyCoins: 5700 },
+      [`users/${selma.uniqueId}`]: { beans: 10000 },
+    });
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep({ kind: 'Given', text: 'Alice has just sent Selma a crown' }, ctx);
+    expect(r.ok).toBe(true);
+    expect(db._docs[`users/${alice.uniqueId}`].shyCoins).toBe(5200);
+    expect(db._docs[`users/${selma.uniqueId}`].beans).toBe(10250);
+    // Sender's GIFT_SENT transaction
+    const senderTxns = Object.entries(db._docs).filter(([k]) =>
+      k.startsWith(`users/${alice.uniqueId}/transactions/`),
+    );
+    expect(senderTxns).toHaveLength(1);
+    const [, sentTxn] = senderTxns[0];
+    expect(sentTxn.type).toBe('GIFT_SENT');
+    expect(sentTxn.amount).toBe(-500);
+    expect(sentTxn.giftId).toBe('crown');
+    expect(sentTxn.recipientId).toBe(String(selma.uniqueId));
+    // Recipient's GIFT_RECEIVED transaction
+    const recipTxns = Object.entries(db._docs).filter(([k]) =>
+      k.startsWith(`users/${selma.uniqueId}/transactions/`),
+    );
+    expect(recipTxns).toHaveLength(1);
+    const [, recvTxn] = recipTxns[0];
+    expect(recvTxn.type).toBe('GIFT_RECEIVED');
+    expect(recvTxn.amount).toBe(250);
+    expect(recvTxn.senderId).toBe(String(alice.uniqueId));
+    // Gift wall entry for recipient
+    const wallEntries = Object.entries(db._docs).filter(([k]) =>
+      k.startsWith(`giftWalls/${selma.uniqueId}/gifts/`),
+    );
+    expect(wallEntries).toHaveLength(1);
+    const [, wallEntry] = wallEntries[0];
+    expect(wallEntry.giftId).toBe('crown');
+    expect(wallEntry.senderId).toBe(String(alice.uniqueId));
+  });
+
+  test('gift-send rose (cheapest) — uses correct cost/award (10 coins → 5 beans)', async () => {
+    const db = makeStatefulFakeDb({
+      [`users/${alice.uniqueId}`]: { shyCoins: 100 },
+      [`users/${selma.uniqueId}`]: { beans: 0 },
+    });
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep({ kind: 'Given', text: 'Alice has just sent Selma a rose' }, ctx);
+    expect(r.ok).toBe(true);
+    expect(db._docs[`users/${alice.uniqueId}`].shyCoins).toBe(90);
+    expect(db._docs[`users/${selma.uniqueId}`].beans).toBe(5);
+  });
+
+  test('gift-send diamond (priciest) — uses correct cost/award (1000 coins → 500 beans)', async () => {
+    const db = makeStatefulFakeDb({
+      [`users/${alice.uniqueId}`]: { shyCoins: 2000 },
+      [`users/${selma.uniqueId}`]: { beans: 0 },
+    });
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Alice has just sent Selma a diamond' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(db._docs[`users/${alice.uniqueId}`].shyCoins).toBe(1000);
+    expect(db._docs[`users/${selma.uniqueId}`].beans).toBe(500);
+  });
+
+  test('purchase with unknown packageId → coinDelta derived from finalShyCoins - prior', async () => {
+    const db = makeStatefulFakeDb({
+      [`users/${alice.uniqueId}`]: { shyCoins: 5000 },
+    });
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      // No trailing number suffix → fallback to finalShyCoins - prior
+      { kind: 'Given', text: 'Alice has just purchased starter-pack and has shyCoins=5500' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(db._docs[`users/${alice.uniqueId}`].shyCoins).toBe(5500);
+    const txns = Object.entries(db._docs).filter(([k]) =>
+      k.startsWith(`users/${alice.uniqueId}/transactions/`),
+    );
+    expect(txns).toHaveLength(1);
+    const [, txn] = txns[0];
+    // Bare packageId has trailing digits in `pack` part? Let's verify the
+    // regex behaves: /-(\d+)$/ on "starter-pack" → no match, falls back.
+    // (Note: a packageId like "starter-1" WOULD match -1$. That's accepted
+    // behaviour — packageIds in the corpus all use coins-<N> form.)
+    expect(txn.productId).toBe('starter-pack');
+    expect(txn.amount).toBe(500);
+  });
+
+  test('purchase with unknown persona → actionable error', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Zonk has just purchased coins-1000 and has shyCoins=6000' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/persona "Zonk" not in registry/);
+  });
+
+  test('gift-send with unknown recipient → actionable error', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep({ kind: 'Given', text: 'Alice has just sent Zonk a crown' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/recipient "Zonk" not in registry/);
+  });
+
+  test('purchase: ctx.db missing → actionable error, not crash', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Given', text: 'Alice has just purchased coins-1000 and has shyCoins=6000' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.db.*not initialised/);
+  });
+
+  test('gift-send: ctx.db missing → actionable error, not crash', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Given', text: 'Alice has just sent Selma a crown' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.db.*not initialised/);
+  });
+
+  test('"<persona> has shyCoins=<N>" (existing assignment matcher, j05 line 88) — sets coins via merge', async () => {
+    const db = makeStatefulFakeDb({
+      [`users/${alice.uniqueId}`]: { shyCoins: 9999, beans: 2000 },
+    });
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep({ kind: 'Given', text: 'Alice has shyCoins=5000' }, ctx);
+    expect(r.ok).toBe(true);
+    expect(db._docs[`users/${alice.uniqueId}`].shyCoins).toBe(5000);
+    // Sibling fields preserved via merge
+    expect(db._docs[`users/${alice.uniqueId}`].beans).toBe(2000);
+  });
+});
+
 describe('Dialog confirm action (platform-dispatch)', () => {
   test('"X on Android confirms in the dialog" → driver', async () => {
     const spy = jest.fn(async () => undefined);

--- a/journey-tests/j05-alice-monetization.feature
+++ b/journey-tests/j05-alice-monetization.feature
@@ -54,7 +54,7 @@ Feature: j05 — Alice's monetization day
 
   @blocker @browser-chromium
   Scenario: Alice sends a crown to Selma — atomic coins-to-beans transfer with both transactions
-    Given Alice has shyCoins=5700 after gacha pulls
+    Given Alice has shyCoins=5700
     When Alice on Web opens "/wallet#send-gift"
     When Alice on Web selects recipient "Selma" and gift "crown"
     When Alice on Web taps "sendGift_confirmButton"
@@ -95,6 +95,6 @@ Feature: j05 — Alice's monetization day
   @android-physical
   Scenario: Alice on a 2nd device sees coins update in real-time
     Given Alice is signed in on Web Chromium AND on Android physical with the same Firebase user
-    Given Alice has shyCoins=5000 on both
+    Given Alice has shyCoins=5000
     When Alice on Web purchases "coins-1000" with sandbox receipt
     Then within 3000ms Alice's Android UI shows "6,000" next to the ShyCoins icon (real-time Firestore listener)


### PR DESCRIPTION
## Summary

Two compose-form setup-Given matchers + two state-seed primitives for j05 monetization scenarios. Mirrors production write shapes for IAP purchase and gift-send so phase-scoped scenarios can establish their preconditions without re-running the full UI flow.

## Primitives
- `applyPurchase(persona, packageId, finalShyCoins)` — writes PURCHASE transaction + sets shyCoins. Coin delta derived from packageId suffix (`coins-1000` → 1000), with fallback to (final − prior). No FieldValue.increment — preserves fake-db compatibility.
- `applyGiftSend(sender, recipient, giftId)` — mirrors all 5 production writes (sender/recipient wallets, both transactions, gift wall). Gift cost table grounded in j05 background: rose=10/5, crown=500/250, diamond=1000/500.

## Matchers
- `<persona> has just purchased <pkg> and has <field>=<N>` (j05 line 46)
- `<persona> has just sent <recipient> a <gift>` (j05 lines 69/76/81)

## Feature trims (j05)
Two lines had trailing prose that fell through `parseLiteral` as a string instead of a number:
- line 57: `has shyCoins=5700 after gacha pulls` → `has shyCoins=5700`
- line 98: `has shyCoins=5000 on both` → `has shyCoins=5000`

The previous-scenario / multi-platform context the trimmed prose described is already conveyed by the surrounding Background / earlier setup-Given.

## Tests
10 new tests in `Monetization setup Givens` describe block:
- Happy-path purchase, happy-path gift
- rose + diamond cost-table coverage (cheapest/priciest)
- Unknown-packageId fallback delta
- Unknown-persona / unknown-recipient errors
- `ctx.db` missing → actionable error (both matchers)
- Sibling-field preservation for the existing assignment matcher (line 88 form)

All 1840/1840 `manual-qa-runner.test.js` tests pass; prettier + eslint clean.

## Pattern continuity
Follows the established 3-PR pattern (PR #877 room-state, PR #884 admin-moderation, PR #885 j01 onboarding): each PR delivers a small primitive cluster + matchers + comprehensive tests, composed by setup-Givens in one journey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)