### PR TITLE
feat(qa-runner): 2 j02 minor-cohort setup-Given handlers (Mia restricted minor)

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -9480,6 +9480,43 @@ const matchers = [
     },
   },
   {
+    // j02 phrasing: "Mia has just signed up as a minor". Same outcome as
+    // the j01 "minor-default cohort" form — they're synonymous, and the
+    // matcher just routes to the same seedSignedUpUser primitive. Kept as
+    // a separate pattern (rather than alternating one regex) so each
+    // journey reads naturally in its own voice — j01 emphasises that
+    // minor is the SIGNUP DEFAULT (because Adam will later be approved
+    // to adult); j02 emphasises that Mia STAYS a minor (because the
+    // restrictions are her permanent UX, not a temporary state).
+    pattern: /^([A-Z][a-z]+)\s+has just signed up as a minor$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        await seedSignedUpUser(ctx, m[1]);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
+    // j02 phrasing: "Mia has accepted legal as a minor". Composes
+    // signup-as-minor + accepted-policies. Same primitives as the j01
+    // "minor-default user" form; see paired comment above for why the
+    // two phrasings exist side-by-side.
+    pattern: /^([A-Z][a-z]+)\s+has accepted legal as a minor$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      try {
+        await seedSignedUpUser(ctx, m[1]);
+        await seedAcceptedPolicies(ctx, m[1]);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
     // "Adam has just been approved to cohort=adult by Greta"
     pattern: /^([A-Z][a-z]+)\s+has just been approved to cohort=adult by ([A-Z][a-z]+)$/,
     async handler(m, ctx) {

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -10248,6 +10248,108 @@ describe("Adam's first-day setup Givens (j01 phase-scoped scenario setup)", () =
   });
 });
 
+// ─── Mia's restricted-minor setup Givens (j02 phase-scoped scenarios) ─────
+describe("Mia's restricted-minor setup Givens (j02 phase-scoped scenario setup)", () => {
+  // Mia is an EPHEMERAL persona (P-03 in EPHEMERAL_PERSONAS, uniqueId
+  // 90000003). loadPersonas() merges ephemerals so the matcher resolves
+  // persona via `personas.get('Mia')`. Distinct from Adam (P-01) — Mia
+  // exists to exercise the minor-cohort restrictions specifically.
+  const MIA_UNIQUE_ID = 90000003;
+
+  test('"<persona> has just signed up as a minor" — seeds users/<uniqueId> with cohort=minor + isAgeVerified=false', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep({ kind: 'Given', text: 'Mia has just signed up as a minor' }, ctx);
+    expect(r.ok).toBe(true);
+    const user = db._docs[`users/${MIA_UNIQUE_ID}`];
+    expect(user).toBeDefined();
+    expect(user.cohort).toBe('minor');
+    expect(user.isAgeVerified).toBe(false);
+    expect(user.uniqueId).toBe(MIA_UNIQUE_ID);
+    // {newUniqueId} interpolation variable seeded for downstream
+    // assertions referencing users/{newUniqueId}.
+    expect(ctx.scenarioVars.get('newUniqueId')).toBe(String(MIA_UNIQUE_ID));
+  });
+
+  test('"<persona> has accepted legal as a minor" — composes signup-as-minor + accepted-policies', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep({ kind: 'Given', text: 'Mia has accepted legal as a minor' }, ctx);
+    expect(r.ok).toBe(true);
+    // User-doc seeded with minor cohort (NOT flipped to adult — distinct
+    // from the j01 case where Adam later flips to adult).
+    const user = db._docs[`users/${MIA_UNIQUE_ID}`];
+    expect(user.cohort).toBe('minor');
+    expect(user.isAgeVerified).toBe(false);
+    // usersAcceptedPolicies entry written with current versions.
+    const policies = db._docs[`usersAcceptedPolicies/${MIA_UNIQUE_ID}`];
+    expect(policies).toBeDefined();
+    expect(policies.privacyVersion).toBeGreaterThan(0);
+    expect(policies.termsVersion).toBeGreaterThan(0);
+  });
+
+  test('"<persona> has just signed up as a minor" — unknown persona → actionable error', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep({ kind: 'Given', text: 'Zonk has just signed up as a minor' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/persona "Zonk" not in registry/);
+  });
+
+  test('"<persona> has accepted legal as a minor" — unknown persona → actionable error', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep({ kind: 'Given', text: 'Zonk has accepted legal as a minor' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/persona "Zonk" not in registry/);
+  });
+
+  test('"<persona> has just signed up as a minor" — ctx.db missing → actionable error', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Given', text: 'Mia has just signed up as a minor' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.db not initialised/);
+  });
+
+  test('"<persona> has accepted legal as a minor" — ctx.db missing → actionable error', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Given', text: 'Mia has accepted legal as a minor' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.db not initialised/);
+  });
+
+  test('"Mia has accepted legal as a minor" — re-running is idempotent (no duplicate policies row)', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r1 = await executeStep({ kind: 'Given', text: 'Mia has accepted legal as a minor' }, ctx);
+    expect(r1.ok).toBe(true);
+    const r2 = await executeStep({ kind: 'Given', text: 'Mia has accepted legal as a minor' }, ctx);
+    expect(r2.ok).toBe(true);
+    // Only ONE usersAcceptedPolicies entry — re-running merges the same
+    // doc, doesn't create a duplicate.
+    const policies = Object.entries(db._docs).filter(([k]) =>
+      k.startsWith('usersAcceptedPolicies/'),
+    );
+    expect(policies).toHaveLength(1);
+  });
+
+  test('Mia matcher does NOT collide with Adam matcher (j01) — different cohort phrasing routes correctly', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    // Adam's j01 phrasing should NOT match Mia's j02 phrasing matcher
+    // (it must hit the j01 pattern, not the j02 pattern, even though
+    // both end up calling seedSignedUpUser).
+    const ADAM_UNIQUE_ID = 90000001;
+    const r = await executeStep(
+      { kind: 'Given', text: 'Adam has just signed up with a minor-default cohort' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(db._docs[`users/${ADAM_UNIQUE_ID}`]).toBeDefined();
+    expect(db._docs[`users/${MIA_UNIQUE_ID}`]).toBeUndefined();
+  });
+});
+
 describe('Dialog confirm action (platform-dispatch)', () => {
   test('"X on Android confirms in the dialog" → driver', async () => {
     const spy = jest.fn(async () => undefined);


### PR DESCRIPTION
## Summary

Two compose-form setup-Given matchers for the j02 (Mia minor) journey's phase-scoped scenarios. Both route to the j01 primitives (`seedSignedUpUser`, `seedAcceptedPolicies`) that landed via PR #885 — no new primitives needed.

## Matchers
- `<persona> has just signed up as a minor` (j02 line 40)
- `<persona> has accepted legal as a minor` (j02 lines 46, 53, 63, 71, 78, 87, 95, 102)

## Why two phrasings (j01 + j02)
The two pattern strings coexist deliberately:
- j01 says **`minor-default cohort`** — emphasising minor is the SIGNUP DEFAULT (Adam later flips to adult after age verification)
- j02 says **`minor`** — emphasising Mia STAYS a minor (the restrictions are her permanent UX)

Each journey reads in its own voice rather than alternating one regex.

## Tests
8 new tests in `Mia restricted-minor setup Givens` describe block:
- Happy-path signup-as-minor (with `newUniqueId` interpolation seeded)
- Happy-path accepted-legal (compose of signup + policies)
- Unknown-persona errors (both matchers)
- `ctx.db` missing → actionable error (both matchers)
- Idempotency: re-running 'accepted legal' doesn't duplicate policies row
- Collision guard: Adam's j01 phrasing routes to j01 matcher, not j02

All 1844/1844 `manual-qa-runner.test.js` tests pass; prettier + eslint clean.

## Pattern continuity
Follows the established journey-PR pattern: small matcher cluster + comprehensive tests, composed via existing primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)