### PR TITLE
feat(qa-runner): 2 j07 setup-Given handlers (follow state + DIRECT conversation)

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -705,6 +705,64 @@ async function applyAgeVerificationApproval(ctx, personaName, adminPersonaName) 
   return { auditDocId };
 }
 
+async function applyFollow(ctx, followerName, followeeName) {
+  // Mirrors the production /api/users/follow writes:
+  //   1. users/<follower>.followingIds = unique-add(followee uniqueId)
+  //   2. users/<followee>.followerIds  = unique-add(follower uniqueId)
+  // No FieldValue.arrayUnion — read-modify-set preserves fake-db
+  // compatibility (jest stateful fake doesn't expand FieldValue sentinels).
+  // Idempotent: re-running the same follow is a no-op (set dedup).
+  // segregationEvents NOT written — that's only on cross-cohort BLOCK,
+  // which the existing routes/users-follow.js gates behind a cohort check.
+  // The Given form represents a SUCCESSFUL follow, so no audit row.
+  const personas = loadPersonas();
+  const follower = personas.get(followerName);
+  const followee = personas.get(followeeName);
+  if (!follower?.uniqueId) {
+    throw new Error(`follower "${followerName}" not in registry`);
+  }
+  if (!followee?.uniqueId) {
+    throw new Error(`followee "${followeeName}" not in registry`);
+  }
+  const followerRef = ctx.db.doc(`users/${follower.uniqueId}`);
+  const followerSnap = await followerRef.get();
+  const followerData = followerSnap.exists ? followerSnap.data() : {};
+  const followingIds = Array.from(
+    new Set([...(followerData.followingIds || []), followee.uniqueId]),
+  );
+  await followerRef.set({ followingIds }, { merge: true });
+  const followeeRef = ctx.db.doc(`users/${followee.uniqueId}`);
+  const followeeSnap = await followeeRef.get();
+  const followeeData = followeeSnap.exists ? followeeSnap.data() : {};
+  const followerIds = Array.from(new Set([...(followeeData.followerIds || []), follower.uniqueId]));
+  await followeeRef.set({ followerIds }, { merge: true });
+  return { followerUniqueId: follower.uniqueId, followeeUniqueId: followee.uniqueId };
+}
+
+async function seedDirectConversation(ctx, p1Name, p2Name) {
+  // Mirrors a successful /api/conversations create:
+  //   - conversations/<participantIds sorted-pair>: { type: 'DIRECT',
+  //     participantIds: [a, b] (sorted, String-coerced per wire format),
+  //     createdAt: now }
+  // Deterministic doc-id (sorted pair) makes the seed idempotent and lets
+  // downstream assertions look it up by participant lookup without needing
+  // a query for an auto-generated id. participantIds are stringified
+  // because the production routes (Express) call String(req.auth.uniqueId).
+  const personas = loadPersonas();
+  const p1 = personas.get(p1Name);
+  const p2 = personas.get(p2Name);
+  if (!p1?.uniqueId) throw new Error(`persona "${p1Name}" not in registry`);
+  if (!p2?.uniqueId) throw new Error(`persona "${p2Name}" not in registry`);
+  const ids = [String(p1.uniqueId), String(p2.uniqueId)].sort();
+  const convId = `direct-${ids[0]}-${ids[1]}`;
+  await ctx.db.doc(`conversations/${convId}`).set({
+    type: 'DIRECT',
+    participantIds: ids,
+    createdAt: Date.now(),
+  });
+  return { conversationId: convId };
+}
+
 async function seedSystemPmFromOfficia(ctx, recipientPersonaName, key) {
   // Officia is uniqueId 1 (SHYTALK_OFFICIAL). The PM flow writes:
   //   1. conversations/<auto> with participantIds=[1, recipient]
@@ -5618,6 +5676,56 @@ const matchers = [
       ctx.personaPlatforms.set(name, platform);
       ctx.personaPaths.set(name, urlPath);
       return { ok: true };
+    },
+  },
+  {
+    // j07 follow-state setup-Given: "<persona> is following <other>".
+    // Composes applyFollow, which mirrors the production /api/users/follow
+    // writes: follower's followingIds += followee's uniqueId, and the
+    // mirror followerIds += follower's uniqueId. Idempotent — re-running
+    // dedups (Set-backed merge).
+    //
+    // This is the POSITIVE complement to the existing "neither user is
+    // following the other" assertion below — together they let j07's
+    // phase-scoped scenarios establish either pre-condition cleanly.
+    pattern: /^([A-Z][a-z]+)(?:\s*\[(P-\d{2})\])?\s+is following\s+([A-Z][a-z]+)$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      const followerName = m[1];
+      const followeeName = m[3];
+      try {
+        await applyFollow(ctx, followerName, followeeName);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
+    // j07 conversation setup-Given: "<persona> has an open DIRECT
+    // conversation thread with <other>". Composes seedDirectConversation,
+    // which writes a conversations/<deterministic-id> doc with type='DIRECT'
+    // and sorted, String-coerced participantIds. Downstream PM-send /
+    // PM-read assertions look up the thread by participant pair, so the
+    // doc-id determinism keeps tests stable.
+    //
+    // Note this is a UNIDIRECTIONAL phrasing ("Adam has an open thread
+    // WITH Alice") but DIRECT conversations are inherently symmetric —
+    // either persona is a valid subject. The matcher captures the
+    // subject as a sender hint for downstream assertions, but doesn't
+    // mark the thread as "owned" by them.
+    pattern:
+      /^([A-Z][a-z]+)(?:\s*\[(P-\d{2})\])?\s+has an open DIRECT conversation thread with\s+([A-Z][a-z]+)$/,
+    async handler(m, ctx) {
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      const p1Name = m[1];
+      const p2Name = m[3];
+      try {
+        await seedDirectConversation(ctx, p1Name, p2Name);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
     },
   },
   {

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -10415,6 +10415,148 @@ describe("Adam's first-day setup Givens (j01 phase-scoped scenario setup)", () =
   });
 });
 
+// ─── j07 follow + conversation setup Givens (phase-scoped scenarios) ─────
+describe('j07 follow + conversation setup Givens (Adam discovery → PM)', () => {
+  const { personas: PERSONAS } = require('../../scripts/provision-test-personas');
+  const alice = PERSONAS.find((p) => p.id === 'P-02');
+  const ADAM_UNIQUE_ID = 90000001; // ephemeral P-01
+
+  test('"<persona> is following <other>" — adds follower→followee + mirror in followerIds', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep({ kind: 'Given', text: 'Adam is following Alice' }, ctx);
+    expect(r.ok).toBe(true);
+    // Follower's followingIds contains followee's uniqueId
+    const adam = db._docs[`users/${ADAM_UNIQUE_ID}`];
+    expect(adam).toBeDefined();
+    expect(adam.followingIds).toContain(alice.uniqueId);
+    // Mirror: followee's followerIds contains follower's uniqueId
+    const aliceDoc = db._docs[`users/${alice.uniqueId}`];
+    expect(aliceDoc).toBeDefined();
+    expect(aliceDoc.followerIds).toContain(ADAM_UNIQUE_ID);
+  });
+
+  test('"<persona> is following <other>" — idempotent (re-running dedups, no duplicate ids)', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    await executeStep({ kind: 'Given', text: 'Adam is following Alice' }, ctx);
+    await executeStep({ kind: 'Given', text: 'Adam is following Alice' }, ctx);
+    const adam = db._docs[`users/${ADAM_UNIQUE_ID}`];
+    expect(adam.followingIds.filter((id) => id === alice.uniqueId)).toHaveLength(1);
+    const aliceDoc = db._docs[`users/${alice.uniqueId}`];
+    expect(aliceDoc.followerIds.filter((id) => id === ADAM_UNIQUE_ID)).toHaveLength(1);
+  });
+
+  test('"<persona> is following <other>" — preserves pre-existing followingIds entries', async () => {
+    // Pre-seed Adam with a follow on Marcus (P-04, uniqueId 60000010).
+    const MARCUS_UNIQUE_ID = 60000010;
+    const db = makeStatefulFakeDb({
+      [`users/${ADAM_UNIQUE_ID}`]: { followingIds: [MARCUS_UNIQUE_ID] },
+    });
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep({ kind: 'Given', text: 'Adam is following Alice' }, ctx);
+    expect(r.ok).toBe(true);
+    const adam = db._docs[`users/${ADAM_UNIQUE_ID}`];
+    expect(adam.followingIds).toContain(MARCUS_UNIQUE_ID);
+    expect(adam.followingIds).toContain(alice.uniqueId);
+  });
+
+  test('"<persona> is following <other>" — unknown follower → actionable error', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep({ kind: 'Given', text: 'Zonk is following Alice' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/follower "Zonk" not in registry/);
+  });
+
+  test('"<persona> is following <other>" — unknown followee → actionable error', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep({ kind: 'Given', text: 'Adam is following Zonk' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/followee "Zonk" not in registry/);
+  });
+
+  test('"<persona> is following <other>" — ctx.db missing → actionable error', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep({ kind: 'Given', text: 'Adam is following Alice' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.db not initialised/);
+  });
+
+  test('"<persona> has an open DIRECT conversation thread with <other>" — writes conversations/<sorted-pair>', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Adam has an open DIRECT conversation thread with Alice' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    // Conversation id is deterministic — sorted-pair of String-coerced uniqueIds
+    const ids = [String(ADAM_UNIQUE_ID), String(alice.uniqueId)].sort();
+    const convId = `direct-${ids[0]}-${ids[1]}`;
+    const conv = db._docs[`conversations/${convId}`];
+    expect(conv).toBeDefined();
+    expect(conv.type).toBe('DIRECT');
+    expect(conv.participantIds).toEqual(ids);
+    expect(conv.createdAt).toBeGreaterThan(0);
+  });
+
+  test('"<persona> has an open DIRECT conversation thread with <other>" — idempotent (re-running overwrites same doc-id, no duplicate)', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    await executeStep(
+      { kind: 'Given', text: 'Adam has an open DIRECT conversation thread with Alice' },
+      ctx,
+    );
+    await executeStep(
+      { kind: 'Given', text: 'Adam has an open DIRECT conversation thread with Alice' },
+      ctx,
+    );
+    const convs = Object.entries(db._docs).filter(([k]) => k.startsWith('conversations/'));
+    expect(convs).toHaveLength(1);
+  });
+
+  test('"<persona> has an open DIRECT conversation thread with <other>" — order-invariant doc-id (Alice → Adam = Adam → Alice)', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r1 = await executeStep(
+      { kind: 'Given', text: 'Adam has an open DIRECT conversation thread with Alice' },
+      ctx,
+    );
+    expect(r1.ok).toBe(true);
+    const r2 = await executeStep(
+      { kind: 'Given', text: 'Alice has an open DIRECT conversation thread with Adam' },
+      ctx,
+    );
+    expect(r2.ok).toBe(true);
+    // Still 1 conversation — sorted-pair doc-id is bidirectional
+    const convs = Object.entries(db._docs).filter(([k]) => k.startsWith('conversations/'));
+    expect(convs).toHaveLength(1);
+  });
+
+  test('"<persona> has an open DIRECT conversation thread with <other>" — unknown persona → actionable error', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Adam has an open DIRECT conversation thread with Zonk' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/persona "Zonk" not in registry/);
+  });
+
+  test('"<persona> has an open DIRECT conversation thread with <other>" — ctx.db missing → actionable error', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Given', text: 'Adam has an open DIRECT conversation thread with Alice' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.db not initialised/);
+  });
+});
+
 describe('Dialog confirm action (platform-dispatch)', () => {
   test('"X on Android confirms in the dialog" → driver', async () => {
     const spy = jest.fn(async () => undefined);


### PR DESCRIPTION
## Summary

Two setup-Givens for j07 (Adam discovery → PM) phase-scoped scenarios, backed by two new state-seed primitives.

## Primitives
- `applyFollow(follower, followee)` — mirrors `/api/users/follow` writes (followingIds + mirror followerIds). Set-backed dedup makes it idempotent. Read-modify-set preserves fake-db compatibility.
- `seedDirectConversation(p1, p2)` — writes `conversations/<sorted-pair-id>` with `type='DIRECT'`, participantIds=[a, b] sorted + String-coerced per production wire format. Deterministic doc-id makes re-running idempotent (overwrites, no duplicates), and lets downstream PM assertions look up the thread by participant pair without auto-id resolution.

## Matchers
- `<persona> is following <other>` (j07 line 26 et al.)
- `<persona> has an open DIRECT conversation thread with <other>` (j07 line 47 — DIRECT conversation precondition for PM scenarios)

## Tests
11 new tests in `j07 follow + conversation setup Givens` describe block:
- Happy-path follow with mirror writes
- Idempotency: re-running follow dedups, single conversation doc per pair
- Pre-existing followingIds preserved (merge-aware)
- Order-invariant conversation doc-id (Alice→Adam == Adam→Alice)
- Unknown follower/followee/persona → actionable error (3 cases)
- ctx.db missing → actionable error (both matchers)

All 1857/1857 `manual-qa-runner.test.js` tests pass; prettier + eslint clean.

The matchers complement the existing 'neither user is following the other' assertion — together they cover both follow-state preconditions cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)