### PR TITLE
feat(qa-runner): 2 warning-state setup-Given handlers (j10 + j11 moderation)

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -8073,6 +8073,68 @@ const matchers = [
     },
   },
   {
+    // j11 setup-Given: "<persona> has been issued a first-strike warning".
+    // Mirrors the production /api/admin/moderation/warn handler's user-doc
+    // writes:
+    //   - hasActiveWarning = true
+    //   - warningCount = 1 (first strike — second-strike form differs)
+    //   - warningAcknowledged = false (operator-facing UI is pending ack)
+    //   - lastWarningAt = now (audit timestamp)
+    // No audit row here — that's covered by the moderation action matcher
+    // (the audit semantics belong to the admin UI flow, not the state-seed).
+    pattern: /^([A-Z][a-z]+)\s+has been issued a first-strike warning$/,
+    async handler(m, ctx) {
+      const name = m[1];
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      const personas = loadPersonas();
+      const p = personas.get(name);
+      if (!p?.uniqueId) {
+        return { ok: false, error: `persona "${name}" not in registry` };
+      }
+      await ctx.db.doc(`users/${p.uniqueId}`).set(
+        {
+          hasActiveWarning: true,
+          warningCount: 1,
+          warningAcknowledged: false,
+          lastWarningAt: Date.now(),
+        },
+        { merge: true },
+      );
+      return { ok: true };
+    },
+  },
+  {
+    // j11 setup-Given: "<persona> has acknowledged his/her/their first-strike
+    // warning". Composes the issued-warning state PLUS flips
+    // warningAcknowledged → true. This is the state Raul reaches after he
+    // taps the "I understand" button on the warning screen — distinct from
+    // the issued state where the warning still requires acknowledgement.
+    //
+    // Pronoun alternation captures all three forms ("his", "her", "their")
+    // since the corpus uses them depending on persona gender — anchored to
+    // a fixed word list, no \w+ expansion.
+    pattern: /^([A-Z][a-z]+)\s+has acknowledged (?:his|her|their) first-strike warning$/,
+    async handler(m, ctx) {
+      const name = m[1];
+      if (!ctx.db) return { ok: false, error: 'ctx.db not initialised' };
+      const personas = loadPersonas();
+      const p = personas.get(name);
+      if (!p?.uniqueId) {
+        return { ok: false, error: `persona "${name}" not in registry` };
+      }
+      await ctx.db.doc(`users/${p.uniqueId}`).set(
+        {
+          hasActiveWarning: true,
+          warningCount: 1,
+          warningAcknowledged: true,
+          lastWarningAt: Date.now(),
+        },
+        { merge: true },
+      );
+      return { ok: true };
+    },
+  },
+  {
     // Wake 71 — "<Name> on <Plat> opens his/her conversation with <Other>".
     // j11:93 — composite navigation: open PM thread between the speaker
     // and the named other persona. Driver resolves the conv id from the

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -10517,6 +10517,158 @@ describe("Mia's restricted-minor setup Givens (j02 phase-scoped scenario setup)"
   });
 });
 
+// ─── j10/j11 warning-state setup Givens (moderation phase-scoped scenarios) ─────
+describe('Warning-state setup Givens (j10 + j11 phase-scoped scenarios)', () => {
+  const { personas: PERSONAS } = require('../../scripts/provision-test-personas');
+  const raul = PERSONAS.find((p) => p.id === 'P-08');
+  const theo = PERSONAS.find((p) => p.id === 'P-10');
+
+  test('"<persona> has been issued a first-strike warning" — sets hasActiveWarning + warningCount=1 + acknowledged=false', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Raul has been issued a first-strike warning' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const u = db._docs[`users/${raul.uniqueId}`];
+    expect(u.hasActiveWarning).toBe(true);
+    expect(u.warningCount).toBe(1);
+    expect(u.warningAcknowledged).toBe(false);
+    expect(u.lastWarningAt).toBeGreaterThan(0);
+  });
+
+  test('"<persona> has acknowledged his first-strike warning" — composes issued + flips acknowledged=true', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Raul has acknowledged his first-strike warning' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const u = db._docs[`users/${raul.uniqueId}`];
+    expect(u.hasActiveWarning).toBe(true);
+    expect(u.warningCount).toBe(1);
+    expect(u.warningAcknowledged).toBe(true);
+    expect(u.lastWarningAt).toBeGreaterThan(0);
+  });
+
+  test('"<persona> has acknowledged her first-strike warning" — pronoun "her" form matches', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Nora has acknowledged her first-strike warning' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    // Persona Nora is P-09 — fetch from registry
+    const nora = PERSONAS.find((p) => p.id === 'P-09');
+    expect(db._docs[`users/${nora.uniqueId}`].warningAcknowledged).toBe(true);
+  });
+
+  test('"<persona> has acknowledged their first-strike warning" — pronoun "their" form matches', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Raul has acknowledged their first-strike warning' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(db._docs[`users/${raul.uniqueId}`].warningAcknowledged).toBe(true);
+  });
+
+  test('multi-field assignment matcher (existing) handles "hasActiveWarning=true, warningReason=<quoted>" cleanly (j10 refactor)', async () => {
+    // j10 line 58 was originally "Theo has hasActiveWarning=true with
+    // reason \"...\"" — that collided with the (assignment matcher,
+    // wider scope at line ~1898) which greedily captured the trailing
+    // " with reason \"...\"" as part of the field value. Refactored to
+    // the comma form so the EXISTING multi-field matcher handles it.
+    // This test pins the new j10 phrasing's behaviour.
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      {
+        kind: 'Given',
+        text: 'Theo has hasActiveWarning=true, warningReason="Inappropriate language in voice room"',
+      },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const u = db._docs[`users/${theo.uniqueId}`];
+    expect(u.hasActiveWarning).toBe(true);
+    expect(u.warningReason).toBe('Inappropriate language in voice room');
+  });
+
+  test('issued + acknowledged: merge preserves pre-existing user-doc fields (shyCoins, beans)', async () => {
+    const db = makeStatefulFakeDb({
+      [`users/${raul.uniqueId}`]: { shyCoins: 500, beans: 200 },
+    });
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    await executeStep({ kind: 'Given', text: 'Raul has been issued a first-strike warning' }, ctx);
+    const u = db._docs[`users/${raul.uniqueId}`];
+    // Warning fields set
+    expect(u.hasActiveWarning).toBe(true);
+    // Pre-existing fields preserved via merge (the moderation flow doesn't
+    // touch economy state — see j11:71 "shyCoins=0 and beans=0 — irrelevant"
+    // comment in the feature file).
+    expect(u.shyCoins).toBe(500);
+    expect(u.beans).toBe(200);
+  });
+
+  test('"issued" + "acknowledged" — sequence flips acknowledged true with one final state', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    await executeStep({ kind: 'Given', text: 'Raul has been issued a first-strike warning' }, ctx);
+    const intermediate = db._docs[`users/${raul.uniqueId}`].warningAcknowledged;
+    expect(intermediate).toBe(false);
+    await executeStep(
+      { kind: 'Given', text: 'Raul has acknowledged his first-strike warning' },
+      ctx,
+    );
+    expect(db._docs[`users/${raul.uniqueId}`].warningAcknowledged).toBe(true);
+    // warningCount stays 1 (still a first strike), not incremented
+    expect(db._docs[`users/${raul.uniqueId}`].warningCount).toBe(1);
+  });
+
+  test('unknown persona → actionable error (issued)', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Zonk has been issued a first-strike warning' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/persona "Zonk" not in registry/);
+  });
+
+  test('unknown persona → actionable error (acknowledged)', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Zonk has acknowledged his first-strike warning' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/persona "Zonk" not in registry/);
+  });
+
+  test('ctx.db missing → actionable error (both warning matchers)', async () => {
+    const ctx = makeCtx();
+    const issuedR = await executeStep(
+      { kind: 'Given', text: 'Raul has been issued a first-strike warning' },
+      ctx,
+    );
+    expect(issuedR.ok).toBe(false);
+    expect(issuedR.error).toMatch(/ctx\.db not initialised/);
+    const ackR = await executeStep(
+      { kind: 'Given', text: 'Raul has acknowledged his first-strike warning' },
+      ctx,
+    );
+    expect(ackR.ok).toBe(false);
+    expect(ackR.error).toMatch(/ctx\.db not initialised/);
+  });
+});
+
 describe('Dialog confirm action (platform-dispatch)', () => {
   test('"X on Android confirms in the dialog" → driver', async () => {
     const spy = jest.fn(async () => undefined);

--- a/journey-tests/j10-mid-room-warning.feature
+++ b/journey-tests/j10-mid-room-warning.feature
@@ -55,7 +55,7 @@ Feature: j10 — Admin warning lands during an active voice room
 
   @blocker @android-physical
   Scenario: Theo's Android UI navigates to the warning screen with reason + duck + acknowledge
-    Given Theo has hasActiveWarning=true with reason "Inappropriate language in voice room"
+    Given Theo has hasActiveWarning=true, warningReason="Inappropriate language in voice room"
     Then within 5000ms Theo's Android UI navigates to the warning screen
     Then Theo's Android UI shows the warning reason "Inappropriate language in voice room"
     Then Theo's Android UI shows the police duck image


### PR DESCRIPTION
## Summary

Two phase-scoped setup-Givens for the j11 (harassment moderation cycle) journey, sharing infrastructure that j10 (mid-room warning) also benefits from. The warning state machine is the same across both journeys; only the entry path differs.

## Matchers
- `<persona> has been issued a first-strike warning` (j11 line 31)
  → writes `hasActiveWarning=true`, `warningCount=1`, `warningAcknowledged=false`, `lastWarningAt=now`
- `<persona> has acknowledged his/her/their first-strike warning` (j11 line 50, gender-pronoun alternation)
  → composes the issued state PLUS flips `warningAcknowledged=true`

## j10 feature-file refactor
- line 58: `has hasActiveWarning=true with reason "..."` → `has hasActiveWarning=true, warningReason="..."`

The original 'with reason' wording collided with the existing single-field assignment matcher (line ~1898) which greedily captured the trailing prose as part of the field value. Refactored to the comma form so the EXISTING multi-field user-doc matcher handles it cleanly with no new dedicated matcher needed.

## Tests
10 new tests in `Warning-state setup Givens` describe block:
- Issued: full field shape (hasActiveWarning, warningCount, warningAcknowledged=false, lastWarningAt)
- Acknowledged: 3 pronoun forms (his/her/their)
- Multi-field assignment matcher handles refactored j10 line
- Merge preserves sibling fields (shyCoins, beans — explicit j11 precondition: 'moderation must not touch economy')
- Sequence: issued → acknowledged flips correctly, warningCount stays 1
- Unknown-persona errors (issued + acknowledged)
- ctx.db missing → actionable error (both matchers)

All 1864/1864 `manual-qa-runner.test.js` tests pass; prettier + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)