### PR TITLE
feat(qa-runner): seed admin-queue Firestore docs (j12 — extends Wake 95)

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -705,6 +705,50 @@ async function applyAgeVerificationApproval(ctx, personaName, adminPersonaName) 
   return { auditDocId };
 }
 
+async function seedAdminQueueEntries(ctx, queueId, count) {
+  // j12 admin-dashboard queue seeder. Writes N docs to the given
+  // queue collection so admin-dashboard scenarios can assert on
+  // queue-card counts (e.g. "5 pending age-verification submissions"
+  // → the queue card shows "5"). Each doc gets a deterministic
+  // `test-seed-<i>` id for idempotency — re-running overwrites the
+  // same docs, count stays N.
+  //
+  // QUEUE_REGISTRY maps the journey's queue-name to the production
+  // collection name + the canonical pending status string. Adding a
+  // new queue here is the only change needed to unlock its matcher;
+  // the matcher itself is queue-agnostic.
+  const QUEUE_REGISTRY = {
+    'age-verification': {
+      collection: 'ageVerificationSubmissions',
+      status: 'PENDING',
+    },
+    reports: {
+      collection: 'reports',
+      status: 'PENDING',
+    },
+    'suspension-appeals': {
+      collection: 'suspensionAppeals',
+      status: 'PENDING',
+    },
+  };
+  const entry = QUEUE_REGISTRY[queueId];
+  if (!entry) {
+    throw new Error(`unknown admin queue "${queueId}" — add to QUEUE_REGISTRY`);
+  }
+  for (let i = 0; i < count; i++) {
+    await ctx.db.doc(`${entry.collection}/test-seed-${i}`).set({
+      status: entry.status,
+      submittedAt: Date.now() + i,
+      // userId is a test placeholder — real flows have a backref,
+      // but for queue-count assertions the field value doesn't matter.
+      // Use a numeric range that doesn't collide with persona uniqueIds
+      // (50000010+) or ephemeral ones (90000001+).
+      userId: 10000 + i,
+    });
+  }
+  return { count, queueId };
+}
+
 async function seedSystemPmFromOfficia(ctx, recipientPersonaName, key) {
   // Officia is uniqueId 1 (SHYTALK_OFFICIAL). The PM flow writes:
   //   1. conversations/<auto> with participantIds=[1, recipient]
@@ -856,7 +900,6 @@ const matchers = [
       return { ok: true };
     },
   },
-
   // ── Persona sign-in ──
   // Accepts an optional `on <Platform>` clause (bounded {0,2} repetition to
   // handle multi-word platforms — see PR-C state-seed matcher). The runner
@@ -12252,9 +12295,14 @@ const matchers = [
   },
   {
     // Wake 95 — "the <queue> queue has N pending <noun>". j12 Background.
-    // Records queue depth on ctx.adminQueues. Downstream "Greta opens
-    // the X queue" steps could read this to validate the count is
-    // shown in the UI. MVP just persists for inspection.
+    // Records queue depth on ctx.adminQueues for downstream "Greta opens
+    // the X queue" steps that read this to validate the count is shown in
+    // the UI. Also (extended below) seeds N Firestore docs to the matching
+    // collection so scenarios that ASSERT on real queue counts (not just
+    // ctx bookkeeping) also pass — the seed primitive is best-effort: if
+    // the queueName isn't a registered seedable queue (e.g. "subscribers"
+    // for a forward-looking scenario), the ctx.adminQueues record still
+    // happens and the seed skips silently.
     pattern: /^the ([\w-]+) queue has (\d+) pending (\w+)$/,
     async handler(m, ctx) {
       const queueName = m[1];
@@ -12262,6 +12310,21 @@ const matchers = [
       const noun = m[3];
       if (!ctx.adminQueues) ctx.adminQueues = {};
       ctx.adminQueues[queueName] = { count, noun };
+      // Seed Firestore queue docs if (a) db is available AND (b) the
+      // queue is in QUEUE_REGISTRY. Silent skip otherwise — preserves
+      // backward compatibility with scenarios that only need the ctx
+      // bookkeeping (the prior MVP behaviour).
+      if (ctx.db) {
+        try {
+          await seedAdminQueueEntries(ctx, queueName, count);
+        } catch (e) {
+          // Unknown queue → silent skip (preserves backward compat);
+          // any OTHER error (db throw, etc.) bubbles up actionably.
+          if (!/unknown admin queue/.test(e.message)) {
+            return { ok: false, error: e.message };
+          }
+        }
+      }
       return { ok: true };
     },
   },

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -10517,6 +10517,126 @@ describe("Mia's restricted-minor setup Givens (j02 phase-scoped scenario setup)"
   });
 });
 
+// ─── j12 admin-queue setup Givens (queue-state phase-scoped scenarios) ─────
+describe('Admin-queue setup Givens (j12 phase-scoped scenarios)', () => {
+  test('"the age-verification queue has 5 pending submissions" — seeds 5 PENDING docs', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'the age-verification queue has 5 pending submissions' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const submissions = Object.entries(db._docs).filter(([k]) =>
+      k.startsWith('ageVerificationSubmissions/'),
+    );
+    expect(submissions).toHaveLength(5);
+    // Each is PENDING
+    for (const [, doc] of submissions) {
+      expect(doc.status).toBe('PENDING');
+    }
+  });
+
+  test('"the reports queue has 3 pending reports" — seeds 3 PENDING reports', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'the reports queue has 3 pending reports' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const reports = Object.entries(db._docs).filter(([k]) => k.startsWith('reports/'));
+    expect(reports).toHaveLength(3);
+    for (const [, doc] of reports) {
+      expect(doc.status).toBe('PENDING');
+    }
+  });
+
+  test('"the suspension-appeals queue has 2 pending appeals" — seeds 2 PENDING appeals', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'the suspension-appeals queue has 2 pending appeals' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const appeals = Object.entries(db._docs).filter(([k]) => k.startsWith('suspensionAppeals/'));
+    expect(appeals).toHaveLength(2);
+    for (const [, doc] of appeals) {
+      expect(doc.status).toBe('PENDING');
+    }
+  });
+
+  test('queue-seed is idempotent (re-running gives the same count — deterministic doc-ids)', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    await executeStep({ kind: 'Given', text: 'the reports queue has 3 pending reports' }, ctx);
+    await executeStep({ kind: 'Given', text: 'the reports queue has 3 pending reports' }, ctx);
+    const reports = Object.entries(db._docs).filter(([k]) => k.startsWith('reports/'));
+    // Still exactly 3 — deterministic `test-seed-<i>` ids overwrite cleanly
+    expect(reports).toHaveLength(3);
+  });
+
+  test('queue-seed accepts 0 count (empty queue setup)', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'the reports queue has 0 pending reports' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const reports = Object.entries(db._docs).filter(([k]) => k.startsWith('reports/'));
+    expect(reports).toHaveLength(0);
+  });
+
+  test('unknown queue → silent skip (preserves backward-compat with bookkeeping-only scenarios)', async () => {
+    // Wake 95 is older than the QUEUE_REGISTRY seed primitive. Some
+    // scenarios use queue names that aren't registered (forward-looking
+    // names, hypothetical queues). The handler still records the
+    // ctx.adminQueues bookkeeping but skips the Firestore seed
+    // silently — preserving the prior MVP behaviour.
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'the unknown-queue queue has 5 pending things' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    // ctx bookkeeping happened
+    expect(ctx.adminQueues['unknown-queue']).toEqual({ count: 5, noun: 'things' });
+    // Firestore got nothing seeded (no matching collection in registry)
+    const docs = Object.keys(db._docs);
+    expect(docs).toHaveLength(0);
+  });
+
+  test('ctx.db missing → still succeeds (bookkeeping-only, no Firestore seed)', async () => {
+    // Wake 95 predates ctx.db being required. To preserve backward
+    // compatibility, the handler should still set ctx.adminQueues even
+    // when ctx.db is missing — the seed step is best-effort.
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Given', text: 'the reports queue has 3 pending reports' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(ctx.adminQueues.reports).toEqual({ count: 3, noun: 'reports' });
+  });
+
+  test('large count (50) does not crash + writes correct number', async () => {
+    const db = makeStatefulFakeDb({});
+    const ctx = makeCtx({ db, scenarioVars: new Map() });
+    const r = await executeStep(
+      { kind: 'Given', text: 'the age-verification queue has 50 pending submissions' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const subs = Object.entries(db._docs).filter(([k]) =>
+      k.startsWith('ageVerificationSubmissions/'),
+    );
+    expect(subs).toHaveLength(50);
+  });
+});
+
 describe('Dialog confirm action (platform-dispatch)', () => {
   test('"X on Android confirms in the dialog" → driver', async () => {
     const spy = jest.fn(async () => undefined);


### PR DESCRIPTION
## Summary

The existing **Wake 95** matcher `the <queue> queue has N pending <noun>` only recorded `ctx.adminQueues` bookkeeping — j12 admin-dashboard scenarios that ASSERTED on real Firestore queue counts (not just ctx state) had no docs to count.

## Primitive
- `seedAdminQueueEntries(ctx, queueId, count)` — writes N docs with `status='PENDING'` to the registered queue collection.

`QUEUE_REGISTRY` maps queue names to (collection, status) pairs:
- `age-verification` → `ageVerificationSubmissions/`
- `reports` → `reports/`
- `suspension-appeals` → `suspensionAppeals/`

Deterministic `test-seed-<i>` ids make re-running idempotent.

## Wake 95 extension
Now ALSO seeds Firestore docs when `ctx.db` is available AND the queue is registered. Backward-compat preserved:
- Unknown queue → **silent skip** (preserves bookkeeping-only scenarios)
- `ctx.db` missing → **still succeeds with bookkeeping** (Wake 95 predates `ctx.db` being required)
- Any OTHER error bubbles up actionably

## Tests
8 new tests in `Admin-queue setup Givens` describe block:
- age-verification + reports + suspension-appeals — happy-path seeds PENDING docs in matching collection
- Idempotency: re-running keeps exactly N docs (deterministic ids)
- Zero-count accepted (empty queue setup)
- Unknown queue: ctx bookkeeping still happens, Firestore stays empty
- `ctx.db` missing: bookkeeping-only, no crash
- Large count (50): no crash, exact doc count

All 1862/1862 `manual-qa-runner.test.js` tests pass; existing Wake 95 tests still pass (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)