### PR TITLE
fix(android-driver): refuse androidNetworkDropFor on wireless adb (self-severs the tunnel)

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -2213,7 +2213,35 @@ async function createAndroidDriver({ serial: preferred } = {}) {
   // accepted for matcher-contract alignment (the runner step
   // "<persona>'s Android network drops for N seconds" passes it) but
   // unused — the driver acts on the singleton device under its serial.
+  // Wireless adb (TCP over WiFi) makes the WiFi/data disable approach
+  // self-destructive: dropping WiFi cuts the adb tunnel itself, so the
+  // device goes "offline" and every subsequent UI step on the same
+  // dispatch fails — surfaced 2026-05-30 against the operator's
+  // wireless-adb device `adb-3b402284-56nfBT._adb-tls-connect._tcp`.
+  //
+  // Wireless serial fingerprints:
+  //   - mDNS-discovered: contains `_adb-tls-connect` or starts with `adb-`
+  //   - manual TCP:      `IP:PORT` (digits, dots, colon)
+  // USB serials are hex/alphanumeric without `:` or the mDNS suffix.
+  function isWirelessAdb(s) {
+    if (!s) return false;
+    if (s.includes('_adb-tls-connect')) return true;
+    if (/^adb-/.test(s)) return true;
+    if (/^\d{1,3}(?:\.\d{1,3}){3}:\d+$/.test(s)) return true;
+    return false;
+  }
   driver.androidNetworkDropFor = async (name, seconds) => {
+    // Refuse to disable WiFi over a wireless-adb connection — it would
+    // sever the adb tunnel mid-scenario and break every downstream step.
+    // The matcher surfaces this as a finding so the scenario stays
+    // visible (rather than silently passing) — the operator can re-run
+    // over USB adb if the network-drop scenario is in scope, or skip
+    // it via the @needs-usb-adb tag on the scenario.
+    if (isWirelessAdb(serial)) {
+      throw new Error(
+        `androidNetworkDropFor requires USB adb (current serial "${serial}" is wireless — disabling WiFi would kill the adb tunnel itself). Connect via USB and re-dispatch, or tag the scenario @needs-usb-adb to skip it on wireless runs.`,
+      );
+    }
     const durationMs = Math.max(0, Number(seconds) * 1000);
     let dropOk = true;
     try {
@@ -2238,6 +2266,10 @@ async function createAndroidDriver({ serial: preferred } = {}) {
     }
     return dropOk && restoreOk;
   };
+  // Export the wireless-adb detector for unit tests + potential reuse
+  // by other "kills-the-tunnel" driver methods (e.g. a future airplane-
+  // mode helper).
+  driver._isWirelessAdb = () => isWirelessAdb(serial);
 
   driver.close = async () => {
     /* adb sessions are stateless; nothing to release */

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -16088,6 +16088,93 @@ describe('android-adb-driver — androidNetworkDropFor', () => {
     await jest.advanceTimersByTimeAsync(0);
     expect(await promise).toBe(true);
   });
+
+  // Wireless-adb guard. Surfaced 2026-05-30 against the operator's
+  // wireless device `adb-3b402284-56nfBT._adb-tls-connect._tcp` — the
+  // network-drop scenario was disabling WiFi via `svc wifi disable`,
+  // which cut the adb tunnel itself (wireless adb runs over WiFi) and
+  // turned every subsequent step into "device offline". The driver
+  // now refuses to disable WiFi when the serial fingerprints as
+  // wireless, throwing an actionable error so the operator can
+  // either re-dispatch via USB or tag the scenario @needs-usb-adb.
+  describe('wireless-adb guard', () => {
+    test('mDNS-discovered wireless serial → throws actionable error, no svc calls', async () => {
+      mockExec({
+        'adb devices':
+          'List of devices attached\nadb-3b402284-56nfBT._adb-tls-connect._tcp\tdevice\n',
+      });
+      const driver = await createAndroidDriver();
+      await expect(driver.androidNetworkDropFor('Theo', 30)).rejects.toThrow(
+        /androidNetworkDropFor requires USB adb/,
+      );
+      // Verify NO svc disable/enable calls were issued — the throw must
+      // happen before any device-state mutation.
+      const svcCalls = execSync.mock.calls.map((c) => c[0]).filter((c) => c.includes("'svc'"));
+      expect(svcCalls).toEqual([]);
+    });
+
+    test('manual-TCP wireless serial (IP:PORT) → throws actionable error', async () => {
+      mockExec({
+        'adb devices': 'List of devices attached\n192.168.1.123:5555\tdevice\n',
+      });
+      const driver = await createAndroidDriver();
+      await expect(driver.androidNetworkDropFor('Theo', 30)).rejects.toThrow(
+        /androidNetworkDropFor requires USB adb/,
+      );
+      // Error message names the actual wireless serial so the operator
+      // can verify which device they're connected to.
+      await expect(driver.androidNetworkDropFor('Theo', 30)).rejects.toThrow(
+        /192\.168\.1\.123:5555/,
+      );
+    });
+
+    test('USB serial (no wireless fingerprint) → proceeds normally', async () => {
+      mockExec({
+        'adb devices': 'List of devices attached\nR5CT304ABC1Z\tdevice\n',
+      });
+      const driver = await createAndroidDriver();
+      const promise = driver.androidNetworkDropFor('Theo', 1);
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(await promise).toBe(true);
+    });
+
+    test('emulator serial → also proceeds normally (emulator is not wireless adb)', async () => {
+      // The emulator-NNNN serial fingerprint is NOT wireless — it's a
+      // local QEMU connection over a host-side socket, not WiFi-tunnelled.
+      // The default test fixture serial is emulator-5554; pin that it
+      // doesn't trigger the guard.
+      mockExec({});
+      const driver = await createAndroidDriver();
+      const promise = driver.androidNetworkDropFor('Theo', 1);
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(await promise).toBe(true);
+    });
+
+    test('_isWirelessAdb classifier (exposed for tests + reuse) — fingerprint coverage', async () => {
+      // Pin the classifier matrix so future "kills-the-tunnel" driver
+      // helpers (airplane-mode toggle, modem reset, etc.) can reuse it.
+      mockExec({
+        'adb devices':
+          'List of devices attached\nadb-3b402284-56nfBT._adb-tls-connect._tcp\tdevice\n',
+      });
+      const wirelessDriver = await createAndroidDriver();
+      expect(wirelessDriver._isWirelessAdb()).toBe(true);
+
+      jest.clearAllMocks();
+      mockExec({
+        'adb devices': 'List of devices attached\nR5CT304ABC1Z\tdevice\n',
+      });
+      const usbDriver = await createAndroidDriver();
+      expect(usbDriver._isWirelessAdb()).toBe(false);
+
+      jest.clearAllMocks();
+      mockExec({
+        'adb devices': 'List of devices attached\nemulator-5554\tdevice\n',
+      });
+      const emuDriver = await createAndroidDriver();
+      expect(emuDriver._isWirelessAdb()).toBe(false);
+    });
+  });
 });
 
 describe('android-adb-driver — androidTapQuotedTarget', () => {


### PR DESCRIPTION
## Summary

Surfaced 2026-05-30 during the first j09 dispatch with `--driver all` against dev. Operator's adb device is wireless (`adb-3b402284-56nfBT._adb-tls-connect._tcp`). The j09 'Host disconnects unexpectedly' scenario calls `androidNetworkDropFor`, which ran `adb shell svc wifi disable` — **wireless adb tunnels OVER WiFi, so disabling WiFi cut the adb tunnel itself** → device offline → every subsequent UI step failed → re-enable couldn't reach the device.

## Fix

Detect wireless adb by serial fingerprint and refuse to disable WiFi when detected. Throws an actionable error naming the actual wireless serial so the operator can either re-dispatch over USB or tag the scenario `@needs-usb-adb`.

**Wireless serial fingerprints:**
- mDNS-discovered (Apple-style): contains `_adb-tls-connect`
- adb-prefixed: starts with `adb-` (catches the operator's serial)
- manual TCP: matches `IP:PORT` (digits + dots + colon)

**Not classified wireless:** USB serials (hex/alphanumeric), emulator serials (host-side socket, not WiFi).

Classifier exported as `driver._isWirelessAdb()` so future 'kills-the-tunnel' helpers (airplane mode toggle, modem reset, etc.) can reuse the matrix without duplicating the regex.

## Tests
5 new tests in 'wireless-adb guard' describe block:
- mDNS wireless serial → throws, NO svc calls issued (no device mutation)
- IP:PORT wireless serial → throws, error names the serial verbatim
- USB serial → proceeds normally with svc disable/enable
- Emulator serial → also proceeds (not wireless)
- `_isWirelessAdb` classifier matrix coverage

All 1289/1289 `android-adb-driver.test.js` tests pass; prettier + eslint clean.

## Follow-up

A future PR could re-enable the network-drop scenario on wireless adb by simulating connectivity loss at the app layer (route-table block for API/LiveKit hosts) instead of killing WiFi. Out of scope for this PR — the immediate fix is to stop the self-DOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)