### PR TITLE
feat(android-driver): androidPersonaSignIn — drives persona picker for j09 BG sign-in

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -139,6 +139,15 @@ const ANDROID_METHOD_NAMES = [
   'androidTapQuotedTarget',
   'androidTapRoomCard',
   'androidLongPressSeat',
+  // j09 + every journey Background's "<persona> is signed in on
+  // Android physical at the <tab> tab" — drives the persona picker
+  // (visible on local + dev since PR #882) to sign the device's APP
+  // into the named persona, then taps the requested main-nav tab.
+  // Distinct from the Firebase REST sign-in the runner does on the
+  // server side: that gets a token into ctx.sessions; this one drives
+  // the device APP's UI through the picker dialog so the device is
+  // on the right screen for subsequent UI-action steps.
+  'androidPersonaSignIn',
 ];
 
 function listMethods() {
@@ -2237,6 +2246,106 @@ async function createAndroidDriver({ serial: preferred } = {}) {
       );
     }
     return dropOk && restoreOk;
+  };
+
+  // Internal helper: poll androidUiDump until `tag` appears or the
+  // timeout elapses. Returns true on found, false on timeout. Used by
+  // androidPersonaSignIn for the post-tap settles where exact timing
+  // depends on Firebase network latency + Compose layout passes; a
+  // fixed setTimeout would either over-wait (slow tests) or under-wait
+  // (flake on slow runs).
+  async function waitForTag(tag, timeoutMs, pollMs = 200) {
+    const deadline = Date.now() + timeoutMs;
+    const escTag = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(`resource-id="(?:[^"]*:id/)?${escTag}"`);
+    while (Date.now() < deadline) {
+      try {
+        const dump = await driver.androidUiDump();
+        if (re.test(dump)) return true;
+      } catch {
+        // Transient dump failures are tolerated within the wait window.
+      }
+      await new Promise((r) => setTimeout(r, pollMs));
+    }
+    return false;
+  }
+
+  // j09 + every-journey Background: "<persona> is signed in on Android
+  // physical at the <tab> tab". Drives the device APP through the
+  // persona picker, which is the canonical journey-test auth path
+  // (per feedback-test-personas-not-oauth: never drive Google/Apple
+  // OAuth in journey tests). Distinct from the runner's Firebase REST
+  // sign-in which only seeds ctx.sessions server-side — this also
+  // gets the device's APP onto the main screen so subsequent UI-action
+  // steps (taps, dumps) find the tags they expect.
+  //
+  // Personas need a P-NN id (P-02..P-19); the picker dialog rows are
+  // keyed by that id. Ephemeral personas (P-01 Adam, P-03 Mia) have
+  // no persisted Firebase account so they CAN'T sign in via the
+  // picker — they'd need the prod-flow signup which is a separate
+  // matcher's responsibility.
+  //
+  // Throws with an actionable error naming the step that failed
+  // (open-picker / pick-row / wait-for-main) so the runner surfaces
+  // a precise finding rather than the generic "ui dump didn't
+  // contain X" downstream.
+  driver.androidPersonaSignIn = async (personaId, tab) => {
+    if (!/^P-\d{2}$/.test(personaId)) {
+      throw new Error(
+        `androidPersonaSignIn requires a P-NN persona id (got "${personaId}") — ephemeral personas P-01/P-03 sign up via the prod flow, not the picker`,
+      );
+    }
+    // Step 1: tap `persona_picker_open` on the sign-in screen.
+    // Available on local + dev (PR #882); on prod the button is
+    // hidden so this will return false → actionable error.
+    const opened = await driver.androidTapByTag('persona_picker_open');
+    if (!opened) {
+      throw new Error(
+        'androidPersonaSignIn: could not tap "persona_picker_open" — device may not be on the sign-in screen, or the build flavor is "prod" (the picker is hidden on prod)',
+      );
+    }
+    // Step 2: wait for the dialog to render. Pick a row testTag that
+    // exists for ALL personas (P-02..P-19) — anchor on the requested
+    // one, since the dialog renders all rows together.
+    const rowTag = `persona_row_${personaId}`;
+    const dialogReady = await waitForTag(rowTag, 5000);
+    if (!dialogReady) {
+      throw new Error(
+        `androidPersonaSignIn: picker dialog never showed "${rowTag}" within 5s — persona may not be in the dev personas registry (provision-test-personas.js)`,
+      );
+    }
+    // Step 3: tap the persona row.
+    const picked = await driver.androidTapByTag(rowTag);
+    if (!picked) {
+      throw new Error(
+        `androidPersonaSignIn: tap on "${rowTag}" failed despite dialog showing the row — UI dump may be racing the tap`,
+      );
+    }
+    // Step 4: wait for sign-in completion. Anchor on `main_roomsTab`
+    // since that's the default landing tab for all signed-in users.
+    // Firebase REST sign-in via the picker can take 3-5s in the worst
+    // case (network roundtrip + Firestore profile fetch + Compose nav).
+    const signedIn = await waitForTag('main_roomsTab', 10000);
+    if (!signedIn) {
+      throw new Error(
+        `androidPersonaSignIn: never reached main screen ("main_roomsTab") within 10s of picking ${personaId} — Firebase sign-in may have failed (check device logcat) or main nav testTag has drifted`,
+      );
+    }
+    // Step 5: if the requested tab is not "rooms" (default landing),
+    // tap the requested tab. Mirrors the main-nav convention
+    // `main_<lowered>Tab` used by tapMainNavTab.
+    const loweredTab = String(tab).toLowerCase();
+    if (loweredTab !== 'rooms') {
+      const navOk = await driver.androidTapByTag(`main_${loweredTab}Tab`);
+      if (!navOk) {
+        throw new Error(
+          `androidPersonaSignIn: signed in OK but couldn't navigate to "main_${loweredTab}Tab" — tab name may not match the main nav convention`,
+        );
+      }
+      // Settle for the tab content to render before subsequent steps.
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    return true;
   };
 
   driver.close = async () => {

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -976,6 +976,94 @@ const matchers = [
   // The strategy is permissive consumption: anything after `is signed in`
   // that doesn't drive a distinct API call is treated as documentation.
   {
+    // j09 + every journey Background: "<persona> [P-NN] is signed in on
+    // Android physical at the <tab> tab". Declared BEFORE the catch-all
+    // (file order = match priority) so this more-specific form fires
+    // first when target=dev and the adb driver is wired.
+    //
+    // Two-layer sign-in:
+    //   1. Server-side: Firebase REST signInWithPassword → token into
+    //      ctx.sessions[name] so downstream API/Firestore-admin steps
+    //      use the correct identity. This is the same path the catch-
+    //      all does.
+    //   2. Device-side: ctx.uiDriver.androidPersonaSignIn — drives the
+    //      app through the persona picker (visible on local + dev per
+    //      PR #882), waits for main_roomsTab, then taps the requested
+    //      tab. Without this, the device's app sits on the sign-in
+    //      screen and every downstream UI step fails with "tag X not
+    //      found in UI dump".
+    //
+    // If the driver isn't wired (--driver flag omitted or adb not
+    // available), only the server-side sign-in happens — the matcher
+    // still returns ok=true so REST-only scenarios still pass, but a
+    // warning is logged to stderr so the operator notices the missing
+    // device-side context.
+    pattern:
+      /^([A-Z][a-z]+)\s*\[(P-\d{2})\]\s+is signed in on Android physical at the "([^"]+)" tab$/,
+    async handler(m, ctx) {
+      const name = m[1];
+      const personaId = m[2];
+      const tab = m[3];
+      const personas = loadPersonas();
+      const p = personas.get(personaId) || personas.get(name);
+      if (!p) return { ok: false, error: `persona "${name}" not in registry` };
+      if (!ctx.personasPassword) {
+        return { ok: false, error: 'PERSONAS_PASSWORD env not set' };
+      }
+      // Layer 1: Firebase REST sign-in. Mirrors the catch-all matcher's
+      // flow exactly (line ~975-1001) — kept inline rather than DRY-
+      // factored because the two share intent but not lifecycle: the
+      // catch-all is "permissive consumption", this one is the
+      // strict device-driven path.
+      const authBase =
+        ctx.target === 'local' && process.env.FIREBASE_AUTH_EMULATOR_HOST
+          ? `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}/identitytoolkit.googleapis.com`
+          : 'https://identitytoolkit.googleapis.com';
+      const r = await ctx.fetch(
+        `${authBase}/v1/accounts:signInWithPassword?key=${ctx.firebaseApiKey}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: p.email,
+            password: ctx.personasPassword,
+            returnSecureToken: true,
+          }),
+        },
+      );
+      if (r.status !== 200) {
+        return { ok: false, error: `Firebase sign-in failed for ${p.email}: ${r.status}` };
+      }
+      const body = await r.json();
+      ctx.sessions.set(name, {
+        persona: p,
+        idToken: body.idToken,
+        refreshToken: body.refreshToken,
+        localId: body.localId,
+        customClaims: decodeJwtPayload(body.idToken),
+      });
+      if (!ctx.personaPlatforms) ctx.personaPlatforms = new Map();
+      ctx.personaPlatforms.set(name, 'Android physical');
+      // Layer 2: device-side persona picker drive. Optional — if the
+      // driver isn't wired (e.g. running with --driver stub), surface
+      // a warning to stderr but still return ok so REST-only assertions
+      // pass; the downstream UI-action steps will surface their own
+      // "ctx.uiDriver not configured" finding cleanly.
+      if (!ctx.uiDriver?.androidPersonaSignIn) {
+        console.error(
+          `[runner] "${name} is signed in on Android physical at ${tab} tab" — server-side sign-in done but no androidPersonaSignIn driver; device APP not driven through picker. Wire --driver adb (or --driver all) to enable.`,
+        );
+        return { ok: true };
+      }
+      try {
+        await ctx.uiDriver.androidPersonaSignIn(personaId, tab);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
+    },
+  },
+  {
     // j13 phase-scoped continuation: "<persona> is signed in on <platform>
     // with device locale <code>". Declared BEFORE the catch-all sign-in
     // matcher below so this more-specific form fires first.

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -16381,3 +16381,167 @@ describe('android-adb-driver — androidOpenScreen tab-navigation', () => {
     expect(tapCall).toBeDefined();
   });
 });
+
+describe('android-adb-driver — androidPersonaSignIn', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // Helper: build the dump sequence for the happy path. Each dump in
+  // the sequence is consumed by one `androidUiDump()` call. The flow:
+  //   dump 0 — sign-in screen with persona_picker_open (consumed by
+  //            androidTapByTag('persona_picker_open'))
+  //   dump 1 — dialog open with persona_row_<id> (consumed by
+  //            waitForTag('persona_row_<id>'))
+  //   dump 2 — dialog still rendered with persona_row_<id> (consumed
+  //            by androidTapByTag('persona_row_<id>') — dialog is
+  //            visible at tap moment)
+  //   dump 3 — main screen with main_roomsTab (consumed by
+  //            waitForTag('main_roomsTab'))
+  function happyPathDumps(personaId) {
+    const personaRowNode = `<node resource-id="com.shyden.shytalk.local:id/persona_row_${personaId}" bounds="[100,700][800,800]" />`;
+    return [
+      `<node resource-id="com.shyden.shytalk.local:id/persona_picker_open" bounds="[100,500][400,600]" />`,
+      personaRowNode,
+      personaRowNode,
+      `<node resource-id="com.shyden.shytalk.local:id/main_roomsTab" bounds="[100,1900][270,2100]" />`,
+    ];
+  }
+
+  function setupExec(dumps) {
+    // androidUiDump runs TWO adb calls per invocation:
+    //   1. `uiautomator dump --compressed /sdcard/dump.xml` (writes file)
+    //   2. `cat /sdcard/dump.xml` (reads it back)
+    // The CAT call is the one whose stdout becomes the dump XML returned
+    // to androidTapByTag / waitForTag. We advance the dump cursor on
+    // the cat call (not the uiautomator one) so each "dump cycle" gets
+    // one entry from the dumps[] array.
+    let dumpIdx = 0;
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') {
+        return 'List of devices attached\nemulator-5554\tdevice\n';
+      }
+      if (cmd.includes("'cat' '/sdcard/dump.xml'")) {
+        const out = dumps[Math.min(dumpIdx, dumps.length - 1)];
+        dumpIdx += 1;
+        return out;
+      }
+      return '';
+    });
+  }
+
+  test('happy path: P-10 + rooms tab — taps picker, picks row, lands on main_roomsTab', async () => {
+    setupExec(happyPathDumps('P-10'));
+    const driver = await createAndroidDriver();
+    const promise = driver.androidPersonaSignIn('P-10', 'rooms');
+    // Advance through the wait-for-dialog poll (5s ceiling) + wait-for-main
+    // poll (10s ceiling). Dumps return immediately so the poll resolves on
+    // the first tick.
+    await jest.advanceTimersByTimeAsync(15000);
+    expect(await promise).toBe(true);
+    // Verify the 2 testTag taps happened (picker open + persona row).
+    // Don't constrain on exact tap coords — bounds parsing is covered
+    // elsewhere; here we just confirm the sequence ran.
+    const tapCalls = execSync.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c.includes("'input' 'tap'"));
+    expect(tapCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('non-rooms tab (e.g. profile) — also taps main_profileTab after sign-in', async () => {
+    setupExec([
+      ...happyPathDumps('P-10'),
+      // Extra dump for the post-sign-in profile-tab tap
+      `<node resource-id="com.shyden.shytalk.local:id/main_profileTab" bounds="[700,1900][870,2100]" />`,
+    ]);
+    const driver = await createAndroidDriver();
+    const promise = driver.androidPersonaSignIn('P-10', 'profile');
+    await jest.advanceTimersByTimeAsync(16000);
+    expect(await promise).toBe(true);
+  });
+
+  test('invalid personaId (not P-NN form) → throws actionable error', async () => {
+    setupExec(['']);
+    const driver = await createAndroidDriver();
+    await expect(driver.androidPersonaSignIn('Theo', 'rooms')).rejects.toThrow(
+      /requires a P-NN persona id \(got "Theo"\)/,
+    );
+    await expect(driver.androidPersonaSignIn('P-1', 'rooms')).rejects.toThrow(
+      /requires a P-NN persona id/,
+    );
+    // Ephemeral personas explicitly named in the error
+    await expect(driver.androidPersonaSignIn('Adam', 'rooms')).rejects.toThrow(
+      /ephemeral personas P-01\/P-03 sign up via the prod flow/,
+    );
+  });
+
+  test('persona_picker_open not on screen → throws naming the missing testTag', async () => {
+    setupExec(['<node resource-id="something_else" bounds="[0,0][100,100]" />']);
+    const driver = await createAndroidDriver();
+    await expect(driver.androidPersonaSignIn('P-10', 'rooms')).rejects.toThrow(
+      /could not tap "persona_picker_open"/,
+    );
+  });
+
+  test('dialog never shows persona_row → throws after 5s with persona id', async () => {
+    // First CAT-dump has persona_picker_open (so the tap succeeds);
+    // subsequent CAT-dumps never contain persona_row_P-99 — simulates
+    // the operator asking for a persona that isn't in the dev registry.
+    let dumpCalls = 0;
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'cat' '/sdcard/dump.xml'")) {
+        dumpCalls += 1;
+        if (dumpCalls <= 1) {
+          return '<node resource-id="com.shyden.shytalk.local:id/persona_picker_open" bounds="[100,500][400,600]" />';
+        }
+        // Dialog renders P-10 row (not P-99) — waitForTag for P-99 will time out
+        return '<node resource-id="com.shyden.shytalk.local:id/persona_row_P-10" bounds="[0,0][100,100]" />';
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidPersonaSignIn('P-99', 'rooms');
+    // Pre-attach a noop catch so when the timer-flush triggers the
+    // rejection, Node doesn't see an unhandled-promise-rejection (which
+    // jest surfaces as a test failure ahead of the expect.rejects).
+    promise.catch(() => {});
+    await jest.advanceTimersByTimeAsync(6000);
+    await expect(promise).rejects.toThrow(
+      /picker dialog never showed "persona_row_P-99" within 5s/,
+    );
+  });
+
+  test('main_roomsTab never appears within 10s → throws with Firebase-sign-in hint', async () => {
+    let dumpCalls = 0;
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'cat' '/sdcard/dump.xml'")) {
+        dumpCalls += 1;
+        if (dumpCalls === 1) {
+          return '<node resource-id="com.shyden.shytalk.local:id/persona_picker_open" bounds="[100,500][400,600]" />';
+        }
+        if (dumpCalls === 2 || dumpCalls === 3) {
+          // dialog renders P-10 row — wait succeeds (dump 2), tap succeeds (dump 3)
+          return '<node resource-id="com.shyden.shytalk.local:id/persona_row_P-10" bounds="[100,700][800,800]" />';
+        }
+        // Subsequent CAT-dumps never contain main_roomsTab — Firebase sign-in stalled
+        return '<node resource-id="something_else" bounds="[0,0][100,100]" />';
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidPersonaSignIn('P-10', 'rooms');
+    // See the dialog-never-shows test for why this noop catch is needed.
+    promise.catch(() => {});
+    await jest.advanceTimersByTimeAsync(11000);
+    await expect(promise).rejects.toThrow(
+      /never reached main screen \("main_roomsTab"\) within 10s/,
+    );
+    await expect(promise).rejects.toThrow(/Firebase sign-in may have failed/);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -2589,6 +2589,161 @@ describe('Persona "is signed in on <Platform> with device locale <code>" (j13 ph
   });
 });
 
+describe('Persona "is signed in on Android physical at the <tab> tab" (j09 Background — drives picker)', () => {
+  function withSignInFetch(uniqueId = 50000060) {
+    return jest.fn(async (url) => {
+      if (typeof url === 'string' && url.includes('signInWithPassword')) {
+        const idToken =
+          'h.' +
+          Buffer.from(JSON.stringify({ uniqueId, admin: false })).toString('base64url') +
+          '.s';
+        return { status: 200, json: async () => ({ idToken, refreshToken: 'r', localId: 'f' }) };
+      }
+      return { status: 500, text: async () => '{}' };
+    });
+  }
+
+  test('happy path: both server-side sign-in AND androidPersonaSignIn fire when driver wired', async () => {
+    const personaSignInSpy = jest.fn(async () => true);
+    const ctx = makeCtx({
+      fetch: withSignInFetch(50000060),
+      uiDriver: { androidPersonaSignIn: personaSignInSpy },
+    });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Theo [P-10] is signed in on Android physical at the "rooms" tab' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    // Server-side: session populated.
+    expect(ctx.sessions.get('Theo')).toBeDefined();
+    expect(ctx.personaPlatforms.get('Theo')).toBe('Android physical');
+    // Device-side: driver method called with the persona id + tab.
+    expect(personaSignInSpy).toHaveBeenCalledWith('P-10', 'rooms');
+  });
+
+  test('driver not wired → server-side sign-in still succeeds, warning logged, ok=true', async () => {
+    // Capture stderr so we don't pollute test output AND can assert on
+    // the warning text. console.error is called via the runner's
+    // permissive-degradation path.
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const ctx = makeCtx({ fetch: withSignInFetch(50000060) });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Theo [P-10] is signed in on Android physical at the "rooms" tab' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    // Server-side sign-in still happened
+    expect(ctx.sessions.get('Theo')).toBeDefined();
+    // Warning surfaced with actionable hint
+    expect(errSpy).toHaveBeenCalledWith(expect.stringMatching(/no androidPersonaSignIn driver/));
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/Wire --driver adb \(or --driver all\) to enable/),
+    );
+    errSpy.mockRestore();
+  });
+
+  test('driver throws → matcher returns ok=false with the driver error message verbatim', async () => {
+    const personaSignInSpy = jest.fn(async () => {
+      throw new Error(
+        'androidPersonaSignIn: never reached main screen ("main_roomsTab") within 10s of picking P-10',
+      );
+    });
+    const ctx = makeCtx({
+      fetch: withSignInFetch(50000060),
+      uiDriver: { androidPersonaSignIn: personaSignInSpy },
+    });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Theo [P-10] is signed in on Android physical at the "rooms" tab' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/never reached main screen/);
+  });
+
+  test('unknown persona → actionable error, no Firebase call, no driver call', async () => {
+    const fetchSpy = withSignInFetch(50000060);
+    const personaSignInSpy = jest.fn(async () => true);
+    const ctx = makeCtx({
+      fetch: fetchSpy,
+      uiDriver: { androidPersonaSignIn: personaSignInSpy },
+    });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Zonk [P-99] is signed in on Android physical at the "rooms" tab' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/persona "Zonk" not in registry/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(personaSignInSpy).not.toHaveBeenCalled();
+  });
+
+  test('missing PERSONAS_PASSWORD → actionable error', async () => {
+    const ctx = makeCtx({
+      fetch: withSignInFetch(50000060),
+      uiDriver: { androidPersonaSignIn: jest.fn() },
+      personasPassword: undefined,
+    });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Theo [P-10] is signed in on Android physical at the "rooms" tab' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/PERSONAS_PASSWORD env not set/);
+  });
+
+  test('Firebase 401 → actionable error, driver NOT called (server-side gate must pass first)', async () => {
+    const fetchSpy = jest.fn(async () => ({ status: 401, json: async () => ({}) }));
+    const personaSignInSpy = jest.fn(async () => true);
+    const ctx = makeCtx({
+      fetch: fetchSpy,
+      uiDriver: { androidPersonaSignIn: personaSignInSpy },
+    });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Theo [P-10] is signed in on Android physical at the "rooms" tab' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Firebase sign-in failed/);
+    expect(r.error).toMatch(/401/);
+    // Driver must NOT be called when server-side sign-in failed —
+    // signing the device in for a user that doesn't auth would mask
+    // the real failure mode.
+    expect(personaSignInSpy).not.toHaveBeenCalled();
+  });
+
+  test('non-rooms tab (e.g. profile) — driver method gets the tab name', async () => {
+    const personaSignInSpy = jest.fn(async () => true);
+    const ctx = makeCtx({
+      fetch: withSignInFetch(50000060),
+      uiDriver: { androidPersonaSignIn: personaSignInSpy },
+    });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Theo [P-10] is signed in on Android physical at the "profile" tab' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(personaSignInSpy).toHaveBeenCalledWith('P-10', 'profile');
+  });
+
+  test('does NOT fire on platforms other than "Android physical" — falls through to catch-all', async () => {
+    // The catch-all matcher (line ~947) accepts "is signed in on Web Chromium ...",
+    // "is signed in on iOS Sim ...", etc. — those must still work without
+    // hitting the more-specific Android-physical handler.
+    const personaSignInSpy = jest.fn(async () => true);
+    const ctx = makeCtx({
+      fetch: withSignInFetch(50000010),
+      uiDriver: { androidPersonaSignIn: personaSignInSpy },
+    });
+    const r = await executeStep(
+      { kind: 'Given', text: 'Alice [P-02] is signed in on Web Chromium at the "rooms" tab' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    // Driver NOT called — different platform, different matcher fired.
+    expect(personaSignInSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe('Sign-in `at the "X" tab` form (j09 Theo on the rooms tab)', () => {
   function withSignInFetch(uniqueId = 50000110) {
     return jest.fn(async (url) => {


### PR DESCRIPTION
## Summary

First `--driver all` j09 dispatch against dev (today) showed every UI step failing with "tag X not found in Android UI dump". Root cause: the runner's Firebase REST sign-in only seeds `ctx.sessions` server-side — the device APP was still sitting on the sign-in screen, never driven through the picker dialog that PR #882 made visible on dev.

This PR closes that gap with a two-layer matcher for the j09 Background step `<persona> [P-NN] is signed in on Android physical at the <tab> tab`.

## Layer 1 — server-side (mirrors the existing catch-all sign-in)
Firebase REST signInWithPassword → `ctx.sessions[name]`.

## Layer 2 — device-side (NEW driver method `androidPersonaSignIn`)
1. Tap `persona_picker_open`
2. Wait (≤5s) for `persona_row_<P-NN>` to appear in dialog
3. Tap `persona_row_<P-NN>`
4. Wait (≤10s) for `main_roomsTab` (sign-in completion anchor)
5. If tab ≠ rooms, tap `main_<tab>Tab`

Each step throws an actionable error naming which step failed so the runner surfaces a precise finding rather than the generic "dump didn't contain X" downstream.

## Graceful degradation when driver not wired
`--driver stub` (or no `--driver`) → server-side sign-in still happens, warning logged to stderr, ok=true. REST-only assertions still pass; downstream UI-action steps surface their own "ctx.uiDriver not configured" findings cleanly.

## Match priority
Matcher declared BEFORE the catch-all sign-in (file order = match priority). Falls through to catch-all for other platforms (Web Chromium, iOS Sim, etc.).

## Tests
**Driver** (6 tests):
- Happy-path with tab=rooms
- Non-rooms tab (tab=profile) — also taps main_profileTab
- Invalid persona id (incl. ephemeral hint for Adam/Mia)
- persona_picker_open not on screen → actionable error
- Dialog row missing → 5s timeout with persona-not-in-registry hint
- main_roomsTab missing → 10s timeout with Firebase-sign-in hint

**Runner matcher** (8 tests):
- Both layers fire when driver wired
- Driver not wired → graceful (warning + ok=true)
- Driver throws → error passes through verbatim
- Unknown persona → no Firebase call, no driver call
- Missing PERSONAS_PASSWORD env
- Firebase 401 → server gate fails, driver NOT called
- Non-rooms tab name passes through
- Different platform (Web Chromium) → falls through to catch-all (no driver call)

All 3188/3188 (1898 runner + 1290 driver) tests pass; prettier + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)