### PR TITLE
feat(qa-runner): segregationEvents test-isolation cleanup Given (j09 cross-cohort)

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -705,6 +705,40 @@ async function applyAgeVerificationApproval(ctx, personaName, adminPersonaName) 
   return { auditDocId };
 }
 
+async function clearSegregationEventsForPair(ctx, sourceUniqueId, targetUniqueId) {
+  // j09 + every cross-cohort journey: the segregationEvents collection
+  // accumulates across dispatches because the production audit-dedup
+  // window (5 min in sameCohort.js + segregation-audit.js) expires
+  // between runs — so each dispatch's cross-cohort block writes a
+  // FRESH row. Across 4 historical j09 dispatches against dev, the
+  // collection had 4 rows for the same {action,source,target} triple,
+  // which broke the scenario's `expected 1` assertion.
+  //
+  // Per QA-mindset: the production code is correct (5-min dedup is a
+  // DoS guard, not test isolation). The runner is responsible for
+  // pre-cleanup so each scenario's exact-count assertions hold.
+  //
+  // Deletes ALL docs matching {action: 'blocked', sourceUniqueId,
+  // targetUniqueId}. Uses string coercion to match the production wire
+  // format (String(req.auth.uniqueId) in routes/livekit.js,
+  // String(targetUniqueId) in middleware/sameCohort.js).
+  if (!ctx.db) throw new Error('ctx.db (firebase-admin Firestore) not initialised');
+  const src = String(sourceUniqueId);
+  const tgt = String(targetUniqueId);
+  const snap = await ctx.db
+    .collection('segregationEvents')
+    .where('action', '==', 'blocked')
+    .where('sourceUniqueId', '==', src)
+    .where('targetUniqueId', '==', tgt)
+    .get();
+  let deleted = 0;
+  for (const doc of snap.docs) {
+    await doc.ref.delete();
+    deleted++;
+  }
+  return { deleted };
+}
+
 async function seedAdminQueueEntries(ctx, queueId, count) {
   // j12 admin-dashboard queue seeder. Writes N docs to the given
   // queue collection so admin-dashboard scenarios can assert on
@@ -894,6 +928,32 @@ const matchers = [
       const r = await ctx.fetch(`${ctx.apiBase}/api/health`);
       if (r.status !== 200) return { ok: false, error: `health check returned ${r.status}` };
       return { ok: true };
+    },
+  },
+  {
+    // j09 + every cross-cohort journey: test isolation Given that
+    // clears prior segregationEvents matching {action: 'blocked',
+    // sourceUniqueId, targetUniqueId} before the scenario fires its
+    // cross-cohort attempt. Without this, the dispatch accumulates
+    // events across runs (production's 5-min dedup window expires
+    // between dispatches) and exact-count assertions like "1 entries
+    // matching {...}" break with N=2,3,4...
+    //
+    // Accepts numeric or string uniqueIds — coerced to string to
+    // match the production wire format
+    // (String(req.auth.uniqueId) at routes/livekit.js + middleware/
+    // sameCohort.js). Target can be a uniqueId OR a room id (e.g.,
+    // "ra1") — the predicate doesn't constrain shape, only equality.
+    pattern: /^no prior segregationEvents exist between\s+"?(\d+)"?\s+and\s+"([^"]+)"$/,
+    async handler(m, ctx) {
+      const sourceUniqueId = m[1];
+      const targetUniqueId = m[2];
+      try {
+        await clearSegregationEventsForPair(ctx, sourceUniqueId, targetUniqueId);
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e.message };
+      }
     },
   },
   // OSA migration-state precondition (j19) — PROBE-BASED.

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -11033,6 +11033,186 @@ describe('Warning-state setup Givens (j10 + j11 phase-scoped scenarios)', () => 
   });
 });
 
+// ─── segregationEvents test-isolation cleanup (j09 + cross-cohort journeys) ─────
+describe('Given "no prior segregationEvents exist between <source> and <target>"', () => {
+  // Custom fake-db supporting chained .where(...).where(...).get() with
+  // an array of doc-refs that each expose .delete(). The general
+  // makeStatefulFakeDb doesn't support where-chaining, so this is a
+  // local helper.
+  function makeSegEventsFakeDb(initialEvents) {
+    // Each event has { id, action, sourceUniqueId, targetUniqueId, ... }
+    let events = [...initialEvents];
+    function buildQuery(filters) {
+      return {
+        where: (field, op, value) => buildQuery([...filters, { field, op, value }]),
+        get: async () => {
+          const matching = events
+            .filter((evt) =>
+              filters.every(({ field, op, value }) => op === '==' && evt[field] === value),
+            )
+            .map((evt) => ({
+              id: evt.id,
+              data: () => evt,
+              ref: {
+                delete: async () => {
+                  events = events.filter((e) => e.id !== evt.id);
+                },
+              },
+            }));
+          return { docs: matching };
+        },
+      };
+    }
+    return {
+      collection: (name) => {
+        if (name !== 'segregationEvents') {
+          throw new Error(`fake-db only supports segregationEvents (got "${name}")`);
+        }
+        return buildQuery([]);
+      },
+      // Test inspection helpers
+      _events: () => events,
+    };
+  }
+
+  test('deletes all matching {action:"blocked", source, target} events; preserves non-matching', async () => {
+    const db = makeSegEventsFakeDb([
+      {
+        id: 'stale-1',
+        action: 'blocked',
+        sourceUniqueId: '60000010',
+        targetUniqueId: 'ra1',
+        timestamp: 1,
+      },
+      {
+        id: 'stale-2',
+        action: 'blocked',
+        sourceUniqueId: '60000010',
+        targetUniqueId: 'ra1',
+        timestamp: 2,
+      },
+      // Non-matching: different action
+      {
+        id: 'other-action',
+        action: 'allowed',
+        sourceUniqueId: '60000010',
+        targetUniqueId: 'ra1',
+        timestamp: 3,
+      },
+      // Non-matching: different target
+      {
+        id: 'other-target',
+        action: 'blocked',
+        sourceUniqueId: '60000010',
+        targetUniqueId: 'rb1',
+        timestamp: 4,
+      },
+      // Non-matching: different source
+      {
+        id: 'other-source',
+        action: 'blocked',
+        sourceUniqueId: '90000099',
+        targetUniqueId: 'ra1',
+        timestamp: 5,
+      },
+    ]);
+    const ctx = makeCtx({ db });
+    const r = await executeStep(
+      { kind: 'Given', text: 'no prior segregationEvents exist between "60000010" and "ra1"' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    const remaining = db
+      ._events()
+      .map((e) => e.id)
+      .sort();
+    expect(remaining).toEqual(['other-action', 'other-source', 'other-target']);
+  });
+
+  test('empty collection → ok=true (no-op, idempotent)', async () => {
+    const db = makeSegEventsFakeDb([]);
+    const ctx = makeCtx({ db });
+    const r = await executeStep(
+      { kind: 'Given', text: 'no prior segregationEvents exist between "60000010" and "ra1"' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    expect(db._events()).toHaveLength(0);
+  });
+
+  test('re-running is idempotent (second call still ok=true)', async () => {
+    const db = makeSegEventsFakeDb([
+      {
+        id: 'stale-1',
+        action: 'blocked',
+        sourceUniqueId: '60000010',
+        targetUniqueId: 'ra1',
+        timestamp: 1,
+      },
+    ]);
+    const ctx = makeCtx({ db });
+    const r1 = await executeStep(
+      { kind: 'Given', text: 'no prior segregationEvents exist between "60000010" and "ra1"' },
+      ctx,
+    );
+    expect(r1.ok).toBe(true);
+    const r2 = await executeStep(
+      { kind: 'Given', text: 'no prior segregationEvents exist between "60000010" and "ra1"' },
+      ctx,
+    );
+    expect(r2.ok).toBe(true);
+    expect(db._events()).toHaveLength(0);
+  });
+
+  test('numeric uniqueId without quotes is accepted (source must be \\d+)', async () => {
+    // Pin the regex shape — source is `\d+` (with optional surrounding
+    // quotes) so a feature file written without quotes still parses.
+    const db = makeSegEventsFakeDb([]);
+    const ctx = makeCtx({ db });
+    const r = await executeStep(
+      { kind: 'Given', text: 'no prior segregationEvents exist between 60000010 and "ra1"' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test('ctx.db missing → actionable error', async () => {
+    const ctx = makeCtx();
+    const r = await executeStep(
+      { kind: 'Given', text: 'no prior segregationEvents exist between "60000010" and "ra1"' },
+      ctx,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/ctx\.db.*not initialised/);
+  });
+
+  test('values are String-coerced before the query (matches production wire format)', async () => {
+    // Production routes write String(req.auth.uniqueId) — so the runner
+    // must query for the string form too, not the number. This test pins
+    // that the matcher's query uses the string '60000010', not the
+    // number 60000010.
+    const db = makeSegEventsFakeDb([
+      {
+        id: 'stringly-typed',
+        action: 'blocked',
+        sourceUniqueId: '60000010', // STRING per production convention
+        targetUniqueId: 'ra1',
+        timestamp: 1,
+      },
+    ]);
+    const ctx = makeCtx({ db });
+    const r = await executeStep(
+      { kind: 'Given', text: 'no prior segregationEvents exist between "60000010" and "ra1"' },
+      ctx,
+    );
+    expect(r.ok).toBe(true);
+    // The string-keyed event was deleted — proves the query coerced
+    // properly. If the matcher had queried for the NUMBER 60000010, the
+    // string-keyed doc would have survived.
+    expect(db._events()).toHaveLength(0);
+  });
+});
+
 describe('Dialog confirm action (platform-dispatch)', () => {
   test('"X on Android confirms in the dialog" → driver', async () => {
     const spy = jest.fn(async () => undefined);

--- a/journey-tests/j09-voice-room-host.feature
+++ b/journey-tests/j09-voice-room-host.feature
@@ -133,6 +133,7 @@ Feature: j09 — Theo hosts a public voice room
   Scenario: LiveKit access token contains cohort claim matching the room
     Given Theo on Android created an adult-cohort room "ra1"
     Given Marcus [P-04] is signed in on Android
+    Given no prior segregationEvents exist between "60000010" and "ra1"
     When Alice on Web POSTs /api/livekit/token with roomName="ra1"
     Then the response status is 200
     Then the response body has field "token" of type "string"


### PR DESCRIPTION
## Summary

j09's @regression scenario *'LiveKit access token contains cohort claim matching the room'* asserts `1 entries matching {action:'blocked', sourceUniqueId:'60000010', targetUniqueId:'ra1'}` — but the first `--driver all` dispatch against dev today found **4 entries**.

## Investigation: production code is correct

- `middleware/sameCohort.js` writes **exactly 1 segregationEvent per cross-cohort attempt** (line 107), gated by `auditDedup.shouldWrite`
- `auditDedup` window is **5 minutes** — a DoS guard against attackers spamming cross-cohort requests to drain the Spark-tier Firestore write budget
- 4 historical j09 dispatches against dev, each separated by >5min → 4 events accumulate. **Expected behaviour.**

Per QA-mindset memory (`feedback-think-like-qa-real-fixes`): the production audit-dedup is correct — the **runner** is responsible for pre-cleanup so each scenario's exact-count assertions hold.

## Adds

- **`clearSegregationEventsForPair(ctx, sourceUniqueId, targetUniqueId)` primitive** — deletes all docs matching `{action:'blocked', source, target}`. String-coerces both ids to match production wire format (`String(req.auth.uniqueId)` at `routes/livekit.js` + `middleware/sameCohort.js`).
- **Matcher**: `Given no prior segregationEvents exist between <source> and <target>` — accepts numeric or quoted source, quoted-string target.
- **j09 scenario**: prepended the cleanup Given to the @regression scenario (line 137). Now isolates each dispatch from prior runs.

## Tests
6 new tests in 'no prior segregationEvents' describe block:
- Deletes matching events, preserves non-matching (3 distinct non-match cases: different action / target / source)
- Empty collection → ok=true (no-op)
- Re-running is idempotent
- Numeric uniqueId without quotes is accepted
- `ctx.db` missing → actionable error
- String-coercion pin: query uses string `'60000010'`, not number (matches production wire format)

All 1896/1896 `manual-qa-runner.test.js` tests pass; prettier + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)