### PR TITLE
feat(android-driver): androidConfirmDialog — generic confirm-button tap

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -148,6 +148,13 @@ const ANDROID_METHOD_NAMES = [
   // the device APP's UI through the picker dialog so the device is
   // on the right screen for subsequent UI-action steps.
   'androidPersonaSignIn',
+  // Generic "confirm in the dialog" tap. Used by j09's close-room flow
+  // ("When Theo on Android confirms in the dialog" — line 107) and any
+  // future scenario gating a destructive action behind an AlertDialog.
+  // Tries a stack of known confirm-button testTags before failing — the
+  // exact testTag varies by surface (room_endRoomConfirmButton vs
+  // settings_signOutConfirmButton vs dialog_confirmButton, etc.).
+  'androidConfirmDialog',
 ];
 
 function listMethods() {
@@ -2378,6 +2385,55 @@ async function createAndroidDriver({ serial: preferred } = {}) {
       await new Promise((r) => setTimeout(r, 500));
     }
     return true;
+  };
+
+  // j09 "Theo on Android confirms in the dialog" (line 107 close-room
+  // scenario) + future destructive-action confirmations. Tries a stack
+  // of known confirm-button testTags in priority order; first match
+  // wins.
+  //
+  // Priority order:
+  //   1. surface-specific tags (room_endRoomConfirmButton, etc.) —
+  //      tested first because they're unambiguous on the matching screen
+  //   2. generic dialog tags — fallback for AlertDialogs that follow
+  //      the Material convention but don't have a surface-specific tag
+  //
+  // Returns true on tap success. Returns false (with stderr warning)
+  // when NO candidate testTag is present in the dump — this surfaces
+  // a finding rather than silently succeeding on a missing dialog,
+  // matching the QA-mindset rule against plaster-fixes. Distinct from
+  // a tap-failure crash: the caller can decide whether to fail the
+  // step or move on.
+  //
+  // Known callers: j09 close-room (line 107). When that scenario fires
+  // against the current UI, the room_endRoomConfirmButton testTag is
+  // not yet on RoomSettingsSheet (the close action is currently
+  // immediate, no AlertDialog) — see follow-up note in PR body for
+  // the UX gap. This driver method is in place for when the dialog
+  // is added.
+  driver.androidConfirmDialog = async () => {
+    const CONFIRM_TAG_CANDIDATES = [
+      // Surface-specific (j09 close-room, j15 mc-end-stream, etc.)
+      'room_endRoomConfirmButton',
+      'settings_signOutConfirmButton',
+      'settings_clearCacheConfirmButton',
+      'settings_unblockConfirmButton',
+      'settings_deleteAccountConfirmButton',
+      'settings_deletePinConfirmButton',
+      // Generic AlertDialog fallback
+      'dialog_confirmButton',
+      'alertdialog_confirmButton',
+      'confirm_button',
+    ];
+    for (const candidate of CONFIRM_TAG_CANDIDATES) {
+      if (await driver.androidTapByTag(candidate)) {
+        return true;
+      }
+    }
+    console.error(
+      `[android-driver] androidConfirmDialog: no confirm-button testTag found in UI dump (tried ${CONFIRM_TAG_CANDIDATES.length} candidates). If the current scenario expects a confirmation dialog and the surface doesn't render one, this is a UX gap, not a driver bug.`,
+    );
+    return false;
   };
 
   driver.close = async () => {

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -16632,3 +16632,86 @@ describe('android-adb-driver — androidPersonaSignIn', () => {
     await expect(promise).rejects.toThrow(/Firebase sign-in may have failed/);
   });
 });
+
+describe('android-adb-driver — androidConfirmDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function withDumpAndDevices(xml) {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') {
+        return 'List of devices attached\nemulator-5554\tdevice\n';
+      }
+      if (cmd.includes("'cat' '/sdcard/dump.xml'")) {
+        return xml;
+      }
+      return '';
+    });
+  }
+
+  test('surface-specific tag (room_endRoomConfirmButton) wins when present', async () => {
+    withDumpAndDevices(
+      '<node resource-id="com.shyden.shytalk.local:id/room_endRoomConfirmButton" bounds="[100,500][400,600]" />',
+    );
+    const driver = await createAndroidDriver();
+    expect(await driver.androidConfirmDialog()).toBe(true);
+    const tapCalls = execSync.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c.includes("'input' 'tap'"));
+    expect(tapCalls).toHaveLength(1);
+  });
+
+  test('generic dialog_confirmButton fallback when no surface-specific tag', async () => {
+    withDumpAndDevices(
+      '<node resource-id="com.shyden.shytalk.local:id/dialog_confirmButton" bounds="[100,500][400,600]" />',
+    );
+    const driver = await createAndroidDriver();
+    expect(await driver.androidConfirmDialog()).toBe(true);
+    const tapCalls = execSync.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c.includes("'input' 'tap'"));
+    expect(tapCalls).toHaveLength(1);
+  });
+
+  test('returns false + stderr warning when NO candidate tag is in dump (UX gap surfaces, no silent pass)', async () => {
+    withDumpAndDevices('<node resource-id="something_else" bounds="[0,0][100,100]" />');
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const driver = await createAndroidDriver();
+    expect(await driver.androidConfirmDialog()).toBe(false);
+    expect(errSpy).toHaveBeenCalledWith(expect.stringMatching(/no confirm-button testTag found/));
+    expect(errSpy).toHaveBeenCalledWith(expect.stringMatching(/UX gap, not a driver bug/));
+    errSpy.mockRestore();
+    // NO tap was issued — the driver doesn't randomly tap the screen.
+    const tapCalls = execSync.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c.includes("'input' 'tap'"));
+    expect(tapCalls).toHaveLength(0);
+  });
+
+  test('settings-flow tag (settings_signOutConfirmButton) is also tried — covers profile-flow destructives', async () => {
+    withDumpAndDevices(
+      '<node resource-id="com.shyden.shytalk.local:id/settings_signOutConfirmButton" bounds="[100,500][400,600]" />',
+    );
+    const driver = await createAndroidDriver();
+    expect(await driver.androidConfirmDialog()).toBe(true);
+  });
+
+  test('surface-specific takes priority over generic when BOTH present (first match wins, no double-tap)', async () => {
+    withDumpAndDevices(
+      '<node resource-id="com.shyden.shytalk.local:id/room_endRoomConfirmButton" bounds="[100,500][400,600]" />' +
+        '<node resource-id="com.shyden.shytalk.local:id/dialog_confirmButton" bounds="[700,500][1000,600]" />',
+    );
+    const driver = await createAndroidDriver();
+    expect(await driver.androidConfirmDialog()).toBe(true);
+    // Exactly ONE tap — the surface-specific one. If both fired we'd see 2 taps.
+    const tapCalls = execSync.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c.includes("'input' 'tap'"));
+    expect(tapCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

j09 line 107 `When Theo on Android confirms in the dialog` (close-room flow) failed against dev today with `ctx.uiDriver.androidConfirmDialog not configured`. The runner matcher exists (line 7074), the driver method didn't.

## Implementation

Tries a priority list of known confirm-button testTags:

1. **Surface-specific** (`room_endRoomConfirmButton`, `settings_signOutConfirmButton`, etc.) — unambiguous on the matching screen
2. **Generic AlertDialog fallback** (`dialog_confirmButton`, `alertdialog_confirmButton`, `confirm_button`)

First match wins, exactly one tap fires. Per QA-mindset (no plaster fixes): when **NO candidate is in the dump**, returns FALSE with a stderr warning naming the UX-gap pattern — does NOT silently succeed.

## Tests
5 new tests in 'androidConfirmDialog' describe block:
- Surface-specific tag wins
- Generic dialog_confirmButton fallback
- No candidate → false + stderr warning + NO tap issued
- Settings-flow tag also matched
- Surface-specific takes priority over generic (no double-tap)

All 1300/1300 `android-adb-driver.test.js` tests pass.

## ⚠️ Follow-up: j09 close-room UX gap (NOT fixed here)

Verified against `shared/src/commonMain/.../room/RoomScreen.kt` line 857: the current close-room button (`room_endRoomButton`) calls `viewModel.closeRoom()` **immediately — NO confirmation dialog is rendered**.

The j09 scenario line 107 anticipates a dialog that doesn't exist in the current UI. Closing a voice room is destructive (kicks all participants, ends the LiveKit session) and **deserves confirmation** — but adding the dialog is a separate UX PR (Compose AlertDialog + 20 i18n strings). Out of scope here.

The driver method is in place for when the dialog IS added; until then, the j09 close-room scenario will surface the 'no confirm-button testTag found' warning instead of silently passing or crashing.

## iOS methods (`iosTap`, `iosTapSameRoom`, `iosConfirmDialog`) DEFERRED

The iOS driver has stub method-name registrations but no real tap infrastructure — adding it needs **WebDriverAgent setup** (separate larger PR per the deferred status in past summaries). j09 iOS-Sim scenarios will continue to surface 'iosTap not configured' findings until that infra lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)