### PR TITLE
fix(android-driver): androidPersonaSignIn launches the app first

### DIFF
--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -2328,19 +2328,48 @@ async function createAndroidDriver({ serial: preferred } = {}) {
   // (open-picker / pick-row / wait-for-main) so the runner surfaces
   // a precise finding rather than the generic "ui dump didn't
   // contain X" downstream.
-  driver.androidPersonaSignIn = async (personaId, tab) => {
+  driver.androidPersonaSignIn = async (personaId, tab, target = 'dev') => {
     if (!/^P-\d{2}$/.test(personaId)) {
       throw new Error(
         `androidPersonaSignIn requires a P-NN persona id (got "${personaId}") — ephemeral personas P-01/P-03 sign up via the prod flow, not the picker`,
       );
     }
+    // Step 0: launch the ShyTalk app on the device. The first j09
+    // re-dispatch on 2026-05-30 surfaced "could not tap persona_picker_open"
+    // because the device was sitting on com.android.settings — the test
+    // never opened ShyTalk. Per-target package: local → .local,
+    // dev → .dev, prod → bare (no suffix). Mirrors the
+    // applicationIdSuffix config at app/build.gradle.kts lines 43/132.
+    const packageMap = {
+      local: 'com.shyden.shytalk.local',
+      dev: 'com.shyden.shytalk.dev',
+      prod: 'com.shyden.shytalk',
+    };
+    const pkg = packageMap[target] || packageMap.dev;
+    try {
+      // monkey -p <pkg> -c LAUNCHER 1 fires the registered launcher
+      // intent regardless of which activity is currently focused — works
+      // whether ShyTalk was closed, backgrounded, or another app is
+      // foregrounded. The "1" is the event count.
+      adb(['shell', 'monkey', '-p', pkg, '-c', 'android.intent.category.LAUNCHER', '1']);
+    } catch (e) {
+      throw new Error(
+        `androidPersonaSignIn: launch of "${pkg}" failed — is the ${target} build installed? adb error: ${e.message}`,
+        { cause: e },
+      );
+    }
+    // Settle for the launcher → ShyTalk transition. ~3s is enough for
+    // a warm start (app process already running). Cold starts may
+    // need longer; if the dump doesn't have persona_picker_open after
+    // 3s, the test below will catch it with the canonical error.
+    await new Promise((r) => setTimeout(r, 3000));
     // Step 1: tap `persona_picker_open` on the sign-in screen.
     // Available on local + dev (PR #882); on prod the button is
     // hidden so this will return false → actionable error.
     const opened = await driver.androidTapByTag('persona_picker_open');
     if (!opened) {
       throw new Error(
-        'androidPersonaSignIn: could not tap "persona_picker_open" — device may not be on the sign-in screen, or the build flavor is "prod" (the picker is hidden on prod)',
+        `androidPersonaSignIn: could not tap "persona_picker_open" — ShyTalk ${target} launched but the picker testTag isn't visible. Possible causes: (a) the user is ALREADY signed in (sign out via Profile → Settings first), (b) the deployed dev APK predates PR #882 (deploy main to dev and re-install), or (c) the build flavor is "prod" where the picker is hidden by design.`,
       );
     }
     // Step 2: wait for the dialog to render. Pick a row testTag that

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -1116,7 +1116,9 @@ const matchers = [
         return { ok: true };
       }
       try {
-        await ctx.uiDriver.androidPersonaSignIn(personaId, tab);
+        // Pass ctx.target as the 3rd arg so the driver picks the right
+        // applicationIdSuffix (local → .local, dev → .dev, prod → bare).
+        await ctx.uiDriver.androidPersonaSignIn(personaId, tab, ctx.target);
         return { ok: true };
       } catch (e) {
         return { ok: false, error: e.message };

--- a/express-api/tests/scripts/drivers/android-adb-driver.test.js
+++ b/express-api/tests/scripts/drivers/android-adb-driver.test.js
@@ -16521,22 +16521,83 @@ describe('android-adb-driver — androidPersonaSignIn', () => {
     });
   }
 
-  test('happy path: P-10 + rooms tab — taps picker, picks row, lands on main_roomsTab', async () => {
+  test('happy path: P-10 + rooms tab — launches app, taps picker, picks row, lands on main_roomsTab', async () => {
     setupExec(happyPathDumps('P-10'));
     const driver = await createAndroidDriver();
+    // Default target='dev' when not passed — matches the matcher's
+    // ctx.target plumbing for the j09 case.
     const promise = driver.androidPersonaSignIn('P-10', 'rooms');
-    // Advance through the wait-for-dialog poll (5s ceiling) + wait-for-main
-    // poll (10s ceiling). Dumps return immediately so the poll resolves on
-    // the first tick.
-    await jest.advanceTimersByTimeAsync(15000);
+    // Advance through the 3s launch wait + wait-for-dialog poll (5s)
+    // + wait-for-main poll (10s). Dumps return immediately so the
+    // polls resolve on the first tick.
+    await jest.advanceTimersByTimeAsync(18000);
     expect(await promise).toBe(true);
+    // Verify the launch command fired with the dev package.
+    const monkeyCalls = execSync.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c.includes("'monkey'") && c.includes("'com.shyden.shytalk.dev'"));
+    expect(monkeyCalls).toHaveLength(1);
     // Verify the 2 testTag taps happened (picker open + persona row).
-    // Don't constrain on exact tap coords — bounds parsing is covered
-    // elsewhere; here we just confirm the sequence ran.
     const tapCalls = execSync.mock.calls
       .map((c) => c[0])
       .filter((c) => c.includes("'input' 'tap'"));
     expect(tapCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('target="local" → launches com.shyden.shytalk.local', async () => {
+    setupExec(happyPathDumps('P-10'));
+    const driver = await createAndroidDriver();
+    const promise = driver.androidPersonaSignIn('P-10', 'rooms', 'local');
+    await jest.advanceTimersByTimeAsync(18000);
+    expect(await promise).toBe(true);
+    const monkeyCalls = execSync.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c.includes("'monkey'") && c.includes("'com.shyden.shytalk.local'"));
+    expect(monkeyCalls).toHaveLength(1);
+  });
+
+  test('target="prod" → launches bare com.shyden.shytalk (no suffix)', async () => {
+    setupExec(happyPathDumps('P-10'));
+    const driver = await createAndroidDriver();
+    const promise = driver.androidPersonaSignIn('P-10', 'rooms', 'prod');
+    await jest.advanceTimersByTimeAsync(18000);
+    expect(await promise).toBe(true);
+    const monkeyCalls = execSync.mock.calls.map((c) => c[0]).filter((c) => c.includes("'monkey'"));
+    expect(monkeyCalls).toHaveLength(1);
+    // Verify the prod package (no suffix) — match on the SPACE after the
+    // package name's closing quote so 'com.shyden.shytalk.local' doesn't
+    // false-match the 'com.shyden.shytalk' prefix.
+    expect(monkeyCalls[0]).toContain("'com.shyden.shytalk' '-c'");
+  });
+
+  test('unknown target → falls back to dev package (defensive default)', async () => {
+    setupExec(happyPathDumps('P-10'));
+    const driver = await createAndroidDriver();
+    const promise = driver.androidPersonaSignIn('P-10', 'rooms', 'staging');
+    await jest.advanceTimersByTimeAsync(18000);
+    expect(await promise).toBe(true);
+    const monkeyCalls = execSync.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c.includes("'monkey'") && c.includes("'com.shyden.shytalk.dev'"));
+    expect(monkeyCalls).toHaveLength(1);
+  });
+
+  test('app launch throws → actionable error mentioning the target + package + adb error', async () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd === 'adb devices') return 'List of devices attached\nemulator-5554\tdevice\n';
+      if (cmd.includes("'monkey'")) {
+        throw new Error('package not installed: com.shyden.shytalk.dev');
+      }
+      return '';
+    });
+    const driver = await createAndroidDriver();
+    const promise = driver.androidPersonaSignIn('P-10', 'rooms', 'dev');
+    promise.catch(() => {});
+    await jest.advanceTimersByTimeAsync(1000);
+    await expect(promise).rejects.toThrow(
+      /launch of "com\.shyden\.shytalk\.dev" failed — is the dev build installed/,
+    );
+    await expect(promise).rejects.toThrow(/package not installed/);
   });
 
   test('non-rooms tab (e.g. profile) — also taps main_profileTab after sign-in', async () => {
@@ -16547,7 +16608,7 @@ describe('android-adb-driver — androidPersonaSignIn', () => {
     ]);
     const driver = await createAndroidDriver();
     const promise = driver.androidPersonaSignIn('P-10', 'profile');
-    await jest.advanceTimersByTimeAsync(16000);
+    await jest.advanceTimersByTimeAsync(19000);
     expect(await promise).toBe(true);
   });
 
@@ -16566,12 +16627,19 @@ describe('android-adb-driver — androidPersonaSignIn', () => {
     );
   });
 
-  test('persona_picker_open not on screen → throws naming the missing testTag', async () => {
+  test('persona_picker_open not on screen → throws naming the missing testTag (and the three likely causes)', async () => {
     setupExec(['<node resource-id="something_else" bounds="[0,0][100,100]" />']);
     const driver = await createAndroidDriver();
-    await expect(driver.androidPersonaSignIn('P-10', 'rooms')).rejects.toThrow(
-      /could not tap "persona_picker_open"/,
-    );
+    const promise = driver.androidPersonaSignIn('P-10', 'rooms');
+    promise.catch(() => {});
+    // Advance past the 3s app-launch wait so the picker check fires.
+    await jest.advanceTimersByTimeAsync(4000);
+    await expect(promise).rejects.toThrow(/could not tap "persona_picker_open"/);
+    // Error mentions all three likely causes so the operator can
+    // triage without re-reading the driver source.
+    await expect(promise).rejects.toThrow(/ALREADY signed in/);
+    await expect(promise).rejects.toThrow(/predates PR #882/);
+    await expect(promise).rejects.toThrow(/build flavor is "prod"/);
   });
 
   test('dialog never shows persona_row → throws after 5s with persona id', async () => {
@@ -16597,7 +16665,7 @@ describe('android-adb-driver — androidPersonaSignIn', () => {
     // rejection, Node doesn't see an unhandled-promise-rejection (which
     // jest surfaces as a test failure ahead of the expect.rejects).
     promise.catch(() => {});
-    await jest.advanceTimersByTimeAsync(6000);
+    await jest.advanceTimersByTimeAsync(9000);
     await expect(promise).rejects.toThrow(
       /picker dialog never showed "persona_row_P-99" within 5s/,
     );
@@ -16625,7 +16693,7 @@ describe('android-adb-driver — androidPersonaSignIn', () => {
     const promise = driver.androidPersonaSignIn('P-10', 'rooms');
     // See the dialog-never-shows test for why this noop catch is needed.
     promise.catch(() => {});
-    await jest.advanceTimersByTimeAsync(11000);
+    await jest.advanceTimersByTimeAsync(14000);
     await expect(promise).rejects.toThrow(
       /never reached main screen \("main_roomsTab"\) within 10s/,
     );

--- a/express-api/tests/scripts/manual-qa-runner.test.js
+++ b/express-api/tests/scripts/manual-qa-runner.test.js
@@ -2608,6 +2608,7 @@ describe('Persona "is signed in on Android physical at the <tab> tab" (j09 Backg
     const ctx = makeCtx({
       fetch: withSignInFetch(50000060),
       uiDriver: { androidPersonaSignIn: personaSignInSpy },
+      target: 'dev',
     });
     const r = await executeStep(
       { kind: 'Given', text: 'Theo [P-10] is signed in on Android physical at the "rooms" tab' },
@@ -2617,8 +2618,10 @@ describe('Persona "is signed in on Android physical at the <tab> tab" (j09 Backg
     // Server-side: session populated.
     expect(ctx.sessions.get('Theo')).toBeDefined();
     expect(ctx.personaPlatforms.get('Theo')).toBe('Android physical');
-    // Device-side: driver method called with the persona id + tab.
-    expect(personaSignInSpy).toHaveBeenCalledWith('P-10', 'rooms');
+    // Device-side: driver method called with the persona id + tab + target
+    // (target is needed for the app-launch step to pick the right
+    // applicationIdSuffix — local/dev/prod).
+    expect(personaSignInSpy).toHaveBeenCalledWith('P-10', 'rooms', 'dev');
   });
 
   test('driver not wired → server-side sign-in still succeeds, warning logged, ok=true', async () => {
@@ -2711,18 +2714,19 @@ describe('Persona "is signed in on Android physical at the <tab> tab" (j09 Backg
     expect(personaSignInSpy).not.toHaveBeenCalled();
   });
 
-  test('non-rooms tab (e.g. profile) — driver method gets the tab name', async () => {
+  test('non-rooms tab (e.g. profile) — driver method gets the tab name + target', async () => {
     const personaSignInSpy = jest.fn(async () => true);
     const ctx = makeCtx({
       fetch: withSignInFetch(50000060),
       uiDriver: { androidPersonaSignIn: personaSignInSpy },
+      target: 'local',
     });
     const r = await executeStep(
       { kind: 'Given', text: 'Theo [P-10] is signed in on Android physical at the "profile" tab' },
       ctx,
     );
     expect(r.ok).toBe(true);
-    expect(personaSignInSpy).toHaveBeenCalledWith('P-10', 'profile');
+    expect(personaSignInSpy).toHaveBeenCalledWith('P-10', 'profile', 'local');
   });
 
   test('does NOT fire on platforms other than "Android physical" — falls through to catch-all', async () => {


### PR DESCRIPTION
## Summary

First j09 re-dispatch against dev (today, after the 4 framework PRs landed) surfaced "could not tap persona_picker_open" for **all 12 scenarios** — same root cause. Diagnosis via `dumpsys window` showed the device was sitting on `com.android.settings`, NOT ShyTalk. The runner had never launched the app.

## Fix

Adds a Step 0 to `androidPersonaSignIn`: `adb shell monkey -p <pkg> -c LAUNCHER 1` to fire the registered launcher intent.

Per-target package (mirrors `app/build.gradle.kts` lines 26/43/132):
- `local` → `com.shyden.shytalk.local`
- `dev` → `com.shyden.shytalk.dev` (default fallback)
- `prod` → `com.shyden.shytalk` (no suffix)

Settles 3s after launch to absorb the launcher → ShyTalk transition.

## Signature change

`androidPersonaSignIn(personaId, tab, target = 'dev')` — runner matcher now passes `ctx.target` as the 3rd arg.

## Error UX upgrades

- Launch throws → actionable error naming target + package + adb stderr, plus `{ cause }` for the JS standard chain.
- Picker-not-visible error now enumerates THREE likely causes (was 2):
  - (a) ALREADY signed in (sign out first)
  - (b) deployed dev APK predates PR #882 (deploy main + re-install)
  - (c) prod flavor where the picker is hidden by design

## Tests

- happy-path: launches dev package, then taps picker
- target='local' → launches .local package
- target='prod' → launches bare com.shyden.shytalk (regex-anchored to avoid .local prefix false-match)
- unknown target → falls back to dev (defensive)
- launch throws → actionable error with package + adb stderr
- picker not visible: error names all 3 causes
- Existing timer-advance values bumped by 3s (new launch step)
- Runner matcher tests: assert spy got `(persona, tab, target)` not just `(persona, tab)`

All 3208/3208 tests pass; prettier + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)