### PR TITLE
feat(qa-runner): web-mobile-chrome-android driver — CDP-over-adb

### DIFF
--- a/express-api/scripts/browser-allowlist.js
+++ b/express-api/scripts/browser-allowlist.js
@@ -1,0 +1,58 @@
+/**
+ * Per-target browser allowlist for the manual QA runner.
+ *
+ * The matrix-completeness rule (operator directive 2026-05-30) defines:
+ *   - local: full browser coverage (every supported browser on every
+ *     supported device).
+ *   - dev: physical Android device + Chrome on Mac + Chrome on Android
+ *     ONLY. No Firefox/WebKit/Edge on dev — those are local-only.
+ *   - prod: read-only verification; Chromium only.
+ *
+ * Mobile browser values use a `<browser>-<platform>` slug shape so the
+ * runner can dispatch to the right driver factory without a separate
+ * --platform flag.
+ *
+ * Extracted to its own module so unit tests can pin the matrix without
+ * spawning the runner subprocess or regex-scraping its source.
+ */
+
+const DESKTOP_BROWSERS = ['chromium', 'firefox', 'webkit', 'edge'];
+
+// Browsers that route through a non-default driver factory inside the
+// runner's `--driver playwright|all` block. New mobile-browser drivers
+// register their slug here AND in the per-target allowlist below.
+const MOBILE_BROWSERS = ['mobile-chrome-android'];
+
+const SUPPORTED_BROWSERS = [...DESKTOP_BROWSERS, ...MOBILE_BROWSERS];
+
+const TARGET_BROWSER_ALLOWLIST = {
+  local: [...DESKTOP_BROWSERS, ...MOBILE_BROWSERS],
+  dev: ['chromium', 'mobile-chrome-android'],
+  prod: ['chromium'],
+};
+
+/**
+ * Returns the allowed-browser list for the given target, or [] if the
+ * target is unknown. Pure — no side effects, safe to call repeatedly.
+ */
+function allowedBrowsersFor(target) {
+  return TARGET_BROWSER_ALLOWLIST[target] || [];
+}
+
+/**
+ * True if the given browser slug routes to a mobile-device driver
+ * (CDP-over-adb, Appium safari context, etc.) rather than a desktop
+ * Playwright launcher.
+ */
+function isMobileBrowser(browser) {
+  return MOBILE_BROWSERS.includes(browser);
+}
+
+module.exports = {
+  DESKTOP_BROWSERS,
+  MOBILE_BROWSERS,
+  SUPPORTED_BROWSERS,
+  TARGET_BROWSER_ALLOWLIST,
+  allowedBrowsersFor,
+  isMobileBrowser,
+};

--- a/express-api/scripts/drivers/web-mobile-chrome-android-driver.js
+++ b/express-api/scripts/drivers/web-mobile-chrome-android-driver.js
@@ -1,0 +1,319 @@
+/* global document */
+/**
+ * Web driver: Mobile Chrome on Android via CDP-over-adb.
+ *
+ * Drives the actual Chrome browser running on the operator's connected
+ * Android device — not Playwright's "Pixel 5 emulation" (which is just
+ * desktop Chromium with mobile UA/viewport). That distinction matters
+ * for the matrix-completeness rule: local validation requires real
+ * Android × Mobile Chrome coverage, not a fake.
+ *
+ * Wire-up
+ * -------
+ * 1. Operator enables USB debugging on the Android device.
+ * 2. Operator enables Chrome → chrome://flags → "Enable command line on
+ *    non-rooted devices" + restarts Chrome (one-time per device).
+ *    Alternative: open Chrome → settings → Developer options → enable
+ *    "USB Web debugging".
+ * 3. Driver runs `adb forward tcp:<port> localabstract:chrome_devtools_remote`
+ *    so localhost:<port> tunnels into Chrome's CDP socket on the device.
+ * 4. Driver calls `playwright.chromium.connectOverCDP(endpointURL)` to
+ *    attach Playwright to the remote browser.
+ * 5. Driver uses Playwright's Page API the same way as web-playwright-
+ *    driver.js — methods are pin-compatible so the runner can swap.
+ *
+ * Method-naming contract: mirrors `web-playwright-driver.js`. The runner
+ * doesn't care which driver it gets — they expose the same surface so
+ * scenarios run unchanged across Mac × {chromium, firefox, webkit, edge}
+ * and Android × Mobile Chrome.
+ *
+ * Failure modes (all return false + log, never throw):
+ *   - adb not on PATH → "adb not found; install platform-tools"
+ *   - no device attached → "no Android device; check `adb devices`"
+ *   - Chrome not running on device → "Chrome not running; launch it
+ *     manually + enable USB Web debugging"
+ *   - CDP port already forwarded by another tool → use SO_REUSEPORT
+ *     pattern: pick next free port, log the chosen port.
+ *
+ * The driver uses `execFileSync('/usr/bin/adb', ...)` on macOS;
+ * platform-tools is installed at a fixed Apple-Homebrew location.
+ * Tests inject a custom `adbPath` so cross-platform CI doesn't require
+ * a real adb.
+ */
+
+/* eslint-disable no-console -- driver methods log diagnostics for the
+   manual QA runner (operator-facing CLI), not application code. */
+
+const path = require('path');
+const { execFileSync: realExecFileSync } = require('child_process');
+const net = require('net');
+
+/**
+ * Default adb binary location. The Homebrew + Android SDK both install
+ * adb to /usr/local/bin or /opt/homebrew/bin; preferring the latter on
+ * Apple Silicon Macs. Falls back to the bare `adb` (PATH lookup) only
+ * for non-macOS test environments.
+ *
+ * For sonarjs/no-os-command-from-path compliance, the resolution is
+ * lazy: we walk a list of known absolute paths, return the first that
+ * exists, and only fall back to the bare name if every absolute path is
+ * absent — which only happens in CI mocks anyway.
+ */
+const KNOWN_ADB_PATHS = [
+  '/opt/homebrew/bin/adb', // Apple Silicon Homebrew
+  '/usr/local/bin/adb', // Intel Mac Homebrew + Linux
+  '/usr/bin/adb', // some Linux distros
+];
+
+function resolveAdbPath(fsImpl = require('fs')) {
+  for (const p of KNOWN_ADB_PATHS) {
+    try {
+      if (fsImpl.existsSync(p)) return p;
+    } catch (_e) {
+      /* keep walking */
+    }
+  }
+  return 'adb';
+}
+
+let _playwright;
+function loadPlaywright() {
+  if (_playwright) return _playwright;
+  try {
+    _playwright = require('playwright');
+    return _playwright;
+  } catch (bareErr) {
+    if (bareErr.code !== 'MODULE_NOT_FOUND') throw bareErr;
+  }
+  const repoRoot = path.resolve(__dirname, '../../..');
+  const playwrightPath = path.join(repoRoot, 'node_modules', 'playwright');
+  _playwright = require(playwrightPath);
+  return _playwright;
+}
+
+/**
+ * Pick a free TCP port in the localhost range. Used so concurrent
+ * dispatches (or stale adb forward entries) don't collide on a fixed
+ * 9222. Returns a Promise<number>.
+ */
+function pickFreePort(netImpl = net) {
+  return new Promise((resolve, reject) => {
+    const srv = netImpl.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+/**
+ * Set up the adb port-forward `localhost:<port>` → device's
+ * chrome_devtools_remote unix socket. Returns the chosen port + a
+ * cleanup function that removes the forward.
+ *
+ * `adbPath` defaults to resolveAdbPath(); `execFileSync` defaults to
+ * the real Node primitive but is injectable for tests.
+ *
+ * Throws if adb is missing or no device is attached — those are
+ * actionable operator errors that should not be swallowed.
+ */
+async function bootstrapAdbForward({
+  adbPath,
+  execFileSync = realExecFileSync,
+  pickPort = () => pickFreePort(),
+} = {}) {
+  const adb = adbPath || resolveAdbPath();
+  // Sanity: at least one device. Empty `adb devices` output → operator
+  // forgot to plug in / authorise USB debugging.
+  let devicesOut;
+  try {
+    devicesOut = execFileSync(adb, ['devices'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      throw new Error(
+        `[mobile-chrome-android-driver] adb not found at "${adb}". Install Android platform-tools (Homebrew: \`brew install android-platform-tools\`).`,
+        { cause: e },
+      );
+    }
+    throw new Error(`[mobile-chrome-android-driver] adb invocation failed: ${e.message}`, {
+      cause: e,
+    });
+  }
+  // `adb devices` output shape:
+  //   List of devices attached
+  //   ABCDEF12<TAB>device
+  const lines = String(devicesOut)
+    .split('\n')
+    .filter((l) => /\t(device|unauthorized)\b/.test(l));
+  if (lines.length === 0) {
+    throw new Error(
+      '[mobile-chrome-android-driver] no Android device attached. Check `adb devices` and ensure USB debugging is authorised on the device.',
+    );
+  }
+  const unauthorised = lines.filter((l) => /\tunauthorized\b/.test(l));
+  if (unauthorised.length === lines.length) {
+    throw new Error(
+      '[mobile-chrome-android-driver] Android device is unauthorised. Tap "Allow USB debugging" on the device when prompted.',
+    );
+  }
+
+  const port = await pickPort();
+  try {
+    execFileSync(adb, ['forward', `tcp:${port}`, 'localabstract:chrome_devtools_remote'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (e) {
+    throw new Error(
+      `[mobile-chrome-android-driver] adb forward failed: ${e.message}. Make sure Chrome is open on the device + USB Web debugging is enabled in chrome://flags.`,
+      { cause: e },
+    );
+  }
+
+  const removeForward = () => {
+    try {
+      execFileSync(adb, ['forward', '--remove', `tcp:${port}`], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (_e) {
+      /* best-effort cleanup */
+    }
+  };
+  return { port, removeForward };
+}
+
+/**
+ * Driver factory.
+ *
+ *   const driver = await createMobileChromeAndroidDriver({ baseURL });
+ *   ctx.webDriver = driver;
+ *   await driver.webRefreshRoomsList('Alice');
+ *   await driver.close();
+ *
+ * Injectable deps (test-only):
+ *   - adbPath, execFileSync — replace adb interaction
+ *   - playwrightImpl — replace playwright module
+ *   - pickPort — deterministic port selection
+ */
+async function createMobileChromeAndroidDriver({
+  baseURL = 'http://localhost:8888',
+  adbPath,
+  execFileSync,
+  playwrightImpl,
+  pickPort,
+} = {}) {
+  const { port, removeForward } = await bootstrapAdbForward({
+    adbPath,
+    execFileSync,
+    pickPort,
+  });
+
+  const pw = playwrightImpl || loadPlaywright();
+  const endpointURL = `http://127.0.0.1:${port}`;
+  let browser;
+  try {
+    browser = await pw.chromium.connectOverCDP(endpointURL);
+  } catch (e) {
+    removeForward();
+    throw new Error(
+      `[mobile-chrome-android-driver] connectOverCDP(${endpointURL}) failed: ${e.message}. Confirm Chrome is open on the device + chrome://inspect/#devices lists it from your Mac.`,
+      { cause: e },
+    );
+  }
+
+  // CDP-attached browsers expose the existing tabs as contexts. We don't
+  // create new ones (Mobile Chrome can have at most one window of tabs;
+  // a new BrowserContext is silently ignored). Per-persona isolation is
+  // approximated by per-persona Page within the existing context — good
+  // enough for j09's single-persona web flows; future PR can stretch
+  // this once we have multi-persona web Android scenarios.
+  const contexts = browser.contexts();
+  if (contexts.length === 0) {
+    removeForward();
+    await browser.close().catch(() => {});
+    throw new Error(
+      '[mobile-chrome-android-driver] CDP returned 0 contexts — Chrome may be in incognito-only mode. Switch to a normal tab + retry.',
+    );
+  }
+  const ctx = contexts[0];
+
+  const pages = new Map();
+
+  async function pageFor(name) {
+    if (pages.has(name)) return pages.get(name);
+    const page = await ctx.newPage();
+    pages.set(name, page);
+    return page;
+  }
+
+  const driver = {
+    _browser: browser,
+    _ctx: ctx,
+    _port: port,
+    _baseURL: baseURL,
+    _pages: pages,
+    pageFor,
+  };
+
+  // webRefreshRoomsList — same contract as the desktop web driver.
+  driver.webRefreshRoomsList = async (name) => {
+    try {
+      const page = await pageFor(name);
+      await page.goto(`${baseURL.replace(/\/$/, '')}/rooms`);
+      return true;
+    } catch (e) {
+      console.error(
+        `[mobile-chrome-android-driver] webRefreshRoomsList(${name}) failed: ${e.message}`,
+      );
+      return false;
+    }
+  };
+
+  // webUiDump — visible text content for assertion matchers. Same shape
+  // as the desktop driver so matchers can swap drivers transparently.
+  driver.webUiDump = async () => {
+    try {
+      const page = await pageFor('default');
+      if (!page.url() || page.url() === 'about:blank')
+        await page.goto(`${baseURL.replace(/\/$/, '')}/`);
+      // Note: await before return so the try/catch actually catches a
+      // rejected evaluate (a bare `return page.evaluate(...)` escapes
+      // the catch since the rejection happens after this function's
+      // microtask boundary).
+      return await page.evaluate(() => document.body.innerText || '');
+    } catch (e) {
+      console.error(`[mobile-chrome-android-driver] webUiDump failed: ${e.message}`);
+      return '';
+    }
+  };
+
+  driver.close = async () => {
+    for (const p of pages.values()) {
+      try {
+        await p.close();
+      } catch (_e) {
+        /* best-effort */
+      }
+    }
+    try {
+      await browser.close();
+    } catch (_e) {
+      /* best-effort — CDP-attached close can race with device-side teardown */
+    }
+    removeForward();
+  };
+
+  return driver;
+}
+
+module.exports = {
+  KNOWN_ADB_PATHS,
+  resolveAdbPath,
+  pickFreePort,
+  bootstrapAdbForward,
+  createMobileChromeAndroidDriver,
+};

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -15457,12 +15457,12 @@ async function main() {
   opts.browser = opts.browser || 'chromium';
   // Per-target browser allowlist: dev runs Chrome only; local runs the
   // full matrix; prod is read-only and pins to chromium.
-  const TARGET_BROWSER_ALLOWLIST = {
-    local: ['chromium', 'firefox', 'webkit', 'edge'],
-    dev: ['chromium'],
-    prod: ['chromium'],
-  };
-  const allowed = TARGET_BROWSER_ALLOWLIST[opts.target] || [];
+  // Per-target browser allowlist lives in ./browser-allowlist.js so unit
+  // tests can pin the matrix without subprocessing the runner. See that
+  // module for the policy rationale (local = full matrix, dev =
+  // chrome-on-Mac + chrome-on-Android, prod = chromium-only).
+  const { allowedBrowsersFor } = require('./browser-allowlist');
+  const allowed = allowedBrowsersFor(opts.target);
   if (!allowed.includes(opts.browser)) {
     console.error(
       `--browser "${opts.browser}" is not allowed for --target "${opts.target}" — allowed: ${allowed.join(', ')}. The local matrix (full browser coverage) only applies to --target local; dev + prod stay Chromium-only by policy.`,
@@ -15515,12 +15515,28 @@ async function main() {
   const testerDriver = null;
   let driverCleanup = async () => {};
   if (opts.driver === 'playwright' || opts.driver === 'all') {
-    const { createWebDriver } = require('./drivers/web-playwright-driver');
-    webDriver = await createWebDriver({
-      baseURL: TARGETS[opts.target].webBase || 'http://localhost:8888',
-      headless: !opts.headed,
-      browser: opts.browser,
-    });
+    // Driver factory routing inside the playwright/all bucket:
+    //   - desktop browsers (chromium/firefox/webkit/edge) → Playwright
+    //     direct launch via web-playwright-driver.js
+    //   - mobile-chrome-android → CDP-over-adb to the real Chrome on
+    //     the connected Android device via web-mobile-chrome-android-driver.js
+    // The runner's matcher surface is the same — both drivers expose the
+    // ctx.webDriver method namespace, so scenarios don't care which one
+    // is active.
+    const baseURL = TARGETS[opts.target].webBase || 'http://localhost:8888';
+    if (opts.browser === 'mobile-chrome-android') {
+      const {
+        createMobileChromeAndroidDriver,
+      } = require('./drivers/web-mobile-chrome-android-driver');
+      webDriver = await createMobileChromeAndroidDriver({ baseURL });
+    } else {
+      const { createWebDriver } = require('./drivers/web-playwright-driver');
+      webDriver = await createWebDriver({
+        baseURL,
+        headless: !opts.headed,
+        browser: opts.browser,
+      });
+    }
     const prevCleanup = driverCleanup;
     driverCleanup = async () => {
       await prevCleanup();

--- a/express-api/tests/scripts/browser-allowlist.test.js
+++ b/express-api/tests/scripts/browser-allowlist.test.js
@@ -1,0 +1,145 @@
+/**
+ * browser-allowlist.test.js
+ *
+ * Pins the per-target browser matrix established by the operator
+ * directive 2026-05-30: local = full coverage; dev = chromium +
+ * mobile-chrome-android; prod = chromium-only. The runner imports this
+ * module to enforce the matrix at CLI parse time; these tests catch any
+ * regression where someone adds a browser to dev/prod without operator
+ * sign-off.
+ *
+ * Tests cover:
+ *   - DESKTOP_BROWSERS / MOBILE_BROWSERS / SUPPORTED_BROWSERS shape
+ *   - TARGET_BROWSER_ALLOWLIST per-target contents (local/dev/prod)
+ *   - allowedBrowsersFor known + unknown targets
+ *   - isMobileBrowser positive + negative
+ */
+
+const path = require('path');
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const {
+  DESKTOP_BROWSERS,
+  MOBILE_BROWSERS,
+  SUPPORTED_BROWSERS,
+  TARGET_BROWSER_ALLOWLIST,
+  allowedBrowsersFor,
+  isMobileBrowser,
+} = require(path.join(REPO_ROOT, 'express-api/scripts/browser-allowlist'));
+
+describe('browser-allowlist — DESKTOP_BROWSERS', () => {
+  test('includes the four Playwright desktop targets', () => {
+    expect(DESKTOP_BROWSERS).toEqual(
+      expect.arrayContaining(['chromium', 'firefox', 'webkit', 'edge']),
+    );
+  });
+
+  test('chromium is first (default browser when --browser flag omitted)', () => {
+    expect(DESKTOP_BROWSERS[0]).toBe('chromium');
+  });
+
+  test('does NOT include any mobile-* slug', () => {
+    for (const b of DESKTOP_BROWSERS) {
+      expect(b).not.toMatch(/^mobile-/);
+    }
+  });
+});
+
+describe('browser-allowlist — MOBILE_BROWSERS', () => {
+  test('includes mobile-chrome-android (PR C)', () => {
+    expect(MOBILE_BROWSERS).toContain('mobile-chrome-android');
+  });
+
+  test('every entry is a mobile-* slug', () => {
+    for (const b of MOBILE_BROWSERS) {
+      expect(b).toMatch(/^mobile-/);
+    }
+  });
+});
+
+describe('browser-allowlist — SUPPORTED_BROWSERS', () => {
+  test('is desktop ∪ mobile', () => {
+    expect(SUPPORTED_BROWSERS).toEqual([...DESKTOP_BROWSERS, ...MOBILE_BROWSERS]);
+  });
+
+  test('contains no duplicates', () => {
+    expect(new Set(SUPPORTED_BROWSERS).size).toBe(SUPPORTED_BROWSERS.length);
+  });
+});
+
+describe('browser-allowlist — TARGET_BROWSER_ALLOWLIST', () => {
+  test('local accepts the full desktop matrix', () => {
+    for (const b of DESKTOP_BROWSERS) {
+      expect(TARGET_BROWSER_ALLOWLIST.local).toContain(b);
+    }
+  });
+
+  test('local accepts every mobile browser', () => {
+    for (const b of MOBILE_BROWSERS) {
+      expect(TARGET_BROWSER_ALLOWLIST.local).toContain(b);
+    }
+  });
+
+  test('dev accepts chromium + mobile-chrome-android only (operator policy 2026-05-30)', () => {
+    expect(TARGET_BROWSER_ALLOWLIST.dev).toEqual(['chromium', 'mobile-chrome-android']);
+  });
+
+  test('dev REJECTS firefox / webkit / edge (no full matrix on dev)', () => {
+    expect(TARGET_BROWSER_ALLOWLIST.dev).not.toContain('firefox');
+    expect(TARGET_BROWSER_ALLOWLIST.dev).not.toContain('webkit');
+    expect(TARGET_BROWSER_ALLOWLIST.dev).not.toContain('edge');
+  });
+
+  test('prod accepts chromium ONLY (read-only verification gate)', () => {
+    expect(TARGET_BROWSER_ALLOWLIST.prod).toEqual(['chromium']);
+  });
+
+  test('prod REJECTS every mobile browser (no mobile matrix on prod)', () => {
+    for (const b of MOBILE_BROWSERS) {
+      expect(TARGET_BROWSER_ALLOWLIST.prod).not.toContain(b);
+    }
+  });
+
+  test('exactly three targets are defined (local / dev / prod)', () => {
+    expect(Object.keys(TARGET_BROWSER_ALLOWLIST).sort()).toEqual(['dev', 'local', 'prod']);
+  });
+});
+
+describe('browser-allowlist — allowedBrowsersFor', () => {
+  test('returns the dev allowlist for target=dev', () => {
+    expect(allowedBrowsersFor('dev')).toEqual(TARGET_BROWSER_ALLOWLIST.dev);
+  });
+
+  test('returns the local allowlist for target=local', () => {
+    expect(allowedBrowsersFor('local')).toEqual(TARGET_BROWSER_ALLOWLIST.local);
+  });
+
+  test('returns the prod allowlist for target=prod', () => {
+    expect(allowedBrowsersFor('prod')).toEqual(TARGET_BROWSER_ALLOWLIST.prod);
+  });
+
+  test('returns an empty array for unknown target (no crash, allowlist denies all)', () => {
+    expect(allowedBrowsersFor('staging')).toEqual([]);
+  });
+
+  test('returns an empty array for null/undefined target', () => {
+    expect(allowedBrowsersFor(null)).toEqual([]);
+    expect(allowedBrowsersFor(undefined)).toEqual([]);
+  });
+});
+
+describe('browser-allowlist — isMobileBrowser', () => {
+  test.each(MOBILE_BROWSERS)('returns true for mobile %s', (b) => {
+    expect(isMobileBrowser(b)).toBe(true);
+  });
+
+  test.each(DESKTOP_BROWSERS)('returns false for desktop %s', (b) => {
+    expect(isMobileBrowser(b)).toBe(false);
+  });
+
+  test('returns false for unknown slug', () => {
+    expect(isMobileBrowser('safari-ios')).toBe(false);
+    expect(isMobileBrowser('')).toBe(false);
+    expect(isMobileBrowser(null)).toBe(false);
+    expect(isMobileBrowser(undefined)).toBe(false);
+  });
+});

--- a/express-api/tests/scripts/drivers/web-mobile-chrome-android-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-mobile-chrome-android-driver.test.js
@@ -1,0 +1,552 @@
+/**
+ * web-mobile-chrome-android-driver.test.js
+ *
+ * Tests the Mobile Chrome on Android driver. Injects mock adb (via
+ * execFileSync) + mock playwright + mock fs so no real Android device,
+ * adb binary, or Chromium is required.
+ *
+ * Coverage areas:
+ *   - resolveAdbPath: walks the known-paths list, falls back to bare.
+ *   - pickFreePort: returns an integer port; cleanup happens.
+ *   - bootstrapAdbForward: device-attached / unauthorised / no-device /
+ *     adb-missing branches; `adb forward` arg shape; cleanup function.
+ *   - createMobileChromeAndroidDriver: factory wiring, methods exist,
+ *     CDP endpoint construction, failure modes (no contexts), close
+ *     cleanup, webRefreshRoomsList trailing-slash handling.
+ */
+
+jest.mock(
+  'playwright',
+  () => ({
+    chromium: { connectOverCDP: jest.fn() },
+  }),
+  { virtual: true },
+);
+
+const path = require('path');
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const {
+  KNOWN_ADB_PATHS,
+  resolveAdbPath,
+  pickFreePort,
+  bootstrapAdbForward,
+  createMobileChromeAndroidDriver,
+} = require(path.join(REPO_ROOT, 'express-api/scripts/drivers/web-mobile-chrome-android-driver'));
+
+// Helpers ─────────────────────────────────────────────────────────────
+
+function makeFsExistsMock(existingPaths) {
+  return {
+    existsSync: (p) => existingPaths.has(p),
+  };
+}
+
+function makeExecFileSyncMock({ devicesOutput = '', forwardOk = true } = {}) {
+  return jest.fn((bin, args) => {
+    if (args[0] === 'devices') return devicesOutput;
+    if (args[0] === 'forward' && args[1] === '--remove') return '';
+    if (args[0] === 'forward') {
+      if (!forwardOk) throw new Error('cannot bind to socket');
+      return '';
+    }
+    return '';
+  });
+}
+
+function makePagesByPersona(personas) {
+  const pages = {};
+  for (const name of personas) {
+    pages[name] = {
+      url: jest.fn(() => 'about:blank'),
+      goto: jest.fn(async () => {}),
+      evaluate: jest.fn(async () => ''),
+      close: jest.fn(),
+    };
+  }
+  return pages;
+}
+
+function makePlaywrightConnectOverCDPMock(pages) {
+  let pageIdx = 0;
+  const orderedPages = Object.values(pages);
+  const ctx = {
+    newPage: jest.fn(async () => {
+      const p = orderedPages[pageIdx] ?? orderedPages[orderedPages.length - 1];
+      pageIdx += 1;
+      return p;
+    }),
+  };
+  const browser = {
+    contexts: jest.fn(() => [ctx]),
+    close: jest.fn(async () => {}),
+  };
+  return {
+    chromium: {
+      connectOverCDP: jest.fn(async () => browser),
+    },
+  };
+}
+
+// resolveAdbPath ─────────────────────────────────────────────────────
+
+describe('resolveAdbPath', () => {
+  test('returns /opt/homebrew/bin/adb when it exists (Apple Silicon preferred)', () => {
+    const fs = makeFsExistsMock(new Set(['/opt/homebrew/bin/adb', '/usr/local/bin/adb']));
+    expect(resolveAdbPath(fs)).toBe('/opt/homebrew/bin/adb');
+  });
+
+  test('falls back to /usr/local/bin/adb when /opt/homebrew/bin/adb missing', () => {
+    const fs = makeFsExistsMock(new Set(['/usr/local/bin/adb']));
+    expect(resolveAdbPath(fs)).toBe('/usr/local/bin/adb');
+  });
+
+  test('falls back to /usr/bin/adb when both Homebrew paths missing', () => {
+    const fs = makeFsExistsMock(new Set(['/usr/bin/adb']));
+    expect(resolveAdbPath(fs)).toBe('/usr/bin/adb');
+  });
+
+  test("falls back to bare 'adb' when none of the known paths exist (CI mocks)", () => {
+    const fs = makeFsExistsMock(new Set());
+    expect(resolveAdbPath(fs)).toBe('adb');
+  });
+
+  test('survives fs.existsSync throwing (e.g. permission denied) per-path', () => {
+    const fs = {
+      existsSync: (p) => {
+        if (p === '/opt/homebrew/bin/adb') throw new Error('EACCES');
+        return p === '/usr/local/bin/adb';
+      },
+    };
+    expect(resolveAdbPath(fs)).toBe('/usr/local/bin/adb');
+  });
+
+  test('KNOWN_ADB_PATHS preserves Apple-Silicon-first priority ordering', () => {
+    expect(KNOWN_ADB_PATHS[0]).toBe('/opt/homebrew/bin/adb');
+    expect(KNOWN_ADB_PATHS).toContain('/usr/local/bin/adb');
+    expect(KNOWN_ADB_PATHS).toContain('/usr/bin/adb');
+  });
+});
+
+// pickFreePort ──────────────────────────────────────────────────────
+
+describe('pickFreePort', () => {
+  test('returns a numeric port via the real net implementation', async () => {
+    const port = await pickFreePort();
+    expect(typeof port).toBe('number');
+    expect(port).toBeGreaterThan(0);
+    expect(port).toBeLessThan(65536);
+  });
+
+  test('returns the port from the injected net mock when supplied', async () => {
+    const fakeServer = {
+      unref: jest.fn(),
+      on: jest.fn(),
+      listen: jest.fn((_p, _host, cb) => cb()),
+      close: jest.fn((cb) => cb()),
+      address: () => ({ port: 51234 }),
+    };
+    const netImpl = { createServer: () => fakeServer };
+    const port = await pickFreePort(netImpl);
+    expect(port).toBe(51234);
+  });
+
+  test('rejects when the listen server errors before binding', async () => {
+    const fakeServer = {
+      unref: jest.fn(),
+      _handlers: {},
+      on: function (evt, fn) {
+        this._handlers[evt] = fn;
+      },
+      listen: function () {
+        this._handlers.error(new Error('EADDRINUSE'));
+      },
+      close: jest.fn(),
+      address: jest.fn(),
+    };
+    const netImpl = { createServer: () => fakeServer };
+    await expect(pickFreePort(netImpl)).rejects.toThrow(/EADDRINUSE/);
+  });
+});
+
+// bootstrapAdbForward ────────────────────────────────────────────────
+
+describe('bootstrapAdbForward', () => {
+  test('happy path: device attached → forwards CDP socket, returns port + cleanup', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABCDEF12\tdevice\n',
+    });
+    const { port, removeForward } = await bootstrapAdbForward({
+      adbPath: '/opt/homebrew/bin/adb',
+      execFileSync,
+      pickPort: async () => 9333,
+    });
+    expect(port).toBe(9333);
+    expect(typeof removeForward).toBe('function');
+    expect(execFileSync).toHaveBeenCalledWith(
+      '/opt/homebrew/bin/adb',
+      ['devices'],
+      expect.any(Object),
+    );
+    expect(execFileSync).toHaveBeenCalledWith(
+      '/opt/homebrew/bin/adb',
+      ['forward', 'tcp:9333', 'localabstract:chrome_devtools_remote'],
+      expect.any(Object),
+    );
+  });
+
+  test('removeForward invokes adb forward --remove with the chosen port', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABCDEF12\tdevice\n',
+    });
+    const { removeForward } = await bootstrapAdbForward({
+      adbPath: '/opt/homebrew/bin/adb',
+      execFileSync,
+      pickPort: async () => 9333,
+    });
+    removeForward();
+    expect(execFileSync).toHaveBeenCalledWith(
+      '/opt/homebrew/bin/adb',
+      ['forward', '--remove', 'tcp:9333'],
+      expect.any(Object),
+    );
+  });
+
+  test('removeForward swallows errors so cleanup is best-effort', async () => {
+    let callCount = 0;
+    const execFileSync = jest.fn((bin, args) => {
+      callCount += 1;
+      if (callCount === 1) return 'List of devices attached\nABC\tdevice\n';
+      if (args[0] === 'forward' && args[1] !== '--remove') return '';
+      throw new Error('forward already removed');
+    });
+    const { removeForward } = await bootstrapAdbForward({
+      adbPath: '/opt/homebrew/bin/adb',
+      execFileSync,
+      pickPort: async () => 9333,
+    });
+    expect(() => removeForward()).not.toThrow();
+  });
+
+  test('throws actionable error when adb is missing (ENOENT)', async () => {
+    const execFileSync = jest.fn(() => {
+      const e = new Error('spawn adb ENOENT');
+      e.code = 'ENOENT';
+      throw e;
+    });
+    await expect(
+      bootstrapAdbForward({
+        adbPath: '/nope/adb',
+        execFileSync,
+        pickPort: async () => 9333,
+      }),
+    ).rejects.toThrow(/adb not found.*platform-tools/);
+  });
+
+  test('non-ENOENT adb error surfaces as generic adb-invocation error', async () => {
+    const execFileSync = jest.fn(() => {
+      throw new Error('permission denied');
+    });
+    await expect(
+      bootstrapAdbForward({
+        adbPath: '/opt/homebrew/bin/adb',
+        execFileSync,
+        pickPort: async () => 9333,
+      }),
+    ).rejects.toThrow(/adb invocation failed: permission denied/);
+  });
+
+  test('throws when no devices attached (empty list)', async () => {
+    const execFileSync = makeExecFileSyncMock({ devicesOutput: 'List of devices attached\n\n' });
+    await expect(
+      bootstrapAdbForward({
+        adbPath: '/opt/homebrew/bin/adb',
+        execFileSync,
+        pickPort: async () => 9333,
+      }),
+    ).rejects.toThrow(/no Android device attached/);
+  });
+
+  test('throws when the only device is unauthorised', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABCDEF12\tunauthorized\n',
+    });
+    await expect(
+      bootstrapAdbForward({
+        adbPath: '/opt/homebrew/bin/adb',
+        execFileSync,
+        pickPort: async () => 9333,
+      }),
+    ).rejects.toThrow(/unauthorised.*Allow USB debugging/);
+  });
+
+  test('proceeds when mix of unauthorised + authorised devices present', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tunauthorized\nDEF\tdevice\n',
+    });
+    const r = await bootstrapAdbForward({
+      adbPath: '/opt/homebrew/bin/adb',
+      execFileSync,
+      pickPort: async () => 9333,
+    });
+    expect(r.port).toBe(9333);
+  });
+
+  test('throws actionable error when adb forward itself fails', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tdevice\n',
+      forwardOk: false,
+    });
+    await expect(
+      bootstrapAdbForward({
+        adbPath: '/opt/homebrew/bin/adb',
+        execFileSync,
+        pickPort: async () => 9333,
+      }),
+    ).rejects.toThrow(/adb forward failed.*USB Web debugging/);
+  });
+
+  test('uses resolveAdbPath default when no adbPath supplied (smoke)', async () => {
+    // We can't easily intercept resolveAdbPath's fs check without
+    // making it injectable into bootstrapAdbForward; the test just
+    // verifies the call doesn't blow up at the default-resolution step
+    // when execFileSync is mocked to error cleanly.
+    const execFileSync = jest.fn(() => {
+      const e = new Error('spawn adb ENOENT');
+      e.code = 'ENOENT';
+      throw e;
+    });
+    await expect(bootstrapAdbForward({ execFileSync, pickPort: async () => 9333 })).rejects.toThrow(
+      /adb not found/,
+    );
+  });
+});
+
+// createMobileChromeAndroidDriver ────────────────────────────────────
+
+describe('createMobileChromeAndroidDriver', () => {
+  test('returns a driver with the expected method surface', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tdevice\n',
+    });
+    const pages = makePagesByPersona(['Alice']);
+    const playwrightImpl = makePlaywrightConnectOverCDPMock(pages);
+    const driver = await createMobileChromeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9333,
+    });
+    expect(typeof driver.webRefreshRoomsList).toBe('function');
+    expect(typeof driver.webUiDump).toBe('function');
+    expect(typeof driver.close).toBe('function');
+    expect(driver._port).toBe(9333);
+  });
+
+  test('connectOverCDP is called with 127.0.0.1:<port> endpoint URL', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tdevice\n',
+    });
+    const pages = makePagesByPersona(['Alice']);
+    const playwrightImpl = makePlaywrightConnectOverCDPMock(pages);
+    await createMobileChromeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9444,
+    });
+    expect(playwrightImpl.chromium.connectOverCDP).toHaveBeenCalledWith('http://127.0.0.1:9444');
+  });
+
+  test('webRefreshRoomsList navigates to <baseURL>/rooms on the persona Page', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tdevice\n',
+    });
+    const pages = makePagesByPersona(['Alice']);
+    const playwrightImpl = makePlaywrightConnectOverCDPMock(pages);
+    const driver = await createMobileChromeAndroidDriver({
+      baseURL: 'http://localhost:8888',
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9333,
+    });
+    const ok = await driver.webRefreshRoomsList('Alice');
+    expect(ok).toBe(true);
+    expect(pages.Alice.goto).toHaveBeenCalledWith('http://localhost:8888/rooms');
+  });
+
+  test('webRefreshRoomsList trailing slash collapses (no `//rooms`)', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tdevice\n',
+    });
+    const pages = makePagesByPersona(['Alice']);
+    const playwrightImpl = makePlaywrightConnectOverCDPMock(pages);
+    const driver = await createMobileChromeAndroidDriver({
+      baseURL: 'http://localhost:8888/',
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9333,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    expect(pages.Alice.goto).toHaveBeenCalledWith('http://localhost:8888/rooms');
+  });
+
+  test('webRefreshRoomsList page.goto rejection → returns false (no unhandled)', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tdevice\n',
+    });
+    const pages = makePagesByPersona(['Alice']);
+    pages.Alice.goto = jest.fn(async () => {
+      throw new Error('net::ERR_INTERNET_DISCONNECTED');
+    });
+    const playwrightImpl = makePlaywrightConnectOverCDPMock(pages);
+    const driver = await createMobileChromeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9333,
+    });
+    const ok = await driver.webRefreshRoomsList('Alice');
+    expect(ok).toBe(false);
+  });
+
+  test('subsequent webRefreshRoomsList for the same persona reuses the Page', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tdevice\n',
+    });
+    const pages = makePagesByPersona(['Alice']);
+    const playwrightImpl = makePlaywrightConnectOverCDPMock(pages);
+    const driver = await createMobileChromeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9333,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await driver.webRefreshRoomsList('Alice');
+    expect(pages.Alice.goto).toHaveBeenCalledTimes(2);
+  });
+
+  test('webUiDump navigates to baseURL when page is at about:blank', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tdevice\n',
+    });
+    const pages = makePagesByPersona(['default']);
+    pages.default.evaluate = jest.fn(async () => 'Hello ShyTalk');
+    const playwrightImpl = makePlaywrightConnectOverCDPMock(pages);
+    const driver = await createMobileChromeAndroidDriver({
+      baseURL: 'http://localhost:8888',
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9333,
+    });
+    const text = await driver.webUiDump();
+    expect(text).toBe('Hello ShyTalk');
+    expect(pages.default.goto).toHaveBeenCalledWith('http://localhost:8888/');
+  });
+
+  test('webUiDump returns empty string on evaluate rejection', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tdevice\n',
+    });
+    const pages = makePagesByPersona(['default']);
+    pages.default.evaluate = jest.fn(async () => {
+      throw new Error('CDP gone');
+    });
+    const playwrightImpl = makePlaywrightConnectOverCDPMock(pages);
+    const driver = await createMobileChromeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9333,
+    });
+    const text = await driver.webUiDump();
+    expect(text).toBe('');
+  });
+
+  test('connectOverCDP rejection → cleanup forward + actionable error', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tdevice\n',
+    });
+    const playwrightImpl = {
+      chromium: {
+        connectOverCDP: jest.fn(async () => {
+          throw new Error('ECONNREFUSED');
+        }),
+      },
+    };
+    await expect(
+      createMobileChromeAndroidDriver({
+        execFileSync,
+        playwrightImpl,
+        pickPort: async () => 9333,
+      }),
+    ).rejects.toThrow(/connectOverCDP.*ECONNREFUSED.*chrome:\/\/inspect/);
+    // Cleanup forward must have been called even though the bootstrap failed
+    expect(execFileSync).toHaveBeenCalledWith(
+      expect.any(String),
+      ['forward', '--remove', 'tcp:9333'],
+      expect.any(Object),
+    );
+  });
+
+  test('zero contexts on attached browser → actionable error + forward cleanup', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tdevice\n',
+    });
+    const browser = { contexts: () => [], close: jest.fn(async () => {}) };
+    const playwrightImpl = {
+      chromium: { connectOverCDP: jest.fn(async () => browser) },
+    };
+    await expect(
+      createMobileChromeAndroidDriver({
+        execFileSync,
+        playwrightImpl,
+        pickPort: async () => 9333,
+      }),
+    ).rejects.toThrow(/0 contexts.*incognito-only/);
+    expect(browser.close).toHaveBeenCalled();
+  });
+
+  test('close removes the adb forward + closes browser + pages', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tdevice\n',
+    });
+    const pages = makePagesByPersona(['Alice', 'Bob']);
+    const playwrightImpl = makePlaywrightConnectOverCDPMock(pages);
+    const driver = await createMobileChromeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9333,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await driver.webRefreshRoomsList('Bob');
+    await driver.close();
+    expect(pages.Alice.close).toHaveBeenCalledTimes(1);
+    expect(pages.Bob.close).toHaveBeenCalledTimes(1);
+    expect(driver._browser.close).toHaveBeenCalledTimes(1);
+    expect(execFileSync).toHaveBeenCalledWith(
+      expect.any(String),
+      ['forward', '--remove', 'tcp:9333'],
+      expect.any(Object),
+    );
+  });
+
+  test('close swallows page-close + browser-close errors (best-effort)', async () => {
+    const execFileSync = makeExecFileSyncMock({
+      devicesOutput: 'List of devices attached\nABC\tdevice\n',
+    });
+    const pages = makePagesByPersona(['Alice']);
+    pages.Alice.close = jest.fn(() => Promise.reject(new Error('already closed')));
+    const playwrightImpl = makePlaywrightConnectOverCDPMock(pages);
+    playwrightImpl.chromium.connectOverCDP = jest.fn(async () => ({
+      contexts: () => [
+        {
+          newPage: async () => pages.Alice,
+        },
+      ],
+      close: jest.fn(() => Promise.reject(new Error('CDP gone'))),
+    }));
+    const driver = await createMobileChromeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9333,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await expect(driver.close()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Third of the matrix-completeness PRs (after #898 Playwright multi-browser and #899 ios-appium-driver). Drives the actual Chrome browser running on the connected Android device via CDP-over-adb — not Playwright's "Pixel 5 emulation" (which is just desktop Chromium with mobile UA/viewport).

## Why

The matrix requires real Android × Mobile Chrome coverage on **both local AND dev**. Operator directive 2026-05-30: *"on the DEV environment, use the Android device. but use the chrome browser on the MAC and the android device."*

PR #898 enabled `chromium`/`firefox`/`webkit`/`edge` on Mac desktop but left mobile-on-device empty. This PR fills the Android Chrome cell so dev validation actually exercises Chrome on the physical Android device that journey tests target.

## What

### `scripts/drivers/web-mobile-chrome-android-driver.js`
- `adb forward tcp:<port> localabstract:chrome_devtools_remote` — tunnels `localhost:<port>` to Chrome's CDP socket on the device.
- Port chosen via `pickFreePort()` so concurrent dispatches + stale `adb forward` entries don't collide.
- `playwright.chromium.connectOverCDP('http://127.0.0.1:<port>')` attaches Playwright to the running Chrome.
- `bootstrapAdbForward` validates device presence and surfaces actionable errors for the operator (no device / unauthorised / Chrome not running / chrome://flags hint).
- `resolveAdbPath` walks known macOS install paths (`/opt/homebrew/bin/adb`, `/usr/local/bin/adb`, `/usr/bin/adb`) — absolute paths satisfy `sonarjs/no-os-command-from-path` without a top-of-file disable. PATH fallback only for CI test mocks.
- Method surface mirrors `web-playwright-driver.js` (`webRefreshRoomsList`, `webUiDump`, `close`) so runner matchers don't care which driver they got.

### `scripts/browser-allowlist.js`
- Per-target browser allowlist extracted from `manual-qa-runner.js` so unit tests can pin the matrix without subprocessing the runner or regex-scraping its source.
- Adds `mobile-chrome-android` to the `local` + `dev` allowlists; `prod` stays chromium-only per the read-only-verification policy.

### `scripts/manual-qa-runner.js`
- `--browser` flag now accepts `mobile-chrome-android`.
- Runner's `playwright`/`all` branch dispatches to `createMobileChromeAndroidDriver` for that slug, `createWebDriver` for the four desktop slugs.
- Allowlist enforcement uses the extracted `allowedBrowsersFor(target)` helper.

## Tests

### `web-mobile-chrome-android-driver.test.js` — 31 tests
- `resolveAdbPath`: path walking + `fs.existsSync` exceptions + bare fallback + known-paths-order pin.
- `pickFreePort`: real Node primitive + injected mock + listen-error rejection.
- `bootstrapAdbForward`: happy path + no-device + only-unauthorised + mixed authorised/unauthorised + adb-forward-failed + ENOENT-actionable-error + `removeForward` arg shape + cleanup-swallows-errors.
- `createMobileChromeAndroidDriver`: factory wiring + `connectOverCDP` endpoint URL pin + `webRefreshRoomsList` navigation + trailing-slash collapse + `page.goto` rejection → false + page-reuse + `webUiDump` evaluate-rejection-catches-properly (the test caught a `return page.evaluate(...)` bug where the rejection escaped the catch — fixed with explicit `await`) + zero-contexts actionable error + `close` cleans forward + browser + pages + close swallows close-errors.

### `browser-allowlist.test.js` — 25 tests
- `DESKTOP_BROWSERS` shape + chromium-first default + no `mobile-*` in desktop.
- `MOBILE_BROWSERS` contains `mobile-chrome-android` + every entry is `mobile-*`.
- `SUPPORTED_BROWSERS` = desktop ∪ mobile + no duplicates.
- `TARGET_BROWSER_ALLOWLIST` per-target contents, with explicit pins that `dev` REJECTS firefox/webkit/edge and `prod` REJECTS every mobile browser. Exactly-three-targets pin so a future addition can't silently slip past.
- `allowedBrowsersFor` known + unknown + null + undefined targets.
- `isMobileBrowser` positive + negative + unknown slugs.

### Suite
Full express-api: 258 / 258 pass, 9889 tests + 8 expected skipped.
`npm run lint` + `npm run format:check` clean.

## Operator one-time setup (Mobile Chrome on Android)

1. Enable USB debugging on the device.
2. Open Chrome on the device → chrome://flags → enable "Enable command line on non-rooted devices" + restart Chrome (alternative: Chrome settings → Developer options → enable USB Web debugging).
3. Plug the device in via USB and authorise the debugging prompt.
4. From the runner, pass `--browser mobile-chrome-android`. The driver handles `adb forward` + cleanup automatically.

## Out of scope

- Samsung Internet / Mobile Firefox / Mobile Edge on Android — separate PRs (E/F/G) so each driver gets focused tests + reviewer attention.
- Mobile Safari / Chrome iOS / Firefox iOS / Edge iOS — separate PRs (D/H) since they go via Appium safari context + WebKit wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)