### PR TITLE
feat(qa-runner): web-mobile-safari-ios driver — Appium safari context

### DIFF
--- a/express-api/scripts/browser-allowlist.js
+++ b/express-api/scripts/browser-allowlist.js
@@ -21,10 +21,20 @@ const DESKTOP_BROWSERS = ['chromium', 'firefox', 'webkit', 'edge'];
 // Browsers that route through a non-default driver factory inside the
 // runner's `--driver playwright|all` block. New mobile-browser drivers
 // register their slug here AND in the per-target allowlist below.
-const MOBILE_BROWSERS = ['mobile-chrome-android'];
+// Order intentional: Android slugs first, then iOS — keeps test
+// `.toEqual` expectations stable across PRs that add more of either.
+const MOBILE_BROWSERS = ['mobile-chrome-android', 'mobile-safari-ios'];
 
 const SUPPORTED_BROWSERS = [...DESKTOP_BROWSERS, ...MOBILE_BROWSERS];
 
+// Per-target allowlist:
+//   local — full matrix (every desktop browser + every mobile slug).
+//   dev   — operator policy 2026-05-30: chromium on Mac + mobile-chrome
+//           on Android. Mobile Safari is local-only because the
+//           dev-tier Android-Chrome cell + Mac-Chrome cell are the
+//           operator's chosen dev gate; iOS WebKit coverage lives in
+//           the local matrix.
+//   prod  — chromium only (read-only verification gate).
 const TARGET_BROWSER_ALLOWLIST = {
   local: [...DESKTOP_BROWSERS, ...MOBILE_BROWSERS],
   dev: ['chromium', 'mobile-chrome-android'],

--- a/express-api/scripts/drivers/web-mobile-safari-ios-driver.js
+++ b/express-api/scripts/drivers/web-mobile-safari-ios-driver.js
@@ -1,0 +1,225 @@
+/**
+ * Web driver: Mobile Safari on iPhone via Appium safari context.
+ *
+ * Drives the actual Mobile Safari browser on the operator's connected
+ * physical iPhone. The Appium XCUITest driver bootstraps a session with
+ * `browserName: 'safari'` capability; the underlying transport is the
+ * Safari WebKit Remote Inspector (which Appium signs + manages through
+ * WebDriverAgent the same way ios-appium-driver.js does for the app).
+ *
+ * App Store policy means every "browser" on iPhone (Chrome iOS, Firefox
+ * iOS, Edge iOS) is required to use WebKit. So this driver is the
+ * canonical iOS web driver; the other iOS-browser drivers in upcoming
+ * PRs are thin wrappers that share this session's transport.
+ *
+ * Wire-up
+ * -------
+ * 1. Operator has already done the Appium setup steps from
+ *    `ios-appium-setup.md` (install Appium, install xcuitest driver,
+ *    set WDA_TEAM_ID, pair iPhone, trust dev cert, run `appium server`).
+ * 2. Pass `--browser mobile-safari-ios` to the runner.
+ * 3. The driver opens a new session with `browserName: 'safari'`;
+ *    Appium handles all the WDA + WebKit remote-inspector plumbing.
+ * 4. Driver invokes the standard W3C WebDriver protocol for navigation,
+ *    element find, and page-source dumps.
+ *
+ * Method-naming contract: mirrors `web-playwright-driver.js`. Same
+ * surface so runner matchers don't care which driver is active.
+ *
+ * Failure modes (all return false + log, never throw):
+ *   - Appium server not reachable → actionable error pointing at port
+ *     4723 + setup doc.
+ *   - WDA_TEAM_ID missing → re-uses ios-appium-driver's same error text
+ *     to keep operator's mental model consistent.
+ *   - No iPhone connected → uses xcrun devicectl from the existing iOS
+ *     driver's selectUdid (shared via module re-export).
+ *   - Safari is not the focused app → Appium safari context auto-focuses
+ *     it via the WebKit Remote Inspector activation; no operator action
+ *     required.
+ */
+
+/* eslint-disable no-console -- driver methods log diagnostics for the
+   manual QA runner (operator-facing CLI), not application code. */
+
+const path = require('path');
+
+// Reuse ios-appium-driver's selectUdid (already pinned in its tests).
+// This driver and that one share the same device-selection logic so
+// concurrent sessions target the same iPhone.
+const REPO_ROOT_DRIVERS = path.resolve(__dirname);
+const { selectUdid } = require(path.join(REPO_ROOT_DRIVERS, 'ios-appium-driver'));
+
+const DEFAULT_APPIUM_BASE_URL = 'http://localhost:4723';
+
+/**
+ * Create a Mobile Safari iOS driver.
+ *
+ *   const driver = await createMobileSafariIosDriver({ baseURL });
+ *   await driver.webRefreshRoomsList('Alice');
+ *   await driver.close();
+ *
+ * Injectable deps (test-only):
+ *   - fetchImpl — HTTP client (default globalThis.fetch)
+ *   - selectUdidImpl — udid picker (default the iOS appium driver's)
+ *   - udid — pre-resolved udid (bypasses selectUdidImpl)
+ *
+ * Required env:
+ *   WDA_TEAM_ID — Apple Developer team ID, same one ios-appium-driver
+ *                 uses. Appium signs WDA + the Safari Remote Inspector
+ *                 bridge with this team.
+ *
+ * Optional:
+ *   APPIUM_BASE_URL — Appium server URL (default http://localhost:4723)
+ */
+async function createMobileSafariIosDriver({
+  baseURL = 'http://localhost:8888',
+  appiumBaseUrl = process.env.APPIUM_BASE_URL || DEFAULT_APPIUM_BASE_URL,
+  wdaTeamId = process.env.WDA_TEAM_ID,
+  udid: preferredUdid,
+  fetchImpl = globalThis.fetch,
+  selectUdidImpl = selectUdid,
+} = {}) {
+  const udid = selectUdidImpl(preferredUdid);
+  if (!udid) {
+    throw new Error(
+      'createMobileSafariIosDriver: no connected iPhone found via `xcrun devicectl list devices`. Pair the device with Xcode, ensure it shows "available" or "connected", then re-run.',
+    );
+  }
+  if (!wdaTeamId) {
+    throw new Error(
+      'createMobileSafariIosDriver: WDA_TEAM_ID env var is required. This is the operator\'s Apple Developer team ID — Appium uses it to sign WebDriverAgent + the Safari Remote Inspector bridge. Find it via `security find-identity -v -p codesigning | grep "Apple Development"`.',
+    );
+  }
+
+  // Lazy session bootstrap. The first webXxx call pays the
+  // session-creation cost (~10-20s including WDA + Safari Remote
+  // Inspector handshake). Subsequent calls reuse.
+  let _sessionId = null;
+  async function ensureSession() {
+    if (_sessionId) return _sessionId;
+    const caps = {
+      capabilities: {
+        alwaysMatch: {
+          platformName: 'iOS',
+          'appium:automationName': 'XCUITest',
+          'appium:udid': udid,
+          // No bundleId — instead use the magic `browserName` cap that
+          // tells the XCUITest driver to bootstrap Mobile Safari + its
+          // WebKit Remote Inspector bridge.
+          'appium:browserName': 'safari',
+          'appium:xcodeSigningId': 'Apple Developer',
+          'appium:xcodeOrgId': wdaTeamId,
+          'appium:useNewWDA': false,
+          'appium:noReset': true,
+          // Auto-accept any URL-bar autofill / safari-suggestion prompts
+          // so the operator doesn't have to babysit the device.
+          'appium:safariIgnoreFraudWarning': true,
+          'appium:safariOpenLinksInBackground': false,
+        },
+      },
+    };
+    const r = await fetchImpl(`${appiumBaseUrl}/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(caps),
+    });
+    if (!r.ok) {
+      const errText = await r.text();
+      throw new Error(
+        `Appium /session failed (${r.status}): ${errText.slice(0, 500)}. Confirm the Appium server is running on ${appiumBaseUrl} + xcuitest driver is installed (\`appium driver install xcuitest\`).`,
+      );
+    }
+    const body = await r.json();
+    _sessionId = body.value?.sessionId || body.sessionId;
+    if (!_sessionId) {
+      throw new Error(
+        `Appium /session returned no sessionId: ${JSON.stringify(body).slice(0, 500)}`,
+      );
+    }
+    return _sessionId;
+  }
+
+  async function navigateTo(url) {
+    const sid = await ensureSession();
+    const r = await fetchImpl(`${appiumBaseUrl}/session/${sid}/url`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url }),
+    });
+    if (!r.ok) {
+      throw new Error(
+        `Appium /url failed (${r.status}) for ${url}: ${(await r.text()).slice(0, 300)}`,
+      );
+    }
+  }
+
+  async function getPageText() {
+    const sid = await ensureSession();
+    // Use the W3C /execute/sync endpoint to read document.body.innerText.
+    // /source returns XML AppML, not the rendered text we want.
+    const r = await fetchImpl(`${appiumBaseUrl}/session/${sid}/execute/sync`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        script: 'return document.body.innerText || "";',
+        args: [],
+      }),
+    });
+    if (!r.ok) {
+      throw new Error(
+        `Appium /execute/sync failed (${r.status}): ${(await r.text()).slice(0, 300)}`,
+      );
+    }
+    const body = await r.json();
+    return body.value || '';
+  }
+
+  const driver = {
+    _udid: udid,
+    _appiumBaseUrl: appiumBaseUrl,
+    _baseURL: baseURL,
+  };
+
+  // webRefreshRoomsList — same contract as desktop + mobile-chrome drivers.
+  driver.webRefreshRoomsList = async (_name) => {
+    try {
+      await navigateTo(`${baseURL.replace(/\/$/, '')}/rooms`);
+      return true;
+    } catch (e) {
+      console.error(
+        `[mobile-safari-ios-driver] webRefreshRoomsList(${_name}) failed: ${e.message}`,
+      );
+      return false;
+    }
+  };
+
+  // webUiDump — visible body text via JS-injection. Per-persona Page
+  // isolation isn't modelled here because Mobile Safari shares one
+  // session per Appium connection; multi-persona web on a single iPhone
+  // would need per-persona Safari profile switching, out of scope.
+  driver.webUiDump = async () => {
+    try {
+      return await getPageText();
+    } catch (e) {
+      console.error(`[mobile-safari-ios-driver] webUiDump failed: ${e.message}`);
+      return '';
+    }
+  };
+
+  driver.close = async () => {
+    if (!_sessionId) return;
+    try {
+      await fetchImpl(`${appiumBaseUrl}/session/${_sessionId}`, { method: 'DELETE' });
+    } catch (_e) {
+      /* best-effort */
+    }
+    _sessionId = null;
+  };
+
+  return driver;
+}
+
+module.exports = {
+  DEFAULT_APPIUM_BASE_URL,
+  createMobileSafariIosDriver,
+};

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -15520,7 +15520,9 @@ async function main() {
     //     direct launch via web-playwright-driver.js
     //   - mobile-chrome-android → CDP-over-adb to the real Chrome on
     //     the connected Android device via web-mobile-chrome-android-driver.js
-    // The runner's matcher surface is the same — both drivers expose the
+    //   - mobile-safari-ios → Appium safari-context session on the
+    //     connected iPhone via web-mobile-safari-ios-driver.js
+    // The runner's matcher surface is the same — every driver exposes the
     // ctx.webDriver method namespace, so scenarios don't care which one
     // is active.
     const baseURL = TARGETS[opts.target].webBase || 'http://localhost:8888';
@@ -15529,6 +15531,9 @@ async function main() {
         createMobileChromeAndroidDriver,
       } = require('./drivers/web-mobile-chrome-android-driver');
       webDriver = await createMobileChromeAndroidDriver({ baseURL });
+    } else if (opts.browser === 'mobile-safari-ios') {
+      const { createMobileSafariIosDriver } = require('./drivers/web-mobile-safari-ios-driver');
+      webDriver = await createMobileSafariIosDriver({ baseURL });
     } else {
       const { createWebDriver } = require('./drivers/web-playwright-driver');
       webDriver = await createWebDriver({

--- a/express-api/tests/scripts/drivers/web-mobile-safari-ios-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-mobile-safari-ios-driver.test.js
@@ -1,0 +1,403 @@
+/**
+ * web-mobile-safari-ios-driver.test.js
+ *
+ * Tests the Mobile Safari iOS driver. The driver delegates udid
+ * selection to ios-appium-driver's exported selectUdid; we inject a
+ * mock selectUdidImpl to avoid needing a real /usr/bin/xcrun.
+ * fetchImpl is mocked so no real Appium server / iPhone is needed.
+ *
+ * Coverage areas:
+ *   - createMobileSafariIosDriver input validation (udid missing,
+ *     WDA_TEAM_ID missing).
+ *   - Session bootstrap: POST /session with browserName:safari + the
+ *     other XCUITest caps; sessionId extraction from both response
+ *     shapes (W3C value.sessionId + legacy sessionId).
+ *   - webRefreshRoomsList: navigates to <baseURL>/rooms; trailing-slash
+ *     collapse; failure → returns false.
+ *   - webUiDump: invokes /execute/sync with the innerText script;
+ *     failure → returns ''.
+ *   - close: DELETEs session; session-not-yet-started no-op; swallows
+ *     network errors.
+ */
+
+const path = require('path');
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const { DEFAULT_APPIUM_BASE_URL, createMobileSafariIosDriver } = require(
+  path.join(REPO_ROOT, 'express-api/scripts/drivers/web-mobile-safari-ios-driver'),
+);
+
+// Helpers ─────────────────────────────────────────────────────────────
+
+function makeJsonResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function makeTextResponse(text, status = 500) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => text,
+    json: async () => ({ value: { error: text } }),
+  };
+}
+
+function makeFetchMock(handlers) {
+  const calls = [];
+  const fetchImpl = jest.fn(async (url, opts = {}) => {
+    calls.push({ url, opts });
+    for (const h of handlers) {
+      if (h.match(url, opts)) return h.respond(url, opts);
+    }
+    return makeJsonResponse({ value: { error: 'unmocked endpoint' } }, 404);
+  });
+  fetchImpl.calls = calls;
+  return fetchImpl;
+}
+
+function defaultHandlers({ sessionId = 'sess-abc', textValue = 'Hello' } = {}) {
+  return [
+    {
+      match: (url, opts) => url.endsWith('/session') && opts.method === 'POST',
+      respond: () => makeJsonResponse({ value: { sessionId } }),
+    },
+    {
+      match: (url, opts) => url.endsWith(`/session/${sessionId}/url`) && opts.method === 'POST',
+      respond: () => makeJsonResponse({ value: null }),
+    },
+    {
+      match: (url, opts) =>
+        url.endsWith(`/session/${sessionId}/execute/sync`) && opts.method === 'POST',
+      respond: () => makeJsonResponse({ value: textValue }),
+    },
+    {
+      match: (url, opts) => url.endsWith(`/session/${sessionId}`) && opts.method === 'DELETE',
+      respond: () => makeJsonResponse({ value: null }),
+    },
+  ];
+}
+
+// createMobileSafariIosDriver — input validation ──────────────────────
+
+describe('createMobileSafariIosDriver — input validation', () => {
+  test('throws when no iPhone is connected (selectUdid returns null)', async () => {
+    await expect(
+      createMobileSafariIosDriver({
+        wdaTeamId: 'TEAM123',
+        selectUdidImpl: () => null,
+        fetchImpl: makeFetchMock([]),
+      }),
+    ).rejects.toThrow(/no connected iPhone found.*xcrun devicectl/);
+  });
+
+  test('throws when WDA_TEAM_ID is missing', async () => {
+    await expect(
+      createMobileSafariIosDriver({
+        wdaTeamId: undefined,
+        selectUdidImpl: () => 'ABCDEFG-12345678',
+        fetchImpl: makeFetchMock([]),
+      }),
+    ).rejects.toThrow(/WDA_TEAM_ID env var is required/);
+  });
+
+  test('preferred udid is forwarded to selectUdidImpl', async () => {
+    const selectUdidImpl = jest.fn((p) => p);
+    await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM123',
+      udid: 'PREFERRED-UDID',
+      selectUdidImpl,
+      fetchImpl: makeFetchMock([]),
+    });
+    expect(selectUdidImpl).toHaveBeenCalledWith('PREFERRED-UDID');
+  });
+
+  test('returned driver exposes the expected methods', async () => {
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM123',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl: makeFetchMock([]),
+    });
+    expect(typeof driver.webRefreshRoomsList).toBe('function');
+    expect(typeof driver.webUiDump).toBe('function');
+    expect(typeof driver.close).toBe('function');
+  });
+});
+
+// Session bootstrap ──────────────────────────────────────────────────
+
+describe('createMobileSafariIosDriver — session bootstrap', () => {
+  test('POSTs /session with browserName=safari + xcodeOrgId capabilities', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM123',
+      selectUdidImpl: () => 'UDID-A',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    const sessionCall = fetchImpl.calls.find((c) => c.url.endsWith('/session'));
+    expect(sessionCall).toBeDefined();
+    const body = JSON.parse(sessionCall.opts.body);
+    const caps = body.capabilities.alwaysMatch;
+    expect(caps.platformName).toBe('iOS');
+    expect(caps['appium:automationName']).toBe('XCUITest');
+    expect(caps['appium:browserName']).toBe('safari');
+    expect(caps['appium:udid']).toBe('UDID-A');
+    expect(caps['appium:xcodeOrgId']).toBe('TEAM123');
+    // No bundleId — Safari mode doesn't take an app target.
+    expect(caps['appium:bundleId']).toBeUndefined();
+  });
+
+  test('subsequent calls reuse the cached sessionId (no second /session POST)', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM123',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await driver.webRefreshRoomsList('Alice');
+    const sessionPosts = fetchImpl.calls.filter(
+      (c) => c.url.endsWith('/session') && c.opts.method === 'POST',
+    );
+    expect(sessionPosts).toHaveLength(1);
+  });
+
+  test('falls back to top-level sessionId when value.sessionId is missing (legacy resp)', async () => {
+    const fetchImpl = makeFetchMock([
+      {
+        match: (url, opts) => url.endsWith('/session') && opts.method === 'POST',
+        respond: () => makeJsonResponse({ sessionId: 'legacy-sess' }),
+      },
+      {
+        match: (url) => url.endsWith('/session/legacy-sess/url'),
+        respond: () => makeJsonResponse({ value: null }),
+      },
+    ]);
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM123',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    const ok = await driver.webRefreshRoomsList('Alice');
+    expect(ok).toBe(true);
+  });
+
+  test('throws actionable error when /session returns non-2xx', async () => {
+    const fetchImpl = makeFetchMock([
+      {
+        match: (url, opts) => url.endsWith('/session') && opts.method === 'POST',
+        respond: () => makeTextResponse('Cannot create session: WDA not installed', 500),
+      },
+    ]);
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM123',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    const ok = await driver.webRefreshRoomsList('Alice');
+    expect(ok).toBe(false);
+  });
+
+  test('throws when /session returns no sessionId at all (degenerate body)', async () => {
+    const fetchImpl = makeFetchMock([
+      {
+        match: (url, opts) => url.endsWith('/session') && opts.method === 'POST',
+        respond: () => makeJsonResponse({ value: {} }),
+      },
+    ]);
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM123',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    const ok = await driver.webRefreshRoomsList('Alice');
+    expect(ok).toBe(false);
+  });
+
+  test('honours injected appiumBaseUrl over the default', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM123',
+      selectUdidImpl: () => 'UDID',
+      appiumBaseUrl: 'http://localhost:7777',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    expect(fetchImpl.calls[0].url).toBe('http://localhost:7777/session');
+  });
+
+  test('DEFAULT_APPIUM_BASE_URL points at localhost:4723', () => {
+    expect(DEFAULT_APPIUM_BASE_URL).toBe('http://localhost:4723');
+  });
+});
+
+// webRefreshRoomsList ────────────────────────────────────────────────
+
+describe('webRefreshRoomsList', () => {
+  test('POSTs /session/<id>/url with <baseURL>/rooms', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      baseURL: 'http://localhost:8888',
+      fetchImpl,
+    });
+    const ok = await driver.webRefreshRoomsList('Alice');
+    expect(ok).toBe(true);
+    const urlCall = fetchImpl.calls.find((c) => c.url.includes('/url'));
+    expect(JSON.parse(urlCall.opts.body)).toEqual({ url: 'http://localhost:8888/rooms' });
+  });
+
+  test('trailing slash collapses (no `//rooms`)', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      baseURL: 'http://localhost:8888/',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    const urlCall = fetchImpl.calls.find((c) => c.url.includes('/url'));
+    expect(JSON.parse(urlCall.opts.body)).toEqual({ url: 'http://localhost:8888/rooms' });
+  });
+
+  test('returns false when /url returns non-2xx (no unhandled rejection)', async () => {
+    // Custom handler ahead of defaultHandlers — first-match-wins in
+    // makeFetchMock, so a failing /url handler must precede the success
+    // one from defaultHandlers.
+    const fetchImpl = makeFetchMock([
+      {
+        match: (url, opts) => /\/session\/sess-abc\/url$/.test(url) && opts.method === 'POST',
+        respond: () => makeTextResponse('webkit: navigation timed out', 500),
+      },
+      ...defaultHandlers(),
+    ]);
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    const ok = await driver.webRefreshRoomsList('Alice');
+    expect(ok).toBe(false);
+  });
+});
+
+// webUiDump ─────────────────────────────────────────────────────────
+
+describe('webUiDump', () => {
+  test('invokes /execute/sync with the innerText script + returns the value', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers({ textValue: 'Welcome to ShyTalk' }));
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    const text = await driver.webUiDump();
+    expect(text).toBe('Welcome to ShyTalk');
+    const execCall = fetchImpl.calls.find((c) => c.url.includes('/execute/sync'));
+    expect(execCall).toBeDefined();
+    const body = JSON.parse(execCall.opts.body);
+    expect(body.script).toMatch(/document\.body\.innerText/);
+    expect(body.args).toEqual([]);
+  });
+
+  test('returns empty string when /execute/sync fails', async () => {
+    const fetchImpl = makeFetchMock([
+      // Custom failing /execute/sync ahead of defaults — first-match-wins.
+      {
+        match: (url) => url.includes('/execute/sync'),
+        respond: () => makeTextResponse('CDP timeout', 500),
+      },
+      ...defaultHandlers(),
+    ]);
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    expect(await driver.webUiDump()).toBe('');
+  });
+
+  test('returns empty string when /execute/sync value is missing', async () => {
+    const fetchImpl = makeFetchMock([
+      // Custom value:null handler ahead of defaults — first-match-wins.
+      {
+        match: (url) => url.includes('/execute/sync'),
+        respond: () => makeJsonResponse({ value: null }),
+      },
+      ...defaultHandlers(),
+    ]);
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    expect(await driver.webUiDump()).toBe('');
+  });
+});
+
+// close ─────────────────────────────────────────────────────────────
+
+describe('close', () => {
+  test('DELETEs /session/<id> after a session was created', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await driver.close();
+    const del = fetchImpl.calls.find((c) => c.opts.method === 'DELETE');
+    expect(del).toBeDefined();
+    expect(del.url).toMatch(/\/session\/sess-abc$/);
+  });
+
+  test('no-ops when called before any session exists (fast-path)', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.close();
+    // No POST /session because we never called webXxx; no DELETE either.
+    expect(fetchImpl.calls.filter((c) => c.opts.method === 'DELETE')).toHaveLength(0);
+  });
+
+  test('swallows DELETE-side network errors so cleanup is best-effort', async () => {
+    const fetchImpl = makeFetchMock([
+      ...defaultHandlers(),
+      {
+        match: (_url, opts) => opts.method === 'DELETE',
+        respond: () => {
+          throw new Error('Appium server gone');
+        },
+      },
+    ]);
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await expect(driver.close()).resolves.toBeUndefined();
+  });
+
+  test('second close after first is a no-op (sessionId cleared)', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileSafariIosDriver({
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await driver.close();
+    await driver.close();
+    expect(fetchImpl.calls.filter((c) => c.opts.method === 'DELETE')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fourth of the matrix-completeness PRs (after #898 Playwright multi-browser, #899 ios-appium-driver, #900 web-mobile-chrome-android-driver). Drives Mobile Safari on the connected iPhone via Appium's safari context — the canonical iOS web driver, since App Store policy mandates every "browser" on iPhone (Chrome iOS / Firefox iOS / Edge iOS) use WebKit.

## Why

Local matrix needs full iPhone × web coverage. #899 wired iOS app testing via Appium; this PR reuses that bootstrap pattern with `browserName: 'safari'` capability for Mobile Safari. Once landed, the follow-on PR H (Chrome iOS / Firefox iOS / Edge iOS) becomes thin wrappers since they all share Safari's WebKit transport.

Per operator policy 2026-05-30, Mobile Safari is **local-only** — dev's matrix is `chromium` on Mac + `mobile-chrome-android` only.

## What

### `scripts/drivers/web-mobile-safari-ios-driver.js`
- HTTP client to the same local Appium server iOS app testing uses (default `http://localhost:4723`).
- Lazy session bootstrap: `POST /session` with `browserName: 'safari'` + `xcodeOrgId: WDA_TEAM_ID` so Appium signs WDA + the WebKit Remote Inspector bridge.
- Reuses `selectUdid` from `ios-appium-driver` — same device-selection logic, no duplicate xcrun call.
- Methods: `webRefreshRoomsList` (POST /url with `<baseURL>/rooms`), `webUiDump` (POST /execute/sync with `document.body.innerText` script), `close` (DELETE /session/<id>).
- All methods return `false` / `''` on failure, never throw — same contract as desktop + mobile-chrome drivers.
- `safariIgnoreFraudWarning` + `safariOpenLinksInBackground` capabilities set so the operator doesn't have to babysit the device through autofill / suggestion prompts.

### `scripts/browser-allowlist.js`
Adds `mobile-safari-ios` to `MOBILE_BROWSERS` (Android slug first, then iOS — keeps test `.toEqual` stable across future additions). Local allowlist includes it via the `[...MOBILE_BROWSERS]` spread. Dev/prod allowlists stay unchanged (Mobile Safari = local-only per operator policy).

### `scripts/manual-qa-runner.js`
`--browser mobile-safari-ios` dispatches to `createMobileSafariIosDriver`. Existing dispatch fork (`mobile-chrome-android` / fall-through to desktop `createWebDriver`) gains the new branch.

## Tests

### `tests/scripts/drivers/web-mobile-safari-ios-driver.test.js` — 21 tests
- Input validation: no-iPhone, missing `WDA_TEAM_ID`, preferred-udid forwarding, driver method surface.
- Session bootstrap: caps shape (`browserName:safari` + no `bundleId` + `xcodeOrgId`), session caching (no duplicate `/session` POSTs), legacy top-level `sessionId` fallback, `/session` non-2xx → driver fails false, degenerate body (no sessionId at all), `APPIUM_BASE_URL` injection, `DEFAULT_APPIUM_BASE_URL` pin.
- `webRefreshRoomsList`: POST `/url` shape, trailing-slash collapse, non-2xx → false.
- `webUiDump`: `/execute/sync` invocation + script shape, failure → `''`, value-missing → `''`.
- `close`: DELETE shape, no-op before any session, swallows DELETE network errors, second close after first is idempotent.

### Existing `browser-allowlist.test.js`
The `test.each(MOBILE_BROWSERS)` iteration + spread-into-`local` checks pick up the new slug automatically — 26 existing tests still pass without modification. (This is the payoff for designing tests as iterations over the constant arrays.)

### Suite
- Full express-api: 261 / 261 suites, 9973 / 9981 tests pass, 8 expected skipped.
- `npm run lint` + `npm run format:check` clean.

## Out of scope

- Chrome iOS / Firefox iOS / Edge iOS — separate PR H. All three are WebKit wrappers but each has its own app bundle launch path.
- Samsung Internet / Mobile Firefox / Mobile Edge on Android — separate PRs E/F/G via CDP-over-adb (Samsung/Edge) and Marionette (Firefox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)