### PR TITLE
fix(ci): skip gh-pages deploy on PR runs to eliminate race

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -66,22 +66,30 @@ jobs:
           echo "{\"passed\":${PASSED},\"failed\":${FAILED},\"total\":${TOTAL},\"date\":\"${DATE}\",\"runUrl\":\"${RUN_URL}\",\"suite\":\"express\",\"env\":\"${REPORT_ENV}\"}" > express-api/coverage/metadata.json
 
       - name: Deploy Express report to GitHub Pages
-        # Skip for dependabot PRs. Two layers of motivation:
+        # Skip for PR runs (the default 'pr' report_env) and for
+        # dependabot PRs. Three layers of motivation:
         #   1) Read-only GITHUB_TOKEN: on dependabot-authored runs
         #      GitHub enforces a read-only token (2021 supply-chain
         #      tightening), so peaceiris/actions-gh-pages can't push.
-        #   2) gh-pages race condition: when N dependabot PRs all
-        #      re-run CI in the same minute (e.g. after a batch
-        #      `merge main into` to pick up workflow fixes), each
-        #      peaceiris invocation does `git clone gh-pages --depth=1`,
-        #      commits its report, then `git push` — and N-1 of those
-        #      pushes are rejected as non-fast-forward because the
-        #      first push got there first. peaceiris doesn't retry.
-        # We guard on `github.head_ref` (PR's source branch) instead
-        # of `github.actor` so the skip applies even when the run is
-        # triggered by a non-dependabot user adding a merge commit to
-        # the PR (which makes github.actor that user, not dependabot).
-        if: always() && !startsWith(github.head_ref, 'dependabot/')
+        #   2) gh-pages race condition: when N PRs run CI in the same
+        #      minute (e.g. matrix-completeness batch + dependabot bumps),
+        #      each peaceiris invocation does `git clone gh-pages
+        #      --depth=1`, commits its report, then `git push` — and
+        #      N-1 of those pushes are rejected as non-fast-forward
+        #      because the first push got there first. peaceiris
+        #      doesn't retry. Verified with PR #901's two consecutive
+        #      failures despite the test step itself passing.
+        #   3) PR-branch reports are nice-to-have, not canonical —
+        #      only the dev/prod main-branch reports are linked from
+        #      docs and consumed downstream. Skipping the racey pr
+        #      deploy preserves the deploys that matter.
+        # The condition skips when the resolved report_env is 'pr'
+        # (i.e. neither dev nor prod was supplied), preserving the
+        # main-branch deploy path. We guard on `github.head_ref` (PR's
+        # source branch) instead of `github.actor` so the dependabot
+        # skip applies even when the run is triggered by a non-dependabot
+        # user adding a merge commit to the PR.
+        if: always() && (inputs.report_env == 'dev' || inputs.report_env == 'prod') && !startsWith(github.head_ref, 'dependabot/')
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PR runs reuse the destination_dir `express/pr/latest`, so when N PRs hit the same workflow in a short window each `peaceiris/actions-gh-pages` invocation clones gh-pages --depth=1, commits, and pushes. N-1 of those pushes are rejected as non-fast-forward; peaceiris doesn't retry.

## The trigger

#901 (Mobile Safari iOS) hit this **twice consecutively** after a matrix-completeness PR batch (#898 / #899 / #900 / #901 in a 30-min window). The \"Deploy Express report to GitHub Pages\" step failed deterministically — not a transient — while every other step incl. the actual test step passed.

The workflow already skips this step for dependabot PRs for exactly this reason (see existing comment). This PR extends the skip to cover **all** PR runs.

## What

Gate on `inputs.report_env == 'dev' || 'prod'`. PR-branch coverage reports are nice-to-have; only the dev/prod main-branch reports are linked from docs and consumed downstream, so this preserves what matters and eliminates the contention class entirely.

## Why this unblocks the framework series

- #901 currently blocks PR Gate on the same step.
- #902 (PR E — Samsung Internet) and PRs F/G/H/I queued next would hit the same race.

Without this fix every matrix-completeness PR would need a manual rerun + pray dance.

## Scope

Workflow-only change. Per CLAUDE.md the workflow-only PR path skips the test suite, so this should land fast (lint + actionlint only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)