### PR TITLE
feat(qa-runner): web-mobile-edge-android driver — CDP-over-adb

### DIFF
--- a/express-api/scripts/browser-allowlist.js
+++ b/express-api/scripts/browser-allowlist.js
@@ -21,7 +21,7 @@ const DESKTOP_BROWSERS = ['chromium', 'firefox', 'webkit', 'edge'];
 // Browsers that route through a non-default driver factory inside the
 // runner's `--driver playwright|all` block. New mobile-browser drivers
 // register their slug here AND in the per-target allowlist below.
-const MOBILE_BROWSERS = ['mobile-chrome-android', 'mobile-samsung-android'];
+const MOBILE_BROWSERS = ['mobile-chrome-android', 'mobile-samsung-android', 'mobile-edge-android'];
 
 const SUPPORTED_BROWSERS = [...DESKTOP_BROWSERS, ...MOBILE_BROWSERS];
 

--- a/express-api/scripts/drivers/web-mobile-edge-android-driver.js
+++ b/express-api/scripts/drivers/web-mobile-edge-android-driver.js
@@ -1,0 +1,164 @@
+/* global document */
+/**
+ * Web driver: Mobile Edge on Android via CDP-over-adb.
+ *
+ * Mobile Edge is Microsoft's Chromium fork. It exposes the same CDP
+ * unix socket pattern as Chrome — just under a different socket name.
+ * Reuses the shared `bootstrapAdbForward` helper from
+ * `android-cdp-helpers.js` with Edge's socket name. Mechanically
+ * identical to web-mobile-samsung-android-driver.js modulo the socket
+ * + operator-hint strings.
+ *
+ * Wire-up
+ * -------
+ * 1. Operator enables USB debugging on the Android device.
+ * 2. Operator opens Mobile Edge → Settings → "About Microsoft Edge"
+ *    → tap the version 5 times to surface developer mode → enable
+ *    "USB Web Debugging". One-time per device.
+ * 3. Driver runs `adb forward tcp:<port>
+ *    localabstract:com.microsoft.emmx_devtools_remote`.
+ * 4. Driver calls `playwright.chromium.connectOverCDP(endpointURL)` —
+ *    works because Mobile Edge IS Chromium under the hood.
+ *
+ * Method-naming contract: mirrors web-mobile-chrome-android-driver.js
+ * (and through it, the desktop web driver). Runner matchers swap
+ * transparently.
+ *
+ * Local-matrix only — operator policy 2026-05-30 keeps dev/prod to
+ * Chromium-only-plus-Chrome-on-Android.
+ */
+
+/* eslint-disable no-console -- driver methods log diagnostics for the
+   manual QA runner (operator-facing CLI), not application code. */
+
+const path = require('path');
+const { bootstrapAdbForward } = require('./android-cdp-helpers');
+
+const EDGE_CDP_SOCKET = 'com.microsoft.emmx_devtools_remote';
+
+let _playwright;
+function loadPlaywright() {
+  if (_playwright) return _playwright;
+  try {
+    _playwright = require('playwright');
+    return _playwright;
+  } catch (bareErr) {
+    if (bareErr.code !== 'MODULE_NOT_FOUND') throw bareErr;
+  }
+  const repoRoot = path.resolve(__dirname, '../../..');
+  const playwrightPath = path.join(repoRoot, 'node_modules', 'playwright');
+  _playwright = require(playwrightPath);
+  return _playwright;
+}
+
+/**
+ * Driver factory. Mirrors createMobileSamsungAndroidDriver — same
+ * injectable deps, same method surface, just routes through Edge's
+ * CDP socket.
+ */
+async function createMobileEdgeAndroidDriver({
+  baseURL = 'http://localhost:8888',
+  adbPath,
+  execFileSync,
+  playwrightImpl,
+  pickPort,
+} = {}) {
+  const { port, removeForward } = await bootstrapAdbForward({
+    socketName: EDGE_CDP_SOCKET,
+    browserNameHint: 'Microsoft Edge',
+    adbPath,
+    execFileSync,
+    pickPort,
+  });
+
+  const pw = playwrightImpl || loadPlaywright();
+  const endpointURL = `http://127.0.0.1:${port}`;
+  let browser;
+  try {
+    browser = await pw.chromium.connectOverCDP(endpointURL);
+  } catch (e) {
+    removeForward();
+    throw new Error(
+      `[mobile-edge-android-driver] connectOverCDP(${endpointURL}) failed: ${e.message}. Confirm Mobile Edge is open on the device + "USB Web Debugging" is enabled in its Developer Settings (tap About-Edge version 5 times).`,
+      { cause: e },
+    );
+  }
+
+  const contexts = browser.contexts();
+  if (contexts.length === 0) {
+    removeForward();
+    await browser.close().catch(() => {});
+    throw new Error(
+      '[mobile-edge-android-driver] CDP returned 0 contexts — Mobile Edge may be in InPrivate mode only. Switch to a normal tab + retry.',
+    );
+  }
+  const ctx = contexts[0];
+
+  const pages = new Map();
+
+  async function pageFor(name) {
+    if (pages.has(name)) return pages.get(name);
+    const page = await ctx.newPage();
+    pages.set(name, page);
+    return page;
+  }
+
+  const driver = {
+    _browser: browser,
+    _ctx: ctx,
+    _port: port,
+    _baseURL: baseURL,
+    _pages: pages,
+    pageFor,
+  };
+
+  driver.webRefreshRoomsList = async (name) => {
+    try {
+      const page = await pageFor(name);
+      await page.goto(`${baseURL.replace(/\/$/, '')}/rooms`);
+      return true;
+    } catch (e) {
+      console.error(
+        `[mobile-edge-android-driver] webRefreshRoomsList(${name}) failed: ${e.message}`,
+      );
+      return false;
+    }
+  };
+
+  driver.webUiDump = async () => {
+    try {
+      const page = await pageFor('default');
+      if (!page.url() || page.url() === 'about:blank')
+        await page.goto(`${baseURL.replace(/\/$/, '')}/`);
+      // Note: await before return so the try/catch actually catches a
+      // rejected evaluate.
+      return await page.evaluate(() => document.body.innerText || '');
+    } catch (e) {
+      console.error(`[mobile-edge-android-driver] webUiDump failed: ${e.message}`);
+      return '';
+    }
+  };
+
+  driver.close = async () => {
+    for (const p of pages.values()) {
+      try {
+        await p.close();
+      } catch (_e) {
+        /* best-effort */
+      }
+    }
+    try {
+      await browser.close();
+    } catch (_e) {
+      /* best-effort */
+    }
+    removeForward();
+  };
+
+  return driver;
+}
+
+module.exports = {
+  EDGE_CDP_SOCKET,
+  createMobileEdgeAndroidDriver,
+};

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -15534,6 +15534,9 @@ async function main() {
         createMobileSamsungAndroidDriver,
       } = require('./drivers/web-mobile-samsung-android-driver');
       webDriver = await createMobileSamsungAndroidDriver({ baseURL });
+    } else if (opts.browser === 'mobile-edge-android') {
+      const { createMobileEdgeAndroidDriver } = require('./drivers/web-mobile-edge-android-driver');
+      webDriver = await createMobileEdgeAndroidDriver({ baseURL });
     } else {
       const { createWebDriver } = require('./drivers/web-playwright-driver');
       webDriver = await createWebDriver({

--- a/express-api/tests/scripts/drivers/web-mobile-edge-android-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-mobile-edge-android-driver.test.js
@@ -1,0 +1,295 @@
+/**
+ * web-mobile-edge-android-driver.test.js
+ *
+ * Tests for the Mobile Edge on Android driver. Mock execFileSync +
+ * playwright + bootstrap helper so no real Android device or adb is
+ * required.
+ *
+ * Coverage areas:
+ *   - EDGE_CDP_SOCKET constant pin
+ *   - createMobileEdgeAndroidDriver factory wiring
+ *   - bootstrapAdbForward invoked with Edge's socket name
+ *   - connectOverCDP endpoint URL
+ *   - 0-contexts → InPrivate-mode hint + forward cleanup
+ *   - webRefreshRoomsList / webUiDump method behaviour
+ *   - close cleans forward + browser + pages
+ */
+
+jest.mock(
+  'playwright',
+  () => ({
+    chromium: { connectOverCDP: jest.fn() },
+  }),
+  { virtual: true },
+);
+
+const path = require('path');
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const { EDGE_CDP_SOCKET, createMobileEdgeAndroidDriver } = require(
+  path.join(REPO_ROOT, 'express-api/scripts/drivers/web-mobile-edge-android-driver'),
+);
+
+// Helpers ─────────────────────────────────────────────────────────────
+
+function makeExecFileSyncMock({ devicesOutput = 'List of devices attached\nABC\tdevice\n' } = {}) {
+  return jest.fn((bin, args) => {
+    if (args[0] === 'devices') return devicesOutput;
+    if (args[0] === 'forward') return '';
+    return '';
+  });
+}
+
+function makePages(personas) {
+  const pages = {};
+  for (const name of personas) {
+    pages[name] = {
+      url: jest.fn(() => 'about:blank'),
+      goto: jest.fn(async () => {}),
+      evaluate: jest.fn(async () => ''),
+      close: jest.fn(),
+    };
+  }
+  return pages;
+}
+
+function makePlaywrightMock(pages) {
+  let pageIdx = 0;
+  const ordered = Object.values(pages);
+  const ctx = {
+    newPage: jest.fn(async () => {
+      const p = ordered[pageIdx] ?? ordered[ordered.length - 1];
+      pageIdx += 1;
+      return p;
+    }),
+  };
+  const browser = {
+    contexts: jest.fn(() => [ctx]),
+    close: jest.fn(async () => {}),
+  };
+  return {
+    chromium: { connectOverCDP: jest.fn(async () => browser) },
+  };
+}
+
+// EDGE_CDP_SOCKET ────────────────────────────────────────────────────
+
+describe('EDGE_CDP_SOCKET', () => {
+  test('is the Mobile Edge devtools socket name', () => {
+    expect(EDGE_CDP_SOCKET).toBe('com.microsoft.emmx_devtools_remote');
+  });
+});
+
+// createMobileEdgeAndroidDriver ──────────────────────────────────────
+
+describe('createMobileEdgeAndroidDriver', () => {
+  test('returns a driver with the expected method surface', async () => {
+    const execFileSync = makeExecFileSyncMock();
+    const pages = makePages(['Alice']);
+    const playwrightImpl = makePlaywrightMock(pages);
+    const driver = await createMobileEdgeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9777,
+    });
+    expect(typeof driver.webRefreshRoomsList).toBe('function');
+    expect(typeof driver.webUiDump).toBe('function');
+    expect(typeof driver.close).toBe('function');
+    expect(driver._port).toBe(9777);
+  });
+
+  test('adb forward targets the Edge CDP socket name', async () => {
+    const execFileSync = makeExecFileSyncMock();
+    const pages = makePages(['Alice']);
+    const playwrightImpl = makePlaywrightMock(pages);
+    await createMobileEdgeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9777,
+    });
+    expect(execFileSync).toHaveBeenCalledWith(
+      expect.any(String),
+      ['forward', 'tcp:9777', `localabstract:${EDGE_CDP_SOCKET}`],
+      expect.any(Object),
+    );
+  });
+
+  test('does NOT use Chrome or Samsung socket names (so all three drivers can co-exist)', async () => {
+    const execFileSync = makeExecFileSyncMock();
+    const pages = makePages(['Alice']);
+    const playwrightImpl = makePlaywrightMock(pages);
+    await createMobileEdgeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9777,
+    });
+    const forwardCalls = execFileSync.mock.calls.filter((c) => c[1][0] === 'forward');
+    for (const c of forwardCalls) {
+      const arg = c[1].join(' ');
+      expect(arg).not.toContain('localabstract:chrome_devtools_remote');
+      expect(arg).not.toContain('localabstract:com.sec.android.app.sbrowser_devtools_remote');
+    }
+  });
+
+  test('connectOverCDP is called with the chosen port', async () => {
+    const execFileSync = makeExecFileSyncMock();
+    const pages = makePages(['Alice']);
+    const playwrightImpl = makePlaywrightMock(pages);
+    await createMobileEdgeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9888,
+    });
+    expect(playwrightImpl.chromium.connectOverCDP).toHaveBeenCalledWith('http://127.0.0.1:9888');
+  });
+
+  test('webRefreshRoomsList navigates to <baseURL>/rooms', async () => {
+    const execFileSync = makeExecFileSyncMock();
+    const pages = makePages(['Alice']);
+    const playwrightImpl = makePlaywrightMock(pages);
+    const driver = await createMobileEdgeAndroidDriver({
+      baseURL: 'http://localhost:8888',
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9777,
+    });
+    const ok = await driver.webRefreshRoomsList('Alice');
+    expect(ok).toBe(true);
+    expect(pages.Alice.goto).toHaveBeenCalledWith('http://localhost:8888/rooms');
+  });
+
+  test('webRefreshRoomsList trailing slash collapses', async () => {
+    const execFileSync = makeExecFileSyncMock();
+    const pages = makePages(['Alice']);
+    const playwrightImpl = makePlaywrightMock(pages);
+    const driver = await createMobileEdgeAndroidDriver({
+      baseURL: 'http://localhost:8888/',
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9777,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    expect(pages.Alice.goto).toHaveBeenCalledWith('http://localhost:8888/rooms');
+  });
+
+  test('webRefreshRoomsList goto rejection → returns false', async () => {
+    const execFileSync = makeExecFileSyncMock();
+    const pages = makePages(['Alice']);
+    pages.Alice.goto = jest.fn(async () => {
+      throw new Error('net::ERR_INTERNET_DISCONNECTED');
+    });
+    const playwrightImpl = makePlaywrightMock(pages);
+    const driver = await createMobileEdgeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9777,
+    });
+    expect(await driver.webRefreshRoomsList('Alice')).toBe(false);
+  });
+
+  test('webUiDump returns innerText', async () => {
+    const execFileSync = makeExecFileSyncMock();
+    const pages = makePages(['default']);
+    pages.default.evaluate = jest.fn(async () => 'Edge says hello');
+    const playwrightImpl = makePlaywrightMock(pages);
+    const driver = await createMobileEdgeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9777,
+    });
+    expect(await driver.webUiDump()).toBe('Edge says hello');
+  });
+
+  test('webUiDump returns "" on evaluate rejection (await-before-return catches it)', async () => {
+    const execFileSync = makeExecFileSyncMock();
+    const pages = makePages(['default']);
+    pages.default.evaluate = jest.fn(async () => {
+      throw new Error('CDP gone');
+    });
+    const playwrightImpl = makePlaywrightMock(pages);
+    const driver = await createMobileEdgeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9777,
+    });
+    expect(await driver.webUiDump()).toBe('');
+  });
+
+  test('connectOverCDP rejection → Edge-specific error + forward cleanup', async () => {
+    const execFileSync = makeExecFileSyncMock();
+    const playwrightImpl = {
+      chromium: {
+        connectOverCDP: jest.fn(async () => {
+          throw new Error('ECONNREFUSED');
+        }),
+      },
+    };
+    await expect(
+      createMobileEdgeAndroidDriver({
+        execFileSync,
+        playwrightImpl,
+        pickPort: async () => 9777,
+      }),
+    ).rejects.toThrow(/connectOverCDP.*ECONNREFUSED.*Mobile Edge.*USB Web Debugging/);
+    expect(execFileSync).toHaveBeenCalledWith(
+      expect.any(String),
+      ['forward', '--remove', 'tcp:9777'],
+      expect.any(Object),
+    );
+  });
+
+  test('0 contexts → InPrivate-mode hint error + forward cleanup', async () => {
+    const execFileSync = makeExecFileSyncMock();
+    const browser = { contexts: () => [], close: jest.fn(async () => {}) };
+    const playwrightImpl = {
+      chromium: { connectOverCDP: jest.fn(async () => browser) },
+    };
+    await expect(
+      createMobileEdgeAndroidDriver({
+        execFileSync,
+        playwrightImpl,
+        pickPort: async () => 9777,
+      }),
+    ).rejects.toThrow(/0 contexts.*InPrivate/);
+    expect(browser.close).toHaveBeenCalled();
+  });
+
+  test('close removes the adb forward + closes browser + pages', async () => {
+    const execFileSync = makeExecFileSyncMock();
+    const pages = makePages(['Alice', 'Bob']);
+    const playwrightImpl = makePlaywrightMock(pages);
+    const driver = await createMobileEdgeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9777,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await driver.webRefreshRoomsList('Bob');
+    await driver.close();
+    expect(pages.Alice.close).toHaveBeenCalledTimes(1);
+    expect(pages.Bob.close).toHaveBeenCalledTimes(1);
+    expect(driver._browser.close).toHaveBeenCalledTimes(1);
+    expect(execFileSync).toHaveBeenCalledWith(
+      expect.any(String),
+      ['forward', '--remove', 'tcp:9777'],
+      expect.any(Object),
+    );
+  });
+
+  test('close swallows page-close + browser-close errors (best-effort)', async () => {
+    const execFileSync = makeExecFileSyncMock();
+    const pages = makePages(['Alice']);
+    pages.Alice.close = jest.fn(() => Promise.reject(new Error('already closed')));
+    const playwrightImpl = makePlaywrightMock(pages);
+    playwrightImpl.chromium.connectOverCDP = jest.fn(async () => ({
+      contexts: () => [{ newPage: async () => pages.Alice }],
+      close: jest.fn(() => Promise.reject(new Error('CDP gone'))),
+    }));
+    const driver = await createMobileEdgeAndroidDriver({
+      execFileSync,
+      playwrightImpl,
+      pickPort: async () => 9777,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await expect(driver.close()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Seventh of the matrix-completeness PRs (after #898 / #899 / #900 / #901 / #902 / #903). Adds Mobile Edge on Android — the third Chromium-fork Android browser, built on the shared `android-cdp-helpers.js` PR #902 extracted.

## Why

Mobile Edge on Android shares the Chromium engine with Chrome and Samsung Internet, so behaviour is largely identical. But it has its own CDP socket name (`com.microsoft.emmx_devtools_remote`) and its own user-base + device-default scenarios worth covering for the local matrix-completeness rule.

The driver is a mechanical sibling of the Samsung driver: same factory shape, same method surface, different socket + operator hint strings. ~50 lines of driver code; the heavy lifting lives in the shared helpers.

## What

### `scripts/drivers/web-mobile-edge-android-driver.js` (NEW)
- `EDGE_CDP_SOCKET = 'com.microsoft.emmx_devtools_remote'`.
- `createMobileEdgeAndroidDriver({ baseURL, ... })` — mirrors `createMobileSamsungAndroidDriver` factory + method surface (`webRefreshRoomsList`, `webUiDump`, `close`).
- Uses shared `bootstrapAdbForward` with the Edge socket name + Mobile Edge operator hint.
- 0-contexts error references Edge's **InPrivate** mode equivalent.
- `connectOverCDP` failure error guides the operator to the **\"tap About-Edge version 5 times\"** developer-mode unlock flow.

### `scripts/browser-allowlist.js`
- `MOBILE_BROWSERS` gains `'mobile-edge-android'`.
- Local allowlist picks it up via the `[...MOBILE_BROWSERS]` spread.
- Dev/prod allowlists unchanged (Mobile Edge = local-only per operator policy).

### `scripts/manual-qa-runner.js`
- `--browser mobile-edge-android` dispatches to `createMobileEdgeAndroidDriver`.

## Tests

### `tests/scripts/drivers/web-mobile-edge-android-driver.test.js` — 14 tests
- `EDGE_CDP_SOCKET` constant pin.
- Factory wiring + method surface.
- adb forward arg shape (Edge socket, **not** chrome/Samsung sockets — pin ensures all three drivers can co-exist).
- `connectOverCDP` endpoint URL.
- `webRefreshRoomsList` navigation + trailing-slash + goto-rejection.
- `webUiDump` value + evaluate-rejection-catches-properly.
- `connectOverCDP` rejection → Edge-specific error + forward cleanup.
- 0-contexts → InPrivate-mode hint + forward cleanup.
- `close` cleans forward + browser + pages + swallows close errors.

### Existing tests
The 26 browser-allowlist tests still pass (`test.each(MOBILE_BROWSERS)` iteration auto-includes the new slug). `android-cdp-helpers` tests cover the Edge socket name via the parameterised dispatch test.

### Suite
Full express-api: 10003/10011 pass, 8 expected skipped. Lint + format clean.

## Operator one-time setup (Mobile Edge)

1. Enable USB debugging on the Android device.
2. Open Mobile Edge → Settings → \"About Microsoft Edge\" → tap the version 5 times to surface developer mode → enable \"USB Web Debugging\".
3. Pass `--browser mobile-edge-android`.

## Out of scope

- Mobile Firefox on Android — different protocol (Marionette/Geckodriver, not CDP), separate PR F.
- Chrome iOS / Firefox iOS / Edge iOS — PR H WebKit wrappers via Appium safari context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)