### PR TITLE
feat(qa-runner): web-mobile-webkit-ios driver — Chrome/Firefox/Edge iOS

### DIFF
--- a/express-api/scripts/browser-allowlist.js
+++ b/express-api/scripts/browser-allowlist.js
@@ -23,7 +23,14 @@ const DESKTOP_BROWSERS = ['chromium', 'firefox', 'webkit', 'edge'];
 // register their slug here AND in the per-target allowlist below.
 // Order intentional: Android slugs first, then iOS — keeps test
 // `.toEqual` expectations stable across PRs that add more of either.
-const MOBILE_BROWSERS = ['mobile-chrome-android', 'mobile-samsung-android', 'mobile-safari-ios'];
+const MOBILE_BROWSERS = [
+  'mobile-chrome-android',
+  'mobile-samsung-android',
+  'mobile-safari-ios',
+  'mobile-chrome-ios',
+  'mobile-firefox-ios',
+  'mobile-edge-ios',
+];
 
 const SUPPORTED_BROWSERS = [...DESKTOP_BROWSERS, ...MOBILE_BROWSERS];
 

--- a/express-api/scripts/drivers/web-mobile-webkit-ios-driver.js
+++ b/express-api/scripts/drivers/web-mobile-webkit-ios-driver.js
@@ -1,0 +1,285 @@
+/**
+ * Web driver: Chrome iOS / Firefox iOS / Edge iOS — WebKit wrappers via
+ * Appium safari context.
+ *
+ * App Store policy mandates every iOS browser use WebKit (the same
+ * engine Mobile Safari uses). Chrome iOS / Firefox iOS / Edge iOS are
+ * functionally WebKit wrappers — they ship distinct UI chrome (URL bar,
+ * tabs, sync) but their page rendering is identical to Safari.
+ *
+ * From a matrix-completeness standpoint each is its own browser slug
+ * — the OPERATOR's matrix lists them separately — but the transport is
+ * the same Appium session pattern as web-mobile-safari-ios-driver.js,
+ * just with `appium:bundleId` set to the per-browser app bundle.
+ *
+ * Strategy
+ * --------
+ * 1. Bootstrap an Appium XCUITest session with `bundleId: <browser>`
+ *    (no `browserName: safari` — that would launch Safari instead).
+ * 2. Wait for the launched browser app to load.
+ * 3. Switch to the webview context (XCUITest exposes the WebKit Remote
+ *    Inspector view as `WEBVIEW_<n>`).
+ * 4. From webview context, the W3C `/url` + `/execute/sync` endpoints
+ *    drive the WebKit content the same way as Safari.
+ *
+ * Method-naming contract: mirrors web-mobile-safari-ios-driver.js. The
+ * runner doesn't care which iOS browser app it's driving — they all
+ * produce identical WebKit-rendered pages.
+ *
+ * Local-matrix only — operator policy 2026-05-30 keeps dev/prod to
+ * Chromium-only-plus-Chrome-on-Android.
+ */
+
+/* eslint-disable no-console -- driver methods log diagnostics for the
+   manual QA runner (operator-facing CLI), not application code. */
+
+const path = require('path');
+
+// Reuse ios-appium-driver's selectUdid for device-selection parity with
+// the other iOS drivers (Safari + native app).
+const REPO_ROOT_DRIVERS = path.resolve(__dirname);
+const { selectUdid } = require(path.join(REPO_ROOT_DRIVERS, 'ios-appium-driver'));
+
+const DEFAULT_APPIUM_BASE_URL = 'http://localhost:4723';
+
+/**
+ * Per-browser bundle IDs. These are the App Store identifiers for the
+ * iOS apps. If Apple changes one (rare — App Store IDs are sticky),
+ * update this map.
+ *
+ * `appName` is the operator-facing string used in error messages so the
+ * setup hint makes sense ("Open Chrome iOS + grant permissions").
+ */
+const WEBKIT_BROWSERS = {
+  chrome: {
+    bundleId: 'com.google.chrome.ios',
+    appName: 'Chrome iOS',
+  },
+  firefox: {
+    bundleId: 'org.mozilla.ios.Firefox',
+    appName: 'Firefox iOS',
+  },
+  edge: {
+    bundleId: 'com.microsoft.msedge.ios',
+    appName: 'Edge iOS',
+  },
+};
+
+function isSupportedBrowser(browser) {
+  return Object.prototype.hasOwnProperty.call(WEBKIT_BROWSERS, browser);
+}
+
+function supportedBrowsersList() {
+  return Object.keys(WEBKIT_BROWSERS).sort();
+}
+
+/**
+ * Driver factory.
+ *
+ *   const driver = await createMobileWebkitIosDriver({ browser: 'chrome', baseURL });
+ *   await driver.webRefreshRoomsList('Alice');
+ *   await driver.close();
+ *
+ * Required:
+ *   browser — one of 'chrome' / 'firefox' / 'edge'.
+ *
+ * Injectable deps (test-only):
+ *   fetchImpl, selectUdidImpl, udid (bypasses selectUdid).
+ */
+async function createMobileWebkitIosDriver({
+  browser,
+  baseURL = 'http://localhost:8888',
+  appiumBaseUrl = process.env.APPIUM_BASE_URL || DEFAULT_APPIUM_BASE_URL,
+  wdaTeamId = process.env.WDA_TEAM_ID,
+  udid: preferredUdid,
+  fetchImpl = globalThis.fetch,
+  selectUdidImpl = selectUdid,
+} = {}) {
+  if (!isSupportedBrowser(browser)) {
+    throw new Error(
+      `createMobileWebkitIosDriver: browser "${browser}" is not supported. Use one of: ${supportedBrowsersList().join(', ')}.`,
+    );
+  }
+  const { bundleId, appName } = WEBKIT_BROWSERS[browser];
+
+  const udid = selectUdidImpl(preferredUdid);
+  if (!udid) {
+    throw new Error(
+      `createMobileWebkitIosDriver(${browser}): no connected iPhone found via \`xcrun devicectl list devices\`. Pair the device with Xcode + ensure it shows "available" or "connected".`,
+    );
+  }
+  if (!wdaTeamId) {
+    throw new Error(
+      `createMobileWebkitIosDriver(${browser}): WDA_TEAM_ID env var is required. This is the operator's Apple Developer team ID — Appium uses it to sign WebDriverAgent + the WebKit Remote Inspector bridge.`,
+    );
+  }
+
+  let _sessionId = null;
+
+  async function ensureSession() {
+    if (_sessionId) return _sessionId;
+    const caps = {
+      capabilities: {
+        alwaysMatch: {
+          platformName: 'iOS',
+          'appium:automationName': 'XCUITest',
+          'appium:udid': udid,
+          // Launch the specific browser app via bundleId — distinct
+          // from Safari's `browserName: 'safari'` capability. Once the
+          // app is up we switch to its webview context.
+          'appium:bundleId': bundleId,
+          'appium:xcodeSigningId': 'Apple Developer',
+          'appium:xcodeOrgId': wdaTeamId,
+          'appium:useNewWDA': false,
+          'appium:noReset': true,
+          // Auto-launch the app (default true, explicit for clarity).
+          'appium:autoLaunch': true,
+        },
+      },
+    };
+    const r = await fetchImpl(`${appiumBaseUrl}/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(caps),
+    });
+    if (!r.ok) {
+      const errText = await r.text();
+      throw new Error(
+        `Appium /session failed (${r.status}) for ${appName}: ${errText.slice(0, 500)}. Confirm the Appium server is on ${appiumBaseUrl}, the xcuitest driver is installed, and ${appName} is installed on the iPhone.`,
+      );
+    }
+    const body = await r.json();
+    _sessionId = body.value?.sessionId || body.sessionId;
+    if (!_sessionId) {
+      throw new Error(
+        `Appium /session for ${appName} returned no sessionId: ${JSON.stringify(body).slice(0, 500)}`,
+      );
+    }
+    return _sessionId;
+  }
+
+  /**
+   * Switch to the first available WebKit webview context. iOS browsers
+   * expose their WebKit page as a `WEBVIEW_<n>` context once a page is
+   * loaded — listing /contexts and picking the first non-`NATIVE_APP`.
+   *
+   * Called automatically before any web operation; cached so subsequent
+   * web ops don't re-switch.
+   */
+  let _onWebviewContext = false;
+  async function ensureWebviewContext() {
+    if (_onWebviewContext) return;
+    const sid = await ensureSession();
+    const ctxResp = await fetchImpl(`${appiumBaseUrl}/session/${sid}/contexts`);
+    if (!ctxResp.ok) {
+      throw new Error(
+        `Appium /contexts failed (${ctxResp.status}) for ${appName}: ${(await ctxResp.text()).slice(0, 300)}`,
+      );
+    }
+    const ctxBody = await ctxResp.json();
+    const contexts = Array.isArray(ctxBody.value) ? ctxBody.value : [];
+    const webview = contexts.find((c) => c.startsWith('WEBVIEW_'));
+    if (!webview) {
+      throw new Error(
+        `Appium /contexts for ${appName} returned no WEBVIEW_ context (got [${contexts.join(', ')}]). ${appName} may not have loaded any page yet; navigate first or grant developer-mode permission in iPhone Settings → Safari → Advanced → Web Inspector ON.`,
+      );
+    }
+    const switchResp = await fetchImpl(`${appiumBaseUrl}/session/${sid}/context`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: webview }),
+    });
+    if (!switchResp.ok) {
+      throw new Error(
+        `Appium context switch to ${webview} failed (${switchResp.status}) for ${appName}: ${(await switchResp.text()).slice(0, 300)}`,
+      );
+    }
+    _onWebviewContext = true;
+  }
+
+  async function navigateTo(url) {
+    const sid = await ensureSession();
+    await ensureWebviewContext();
+    const r = await fetchImpl(`${appiumBaseUrl}/session/${sid}/url`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url }),
+    });
+    if (!r.ok) {
+      throw new Error(
+        `Appium /url failed (${r.status}) for ${appName} → ${url}: ${(await r.text()).slice(0, 300)}`,
+      );
+    }
+  }
+
+  async function getPageText() {
+    const sid = await ensureSession();
+    await ensureWebviewContext();
+    const r = await fetchImpl(`${appiumBaseUrl}/session/${sid}/execute/sync`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        script: 'return document.body.innerText || "";',
+        args: [],
+      }),
+    });
+    if (!r.ok) {
+      throw new Error(
+        `Appium /execute/sync failed (${r.status}) for ${appName}: ${(await r.text()).slice(0, 300)}`,
+      );
+    }
+    const body = await r.json();
+    return body.value || '';
+  }
+
+  const driver = {
+    _browser: browser,
+    _bundleId: bundleId,
+    _appName: appName,
+    _udid: udid,
+    _appiumBaseUrl: appiumBaseUrl,
+    _baseURL: baseURL,
+  };
+
+  driver.webRefreshRoomsList = async (_name) => {
+    try {
+      await navigateTo(`${baseURL.replace(/\/$/, '')}/rooms`);
+      return true;
+    } catch (e) {
+      console.error(
+        `[mobile-webkit-ios-driver(${browser})] webRefreshRoomsList(${_name}) failed: ${e.message}`,
+      );
+      return false;
+    }
+  };
+
+  driver.webUiDump = async () => {
+    try {
+      return await getPageText();
+    } catch (e) {
+      console.error(`[mobile-webkit-ios-driver(${browser})] webUiDump failed: ${e.message}`);
+      return '';
+    }
+  };
+
+  driver.close = async () => {
+    if (!_sessionId) return;
+    try {
+      await fetchImpl(`${appiumBaseUrl}/session/${_sessionId}`, { method: 'DELETE' });
+    } catch (_e) {
+      /* best-effort */
+    }
+    _sessionId = null;
+    _onWebviewContext = false;
+  };
+
+  return driver;
+}
+
+module.exports = {
+  DEFAULT_APPIUM_BASE_URL,
+  WEBKIT_BROWSERS,
+  isSupportedBrowser,
+  supportedBrowsersList,
+  createMobileWebkitIosDriver,
+};

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -15539,6 +15539,20 @@ async function main() {
     } else if (opts.browser === 'mobile-safari-ios') {
       const { createMobileSafariIosDriver } = require('./drivers/web-mobile-safari-ios-driver');
       webDriver = await createMobileSafariIosDriver({ baseURL });
+    } else if (
+      opts.browser === 'mobile-chrome-ios' ||
+      opts.browser === 'mobile-firefox-ios' ||
+      opts.browser === 'mobile-edge-ios'
+    ) {
+      // Chrome/Firefox/Edge for iOS all use WebKit (App Store policy) so
+      // they share a single driver module parameterised by the browser
+      // slug. The slug suffix maps to the per-browser bundle ID inside
+      // the driver's WEBKIT_BROWSERS table.
+      const { createMobileWebkitIosDriver } = require('./drivers/web-mobile-webkit-ios-driver');
+      // Slug shape is `mobile-<browser>-ios` — strip the prefix/suffix
+      // to get the browser key the driver expects ('chrome'|'firefox'|'edge').
+      const browserKey = opts.browser.replace(/^mobile-/, '').replace(/-ios$/, '');
+      webDriver = await createMobileWebkitIosDriver({ browser: browserKey, baseURL });
     } else {
       const { createWebDriver } = require('./drivers/web-playwright-driver');
       webDriver = await createWebDriver({

--- a/express-api/tests/scripts/drivers/web-mobile-webkit-ios-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-mobile-webkit-ios-driver.test.js
@@ -1,0 +1,625 @@
+/**
+ * web-mobile-webkit-ios-driver.test.js
+ *
+ * Tests for the shared Chrome iOS / Firefox iOS / Edge iOS driver
+ * (parameterised by browser slug). All three browsers share the same
+ * underlying WebKit transport; the driver differs only in the
+ * `appium:bundleId` capability and operator-facing app name.
+ *
+ * Coverage areas:
+ *   - WEBKIT_BROWSERS constant pins per-browser bundleId + appName.
+ *   - isSupportedBrowser / supportedBrowsersList exports.
+ *   - createMobileWebkitIosDriver input validation (unknown browser,
+ *     no iPhone, missing WDA_TEAM_ID).
+ *   - Session bootstrap: bundleId per browser, NO browserName:safari
+ *     capability, sessionId extraction from both response shapes.
+ *   - Webview context switching: GET /contexts, POST /context with the
+ *     WEBVIEW_<n> name, error when no webview context available.
+ *   - webRefreshRoomsList: ensures webview switch before navigation,
+ *     POST /url shape, trailing-slash collapse, failure → false.
+ *   - webUiDump: /execute/sync invocation, failure → ''.
+ *   - close: DELETE session + clear webview-context cache.
+ */
+
+const path = require('path');
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const {
+  DEFAULT_APPIUM_BASE_URL,
+  WEBKIT_BROWSERS,
+  isSupportedBrowser,
+  supportedBrowsersList,
+  createMobileWebkitIosDriver,
+} = require(path.join(REPO_ROOT, 'express-api/scripts/drivers/web-mobile-webkit-ios-driver'));
+
+// Helpers ─────────────────────────────────────────────────────────────
+
+function makeJsonResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function makeTextResponse(text, status = 500) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => text,
+    json: async () => ({ value: { error: text } }),
+  };
+}
+
+function makeFetchMock(handlers) {
+  const calls = [];
+  const fetchImpl = jest.fn(async (url, opts = {}) => {
+    calls.push({ url, opts });
+    for (const h of handlers) {
+      if (h.match(url, opts)) return h.respond(url, opts);
+    }
+    return makeJsonResponse({ value: { error: 'unmocked endpoint' } }, 404);
+  });
+  fetchImpl.calls = calls;
+  return fetchImpl;
+}
+
+function defaultHandlers({
+  sessionId = 'sess-iosbrowser',
+  contexts = ['NATIVE_APP', 'WEBVIEW_1'],
+  textValue = 'Hello iOS webkit',
+} = {}) {
+  return [
+    {
+      match: (url, opts) => url.endsWith('/session') && opts.method === 'POST',
+      respond: () => makeJsonResponse({ value: { sessionId } }),
+    },
+    {
+      match: (url, opts) =>
+        url.endsWith(`/session/${sessionId}/contexts`) && (!opts.method || opts.method === 'GET'),
+      respond: () => makeJsonResponse({ value: contexts }),
+    },
+    {
+      match: (url, opts) => url.endsWith(`/session/${sessionId}/context`) && opts.method === 'POST',
+      respond: () => makeJsonResponse({ value: null }),
+    },
+    {
+      match: (url, opts) => url.endsWith(`/session/${sessionId}/url`) && opts.method === 'POST',
+      respond: () => makeJsonResponse({ value: null }),
+    },
+    {
+      match: (url, opts) =>
+        url.endsWith(`/session/${sessionId}/execute/sync`) && opts.method === 'POST',
+      respond: () => makeJsonResponse({ value: textValue }),
+    },
+    {
+      match: (url, opts) => url.endsWith(`/session/${sessionId}`) && opts.method === 'DELETE',
+      respond: () => makeJsonResponse({ value: null }),
+    },
+  ];
+}
+
+// WEBKIT_BROWSERS constant ───────────────────────────────────────────
+
+describe('WEBKIT_BROWSERS', () => {
+  test('contains chrome with the correct App Store bundleId', () => {
+    expect(WEBKIT_BROWSERS.chrome).toEqual({
+      bundleId: 'com.google.chrome.ios',
+      appName: 'Chrome iOS',
+    });
+  });
+
+  test('contains firefox with the correct App Store bundleId', () => {
+    expect(WEBKIT_BROWSERS.firefox).toEqual({
+      bundleId: 'org.mozilla.ios.Firefox',
+      appName: 'Firefox iOS',
+    });
+  });
+
+  test('contains edge with the correct App Store bundleId', () => {
+    expect(WEBKIT_BROWSERS.edge).toEqual({
+      bundleId: 'com.microsoft.msedge.ios',
+      appName: 'Edge iOS',
+    });
+  });
+
+  test('every entry has bundleId + appName (no degenerate config)', () => {
+    for (const [_browser, config] of Object.entries(WEBKIT_BROWSERS)) {
+      expect(typeof config.bundleId).toBe('string');
+      expect(config.bundleId.length).toBeGreaterThan(0);
+      expect(typeof config.appName).toBe('string');
+      expect(config.appName.length).toBeGreaterThan(0);
+      // Sanity: bundleId looks like reverse-DNS
+      expect(config.bundleId).toMatch(/^[a-z]+(\.[a-z]+)+/i);
+    }
+  });
+});
+
+describe('isSupportedBrowser / supportedBrowsersList', () => {
+  test('isSupportedBrowser returns true for chrome/firefox/edge', () => {
+    expect(isSupportedBrowser('chrome')).toBe(true);
+    expect(isSupportedBrowser('firefox')).toBe(true);
+    expect(isSupportedBrowser('edge')).toBe(true);
+  });
+
+  test('isSupportedBrowser returns false for unknown values', () => {
+    expect(isSupportedBrowser('safari')).toBe(false);
+    expect(isSupportedBrowser('opera')).toBe(false);
+    expect(isSupportedBrowser('')).toBe(false);
+    expect(isSupportedBrowser(null)).toBe(false);
+    expect(isSupportedBrowser(undefined)).toBe(false);
+  });
+
+  test('isSupportedBrowser is hasOwnProperty-safe (returns false for prototype keys)', () => {
+    // Inherited properties like 'toString' / 'constructor' must NOT count as
+    // supported browsers — a `for-in`-style implementation would; this one
+    // uses Object.prototype.hasOwnProperty.call which skips inherited keys.
+    expect(isSupportedBrowser('toString')).toBe(false);
+    expect(isSupportedBrowser('constructor')).toBe(false);
+    expect(isSupportedBrowser('hasOwnProperty')).toBe(false);
+  });
+
+  test('supportedBrowsersList returns sorted browser names', () => {
+    expect(supportedBrowsersList()).toEqual(['chrome', 'edge', 'firefox']);
+  });
+});
+
+describe('DEFAULT_APPIUM_BASE_URL', () => {
+  test('matches the Safari + native iOS driver defaults', () => {
+    expect(DEFAULT_APPIUM_BASE_URL).toBe('http://localhost:4723');
+  });
+});
+
+// createMobileWebkitIosDriver — input validation ─────────────────────
+
+describe('createMobileWebkitIosDriver — input validation', () => {
+  test('throws on unknown browser slug', async () => {
+    await expect(
+      createMobileWebkitIosDriver({
+        browser: 'safari',
+        wdaTeamId: 'TEAM',
+        selectUdidImpl: () => 'UDID',
+        fetchImpl: makeFetchMock([]),
+      }),
+    ).rejects.toThrow(/not supported.*chrome, edge, firefox/);
+  });
+
+  test('throws when no iPhone is connected', async () => {
+    await expect(
+      createMobileWebkitIosDriver({
+        browser: 'chrome',
+        wdaTeamId: 'TEAM',
+        selectUdidImpl: () => null,
+        fetchImpl: makeFetchMock([]),
+      }),
+    ).rejects.toThrow(/no connected iPhone found/);
+  });
+
+  test('throws when WDA_TEAM_ID is missing', async () => {
+    await expect(
+      createMobileWebkitIosDriver({
+        browser: 'firefox',
+        wdaTeamId: undefined,
+        selectUdidImpl: () => 'UDID',
+        fetchImpl: makeFetchMock([]),
+      }),
+    ).rejects.toThrow(/WDA_TEAM_ID env var is required/);
+  });
+
+  test('input-validation errors mention the requested browser slug', async () => {
+    // Each error should reference the browser so operator can tell
+    // which session's bootstrap failed when multiple drivers are open.
+    await expect(
+      createMobileWebkitIosDriver({
+        browser: 'edge',
+        wdaTeamId: undefined,
+        selectUdidImpl: () => 'UDID',
+        fetchImpl: makeFetchMock([]),
+      }),
+    ).rejects.toThrow(/edge/);
+  });
+
+  test('returned driver exposes the expected methods + per-browser metadata', async () => {
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'firefox',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID-firefox',
+      fetchImpl: makeFetchMock([]),
+    });
+    expect(typeof driver.webRefreshRoomsList).toBe('function');
+    expect(typeof driver.webUiDump).toBe('function');
+    expect(typeof driver.close).toBe('function');
+    expect(driver._browser).toBe('firefox');
+    expect(driver._bundleId).toBe('org.mozilla.ios.Firefox');
+    expect(driver._appName).toBe('Firefox iOS');
+  });
+});
+
+// Session bootstrap — bundleId per browser ───────────────────────────
+
+describe('Session bootstrap', () => {
+  test.each([
+    ['chrome', 'com.google.chrome.ios'],
+    ['firefox', 'org.mozilla.ios.Firefox'],
+    ['edge', 'com.microsoft.msedge.ios'],
+  ])('%s uses bundleId %s in /session POST', async (browser, bundleId) => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileWebkitIosDriver({
+      browser,
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    const sessionCall = fetchImpl.calls.find((c) => c.url.endsWith('/session'));
+    const body = JSON.parse(sessionCall.opts.body);
+    const caps = body.capabilities.alwaysMatch;
+    expect(caps['appium:bundleId']).toBe(bundleId);
+    // Critical pin: NO browserName:safari capability — that would
+    // launch Safari instead of the requested browser app.
+    expect(caps['appium:browserName']).toBeUndefined();
+  });
+
+  test('session cache: subsequent calls reuse the sessionId', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await driver.webRefreshRoomsList('Alice');
+    const sessionPosts = fetchImpl.calls.filter(
+      (c) => c.url.endsWith('/session') && c.opts.method === 'POST',
+    );
+    expect(sessionPosts).toHaveLength(1);
+  });
+
+  test('legacy top-level sessionId shape is accepted', async () => {
+    const fetchImpl = makeFetchMock([
+      {
+        match: (url, opts) => url.endsWith('/session') && opts.method === 'POST',
+        respond: () => makeJsonResponse({ sessionId: 'legacy-sess' }),
+      },
+      {
+        match: (url) => url.endsWith('/session/legacy-sess/contexts'),
+        respond: () => makeJsonResponse({ value: ['NATIVE_APP', 'WEBVIEW_1'] }),
+      },
+      {
+        match: (url, opts) =>
+          url.endsWith('/session/legacy-sess/context') && opts.method === 'POST',
+        respond: () => makeJsonResponse({ value: null }),
+      },
+      {
+        match: (url, opts) => url.endsWith('/session/legacy-sess/url') && opts.method === 'POST',
+        respond: () => makeJsonResponse({ value: null }),
+      },
+    ]);
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'edge',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    expect(await driver.webRefreshRoomsList('Alice')).toBe(true);
+  });
+
+  test('/session non-2xx → driver returns false (no unhandled rejection)', async () => {
+    const fetchImpl = makeFetchMock([
+      {
+        match: (url, opts) => url.endsWith('/session') && opts.method === 'POST',
+        respond: () => makeTextResponse('Could not launch app', 500),
+      },
+    ]);
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    expect(await driver.webRefreshRoomsList('Alice')).toBe(false);
+  });
+
+  test('/session error message mentions the appName so operator knows which app failed', async () => {
+    const fetchImpl = makeFetchMock([
+      {
+        match: (url, opts) => url.endsWith('/session') && opts.method === 'POST',
+        respond: () => makeTextResponse('bundle not found', 500),
+      },
+    ]);
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'firefox',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await driver.webRefreshRoomsList('Alice');
+    const logged = spy.mock.calls.map((c) => c[0]).join('\n');
+    expect(logged).toMatch(/Firefox iOS/);
+    spy.mockRestore();
+  });
+});
+
+// Webview context switching ─────────────────────────────────────────
+
+describe('Webview context switching', () => {
+  test('first webRefreshRoomsList triggers GET /contexts + POST /context (WEBVIEW_1)', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    const ctxGet = fetchImpl.calls.find((c) => c.url.endsWith('/contexts'));
+    expect(ctxGet).toBeDefined();
+    const ctxPost = fetchImpl.calls.find(
+      (c) => c.url.endsWith('/context') && c.opts.method === 'POST',
+    );
+    expect(ctxPost).toBeDefined();
+    expect(JSON.parse(ctxPost.opts.body)).toEqual({ name: 'WEBVIEW_1' });
+  });
+
+  test('webview context is cached across subsequent web ops (no re-switch)', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await driver.webRefreshRoomsList('Alice');
+    await driver.webUiDump();
+    const ctxPosts = fetchImpl.calls.filter(
+      (c) => c.url.endsWith('/context') && c.opts.method === 'POST',
+    );
+    expect(ctxPosts).toHaveLength(1);
+  });
+
+  test('uses the first WEBVIEW_<n> context when multiple are listed', async () => {
+    const fetchImpl = makeFetchMock(
+      defaultHandlers({ contexts: ['NATIVE_APP', 'WEBVIEW_3', 'WEBVIEW_7'] }),
+    );
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    const ctxPost = fetchImpl.calls.find(
+      (c) => c.url.endsWith('/context') && c.opts.method === 'POST',
+    );
+    expect(JSON.parse(ctxPost.opts.body)).toEqual({ name: 'WEBVIEW_3' });
+  });
+
+  test('no WEBVIEW_ context available → returns false with actionable error log', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers({ contexts: ['NATIVE_APP'] }));
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const ok = await driver.webRefreshRoomsList('Alice');
+    expect(ok).toBe(false);
+    const logged = spy.mock.calls.map((c) => c[0]).join('\n');
+    expect(logged).toMatch(/no WEBVIEW_ context/);
+    expect(logged).toMatch(/Web Inspector ON/);
+    spy.mockRestore();
+  });
+
+  test('non-2xx GET /contexts → returns false', async () => {
+    const fetchImpl = makeFetchMock([
+      {
+        match: (url, opts) => url.endsWith('/session') && opts.method === 'POST',
+        respond: () => makeJsonResponse({ value: { sessionId: 'sess-iosbrowser' } }),
+      },
+      {
+        match: (url) => url.endsWith('/contexts'),
+        respond: () => makeTextResponse('not authorised', 500),
+      },
+    ]);
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    expect(await driver.webRefreshRoomsList('Alice')).toBe(false);
+  });
+
+  test('non-2xx POST /context (switch) → returns false', async () => {
+    const fetchImpl = makeFetchMock([
+      {
+        match: (url, opts) => url.endsWith('/session') && opts.method === 'POST',
+        respond: () => makeJsonResponse({ value: { sessionId: 'sess-iosbrowser' } }),
+      },
+      {
+        match: (url) => url.endsWith('/contexts'),
+        respond: () => makeJsonResponse({ value: ['NATIVE_APP', 'WEBVIEW_1'] }),
+      },
+      {
+        match: (url, opts) => url.endsWith('/context') && opts.method === 'POST',
+        respond: () => makeTextResponse('switch failed', 500),
+      },
+    ]);
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    expect(await driver.webRefreshRoomsList('Alice')).toBe(false);
+  });
+});
+
+// webRefreshRoomsList ───────────────────────────────────────────────
+
+describe('webRefreshRoomsList', () => {
+  test('navigates to <baseURL>/rooms', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      baseURL: 'http://localhost:8888',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    const urlCall = fetchImpl.calls.find((c) => c.url.endsWith('/url') && c.opts.method === 'POST');
+    expect(JSON.parse(urlCall.opts.body)).toEqual({ url: 'http://localhost:8888/rooms' });
+  });
+
+  test('trailing slash collapses', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      baseURL: 'http://localhost:8888/',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    const urlCall = fetchImpl.calls.find((c) => c.url.endsWith('/url') && c.opts.method === 'POST');
+    expect(JSON.parse(urlCall.opts.body)).toEqual({ url: 'http://localhost:8888/rooms' });
+  });
+
+  test('/url non-2xx → returns false', async () => {
+    const fetchImpl = makeFetchMock([
+      {
+        match: (url, opts) => url.endsWith('/url') && opts.method === 'POST',
+        respond: () => makeTextResponse('webkit failed', 500),
+      },
+      ...defaultHandlers(),
+    ]);
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    expect(await driver.webRefreshRoomsList('Alice')).toBe(false);
+  });
+});
+
+// webUiDump ─────────────────────────────────────────────────────────
+
+describe('webUiDump', () => {
+  test('returns innerText from /execute/sync', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers({ textValue: 'Hello Webkit' }));
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'edge',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    expect(await driver.webUiDump()).toBe('Hello Webkit');
+  });
+
+  test('returns "" on /execute/sync failure', async () => {
+    const fetchImpl = makeFetchMock([
+      {
+        match: (url) => url.includes('/execute/sync'),
+        respond: () => makeTextResponse('CDP timeout', 500),
+      },
+      ...defaultHandlers(),
+    ]);
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    expect(await driver.webUiDump()).toBe('');
+  });
+
+  test('returns "" when /execute/sync value is null', async () => {
+    const fetchImpl = makeFetchMock([
+      {
+        match: (url) => url.includes('/execute/sync'),
+        respond: () => makeJsonResponse({ value: null }),
+      },
+      ...defaultHandlers(),
+    ]);
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    expect(await driver.webUiDump()).toBe('');
+  });
+});
+
+// close ─────────────────────────────────────────────────────────────
+
+describe('close', () => {
+  test('DELETEs /session/<id> after a session was created', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await driver.close();
+    const del = fetchImpl.calls.find((c) => c.opts.method === 'DELETE');
+    expect(del).toBeDefined();
+  });
+
+  test('no-ops when no session exists', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.close();
+    expect(fetchImpl.calls.filter((c) => c.opts.method === 'DELETE')).toHaveLength(0);
+  });
+
+  test('swallows DELETE network errors (best-effort)', async () => {
+    const fetchImpl = makeFetchMock([
+      {
+        match: (_url, opts) => opts.method === 'DELETE',
+        respond: () => {
+          throw new Error('Appium gone');
+        },
+      },
+      ...defaultHandlers(),
+    ]);
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await expect(driver.close()).resolves.toBeUndefined();
+  });
+
+  test('after close, next web op re-bootstraps a session + webview context', async () => {
+    const fetchImpl = makeFetchMock(defaultHandlers());
+    const driver = await createMobileWebkitIosDriver({
+      browser: 'chrome',
+      wdaTeamId: 'TEAM',
+      selectUdidImpl: () => 'UDID',
+      fetchImpl,
+    });
+    await driver.webRefreshRoomsList('Alice');
+    await driver.close();
+    await driver.webRefreshRoomsList('Alice');
+    const sessionPosts = fetchImpl.calls.filter(
+      (c) => c.url.endsWith('/session') && c.opts.method === 'POST',
+    );
+    expect(sessionPosts).toHaveLength(2); // re-bootstrapped
+  });
+});


### PR DESCRIPTION
Eighth of the matrix-completeness PRs (after #898 / #899 / #900 / #901 / #902 / #903 / #904 Mobile Edge Android). Adds Chrome iOS / Firefox iOS / Edge iOS as parameterised variants of the Safari WebKit transport.

## Why

App Store policy mandates every iOS browser use WebKit (the same engine Mobile Safari uses). Chrome iOS / Firefox iOS / Edge iOS are functionally WebKit wrappers — they ship distinct UI chrome but their page rendering is identical to Safari. From a matrix-completeness standpoint, each is its own browser slug worth exercising.

The transport is the same Appium session pattern as `web-mobile-safari-ios-driver.js`, just with `appium:bundleId` set to the per-browser app and an extra context-switch step to drop into the launched browser's WebKit webview.

## What

### `scripts/drivers/web-mobile-webkit-ios-driver.js` (NEW)
A single shared driver factory parameterised by `browser` (`chrome` | `firefox` | `edge`).

**WEBKIT_BROWSERS map** — per-browser bundleId + operator-facing appName:

| browser | bundleId | appName |
|---|---|---|
| chrome | `com.google.chrome.ios` | Chrome iOS |
| firefox | `org.mozilla.ios.Firefox` | Firefox iOS |
| edge | `com.microsoft.msedge.ios` | Edge iOS |

- Session bootstrap: `POST /session` with `appium:bundleId: <per-browser>` and **no** `appium:browserName: safari` cap (which would launch Safari instead).
- Webview context switching: `GET /contexts` → `POST /context` with the first `WEBVIEW_<n>` entry. Cached after first switch.
- Methods: `webRefreshRoomsList`, `webUiDump`, `close` — same surface as Safari driver.
- Reuses `selectUdid` from `ios-appium-driver` for device-selection parity.

### `scripts/browser-allowlist.js`
- `MOBILE_BROWSERS` gains `mobile-chrome-ios` / `mobile-firefox-ios` / `mobile-edge-ios`.
- Local allowlist picks them up via the `[...MOBILE_BROWSERS]` spread.
- Dev/prod allowlists unchanged (iPhone browsers = local-only per operator policy).

### `scripts/manual-qa-runner.js`
New dispatch arm: any of `mobile-chrome-ios` / `mobile-firefox-ios` / `mobile-edge-ios` routes to `createMobileWebkitIosDriver`, with the browser key derived from the slug by stripping `mobile-` prefix + `-ios` suffix.

## Tests

### `tests/scripts/drivers/web-mobile-webkit-ios-driver.test.js` — 37 tests
- `WEBKIT_BROWSERS` constant pins: each browser's bundleId + appName + reverse-DNS sanity + no degenerate config.
- `isSupportedBrowser` positive/negative + hasOwnProperty-safe (rejects inherited keys like `toString`).
- `supportedBrowsersList` sorted output.
- `DEFAULT_APPIUM_BASE_URL` pin.
- Input validation: unknown browser slug, no iPhone, missing `WDA_TEAM_ID`, error references the browser slug.
- Session bootstrap per browser (`test.each` parameterised): bundleId per-browser pin, **NO** `browserName:safari` pin (critical), session caching, legacy top-level sessionId fallback, non-2xx → false, error log mentions appName.
- Webview context switching: `GET /contexts` + `POST /context` flow, cached across web ops, picks first `WEBVIEW_<n>`, no-webview actionable error pointing at iPhone Settings → Safari → Advanced → Web Inspector ON, contexts-fetch failure → false, context-switch failure → false.
- `webRefreshRoomsList`: `/url` shape, trailing-slash collapse, failure → false.
- `webUiDump`: value + failure → `''` + value-null → `''`.
- `close`: DELETE shape, no-op-before-session, swallows network errors, re-bootstraps after close.

### Existing tests
- 26 browser-allowlist tests: `test.each(MOBILE_BROWSERS)` auto-includes the new slugs.
- Safari driver tests still pass (independent module).

### Suite
Full express-api: 10051/10059 pass, 8 expected skipped. Lint + format clean.

## Operator one-time setup

1. Ensure the Appium server is running on the local machine (same one ios-appium-driver uses; see `ios-appium-setup.md`).
2. Install Chrome iOS / Firefox iOS / Edge iOS on the connected iPhone.
3. iPhone Settings → Safari → Advanced → **Web Inspector ON** (required for Appium to enumerate the WebKit webviews of the third-party browsers).
4. Pass `--browser mobile-chrome-ios` / `mobile-firefox-ios` / `mobile-edge-ios`.

## Out of scope

- Mobile Firefox on Android — separate PR F, uses Marionette/Geckodriver (not WebKit, not CDP).
- Runner `--matrix` dispatch loop — separate PR I after all driver slots are filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)