### PR TITLE
feat(qa-runner): --report-format json|junit for structured matrix output

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -15446,6 +15446,14 @@ async function main() {
     else if (flat[i] === '--headed') opts.headed = true;
     else if (flat[i] === '--matrix') opts.matrix = true;
     else if (flat[i] === '--fail-fast') opts.failFast = true;
+    else if (flat[i] === '--report-format') opts.reportFormat = flat[++i];
+    else if (flat[i] === '--report-output') opts.reportOutput = flat[++i];
+  }
+  // --report-format validation — only json + junit are supported (used
+  // with --matrix to emit structured output for CI dashboards).
+  if (opts.reportFormat && !['json', 'junit'].includes(opts.reportFormat)) {
+    console.error(`--report-format "${opts.reportFormat}" not recognised. Supported: json, junit.`);
+    process.exit(2);
   }
   opts.target = opts.target || 'dev';
   opts.planDir = opts.planDir || path.resolve(__dirname, '../../journey-tests');
@@ -15483,12 +15491,30 @@ async function main() {
   // state. The iteration helper (./matrix-dispatch.js) aggregates
   // pass / fail / skip outcomes and prints a summary table at the end.
   if (opts.matrix) {
-    const { runMatrix, formatMatrixResult } = require('./matrix-dispatch');
+    const {
+      runMatrix,
+      formatMatrixResult,
+      formatMatrixResultJson,
+      formatMatrixResultJunit,
+    } = require('./matrix-dispatch');
     const { spawnSync } = require('child_process');
-    // Reconstruct the per-cell argv by stripping --matrix + appending
-    // --browser <slug>. If --browser was already supplied, the existing
-    // value gets shadowed (last --browser wins in the parse loop).
-    const baseArgv = process.argv.slice(2).filter((a) => a !== '--matrix');
+    // Reconstruct the per-cell argv by stripping --matrix + report flags
+    // + appending --browser <slug>. Per-cell subprocesses don't need the
+    // matrix-level flags (they'd recurse). Last --browser wins in the
+    // parse loop.
+    const stripFlags = new Set(['--matrix', '--report-format', '--report-output']);
+    const baseArgv = [];
+    const sourceArgv = process.argv.slice(2);
+    for (let i = 0; i < sourceArgv.length; i++) {
+      const a = sourceArgv[i];
+      if (stripFlags.has(a)) {
+        // --matrix is a boolean; --report-format / --report-output
+        // take a value, skip it too.
+        if (a !== '--matrix') i++;
+        continue;
+      }
+      baseArgv.push(a);
+    }
     const matrixResult = await runMatrix({
       browsers: allowed,
       failFast: opts.failFast === true,
@@ -15505,7 +15531,26 @@ async function main() {
         return proc.status === 0;
       },
     });
+    // Always print the human-readable text table to stdout so the
+    // operator gets immediate feedback regardless of --report-format.
     console.log('\n' + formatMatrixResult(matrixResult));
+    // Optional structured-report output for CI consumption.
+    if (opts.reportFormat) {
+      const fsImpl = require('fs');
+      let formatted;
+      if (opts.reportFormat === 'json') {
+        formatted = formatMatrixResultJson(matrixResult);
+      } else {
+        // junit
+        formatted = formatMatrixResultJunit(matrixResult);
+      }
+      if (opts.reportOutput) {
+        fsImpl.writeFileSync(opts.reportOutput, formatted);
+        console.log(`[matrix] ${opts.reportFormat} report written to ${opts.reportOutput}`);
+      } else {
+        console.log(`\n${formatted}`);
+      }
+    }
     process.exit(matrixResult.ok ? 0 : 1);
   }
   const personasPassword = process.env.PERSONAS_PASSWORD;

--- a/express-api/scripts/matrix-dispatch.js
+++ b/express-api/scripts/matrix-dispatch.js
@@ -174,9 +174,85 @@ function formatMatrixResult({ cells, summary }) {
   return lines.join('\n');
 }
 
+/**
+ * Render the matrix result as JSON. Same shape as runMatrix() returns
+ * plus a top-level `format: 'matrix-v1'` discriminator + ISO timestamp,
+ * so CI dashboards can identify the schema version.
+ *
+ *   {
+ *     format: 'matrix-v1',
+ *     generatedAt: '2026-05-30T18:42:00.000Z',
+ *     summary: '...',
+ *     ok: true,
+ *     totals: { pass, fail, skip },
+ *     cells: [{ browser, outcome, durationMs, error? }],
+ *   }
+ *
+ * `nowIso` is injectable for tests (deterministic timestamps).
+ */
+function formatMatrixResultJson(result, { nowIso = () => new Date().toISOString() } = {}) {
+  const payload = {
+    format: 'matrix-v1',
+    generatedAt: nowIso(),
+    summary: result.summary,
+    ok: result.ok,
+    totals: result.totals,
+    cells: result.cells,
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+/**
+ * Render the matrix result as JUnit XML — the canonical format CI
+ * dashboards (Jenkins / GitHub Actions test reporter / GitLab /
+ * CircleCI / etc.) consume.
+ *
+ * One <testsuite> per matrix run, one <testcase> per cell. `outcome`
+ * maps to JUnit semantics:
+ *   - 'pass'  → no failure/skipped tag
+ *   - 'fail'  → <failure message="...">
+ *   - 'skip'  → <skipped message="...">
+ *
+ * Special chars in browser slugs / error messages are XML-escaped so
+ * the output is well-formed. Suite-level `tests`/`failures`/`skipped`
+ * counts pinned for reporter compatibility.
+ *
+ * `nowIso` injectable for tests.
+ */
+function formatMatrixResultJunit(result, { nowIso = () => new Date().toISOString() } = {}) {
+  const escape = (s) =>
+    String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  const totalMs = result.cells.reduce((acc, c) => acc + (c.durationMs || 0), 0);
+  const lines = ['<?xml version="1.0" encoding="UTF-8"?>'];
+  lines.push(
+    `<testsuite name="qa-matrix" tests="${result.cells.length}" failures="${result.totals.fail}" skipped="${result.totals.skip}" time="${(totalMs / 1000).toFixed(3)}" timestamp="${escape(nowIso())}">`,
+  );
+  for (const c of result.cells) {
+    const timeSec = ((c.durationMs || 0) / 1000).toFixed(3);
+    lines.push(`  <testcase classname="qa-matrix" name="${escape(c.browser)}" time="${timeSec}">`);
+    if (c.outcome === 'fail') {
+      lines.push(
+        `    <failure message="${escape(c.error || 'matrix cell failed')}" type="MatrixCellFailure"/>`,
+      );
+    } else if (c.outcome === 'skip') {
+      lines.push(`    <skipped message="${escape(c.error || 'matrix cell skipped')}"/>`);
+    }
+    lines.push('  </testcase>');
+  }
+  lines.push('</testsuite>');
+  return lines.join('\n');
+}
+
 module.exports = {
   INIT_ERROR_SIGNATURES,
   isInitError,
   runMatrix,
   formatMatrixResult,
+  formatMatrixResultJson,
+  formatMatrixResultJunit,
 };

--- a/express-api/tests/scripts/matrix-dispatch.test.js
+++ b/express-api/tests/scripts/matrix-dispatch.test.js
@@ -24,9 +24,14 @@
 
 const path = require('path');
 const REPO_ROOT = path.resolve(__dirname, '../../..');
-const { INIT_ERROR_SIGNATURES, isInitError, runMatrix, formatMatrixResult } = require(
-  path.join(REPO_ROOT, 'express-api/scripts/matrix-dispatch'),
-);
+const {
+  INIT_ERROR_SIGNATURES,
+  isInitError,
+  runMatrix,
+  formatMatrixResult,
+  formatMatrixResultJson,
+  formatMatrixResultJunit,
+} = require(path.join(REPO_ROOT, 'express-api/scripts/matrix-dispatch'));
 
 // isInitError ───────────────────────────────────────────────────────
 
@@ -352,5 +357,179 @@ describe('formatMatrixResult', () => {
     });
     // The long browser name must appear unchopped.
     expect(text).toMatch(/mobile-firefox-android/);
+  });
+});
+
+// formatMatrixResultJson ────────────────────────────────────────────
+
+describe('formatMatrixResultJson', () => {
+  function exampleResult() {
+    return {
+      cells: [
+        { browser: 'chromium', outcome: 'pass', durationMs: 842 },
+        { browser: 'mobile-safari-ios', outcome: 'skip', durationMs: 0, error: 'no iPhone' },
+        { browser: 'firefox', outcome: 'fail', durationMs: 1023, error: 'AssertionError' },
+      ],
+      totals: { pass: 1, fail: 1, skip: 1 },
+      summary: '1 pass / 1 fail / 1 skip',
+      ok: false,
+    };
+  }
+
+  test('emits format=matrix-v1 + ISO timestamp + summary/totals/cells', () => {
+    const json = formatMatrixResultJson(exampleResult(), {
+      nowIso: () => '2026-05-30T18:42:00.000Z',
+    });
+    const obj = JSON.parse(json);
+    expect(obj.format).toBe('matrix-v1');
+    expect(obj.generatedAt).toBe('2026-05-30T18:42:00.000Z');
+    expect(obj.summary).toBe('1 pass / 1 fail / 1 skip');
+    expect(obj.totals).toEqual({ pass: 1, fail: 1, skip: 1 });
+    expect(obj.ok).toBe(false);
+    expect(obj.cells).toHaveLength(3);
+  });
+
+  test('cells include error message for fail + skip outcomes', () => {
+    const obj = JSON.parse(
+      formatMatrixResultJson(exampleResult(), { nowIso: () => '2026-05-30T18:42:00.000Z' }),
+    );
+    const skipCell = obj.cells.find((c) => c.outcome === 'skip');
+    expect(skipCell.error).toBe('no iPhone');
+    const failCell = obj.cells.find((c) => c.outcome === 'fail');
+    expect(failCell.error).toBe('AssertionError');
+  });
+
+  test('output is parseable JSON + pretty-printed (multi-line)', () => {
+    const json = formatMatrixResultJson(exampleResult(), {
+      nowIso: () => '2026-05-30T18:42:00.000Z',
+    });
+    expect(json.split('\n').length).toBeGreaterThan(5); // pretty-printed
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+
+  test('nowIso defaults to a real ISO string when omitted', () => {
+    const obj = JSON.parse(formatMatrixResultJson(exampleResult()));
+    expect(obj.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+});
+
+// formatMatrixResultJunit ───────────────────────────────────────────
+
+describe('formatMatrixResultJunit', () => {
+  function exampleResult() {
+    return {
+      cells: [
+        { browser: 'chromium', outcome: 'pass', durationMs: 842 },
+        { browser: 'mobile-safari-ios', outcome: 'skip', durationMs: 0, error: 'no iPhone' },
+        { browser: 'firefox', outcome: 'fail', durationMs: 1023, error: 'AssertionError' },
+      ],
+      totals: { pass: 1, fail: 1, skip: 1 },
+      summary: '1 pass / 1 fail / 1 skip',
+      ok: false,
+    };
+  }
+
+  test('starts with XML declaration', () => {
+    const xml = formatMatrixResultJunit(exampleResult(), {
+      nowIso: () => '2026-05-30T18:42:00.000Z',
+    });
+    expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+  });
+
+  test('top-level <testsuite> has tests/failures/skipped counts + total time', () => {
+    const xml = formatMatrixResultJunit(exampleResult(), {
+      nowIso: () => '2026-05-30T18:42:00.000Z',
+    });
+    expect(xml).toMatch(/<testsuite name="qa-matrix"/);
+    expect(xml).toMatch(/tests="3"/);
+    expect(xml).toMatch(/failures="1"/);
+    expect(xml).toMatch(/skipped="1"/);
+    expect(xml).toMatch(/time="1\.865"/); // 842 + 0 + 1023 = 1865ms → 1.865s
+    expect(xml).toMatch(/timestamp="2026-05-30T18:42:00.000Z"/);
+  });
+
+  test('one <testcase> per cell with browser slug as name', () => {
+    const xml = formatMatrixResultJunit(exampleResult(), {
+      nowIso: () => '2026-05-30T18:42:00.000Z',
+    });
+    expect(xml).toMatch(/<testcase classname="qa-matrix" name="chromium" time="0\.842"/);
+    expect(xml).toMatch(/<testcase classname="qa-matrix" name="mobile-safari-ios" time="0\.000"/);
+    expect(xml).toMatch(/<testcase classname="qa-matrix" name="firefox" time="1\.023"/);
+  });
+
+  test('pass cells have no <failure> or <skipped> tag', () => {
+    const xml = formatMatrixResultJunit({
+      cells: [{ browser: 'chromium', outcome: 'pass', durationMs: 100 }],
+      totals: { pass: 1, fail: 0, skip: 0 },
+      summary: '1 pass / 0 fail / 0 skip',
+      ok: true,
+    });
+    expect(xml).not.toMatch(/<failure/);
+    expect(xml).not.toMatch(/<skipped/);
+  });
+
+  test('fail cells get a <failure message="..." type="MatrixCellFailure"/>', () => {
+    const xml = formatMatrixResultJunit(exampleResult(), {
+      nowIso: () => '2026-05-30T18:42:00.000Z',
+    });
+    expect(xml).toMatch(/<failure message="AssertionError" type="MatrixCellFailure"\/>/);
+  });
+
+  test('skip cells get a <skipped message="..."/>', () => {
+    const xml = formatMatrixResultJunit(exampleResult(), {
+      nowIso: () => '2026-05-30T18:42:00.000Z',
+    });
+    expect(xml).toMatch(/<skipped message="no iPhone"\/>/);
+  });
+
+  test('XML-escapes special chars in browser slugs + error messages', () => {
+    const result = {
+      cells: [
+        {
+          browser: 'name<with>chars&"\'',
+          outcome: 'fail',
+          durationMs: 10,
+          error: 'err with <special> & "chars"',
+        },
+      ],
+      totals: { pass: 0, fail: 1, skip: 0 },
+      summary: '0 pass / 1 fail / 0 skip',
+      ok: false,
+    };
+    const xml = formatMatrixResultJunit(result, { nowIso: () => '2026-05-30T18:42:00.000Z' });
+    // No raw < or > or unescaped " inside attribute values
+    expect(xml).toMatch(/name="name&lt;with&gt;chars&amp;&quot;&apos;"/);
+    expect(xml).toMatch(/message="err with &lt;special&gt; &amp; &quot;chars&quot;"/);
+  });
+
+  test('fail cell with no error message falls back to a sentinel', () => {
+    const xml = formatMatrixResultJunit({
+      cells: [{ browser: 'chromium', outcome: 'fail', durationMs: 50 }],
+      totals: { pass: 0, fail: 1, skip: 0 },
+      summary: '0 pass / 1 fail / 0 skip',
+      ok: false,
+    });
+    expect(xml).toMatch(/message="matrix cell failed"/);
+  });
+
+  test('skip cell with no error message falls back to a sentinel', () => {
+    const xml = formatMatrixResultJunit({
+      cells: [{ browser: 'chromium', outcome: 'skip', durationMs: 0 }],
+      totals: { pass: 0, fail: 0, skip: 1 },
+      summary: '0 pass / 0 fail / 1 skip',
+      ok: true,
+    });
+    expect(xml).toMatch(/message="matrix cell skipped"/);
+  });
+
+  test('empty cells array still produces valid XML (no rows)', () => {
+    const xml = formatMatrixResultJunit({
+      cells: [],
+      totals: { pass: 0, fail: 0, skip: 0 },
+      summary: '0 pass / 0 fail / 0 skip',
+      ok: true,
+    });
+    expect(xml).toMatch(/<testsuite name="qa-matrix" tests="0"/);
+    expect(xml).not.toMatch(/<testcase/);
   });
 });


### PR DESCRIPTION
After #906 added the `--matrix` dispatch loop, the runner prints a text table to stdout. That's fine for an operator reading terminal output but CI dashboards need structured input (JUnit XML for Jenkins / GHA test reporter / GitLab / CircleCI; JSON for custom dashboards).

This PR adds two output formats + a CLI flag combo.

## What

### `scripts/matrix-dispatch.js`
- `formatMatrixResultJson(result)` — emits a versioned JSON payload:

  ```json
  {
    "format": "matrix-v1",
    "generatedAt": "<ISO timestamp>",
    "summary": "...",
    "ok": true,
    "totals": { "pass": 0, "fail": 0, "skip": 0 },
    "cells": [{ "browser": "...", "outcome": "...", "durationMs": 0 }]
  }
  ```

  The `format` discriminator lets dashboards detect the schema version before parsing.

- `formatMatrixResultJunit(result)` — emits JUnit XML:

  ```xml
  <testsuite tests="N" failures="X" skipped="Y" time="Z" ...>
    <testcase classname="qa-matrix" name="<browser>" time="<s>">
      <failure message="..." type="MatrixCellFailure"/>  (when fail)
      <skipped message="..."/>                            (when skip)
    </testcase>
    ...
  </testsuite>
  ```

  Special chars in browser slugs + error messages are XML-escaped (`&`, `<`, `>`, `"`, `'`).

- `nowIso` injectable on both helpers for deterministic test timestamps.

### `scripts/manual-qa-runner.js`
- New CLI flags:
  - `--report-format json|junit`
  - `--report-output <path>` (write to file; stdout if omitted)
- Validated at parse — unknown values fail with an actionable error before any runner work starts.
- Per-cell subprocesses strip `--report-format` / `--report-output` along with `--matrix` so cells don't re-emit reports recursively.
- The text table still prints to stdout for the operator's immediate feedback. The structured report is **additional**, not a replacement.

## Tests

### `tests/scripts/matrix-dispatch.test.js` — +14 new (60 total)
- `formatMatrixResultJson`:
  - `format=matrix-v1` + ISO timestamp + summary/totals/cells shape
  - cells include error for fail+skip
  - output is parseable JSON + pretty-printed
  - `nowIso` defaults to real ISO
- `formatMatrixResultJunit`:
  - XML declaration prefix
  - top-level `<testsuite>` with tests/failures/skipped/time/timestamp attrs
  - one `<testcase>` per cell
  - pass-cells have no failure/skipped tag
  - fail-cells get `<failure type="MatrixCellFailure">`
  - skip-cells get `<skipped/>`
  - XML escape of `<`, `>`, `&`, `"`, `'` in browser slugs + error messages
  - sentinel messages when error is omitted
  - empty cells array still produces valid XML

### Suite
Full express-api: 263/263 suites, 10157/10165 pass, 8 expected skipped. Lint + format clean.

## Usage

```bash
# Emit JUnit XML to file:
node scripts/manual-qa-runner.js \
    --target local --matrix \
    --report-format junit \
    --report-output reports/matrix.xml

# Emit JSON to stdout (alongside the text table):
node scripts/manual-qa-runner.js \
    --target local --matrix --report-format json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)