### PR TITLE
feat(qa-runner): --check-drivers diagnostic — verify every cell can bootstrap

### DIFF
--- a/express-api/scripts/driver-health-check.js
+++ b/express-api/scripts/driver-health-check.js
@@ -1,0 +1,147 @@
+/**
+ * driver-health-check.js
+ *
+ * Diagnostic command for the runner's `--check-drivers` flag.
+ *
+ * For each browser slug in the supplied list, the helper calls the
+ * matching driver-factory function. If the factory returns a driver,
+ * the helper closes it cleanly and records 'ok'. If the factory throws
+ * with an init-error signature (no device, missing env var, server
+ * unreachable, etc.), the helper records 'skip' with the actionable
+ * error message. Any other throw is recorded as 'fail'.
+ *
+ * This is the fastest way for the operator to verify every device +
+ * server + env-var is in place BEFORE running a full --matrix journey
+ * (which can take 5-10 minutes per cell). A typical health-check run
+ * takes ~10s total for 12 cells.
+ *
+ * The matrix-dispatch's `isInitError` matcher is reused here so the
+ * skip-vs-fail classification stays consistent between the two
+ * commands.
+ */
+
+const { isInitError } = require('./matrix-dispatch');
+
+/**
+ * Runs the health check.
+ *
+ *   const result = await runHealthCheck({
+ *     browsers: ['chromium', 'mobile-chrome-android'],
+ *     factories: { chromium: createChromiumDriver, ... },
+ *     baseURL: 'http://localhost:8888',
+ *   });
+ *   // result.summary === '1 ok / 0 fail / 1 skip'
+ *   // result.cells === [{ browser: 'chromium', outcome: 'ok', durationMs }, ...]
+ *
+ * Returns:
+ *   {
+ *     cells: Array<{ browser, outcome: 'ok' | 'fail' | 'skip', error?, durationMs }>,
+ *     totals: { ok, fail, skip },
+ *     summary: string,
+ *     ok: boolean,        // true iff zero fails (skips don't count)
+ *   }
+ *
+ * Required args:
+ *   - browsers — array of browser slugs to health-check
+ *   - factories — object mapping browser slug → async () => driver
+ *
+ * Optional:
+ *   - baseURL — passed through to each factory (default localhost:8888)
+ *   - onCellStart / onCellEnd — progress callbacks
+ *   - nowMs — clock injection for tests
+ */
+async function runHealthCheck({
+  browsers,
+  factories,
+  baseURL = 'http://localhost:8888',
+  onCellStart,
+  onCellEnd,
+  nowMs = () => Date.now(),
+} = {}) {
+  if (!Array.isArray(browsers)) {
+    throw new Error('runHealthCheck: `browsers` must be an array of browser slugs');
+  }
+  if (browsers.length === 0) {
+    throw new Error('runHealthCheck: `browsers` is empty');
+  }
+  if (!factories || typeof factories !== 'object') {
+    throw new Error('runHealthCheck: `factories` must be an object mapping slug → factory fn');
+  }
+
+  const cells = [];
+  for (const browser of browsers) {
+    if (typeof onCellStart === 'function') onCellStart({ browser });
+    const t0 = nowMs();
+    let outcome;
+    let error;
+    const factory = factories[browser];
+    if (typeof factory !== 'function') {
+      outcome = 'fail';
+      error = `no factory registered for browser slug "${browser}"`;
+    } else {
+      let driver;
+      try {
+        driver = await factory({ baseURL });
+        outcome = 'ok';
+      } catch (e) {
+        if (isInitError(e)) {
+          outcome = 'skip';
+          error = e.message;
+        } else {
+          outcome = 'fail';
+          error = e.message;
+        }
+      }
+      // Best-effort close — never let a close error change the
+      // health-check outcome (the bootstrap succeeded, that's the point).
+      if (driver && typeof driver.close === 'function') {
+        try {
+          await driver.close();
+        } catch (_e) {
+          /* swallow close errors */
+        }
+      }
+    }
+    const durationMs = Math.max(0, nowMs() - t0);
+    const cell = { browser, outcome, durationMs };
+    if (error) cell.error = error;
+    cells.push(cell);
+    if (typeof onCellEnd === 'function') onCellEnd(cell);
+  }
+
+  const totals = cells.reduce(
+    (acc, c) => {
+      acc[c.outcome] = (acc[c.outcome] || 0) + 1;
+      return acc;
+    },
+    { ok: 0, fail: 0, skip: 0 },
+  );
+
+  const summary = `${totals.ok} ok / ${totals.fail} fail / ${totals.skip} skip`;
+  return { cells, totals, summary, ok: totals.fail === 0 };
+}
+
+/**
+ * Render the health-check result as a compact text table. Mirrors the
+ * shape of formatMatrixResult so the operator sees consistent output.
+ */
+function formatHealthCheckResult({ cells, summary }) {
+  const lines = [];
+  const widest = Math.max(7, ...cells.map((c) => c.browser.length));
+  const sep = `${'-'.repeat(widest + 2)}+--------+----------`;
+  lines.push(sep);
+  lines.push(`${'browser'.padEnd(widest + 2)}| outcome | ms`);
+  lines.push(sep);
+  for (const c of cells) {
+    const ms = String(c.durationMs).padStart(8);
+    lines.push(`${c.browser.padEnd(widest + 2)}| ${c.outcome.padEnd(7)}|${ms}`);
+  }
+  lines.push(sep);
+  lines.push(`Health: ${summary}`);
+  return lines.join('\n');
+}
+
+module.exports = {
+  runHealthCheck,
+  formatHealthCheckResult,
+};

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -15446,6 +15446,7 @@ async function main() {
     else if (flat[i] === '--headed') opts.headed = true;
     else if (flat[i] === '--matrix') opts.matrix = true;
     else if (flat[i] === '--fail-fast') opts.failFast = true;
+    else if (flat[i] === '--check-drivers') opts.checkDrivers = true;
   }
   opts.target = opts.target || 'dev';
   opts.planDir = opts.planDir || path.resolve(__dirname, '../../journey-tests');
@@ -15475,6 +15476,90 @@ async function main() {
   if (!TARGETS[opts.target]) {
     console.error(`Unknown target: ${opts.target}. Valid: ${Object.keys(TARGETS).join(', ')}`);
     process.exit(2);
+  }
+
+  // --check-drivers verifies every device + browser app + env-var is
+  // in place by trying to bootstrap each driver in the target's
+  // allowlist + closing it immediately. Faster than --matrix (no
+  // journey scenario runs) — typical 12-cell health-check is ~10s.
+  // Skips for bootstrap failures (no device / missing env / app not
+  // installed) so the operator gets a per-cell readiness report.
+  if (opts.checkDrivers) {
+    const { runHealthCheck, formatHealthCheckResult } = require('./driver-health-check');
+    const baseURL = TARGETS[opts.target].webBase || 'http://localhost:8888';
+    // Each factory is a thin wrapper around the matching createXxxDriver
+    // — same browser → driver mapping as the runner's main dispatch.
+    const factories = {
+      chromium: ({ baseURL: u }) =>
+        require('./drivers/web-playwright-driver').createWebDriver({
+          baseURL: u,
+          headless: !opts.headed,
+          browser: 'chromium',
+        }),
+      firefox: ({ baseURL: u }) =>
+        require('./drivers/web-playwright-driver').createWebDriver({
+          baseURL: u,
+          headless: !opts.headed,
+          browser: 'firefox',
+        }),
+      webkit: ({ baseURL: u }) =>
+        require('./drivers/web-playwright-driver').createWebDriver({
+          baseURL: u,
+          headless: !opts.headed,
+          browser: 'webkit',
+        }),
+      edge: ({ baseURL: u }) =>
+        require('./drivers/web-playwright-driver').createWebDriver({
+          baseURL: u,
+          headless: !opts.headed,
+          browser: 'edge',
+        }),
+      'mobile-chrome-android': ({ baseURL: u }) =>
+        require('./drivers/web-mobile-chrome-android-driver').createMobileChromeAndroidDriver({
+          baseURL: u,
+        }),
+      'mobile-samsung-android': ({ baseURL: u }) =>
+        require('./drivers/web-mobile-samsung-android-driver').createMobileSamsungAndroidDriver({
+          baseURL: u,
+        }),
+      'mobile-edge-android': ({ baseURL: u }) =>
+        require('./drivers/web-mobile-edge-android-driver').createMobileEdgeAndroidDriver({
+          baseURL: u,
+        }),
+      'mobile-firefox-android': ({ baseURL: u }) =>
+        require('./drivers/web-mobile-firefox-android-driver').createMobileFirefoxAndroidDriver({
+          baseURL: u,
+        }),
+      'mobile-safari-ios': ({ baseURL: u }) =>
+        require('./drivers/web-mobile-safari-ios-driver').createMobileSafariIosDriver({
+          baseURL: u,
+        }),
+      'mobile-chrome-ios': ({ baseURL: u }) =>
+        require('./drivers/web-mobile-webkit-ios-driver').createMobileWebkitIosDriver({
+          browser: 'chrome',
+          baseURL: u,
+        }),
+      'mobile-firefox-ios': ({ baseURL: u }) =>
+        require('./drivers/web-mobile-webkit-ios-driver').createMobileWebkitIosDriver({
+          browser: 'firefox',
+          baseURL: u,
+        }),
+      'mobile-edge-ios': ({ baseURL: u }) =>
+        require('./drivers/web-mobile-webkit-ios-driver').createMobileWebkitIosDriver({
+          browser: 'edge',
+          baseURL: u,
+        }),
+    };
+    const healthResult = await runHealthCheck({
+      browsers: allowed,
+      factories,
+      baseURL,
+      onCellStart: ({ browser }) => console.log(`[check-drivers] → ${browser}`),
+      onCellEnd: (cell) =>
+        console.log(`[check-drivers] ← ${cell.browser}: ${cell.outcome} (${cell.durationMs}ms)`),
+    });
+    console.log('\n' + formatHealthCheckResult(healthResult));
+    process.exit(healthResult.ok ? 0 : 1);
   }
 
   // --matrix dispatches the same scenario across every browser in the

--- a/express-api/tests/scripts/driver-health-check.test.js
+++ b/express-api/tests/scripts/driver-health-check.test.js
@@ -1,0 +1,324 @@
+/**
+ * driver-health-check.test.js
+ *
+ * Tests the diagnostic `runHealthCheck` helper used by the runner's
+ * `--check-drivers` flag.
+ *
+ * Coverage areas:
+ *   - Input validation (browsers not array, empty, factories missing)
+ *   - Per-cell outcome classification:
+ *     - factory returns driver → 'ok' + close() called
+ *     - factory throws init-error → 'skip' with message captured
+ *     - factory throws other error → 'fail' with message captured
+ *     - missing factory for slug → 'fail' with "no factory registered"
+ *   - close() error swallowed (doesn't downgrade 'ok' to 'fail')
+ *   - baseURL forwarded to factories
+ *   - onCellStart / onCellEnd callbacks
+ *   - durationMs from injected nowMs
+ *   - totals + summary string shape ("ok" prefix, not "pass")
+ *   - ok flag (false iff any fail)
+ *   - formatHealthCheckResult shape: header + row + summary line
+ */
+
+const path = require('path');
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const { runHealthCheck, formatHealthCheckResult } = require(
+  path.join(REPO_ROOT, 'express-api/scripts/driver-health-check'),
+);
+
+function makeFactoryReturning(driver) {
+  return jest.fn(async () => driver);
+}
+
+function makeFactoryThrowing(err) {
+  return jest.fn(async () => {
+    throw err;
+  });
+}
+
+function makeFakeDriver({ closeImpl = jest.fn() } = {}) {
+  return { close: closeImpl };
+}
+
+// runHealthCheck — input validation ────────────────────────────────
+
+describe('runHealthCheck — input validation', () => {
+  test('throws when browsers is not an array', async () => {
+    await expect(runHealthCheck({ browsers: 'chromium', factories: {} })).rejects.toThrow(
+      /browsers.*must be an array/,
+    );
+  });
+
+  test('throws when browsers is empty', async () => {
+    await expect(runHealthCheck({ browsers: [], factories: {} })).rejects.toThrow(
+      /browsers.*is empty/,
+    );
+  });
+
+  test('throws when factories is missing', async () => {
+    await expect(runHealthCheck({ browsers: ['chromium'] })).rejects.toThrow(
+      /factories.*must be an object/,
+    );
+  });
+
+  test('throws when factories is not an object', async () => {
+    await expect(runHealthCheck({ browsers: ['chromium'], factories: 'oops' })).rejects.toThrow(
+      /factories.*must be an object/,
+    );
+  });
+});
+
+// Per-cell outcome classification ──────────────────────────────────
+
+describe('runHealthCheck — per-cell outcomes', () => {
+  test('factory returning a driver → outcome="ok" + close() called', async () => {
+    const closeImpl = jest.fn();
+    const driver = makeFakeDriver({ closeImpl });
+    const factory = makeFactoryReturning(driver);
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: factory },
+    });
+    expect(r.cells[0].outcome).toBe('ok');
+    expect(closeImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('factory throwing init-error → outcome="skip" with message captured', async () => {
+    const factory = makeFactoryThrowing(new Error('no Android device attached'));
+    const r = await runHealthCheck({
+      browsers: ['mobile-chrome-android'],
+      factories: { 'mobile-chrome-android': factory },
+    });
+    expect(r.cells[0].outcome).toBe('skip');
+    expect(r.cells[0].error).toMatch(/no Android device/);
+  });
+
+  test('factory throwing non-init Error → outcome="fail"', async () => {
+    const factory = makeFactoryThrowing(new Error('TypeError: not a function'));
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: factory },
+    });
+    expect(r.cells[0].outcome).toBe('fail');
+    expect(r.cells[0].error).toMatch(/TypeError/);
+  });
+
+  test('factory throw with err.code=DRIVER_INIT_FAILED forces "skip"', async () => {
+    const err = new Error('connection refused');
+    err.code = 'DRIVER_INIT_FAILED';
+    const factory = makeFactoryThrowing(err);
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: factory },
+    });
+    expect(r.cells[0].outcome).toBe('skip');
+  });
+
+  test('missing factory for slug → outcome="fail" with actionable message', async () => {
+    const r = await runHealthCheck({
+      browsers: ['mobile-unknown'],
+      factories: {},
+    });
+    expect(r.cells[0].outcome).toBe('fail');
+    expect(r.cells[0].error).toMatch(/no factory registered/);
+  });
+
+  test('factory returning null → close skipped (no crash)', async () => {
+    const factory = jest.fn(async () => null);
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: factory },
+    });
+    expect(r.cells[0].outcome).toBe('ok');
+  });
+
+  test('driver.close throwing does NOT downgrade outcome from "ok" to "fail"', async () => {
+    const driver = makeFakeDriver({
+      closeImpl: jest.fn(() => {
+        throw new Error('close failed');
+      }),
+    });
+    const factory = makeFactoryReturning(driver);
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: factory },
+    });
+    expect(r.cells[0].outcome).toBe('ok');
+  });
+
+  test('driver without a close method is tolerated', async () => {
+    const factory = jest.fn(async () => ({
+      /* no close */
+    }));
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: factory },
+    });
+    expect(r.cells[0].outcome).toBe('ok');
+  });
+});
+
+// Multi-cell + aggregation ─────────────────────────────────────────
+
+describe('runHealthCheck — multi-cell aggregation', () => {
+  test('mixed ok/skip/fail totals + summary string', async () => {
+    const r = await runHealthCheck({
+      browsers: ['chromium', 'mobile-chrome-android', 'unknown'],
+      factories: {
+        chromium: makeFactoryReturning(makeFakeDriver()),
+        'mobile-chrome-android': makeFactoryThrowing(new Error('no Android device attached')),
+      },
+    });
+    expect(r.totals).toEqual({ ok: 1, fail: 1, skip: 1 });
+    expect(r.summary).toBe('1 ok / 1 fail / 1 skip');
+    expect(r.ok).toBe(false);
+  });
+
+  test('all-ok matrix: ok=true', async () => {
+    const r = await runHealthCheck({
+      browsers: ['chromium', 'firefox'],
+      factories: {
+        chromium: makeFactoryReturning(makeFakeDriver()),
+        firefox: makeFactoryReturning(makeFakeDriver()),
+      },
+    });
+    expect(r.totals).toEqual({ ok: 2, fail: 0, skip: 0 });
+    expect(r.ok).toBe(true);
+  });
+
+  test('skip outcomes do NOT make ok=false', async () => {
+    const r = await runHealthCheck({
+      browsers: ['mobile-chrome-android', 'mobile-safari-ios'],
+      factories: {
+        'mobile-chrome-android': makeFactoryThrowing(new Error('no Android device attached')),
+        'mobile-safari-ios': makeFactoryThrowing(new Error('no connected iPhone found')),
+      },
+    });
+    expect(r.totals.skip).toBe(2);
+    expect(r.totals.fail).toBe(0);
+    expect(r.ok).toBe(true);
+  });
+
+  test('cell order is preserved', async () => {
+    const browsers = ['firefox', 'chromium', 'webkit'];
+    const factories = Object.fromEntries(
+      browsers.map((b) => [b, makeFactoryReturning(makeFakeDriver())]),
+    );
+    const r = await runHealthCheck({ browsers, factories });
+    expect(r.cells.map((c) => c.browser)).toEqual(browsers);
+  });
+});
+
+// baseURL + callbacks ─────────────────────────────────────────────
+
+describe('runHealthCheck — baseURL + callbacks', () => {
+  test('factories are invoked with the supplied baseURL', async () => {
+    const factory = jest.fn(async () => makeFakeDriver());
+    await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: factory },
+      baseURL: 'http://localhost:9999',
+    });
+    expect(factory).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: 'http://localhost:9999' }),
+    );
+  });
+
+  test('baseURL defaults to localhost:8888 when omitted', async () => {
+    const factory = jest.fn(async () => makeFakeDriver());
+    await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: factory },
+    });
+    expect(factory).toHaveBeenCalledWith({ baseURL: 'http://localhost:8888' });
+  });
+
+  test('onCellStart fires per cell with browser slug', async () => {
+    const events = [];
+    await runHealthCheck({
+      browsers: ['chromium', 'firefox'],
+      factories: {
+        chromium: makeFactoryReturning(makeFakeDriver()),
+        firefox: makeFactoryReturning(makeFakeDriver()),
+      },
+      onCellStart: ({ browser }) => events.push(browser),
+    });
+    expect(events).toEqual(['chromium', 'firefox']);
+  });
+
+  test('onCellEnd fires per cell with outcome', async () => {
+    const events = [];
+    await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(makeFakeDriver()) },
+      onCellEnd: (cell) => events.push(cell.outcome),
+    });
+    expect(events).toEqual(['ok']);
+  });
+});
+
+// Timing ─────────────────────────────────────────────────────────
+
+describe('runHealthCheck — timing', () => {
+  test('durationMs from injected nowMs delta', async () => {
+    let n = 1000;
+    const r = await runHealthCheck({
+      browsers: ['chromium', 'firefox'],
+      factories: {
+        chromium: makeFactoryReturning(makeFakeDriver()),
+        firefox: makeFactoryReturning(makeFakeDriver()),
+      },
+      nowMs: () => {
+        const v = n;
+        n += 200;
+        return v;
+      },
+    });
+    expect(r.cells[0].durationMs).toBe(200);
+    expect(r.cells[1].durationMs).toBe(200);
+  });
+
+  test('durationMs clamped to >= 0 (no negative even if clock skews)', async () => {
+    let n = 0;
+    const ticks = [1000, 500, 800, 1100];
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(makeFakeDriver()) },
+      nowMs: () => ticks[n++],
+    });
+    expect(r.cells[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// formatHealthCheckResult ─────────────────────────────────────────
+
+describe('formatHealthCheckResult', () => {
+  test('header + per-cell rows + summary line with "Health:" prefix', async () => {
+    const r = await runHealthCheck({
+      browsers: ['chromium', 'mobile-safari-ios'],
+      factories: {
+        chromium: makeFactoryReturning(makeFakeDriver()),
+        'mobile-safari-ios': makeFactoryThrowing(new Error('no connected iPhone found')),
+      },
+    });
+    const text = formatHealthCheckResult(r);
+    expect(text).toMatch(/browser/);
+    expect(text).toMatch(/outcome/);
+    expect(text).toMatch(/chromium/);
+    expect(text).toMatch(/mobile-safari-ios/);
+    expect(text).toMatch(/ok/);
+    expect(text).toMatch(/skip/);
+    expect(text).toMatch(/Health: 1 ok \/ 0 fail \/ 1 skip/);
+  });
+
+  test('column width adapts to longest slug', () => {
+    const text = formatHealthCheckResult({
+      cells: [
+        { browser: 'c', outcome: 'ok', durationMs: 10 },
+        { browser: 'mobile-firefox-android', outcome: 'fail', durationMs: 25 },
+      ],
+      summary: '1 ok / 1 fail / 0 skip',
+    });
+    expect(text).toMatch(/mobile-firefox-android/);
+  });
+});


### PR DESCRIPTION
After the matrix-completeness sweep (#898 → #907), the runner has 12 driver cells. Running a full `--matrix` journey to discover that cell 5 fails because the device wasn't connected is wasteful — a typical matrix run is 5-10 minutes per cell.

This PR adds a faster diagnostic: `--check-drivers` tries to bootstrap every driver in the target's allowlist + closes it immediately. A typical 12-cell health-check completes in ~10 seconds. Operator runs it before a full `--matrix` to verify the environment is ready.

## What

### `scripts/driver-health-check.js` (NEW)
- `runHealthCheck({ browsers, factories, baseURL })` iterates browsers, calls each factory, closes the resulting driver, classifies the outcome:
  - `'ok'`   — factory returned + `close()` called successfully
  - `'skip'` — factory threw an init-error (device/env-var/server)
  - `'fail'` — factory threw a non-init error, OR no factory registered
- `isInitError` reused from `./matrix-dispatch` so the skip-vs-fail classification matches the `--matrix` command.
- `close()` failures are swallowed — they don't downgrade `'ok'` to `'fail'`. The bootstrap succeeded; that's what the health-check is verifying.
- `formatHealthCheckResult` renders a compact text table with a `Health:` summary line (vs `--matrix`'s `Matrix:` prefix).

### `scripts/manual-qa-runner.js`
- New CLI flag: `--check-drivers`.
- Builds a `factories` map covering all 12 driver slugs + invokes `runHealthCheck` against `allowedBrowsersFor(target)`.
- Prints the result table + exits (0 if zero fails, 1 otherwise).
- Renamed the factory wrappers' `baseURL` param to `u` to dodge the `no-shadow` lint warning on the outer `baseURL` const.

## Tests

### `tests/scripts/driver-health-check.test.js` — 24 tests
- Input validation: non-array browsers / empty / missing factories / non-object factories.
- Per-cell outcomes: factory returns driver → ok + close called, factory throws init-error → skip + message captured, non-init throw → fail, `err.code='DRIVER_INIT_FAILED'` forces skip, missing factory → fail with `"no factory registered"`, factory returns null → ok (close skipped), `driver.close` throwing doesn't downgrade ok, driver without close tolerated.
- Multi-cell aggregation: mixed totals + summary string (`"X ok / Y fail / Z skip"`), all-ok → ok=true, all-skip → ok=true, cell order preserved.
- `baseURL` forwarded + default; `onCellStart` / `onCellEnd` fire; `nowMs` delta + clamp ≥ 0.
- `formatHealthCheckResult`: header / row / `Health:` summary, column width adapts.

### Suite
Full express-api: 263/263 suites, 10167/10175 pass, 8 expected skipped. Lint + format clean.

## Usage

```bash
cd express-api
set -a && source ~/.shytalk/dev-personas.env && set +a
export WDA_TEAM_ID=...
node scripts/manual-qa-runner.js --target local --check-drivers

# → Runs in ~10s; output:
# [check-drivers] → chromium
# [check-drivers] ← chromium: ok (842ms)
# ...
# Health: 8 ok / 0 fail / 4 skip
```

A `'skip'` means the device/server isn't connected (e.g. iPhone unplugged, Appium not running). `'fail'` means a non-init error — drive into that cell to debug.

**Companion to `--matrix`**: run `--check-drivers` first to verify the environment, then `--matrix` to actually run scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)