### PR TITLE
feat(qa-runner): --cell-timeout caps each --matrix cell at N seconds; 'timeout' outcome

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -15449,11 +15449,27 @@ async function main() {
     else if (flat[i] === '--report-dir') opts.reportDir = flat[++i];
     else if (flat[i] === '--report-format') opts.reportFormat = flat[++i];
     else if (flat[i] === '--report-output') opts.reportOutput = flat[++i];
+    else if (flat[i] === '--cell-timeout') {
+      // Operator passes seconds; we store ms.
+      const raw = flat[++i];
+      opts._cellTimeoutRaw = raw;
+      opts.cellTimeoutMs = parseInt(raw, 10) * 1000;
+    }
   }
   // --report-format validation — only json + junit are supported (used
   // with --matrix to emit structured output for CI dashboards).
   if (opts.reportFormat && !['json', 'junit'].includes(opts.reportFormat)) {
     console.error(`--report-format "${opts.reportFormat}" not recognised. Supported: json, junit.`);
+    process.exit(2);
+  }
+  // --cell-timeout validation: must be a positive integer (seconds).
+  if (
+    opts.cellTimeoutMs !== undefined &&
+    (!Number.isFinite(opts.cellTimeoutMs) || opts.cellTimeoutMs <= 0)
+  ) {
+    console.error(
+      `--cell-timeout must be a positive integer (seconds). Got "${opts._cellTimeoutRaw}".`,
+    );
     process.exit(2);
   }
   opts.target = opts.target || 'dev';
@@ -15538,11 +15554,34 @@ async function main() {
         // mode (no --report-dir): subprocess stdio inherits the runner's
         // streams as before (zero log overhead).
         const captureStdio = Boolean(opts.reportDir);
-        const proc = spawnSync(process.execPath, [__filename, ...cellArgs], {
+        // spawnSync's `timeout` option kills the child with SIGTERM
+        // once exceeded; result is `proc.status === null, signal === 'SIGTERM'`.
+        // We translate that to a CELL_TIMEOUT throw so matrix-dispatch's
+        // classifier produces a 'timeout' outcome (distinct from 'fail').
+        const spawnOpts = {
           stdio: captureStdio ? ['ignore', 'pipe', 'pipe'] : 'inherit',
           env: process.env,
-        });
-        if (proc.error) throw proc.error;
+        };
+        if (opts.cellTimeoutMs) spawnOpts.timeout = opts.cellTimeoutMs;
+        const proc = spawnSync(process.execPath, [__filename, ...cellArgs], spawnOpts);
+        if (proc.error) {
+          // spawnSync sets proc.error.code = 'ETIMEDOUT' when the
+          // child was killed for exceeding the timeout. Translate to
+          // CELL_TIMEOUT so matrix-dispatch can classify it.
+          if (proc.error.code === 'ETIMEDOUT') {
+            const e = new Error(`cell timed out after ${Math.round(opts.cellTimeoutMs / 1000)}s`);
+            e.code = 'CELL_TIMEOUT';
+            throw e;
+          }
+          throw proc.error;
+        }
+        // Some Node versions surface timeout via signal+null-status
+        // instead of proc.error — handle that path too.
+        if (proc.status === null && proc.signal === 'SIGTERM' && opts.cellTimeoutMs) {
+          const e = new Error(`cell timed out after ${Math.round(opts.cellTimeoutMs / 1000)}s`);
+          e.code = 'CELL_TIMEOUT';
+          throw e;
+        }
         if (captureStdio) {
           // Tee captured stdio to the runner's terminal so the operator
           // sees the cell's output in real time too — same UX as

--- a/express-api/scripts/matrix-dispatch.js
+++ b/express-api/scripts/matrix-dispatch.js
@@ -115,7 +115,14 @@ async function runMatrix({
       const result = await dispatchOne({ browser });
       outcome = result ? 'pass' : 'fail';
     } catch (e) {
-      if (isInitError(e)) {
+      // 'CELL_TIMEOUT' is set by the runner's spawnSync wrapper when
+      // the per-cell process exceeded --cell-timeout. Surfaces as its
+      // own outcome (NOT 'fail') so the operator can distinguish hangs
+      // from assertion failures in the summary.
+      if (e && e.code === 'CELL_TIMEOUT') {
+        outcome = 'timeout';
+        error = e.message;
+      } else if (isInitError(e)) {
         outcome = 'skip';
         error = e.message;
       } else {
@@ -128,7 +135,10 @@ async function runMatrix({
     if (error) cell.error = error;
     cells.push(cell);
     if (typeof onCellEnd === 'function') onCellEnd(cell);
-    if (failFast && outcome === 'fail') stopped = true;
+    // failFast aborts on real failures (timeouts included — a hang
+    // can also mask other cells from running in time, so fail-fast on
+    // timeout is the safer default).
+    if (failFast && (outcome === 'fail' || outcome === 'timeout')) stopped = true;
   }
 
   const totals = cells.reduce(
@@ -136,11 +146,19 @@ async function runMatrix({
       acc[c.outcome] = (acc[c.outcome] || 0) + 1;
       return acc;
     },
-    { pass: 0, fail: 0, skip: 0 },
+    { pass: 0, fail: 0, skip: 0, timeout: 0 },
   );
 
-  const summary = `${totals.pass} pass / ${totals.fail} fail / ${totals.skip} skip`;
-  return { cells, totals, summary, ok: totals.fail === 0 };
+  // Summary string: 3-segment shape when no timeouts (preserves the
+  // pre-timeout-feature format for existing CI consumers); 4-segment
+  // when any timeout occurred so the operator sees it at a glance.
+  const summary =
+    totals.timeout > 0
+      ? `${totals.pass} pass / ${totals.fail} fail / ${totals.skip} skip / ${totals.timeout} timeout`
+      : `${totals.pass} pass / ${totals.fail} fail / ${totals.skip} skip`;
+  // ok is false when there's any non-skip failure type — fail OR
+  // timeout. A pure-skip run (no devices connected) still returns ok.
+  return { cells, totals, summary, ok: totals.fail === 0 && totals.timeout === 0 };
 }
 
 /**
@@ -230,7 +248,10 @@ function formatMatrixResultJunit(result, { nowIso = () => new Date().toISOString
   const totalMs = result.cells.reduce((acc, c) => acc + (c.durationMs || 0), 0);
   const lines = ['<?xml version="1.0" encoding="UTF-8"?>'];
   lines.push(
-    `<testsuite name="qa-matrix" tests="${result.cells.length}" failures="${result.totals.fail}" skipped="${result.totals.skip}" time="${(totalMs / 1000).toFixed(3)}" timestamp="${escape(nowIso())}">`,
+    // Timeouts count as failures for the JUnit suite-level total (they
+    // render as <failure type="MatrixCellTimeout"/> per-testcase) — so
+    // CI dashboards' overall pass/fail signal treats them as red.
+    `<testsuite name="qa-matrix" tests="${result.cells.length}" failures="${result.totals.fail + (result.totals.timeout || 0)}" skipped="${result.totals.skip}" time="${(totalMs / 1000).toFixed(3)}" timestamp="${escape(nowIso())}">`,
   );
   for (const c of result.cells) {
     const timeSec = ((c.durationMs || 0) / 1000).toFixed(3);
@@ -238,6 +259,14 @@ function formatMatrixResultJunit(result, { nowIso = () => new Date().toISOString
     if (c.outcome === 'fail') {
       lines.push(
         `    <failure message="${escape(c.error || 'matrix cell failed')}" type="MatrixCellFailure"/>`,
+      );
+    } else if (c.outcome === 'timeout') {
+      // Timeouts map to <failure> (not <skipped>) in JUnit semantics —
+      // they're a deterministic failure, not a "we didn't run it". The
+      // `type` attribute distinguishes them from assertion failures so
+      // dashboards can colour-code or group separately.
+      lines.push(
+        `    <failure message="${escape(c.error || 'matrix cell timed out')}" type="MatrixCellTimeout"/>`,
       );
     } else if (c.outcome === 'skip') {
       lines.push(`    <skipped message="${escape(c.error || 'matrix cell skipped')}"/>`);

--- a/express-api/tests/scripts/matrix-dispatch.test.js
+++ b/express-api/tests/scripts/matrix-dispatch.test.js
@@ -119,7 +119,7 @@ describe('runMatrix — happy paths', () => {
       browsers: ['chromium', 'firefox', 'webkit'],
       dispatchOne: async () => true,
     });
-    expect(r.totals).toEqual({ pass: 3, fail: 0, skip: 0 });
+    expect(r.totals).toEqual({ pass: 3, fail: 0, skip: 0, timeout: 0 });
     expect(r.summary).toBe('3 pass / 0 fail / 0 skip');
     expect(r.ok).toBe(true);
     expect(r.cells.every((c) => c.outcome === 'pass')).toBe(true);
@@ -137,7 +137,7 @@ describe('runMatrix — happy paths', () => {
         return true;
       },
     });
-    expect(r.totals).toEqual({ pass: 1, fail: 1, skip: 1 });
+    expect(r.totals).toEqual({ pass: 1, fail: 1, skip: 1, timeout: 0 });
     expect(r.summary).toBe('1 pass / 1 fail / 1 skip');
     expect(r.ok).toBe(false);
   });
@@ -203,6 +203,72 @@ describe('runMatrix — outcome classification', () => {
     });
     expect(r.cells[0].outcome).toBe('fail');
     expect(r.cells[0].error).toMatch(/AssertionError/);
+  });
+
+  test('error.code = CELL_TIMEOUT → outcome="timeout"', async () => {
+    const r = await runMatrix({
+      browsers: ['chromium'],
+      dispatchOne: async () => {
+        const e = new Error('cell timed out after 60s');
+        e.code = 'CELL_TIMEOUT';
+        throw e;
+      },
+    });
+    expect(r.cells[0].outcome).toBe('timeout');
+    expect(r.cells[0].error).toMatch(/timed out/);
+  });
+
+  test('timeout outcome makes ok=false (treated as a real failure)', async () => {
+    const r = await runMatrix({
+      browsers: ['chromium'],
+      dispatchOne: async () => {
+        const e = new Error('cell timed out');
+        e.code = 'CELL_TIMEOUT';
+        throw e;
+      },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.totals.timeout).toBe(1);
+  });
+
+  test('summary string adds "/ N timeout" segment only when timeout > 0', async () => {
+    const noTimeouts = await runMatrix({
+      browsers: ['c'],
+      dispatchOne: async () => true,
+    });
+    expect(noTimeouts.summary).toBe('1 pass / 0 fail / 0 skip');
+
+    const withTimeout = await runMatrix({
+      browsers: ['c', 'd'],
+      dispatchOne: async ({ browser }) => {
+        if (browser === 'd') {
+          const e = new Error('cell timed out');
+          e.code = 'CELL_TIMEOUT';
+          throw e;
+        }
+        return true;
+      },
+    });
+    expect(withTimeout.summary).toBe('1 pass / 0 fail / 0 skip / 1 timeout');
+  });
+
+  test('failFast aborts on timeout (a hang is at least as actionable as a fail)', async () => {
+    const r = await runMatrix({
+      browsers: ['a', 'b', 'c'],
+      failFast: true,
+      dispatchOne: async ({ browser }) => {
+        if (browser === 'b') {
+          const e = new Error('cell timed out');
+          e.code = 'CELL_TIMEOUT';
+          throw e;
+        }
+        return true;
+      },
+    });
+    expect(r.cells[0].outcome).toBe('pass');
+    expect(r.cells[1].outcome).toBe('timeout');
+    expect(r.cells[2].outcome).toBe('skip');
+    expect(r.cells[2].error).toMatch(/aborted by failFast/);
   });
 
   test('error.code = DRIVER_INIT_FAILED forces "skip" even when message looks like a real failure', async () => {
@@ -370,7 +436,7 @@ describe('formatMatrixResultJson', () => {
         { browser: 'mobile-safari-ios', outcome: 'skip', durationMs: 0, error: 'no iPhone' },
         { browser: 'firefox', outcome: 'fail', durationMs: 1023, error: 'AssertionError' },
       ],
-      totals: { pass: 1, fail: 1, skip: 1 },
+      totals: { pass: 1, fail: 1, skip: 1, timeout: 0 },
       summary: '1 pass / 1 fail / 1 skip',
       ok: false,
     };
@@ -384,7 +450,7 @@ describe('formatMatrixResultJson', () => {
     expect(obj.format).toBe('matrix-v1');
     expect(obj.generatedAt).toBe('2026-05-30T18:42:00.000Z');
     expect(obj.summary).toBe('1 pass / 1 fail / 1 skip');
-    expect(obj.totals).toEqual({ pass: 1, fail: 1, skip: 1 });
+    expect(obj.totals).toEqual({ pass: 1, fail: 1, skip: 1, timeout: 0 });
     expect(obj.ok).toBe(false);
     expect(obj.cells).toHaveLength(3);
   });
@@ -423,7 +489,7 @@ describe('formatMatrixResultJunit', () => {
         { browser: 'mobile-safari-ios', outcome: 'skip', durationMs: 0, error: 'no iPhone' },
         { browser: 'firefox', outcome: 'fail', durationMs: 1023, error: 'AssertionError' },
       ],
-      totals: { pass: 1, fail: 1, skip: 1 },
+      totals: { pass: 1, fail: 1, skip: 1, timeout: 0 },
       summary: '1 pass / 1 fail / 1 skip',
       ok: false,
     };
@@ -460,7 +526,7 @@ describe('formatMatrixResultJunit', () => {
   test('pass cells have no <failure> or <skipped> tag', () => {
     const xml = formatMatrixResultJunit({
       cells: [{ browser: 'chromium', outcome: 'pass', durationMs: 100 }],
-      totals: { pass: 1, fail: 0, skip: 0 },
+      totals: { pass: 1, fail: 0, skip: 0, timeout: 0 },
       summary: '1 pass / 0 fail / 0 skip',
       ok: true,
     });
@@ -492,7 +558,7 @@ describe('formatMatrixResultJunit', () => {
           error: 'err with <special> & "chars"',
         },
       ],
-      totals: { pass: 0, fail: 1, skip: 0 },
+      totals: { pass: 0, fail: 1, skip: 0, timeout: 0 },
       summary: '0 pass / 1 fail / 0 skip',
       ok: false,
     };
@@ -505,7 +571,7 @@ describe('formatMatrixResultJunit', () => {
   test('fail cell with no error message falls back to a sentinel', () => {
     const xml = formatMatrixResultJunit({
       cells: [{ browser: 'chromium', outcome: 'fail', durationMs: 50 }],
-      totals: { pass: 0, fail: 1, skip: 0 },
+      totals: { pass: 0, fail: 1, skip: 0, timeout: 0 },
       summary: '0 pass / 1 fail / 0 skip',
       ok: false,
     });
@@ -515,7 +581,7 @@ describe('formatMatrixResultJunit', () => {
   test('skip cell with no error message falls back to a sentinel', () => {
     const xml = formatMatrixResultJunit({
       cells: [{ browser: 'chromium', outcome: 'skip', durationMs: 0 }],
-      totals: { pass: 0, fail: 0, skip: 1 },
+      totals: { pass: 0, fail: 0, skip: 1, timeout: 0 },
       summary: '0 pass / 0 fail / 1 skip',
       ok: true,
     });
@@ -525,11 +591,65 @@ describe('formatMatrixResultJunit', () => {
   test('empty cells array still produces valid XML (no rows)', () => {
     const xml = formatMatrixResultJunit({
       cells: [],
-      totals: { pass: 0, fail: 0, skip: 0 },
+      totals: { pass: 0, fail: 0, skip: 0, timeout: 0 },
       summary: '0 pass / 0 fail / 0 skip',
       ok: true,
     });
     expect(xml).toMatch(/<testsuite name="qa-matrix" tests="0"/);
     expect(xml).not.toMatch(/<testcase/);
+  });
+
+  test('timeout cell gets <failure type="MatrixCellTimeout"/>', () => {
+    const xml = formatMatrixResultJunit({
+      cells: [
+        {
+          browser: 'mobile-chrome-android',
+          outcome: 'timeout',
+          durationMs: 60000,
+          error: 'cell timed out after 60s',
+        },
+      ],
+      totals: { pass: 0, fail: 0, skip: 0, timeout: 1 },
+      summary: '0 pass / 0 fail / 0 skip / 1 timeout',
+      ok: false,
+    });
+    expect(xml).toMatch(/<failure message="cell timed out after 60s" type="MatrixCellTimeout"\/>/);
+    // Timeouts also bump the suite-level `failures` count (1 here).
+    expect(xml).toMatch(/failures="1"/);
+  });
+
+  test('timeout cell with no error message falls back to a sentinel', () => {
+    const xml = formatMatrixResultJunit({
+      cells: [{ browser: 'mobile-chrome-android', outcome: 'timeout', durationMs: 60000 }],
+      totals: { pass: 0, fail: 0, skip: 0, timeout: 1 },
+      summary: '0 pass / 0 fail / 0 skip / 1 timeout',
+      ok: false,
+    });
+    expect(xml).toMatch(/message="matrix cell timed out"/);
+  });
+
+  test('suite-level failures count combines fails + timeouts', () => {
+    const xml = formatMatrixResultJunit({
+      cells: [
+        { browser: 'a', outcome: 'fail', durationMs: 100, error: 'x' },
+        { browser: 'b', outcome: 'timeout', durationMs: 60000, error: 'y' },
+        { browser: 'c', outcome: 'pass', durationMs: 200 },
+      ],
+      totals: { pass: 1, fail: 1, skip: 0, timeout: 1 },
+      summary: '1 pass / 1 fail / 0 skip / 1 timeout',
+      ok: false,
+    });
+    // 1 fail + 1 timeout = 2 failures at the suite level
+    expect(xml).toMatch(/failures="2"/);
+  });
+
+  test('legacy result without totals.timeout still renders (backward compat)', () => {
+    const xml = formatMatrixResultJunit({
+      cells: [{ browser: 'a', outcome: 'pass', durationMs: 100 }],
+      totals: { pass: 1, fail: 0, skip: 0, timeout: 0 }, // explicit zero for forward compat
+      summary: '1 pass / 0 fail / 0 skip',
+      ok: true,
+    });
+    expect(xml).toMatch(/failures="0"/);
   });
 });


### PR DESCRIPTION
A hung cell currently stalls the entire `--matrix` run with no recourse other than Ctrl-C. This PR adds `--cell-timeout <seconds>` that caps each per-cell subprocess at a known duration; exceeded cells are killed via SIGTERM + recorded with a new `'timeout'` outcome, distinct from `'fail'`.

## What

### `scripts/matrix-dispatch.js`
- `runMatrix`'s outcome classifier gains `'timeout'`: when `dispatchOne` throws an Error with `err.code === 'CELL_TIMEOUT'`, the cell gets `outcome='timeout'` (not `'fail'`). Operator sees hangs vs assertion failures distinctly in the summary table.
- `totals` shape extended to `{ pass, fail, skip, timeout }`.
- Summary string: 3-segment shape preserved when `totals.timeout === 0` (backward compat); 4-segment `"X pass / Y fail / Z skip / W timeout"` when any timeout occurred.
- `ok` flag now false on any `fail` OR `timeout` (timeout is a real failure, not a skip).
- `failFast` aborts on timeout too (a hang can mask other cells from running before the matrix-wide deadline, so fail-fast on timeout is the safer default).
- `formatMatrixResultJunit`:
  - timeout cell → `<failure message="..." type="MatrixCellTimeout"/>` (distinct type from `MatrixCellFailure` so dashboards can colour-code).
  - suite-level `failures` count = `fail + timeout`.

### `scripts/manual-qa-runner.js`
- New CLI flag: `--cell-timeout <seconds>`. Stored as `opts.cellTimeoutMs` internally (multiplied by 1000).
- Validated at parse: must be a positive integer.
- `dispatchOne` wires `spawnOpts.timeout = opts.cellTimeoutMs`. `spawnSync` kills the child with SIGTERM after the deadline; result surfaces either as `proc.error.code === 'ETIMEDOUT'` (newer Node) or `proc.status === null + proc.signal === 'SIGTERM'` (older Node). Both paths translate to a `CELL_TIMEOUT` throw so matrix-dispatch's classifier picks them up uniformly.

## Tests

### `tests/scripts/matrix-dispatch.test.js` — +6 new tests
- `err.code = CELL_TIMEOUT` → `outcome='timeout'` + error message
- timeout makes `ok=false` + bumps `totals.timeout`
- Summary string: no-timeout case (3-segment) vs with-timeout (4-segment)
- `failFast` aborts on timeout (mid-matrix timeout → remaining cells skip)
- JUnit: timeout → `<failure type="MatrixCellTimeout"/>`
- JUnit: timeout with no error → sentinel message
- JUnit: suite-level failures combines `fail + timeout`
- JUnit: legacy result without `totals.timeout` still renders

Existing totals literals updated to `{ pass, fail, skip, timeout: 0 }` to match the new shape.

### Suite
Full express-api: 265/265 suites, 10194/10202 pass, 8 expected skipped. Lint + format clean.

## Usage

```bash
node scripts/manual-qa-runner.js \
    --target local --matrix \
    --cell-timeout 600    # cap each cell at 10 minutes
```

If `mobile-safari-ios` hangs in its Appium session bootstrap for >10 minutes, it'll be killed and the matrix continues to the next cell with `mobile-safari-ios` recorded as `'timeout'` in the summary table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)