### PR TITLE
docs(claude-md): migrate 30 project-specific memories from global MEMORY.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,3 +120,61 @@ Social chat app with voice rooms. Kotlin Multiplatform (Android + iOS), Firebase
 - Stack: Express.js + Firebase Admin SDK + PM2 + Caddy
 - Dev SSH: `ssh -i ~/.ssh/shytalk-oci ubuntu@145.241.224.13`
 - Prod SSH: `ssh -i ~/.ssh/shytalk-oci ubuntu@213.35.98.160`
+
+---
+
+# Project-Specific Memories (migrated from global, 2026-05-30)
+
+These were previously in the global `~/.claude/projects/-Users-shyden/memory/MEMORY.md` index. Moved here so they only load when working in this repo (saves ~50% per-turn memory cost in non-ShyTalk sessions). Original memory files remain at their global paths.
+
+## Test Framework & Driver Architecture
+
+- **QA runner driver architecture** — driver file layout, naming convention (`createX<Surface><Platform>Driver`, `mobile-<browser>-<platform>` slugs), browser-allowlist.js as policy single-source-of-truth, matrix-completion PR sequence #898→#899→#900→D/E/F/G/H/I. Pitfalls: absolute-path satisfies sonarjs, pre-commit only checks .js, `return await` for catching evaluate rejections, fetch-mock handler ordering is first-match-wins, loader uses process.stderr.write not console.error.
+- **Setup-Given PR pattern** — established small-focused PR shape for journey setup-Givens (j01/j05/j02/j07/warning-state/j12/j13 all followed this), with mandatory test-coverage matrix, common matcher collision pitfalls (line 947 catch-all, line 1898 assignment), and conflict-resolution shortcut for parallel describe-block PRs.
+- **Test matrix — FRAMEWORK FIRST** (STRENGTHENED 2026-05-30 ~15:00 BST) — NO local test counts until the framework supports EVERY device × EVERY browser. Currently only Android native + Web Chromium work; 12 other matrix cells (iOS native, Web Safari/Firefox/Edge on Mac, mobile browsers on Android+iPhone) missing. Dev = Android + Chrome on Mac + Chrome on Android only.
+- **Prettier check from express-api cwd** — CI's lint runs `cd express-api && prettier --check .`; `npx --prefix` from repo root uses a different config and yields false-positive passes.
+- **Test every commit via user journeys** — every commit (new + historical) must be journey-tested local-first, then dev; bug-fix-loop until clean at each stage.
+- **Real Android device preferred over emulator** — always probe wireless adb first; emulator is the fallback.
+- **iOS must also be journey-tested via real iPhone** — physical iPhone over wireless (NO simulator anymore); same memory savings as Android.
+- **Journey-test auth = test personas, not OAuth** — canonical auth path is the in-screen persona picker; never drive Google/Apple OAuth in journey tests.
+
+## Driver-Method PR Conventions (Phase 4 cluster)
+
+- **Android driver helper coverage gaps** — Phase 4.5 housekeeping cluster: `androidTap` / `androidTapByTag` error / `androidOpenScreen` / `selectSerial` need direct tests (surfaced from PR #732 R2).
+- **Null/undefined pins for string args** — Phase 4 driver methods must pin all 4 input-rejection cases (`''`/`'   '`/`null`/`undefined`) from Round 0; reviewer flags missing null/undefined as Important across 5+ PRs.
+- **adb() shell-escape pattern for user text** — driver methods passing free-form user text to `adb()` must POSIX-escape `'` first (PR #741 fix); applies to JoinEventRoom, SubmitStarFeedback, future action methods.
+- **escTag on all *_TAGS scaffolds** — every NEW *_TAGS scaffold in android-adb-driver.js must regex-escape its tag value before `new RegExp(...)`; apply preemptively to avoid burning an R1 review cycle.
+- **Runner-branch tests with driver method** — every new driver-method PR must ALSO add manual-qa-runner.test.js tests for the matcher's Android + iOS Sim branches (3 each).
+- **Cluster preemptive checklist** — complete pre-flight list to reach ZERO-findings one-round merges on Phase-4 PRs (driver tests, prod code, runner-routing, commit/PR); PR #764 hit all items and achieved cluster's first 10-min merge.
+- **Input-rejection isolation via throwing fetcher** — for guard-then-fetch methods, the 4 input-rejection tests must use a throwing iosUiDump so a future reorder regresses.
+- **Verify runner-routing per platform, not per Wake** — "runner-routing pre-existing" claim must grep for `uiDriver: { iosShows<Method>:` specifically, not just the Wake-N describe header; many Wake blocks have Web+Android but no iOS Sim.
+
+## Local Stack & Build Tooling
+
+- **Run local stack detached — no stuck shells** — start.sh idles forever; launch detached `( nohup bash local/start.sh >/tmp/shytalk-stack.log 2>&1 </dev/null & )` (subshell orphan — macOS has no setsid) + poll the log, NOT as a perpetual bg task; `./gradlew --stop` after every Sonar/push; never boot the AVD on 8GB (use the MultiApp clone user 999).
+- **`./gradlew --stop` BEFORE every push too** — HARD RULE self-discovered 2026-05-30: pre-push Sonar hook fails silently with `husky - pre-push script failed (code 1)` when a gradle daemon is busy. Always stop daemon BEFORE push (not just after); silent failure ≠ test failure.
+
+## iOS-Specific
+
+- **iOS Metal Toolchain — runner-image regression, NOT a flake** (CORRECTED 2026-05-30) — `Asset is already installed for Metal Toolchain` is DETERMINISTIC. May 2026 macos-15 image pre-installs the toolchain; `-importComponent`/`-downloadComponent` both fail exit 70. Fix the workflow with `-showComponent` pre-check, don't re-trigger.
+- **iOS deploy hang — root cause + fix** — parallel K/N link deadlock; fix is `--max-workers=1` in build-phase script + warm-up step (commit 1b788059cb0, validated 2026-05-22 via 5+ successful deploys).
+- **pbxproj mutation needs explicit auth** — `ruby scripts/ios/*` that touch `project.pbxproj` are blocked by classifier; AskUserQuestion before each Phase 3.x sub-PR's script run.
+
+## Deploy / Release
+
+- **Pause merges while release PR is open** — each main commit triggers release PR's E2E pipeline to re-evaluate (~30-45min queued); hold all new branch merges until release lands.
+- **Local-first then dev verify — STRENGTHENED** (HARD GLOBAL, operator flagged 2x: 2026-05-28 + 2026-05-30 ~12:55 BST) — full loop = test LOCAL first (all devices × all browsers) → fix locally → write tests → retest locally until clean → deploy dev → reverify on dev (Android device + Chrome on Mac + Chrome on Android only — no iPhone, no other browsers in dev) → if dev finds a bug, fix LOCALLY first, retest LOCALLY, redeploy, reverify. NEVER skip local. NEVER ask permission to deploy-dev — direct authority, do it.
+
+## Persona & Auth Setup
+
+- **PERSONAS_PASSWORD location** — journey-runner secret lives at `~/.shytalk/dev-personas.env` (chmod 600, 1-line env-file, 22 chars). Created by past Claude 2026-05-16. Source via `set -a && source ~/.shytalk/dev-personas.env && set +a` or `$(grep '^PERSONAS_PASSWORD=' ~/.shytalk/dev-personas.env | cut -d= -f2-)`. Re-provision via `provision-test-personas.js` if missing.
+- **Firebase Admin SA (dev) location** — Firebase Admin SDK service-account JSON for shytalk-dev lives at `~/.shytalk/firebase-admin-dev.json` (chmod 600). Set `GOOGLE_APPLICATION_CREDENTIALS` to this path for the manual-qa-runner against dev. **NEVER commit; never log `private_key` value**.
+- **Personas NOT provisioned on dev — 400 Firebase signIn** (discovered 2026-05-29, RESOLVED via PR #867 + #868 + #869) — all 25+ past journey runs are `local-*` only; dev Firebase Auth was never seeded. Now auto-seeded on every dev deploy via `.github/actions/seed-test-personas/`.
+- **CI action docstring-adaptation pitfalls** (operator-surfaced 2026-05-29) — when wrapping a Node CLI script in a composite action, each part of the script's `Usage:` docstring needs INDIVIDUAL evaluation. `cd <dir>` is for module-resolution KEEP; `-r dotenv/config` is for local .env DROP; env vars get set via `env:` block. Failed twice (#867 → #868 → #869) on cascading CWD bugs in seed-test-personas action.
+- **Keep seed data current with feature work** (HARD RULE, operator 2026-05-29) — the persona registry in `provision-test-personas.js` is the test contract. When feature work touches user schema / userType / cohort / wallet / claims, the registry MUST be updated in the same PR + dev re-seeded via `gh workflow run seed-dev-personas.yml`. Standalone re-seed workflow (~30 sec) avoids needing a full deploy.
+- **Journey-test corpus was aspirational — expect drift cascade** (operator-surfaced 2026-05-29 via the j09 dispatch trail) — corpus was gitignored for months + never live-validated; first authenticated dispatch surfaced 12 findings + each fix unblocked the next drift layer. Pattern: test contract → production schema asymmetry. 5+ PRs across server, runner, feature corpus before one scenario approaches green.
+
+## In-Flight Initiatives
+
+- **Room mutations → server-side authz plan** (IN PROGRESS, operator 2026-05-27) — harden room write path (verified bugs: rules let any participant write any room field = client-only role gates; takeSeat/acceptInvite non-race-safe). Chosen: route all room-doc mutations through Express+AdminSDK (role-checked, transactional seat-claims) then lock firestore.rules. Phased P1 Express→P2 client migrate(Android+iOS)→P3 rules lockdown→P4 prod; rules/prod phases CHECKPOINT operator.
+


### PR DESCRIPTION
## Summary
Move 30 ShyTalk-specific memory entries from global `~/.claude/projects/.../memory/MEMORY.md` into this repo's `CLAUDE.md`. They now load only when working in this repo, saving substantial per-turn memory cost in non-ShyTalk Claude Code sessions while preserving full coverage when in this repo.

This was item #2 from a session-wide token-discipline pass (others: pruning 11 superseded entries from global, disabling 6 unused plugins, compressing global-rules by 40%, installing a lockfile-read blocker with one-shot override flag).

## What changes
- `+58 lines` appended to `CLAUDE.md` under a new section: *"Project-Specific Memories (migrated from global, 2026-05-30)"*
- Entries grouped by domain:
  - Test Framework & Driver Architecture (8)
  - Driver-Method PR Conventions / Phase-4 cluster (8)
  - Local Stack & Build Tooling (2)
  - iOS-Specific (3)
  - Deploy / Release (2)
  - Persona & Auth Setup (6)
  - In-Flight Initiatives (1)
- **No code or build changes** — pure documentation/instructions move
- Original memory files at `~/.claude/projects/.../memory/feedback-*.md` remain in place for reference; only the index entries in global MEMORY.md were removed

## Test plan
- [x] `git diff --stat` confirms only `CLAUDE.md` modified (+58 lines)
- [x] Self-reviewed the appended section — pure relocation of existing operator memories, no new claims
- [x] Per CLAUDE.md PR Quality Gate: *"Workflow-only changes (`.github/`, `.claude/`, `*.md`) don't need app testing"*
- [x] Pre-push hook ran clean (Sonar skipped — no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)