### PR TITLE
ci(qa-runner): pr-checks workflow for driver changes (gap E4)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,6 +29,7 @@ jobs:
       backend_changed: ${{ steps.changes.outputs.backend_changed }}
       web_changed: ${{ steps.changes.outputs.web_changed }}
       integration_changed: ${{ steps.changes.outputs.integration_changed }}
+      qa_runner_drivers_changed: ${{ steps.changes.outputs.qa_runner_drivers_changed }}
       workflow_only: ${{ steps.changes.outputs.workflow_only }}
       skip_android_e2e: ${{ steps.changes.outputs.skip_android_e2e }}
       skip_ios_e2e: ${{ steps.changes.outputs.skip_ios_e2e }}
@@ -53,7 +54,7 @@ jobs:
           # retained for lint/sonarcloud/integration-tests which
           # cover both platforms; only the heavy build/E2E jobs
           # gate on the granular ANDROID_APP / IOS_APP flags.
-          ANDROID_APP=false IOS_APP=false APP=false BACKEND=false WEB=false INTEGRATION=false OTHER=false
+          ANDROID_APP=false IOS_APP=false APP=false BACKEND=false WEB=false INTEGRATION=false QA_RUNNER_DRIVERS=false OTHER=false
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             case "$file" in
@@ -92,6 +93,13 @@ jobs:
               # integration job without dragging in the heavier
               # backend-changed gate (Sonar, full backend suite).
               tests/integration/*|playwright.integration.config.ts) INTEGRATION=true ;;
+              # Driver-specific PR signal — matched BEFORE the generic
+              # express-api/* branch so a driver-only change can light up
+              # the fast qa-runner-driver-checks job in parallel with
+              # the heavier test-backend job. BACKEND is set too so the
+              # existing backend test suite still runs (regression safety
+              # — driver code is a subset of the backend).
+              express-api/scripts/drivers/*|express-api/tests/scripts/drivers/*) QA_RUNNER_DRIVERS=true; BACKEND=true ;;
               express-api/*|firestore.rules|database.rules.json) BACKEND=true ;;
               .github/*|.claude/*|.project/*|*.md|.gitignore|.gitattributes) ;;
               *) OTHER=true ;;
@@ -120,10 +128,10 @@ jobs:
           if printf '%s' "$PR_BODY" | grep -qE '^[[:space:]]*\[skip-ios-e2e\][[:space:]]*$'; then
             SKIP_IOS_E2E=true
           fi
-          for v in app_changed=$APP android_app_changed=$ANDROID_APP ios_app_changed=$IOS_APP backend_changed=$BACKEND web_changed=$WEB integration_changed=$INTEGRATION workflow_only=$WORKFLOW_ONLY skip_android_e2e=$SKIP_ANDROID_E2E skip_ios_e2e=$SKIP_IOS_E2E; do
+          for v in app_changed=$APP android_app_changed=$ANDROID_APP ios_app_changed=$IOS_APP backend_changed=$BACKEND web_changed=$WEB integration_changed=$INTEGRATION qa_runner_drivers_changed=$QA_RUNNER_DRIVERS workflow_only=$WORKFLOW_ONLY skip_android_e2e=$SKIP_ANDROID_E2E skip_ios_e2e=$SKIP_IOS_E2E; do
             echo "$v" >> "$GITHUB_OUTPUT"
           done
-          echo "Detection results: app=$APP android_app=$ANDROID_APP ios_app=$IOS_APP backend=$BACKEND web=$WEB integration=$INTEGRATION workflow_only=$WORKFLOW_ONLY skip_android_e2e=$SKIP_ANDROID_E2E skip_ios_e2e=$SKIP_IOS_E2E"
+          echo "Detection results: app=$APP android_app=$ANDROID_APP ios_app=$IOS_APP backend=$BACKEND web=$WEB integration=$INTEGRATION qa_runner_drivers=$QA_RUNNER_DRIVERS workflow_only=$WORKFLOW_ONLY skip_android_e2e=$SKIP_ANDROID_E2E skip_ios_e2e=$SKIP_IOS_E2E"
 
   lint:
     needs: [detect-changes]
@@ -371,9 +379,22 @@ jobs:
       ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
 
+  qa-runner-driver-checks:
+    # Fast signal for PRs touching express-api/scripts/drivers/** — runs
+    # the driver-contract test + --check-drivers in parallel with the
+    # heavier test-backend job. Closes gap E4 from the QA-runner framework
+    # tracker. Skipped on non-driver PRs; required when triggered.
+    needs: [detect-changes]
+    if: |
+      always() &&
+      needs.detect-changes.outputs.qa_runner_drivers_changed == 'true'
+    uses: ./.github/workflows/qa-runner-driver-checks.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
   gate:
     name: PR Gate
-    needs: [detect-changes, lint, build-and-test, sonarcloud, test-backend, android-e2e, playwright-web, integration-tests, ios-e2e]
+    needs: [detect-changes, lint, build-and-test, sonarcloud, test-backend, android-e2e, playwright-web, integration-tests, ios-e2e, qa-runner-driver-checks]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -395,7 +416,8 @@ jobs:
             "${{ needs.android-e2e.result }}" \
             "${{ needs.playwright-web.result }}" \
             "${{ needs.integration-tests.result }}" \
-            "${{ needs.ios-e2e.result }}"; do
+            "${{ needs.ios-e2e.result }}" \
+            "${{ needs.qa-runner-driver-checks.result }}"; do
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
               echo "Required check failed: $result"
               exit 1

--- a/.github/workflows/qa-runner-driver-checks.yml
+++ b/.github/workflows/qa-runner-driver-checks.yml
@@ -1,0 +1,86 @@
+name: QA Runner Driver Checks
+
+# Reusable workflow — invoked from pr-checks.yml when a PR touches
+# express-api/scripts/drivers/**. Provides a fast signal that the
+# runner's driver factories still load + bootstrap without surprising
+# regressions, BEFORE the full backend test suite finishes.
+#
+# Closes gap E4 from the QA-runner framework tracker: "No pr-checks
+# job that runs --check-drivers on PRs touching drivers/."
+#
+# Per [[feedback-no-self-hosted-runners]] uses ubuntu-latest only.
+# Per [[feedback-ci-cache-downloads-version-aware]] Playwright browser
+# binaries are cached on the resolved Playwright version (busts when
+# the dependency bumps).
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: SHA to check out (PR head sha; main for nightly).
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  driver-checks:
+    name: --check-drivers + contract test (ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: express-api/package-lock.json
+
+      - name: Install express-api deps
+        run: npm ci
+        working-directory: express-api
+
+      - name: Resolve Playwright version (for cache key)
+        id: pw
+        run: |
+          # Read the installed Playwright version so the cache key changes
+          # when Playwright bumps — per [[feedback-ci-cache-downloads-version-aware]].
+          # node -p prints the field; trim any whitespace defensively.
+          PW_VERSION=$(node -p "require('playwright/package.json').version" | tr -d '[:space:]')
+          echo "version=$PW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Playwright version resolved: $PW_VERSION"
+        working-directory: express-api
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright browsers (chromium + firefox + webkit)
+        # `--with-deps` pulls apt packages on Ubuntu so headless WebKit
+        # actually launches; without it WebKit silently fails to start
+        # because libgtk/libgstreamer aren't present on the base image.
+        run: npx playwright install --with-deps chromium firefox webkit
+        working-directory: express-api
+
+      - name: Driver contract test
+        # Bounded subset of the full express-api suite — fastest signal
+        # that any driver-shape regression surfaces before the full
+        # backend suite finishes.
+        run: npm test -- --testPathPattern tests/scripts/drivers/ --silent
+        working-directory: express-api
+
+      - name: --check-drivers diagnostic (local target)
+        # Desktop browsers should report 'ok' on ubuntu (Playwright
+        # provides chromium/firefox/webkit; edge unavailable). Mobile
+        # cells report 'skip' on ubuntu (no adb device, no iOS simulator).
+        # Exit code is 0 iff no cell reports 'fail' — 'skip' is acceptable.
+        run: node scripts/manual-qa-runner.js --check-drivers --target local
+        working-directory: express-api

--- a/express-api/tests/scripts/qa-runner-driver-checks-pin.test.js
+++ b/express-api/tests/scripts/qa-runner-driver-checks-pin.test.js
@@ -1,0 +1,162 @@
+/**
+ * qa-runner-driver-checks-pin.test.js
+ *
+ * Pins the structure of `.github/workflows/qa-runner-driver-checks.yml`
+ * and the pr-checks.yml integration that triggers it. Closes gap E4
+ * from the QA-runner framework tracker — without this pin, a future
+ * PR could silently break the fast driver-feedback loop by:
+ *   - removing the workflow file
+ *   - removing the `qa-runner-driver-checks` job from pr-checks.yml
+ *   - removing the path-filter that triggers it on driver changes
+ *   - removing the gate-job dependency that makes it required
+ *
+ * Pure-test PR — no production code. Reads YAML as text + minimal
+ * parsing (no yaml dep required) to assert the structural invariants.
+ *
+ * Per [feedback-workflow-verify-by-running]: this PIN is not a
+ * substitute for dispatching the workflow and observing success.
+ * After merge, the workflow runs on PRs touching driver files; the
+ * first such PR is the live verification.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const REUSABLE_PATH = path.join(REPO_ROOT, '.github/workflows/qa-runner-driver-checks.yml');
+const PR_CHECKS_PATH = path.join(REPO_ROOT, '.github/workflows/pr-checks.yml');
+
+const reusable = fs.readFileSync(REUSABLE_PATH, 'utf8');
+const prChecks = fs.readFileSync(PR_CHECKS_PATH, 'utf8');
+
+// ── Reusable workflow shape ────────────────────────────────────────
+
+describe('.github/workflows/qa-runner-driver-checks.yml', () => {
+  test('file exists and is non-empty', () => {
+    expect(reusable.length).toBeGreaterThan(0);
+  });
+
+  test('declares a workflow_call trigger (reusable)', () => {
+    expect(reusable).toMatch(/^on:[\s\S]{0,200}?workflow_call:/m);
+  });
+
+  test('requires a "ref" input', () => {
+    expect(reusable).toMatch(/inputs:[\s\S]{0,200}?ref:/);
+    expect(reusable).toMatch(/ref:[\s\S]{0,200}?required:\s*true/);
+  });
+
+  test('runs on ubuntu-latest (no self-hosted runners)', () => {
+    // [[feedback-no-self-hosted-runners]] HARD policy.
+    expect(reusable).toMatch(/runs-on:\s*ubuntu-latest/);
+    expect(reusable).not.toMatch(/runs-on:[\s\S]{0,200}?self-hosted/);
+  });
+
+  test('caches Playwright browsers keyed on Playwright version', () => {
+    // [[feedback-ci-cache-downloads-version-aware]] — newer Playwright
+    // must bust the cache automatically. The key must reference the
+    // resolved version (steps.pw.outputs.version), not just runner.os.
+    expect(reusable).toMatch(/uses:\s*actions\/cache@v4/);
+    expect(reusable).toMatch(
+      /key:\s*playwright-\$\{\{\s*runner\.os\s*\}\}-\$\{\{\s*steps\.pw\.outputs\.version\s*\}\}/,
+    );
+  });
+
+  test('installs Playwright browsers with --with-deps for headless WebKit', () => {
+    expect(reusable).toMatch(/npx playwright install --with-deps/);
+  });
+
+  test('runs the driver-contract test suite', () => {
+    expect(reusable).toMatch(/--testPathPattern\s+tests\/scripts\/drivers\//);
+  });
+
+  test('runs --check-drivers diagnostic', () => {
+    expect(reusable).toMatch(/manual-qa-runner\.js\s+--check-drivers/);
+  });
+
+  test('grants read-only contents permission', () => {
+    // No write needed — this workflow only runs tests + diagnostics.
+    expect(reusable).toMatch(/permissions:[\s\S]{0,200}?contents:\s*read/);
+  });
+
+  test('has a sensible timeout (≤ 15 minutes)', () => {
+    const m = reusable.match(/timeout-minutes:\s*(\d+)/);
+    expect(m).not.toBeNull();
+    expect(parseInt(m[1], 10)).toBeLessThanOrEqual(15);
+  });
+});
+
+// ── pr-checks.yml integration ──────────────────────────────────────
+
+describe('.github/workflows/pr-checks.yml — driver-checks integration', () => {
+  test('detect-changes emits qa_runner_drivers_changed output', () => {
+    expect(prChecks).toMatch(
+      /qa_runner_drivers_changed:\s*\$\{\{\s*steps\.changes\.outputs\.qa_runner_drivers_changed\s*\}\}/,
+    );
+  });
+
+  test('case branch sets QA_RUNNER_DRIVERS=true for express-api/scripts/drivers/**', () => {
+    expect(prChecks).toMatch(/express-api\/scripts\/drivers\/\*[\s\S]{0,80}QA_RUNNER_DRIVERS=true/);
+  });
+
+  test('case branch ALSO sets BACKEND=true (regression safety — drivers are a backend subset)', () => {
+    expect(prChecks).toMatch(/express-api\/scripts\/drivers\/\*[\s\S]{0,120}BACKEND=true/);
+  });
+
+  test('driver case branch precedes the generic express-api/* branch', () => {
+    const driverIdx = prChecks.indexOf('express-api/scripts/drivers/');
+    const genericIdx = prChecks.indexOf('express-api/*|firestore.rules');
+    expect(driverIdx).toBeGreaterThan(0);
+    expect(genericIdx).toBeGreaterThan(driverIdx);
+  });
+
+  test('initializes QA_RUNNER_DRIVERS=false alongside other flags', () => {
+    expect(prChecks).toMatch(/QA_RUNNER_DRIVERS=false/);
+  });
+
+  test('writes qa_runner_drivers_changed to GITHUB_OUTPUT', () => {
+    expect(prChecks).toMatch(/qa_runner_drivers_changed=\$QA_RUNNER_DRIVERS/);
+  });
+
+  // Slice the qa-runner-driver-checks job body once so per-assertion
+  // regexes can stay anchored and bounded. Avoids the lazy [\s\S]*?
+  // pattern that sonarjs/slow-regex flags (super-linear backtracking
+  // on adversarial input — not a real risk here but disallowed per
+  // [feedback-warnings-are-failures]).
+  function jobSection(name) {
+    const start = prChecks.indexOf(`${name}:`);
+    if (start < 0) return '';
+    // A pr-checks job is comfortably under 2KB; clamp the window.
+    return prChecks.slice(start, start + 2000);
+  }
+  const driverJobSection = jobSection('qa-runner-driver-checks');
+
+  test('qa-runner-driver-checks job exists', () => {
+    expect(driverJobSection.length).toBeGreaterThan(0);
+    expect(prChecks).toMatch(/^\s{1,10}qa-runner-driver-checks:/m);
+  });
+
+  test('qa-runner-driver-checks job calls the reusable workflow', () => {
+    expect(driverJobSection).toMatch(
+      /uses:\s*\.\/\.github\/workflows\/qa-runner-driver-checks\.yml/,
+    );
+  });
+
+  test('qa-runner-driver-checks job gates on qa_runner_drivers_changed', () => {
+    expect(driverJobSection).toMatch(/qa_runner_drivers_changed\s*==\s*'true'/);
+  });
+
+  test('qa-runner-driver-checks job passes ref from pull_request.head.sha', () => {
+    // [feedback security] — SHA from GitHub API, not attacker-controllable.
+    expect(driverJobSection).toMatch(
+      /ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/,
+    );
+  });
+
+  test('gate job includes qa-runner-driver-checks in needs (required check)', () => {
+    expect(prChecks).toMatch(/needs:\s*\[[^\]]*qa-runner-driver-checks[^\]]*\]/);
+  });
+
+  test('gate job checks qa-runner-driver-checks result in the failure loop', () => {
+    expect(prChecks).toMatch(/needs\.qa-runner-driver-checks\.result/);
+  });
+});


### PR DESCRIPTION
## Summary
PR #5 in the QA-runner framework-completion sequence — closes gap **E4**. Adds a fast-signal CI job that runs the driver-contract test + `--check-drivers` diagnostic on PRs touching `express-api/scripts/drivers/**` or `express-api/tests/scripts/drivers/**`.

**Before:** a broken driver could land if test-backend skipped the slow path or completed after merge; operators discovered driver regressions on their next local matrix run.
**After:** any PR touching driver code lights up `qa-runner-driver-checks` in parallel with test-backend. Failure blocks merge via the gate job.

## Files
- **NEW** `.github/workflows/qa-runner-driver-checks.yml` — reusable workflow invoked from `pr-checks.yml`. `ubuntu-latest`, Playwright browsers cached by version (per [feedback-ci-cache-downloads-version-aware]), `--with-deps` for headless WebKit. Runs driver-contract test subset + `--check-drivers --target local`.
- **MODIFIED** `.github/workflows/pr-checks.yml`
  - `detect-changes` emits `qa_runner_drivers_changed`. New case branch matches `express-api/scripts/drivers/*` AND `express-api/tests/scripts/drivers/*` — sets both `QA_RUNNER_DRIVERS=true` AND `BACKEND=true` (regression safety).
  - New `qa-runner-driver-checks` job gated on the flag, passes `head.sha` (SHA from GitHub API — not user-controllable).
  - Added to `gate` job's `needs[]` + failure-check loop (required check).
- **NEW** `tests/scripts/qa-runner-driver-checks-pin.test.js` — 22 tests pinning workflow structure + integration.

## Test plan
- [x] **22/22 pin tests pass**
- [x] Full express-api suite (274 suites / 10,407 tests) — no regressions
- [x] `actionlint` clean on both workflow files
- [x] ESLint `--max-warnings=0` clean (regexes bounded for sonarjs/slow-regex per [feedback-warnings-are-failures])
- [x] Prettier-clean
- [x] Sonar pre-push gate passed

## Verify-by-running
Per [feedback-workflow-verify-by-running]: pin tests are NOT a substitute for dispatching. The first driver-touching PR after this merges will be the live verification of the workflow firing correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)