### PR TITLE
feat(qa-runner): add --bail N flag for matrix early-termination (gap A7)

### DIFF
--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -15450,6 +15450,9 @@ function formatUsage() {
     '  --headed                  Run the browser in headed (visible) mode',
     '  --matrix                  Dispatch every allowed cell in sequence',
     '  --fail-fast               Stop the matrix at the first failing cell',
+    '  --bail <n>                Stop the matrix after <n> failures (timeouts',
+    '                              count as failures, skips do not). 0 = no bail.',
+    '                              --bail 1 is equivalent in effect to --fail-fast.',
     '  --check-drivers           Diagnostic — verify each driver bootstraps',
     '  --list                    Enumerate matrix cells as JSON (use with --target',
     '                              to filter to one target). Exits 0 without env vars',
@@ -15570,6 +15573,7 @@ async function main() {
     else if (flat[i] === '--headed') opts.headed = true;
     else if (flat[i] === '--matrix') opts.matrix = true;
     else if (flat[i] === '--fail-fast') opts.failFast = true;
+    else if (flat[i] === '--bail') opts.bailAfter = parseInt(flat[++i], 10);
     else if (flat[i] === '--check-drivers') opts.checkDrivers = true;
     else if (flat[i] === '--report-dir') opts.reportDir = flat[++i];
     else if (flat[i] === '--report-format') opts.reportFormat = flat[++i];
@@ -15620,6 +15624,13 @@ async function main() {
     console.error(
       `--cell-timeout must be a positive integer (seconds). Got "${opts._cellTimeoutRaw}".`,
     );
+    process.exit(2);
+  }
+  // --bail validation: 0 (off) or positive integer. Negative values
+  // are operator error and should fail loudly rather than be silently
+  // floored to 0.
+  if (opts.bailAfter !== undefined && (!Number.isFinite(opts.bailAfter) || opts.bailAfter < 0)) {
+    console.error(`--bail must be a non-negative integer. Got "${opts.bailAfter}".`);
     process.exit(2);
   }
   opts.target = opts.target || 'dev';
@@ -15778,6 +15789,7 @@ async function main() {
     const matrixResult = await runMatrix({
       browsers: allowed,
       failFast: opts.failFast === true,
+      bailAfter: opts.bailAfter > 0 ? opts.bailAfter : 0,
       onCellStart: ({ browser }) => console.log(`[matrix] → dispatching ${browser}`),
       onCellEnd: (cell) =>
         console.log(`[matrix] ← ${cell.browser}: ${cell.outcome} (${cell.durationMs}ms)`),

--- a/express-api/scripts/matrix-dispatch.js
+++ b/express-api/scripts/matrix-dispatch.js
@@ -83,6 +83,13 @@ async function runMatrix({
   browsers,
   dispatchOne,
   failFast = false,
+  // bailAfter — stop the matrix after N failures (or timeouts —
+  // counted the same way failFast counts them). 0 = no bail (run all).
+  // Strictly additive to failFast: both gates checked; whichever
+  // triggers first stops the matrix. failFast=true is equivalent in
+  // effect to bailAfter=1, but kept as a distinct flag for backward
+  // compatibility and operator readability.
+  bailAfter = 0,
   onCellStart,
   onCellEnd,
   nowMs = () => Date.now(),
@@ -101,10 +108,16 @@ async function runMatrix({
 
   const cells = [];
   let stopped = false;
+  let failureCount = 0;
+  // First-fire wins: preserves the original "matrix aborted by failFast"
+  // sentinel when failFast triggers, and surfaces the bail count
+  // explicitly when --bail triggers. Operators reading per-cell
+  // skip-error logs see which gate stopped the run.
+  let abortReason = '';
 
   for (const browser of browsers) {
     if (stopped) {
-      cells.push({ browser, outcome: 'skip', error: 'matrix aborted by failFast', durationMs: 0 });
+      cells.push({ browser, outcome: 'skip', error: abortReason, durationMs: 0 });
       continue;
     }
     if (typeof onCellStart === 'function') onCellStart({ browser });
@@ -135,10 +148,25 @@ async function runMatrix({
     if (error) cell.error = error;
     cells.push(cell);
     if (typeof onCellEnd === 'function') onCellEnd(cell);
+    // Increment failure count first — both failFast and bailAfter
+    // gates use the same definition (real failure or hang, not skip).
+    if (outcome === 'fail' || outcome === 'timeout') failureCount++;
     // failFast aborts on real failures (timeouts included — a hang
     // can also mask other cells from running in time, so fail-fast on
     // timeout is the safer default).
-    if (failFast && (outcome === 'fail' || outcome === 'timeout')) stopped = true;
+    if (failFast && (outcome === 'fail' || outcome === 'timeout')) {
+      stopped = true;
+      if (!abortReason) abortReason = 'matrix aborted by failFast';
+    }
+    // bailAfter aborts after the configured failure count is hit.
+    // bailAfter=1 is equivalent in effect to failFast=true; both can
+    // be set together with no conflict.
+    if (bailAfter > 0 && failureCount >= bailAfter) {
+      stopped = true;
+      if (!abortReason) {
+        abortReason = `matrix aborted by --bail ${bailAfter} after ${failureCount} failure(s)`;
+      }
+    }
   }
 
   const totals = cells.reduce(

--- a/express-api/tests/scripts/matrix-dispatch.test.js
+++ b/express-api/tests/scripts/matrix-dispatch.test.js
@@ -331,6 +331,100 @@ describe('runMatrix — failFast', () => {
   });
 });
 
+// runMatrix — bailAfter ─────────────────────────────────────────────
+
+describe('runMatrix — bailAfter', () => {
+  test('bailAfter=0 (default) means no bail — all cells run regardless of fails', async () => {
+    const r = await runMatrix({
+      browsers: ['a', 'b', 'c', 'd', 'e'],
+      bailAfter: 0,
+      dispatchOne: async () => false, // every cell fails
+    });
+    expect(r.cells.map((c) => c.outcome)).toEqual(['fail', 'fail', 'fail', 'fail', 'fail']);
+  });
+
+  test('bailAfter=1 is equivalent in effect to failFast=true', async () => {
+    const r = await runMatrix({
+      browsers: ['a', 'b', 'c'],
+      bailAfter: 1,
+      dispatchOne: async ({ browser }) => browser !== 'a', // a fails, rest pass
+    });
+    expect(r.cells[0].outcome).toBe('fail');
+    expect(r.cells[1].outcome).toBe('skip');
+    expect(r.cells[2].outcome).toBe('skip');
+    expect(r.cells[1].error).toMatch(/matrix aborted by --bail 1/);
+  });
+
+  test('bailAfter=3 stops at the 3rd failure (counts itself; 4th cell is skip)', async () => {
+    const r = await runMatrix({
+      browsers: ['a', 'b', 'c', 'd', 'e'],
+      bailAfter: 3,
+      dispatchOne: async () => false, // every cell fails
+    });
+    expect(r.cells.map((c) => c.outcome)).toEqual(['fail', 'fail', 'fail', 'skip', 'skip']);
+    expect(r.cells[3].error).toMatch(/matrix aborted by --bail 3 after 3 failure\(s\)/);
+  });
+
+  test('bailAfter counts timeouts as failures (matches failFast semantics)', async () => {
+    const r = await runMatrix({
+      browsers: ['a', 'b', 'c'],
+      bailAfter: 2,
+      dispatchOne: async ({ browser }) => {
+        if (browser === 'a' || browser === 'b') {
+          const e = new Error('took too long');
+          e.code = 'CELL_TIMEOUT';
+          throw e;
+        }
+        return true;
+      },
+    });
+    expect(r.cells[0].outcome).toBe('timeout');
+    expect(r.cells[1].outcome).toBe('timeout');
+    expect(r.cells[2].outcome).toBe('skip'); // bail triggered after 2 timeouts
+  });
+
+  test('bailAfter does NOT count "skip" outcomes (device-not-connected ≠ failure)', async () => {
+    const r = await runMatrix({
+      browsers: ['a', 'b', 'c', 'd', 'e'],
+      bailAfter: 2,
+      dispatchOne: async ({ browser }) => {
+        // a, b, c all skip; d fails; e fails — bail after 2 fails
+        if (browser === 'a' || browser === 'b' || browser === 'c') {
+          throw new Error('no Android device attached');
+        }
+        return false;
+      },
+    });
+    expect(r.cells.map((c) => c.outcome)).toEqual(['skip', 'skip', 'skip', 'fail', 'fail']);
+    // No 6th cell to be aborted — fine. All 5 ran because skips didn't count.
+  });
+
+  test('bailAfter + failFast=true together: whichever fires first wins', async () => {
+    // bailAfter=5 but failFast=true should still stop at the first fail.
+    const r = await runMatrix({
+      browsers: ['a', 'b', 'c'],
+      bailAfter: 5,
+      failFast: true,
+      dispatchOne: async () => false,
+    });
+    expect(r.cells[0].outcome).toBe('fail');
+    expect(r.cells[1].outcome).toBe('skip');
+    expect(r.cells[2].outcome).toBe('skip');
+    // failFast fired first — its sentinel should be the abort reason.
+    expect(r.cells[1].error).toMatch(/matrix aborted by failFast/);
+  });
+
+  test('totals reflect the truncated run (skips include the bail-aborted cells)', async () => {
+    const r = await runMatrix({
+      browsers: ['a', 'b', 'c', 'd'],
+      bailAfter: 2,
+      dispatchOne: async () => false,
+    });
+    expect(r.totals).toEqual({ pass: 0, fail: 2, skip: 2, timeout: 0 });
+    expect(r.ok).toBe(false); // any fail = not ok
+  });
+});
+
 // runMatrix — callbacks + timing ─────────────────────────────────────
 
 describe('runMatrix — callbacks + timing', () => {


### PR DESCRIPTION
## Summary
PR #10 in the QA-runner framework-completion sequence — closes gap **A7**. Refines `--fail-fast` (binary) with a count threshold: `--bail N` stops the matrix after N failures.

## Semantics
| Flag combination | Behavior |
|------------------|----------|
| `--bail 0` (default) | No bail; all cells run |
| `--bail 1` | Equivalent in effect to `--fail-fast` |
| `--bail 3` | Stop after 3rd failure or timeout |
| `--bail N --fail-fast` | Whichever fires first wins |
| Skips | Don't count toward bail |
| Timeouts | Count as failures |

Skip-sentinel distinguishes which gate fired:
- `matrix aborted by failFast` (existing, unchanged)
- `matrix aborted by --bail N after K failure(s)` (new)

## Changes
- `matrix-dispatch.js`: `runMatrix()` gains `bailAfter` param (default 0) + `failureCount` tracking + dual-gate stop check. First-fire-wins on the abort-reason sentinel preserves backward-compat.
- `manual-qa-runner.js`: parser recognises `--bail <n>`, validates as non-negative integer (negative → exit 2), passes to runMatrix. `formatUsage()` documents the flag.

## Test plan
- [x] **7 new tests in matrix-dispatch.test.js** (75 total in suite pass)
- [x] Full express-api suite (275 suites / 10,440 tests) — no regressions
- [x] ESLint `--max-warnings=0` clean
- [x] Prettier-clean
- [x] Sonar pre-push gate passed (on retry — known transient on coverage step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)