### PR TITLE
feat(qa-runner): stale-session cleanup script for orphan QA processes (gap G2)

### DIFF
--- a/express-api/scripts/qa-cleanup-orphans.sh
+++ b/express-api/scripts/qa-cleanup-orphans.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# qa-cleanup-orphans.sh — sweep orphaned QA-runner sessions after a
+# matrix run. Closes gap G2 from the QA framework tracker.
+#
+# Long matrix runs accumulate orphan processes on the operator's laptop:
+#   - Appium server processes (from --driver mode) that didn't shut down
+#   - adb daemons in 'unauthorized'/'offline' state needing restart
+#   - Playwright browser temp dirs that leaked
+#   - Orphan node processes whose parent matrix died
+#
+# Usage:
+#   ./qa-cleanup-orphans.sh                # report + clean (default)
+#   ./qa-cleanup-orphans.sh --dry-run      # report only, no kills
+#   ./qa-cleanup-orphans.sh --verbose      # explain each step
+#
+# Companion to QA_FRAMEWORK_TROUBLESHOOTING.md. Run this when:
+#   - matrix invocation hangs / errors out without clean teardown
+#   - `--check-drivers` reports unexpected 'fail' on cells that worked yesterday
+#   - operator switches between Android-only and iOS-only matrix runs
+
+set -euo pipefail
+
+MODE="clean"
+VERBOSE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) MODE="dry-run" ;;
+    --verbose) VERBOSE=true ;;
+    --help|-h)
+      sed -n '1,18p' "$0" | tail -n +2 | sed 's|^# \?||'
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $arg" >&2
+      echo "Usage: $0 [--dry-run] [--verbose]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+vlog() { [ "$VERBOSE" = true ] && echo "  $*" >&2 || true; }
+
+say() { echo "[qa-cleanup] $*"; }
+
+# --- 1. Appium orphans -------------------------------------------------
+
+say "checking Appium processes…"
+APPIUM_PIDS=$(pgrep -f "node.*appium" 2>/dev/null || true)
+if [ -n "$APPIUM_PIDS" ]; then
+  say "  found Appium PIDs: $APPIUM_PIDS"
+  if [ "$MODE" = "clean" ]; then
+    vlog "killing Appium PIDs"
+    # SIGTERM first; processes that ignore it (rare) need SIGKILL fallback
+    # after a brief grace window.
+    echo "$APPIUM_PIDS" | xargs -r kill 2>/dev/null || true
+    sleep 1
+    REMAINING=$(pgrep -f "node.*appium" 2>/dev/null || true)
+    if [ -n "$REMAINING" ]; then
+      vlog "SIGTERM didn't take; SIGKILL fallback for: $REMAINING"
+      echo "$REMAINING" | xargs -r kill -9 2>/dev/null || true
+    fi
+    say "  ✓ Appium killed"
+  fi
+else
+  say "  ✓ no Appium orphans"
+fi
+
+# --- 2. adb daemon state ----------------------------------------------
+
+say "checking adb daemon state…"
+if command -v adb >/dev/null 2>&1; then
+  ADB_DEVICES=$(adb devices 2>/dev/null | tail -n +2 | grep -v '^$' || true)
+  if echo "$ADB_DEVICES" | grep -qE "(unauthorized|offline)"; then
+    say "  found unauthorized/offline devices — restarting adb"
+    if [ "$MODE" = "clean" ]; then
+      adb kill-server 2>/dev/null || true
+      adb start-server 2>/dev/null || true
+      say "  ✓ adb restarted (re-tap the RSA-key dialog on the device if needed)"
+    fi
+  else
+    say "  ✓ adb daemon healthy"
+  fi
+else
+  vlog "adb not installed — skipping"
+fi
+
+# --- 3. Orphan adb-forward ports --------------------------------------
+
+if command -v adb >/dev/null 2>&1; then
+  say "checking adb forward ports…"
+  FORWARDS=$(adb forward --list 2>/dev/null || true)
+  if [ -n "$FORWARDS" ]; then
+    say "  active forwards:"
+    echo "$FORWARDS" | awk '{print "    " $0}'
+    if [ "$MODE" = "clean" ]; then
+      adb forward --remove-all 2>/dev/null || true
+      say "  ✓ all forwards cleared"
+    fi
+  else
+    say "  ✓ no orphan forwards"
+  fi
+fi
+
+# --- 4. Orphan manual-qa-runner subprocesses --------------------------
+
+say "checking manual-qa-runner orphans…"
+RUNNER_PIDS=$(pgrep -f "manual-qa-runner" 2>/dev/null || true)
+# Exclude THIS script's own PID (if launched via npm/node ancestry that
+# happens to grep-match), plus any cleanup we're currently spawning.
+SELF_PID=$$
+RUNNER_PIDS=$(echo "$RUNNER_PIDS" | grep -v "^$SELF_PID$" || true)
+if [ -n "$RUNNER_PIDS" ]; then
+  say "  found runner PIDs: $RUNNER_PIDS"
+  if [ "$MODE" = "clean" ]; then
+    echo "$RUNNER_PIDS" | xargs -r kill 2>/dev/null || true
+    say "  ✓ orphan runners killed"
+  fi
+else
+  say "  ✓ no orphan runners"
+fi
+
+# --- 5. Playwright temp dirs ------------------------------------------
+
+# Playwright leaves browser profile dirs in /tmp during long runs.
+# Conservative cleanup: only delete dirs older than 1 hour to avoid
+# racing an in-flight run.
+say "checking Playwright temp dirs…"
+PW_TMP=$(find /tmp -maxdepth 2 -type d -name "playwright_*" -mmin +60 2>/dev/null || true)
+if [ -n "$PW_TMP" ]; then
+  say "  found stale Playwright dirs (>1h old):"
+  echo "$PW_TMP" | awk '{print "    " $0}'
+  if [ "$MODE" = "clean" ]; then
+    echo "$PW_TMP" | xargs -r rm -rf 2>/dev/null || true
+    say "  ✓ stale Playwright dirs removed"
+  fi
+else
+  say "  ✓ no stale Playwright dirs"
+fi
+
+# --- Summary ----------------------------------------------------------
+
+if [ "$MODE" = "dry-run" ]; then
+  say "dry-run complete — no processes killed, no dirs removed"
+else
+  say "cleanup complete"
+fi

--- a/express-api/scripts/qa-cleanup-orphans.sh
+++ b/express-api/scripts/qa-cleanup-orphans.sh
@@ -81,7 +81,7 @@ if command -v adb >/dev/null 2>&1; then
     say "  ✓ adb daemon healthy"
   fi
 else
-  vlog "adb not installed — skipping"
+  say "  ✓ adb not installed — skipping"
 fi
 
 # --- 3. Orphan adb-forward ports --------------------------------------
@@ -99,6 +99,12 @@ if command -v adb >/dev/null 2>&1; then
   else
     say "  ✓ no orphan forwards"
   fi
+else
+  # Operator-friendly: emit a status line even when the toolchain is
+  # absent (CI on ubuntu has no adb). Without this, the operator
+  # would have no signal that the adb-forward check was skipped vs run.
+  # Also pinned by qa-cleanup-orphans-pin.test.js (CI ubuntu has no adb).
+  say "checking adb forward ports… (adb not installed — skipping)"
 fi
 
 # --- 4. Orphan manual-qa-runner subprocesses --------------------------

--- a/express-api/tests/scripts/qa-cleanup-orphans-pin.test.js
+++ b/express-api/tests/scripts/qa-cleanup-orphans-pin.test.js
@@ -1,0 +1,148 @@
+/**
+ * qa-cleanup-orphans-pin.test.js
+ *
+ * Pins the structure of `express-api/scripts/qa-cleanup-orphans.sh`.
+ * Closes gap G2 from the QA-runner framework tracker — without this
+ * pin, a future PR could silently break:
+ *   - the dry-run mode (operators rely on it to preview kills)
+ *   - the per-section coverage (Appium / adb / forwards / runners /
+ *     Playwright temp dirs) that the troubleshooting doc cross-refs
+ *   - the safe defaults (don't touch dirs <1h old; --dry-run works
+ *     without any tools installed)
+ *
+ * Read-only test — runs the script with `--dry-run` and asserts the
+ * sentinel strings + exit codes.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const SCRIPT_PATH = path.join(REPO_ROOT, 'express-api/scripts/qa-cleanup-orphans.sh');
+
+// ── File-level invariants ──────────────────────────────────────────
+
+describe('qa-cleanup-orphans.sh — file invariants', () => {
+  test('script exists at the expected path', () => {
+    expect(fs.existsSync(SCRIPT_PATH)).toBe(true);
+  });
+
+  test('script is executable', () => {
+    const mode = fs.statSync(SCRIPT_PATH).mode;
+    // bit-and with 0o111 — any of owner/group/other execute set.
+    expect(mode & 0o111).not.toBe(0);
+  });
+
+  test('script uses /usr/bin/env bash (portable shebang)', () => {
+    const head = fs.readFileSync(SCRIPT_PATH, 'utf8').split('\n')[0];
+    expect(head).toBe('#!/usr/bin/env bash');
+  });
+
+  test('script sets safe shell options (set -euo pipefail)', () => {
+    const src = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    expect(src).toMatch(/^set -euo pipefail\b/m);
+  });
+});
+
+// ── --dry-run mode ─────────────────────────────────────────────────
+
+describe('qa-cleanup-orphans.sh — --dry-run', () => {
+  let result;
+  beforeAll(() => {
+    // process.execPath isn't relevant here — this is a shell script.
+    // Use the absolute path + the shell directly to silence
+    // sonarjs/no-os-command-from-path.
+    result = spawnSync('/bin/bash', [SCRIPT_PATH, '--dry-run'], {
+      encoding: 'utf8',
+      timeout: 30000,
+    });
+  });
+
+  test('exits 0', () => {
+    expect(result.status).toBe(0);
+  });
+
+  test('emits dry-run completion sentinel', () => {
+    expect(result.stdout).toMatch(/dry-run complete — no processes killed/);
+  });
+
+  test('covers Appium processes section', () => {
+    expect(result.stdout).toMatch(/checking Appium processes/);
+  });
+
+  test('covers adb daemon state section', () => {
+    expect(result.stdout).toMatch(/checking adb daemon state/);
+  });
+
+  test('covers adb forward ports section', () => {
+    expect(result.stdout).toMatch(/checking adb forward ports|adb not installed/);
+  });
+
+  test('covers manual-qa-runner orphans section', () => {
+    expect(result.stdout).toMatch(/checking manual-qa-runner orphans/);
+  });
+
+  test('covers Playwright temp dirs section', () => {
+    expect(result.stdout).toMatch(/checking Playwright temp dirs/);
+  });
+});
+
+// ── arg handling ───────────────────────────────────────────────────
+
+describe('qa-cleanup-orphans.sh — arg handling', () => {
+  test('rejects unknown args with exit 2', () => {
+    const r = spawnSync('/bin/bash', [SCRIPT_PATH, '--bogus-flag'], {
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/Unknown arg/);
+  });
+
+  test('--help exits 0 with usage text', () => {
+    const r = spawnSync('/bin/bash', [SCRIPT_PATH, '--help'], {
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Usage:/);
+  });
+
+  test('-h is an alias for --help', () => {
+    const r = spawnSync('/bin/bash', [SCRIPT_PATH, '-h'], {
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Usage:/);
+  });
+});
+
+// ── safety guardrails encoded in the script ────────────────────────
+
+describe('qa-cleanup-orphans.sh — safety invariants', () => {
+  const src = fs.readFileSync(SCRIPT_PATH, 'utf8');
+
+  test('Playwright cleanup only deletes dirs > 1h old (no race with in-flight runs)', () => {
+    // The find expression must include `-mmin +60` so an in-flight
+    // matrix run's freshly-created tmpdir isn't reaped underneath it.
+    expect(src).toMatch(/find\s+\/tmp\s+[^\n]{0,200}-mmin\s+\+60/);
+  });
+
+  test('excludes own PID from manual-qa-runner orphan kill', () => {
+    // Without this guard, the script could match itself via pgrep
+    // ancestry and try to kill its own PID (it wouldn't, because
+    // qa-cleanup-orphans doesn't have "manual-qa-runner" in args —
+    // but the guard documents intent + protects against future
+    // refactors that rename the script).
+    expect(src).toMatch(/\bSELF_PID\b/);
+    expect(src).toMatch(/grep -v "\^\$SELF_PID\$"/);
+  });
+
+  test('uses SIGTERM first, SIGKILL only as fallback (graceful shutdown)', () => {
+    // kill (SIGTERM default) appears before kill -9 in the Appium section.
+    expect(src).toMatch(/xargs -r kill 2>\/dev\/null/);
+    expect(src).toMatch(/kill -9/);
+  });
+});


### PR DESCRIPTION
## Summary
PR #11 in the QA-runner framework-completion sequence — closes gap **G2**. Long matrix runs accumulate orphan processes; this script sweeps them in one command.

## Files
- **NEW** `express-api/scripts/qa-cleanup-orphans.sh`
  - `--dry-run` / `--verbose` / `--help`
  - Covers 5 sections: Appium / adb daemon / adb forwards / orphan manual-qa-runner subprocesses / Playwright temp dirs
  - Safe defaults: SIGTERM before SIGKILL; Playwright dirs only deleted if >1h old; SELF_PID excluded
  - shellcheck clean

- **NEW** `express-api/tests/scripts/qa-cleanup-orphans-pin.test.js` — **17 pin tests**

## Operator use case
After a matrix run that errored without clean teardown, or before switching between Android-only and iOS-only matrix modes:
```bash
./express-api/scripts/qa-cleanup-orphans.sh --dry-run   # preview
./express-api/scripts/qa-cleanup-orphans.sh             # actually clean
```

## Test plan
- [x] **17/17 pin tests pass**
- [x] shellcheck clean
- [x] Full express-api suite — no regressions
- [x] ESLint `--max-warnings=0` clean
- [x] Sonar pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)