### PR TITLE
feat(qa-runner): add --check-env diagnostic flag (gap G3)

### DIFF
--- a/express-api/scripts/env-health-check.js
+++ b/express-api/scripts/env-health-check.js
@@ -1,0 +1,122 @@
+/**
+ * env-health-check.js
+ *
+ * Diagnostic helper backing the runner's `--check-env` flag. Verifies
+ * the operator's local env has the credentials + toolchain needed for
+ * a journey-test run, BEFORE the matrix dispatches. Mirrors the shape
+ * of `driver-health-check.js` (which verifies driver bootstrap):
+ *
+ *   const result = await runEnvCheck({ target: 'dev' });
+ *   // result.ok === true|false
+ *   // result.checks === [{ name, ok, error? }, ...]
+ *   console.log(formatEnvHealthResult(result));
+ *
+ * Closes gap G3 from the QA-runner framework tracker — the existing
+ * env-validation block fires AFTER several minutes of driver setup
+ * + matrix dispatch overhead, so operators learn about a missing
+ * env var late. `--check-env` surfaces all problems up-front in
+ * a single diagnostic pass.
+ */
+
+const { spawnSync } = require('child_process');
+
+/**
+ * Returns the FIREBASE env-var name expected for the given target.
+ * Mirrors the runner's existing per-target env-var lookup logic.
+ */
+function firebaseEnvFor(target) {
+  if (target === 'dev') return 'FIREBASE_DEV_API_KEY';
+  if (target === 'local') return 'FIREBASE_LOCAL_API_KEY';
+  if (target === 'prod') return 'FIREBASE_PROD_API_KEY';
+  return null;
+}
+
+/**
+ * Run every env check, return the structured result.
+ *
+ * Args:
+ *   target — one of 'local'|'dev'|'prod' (default 'dev', matching
+ *     the runner's default).
+ *   env — process.env-shaped object (test injection).
+ *   execImpl — spawnSync-shaped function (test injection).
+ */
+async function runEnvCheck({ target = 'dev', env = process.env, execImpl = spawnSync } = {}) {
+  const checks = [];
+
+  // 1. PERSONAS_PASSWORD — required for every journey run.
+  checks.push({
+    name: 'PERSONAS_PASSWORD',
+    ok: Boolean(env.PERSONAS_PASSWORD && env.PERSONAS_PASSWORD.length > 0),
+    error: env.PERSONAS_PASSWORD ? undefined : 'not set',
+  });
+
+  // 2. FIREBASE_<TARGET>_API_KEY — required per resolved target.
+  const fbName = firebaseEnvFor(target);
+  if (fbName) {
+    checks.push({
+      name: fbName,
+      ok: Boolean(env[fbName] && env[fbName].length > 0),
+      error: env[fbName] ? undefined : `not set (required for --target ${target})`,
+    });
+  } else {
+    checks.push({
+      name: `FIREBASE_<TARGET>_API_KEY`,
+      ok: false,
+      error: `unknown target "${target}" — no FIREBASE env mapping`,
+    });
+  }
+
+  // 3. node + npm in PATH — necessary for the matrix dispatcher to
+  // spawn per-cell subprocesses. Use process.execPath for node (we're
+  // running under it). npm we probe via `--version`.
+  checks.push({
+    name: 'node',
+    ok: true,
+    error: undefined,
+    detail: process.version,
+  });
+
+  try {
+    const r = execImpl('npm', ['--version'], { encoding: 'utf8', timeout: 5000 });
+    if (r && r.status === 0 && r.stdout) {
+      checks.push({ name: 'npm', ok: true, detail: r.stdout.trim() });
+    } else {
+      checks.push({
+        name: 'npm',
+        ok: false,
+        error: `not found in PATH (exit=${r ? r.status : '?'})`,
+      });
+    }
+  } catch (e) {
+    checks.push({ name: 'npm', ok: false, error: e.message });
+  }
+
+  return {
+    ok: checks.every((c) => c.ok),
+    checks,
+  };
+}
+
+/**
+ * Format the result for human reading. Symbol prefix (✓/✗) + name +
+ * detail or error. Operator-friendly summary line at the bottom.
+ */
+function formatEnvHealthResult(result) {
+  const lines = ['Env health check:'];
+  for (const c of result.checks) {
+    const mark = c.ok ? '✓' : '✗';
+    const tail = c.ok ? (c.detail ? ` (${c.detail})` : '') : c.error ? ` — ${c.error}` : '';
+    lines.push(`  ${mark} ${c.name}${tail}`);
+  }
+  lines.push('');
+  const passed = result.checks.filter((c) => c.ok).length;
+  const total = result.checks.length;
+  lines.push(result.ok ? `All ${total} checks passed.` : `${passed}/${total} checks passed.`);
+  return lines.join('\n');
+}
+
+module.exports = {
+  runEnvCheck,
+  formatEnvHealthResult,
+  firebaseEnvFor,
+};

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -15454,6 +15454,9 @@ function formatUsage() {
     '                              count as failures, skips do not). 0 = no bail.',
     '                              --bail 1 is equivalent in effect to --fail-fast.',
     '  --check-drivers           Diagnostic — verify each driver bootstraps',
+    '  --check-env               Diagnostic — verify env credentials + toolchain',
+    '                              (PERSONAS_PASSWORD, FIREBASE_<TARGET>_API_KEY,',
+    '                              node, npm). Exits 0 iff every check passes.',
     '  --list                    Enumerate matrix cells as JSON (use with --target',
     '                              to filter to one target). Exits 0 without env vars',
     '                              so it is safe to pipe into jq for scripting.',
@@ -15587,6 +15590,7 @@ async function main() {
     else if (flat[i] === '--version' || flat[i] === '-v') opts.version = true;
     else if (flat[i] === '--list') opts.list = true;
     else if (flat[i] === '--dry-run') opts.dryRun = true;
+    else if (flat[i] === '--check-env') opts.checkEnv = true;
   }
   // --help / --version / --list short-circuit BEFORE any further
   // validation or env checks. Operators must be able to discover the
@@ -15609,6 +15613,17 @@ async function main() {
   if (opts.dryRun) {
     console.log(formatDryRunJson(opts));
     process.exit(0);
+  }
+  if (opts.checkEnv) {
+    // Pre-flight env audit — verify PERSONAS_PASSWORD, FIREBASE_<TARGET>_API_KEY,
+    // and toolchain (node + npm). Surfaces ALL problems up-front instead of the
+    // existing "MISSING_ENV" failures fired one-at-a-time after several
+    // minutes of matrix-dispatch setup. Pure diagnostic — exits 0 iff every
+    // check passes, 1 if any fails. Doesn't run the matrix.
+    const { runEnvCheck, formatEnvHealthResult } = require('./env-health-check');
+    const result = await runEnvCheck({ target: opts.target || 'dev' });
+    console.log(formatEnvHealthResult(result));
+    process.exit(result.ok ? 0 : 1);
   }
   // --report-format validation — only json + junit are supported (used
   // with --matrix to emit structured output for CI dashboards).

--- a/express-api/tests/scripts/env-health-check.test.js
+++ b/express-api/tests/scripts/env-health-check.test.js
@@ -1,0 +1,241 @@
+/**
+ * env-health-check.test.js
+ *
+ * Tests the diagnostic `runEnvCheck` helper used by the runner's
+ * `--check-env` flag (gap G3). Verifies per-check correctness +
+ * the formatEnvHealthResult string shape.
+ */
+
+const path = require('path');
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const { runEnvCheck, formatEnvHealthResult, firebaseEnvFor } = require(
+  path.join(REPO_ROOT, 'scripts/env-health-check'),
+);
+
+function fakeExec(stdout, status = 0) {
+  return () => ({ status, stdout });
+}
+
+function fakeExecThrowing(err) {
+  return () => {
+    throw err;
+  };
+}
+
+// ── firebaseEnvFor — target → env-var mapping ──────────────────────
+
+describe('firebaseEnvFor', () => {
+  test('dev → FIREBASE_DEV_API_KEY', () => {
+    expect(firebaseEnvFor('dev')).toBe('FIREBASE_DEV_API_KEY');
+  });
+  test('local → FIREBASE_LOCAL_API_KEY', () => {
+    expect(firebaseEnvFor('local')).toBe('FIREBASE_LOCAL_API_KEY');
+  });
+  test('prod → FIREBASE_PROD_API_KEY', () => {
+    expect(firebaseEnvFor('prod')).toBe('FIREBASE_PROD_API_KEY');
+  });
+  test('unknown target → null', () => {
+    expect(firebaseEnvFor('staging')).toBeNull();
+    expect(firebaseEnvFor('')).toBeNull();
+    expect(firebaseEnvFor(undefined)).toBeNull();
+  });
+});
+
+// ── runEnvCheck — happy paths ─────────────────────────────────────
+
+describe('runEnvCheck — happy paths', () => {
+  test('all envs set + npm available → ok=true', async () => {
+    const r = await runEnvCheck({
+      target: 'dev',
+      env: { PERSONAS_PASSWORD: 'pw', FIREBASE_DEV_API_KEY: 'k' },
+      execImpl: fakeExec('11.0.0\n'),
+    });
+    expect(r.ok).toBe(true);
+    expect(r.checks.every((c) => c.ok)).toBe(true);
+  });
+
+  test('reports node detail = process.version', async () => {
+    const r = await runEnvCheck({
+      target: 'dev',
+      env: { PERSONAS_PASSWORD: 'pw', FIREBASE_DEV_API_KEY: 'k' },
+      execImpl: fakeExec('11.0.0\n'),
+    });
+    const nodeCheck = r.checks.find((c) => c.name === 'node');
+    expect(nodeCheck.detail).toBe(process.version);
+  });
+
+  test('reports npm detail = stdout', async () => {
+    const r = await runEnvCheck({
+      target: 'dev',
+      env: { PERSONAS_PASSWORD: 'pw', FIREBASE_DEV_API_KEY: 'k' },
+      execImpl: fakeExec('11.0.0\n'),
+    });
+    const npmCheck = r.checks.find((c) => c.name === 'npm');
+    expect(npmCheck.detail).toBe('11.0.0');
+  });
+});
+
+// ── runEnvCheck — missing PERSONAS_PASSWORD ─────────────────────
+
+describe('runEnvCheck — missing PERSONAS_PASSWORD', () => {
+  test('PERSONAS_PASSWORD missing → ok=false + check fails with "not set"', async () => {
+    const r = await runEnvCheck({
+      target: 'dev',
+      env: { FIREBASE_DEV_API_KEY: 'k' },
+      execImpl: fakeExec('11.0.0\n'),
+    });
+    expect(r.ok).toBe(false);
+    const personasCheck = r.checks.find((c) => c.name === 'PERSONAS_PASSWORD');
+    expect(personasCheck.ok).toBe(false);
+    expect(personasCheck.error).toBe('not set');
+  });
+
+  test('PERSONAS_PASSWORD empty string → still fails', async () => {
+    const r = await runEnvCheck({
+      target: 'dev',
+      env: { PERSONAS_PASSWORD: '', FIREBASE_DEV_API_KEY: 'k' },
+      execImpl: fakeExec('11.0.0\n'),
+    });
+    expect(r.checks.find((c) => c.name === 'PERSONAS_PASSWORD').ok).toBe(false);
+  });
+});
+
+// ── runEnvCheck — per-target FIREBASE env mapping ───────────────────
+
+describe('runEnvCheck — per-target FIREBASE env', () => {
+  test('target=dev checks FIREBASE_DEV_API_KEY', async () => {
+    const r = await runEnvCheck({
+      target: 'dev',
+      env: { PERSONAS_PASSWORD: 'pw', FIREBASE_DEV_API_KEY: 'k' },
+      execImpl: fakeExec('11.0.0\n'),
+    });
+    expect(r.checks.find((c) => c.name === 'FIREBASE_DEV_API_KEY').ok).toBe(true);
+  });
+
+  test('target=local checks FIREBASE_LOCAL_API_KEY', async () => {
+    const r = await runEnvCheck({
+      target: 'local',
+      env: { PERSONAS_PASSWORD: 'pw', FIREBASE_LOCAL_API_KEY: 'k' },
+      execImpl: fakeExec('11.0.0\n'),
+    });
+    expect(r.checks.find((c) => c.name === 'FIREBASE_LOCAL_API_KEY').ok).toBe(true);
+  });
+
+  test('target=prod checks FIREBASE_PROD_API_KEY', async () => {
+    const r = await runEnvCheck({
+      target: 'prod',
+      env: { PERSONAS_PASSWORD: 'pw', FIREBASE_PROD_API_KEY: 'k' },
+      execImpl: fakeExec('11.0.0\n'),
+    });
+    expect(r.checks.find((c) => c.name === 'FIREBASE_PROD_API_KEY').ok).toBe(true);
+  });
+
+  test('unknown target → error check with "no FIREBASE env mapping"', async () => {
+    const r = await runEnvCheck({
+      target: 'staging',
+      env: { PERSONAS_PASSWORD: 'pw' },
+      execImpl: fakeExec('11.0.0\n'),
+    });
+    const fbCheck = r.checks.find((c) => c.name.startsWith('FIREBASE_'));
+    expect(fbCheck.ok).toBe(false);
+    expect(fbCheck.error).toMatch(/unknown target/);
+  });
+
+  test('FIREBASE env missing → fail with target hint in error', async () => {
+    const r = await runEnvCheck({
+      target: 'dev',
+      env: { PERSONAS_PASSWORD: 'pw' },
+      execImpl: fakeExec('11.0.0\n'),
+    });
+    const fbCheck = r.checks.find((c) => c.name === 'FIREBASE_DEV_API_KEY');
+    expect(fbCheck.ok).toBe(false);
+    expect(fbCheck.error).toMatch(/required for --target dev/);
+  });
+});
+
+// ── runEnvCheck — npm probe ─────────────────────────────────────
+
+describe('runEnvCheck — npm probe', () => {
+  test('npm not in PATH (status=1) → check fails', async () => {
+    const r = await runEnvCheck({
+      target: 'dev',
+      env: { PERSONAS_PASSWORD: 'pw', FIREBASE_DEV_API_KEY: 'k' },
+      execImpl: fakeExec('', 1),
+    });
+    const npmCheck = r.checks.find((c) => c.name === 'npm');
+    expect(npmCheck.ok).toBe(false);
+    expect(npmCheck.error).toMatch(/not found in PATH/);
+  });
+
+  test('execImpl throws → npm check fails with the error message', async () => {
+    const r = await runEnvCheck({
+      target: 'dev',
+      env: { PERSONAS_PASSWORD: 'pw', FIREBASE_DEV_API_KEY: 'k' },
+      execImpl: fakeExecThrowing(new Error('ENOENT')),
+    });
+    const npmCheck = r.checks.find((c) => c.name === 'npm');
+    expect(npmCheck.ok).toBe(false);
+    expect(npmCheck.error).toMatch(/ENOENT/);
+  });
+});
+
+// ── runEnvCheck — defaults ──────────────────────────────────────
+
+describe('runEnvCheck — defaults', () => {
+  test('default target = dev (matches runner default)', async () => {
+    const r = await runEnvCheck({
+      env: { PERSONAS_PASSWORD: 'pw', FIREBASE_DEV_API_KEY: 'k' },
+      execImpl: fakeExec('11.0.0\n'),
+    });
+    expect(r.checks.some((c) => c.name === 'FIREBASE_DEV_API_KEY')).toBe(true);
+  });
+});
+
+// ── formatEnvHealthResult — string shape ────────────────────────
+
+describe('formatEnvHealthResult', () => {
+  test('emits header + per-check line + summary', () => {
+    const result = {
+      ok: true,
+      checks: [
+        { name: 'PERSONAS_PASSWORD', ok: true },
+        { name: 'FIREBASE_DEV_API_KEY', ok: true },
+      ],
+    };
+    const out = formatEnvHealthResult(result);
+    expect(out).toMatch(/Env health check:/);
+    expect(out).toMatch(/✓ PERSONAS_PASSWORD/);
+    expect(out).toMatch(/✓ FIREBASE_DEV_API_KEY/);
+    expect(out).toMatch(/All 2 checks passed/);
+  });
+
+  test('failing checks use ✗ + error message', () => {
+    const result = {
+      ok: false,
+      checks: [{ name: 'PERSONAS_PASSWORD', ok: false, error: 'not set' }],
+    };
+    const out = formatEnvHealthResult(result);
+    expect(out).toMatch(/✗ PERSONAS_PASSWORD — not set/);
+    expect(out).toMatch(/0\/1 checks passed/);
+  });
+
+  test('passing check with detail uses (detail) suffix', () => {
+    const result = {
+      ok: true,
+      checks: [{ name: 'node', ok: true, detail: 'v24.0.0' }],
+    };
+    expect(formatEnvHealthResult(result)).toMatch(/✓ node \(v24\.0\.0\)/);
+  });
+
+  test('mixed pass/fail counts correctly', () => {
+    const result = {
+      ok: false,
+      checks: [
+        { name: 'a', ok: true },
+        { name: 'b', ok: false, error: 'x' },
+        { name: 'c', ok: true },
+      ],
+    };
+    expect(formatEnvHealthResult(result)).toMatch(/2\/3 checks passed/);
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner-check-env.test.js
+++ b/express-api/tests/scripts/manual-qa-runner-check-env.test.js
@@ -1,0 +1,117 @@
+/**
+ * manual-qa-runner-check-env.test.js
+ *
+ * CLI integration tests for the `--check-env` flag (gap G3). Verifies:
+ *   - --check-env runs the diagnostic + exits 0 when env is complete
+ *   - --check-env exits 1 when env is incomplete (a check fails)
+ *   - --check-env runs BEFORE the env-validation block (so it works
+ *     without PERSONAS_PASSWORD set)
+ *   - --check-env is documented in formatUsage() (drift-catch)
+ *   - --help / --version / --list / --dry-run all win over --check-env
+ *     (consistent precedence chain)
+ */
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const RUNNER_PATH = path.join(REPO_ROOT, 'express-api/scripts/manual-qa-runner.js');
+
+function runCli(args, env = {}) {
+  // Strip the credentials from process.env FIRST, THEN apply the caller's
+  // env overrides. The earlier --help/--list/--dry-run tests use the same
+  // shape and don't need credentials so the order doesn't matter there —
+  // but --check-env tests inject FIREBASE_DEV_API_KEY etc to verify the
+  // ok=true path. If the delete ran AFTER the spread, those injections
+  // would be silently removed and the diagnostic would always report
+  // "not set".
+  const baseEnv = { ...process.env };
+  delete baseEnv.PERSONAS_PASSWORD;
+  delete baseEnv.FIREBASE_DEV_API_KEY;
+  delete baseEnv.FIREBASE_LOCAL_API_KEY;
+  delete baseEnv.FIREBASE_PROD_API_KEY;
+  return spawnSync(process.execPath, [RUNNER_PATH, ...args], {
+    encoding: 'utf8',
+    env: { ...baseEnv, ...env },
+    timeout: 10000,
+  });
+}
+
+describe('CLI integration — --check-env', () => {
+  test('--check-env exits 1 when PERSONAS_PASSWORD is missing', () => {
+    const r = runCli(['--check-env']);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toMatch(/✗ PERSONAS_PASSWORD/);
+  });
+
+  test('--check-env exits 1 when FIREBASE_<TARGET>_API_KEY is missing', () => {
+    const r = runCli(['--check-env', '--target', 'dev'], { PERSONAS_PASSWORD: 'fake' });
+    expect(r.status).toBe(1);
+    expect(r.stdout).toMatch(/✗ FIREBASE_DEV_API_KEY/);
+  });
+
+  test('--check-env exits 0 when all required vars are set', () => {
+    const r = runCli(['--check-env', '--target', 'dev'], {
+      PERSONAS_PASSWORD: 'fake',
+      FIREBASE_DEV_API_KEY: 'fake',
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/All 4 checks passed/);
+  });
+
+  test('--check-env defaults to target=dev when --target absent', () => {
+    const r = runCli(['--check-env']);
+    expect(r.stdout).toMatch(/FIREBASE_DEV_API_KEY/);
+  });
+
+  test('--check-env --target local checks FIREBASE_LOCAL_API_KEY', () => {
+    const r = runCli(['--check-env', '--target', 'local']);
+    expect(r.stdout).toMatch(/FIREBASE_LOCAL_API_KEY/);
+  });
+
+  test('--check-env --target prod checks FIREBASE_PROD_API_KEY', () => {
+    const r = runCli(['--check-env', '--target', 'prod']);
+    expect(r.stdout).toMatch(/FIREBASE_PROD_API_KEY/);
+  });
+
+  test('--check-env is documented in formatUsage', () => {
+    const { formatUsage } = require(RUNNER_PATH);
+    expect(formatUsage()).toMatch(/--check-env\b/);
+  });
+
+  test('--check-env runs without crashing when no env vars at all are set', () => {
+    // The whole point of a diagnostic — it should never crash, only
+    // report what's missing.
+    const r = runCli(['--check-env']);
+    expect(r.status).not.toBe(null); // didn't time out
+    expect(r.stdout).toMatch(/Env health check:/);
+  });
+});
+
+describe('CLI integration — --check-env flag-combination precedence', () => {
+  test('--help wins over --check-env', () => {
+    const r = runCli(['--help', '--check-env']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Usage:/);
+    expect(r.stdout).not.toMatch(/Env health check/);
+  });
+
+  test('--version wins over --check-env', () => {
+    const r = runCli(['--version', '--check-env']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/manual-qa-runner /);
+    expect(r.stdout).not.toMatch(/Env health check/);
+  });
+
+  test('--list wins over --check-env', () => {
+    const r = runCli(['--list', '--check-env']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/"supported"/);
+  });
+
+  test('--dry-run wins over --check-env', () => {
+    const r = runCli(['--dry-run', '--check-env']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/"cells"/);
+  });
+});


### PR DESCRIPTION
## Summary
PR #12 in the QA-runner framework-completion sequence — closes gap **G3**. Pre-flight env audit complementing `--check-drivers`. Verifies the operator's local credentials + toolchain are complete BEFORE the matrix dispatches.

**Why:** the existing env-validation block fires AFTER several minutes of driver-setup overhead. `--check-env` surfaces ALL problems in a single up-front pass.

## Example
```bash
$ node express-api/scripts/manual-qa-runner.js --check-env --target dev
Env health check:
  ✗ PERSONAS_PASSWORD — not set
  ✗ FIREBASE_DEV_API_KEY — not set (required for --target dev)
  ✓ node (v24.0.0)
  ✓ npm (11.0.0)

2/4 checks passed.
$ echo $?
1
```

## Changes
- **NEW** `express-api/scripts/env-health-check.js`
  - `runEnvCheck({target, env, execImpl})` — pure helper, test-injectable
  - Checks: PERSONAS_PASSWORD, FIREBASE_<TARGET>_API_KEY, node version, npm availability
  - `formatEnvHealthResult` — operator-friendly stdout with ✓/✗ markers
- `manual-qa-runner.js`: parser recognises `--check-env`, early-exit in `main()` AFTER `--dry-run` and BEFORE env validation. Exits 0/1 based on result. `formatUsage()` documents (drift-catch enforces).

## Test plan
- [x] **33 new tests pass** (21 helper + 12 CLI integration)
- [x] Full express-api suite (277 suites / 10,490 tests) — no regressions
- [x] ESLint `--max-warnings=0` clean
- [x] Prettier-clean
- [x] Sonar pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)