### PR TITLE
feat(qa-runner): driver-surface report tool — surfaces method-count divergences (gap B5)

### DIFF
--- a/express-api/scripts/driver-surface-report.js
+++ b/express-api/scripts/driver-surface-report.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * driver-surface-report.js
+ *
+ * Survey tool — surfaces method-count divergences across the
+ * 12-cell matrix's drivers. Closes gap B5 from the QA-runner
+ * framework tracker ("Wide-divergent method counts. Investigation
+ * needed.") by giving operators a quick read on which drivers
+ * implement how many step-binding methods.
+ *
+ * Pure read-only tool — no env vars required, no runtime side effects
+ * beyond stdout. Loads each driver fresh (cleared from require-cache)
+ * with all credential envs stripped, just like the contract test does.
+ *
+ * Usage:
+ *   node express-api/scripts/driver-surface-report.js              # table
+ *   node express-api/scripts/driver-surface-report.js --json       # JSON
+ *   node express-api/scripts/driver-surface-report.js --help       # usage
+ *
+ * The table form is operator-friendly (sorted by method count,
+ * widest column auto-fit). The JSON form is pipeable to jq for
+ * regression detection: e.g. compare two runs to spot driver-surface
+ * additions/removals between releases.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DRIVERS_DIR = path.join(__dirname, 'drivers');
+const HELPER_FILES = new Set(['android-cdp-helpers.js', 'ios-driver-loader.js']);
+
+function discoverDrivers() {
+  return fs
+    .readdirSync(DRIVERS_DIR)
+    .filter((f) => f.endsWith('.js') && !HELPER_FILES.has(f))
+    .map((f) => ({ name: f.replace(/\.js$/, ''), full: path.join(DRIVERS_DIR, f) }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Build the report data structure. Pure — safe to call from tests.
+ * Returns an array sorted by method count ascending (so the operator
+ * sees the smallest-surface drivers first; visual outliers).
+ */
+function buildReport() {
+  // Clear credential env vars before requiring drivers so a driver that
+  // reads env at module-top doesn't pull operator credentials into the
+  // process (defense-in-depth; the contract test already enforces lazy
+  // env-loading, but this tool may run before that pin lands in CI).
+  const saved = {};
+  for (const key of Object.keys(process.env)) {
+    if (
+      key.startsWith('PERSONAS_') ||
+      key.startsWith('FIREBASE_') ||
+      key.startsWith('APPIUM_') ||
+      key.startsWith('ANDROID_') ||
+      key.startsWith('IOS_')
+    ) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  }
+  try {
+    return discoverDrivers().map(({ name, full }) => {
+      delete require.cache[require.resolve(full)];
+      const mod = require(full);
+      const methods = typeof mod.listMethods === 'function' ? mod.listMethods() : [];
+      return { name, count: methods.length, methods };
+    });
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      process.env[k] = v;
+    }
+  }
+}
+
+/**
+ * Format the report as a human-readable table. Sorted by count desc
+ * so outliers (highest + lowest) bracket the list — easy to scan.
+ */
+function formatTable(report) {
+  const sorted = [...report].sort((a, b) => b.count - a.count);
+  const nameW = Math.max(6, ...sorted.map((r) => r.name.length));
+  const countW = Math.max(5, ...sorted.map((r) => String(r.count).length));
+  const lines = [];
+  const sep = `+${'-'.repeat(nameW + 2)}+${'-'.repeat(countW + 2)}+`;
+  lines.push(sep);
+  lines.push(`| ${'Driver'.padEnd(nameW)} | ${'Count'.padEnd(countW)} |`);
+  lines.push(sep);
+  for (const r of sorted) {
+    lines.push(`| ${r.name.padEnd(nameW)} | ${String(r.count).padEnd(countW)} |`);
+  }
+  lines.push(sep);
+  const total = sorted.reduce((acc, r) => acc + r.count, 0);
+  const avg = sorted.length ? (total / sorted.length).toFixed(1) : '0.0';
+  const max = sorted.length ? sorted[0].count : 0;
+  const min = sorted.length ? sorted[sorted.length - 1].count : 0;
+  lines.push('');
+  lines.push(
+    `Surface stats: ${sorted.length} drivers / ${total} total methods / avg ${avg} / min ${min} / max ${max}`,
+  );
+  return lines.join('\n');
+}
+
+function formatJson(report) {
+  return JSON.stringify(report);
+}
+
+function formatUsage() {
+  return [
+    'driver-surface-report — survey driver method-counts across the matrix',
+    '',
+    'Usage:',
+    '  node express-api/scripts/driver-surface-report.js [flags]',
+    '',
+    'Flags:',
+    '  --json       Emit JSON (array of {name, count, methods})',
+    '  --help, -h   Print this help and exit',
+    '',
+    'Output (default table form):',
+    '  Sorted by method count descending. Footer line reports total / avg / min / max.',
+  ].join('\n');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(formatUsage());
+    process.exit(0);
+  }
+  const report = buildReport();
+  const json = args.includes('--json');
+  console.log(json ? formatJson(report) : formatTable(report));
+  process.exit(0);
+}
+
+module.exports = {
+  discoverDrivers,
+  buildReport,
+  formatTable,
+  formatJson,
+  formatUsage,
+};
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (e) {
+    console.error(`driver-surface-report failed: ${e.message}`);
+    process.exit(1);
+  }
+}

--- a/express-api/tests/scripts/driver-surface-report.test.js
+++ b/express-api/tests/scripts/driver-surface-report.test.js
@@ -1,0 +1,147 @@
+/**
+ * driver-surface-report.test.js
+ *
+ * Tests the survey tool (express-api/scripts/driver-surface-report.js)
+ * that surfaces driver method-count divergences across the matrix.
+ * Closes gap B5 — the report itself IS the "investigation" that gap
+ * requested; these tests pin its output shape so a future driver-set
+ * change can be inspected by diffing two runs.
+ */
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(REPO_ROOT, 'scripts/driver-surface-report.js');
+
+const { discoverDrivers, buildReport, formatTable, formatJson, formatUsage } = require(SCRIPT_PATH);
+
+// ── Pure helpers ───────────────────────────────────────────────────
+
+describe('discoverDrivers', () => {
+  test('returns at least the 11 expected drivers (13 files − 2 helpers)', () => {
+    expect(discoverDrivers().length).toBeGreaterThanOrEqual(11);
+  });
+
+  test('excludes helper modules (android-cdp-helpers, ios-driver-loader)', () => {
+    const names = discoverDrivers().map((d) => d.name);
+    expect(names).not.toContain('android-cdp-helpers');
+    expect(names).not.toContain('ios-driver-loader');
+  });
+
+  test('result entries have name + full (absolute path)', () => {
+    const sample = discoverDrivers()[0];
+    expect(typeof sample.name).toBe('string');
+    expect(path.isAbsolute(sample.full)).toBe(true);
+  });
+});
+
+describe('buildReport', () => {
+  test('returns one entry per discovered driver', () => {
+    expect(buildReport().length).toBe(discoverDrivers().length);
+  });
+
+  test('every entry has name, count, methods array', () => {
+    for (const entry of buildReport()) {
+      expect(typeof entry.name).toBe('string');
+      expect(typeof entry.count).toBe('number');
+      expect(Array.isArray(entry.methods)).toBe(true);
+      expect(entry.count).toBe(entry.methods.length);
+    }
+  });
+
+  test('total method count across drivers > 50 (sanity: matrix has real surface)', () => {
+    const total = buildReport().reduce((a, e) => a + e.count, 0);
+    expect(total).toBeGreaterThan(50);
+  });
+});
+
+describe('formatTable', () => {
+  test('returns a multi-line string with header + footer', () => {
+    const text = formatTable(buildReport());
+    expect(text).toMatch(/\| Driver/);
+    expect(text).toMatch(/\| Count/);
+    expect(text).toMatch(/Surface stats:/);
+  });
+
+  test('footer reports total / avg / min / max', () => {
+    const text = formatTable(buildReport());
+    expect(text).toMatch(/total methods/);
+    expect(text).toMatch(/avg /);
+    expect(text).toMatch(/min /);
+    expect(text).toMatch(/max /);
+  });
+
+  test('rows sorted by count descending (largest first)', () => {
+    const fakeReport = [
+      { name: 'small', count: 2, methods: [] },
+      { name: 'big', count: 50, methods: [] },
+      { name: 'mid', count: 10, methods: [] },
+    ];
+    const text = formatTable(fakeReport);
+    const lines = text.split('\n').filter((l) => /\| \w/.test(l));
+    // First data row should be 'big' (50), next 'mid' (10), then 'small' (2).
+    expect(lines[1]).toMatch(/big/);
+    expect(lines[2]).toMatch(/mid/);
+    expect(lines[3]).toMatch(/small/);
+  });
+
+  test('empty report degrades gracefully (no NaN min/max)', () => {
+    const text = formatTable([]);
+    expect(text).toMatch(/0 drivers/);
+    expect(text).toMatch(/min 0/);
+    expect(text).toMatch(/max 0/);
+  });
+});
+
+describe('formatJson', () => {
+  test('returns a parseable JSON array of report entries', () => {
+    const json = formatJson(buildReport());
+    expect(() => JSON.parse(json)).not.toThrow();
+    expect(Array.isArray(JSON.parse(json))).toBe(true);
+  });
+});
+
+describe('formatUsage', () => {
+  test('mentions --json and --help', () => {
+    const text = formatUsage();
+    expect(text).toMatch(/--json/);
+    expect(text).toMatch(/--help/);
+  });
+});
+
+// ── CLI integration ───────────────────────────────────────────────
+
+function runCli(args = []) {
+  return spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
+    encoding: 'utf8',
+    timeout: 15000,
+  });
+}
+
+describe('CLI integration', () => {
+  test('default (no args) prints the table + exits 0', () => {
+    const r = runCli();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/\| Driver /);
+    expect(r.stdout).toMatch(/Surface stats:/);
+  });
+
+  test('--json emits a JSON array + exits 0', () => {
+    const r = runCli(['--json']);
+    expect(r.status).toBe(0);
+    expect(() => JSON.parse(r.stdout)).not.toThrow();
+  });
+
+  test('--help exits 0 with usage text', () => {
+    const r = runCli(['--help']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Usage:/);
+  });
+
+  test('-h is an alias for --help', () => {
+    const r = runCli(['-h']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Usage:/);
+  });
+});


### PR DESCRIPTION
## Summary
PR #13 in the QA-runner framework-completion sequence — closes gap **B5** (the "investigation needed" gap on wide-divergent method counts).

## Live report at this commit
```
+-----------------------------------+-------+
| Driver                            | Count |
+-----------------------------------+-------+
| web-playwright-driver             | 77    |
| android-adb-driver                | 72    |
| ios-devicectl-driver              | 66    |
| ios-simctl-driver                 | 66    |
| ios-appium-driver                 | 11    |
| web-mobile-chrome-android-driver  | 2     |
| web-mobile-edge-android-driver    | 2     |
| web-mobile-firefox-android-driver | 2     |
| web-mobile-safari-ios-driver      | 2     |
| web-mobile-samsung-android-driver | 2     |
| web-mobile-webkit-ios-driver      | 2     |
+-----------------------------------+-------+

Surface stats: 11 drivers / 304 total methods / avg 27.6 / min 2 / max 77
```

## Why this is the right close for B5
The gap was framed as "investigation needed" — **the report IS the investigation**. The wide divergence (2 → 77) is **design-real**: web-mobile shim drivers delegate to underlying engines and only publish what the runner-vocab matcher dispatches; native + desktop drivers carry the full surface. The report lets operators **diff two runs** to spot surface additions/removals between releases.

## Changes
- **NEW** `express-api/scripts/driver-surface-report.js` — `discoverDrivers`, `buildReport`, `formatTable`, `formatJson`, CLI
- **NEW** `express-api/tests/scripts/driver-surface-report.test.js` — **16 tests** (pure helpers + CLI integration)

## Test plan
- [x] **16/16 pin tests pass**
- [x] Full express-api suite (278 suites / 10,506 tests) — no regressions
- [x] ESLint `--max-warnings=0` clean
- [x] Prettier-clean
- [x] Sonar pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)