### PR TITLE
feat(qa-runner): HTML report aggregation tool (gap C1)

### DIFF
--- a/express-api/scripts/qa-html-report.js
+++ b/express-api/scripts/qa-html-report.js
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * qa-html-report.js
+ *
+ * Convert a matrix-report JSON file (produced by `manual-qa-runner.js`
+ * with `--report-format json --report-output PATH`) into a single
+ * self-contained HTML file with inline CSS. Closes gap C1 from the
+ * QA-runner framework tracker — "HTML report aggregation across cells".
+ *
+ * Standalone tool — no runner integration, no external CSS, no
+ * JS dependencies. The output is one .html file the operator can
+ * open in any browser or attach to a PR / Slack thread.
+ *
+ * Usage:
+ *   node express-api/scripts/qa-html-report.js report.json > report.html
+ *   node express-api/scripts/qa-html-report.js report.json -o report.html
+ *   node express-api/scripts/qa-html-report.js --help
+ *
+ * Design: keep it small and inert. No external links (CSS or analytics),
+ * no remote fonts (system stack), no JS (operators paste into Slack as
+ * attachments and unfurl previews matter). HTML escaping is mandatory
+ * for cell.error and cell.browser since they can contain `<`/`>` and
+ * pre-rendered content goes into a markdown/Slack context.
+ */
+
+const fs = require('fs');
+
+const OUTCOME_COLOR = {
+  pass: '#1f7a1f',
+  fail: '#b22222',
+  timeout: '#b86a00',
+  skip: '#666666',
+};
+const OUTCOME_BG = {
+  pass: '#e6f4e6',
+  fail: '#fce4e4',
+  timeout: '#fdefd9',
+  skip: '#eeeeee',
+};
+
+function escHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderRow(cell) {
+  const outcome = cell.outcome || 'unknown';
+  const color = OUTCOME_COLOR[outcome] || '#444';
+  const bg = OUTCOME_BG[outcome] || '#f8f8f8';
+  const errorCell = cell.error
+    ? `<td class="err">${escHtml(cell.error)}</td>`
+    : '<td class="err"></td>';
+  return (
+    `<tr style="background:${bg}">` +
+    `<td class="browser">${escHtml(cell.browser)}</td>` +
+    `<td class="outcome" style="color:${color};font-weight:bold;">${escHtml(outcome)}</td>` +
+    `<td class="duration">${Number.isFinite(cell.durationMs) ? cell.durationMs : 0}ms</td>` +
+    `${errorCell}` +
+    `</tr>`
+  );
+}
+
+function renderHtml(report, { title = 'QA Matrix Report' } = {}) {
+  const cells = Array.isArray(report.cells) ? report.cells : [];
+  const totals = report.totals || { pass: 0, fail: 0, skip: 0, timeout: 0 };
+  const summary = report.summary || '';
+  const ok = Boolean(report.ok);
+
+  const rows = cells.map(renderRow).join('\n');
+  const statusBadge = ok
+    ? `<span class="badge badge-ok">PASS</span>`
+    : `<span class="badge badge-fail">FAIL</span>`;
+
+  return [
+    `<!DOCTYPE html>`,
+    `<html lang="en">`,
+    `<head>`,
+    `<meta charset="utf-8">`,
+    `<meta name="viewport" content="width=device-width,initial-scale=1">`,
+    `<title>${escHtml(title)}</title>`,
+    `<style>`,
+    `body { font-family: -apple-system, system-ui, sans-serif; max-width: 900px; margin: 2em auto; padding: 0 1em; color: #222; }`,
+    `h1 { font-size: 1.5em; margin: 0 0 0.5em; }`,
+    `.subtitle { color: #666; margin: 0 0 1em; }`,
+    `.badge { display: inline-block; padding: 0.2em 0.6em; border-radius: 3px; font-size: 0.85em; font-weight: bold; vertical-align: middle; }`,
+    `.badge-ok { background: #1f7a1f; color: #fff; }`,
+    `.badge-fail { background: #b22222; color: #fff; }`,
+    `table { width: 100%; border-collapse: collapse; margin-top: 1em; font-size: 0.95em; }`,
+    `th, td { text-align: left; padding: 0.45em 0.6em; border-bottom: 1px solid #ddd; }`,
+    `th { background: #f0f0f0; font-weight: 600; }`,
+    `td.browser { font-family: ui-monospace, Menlo, monospace; }`,
+    `td.duration { text-align: right; font-variant-numeric: tabular-nums; color: #555; }`,
+    `td.err { font-family: ui-monospace, Menlo, monospace; font-size: 0.85em; color: #b22222; max-width: 360px; word-break: break-word; }`,
+    `.totals { margin-top: 1em; font-size: 0.9em; color: #555; }`,
+    `</style>`,
+    `</head>`,
+    `<body>`,
+    `<h1>${escHtml(title)} ${statusBadge}</h1>`,
+    `<p class="subtitle">${escHtml(summary)}</p>`,
+    `<table>`,
+    `<thead><tr><th>Browser</th><th>Outcome</th><th>Duration</th><th>Error</th></tr></thead>`,
+    `<tbody>`,
+    rows,
+    `</tbody>`,
+    `</table>`,
+    `<p class="totals">Totals: ${totals.pass} pass / ${totals.fail} fail / ${totals.skip} skip / ${totals.timeout} timeout</p>`,
+    `</body>`,
+    `</html>`,
+  ].join('\n');
+}
+
+function formatUsage() {
+  return [
+    'qa-html-report — convert a matrix-report JSON to self-contained HTML',
+    '',
+    'Usage:',
+    '  node express-api/scripts/qa-html-report.js <report.json>           # HTML to stdout',
+    '  node express-api/scripts/qa-html-report.js <report.json> -o out.html',
+    '  node express-api/scripts/qa-html-report.js --help',
+    '',
+    'Output is a single self-contained .html file (inline CSS, no external',
+    'fonts/scripts) safe to attach to Slack or paste into a PR description.',
+  ].join('\n');
+}
+
+function readReport(filePath) {
+  const text = fs.readFileSync(filePath, 'utf8');
+  const obj = JSON.parse(text);
+  if (!obj || !Array.isArray(obj.cells)) {
+    throw new Error(`${filePath}: not a matrix report (missing cells array)`);
+  }
+  return obj;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    console.log(formatUsage());
+    process.exit(args.length === 0 ? 2 : 0);
+  }
+  let outputPath = null;
+  const positional = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '-o' || args[i] === '--output') {
+      outputPath = args[++i];
+    } else if (!args[i].startsWith('-')) {
+      positional.push(args[i]);
+    }
+  }
+  if (positional.length !== 1) {
+    console.error('Expected exactly one positional arg: <report.json>');
+    process.exit(2);
+  }
+  const report = readReport(positional[0]);
+  const html = renderHtml(report);
+  if (outputPath) {
+    fs.writeFileSync(outputPath, html);
+  } else {
+    process.stdout.write(html + '\n');
+  }
+  process.exit(0);
+}
+
+module.exports = {
+  escHtml,
+  renderRow,
+  renderHtml,
+  formatUsage,
+  readReport,
+};
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (e) {
+    console.error(`qa-html-report failed: ${e.message}`);
+    process.exit(1);
+  }
+}

--- a/express-api/tests/scripts/qa-html-report.test.js
+++ b/express-api/tests/scripts/qa-html-report.test.js
@@ -1,0 +1,262 @@
+/**
+ * qa-html-report.test.js
+ *
+ * Tests the matrix-report → HTML converter (gap C1). Covers HTML
+ * escaping, structural invariants, and CLI integration.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(REPO_ROOT, 'scripts/qa-html-report.js');
+
+const { escHtml, renderRow, renderHtml, formatUsage, readReport } = require(SCRIPT_PATH);
+
+// ── escHtml ────────────────────────────────────────────────────────
+
+describe('escHtml', () => {
+  test('escapes the five XML-significant characters', () => {
+    expect(escHtml('<script>alert("x&y\'z")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;x&amp;y&#39;z&quot;)&lt;/script&gt;',
+    );
+  });
+
+  test('returns empty string for empty input', () => {
+    expect(escHtml('')).toBe('');
+  });
+
+  test('coerces non-string input to string before escaping', () => {
+    expect(escHtml(123)).toBe('123');
+    expect(escHtml(null)).toBe('null');
+  });
+});
+
+// ── renderRow ─────────────────────────────────────────────────────
+
+describe('renderRow', () => {
+  test('emits <tr> with browser, outcome, duration cells', () => {
+    const html = renderRow({ browser: 'chromium', outcome: 'pass', durationMs: 1234 });
+    expect(html).toMatch(/^<tr/);
+    expect(html).toMatch(/chromium/);
+    expect(html).toMatch(/pass/);
+    expect(html).toMatch(/1234ms/);
+  });
+
+  test('error cell present when cell.error is set', () => {
+    const html = renderRow({
+      browser: 'firefox',
+      outcome: 'fail',
+      durationMs: 100,
+      error: 'AssertionError: expected x',
+    });
+    expect(html).toMatch(/AssertionError: expected x/);
+  });
+
+  test('error cell is escaped (no raw HTML injection from error message)', () => {
+    const html = renderRow({
+      browser: 'chromium',
+      outcome: 'fail',
+      durationMs: 100,
+      error: '<script>alert(1)</script>',
+    });
+    expect(html).not.toMatch(/<script>/);
+    expect(html).toMatch(/&lt;script&gt;/);
+  });
+
+  test('browser slug is escaped (defense-in-depth — unlikely but possible)', () => {
+    const html = renderRow({ browser: 'chrome<x>', outcome: 'pass', durationMs: 0 });
+    expect(html).toMatch(/chrome&lt;x&gt;/);
+  });
+
+  test('uses outcome color (pass = green) in style', () => {
+    const html = renderRow({ browser: 'a', outcome: 'pass', durationMs: 0 });
+    expect(html).toMatch(/color:#1f7a1f/);
+  });
+
+  test('uses outcome color (fail = red) in style', () => {
+    const html = renderRow({ browser: 'a', outcome: 'fail', durationMs: 0 });
+    expect(html).toMatch(/color:#b22222/);
+  });
+
+  test('unknown outcome degrades to neutral color without throwing', () => {
+    const html = renderRow({ browser: 'a', outcome: 'whatever', durationMs: 0 });
+    expect(html).toMatch(/whatever/);
+  });
+
+  test('non-finite duration defaults to 0ms', () => {
+    expect(renderRow({ browser: 'a', outcome: 'pass', durationMs: NaN })).toMatch(/0ms/);
+  });
+});
+
+// ── renderHtml ────────────────────────────────────────────────────
+
+describe('renderHtml', () => {
+  const report = {
+    cells: [
+      { browser: 'chromium', outcome: 'pass', durationMs: 1000 },
+      { browser: 'firefox', outcome: 'fail', durationMs: 2000, error: 'oops' },
+    ],
+    totals: { pass: 1, fail: 1, skip: 0, timeout: 0 },
+    summary: '1 pass / 1 fail / 0 skip',
+    ok: false,
+  };
+
+  test('emits a doctype + html/head/body structure', () => {
+    const html = renderHtml(report);
+    expect(html).toMatch(/^<!DOCTYPE html>/);
+    expect(html).toMatch(/<head>/);
+    expect(html).toMatch(/<body>/);
+  });
+
+  test('inline CSS — no external <link> for stylesheets', () => {
+    const html = renderHtml(report);
+    expect(html).toMatch(/<style>/);
+    expect(html).not.toMatch(/<link[^>]+rel=["']?stylesheet/);
+  });
+
+  test('no external scripts (no JS attack surface, no network calls)', () => {
+    expect(renderHtml(report)).not.toMatch(/<script/);
+  });
+
+  test('PASS badge shown when ok=true', () => {
+    expect(renderHtml({ ...report, ok: true })).toMatch(/badge-ok/);
+  });
+
+  test('FAIL badge shown when ok=false', () => {
+    expect(renderHtml(report)).toMatch(/badge-fail/);
+  });
+
+  test('renders one row per cell', () => {
+    const html = renderHtml(report);
+    const trCount = (html.match(/<tr/g) || []).length;
+    // 1 header + 2 data rows = 3 total
+    expect(trCount).toBe(3);
+  });
+
+  test('includes totals footer', () => {
+    expect(renderHtml(report)).toMatch(/1 pass \/ 1 fail \/ 0 skip \/ 0 timeout/);
+  });
+
+  test('empty cells array renders without crashing', () => {
+    const html = renderHtml({ cells: [], totals: { pass: 0, fail: 0, skip: 0, timeout: 0 } });
+    expect(html).toMatch(/<table/);
+    expect(html).toMatch(/0 pass/);
+  });
+
+  test('custom title used in <title> + <h1>', () => {
+    const html = renderHtml(report, { title: 'My Custom Title' });
+    expect(html).toMatch(/<title>My Custom Title<\/title>/);
+    expect(html).toMatch(/<h1>My Custom Title/);
+  });
+
+  test('title is escaped', () => {
+    const html = renderHtml(report, { title: '<x>' });
+    expect(html).toMatch(/<title>&lt;x&gt;<\/title>/);
+  });
+});
+
+// ── formatUsage / readReport ────────────────────────────────────
+
+describe('formatUsage', () => {
+  test('mentions <report.json>, -o, --help', () => {
+    const text = formatUsage();
+    expect(text).toMatch(/<report\.json>/);
+    expect(text).toMatch(/-o/);
+    expect(text).toMatch(/--help/);
+  });
+});
+
+describe('readReport', () => {
+  test('throws on non-report JSON', () => {
+    const tmp = path.join(os.tmpdir(), `qa-html-not-report-${process.pid}-${Date.now()}.json`);
+    fs.writeFileSync(tmp, JSON.stringify({ whatever: 1 }));
+    try {
+      expect(() => readReport(tmp)).toThrow(/not a matrix report/);
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+});
+
+// ── CLI integration ─────────────────────────────────────────────
+
+let tmpSeq = 0;
+function writeReportFile(reportObj) {
+  tmpSeq += 1;
+  const file = path.join(os.tmpdir(), `qa-html-report-${process.pid}-${Date.now()}-${tmpSeq}.json`);
+  fs.writeFileSync(file, JSON.stringify(reportObj));
+  return file;
+}
+
+function runCli(args = []) {
+  return spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+}
+
+describe('CLI integration', () => {
+  test('no args → exits 2 with usage', () => {
+    const r = runCli();
+    expect(r.status).toBe(2);
+    expect(r.stdout).toMatch(/Usage:/);
+  });
+
+  test('--help exits 0 with usage', () => {
+    const r = runCli(['--help']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Usage:/);
+  });
+
+  test('valid report → exits 0 with HTML on stdout', () => {
+    const report = writeReportFile({
+      cells: [{ browser: 'chromium', outcome: 'pass', durationMs: 1000 }],
+      totals: { pass: 1, fail: 0, skip: 0, timeout: 0 },
+      summary: '1 pass',
+      ok: true,
+    });
+    try {
+      const r = runCli([report]);
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/^<!DOCTYPE html>/);
+      expect(r.stdout).toMatch(/chromium/);
+    } finally {
+      fs.unlinkSync(report);
+    }
+  });
+
+  test('-o FILE writes to file + nothing on stdout', () => {
+    const report = writeReportFile({
+      cells: [{ browser: 'chromium', outcome: 'pass', durationMs: 0 }],
+      totals: { pass: 1, fail: 0, skip: 0, timeout: 0 },
+      summary: '',
+      ok: true,
+    });
+    const outFile = path.join(os.tmpdir(), `qa-html-out-${process.pid}-${Date.now()}.html`);
+    try {
+      const r = runCli([report, '-o', outFile]);
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe('');
+      expect(fs.readFileSync(outFile, 'utf8')).toMatch(/<!DOCTYPE html>/);
+    } finally {
+      fs.unlinkSync(report);
+      if (fs.existsSync(outFile)) fs.unlinkSync(outFile);
+    }
+  });
+
+  test('two positional args → exits 2 with error', () => {
+    const a = writeReportFile({ cells: [] });
+    const b = writeReportFile({ cells: [] });
+    try {
+      const r = runCli([a, b]);
+      expect(r.status).toBe(2);
+      expect(r.stderr).toMatch(/exactly one positional/);
+    } finally {
+      fs.unlinkSync(a);
+      fs.unlinkSync(b);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
PR #16 in the QA-runner framework-completion sequence — closes gap **C1** ("HTML report aggregation across cells"). Converts a matrix-report JSON file into a single self-contained HTML file.

## Output design
- **Self-contained** — inline CSS, no external links/fonts/scripts
- **Operator-portable** — attach to PR, paste into Slack, open in any browser
- **Color-coded** — pass=green, fail=red, timeout=orange, skip=gray; PASS/FAIL badge in header
- **Safe** — full HTML escaping on cell.error, cell.browser, title

## Usage
```bash
# Stdout
node express-api/scripts/qa-html-report.js report.json > report.html

# Direct file write
node express-api/scripts/qa-html-report.js report.json -o report.html
```

## Changes
- **NEW** `express-api/scripts/qa-html-report.js` (~170 lines)
- **NEW** `express-api/tests/scripts/qa-html-report.test.js` (**28 tests**)

## Test plan
- [x] 28/28 pin tests pass — escaping, structure, no scripts (XSS-safe), CLI integration
- [x] Full express-api suite — no regressions
- [x] ESLint `--max-warnings=0` clean
- [x] Prettier-clean
- [x] Sonar pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)