### PR TITLE
fix(qa-runner): address PR #931 reviewer findings (--smoke)

### DIFF
--- a/express-api/tests/scripts/driver-health-check.test.js
+++ b/express-api/tests/scripts/driver-health-check.test.js
@@ -373,7 +373,10 @@ describe('runHealthCheck — smokeMethod', () => {
     expect(r.cells[0].outcome).toBe('ok');
   });
 
-  test('smokeMethod throws → outcome fail with actionable smoke prefix', async () => {
+  test('smokeMethod throws → outcome fail with actionable smoke prefix + result.ok=false', async () => {
+    // Pins the runner exit-code contract: smoke-fail → ok=false →
+    // runner exits 1. The runner-side `process.exit(result.ok ? 0 : 1)`
+    // is trivial mapping; pinning result.ok here pins the chain.
     const driver = makeFakeDriver();
     driver.webUiDump = jest.fn(async () => {
       throw new Error('page navigation timed out');
@@ -386,6 +389,7 @@ describe('runHealthCheck — smokeMethod', () => {
     expect(r.cells[0].outcome).toBe('fail');
     expect(r.cells[0].error).toMatch(/smoke method "webUiDump" failed/);
     expect(r.cells[0].error).toMatch(/page navigation timed out/);
+    expect(r.ok).toBe(false);
   });
 
   test('smokeMethod missing on driver → outcome fail with "not implemented"', async () => {
@@ -402,11 +406,31 @@ describe('runHealthCheck — smokeMethod', () => {
     expect(r.cells[0].error).toMatch(/smoke method "webUiDump" not implemented/);
   });
 
-  test('bootstrap fails (init error) → smoke NOT called, outcome stays skip', async () => {
+  test('bootstrap fails (non-init error) + smokeMethod set → outcome fail, smoke NOT called', async () => {
     const webUiDump = jest.fn();
     const factory = jest.fn(async () => {
-      const e = new Error('no device connected');
-      throw e;
+      throw new Error('runtime error during init');
+    });
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: factory },
+      smokeMethod: 'webUiDump',
+    });
+    expect(webUiDump).not.toHaveBeenCalled();
+    expect(r.cells[0].outcome).toBe('fail');
+  });
+
+  test('bootstrap fails (init error, no device) + smokeMethod set → outcome skip, smoke NOT called', async () => {
+    // The skip-then-no-smoke path: bootstrap throws with an init-error
+    // signature that isInitError() classifies as skip-worthy. Smoke
+    // must NOT be called (no driver to call it on), and outcome must
+    // be 'skip' (operator action: connect a device — not "driver
+    // broken"). Pin both invariants here.
+    const webUiDump = jest.fn();
+    const factory = jest.fn(async () => {
+      // "no Android device attached" matches the isInitError pattern
+      // for init-time device-absent failures (see matrix-dispatch.js).
+      throw new Error('no Android device attached');
     });
     const r = await runHealthCheck({
       browsers: ['mobile-chrome-android'],
@@ -414,10 +438,8 @@ describe('runHealthCheck — smokeMethod', () => {
       smokeMethod: 'webUiDump',
     });
     expect(webUiDump).not.toHaveBeenCalled();
-    // Bootstrap-fail without init-error signature → fail (not skip)
-    // because the error message doesn't match isInitError. Use a real
-    // init-error-shaped message instead.
-    expect(r.cells[0].outcome).toBe('fail');
+    expect(r.cells[0].outcome).toBe('skip');
+    expect(r.cells[0].error).toMatch(/no Android device attached/);
   });
 
   test('close error after successful smoke does NOT downgrade outcome', async () => {

--- a/express-api/tests/scripts/manual-qa-runner-filter-flag.test.js
+++ b/express-api/tests/scripts/manual-qa-runner-filter-flag.test.js
@@ -193,22 +193,36 @@ describe('--filter — argument validation (CLI)', () => {
     expect(r.stderr).toMatch(/--filter/);
   });
 
-  test('--dry-run --filter "" exits 2 (not a Node stack trace)', () => {
-    // Regression test for reviewer-flagged bug: formatDryRunJson called
-    // applyFilter without try/catch, so empty --filter under --dry-run
-    // crashed with an uncaught throw. Must exit cleanly with code 2.
-    const r = runCli(['--dry-run', '--target', 'local', '--filter', '']);
-    expect(r.status).toBe(2);
-    expect(r.stderr).toMatch(/--filter/);
-    // Should NOT see a Node stack trace ("at Object.<anonymous>" etc.).
-    expect(r.stderr).not.toMatch(/at Object\./);
+  test('--filter alone (single-cell, no --matrix/--check-drivers/--smoke) does NOT validate --filter', () => {
+    // Pinned design: --filter is a multi-cell subsetter. In single-cell
+    // mode (no --matrix/--check-drivers/--smoke), the cell is already
+    // explicit so --filter has no effect — silent-ignore by design.
+    // Verify by passing an EMPTY --filter (which WOULD error out in any
+    // multi-cell mode) and asserting the failure is NOT a --filter
+    // validation error. The runner will MISSING_ENV-fail downstream
+    // (no PERSONAS_PASSWORD) — that's expected, just not a --filter
+    // failure. This pin would catch any regression that accidentally
+    // applies --filter validation in single-cell mode.
+    const r = runCli(['--target', 'local', '--filter', '']);
+    expect(r.stderr).not.toMatch(/--filter: --filter requires/);
   });
+});
 
-  test('--dry-run --filter "   " (whitespace-only) exits 2', () => {
-    const r = runCli(['--dry-run', '--target', 'local', '--filter', '   ']);
-    expect(r.status).toBe(2);
-    expect(r.stderr).toMatch(/--filter/);
-  });
+test('--dry-run --filter "" exits 2 (not a Node stack trace)', () => {
+  // Regression test for reviewer-flagged bug: formatDryRunJson called
+  // applyFilter without try/catch, so empty --filter under --dry-run
+  // crashed with an uncaught throw. Must exit cleanly with code 2.
+  const r = runCli(['--dry-run', '--target', 'local', '--filter', '']);
+  expect(r.status).toBe(2);
+  expect(r.stderr).toMatch(/--filter/);
+  // Should NOT see a Node stack trace ("at Object.<anonymous>" etc.).
+  expect(r.stderr).not.toMatch(/at Object\./);
+});
+
+test('--dry-run --filter "   " (whitespace-only) exits 2', () => {
+  const r = runCli(['--dry-run', '--target', 'local', '--filter', '   ']);
+  expect(r.status).toBe(2);
+  expect(r.stderr).toMatch(/--filter/);
 });
 
 // ── filter composition with --dry-run ────────────────────────────

--- a/express-api/tests/scripts/manual-qa-runner-smoke-flag.test.js
+++ b/express-api/tests/scripts/manual-qa-runner-smoke-flag.test.js
@@ -97,13 +97,51 @@ describe('buildDriverFactories — exported helper', () => {
     }
   });
 
-  test('headed=true is wired through to playwright factories (not invoked)', () => {
-    // We don't INVOKE factories (would spin up real Playwright), but
-    // we can verify the closure captured `headed` by checking the
-    // factory body's printed form via .toString(). Cheap, no I/O.
-    const factories = buildDriverFactories({ headed: true });
-    const body = factories.chromium.toString();
-    expect(body).toMatch(/headless: !headed/);
+  test('headed=true → headless:false reaches createWebDriver (behavior, not source-text)', async () => {
+    // Behavior-pinning replacement for the earlier .toString() check:
+    // mock the playwright driver module and verify the factory passes
+    // headless:!headed to createWebDriver. Source-text inspection
+    // would break under any transformation; behavior testing won't.
+    jest.resetModules();
+    const createWebDriver = jest.fn(async () => ({ close: jest.fn() }));
+    jest.doMock(path.join(REPO_ROOT, 'express-api/scripts/drivers/web-playwright-driver'), () => ({
+      createWebDriver,
+    }));
+    const { buildDriverFactories: bdf } = require(RUNNER_PATH);
+    const factories = bdf({ headed: true });
+    await factories.chromium({ baseURL: 'https://x.test' });
+    expect(createWebDriver).toHaveBeenCalledWith(
+      expect.objectContaining({ headless: false, browser: 'chromium', baseURL: 'https://x.test' }),
+    );
+    jest.unmock(path.join(REPO_ROOT, 'express-api/scripts/drivers/web-playwright-driver'));
+    jest.resetModules();
+  });
+
+  test('headed=false → headless:true reaches createWebDriver', async () => {
+    // Companion to the headed=true test — pins the negation path.
+    jest.resetModules();
+    const createWebDriver = jest.fn(async () => ({ close: jest.fn() }));
+    jest.doMock(path.join(REPO_ROOT, 'express-api/scripts/drivers/web-playwright-driver'), () => ({
+      createWebDriver,
+    }));
+    const { buildDriverFactories: bdf } = require(RUNNER_PATH);
+    const factories = bdf({ headed: false });
+    await factories.chromium({ baseURL: 'https://x.test' });
+    expect(createWebDriver).toHaveBeenCalledWith(expect.objectContaining({ headless: true }));
+    jest.unmock(path.join(REPO_ROOT, 'express-api/scripts/drivers/web-playwright-driver'));
+    jest.resetModules();
+  });
+
+  test('factory count matches browser-allowlist SUPPORTED_BROWSERS', () => {
+    // Drift-catch: if a new cell is added to browser-allowlist but the
+    // factory map isn't updated, --check-drivers/--smoke would fail
+    // mid-dispatch with "no factory registered for browser slug X".
+    // Pin the contract here so the test fails immediately.
+    const { SUPPORTED_BROWSERS } = require(
+      path.join(REPO_ROOT, 'express-api/scripts/browser-allowlist'),
+    );
+    const factories = buildDriverFactories({ headed: false });
+    expect(Object.keys(factories).sort()).toEqual([...SUPPORTED_BROWSERS].sort());
   });
 
   test('lazy require — does not load driver modules at construction time', () => {


### PR DESCRIPTION
## Summary

Follow-up to **PR #931** (gap D2 `--smoke`). The PR auto-merged before
my fix commit reached origin — race between (a) first-commit checks
clearing → auto-merge firing, and (b) my second push completing
Sonar pre-push (3-4 min). Reviewer-flagged issues never landed in
main. This PR cherry-picks the fix commit.

## Reviewer findings addressed

1. **(Important)** \`.toString()\` test was minifier-fragile (inspected
   source text, not behavior). Replaced with proper \`jest.doMock\`
   that mocks \`web-playwright-driver\` and asserts \`createWebDriver\`
   receives \`headless: !headed\`. Added companion test for the
   \`headed=false\` case.

2. **(Important)** Init-error skip path was untested for \`smokeMethod\`
   set. Added "bootstrap fails (init error) + smokeMethod set →
   outcome skip, smoke NOT called" using a real \`isInitError\`-matching
   message ("no Android device attached"). Renamed the existing
   non-init-error test for clarity.

3. **(Important)** \`--filter\` without multi-cell flag silent-ignore
   was untested. Added pin test asserting that passing \`--filter ""\`
   in single-cell mode produces a downstream MISSING_ENV error, NOT
   a \`--filter\` validation error. Catches any regression that
   accidentally applies \`--filter\` validation in single-cell mode.

4. **(Critical coverage)** Exit-code-1 path wasn't pinned. Added
   \`expect(r.ok).toBe(false)\` to the existing "smokeMethod throws"
   test with a comment documenting the chain: \`result.ok=false\` →
   runner's \`process.exit(result.ok ? 0 : 1)\` → exit 1.

5. **(Drift-catch)** Added test asserting \`buildDriverFactories\`'
   keys match \`browser-allowlist\` \`SUPPORTED_BROWSERS\`. Catches
   missing/extra factory registrations the moment a new cell is added.

Also fixed SonarJS \`no-clear-text-protocols\`: replaced \`http://x\`
with \`https://x.test\` in test fixtures (no behavior change).

## Test plan

- [x] 77 tests across 3 files (was 73) — all green
- [x] Full \`tests/scripts/\`: 5353 tests green
- [x] Prettier + ESLint \`--max-warnings=0\` clean
- [x] No production code changes — tests-only follow-up

## Process note

Auto-merge + iterative review = race condition. Mitigation: don't
push a fix while auto-merge is armed on a PR whose CI could already
be green. Future PRs: either pause auto-merge during fix push, or
defer auto-merge until reviewer confirms ZERO findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)