### PR TITLE
feat(qa-runner): per-cell phase timing breakdown (gap C5)

### DIFF
--- a/express-api/scripts/driver-health-check.js
+++ b/express-api/scripts/driver-health-check.js
@@ -126,11 +126,15 @@ async function runHealthCheck({
       // its own method is broken at runtime — separate from init
       // failures (which are 'skip'-classified above).
       if (outcome === 'ok' && smokeMethod && driver) {
-        const tSmoke = nowMs();
         if (typeof driver[smokeMethod] !== 'function') {
           outcome = 'fail';
           error = `smoke method "${smokeMethod}" not implemented on driver`;
         } else {
+          // tSmoke captured INSIDE the else branch so the not-
+          // implemented path doesn't consume a nowMs() tick that
+          // never feeds a phase-timing field. Keeps tick-count
+          // analysis predictable for tests that inject nowMs.
+          const tSmoke = nowMs();
           try {
             await driver[smokeMethod]();
             smokeMs = Math.max(0, nowMs() - tSmoke);

--- a/express-api/scripts/driver-health-check.js
+++ b/express-api/scripts/driver-health-check.js
@@ -87,16 +87,32 @@ async function runHealthCheck({
     const t0 = nowMs();
     let outcome;
     let error;
+    // Phase metrics — declared at cell scope so they survive the
+    // factory/else branching and reach the cell-building block below.
+    let cellBootstrapMs;
+    let cellSmokeMs;
+    let cellCloseMs;
     const factory = factories[browser];
     if (typeof factory !== 'function') {
       outcome = 'fail';
       error = `no factory registered for browser slug "${browser}"`;
     } else {
       let driver;
+      // Phase timing (gap C5): bootstrap / smoke / close ms each recorded
+      // when their phase executes. Operator can identify which phase
+      // dominates the cell's total wall time. Phases that don't run
+      // leave their field undefined (NOT 0 — a 0 would falsely imply
+      // the phase ran instantly).
+      let bootstrapMs;
+      let smokeMs;
+      let closeMs;
+      const tBoot = nowMs();
       try {
         driver = await factory({ baseURL });
+        bootstrapMs = Math.max(0, nowMs() - tBoot);
         outcome = 'ok';
       } catch (e) {
+        bootstrapMs = Math.max(0, nowMs() - tBoot);
         if (isInitError(e)) {
           outcome = 'skip';
           error = e.message;
@@ -110,13 +126,16 @@ async function runHealthCheck({
       // its own method is broken at runtime — separate from init
       // failures (which are 'skip'-classified above).
       if (outcome === 'ok' && smokeMethod && driver) {
+        const tSmoke = nowMs();
         if (typeof driver[smokeMethod] !== 'function') {
           outcome = 'fail';
           error = `smoke method "${smokeMethod}" not implemented on driver`;
         } else {
           try {
             await driver[smokeMethod]();
+            smokeMs = Math.max(0, nowMs() - tSmoke);
           } catch (e) {
+            smokeMs = Math.max(0, nowMs() - tSmoke);
             outcome = 'fail';
             error = `smoke method "${smokeMethod}" failed: ${e.message}`;
           }
@@ -125,16 +144,27 @@ async function runHealthCheck({
       // Best-effort close — never let a close error change the
       // health-check outcome (the bootstrap succeeded, that's the point).
       if (driver && typeof driver.close === 'function') {
+        const tClose = nowMs();
         try {
           await driver.close();
+          closeMs = Math.max(0, nowMs() - tClose);
         } catch (_e) {
+          closeMs = Math.max(0, nowMs() - tClose);
           /* swallow close errors */
         }
       }
+      // Hoist phase metrics to cell scope so the cell-builder below
+      // can pick them up after the factory/else branching closes.
+      cellBootstrapMs = bootstrapMs;
+      cellSmokeMs = smokeMs;
+      cellCloseMs = closeMs;
     }
     const durationMs = Math.max(0, nowMs() - t0);
     const cell = { browser, outcome, durationMs };
     if (error) cell.error = error;
+    if (cellBootstrapMs !== undefined) cell.bootstrapMs = cellBootstrapMs;
+    if (cellSmokeMs !== undefined) cell.smokeMs = cellSmokeMs;
+    if (cellCloseMs !== undefined) cell.closeMs = cellCloseMs;
     cells.push(cell);
     if (typeof onCellEnd === 'function') onCellEnd(cell);
   }

--- a/express-api/tests/scripts/driver-health-check.test.js
+++ b/express-api/tests/scripts/driver-health-check.test.js
@@ -261,6 +261,10 @@ describe('runHealthCheck — baseURL + callbacks', () => {
 
 describe('runHealthCheck — timing', () => {
   test('durationMs from injected nowMs delta', async () => {
+    // Phase timing (gap C5) added 5 additional nowMs() calls per cell:
+    //   t0 + tBoot + bootstrapEnd + tClose + closeEnd + final = 6 calls.
+    // With +200 per call, each cell spans 6*200 = 1200ms wall time;
+    // durationMs = (6-1)*200 = 1000ms (final - t0).
     let n = 1000;
     const r = await runHealthCheck({
       browsers: ['chromium', 'firefox'],
@@ -274,13 +278,16 @@ describe('runHealthCheck — timing', () => {
         return v;
       },
     });
-    expect(r.cells[0].durationMs).toBe(200);
-    expect(r.cells[1].durationMs).toBe(200);
+    expect(r.cells[0].durationMs).toBe(1000);
+    expect(r.cells[1].durationMs).toBe(1000);
   });
 
   test('durationMs clamped to >= 0 (no negative even if clock skews)', async () => {
+    // 6 ticks per cell (phase timing): t0, tBoot, bootEnd, tClose,
+    // closeEnd, final. Use deliberately-bad clock to force a negative
+    // delta on final-t0 and assert clamp.
     let n = 0;
-    const ticks = [1000, 500, 800, 1100];
+    const ticks = [1000, 500, 800, 1100, 900, 700]; // final < t0
     const r = await runHealthCheck({
       browsers: ['chromium'],
       factories: { chromium: makeFactoryReturning(makeFakeDriver()) },
@@ -476,5 +483,130 @@ describe('runHealthCheck — smokeMethod', () => {
     expect(r.cells[0].outcome).toBe('ok');
     expect(r.cells[1].outcome).toBe('fail');
     expect(r.totals).toEqual({ ok: 1, fail: 1, skip: 0 });
+  });
+});
+
+// runHealthCheck — per-cell phase timing breakdown ──────────────────
+
+describe('runHealthCheck — phase timing breakdown (gap C5)', () => {
+  test('bootstrapMs is set when factory succeeds', async () => {
+    const driver = makeFakeDriver();
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+    });
+    expect(typeof r.cells[0].bootstrapMs).toBe('number');
+    expect(r.cells[0].bootstrapMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test('bootstrapMs is set even when factory throws (measured before classify)', async () => {
+    // Operator wants to know "how long did the failing bootstrap take?"
+    // — useful for distinguishing "fails immediately" from "fails after
+    // long timeout" (e.g., a flaky CDP connection). Pin the metric is
+    // present on failure paths too.
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryThrowing(new Error('boom')) },
+    });
+    expect(r.cells[0].outcome).toBe('fail');
+    expect(typeof r.cells[0].bootstrapMs).toBe('number');
+    expect(r.cells[0].bootstrapMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test('smokeMs is set when smoke method called successfully', async () => {
+    const driver = makeFakeDriver();
+    driver.webUiDump = jest.fn(async () => 'dump');
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+      smokeMethod: 'webUiDump',
+    });
+    expect(typeof r.cells[0].smokeMs).toBe('number');
+    expect(r.cells[0].smokeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test('smokeMs is set even when smoke method throws', async () => {
+    const driver = makeFakeDriver();
+    driver.webUiDump = jest.fn(async () => {
+      throw new Error('navigation timed out');
+    });
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+      smokeMethod: 'webUiDump',
+    });
+    expect(r.cells[0].outcome).toBe('fail');
+    expect(typeof r.cells[0].smokeMs).toBe('number');
+  });
+
+  test('smokeMs is undefined when smokeMethod not requested', async () => {
+    // Backward compat: --check-drivers paths don't set smokeMethod;
+    // smokeMs field must be omitted entirely (not set to 0).
+    const driver = makeFakeDriver();
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+    });
+    expect(r.cells[0].smokeMs).toBeUndefined();
+  });
+
+  test('smokeMs is undefined when bootstrap failed (smoke not called)', async () => {
+    // Phase-omission invariant: if a phase didn't execute, its timing
+    // field is undefined — not 0 (which would falsely imply the phase
+    // ran in zero time).
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryThrowing(new Error('boom')) },
+      smokeMethod: 'webUiDump',
+    });
+    expect(r.cells[0].smokeMs).toBeUndefined();
+  });
+
+  test('closeMs is set when close called', async () => {
+    const driver = makeFakeDriver();
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+    });
+    expect(typeof r.cells[0].closeMs).toBe('number');
+  });
+
+  test('closeMs is set even when close throws (swallowed)', async () => {
+    const driver = makeFakeDriver({
+      closeImpl: jest.fn(async () => {
+        throw new Error('close error');
+      }),
+    });
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+    });
+    // close error is swallowed; outcome stays ok; closeMs still recorded
+    expect(r.cells[0].outcome).toBe('ok');
+    expect(typeof r.cells[0].closeMs).toBe('number');
+  });
+
+  test('closeMs is undefined when bootstrap failed (no driver to close)', async () => {
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryThrowing(new Error('boom')) },
+    });
+    expect(r.cells[0].closeMs).toBeUndefined();
+  });
+
+  test('phase sum approximately equals durationMs (within ms rounding)', async () => {
+    // Sanity invariant: bootstrapMs + smokeMs + closeMs ≈ durationMs.
+    // Tolerance: 5ms for rounding + any small overhead between
+    // nowMs() calls outside the phase timers.
+    const driver = makeFakeDriver();
+    driver.webUiDump = jest.fn(async () => 'ok');
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+      smokeMethod: 'webUiDump',
+    });
+    const cell = r.cells[0];
+    const phaseSum = (cell.bootstrapMs || 0) + (cell.smokeMs || 0) + (cell.closeMs || 0);
+    expect(Math.abs(cell.durationMs - phaseSum)).toBeLessThanOrEqual(5);
   });
 });

--- a/express-api/tests/scripts/driver-health-check.test.js
+++ b/express-api/tests/scripts/driver-health-check.test.js
@@ -83,7 +83,11 @@ describe('runHealthCheck — per-cell outcomes', () => {
     expect(closeImpl).toHaveBeenCalledTimes(1);
   });
 
-  test('factory throwing init-error → outcome="skip" with message captured', async () => {
+  test('factory throwing init-error → outcome="skip" with message captured + bootstrapMs recorded', async () => {
+    // bootstrapMs is recorded even on skip-classified throws — the
+    // factory ran (and threw), so its duration is meaningful. The
+    // operator distinguishes "skipped immediately" from "skipped
+    // after a slow timeout" via this field.
     const factory = makeFactoryThrowing(new Error('no Android device attached'));
     const r = await runHealthCheck({
       browsers: ['mobile-chrome-android'],
@@ -91,6 +95,7 @@ describe('runHealthCheck — per-cell outcomes', () => {
     });
     expect(r.cells[0].outcome).toBe('skip');
     expect(r.cells[0].error).toMatch(/no Android device/);
+    expect(typeof r.cells[0].bootstrapMs).toBe('number');
   });
 
   test('factory throwing non-init Error → outcome="fail"', async () => {
@@ -114,13 +119,20 @@ describe('runHealthCheck — per-cell outcomes', () => {
     expect(r.cells[0].outcome).toBe('skip');
   });
 
-  test('missing factory for slug → outcome="fail" with actionable message', async () => {
+  test('missing factory for slug → outcome="fail" + all phase fields undefined', async () => {
+    // No factory means no phase ran — bootstrap/smoke/close fields
+    // must ALL be undefined (not 0 — a 0 would falsely imply the
+    // phase ran instantly). Symmetric to other "phase didn't run"
+    // pins above.
     const r = await runHealthCheck({
       browsers: ['mobile-unknown'],
       factories: {},
     });
     expect(r.cells[0].outcome).toBe('fail');
     expect(r.cells[0].error).toMatch(/no factory registered/);
+    expect(r.cells[0].bootstrapMs).toBeUndefined();
+    expect(r.cells[0].smokeMs).toBeUndefined();
+    expect(r.cells[0].closeMs).toBeUndefined();
   });
 
   test('factory returning null → close skipped (no crash)', async () => {
@@ -146,7 +158,9 @@ describe('runHealthCheck — per-cell outcomes', () => {
     expect(r.cells[0].outcome).toBe('ok');
   });
 
-  test('driver without a close method is tolerated', async () => {
+  test('driver without a close method is tolerated + closeMs undefined', async () => {
+    // No close method → close phase doesn't run → closeMs is
+    // undefined (not 0). Symmetric to other "phase didn't run" pins.
     const factory = jest.fn(async () => ({
       /* no close */
     }));
@@ -155,6 +169,7 @@ describe('runHealthCheck — per-cell outcomes', () => {
       factories: { chromium: factory },
     });
     expect(r.cells[0].outcome).toBe('ok');
+    expect(r.cells[0].closeMs).toBeUndefined();
   });
 });
 
@@ -261,8 +276,11 @@ describe('runHealthCheck — baseURL + callbacks', () => {
 
 describe('runHealthCheck — timing', () => {
   test('durationMs from injected nowMs delta', async () => {
-    // Phase timing (gap C5) added 5 additional nowMs() calls per cell:
-    //   t0 + tBoot + bootstrapEnd + tClose + closeEnd + final = 6 calls.
+    // Phase timing (gap C5) added 4 additional nowMs() calls per cell
+    // (no smoke):
+    //   Before: t0 + final = 2 calls.
+    //   After:  t0 + tBoot + bootstrapEnd + tClose + closeEnd + final
+    //           = 6 calls.
     // With +200 per call, each cell spans 6*200 = 1200ms wall time;
     // durationMs = (6-1)*200 = 1000ms (final - t0).
     let n = 1000;
@@ -399,10 +417,12 @@ describe('runHealthCheck — smokeMethod', () => {
     expect(r.ok).toBe(false);
   });
 
-  test('smokeMethod missing on driver → outcome fail with "not implemented"', async () => {
+  test('smokeMethod missing on driver → outcome fail with "not implemented" + smokeMs undefined', async () => {
     // Native drivers (android-adb, ios-*) don't implement webUiDump.
     // If operator runs --smoke against such a cell, we must fail
-    // clearly rather than silently pass.
+    // clearly rather than silently pass. Phase-field pin: smokeMs
+    // is UNDEFINED (not 0) on the not-implemented path — the smoke
+    // method was never called, so its timing is absent, not zero.
     const driver = makeFakeDriver(); // no webUiDump
     const r = await runHealthCheck({
       browsers: ['some-native-cell'],
@@ -411,6 +431,7 @@ describe('runHealthCheck — smokeMethod', () => {
     });
     expect(r.cells[0].outcome).toBe('fail');
     expect(r.cells[0].error).toMatch(/smoke method "webUiDump" not implemented/);
+    expect(r.cells[0].smokeMs).toBeUndefined();
   });
 
   test('bootstrap fails (non-init error) + smokeMethod set → outcome fail, smoke NOT called', async () => {
@@ -594,19 +615,36 @@ describe('runHealthCheck — phase timing breakdown (gap C5)', () => {
     expect(r.cells[0].closeMs).toBeUndefined();
   });
 
-  test('phase sum approximately equals durationMs (within ms rounding)', async () => {
-    // Sanity invariant: bootstrapMs + smokeMs + closeMs ≈ durationMs.
-    // Tolerance: 5ms for rounding + any small overhead between
-    // nowMs() calls outside the phase timers.
+  test('phase sum exactly equals durationMs with injected deterministic nowMs', async () => {
+    // Structural invariant via injected clock — zero tolerance, no
+    // flakiness from real-clock jitter. Tick sequence (smoke-method
+    // path = 8 calls per cell):
+    //   t0=1000, tBoot=1100 → bootstrapMs=200 (calc at 1300),
+    //   tSmoke=1400 → smokeMs=300 (calc at 1700),
+    //   tClose=1800 → closeMs=100 (calc at 1900),
+    //   durationMs=1900-1000=900.
+    // Expected: bootstrap(200) + smoke(300) + close(100) = 600,
+    //   durationMs(900) - phaseSum(600) = 300 (inter-phase gaps).
+    // The invariant is `durationMs >= phaseSum` (phase sum can't
+    // exceed wall time), not equality, because inter-phase gaps are
+    // legitimate. Pin the inequality structurally.
+    let i = 0;
+    const ticks = [1000, 1100, 1300, 1400, 1700, 1800, 1900, 1900];
     const driver = makeFakeDriver();
     driver.webUiDump = jest.fn(async () => 'ok');
     const r = await runHealthCheck({
       browsers: ['chromium'],
       factories: { chromium: makeFactoryReturning(driver) },
       smokeMethod: 'webUiDump',
+      nowMs: () => ticks[i++],
     });
     const cell = r.cells[0];
     const phaseSum = (cell.bootstrapMs || 0) + (cell.smokeMs || 0) + (cell.closeMs || 0);
-    expect(Math.abs(cell.durationMs - phaseSum)).toBeLessThanOrEqual(5);
+    expect(cell.durationMs).toBeGreaterThanOrEqual(phaseSum);
+    // Exact values from the tick sequence above:
+    expect(cell.bootstrapMs).toBe(200);
+    expect(cell.smokeMs).toBe(300);
+    expect(cell.closeMs).toBe(100);
+    expect(cell.durationMs).toBe(900);
   });
 });


### PR DESCRIPTION
## Summary

Adds optional \`bootstrapMs\`, \`smokeMs\`, \`closeMs\` to each cell result
returned by \`runHealthCheck\`. Closes gap C5. Operator can identify
which phase dominates the cell's total wall time — slow factory vs
slow smoke method vs slow teardown.

## Scope decision

C5 in the tracker says "setup vs execution vs teardown". This PR
addresses it WHERE phase timing is technically possible:

| Surface | Phase visibility | Status |
|---------|-----------------|--------|
| \`driver-health-check\` (--check-drivers / --smoke) | In-process — phases fully visible | **IMPLEMENTED** |
| \`matrix-dispatch\` (per-cell subprocess) | Hidden inside subprocess | **DEFERRED** (would need IPC) |

Honest scope: deliver where it's actionable; defer where it requires
new IPC/protocol design.

## Field semantics

- \`bootstrapMs\` — time to call \`factory({baseURL})\`. Recorded EVEN on
  factory throw (operator wants "fails fast" vs "fails after long timeout").
- \`smokeMs\` — time to call \`driver[smokeMethod]()\`. Recorded EVEN on
  throw. Undefined when smokeMethod wasn't requested OR bootstrap failed.
- \`closeMs\` — time to call \`driver.close()\`. Recorded EVEN on close
  error (which is swallowed per existing contract).
- Phase fields ABSENT (undefined) when the phase didn't run.
  Distinguishes "ran in zero time" (0) from "didn't run at all".

## Sample output

\`\`\`json
{
  "browser": "chromium",
  "outcome": "ok",
  "durationMs": 1840,
  "bootstrapMs": 1500,
  "smokeMs": 320,
  "closeMs": 20
}
\`\`\`

Operator sees the bootstrap phase dominates this cell — driver factory
is slow. Diagnostic actionable WITHOUT running additional commands.

## Test plan

- [x] 10 new tests in \`driver-health-check.test.js\` covering all field
      presence/absence permutations + phase-sum ≈ durationMs invariant
- [x] 2 existing timing tests updated for new tick count (6 \`nowMs()\`
      calls per cell vs 2). Test logic unchanged; expected values +
      tick array sizes adjusted.
- [x] Full \`tests/scripts/\`: 5439 / 5439 green
- [x] Prettier + ESLint --max-warnings=0 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)