### PR TITLE
feat(qa-runner): per-cell peak RSS sampling (gap C4)

### DIFF
--- a/express-api/scripts/driver-health-check.js
+++ b/express-api/scripts/driver-health-check.js
@@ -70,6 +70,13 @@ async function runHealthCheck({
   onCellStart,
   onCellEnd,
   nowMs = () => Date.now(),
+  // processStats — injected for tests (default: process.memoryUsage()).
+  // Returns an object with at least a `rss` field in bytes. Used to
+  // sample per-cell peak RSS (gap C4). Operator sees which cells push
+  // process memory the highest, useful for catching driver leaks.
+  // Sampling is best-effort and parent-process-scoped: matrix-dispatch
+  // subprocesses are NOT captured (would require IPC).
+  processStats = () => process.memoryUsage(),
 } = {}) {
   if (!Array.isArray(browsers)) {
     throw new Error('runHealthCheck: `browsers` must be an array of browser slugs');
@@ -92,6 +99,23 @@ async function runHealthCheck({
     let cellBootstrapMs;
     let cellSmokeMs;
     let cellCloseMs;
+    // Peak RSS sampled at cell start and each phase boundary. Records
+    // the highest RSS observed during this cell's execution. Stays
+    // undefined when the cell doesn't reach the factory branch (e.g.
+    // no factory registered for slug).
+    let cellPeakRssBytes;
+    const samplePeakRss = () => {
+      try {
+        const stats = processStats();
+        if (stats && typeof stats.rss === 'number') {
+          if (cellPeakRssBytes === undefined || stats.rss > cellPeakRssBytes) {
+            cellPeakRssBytes = stats.rss;
+          }
+        }
+      } catch (_e) {
+        /* swallow — RSS sampling is best-effort, never fails the cell */
+      }
+    };
     const factory = factories[browser];
     if (typeof factory !== 'function') {
       outcome = 'fail';
@@ -106,13 +130,18 @@ async function runHealthCheck({
       let bootstrapMs;
       let smokeMs;
       let closeMs;
+      // Cell-start RSS sample — establishes the baseline before any
+      // phase runs. Each phase boundary updates the peak.
+      samplePeakRss();
       const tBoot = nowMs();
       try {
         driver = await factory({ baseURL });
         bootstrapMs = Math.max(0, nowMs() - tBoot);
+        samplePeakRss();
         outcome = 'ok';
       } catch (e) {
         bootstrapMs = Math.max(0, nowMs() - tBoot);
+        samplePeakRss();
         if (isInitError(e)) {
           outcome = 'skip';
           error = e.message;
@@ -157,6 +186,8 @@ async function runHealthCheck({
           /* swallow close errors */
         }
       }
+      // Final RSS sample — captures any close-phase memory growth.
+      samplePeakRss();
       // Hoist phase metrics to cell scope so the cell-builder below
       // can pick them up after the factory/else branching closes.
       cellBootstrapMs = bootstrapMs;
@@ -169,6 +200,7 @@ async function runHealthCheck({
     if (cellBootstrapMs !== undefined) cell.bootstrapMs = cellBootstrapMs;
     if (cellSmokeMs !== undefined) cell.smokeMs = cellSmokeMs;
     if (cellCloseMs !== undefined) cell.closeMs = cellCloseMs;
+    if (cellPeakRssBytes !== undefined) cell.peakRssBytes = cellPeakRssBytes;
     cells.push(cell);
     if (typeof onCellEnd === 'function') onCellEnd(cell);
   }

--- a/express-api/scripts/driver-health-check.js
+++ b/express-api/scripts/driver-health-check.js
@@ -167,8 +167,17 @@ async function runHealthCheck({
           try {
             await driver[smokeMethod]();
             smokeMs = Math.max(0, nowMs() - tSmoke);
+            // Sample RSS after smoke success — driver may have allocated
+            // significant memory during the method call (e.g. screenshot
+            // buffers, DOM dumps). Without this sample, a memory spike
+            // during smoke that's freed during close would be invisible
+            // (the post-close sample wouldn't see it).
+            samplePeakRss();
           } catch (e) {
             smokeMs = Math.max(0, nowMs() - tSmoke);
+            // Sample after smoke fail too — failure path may have left
+            // dangling allocations that the operator wants to detect.
+            samplePeakRss();
             outcome = 'fail';
             error = `smoke method "${smokeMethod}" failed: ${e.message}`;
           }

--- a/express-api/tests/scripts/driver-health-check.test.js
+++ b/express-api/tests/scripts/driver-health-check.test.js
@@ -666,6 +666,97 @@ describe('runHealthCheck — phase timing breakdown (gap C5)', () => {
     expect(r.cells[0].peakRssBytes).toBeGreaterThan(0);
   });
 
+  test('peakRssBytes captures smoke-phase peak even when close frees memory', async () => {
+    // Smoke-phase sampling: the smoke method may allocate buffers
+    // (screenshot, DOM dump) that close() frees. Without an after-
+    // smoke sample, that peak would be invisible. Tick sequence:
+    //   cell-start: 100M
+    //   after-bootstrap: 110M
+    //   after-smoke: 250M  ← THE PEAK (would be invisible without I1 fix)
+    //   after-close (final): 80M  (driver freed buffers)
+    let i = 0;
+    const samples = [
+      { rss: 100_000_000 },
+      { rss: 110_000_000 },
+      { rss: 250_000_000 },
+      { rss: 80_000_000 },
+    ];
+    const driver = makeFakeDriver();
+    driver.webUiDump = jest.fn(async () => 'big-dump');
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+      smokeMethod: 'webUiDump',
+      processStats: () => samples[i++],
+    });
+    expect(r.cells[0].peakRssBytes).toBe(250_000_000);
+  });
+
+  test('peakRssBytes undefined when processStats consistently throws', async () => {
+    // Best-effort sampling: try/catch silently swallows processStats
+    // errors. If EVERY sample throws, peakRssBytes stays undefined.
+    // Documented contract — pin so future "improvement" that tries
+    // to fall back to a sentinel value (e.g. 0) surfaces here.
+    const driver = makeFakeDriver();
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+      processStats: () => {
+        throw new Error('memoryUsage failed');
+      },
+    });
+    expect(r.cells[0].outcome).toBe('ok');
+    expect(r.cells[0].peakRssBytes).toBeUndefined();
+  });
+
+  test('peakRssBytes undefined when processStats returns null', async () => {
+    // Guard `if (stats && typeof stats.rss === 'number')` skips
+    // null returns. Pin: this is intentional silent-skip behavior.
+    const driver = makeFakeDriver();
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+      processStats: () => null,
+    });
+    expect(r.cells[0].peakRssBytes).toBeUndefined();
+  });
+
+  test('peakRssBytes undefined when processStats returns object without rss', async () => {
+    // Same guard, no `rss` field. Some Node profiling tools return
+    // partial memory objects; pin the defensive behaviour.
+    const driver = makeFakeDriver();
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+      processStats: () => ({ heapUsed: 50_000_000 }), // no rss
+    });
+    expect(r.cells[0].peakRssBytes).toBeUndefined();
+  });
+
+  test('peakRssBytes undefined when processStats returns rss as non-number', async () => {
+    // typeof check on rss specifically. NaN, null, string all skip.
+    const driver = makeFakeDriver();
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+      processStats: () => ({ rss: 'not-a-number' }),
+    });
+    expect(r.cells[0].peakRssBytes).toBeUndefined();
+  });
+
+  test('peakRssBytes = 0 when processStats consistently returns { rss: 0 }', async () => {
+    // Lazy-init path: `cellPeakRssBytes === undefined` branch sets it
+    // to 0 on the first sample; subsequent 0-returns don't lower it.
+    // 0 is a valid number — must not be confused with "didn't sample".
+    const driver = makeFakeDriver();
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+      processStats: () => ({ rss: 0 }),
+    });
+    expect(r.cells[0].peakRssBytes).toBe(0);
+  });
+
   test('peakRssBytes per-cell — independent samples for each cell', async () => {
     // Verify per-cell scoping: cell A's peak is independent of cell B's.
     // Inject samples such that cell A's peak is lower than cell B's

--- a/express-api/tests/scripts/driver-health-check.test.js
+++ b/express-api/tests/scripts/driver-health-check.test.js
@@ -615,6 +615,87 @@ describe('runHealthCheck — phase timing breakdown (gap C5)', () => {
     expect(r.cells[0].closeMs).toBeUndefined();
   });
 
+  test('peakRssBytes records process RSS during cell (gap C4)', async () => {
+    // Inject deterministic processStats so the value is pinned exactly.
+    // Default would use process.memoryUsage() — varies by environment.
+    let i = 0;
+    const samples = [
+      { rss: 100_000_000 }, // baseline / sample at cell start
+      { rss: 150_000_000 }, // after bootstrap
+      { rss: 180_000_000 }, // after close (peak)
+    ];
+    const driver = makeFakeDriver();
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+      processStats: () => samples[i++],
+    });
+    expect(r.cells[0].peakRssBytes).toBe(180_000_000);
+  });
+
+  test('peakRssBytes is undefined on no-factory path (no phase ran)', async () => {
+    const r = await runHealthCheck({
+      browsers: ['unknown-cell'],
+      factories: {},
+    });
+    expect(r.cells[0].outcome).toBe('fail');
+    expect(r.cells[0].peakRssBytes).toBeUndefined();
+  });
+
+  test('peakRssBytes recorded even on bootstrap failure (sampled before failure)', async () => {
+    let i = 0;
+    const samples = [{ rss: 100_000_000 }, { rss: 130_000_000 }];
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryThrowing(new Error('boom')) },
+      processStats: () => samples[i++],
+    });
+    expect(r.cells[0].outcome).toBe('fail');
+    expect(typeof r.cells[0].peakRssBytes).toBe('number');
+  });
+
+  test('peakRssBytes defaults to process.memoryUsage when processStats not injected', async () => {
+    // Real-process default — value varies but must be a positive number
+    // matching the live process RSS (typically 50MB+ for Jest+Node).
+    const driver = makeFakeDriver();
+    const r = await runHealthCheck({
+      browsers: ['chromium'],
+      factories: { chromium: makeFactoryReturning(driver) },
+    });
+    expect(typeof r.cells[0].peakRssBytes).toBe('number');
+    expect(r.cells[0].peakRssBytes).toBeGreaterThan(0);
+  });
+
+  test('peakRssBytes per-cell — independent samples for each cell', async () => {
+    // Verify per-cell scoping: cell A's peak is independent of cell B's.
+    // Inject samples such that cell A's peak is lower than cell B's
+    // peak, then assert each cell's peakRssBytes reflects its own
+    // sample window.
+    let i = 0;
+    const samples = [
+      // cell A: start=100M, bootstrap=110M, close=120M (peak 120M)
+      { rss: 100_000_000 },
+      { rss: 110_000_000 },
+      { rss: 120_000_000 },
+      // cell B: start=200M, bootstrap=250M, close=300M (peak 300M)
+      { rss: 200_000_000 },
+      { rss: 250_000_000 },
+      { rss: 300_000_000 },
+    ];
+    const driverA = makeFakeDriver();
+    const driverB = makeFakeDriver();
+    const r = await runHealthCheck({
+      browsers: ['a', 'b'],
+      factories: {
+        a: makeFactoryReturning(driverA),
+        b: makeFactoryReturning(driverB),
+      },
+      processStats: () => samples[i++],
+    });
+    expect(r.cells[0].peakRssBytes).toBe(120_000_000);
+    expect(r.cells[1].peakRssBytes).toBe(300_000_000);
+  });
+
   test('phase sum exactly equals durationMs with injected deterministic nowMs', async () => {
     // Structural invariant via injected clock — zero tolerance, no
     // flakiness from real-clock jitter. Tick sequence (smoke-method


### PR DESCRIPTION
## Summary

Adds optional \`peakRssBytes\` to each cell result returned by
\`runHealthCheck\`. Closes gap C4. Operator can identify which cells
push process memory the highest — useful for spotting driver leaks.

Same scope pattern as the C5 phase-timing PR:
- driver-health-check (--check-drivers / --smoke): IMPLEMENTED via
  process.memoryUsage() sampled at phase boundaries
- matrix-dispatch (subprocess): DEFERRED — subprocess RSS hidden
  without IPC

## Sampling strategy

\`peakRssBytes\` is the maximum RSS observed at four sample points
per cell: cell start, after bootstrap, after smoke (if any), after
close. Best-effort try/catch — never fails the cell.

New optional \`processStats\` param (default \`process.memoryUsage\`)
enables deterministic testing.

## Sample output

\`\`\`json
{
  "browser": "chromium",
  "outcome": "ok",
  "durationMs": 1840,
  "bootstrapMs": 1500,
  "smokeMs": 320,
  "closeMs": 20,
  "peakRssBytes": 287654321
}
\`\`\`

## Test plan

- [x] 5 new tests:
  - peakRssBytes records highest RSS across deterministic samples
  - peakRssBytes undefined on no-factory path
  - peakRssBytes recorded even on bootstrap failure
  - Default processStats falls back to process.memoryUsage()
  - Per-cell independence (cell A's peak doesn't bleed into cell B's)
- [x] Full \`tests/scripts/\`: 5479 / 5479 green
- [x] Prettier + ESLint --max-warnings=0 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)