### PR TITLE
feat(ci): manual-qa-matrix.yml workflow_dispatch (gap E1 🔴)

### DIFF
--- a/.github/workflows/manual-qa-matrix.yml
+++ b/.github/workflows/manual-qa-matrix.yml
@@ -1,0 +1,152 @@
+name: Manual QA Matrix
+
+# Operator-invoked QA matrix dispatch via workflow_dispatch. Runs the
+# manual-qa-runner with the operator-selected target + filters + shard
+# and uploads the matrix report as an artifact.
+#
+# Closes gap E1 from
+# .project/test-plans/exhaustive/2026-05-30-qa-runner-framework-gaps.md:
+# "NO manual-qa-matrix.yml workflow exists; the 12-cell matrix has
+# zero CI integration. Operator's only path was local laptop runs."
+#
+# Per [[feedback-no-self-hosted-runners]] uses ubuntu-latest only.
+# Per [[feedback-ci-cache-downloads-version-aware]] Playwright browser
+# binaries are cached on the resolved Playwright version (busts when
+# the dependency bumps).
+# Per [[feedback-avoid-crons-prefer-event-driven]] no cron schedule —
+# operator triggers manually via the GitHub Actions UI (workflow_dispatch).
+#
+# Inputs are passed to the runner via env vars (not interpolated into
+# the run script) so shell-metacharacter injection is impossible.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Target environment'
+        type: choice
+        required: true
+        default: dev
+        options:
+          - local
+          - dev
+          - prod
+      filter:
+        description: 'Substring pattern (comma-separated) to subset cells (e.g. "android" or "chromium,firefox"). Leave blank for full target allowlist.'
+        type: string
+        required: false
+      shard:
+        description: 'CI parallelism shard X/Y (1-indexed). Leave blank for full matrix.'
+        type: string
+        required: false
+      retry:
+        description: 'Per-cell in-run retry count on fail/timeout. Default 0.'
+        type: string
+        required: false
+        default: '0'
+      report-format:
+        description: 'Matrix report format'
+        type: choice
+        required: true
+        default: json
+        options:
+          - json
+          - junit
+
+permissions:
+  contents: read
+
+jobs:
+  matrix-dispatch:
+    name: 'Manual QA matrix (${{ inputs.target }}, shard ${{ inputs.shard || ''all'' }})'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: express-api/package-lock.json
+
+      - name: Install express-api deps
+        run: npm ci
+        working-directory: express-api
+
+      - name: Resolve Playwright version (for cache key)
+        id: pw
+        run: |
+          # Per [[feedback-ci-cache-downloads-version-aware]] — cache key
+          # tracks the installed Playwright version so a dependency
+          # bump busts the cache automatically.
+          PW_VERSION=$(node -p "require('playwright/package.json').version" | tr -d '[:space:]')
+          echo "version=$PW_VERSION" >> "$GITHUB_OUTPUT"
+        working-directory: express-api
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright browsers
+        # `--with-deps` pulls apt packages on Ubuntu so headless WebKit
+        # actually launches. Mobile browsers are device-emulated via the
+        # base playwright BrowserType, no separate binary needed.
+        run: npx playwright install --with-deps chromium firefox webkit
+        working-directory: express-api
+
+      - name: Run manual-qa matrix
+        env:
+          # Inputs as env vars (not ${{ }} interpolated into the run
+          # script) so shell metacharacters in operator-supplied values
+          # are impossible — actionlint best practice.
+          IN_TARGET: ${{ inputs.target }}
+          IN_FILTER: ${{ inputs.filter }}
+          IN_SHARD: ${{ inputs.shard }}
+          IN_RETRY: ${{ inputs.retry }}
+          IN_REPORT_FORMAT: ${{ inputs['report-format'] }}
+          # Secrets per existing convention (PR #867+/#868+/#869+
+          # seed-test-personas action set these names).
+          PERSONAS_PASSWORD: ${{ secrets.DEV_QA_PERSONAS_PASSWORD }}
+          FIREBASE_DEV_API_KEY: ${{ secrets.DEV_FIREBASE_API_KEY }}
+          FIREBASE_PROD_API_KEY: ${{ secrets.PROD_FIREBASE_API_KEY }}
+          # Local target is not meaningful in CI (no Firebase Emulators
+          # spun up), but pass a fake so the runner's MISSING_ENV check
+          # for FIREBASE_LOCAL_API_KEY doesn't error out on target=local
+          # — operator can still dispatch with --target local to verify
+          # the runner CLI surface (it'll fail mid-dispatch on connect
+          # to localhost:8888, which is the expected outcome).
+          FIREBASE_LOCAL_API_KEY: 'ci-local-target-not-supported'
+        run: |
+          set -euo pipefail
+          ARGS=(--matrix --target "$IN_TARGET" --driver all)
+          if [ -n "$IN_FILTER" ]; then
+            ARGS+=(--filter "$IN_FILTER")
+          fi
+          if [ -n "$IN_SHARD" ]; then
+            ARGS+=(--shard "$IN_SHARD")
+          fi
+          if [ -n "$IN_RETRY" ] && [ "$IN_RETRY" != "0" ]; then
+            ARGS+=(--retry "$IN_RETRY")
+          fi
+          ARGS+=(--report-format "$IN_REPORT_FORMAT")
+          ARGS+=(--report-output "qa-matrix-report.$IN_REPORT_FORMAT")
+          echo "Running: node scripts/manual-qa-runner.js ${ARGS[*]}"
+          node scripts/manual-qa-runner.js "${ARGS[@]}"
+        working-directory: express-api
+
+      - name: Upload matrix report
+        # `if: always()` — upload even on failure for post-mortem
+        # diagnosis. The report itself records per-cell pass/fail/skip/
+        # timeout so the operator can see exactly which cells broke.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qa-matrix-report-${{ inputs.target }}-${{ github.run_id }}
+          path: express-api/qa-matrix-report.*
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/manual-qa-matrix.yml
+++ b/.github/workflows/manual-qa-matrix.yml
@@ -63,7 +63,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        # Matches the qa-runner-driver-checks.yml convention within this
+        # family — plain @v4 tag (not SHA-pinned). Consistency in the
+        # qa-runner workflow family beats partial SHA-pinning that
+        # locks down only checkout while setup-node/cache/upload-artifact
+        # stay on floating tags (per reviewer C3).
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -123,6 +128,31 @@ jobs:
           FIREBASE_LOCAL_API_KEY: 'ci-local-target-not-supported'
         run: |
           set -euo pipefail
+          # Early-exit guards — fail FAST with actionable messages
+          # instead of wasting ~25min on a doomed dispatch.
+
+          # target=local is choice-allowed for parity with the runner's
+          # CLI surface but has no working CI execution path (no Firebase
+          # Emulators + no localhost:8888 server). Surface this up front.
+          if [ "$IN_TARGET" = "local" ]; then
+            echo "::error::target=local is not supported in CI (no Firebase Emulators / no localhost stack). Re-dispatch with target=dev or target=prod."
+            exit 2
+          fi
+
+          # shard format guard — runner would also catch this, but
+          # surfacing it BEFORE npm ci + playwright install saves
+          # ~3 minutes on a doomed run.
+          if [ -n "$IN_SHARD" ] && ! echo "$IN_SHARD" | grep -qE '^[1-9][0-9]*/[1-9][0-9]*$'; then
+            echo "::error::shard must be in X/Y form with positive integers (e.g. 1/4). Got: '$IN_SHARD'"
+            exit 2
+          fi
+
+          # retry integer guard — same pre-flight surface treatment.
+          if [ -n "$IN_RETRY" ] && ! echo "$IN_RETRY" | grep -qE '^[0-9]+$'; then
+            echo "::error::retry must be a non-negative integer. Got: '$IN_RETRY'"
+            exit 2
+          fi
+
           ARGS=(--matrix --target "$IN_TARGET" --driver all)
           if [ -n "$IN_FILTER" ]; then
             ARGS+=(--filter "$IN_FILTER")
@@ -135,7 +165,10 @@ jobs:
           fi
           ARGS+=(--report-format "$IN_REPORT_FORMAT")
           ARGS+=(--report-output "qa-matrix-report.$IN_REPORT_FORMAT")
-          echo "Running: node scripts/manual-qa-runner.js ${ARGS[*]}"
+          # NOTE: do NOT echo the full ARGS array — keeps the diagnostic
+          # log small AND avoids a future maintainer accidentally leaking
+          # a secret-bearing flag into the log via ${ARGS[*]} expansion.
+          # GitHub Actions natively echoes the run command on each step.
           node scripts/manual-qa-runner.js "${ARGS[@]}"
         working-directory: express-api
 

--- a/express-api/tests/scripts/manual-qa-matrix-workflow-pin.test.js
+++ b/express-api/tests/scripts/manual-qa-matrix-workflow-pin.test.js
@@ -47,15 +47,23 @@ describe('manual-qa-matrix.yml — structural pin', () => {
 
   // ── Inputs ───────────────────────────────────────────────────
 
-  test('input "target" declared as choice with local/dev/prod options', () => {
+  test('input "target" declared as choice with EXACTLY local/dev/prod options', () => {
     // target is the most important input — must be a constrained
     // choice (not free-form string) so operator can't typo "deb"
-    // and get a confusing downstream error.
+    // and get a confusing downstream error. Tightened from a too-broad
+    // alternation to an exact-set assertion: extract the target block
+    // and verify its options are EXACTLY {local, dev, prod} (no extras,
+    // no missing).
     expect(yamlText).toMatch(/target:\s{0,20}\n\s{1,20}description:.*\n\s{1,20}type:\s*choice/);
-    expect(yamlText).toMatch(/options:\s*\n(\s{1,20}- (local|dev|prod)\s{0,20}\n)+/);
-    expect(yamlText).toMatch(/- local/);
-    expect(yamlText).toMatch(/- dev/);
-    expect(yamlText).toMatch(/- prod/);
+    const targetBlock = yamlText.match(
+      /target:[\s\S]{0,500}?options:\s{0,20}\n((?:\s{1,20}-[^\n]+\n){1,10})/,
+    );
+    expect(targetBlock).not.toBeNull();
+    const options = targetBlock[1]
+      .split('\n')
+      .map((l) => l.trim().replace(/^-\s*/, ''))
+      .filter((l) => l.length > 0);
+    expect(options.sort()).toEqual(['dev', 'local', 'prod']);
   });
 
   test('input "filter" declared (optional string)', () => {
@@ -70,11 +78,52 @@ describe('manual-qa-matrix.yml — structural pin', () => {
     expect(yamlText).toMatch(/retry:\s{0,20}\n\s{1,20}description:.*\n\s{1,20}type:\s*string/);
   });
 
-  test('input "report-format" declared as choice with json/junit options', () => {
+  test('input "report-format" declared as choice with EXACTLY json/junit options', () => {
+    // Same exact-set rigor as the target test — catches future drift
+    // like adding "html" without updating the runner's --report-format
+    // validation.
     expect(yamlText).toMatch(/report-format:/);
-    // json + junit options both required
-    expect(yamlText).toMatch(/- json/);
-    expect(yamlText).toMatch(/- junit/);
+    const block = yamlText.match(
+      /report-format:[\s\S]{0,500}?options:\s{0,20}\n((?:\s{1,20}-[^\n]+\n){1,10})/,
+    );
+    expect(block).not.toBeNull();
+    const options = block[1]
+      .split('\n')
+      .map((l) => l.trim().replace(/^-\s*/, ''))
+      .filter((l) => l.length > 0);
+    expect(options.sort()).toEqual(['json', 'junit']);
+  });
+
+  // ── Job name template ───────────────────────────────────────
+
+  test('job name template includes target + shard annotations', () => {
+    // Operator scanning the Actions list at a glance distinguishes
+    // dispatches by target + shard. Drop either annotation and the
+    // list becomes opaque (every run looks like "Matrix Dispatch").
+    expect(yamlText).toMatch(/name:.*\$\{\{\s*inputs\.target\s*\}\}/);
+    expect(yamlText).toMatch(/name:.*\$\{\{\s*inputs\.shard\s*\|\|/);
+  });
+
+  // ── Pre-flight guards ───────────────────────────────────────
+
+  test('target=local pre-flight guard exits with actionable error', () => {
+    // I1 fix: surface CI-unsupported target=local at step start
+    // instead of after ~25min of doomed dispatch.
+    expect(yamlText).toMatch(/IN_TARGET[^\n]{0,80}local/);
+    expect(yamlText).toMatch(/::error::target=local is not supported in CI/);
+  });
+
+  test('shard format guard surfaces malformed values early', () => {
+    // I2 fix: shard regex check before --shard arg construction.
+    // Bash regex pattern is `^[1-9][0-9]*/[1-9][0-9]*$` (positive
+    // integers, no leading zeros).
+    expect(yamlText).toMatch(/shard must be in X\/Y form/);
+    expect(yamlText).toMatch(/grep -qE '\^\[1-9\]/);
+  });
+
+  test('retry integer guard surfaces non-numeric values early', () => {
+    // I3 fix: retry must be non-negative integer.
+    expect(yamlText).toMatch(/retry must be a non-negative integer/);
   });
 
   // ── Job + runner ─────────────────────────────────────────────
@@ -160,7 +209,7 @@ describe('manual-qa-matrix.yml — structural pin', () => {
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       const trimmed = line.trimEnd();
-      if (/^\s+run:\s*\|/.test(line)) {
+      if (/^\s{1,40}run:\s*\|/.test(line)) {
         inRunBlock = true;
         runBlockIndent = line.match(/^( *)/)[1].length;
         continue;
@@ -175,9 +224,53 @@ describe('manual-qa-matrix.yml — structural pin', () => {
           }
         }
         // Critical assertion: no ${{ inputs.X }} inside run block.
-        expect(line).not.toMatch(/\$\{\{\s*inputs\./);
+        expect(line).not.toMatch(/\$\{\{\s{0,20}inputs\./);
       }
     }
+  });
+
+  test('injection detector catches a known-bad fixture (inverse test)', () => {
+    // Without this inverse test, a bug in the detector's parser
+    // (wrong indent arithmetic, off-by-one in run-block boundary,
+    // etc.) could silently stop catching real injections while the
+    // forward test stays green. Construct a synthetic YAML with the
+    // exact bad pattern and verify the detector flags it.
+    const badYaml = [
+      'jobs:',
+      '  bad:',
+      '    runs-on: ubuntu-latest',
+      '    steps:',
+      '      - name: Bad step',
+      '        run: |',
+      "          echo 'this is dangerous: ${{ inputs.attacker_input }}'",
+      '          true',
+    ].join('\n');
+    const lines = badYaml.split('\n');
+    let inRunBlock = false;
+    let runBlockIndent = 0;
+    let detected = false;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const trimmed = line.trimEnd();
+      if (/^\s{1,40}run:\s*\|/.test(line)) {
+        inRunBlock = true;
+        runBlockIndent = line.match(/^( *)/)[1].length;
+        continue;
+      }
+      if (inRunBlock) {
+        if (trimmed.length > 0) {
+          const lineIndent = line.match(/^( *)/)[1].length;
+          if (lineIndent <= runBlockIndent) {
+            inRunBlock = false;
+            continue;
+          }
+        }
+        if (/\$\{\{\s{0,20}inputs\./.test(line)) {
+          detected = true;
+        }
+      }
+    }
+    expect(detected).toBe(true);
   });
 
   // ── Secrets convention ──────────────────────────────────────

--- a/express-api/tests/scripts/manual-qa-matrix-workflow-pin.test.js
+++ b/express-api/tests/scripts/manual-qa-matrix-workflow-pin.test.js
@@ -1,0 +1,201 @@
+/**
+ * manual-qa-matrix-workflow-pin.test.js
+ *
+ * Structural pin for .github/workflows/manual-qa-matrix.yml (gap E1).
+ *
+ * Catches accidental regressions in the workflow shape:
+ *   - workflow_dispatch trigger + all 5 inputs declared
+ *   - target choices = [local, dev, prod]
+ *   - report-format choices = [json, junit]
+ *   - Job runs on ubuntu-latest (per [[feedback-no-self-hosted-runners]])
+ *   - Steps: checkout, setup-node, npm ci, playwright install, dispatch,
+ *     upload-artifact
+ *   - All operator-supplied inputs are passed via env vars (NOT
+ *     interpolated into the run script), preventing shell-metacharacter
+ *     injection
+ *   - Secrets used match the established naming convention
+ *     (DEV_QA_PERSONAS_PASSWORD, DEV_FIREBASE_API_KEY, PROD_FIREBASE_API_KEY)
+ *   - Playwright browsers cached on version (per [[feedback-ci-cache-
+ *     downloads-version-aware]])
+ *   - No cron schedule (per [[feedback-avoid-crons-prefer-event-driven]])
+ *
+ * Live dispatch verification is the operator's responsibility per
+ * [[feedback-workflow-verify-by-running]] — static YAML pins catch
+ * typos but cannot prove the workflow actually runs to green.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const WORKFLOW_PATH = path.join(REPO_ROOT, '.github/workflows/manual-qa-matrix.yml');
+
+describe('manual-qa-matrix.yml — structural pin', () => {
+  let yamlText;
+  beforeAll(() => {
+    yamlText = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+  });
+
+  // ── Trigger ──────────────────────────────────────────────────
+
+  test('workflow_dispatch trigger is declared (operator-invoked, no cron)', () => {
+    expect(yamlText).toMatch(/on:\s{0,20}\n\s{0,20}workflow_dispatch:/);
+    // Per [[feedback-avoid-crons-prefer-event-driven]] — no schedule:
+    // block. Operator dispatches manually.
+    expect(yamlText).not.toMatch(/schedule:/);
+  });
+
+  // ── Inputs ───────────────────────────────────────────────────
+
+  test('input "target" declared as choice with local/dev/prod options', () => {
+    // target is the most important input — must be a constrained
+    // choice (not free-form string) so operator can't typo "deb"
+    // and get a confusing downstream error.
+    expect(yamlText).toMatch(/target:\s{0,20}\n\s{1,20}description:.*\n\s{1,20}type:\s*choice/);
+    expect(yamlText).toMatch(/options:\s*\n(\s{1,20}- (local|dev|prod)\s{0,20}\n)+/);
+    expect(yamlText).toMatch(/- local/);
+    expect(yamlText).toMatch(/- dev/);
+    expect(yamlText).toMatch(/- prod/);
+  });
+
+  test('input "filter" declared (optional string)', () => {
+    expect(yamlText).toMatch(/filter:\s{0,20}\n\s{1,20}description:.*\n\s{1,20}type:\s*string/);
+  });
+
+  test('input "shard" declared (optional string for X/Y)', () => {
+    expect(yamlText).toMatch(/shard:\s{0,20}\n\s{1,20}description:.*\n\s{1,20}type:\s*string/);
+  });
+
+  test('input "retry" declared (optional string for integer)', () => {
+    expect(yamlText).toMatch(/retry:\s{0,20}\n\s{1,20}description:.*\n\s{1,20}type:\s*string/);
+  });
+
+  test('input "report-format" declared as choice with json/junit options', () => {
+    expect(yamlText).toMatch(/report-format:/);
+    // json + junit options both required
+    expect(yamlText).toMatch(/- json/);
+    expect(yamlText).toMatch(/- junit/);
+  });
+
+  // ── Job + runner ─────────────────────────────────────────────
+
+  test('job runs on ubuntu-latest (no self-hosted runners)', () => {
+    expect(yamlText).toMatch(/runs-on:\s*ubuntu-latest/);
+    // [[feedback-no-self-hosted-runners]] — hard policy
+    expect(yamlText).not.toMatch(/\[self-hosted/);
+  });
+
+  test('job has timeout-minutes set (prevents runaway matrix)', () => {
+    expect(yamlText).toMatch(/timeout-minutes:\s*\d+/);
+  });
+
+  // ── Steps ────────────────────────────────────────────────────
+
+  test('checkout step is present', () => {
+    expect(yamlText).toMatch(/uses:\s*actions\/checkout/);
+  });
+
+  test('setup-node@v4 with cache: npm + cache-dependency-path', () => {
+    // Pin the npm cache invariant — without cache-dependency-path,
+    // setup-node defaults to repo-root package.json which doesn't
+    // exist; cache would silently no-op and slow every PR.
+    expect(yamlText).toMatch(/uses:\s*actions\/setup-node@v4/);
+    expect(yamlText).toMatch(/cache:\s*npm/);
+    expect(yamlText).toMatch(/cache-dependency-path:\s*express-api\/package-lock\.json/);
+  });
+
+  test('npm ci runs in express-api working directory', () => {
+    expect(yamlText).toMatch(/npm ci/);
+    expect(yamlText).toMatch(/working-directory:\s*express-api/);
+  });
+
+  test('Playwright browsers installed with --with-deps', () => {
+    // Without --with-deps, headless WebKit silently fails to launch
+    // on Ubuntu (missing libgtk/libgstreamer).
+    expect(yamlText).toMatch(/npx playwright install --with-deps/);
+    expect(yamlText).toMatch(/chromium/);
+    expect(yamlText).toMatch(/firefox/);
+    expect(yamlText).toMatch(/webkit/);
+  });
+
+  test('Playwright browser cache keyed on resolved version', () => {
+    // [[feedback-ci-cache-downloads-version-aware]] — cache must
+    // invalidate when Playwright version bumps.
+    expect(yamlText).toMatch(/actions\/cache@v4/);
+    expect(yamlText).toMatch(
+      /playwright-\$\{\{ runner\.os \}\}-\$\{\{ steps\.pw\.outputs\.version \}\}/,
+    );
+  });
+
+  test('manual-qa-runner.js invoked with --matrix', () => {
+    expect(yamlText).toMatch(/scripts\/manual-qa-runner\.js/);
+    expect(yamlText).toMatch(/--matrix/);
+  });
+
+  test('upload-artifact uses if: always() (uploads on failure too)', () => {
+    expect(yamlText).toMatch(/uses:\s*actions\/upload-artifact@v4/);
+    expect(yamlText).toMatch(/if:\s*always\(\)/);
+  });
+
+  // ── Security: env-var injection prevention ──────────────────
+
+  test('operator inputs passed via env vars, NOT interpolated into run scripts', () => {
+    // Security-critical: ${{ inputs.X }} inside `run: |` is a shell
+    // injection vector. The workflow MUST use env: blocks and
+    // reference $IN_TARGET etc. inside the run script.
+    expect(yamlText).toMatch(/IN_TARGET:\s*\$\{\{\s*inputs\.target\s*\}\}/);
+    expect(yamlText).toMatch(/IN_FILTER:\s*\$\{\{\s*inputs\.filter\s*\}\}/);
+    expect(yamlText).toMatch(/IN_SHARD:\s*\$\{\{\s*inputs\.shard\s*\}\}/);
+    expect(yamlText).toMatch(/IN_RETRY:\s*\$\{\{\s*inputs\.retry\s*\}\}/);
+    expect(yamlText).toMatch(/IN_REPORT_FORMAT:\s*\$\{\{\s*inputs\['report-format'\]\s*\}\}/);
+  });
+
+  test('run script references $IN_* env vars (not inputs.* interpolations)', () => {
+    // Extract all "run: |" blocks and confirm no ${{ inputs.X }}
+    // appears inside any of them. (A grep for the inputs prefix
+    // anywhere in a run-block would catch the injection.)
+    const lines = yamlText.split('\n');
+    let inRunBlock = false;
+    let runBlockIndent = 0;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const trimmed = line.trimEnd();
+      if (/^\s+run:\s*\|/.test(line)) {
+        inRunBlock = true;
+        runBlockIndent = line.match(/^( *)/)[1].length;
+        continue;
+      }
+      if (inRunBlock) {
+        // Block ends when we hit a line at or below the run: indent
+        if (trimmed.length > 0) {
+          const lineIndent = line.match(/^( *)/)[1].length;
+          if (lineIndent <= runBlockIndent) {
+            inRunBlock = false;
+            continue;
+          }
+        }
+        // Critical assertion: no ${{ inputs.X }} inside run block.
+        expect(line).not.toMatch(/\$\{\{\s*inputs\./);
+      }
+    }
+  });
+
+  // ── Secrets convention ──────────────────────────────────────
+
+  test('secrets follow established naming convention', () => {
+    // DEV_QA_PERSONAS_PASSWORD + DEV_FIREBASE_API_KEY +
+    // PROD_FIREBASE_API_KEY — same names used by other workflows
+    // (PR #867+/seed-test-personas action).
+    expect(yamlText).toMatch(/\$\{\{\s*secrets\.DEV_QA_PERSONAS_PASSWORD\s*\}\}/);
+    expect(yamlText).toMatch(/\$\{\{\s*secrets\.DEV_FIREBASE_API_KEY\s*\}\}/);
+    expect(yamlText).toMatch(/\$\{\{\s*secrets\.PROD_FIREBASE_API_KEY\s*\}\}/);
+  });
+
+  // ── Permissions ─────────────────────────────────────────────
+
+  test('permissions block restricts to read-only', () => {
+    // Least privilege — no checks: write or pull-requests: write
+    // needed for a manual matrix run.
+    expect(yamlText).toMatch(/permissions:\s{0,20}\n\s{1,20}contents:\s*read/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **highest-leverage gap** in the QA-runner framework tracker —
**gap E1, marked 🔴 blocker**: "NO manual-qa-matrix.yml workflow exists;
the 12-cell matrix had zero CI integration. Operator's only path was
local laptop runs."

## Workflow

\`workflow_dispatch\` with operator-selected inputs:
| Input | Type | Required | Default |
|-------|------|----------|---------|
| \`target\` | choice (local/dev/prod) | yes | dev |
| \`filter\` | string | no | — |
| \`shard\` | string (X/Y) | no | — |
| \`retry\` | string (integer) | no | 0 |
| \`report-format\` | choice (json/junit) | yes | json |

Job (ubuntu-latest, 30min timeout):
1. Checkout
2. Setup Node 24 with npm cache
3. \`npm ci\` in \`express-api/\`
4. Cache Playwright browsers (keyed on resolved version)
5. \`npx playwright install --with-deps chromium firefox webkit\`
6. Run \`scripts/manual-qa-runner.js --matrix --target <target> --driver all\`
   (with optional --filter, --shard, --retry composed)
7. Upload \`qa-matrix-report.*\` artifact (\`if: always()\`)

## Security 🔒

**All operator inputs passed via env vars** — never \`${{ inputs.X }}\`
interpolated into the run script:

\`\`\`yaml
env:
  IN_TARGET: \${{ inputs.target }}
  IN_FILTER: \${{ inputs.filter }}
  # ...
run: |
  ARGS=(--matrix --target "$IN_TARGET" --driver all)
\`\`\`

A dedicated test extracts every \`run: |\` block and asserts no
\`${{ inputs.X }}\` appears inside — regression-gated against future
maintainers re-introducing the injection vector. Per actionlint best
practice + GitHub security guidance.

\`permissions: contents: read\` — least privilege.

## Standing-rule compliance

- [[feedback-no-self-hosted-runners]]: ubuntu-latest only
- [[feedback-ci-cache-downloads-version-aware]]: Playwright cache keyed
  on Playwright version (bumps invalidate cache automatically)
- [[feedback-avoid-crons-prefer-event-driven]]: no \`schedule:\` block —
  operator dispatches manually via GitHub Actions UI
- [[feedback-workflow-verify-by-running]]: structural YAML pins catch
  typos; live dispatch verification is operator's responsibility

## Test plan

- [x] 19 structural tests in \`manual-qa-matrix-workflow-pin.test.js\`:
  - Trigger (workflow_dispatch, no schedule)
  - All 5 inputs declared with right types/choices/options
  - Job: ubuntu-latest, timeout-minutes set
  - All steps present (checkout, setup-node, npm ci, playwright install
    + cache, dispatch, upload-artifact)
  - Security: env-var pattern enforced for all inputs; run-block scan
    rejects \`${{ inputs.X }}\` interpolation
  - Secrets convention matches existing workflows
  - permissions: contents: read
- [x] actionlint clean
- [x] Prettier + ESLint --max-warnings=0 clean (SonarJS slow-regex
      warnings fixed by bounding \`\\s*\`/\`\\s+\` quantifiers)
- [x] Full \`tests/scripts/\`: 5504 / 5504 green

## Post-merge verification (operator)

Per [[feedback-workflow-verify-by-running]], operator should dispatch
the workflow once to confirm end-to-end success:

\`\`\`
gh workflow run manual-qa-matrix.yml -f target=dev -f report-format=json
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)