### PR TITLE
feat(ci): extend driver-checks with --smoke (gap E3)

### DIFF
--- a/.github/workflows/qa-runner-driver-checks.yml
+++ b/.github/workflows/qa-runner-driver-checks.yml
@@ -96,28 +96,51 @@ jobs:
         run: node scripts/manual-qa-runner.js --check-drivers --target local
         working-directory: express-api
 
-      - name: --smoke diagnostic — chromium (PR-gated subset, gap E3)
+      - name: --smoke diagnostic — chromium+firefox (PR-gated subset, gap E3)
         # Goes one level deeper than --check-drivers: bootstrap the
         # driver AND invoke ONE real method (webUiDump) per cell.
         # Catches cells that bootstrap clean but can't service runtime
         # calls (broken page navigation, driver-method drift, browser
         # silently degraded).
         #
-        # Scope: --filter chromium (one cell) to keep PR CI under
-        # ~30s extra. Operator can run the full matrix via E1
+        # Scope: --filter chromium,firefox (the 2 desktop cells Playwright
+        # provides on ubuntu — webkit is also available but slower to
+        # boot). Both browsers cover the divergent web-playwright code
+        # paths. Operator runs full 12-cell matrix via E1
         # (manual-qa-matrix.yml) when a deeper run is warranted.
         #
-        # Target: local. The smoke method navigates to baseURL which
-        # is localhost:8888 — there's no Firebase Emulator running in
-        # PR-CI, so the smoke method will hit a connection error.
-        # That's OK for now: this step validates the runner CLI surface
-        # (--smoke parses + dispatches correctly) without burning real
-        # cloud quota. Future: spin up a static placeholder server in
-        # the workflow if the connection check needs to pass.
+        # if: always() — independent diagnostic. Runs even if
+        # --check-drivers above fails (the operator wants the smoke
+        # signal regardless, e.g. to see whether the failure is
+        # bootstrap-only or method-level too).
         #
-        # Exit 0 || true — the smoke method's connection error is
-        # expected in CI; we don't want to fail driver-checks on it.
-        # The diagnostic value is in the parse/dispatch surface, not
-        # the smoke outcome.
-        run: node scripts/manual-qa-runner.js --smoke --target local --filter chromium || true
+        # Selective failure swallowing — only the EXPECTED localhost-
+        # ECONNREFUSED is tolerated (no Firebase Emulator in PR CI).
+        # ANY OTHER failure (e.g. --smoke parser regression, factory
+        # missing, smoke method renamed) propagates as a step failure.
+        # Without this, `|| true` would mask real bugs (reviewer-flagged
+        # 2026-05-31: factory-not-registered + method-not-implemented
+        # paths also exit 1; `|| true` would silently swallow them).
+        if: always()
+        run: |
+          set +e
+          OUT=$(node scripts/manual-qa-runner.js --smoke --target local --filter chromium,firefox 2>&1)
+          EXIT=$?
+          echo "$OUT"
+          if [ "$EXIT" -eq 0 ]; then
+            echo "[smoke-pr-gate] passed — no localhost connection error and all cells OK"
+            exit 0
+          fi
+          # Acceptable error: localhost connection refused (no Firebase
+          # Emulator running in PR CI). Playwright + Node emit several
+          # variations of this; match the canonical strings.
+          if echo "$OUT" | grep -qE 'ECONNREFUSED|net::ERR_CONNECTION_REFUSED|connect ECONNREFUSED'; then
+            echo "[smoke-pr-gate] expected localhost ECONNREFUSED — swallowing step failure (no Firebase Emulator in PR CI)"
+            exit 0
+          fi
+          # Any other failure is a real bug (parser regression, factory
+          # not registered, smoke method renamed/removed, etc.). Surface
+          # it as a step failure so CI catches the regression.
+          echo "::error::--smoke failed with a NON-CONNECTION error — likely a CLI parse regression, missing factory, or renamed method. See log above."
+          exit "$EXIT"
         working-directory: express-api

--- a/.github/workflows/qa-runner-driver-checks.yml
+++ b/.github/workflows/qa-runner-driver-checks.yml
@@ -8,10 +8,21 @@ name: QA Runner Driver Checks
 # Closes gap E4 from the QA-runner framework tracker: "No pr-checks
 # job that runs --check-drivers on PRs touching drivers/."
 #
+# Also closes gap E3 ("PR-gated subset matrix") via the --smoke step:
+# rather than a full --matrix run (which would need PERSONAS_PASSWORD
+# and burn Firebase quota on every PR), we run --smoke chromium-only
+# against target=local. This bootstraps the driver AND makes ONE real
+# webUiDump method call per cell — deeper diagnostic than
+# --check-drivers (bootstrap-only) without the cost of full journey
+# scenarios. Adds ~30s to PR CI.
+#
 # Per [[feedback-no-self-hosted-runners]] uses ubuntu-latest only.
 # Per [[feedback-ci-cache-downloads-version-aware]] Playwright browser
 # binaries are cached on the resolved Playwright version (busts when
 # the dependency bumps).
+# Per [[feedback-avoid-crons-prefer-event-driven]] no schedule:
+# block. Operator's E1 (manual-qa-matrix.yml) is the full-matrix
+# entrypoint; PR-time runs the cheap subset.
 
 on:
   workflow_call:
@@ -83,4 +94,30 @@ jobs:
         # cells report 'skip' on ubuntu (no adb device, no iOS simulator).
         # Exit code is 0 iff no cell reports 'fail' — 'skip' is acceptable.
         run: node scripts/manual-qa-runner.js --check-drivers --target local
+        working-directory: express-api
+
+      - name: --smoke diagnostic — chromium (PR-gated subset, gap E3)
+        # Goes one level deeper than --check-drivers: bootstrap the
+        # driver AND invoke ONE real method (webUiDump) per cell.
+        # Catches cells that bootstrap clean but can't service runtime
+        # calls (broken page navigation, driver-method drift, browser
+        # silently degraded).
+        #
+        # Scope: --filter chromium (one cell) to keep PR CI under
+        # ~30s extra. Operator can run the full matrix via E1
+        # (manual-qa-matrix.yml) when a deeper run is warranted.
+        #
+        # Target: local. The smoke method navigates to baseURL which
+        # is localhost:8888 — there's no Firebase Emulator running in
+        # PR-CI, so the smoke method will hit a connection error.
+        # That's OK for now: this step validates the runner CLI surface
+        # (--smoke parses + dispatches correctly) without burning real
+        # cloud quota. Future: spin up a static placeholder server in
+        # the workflow if the connection check needs to pass.
+        #
+        # Exit 0 || true — the smoke method's connection error is
+        # expected in CI; we don't want to fail driver-checks on it.
+        # The diagnostic value is in the parse/dispatch surface, not
+        # the smoke outcome.
+        run: node scripts/manual-qa-runner.js --smoke --target local --filter chromium || true
         working-directory: express-api

--- a/express-api/tests/scripts/qa-runner-driver-checks-pin.test.js
+++ b/express-api/tests/scripts/qa-runner-driver-checks-pin.test.js
@@ -73,22 +73,36 @@ describe('.github/workflows/qa-runner-driver-checks.yml', () => {
     expect(reusable).toMatch(/manual-qa-runner\.js\s+--check-drivers/);
   });
 
-  test('runs --smoke diagnostic (PR-gated subset, gap E3)', () => {
-    // Closes gap E3: PR-time subset uses --smoke (one method call
-    // per cell) instead of --matrix (full journey scenarios — would
-    // need PERSONAS_PASSWORD + burn Firebase quota).
-    expect(reusable).toMatch(/manual-qa-runner\.js\s+--smoke/);
-    // Scoped to chromium so PR CI overhead is ~30s, not minutes.
-    expect(reusable).toMatch(/--filter\s+chromium/);
+  test('runs --smoke diagnostic with anchored flag + chromium,firefox filter (gap E3)', () => {
+    // Anchored regex (--smoke followed by space or end-of-token) so
+    // a future typo like --smok or --smokes wouldn't pass the pin.
+    // Reviewer-flagged 2026-05-31 — unknown-flag silent-drop risk.
+    expect(reusable).toMatch(/--smoke(?:\s|\b)/);
+    // Scope: both desktop browsers Playwright provides on ubuntu —
+    // chromium AND firefox. Covers the divergent web-playwright code
+    // paths without bloating PR CI.
+    expect(reusable).toMatch(/--filter\s+chromium,firefox/);
   });
 
-  test('--smoke step uses `|| true` to tolerate expected CI connection error', () => {
-    // In PR CI there's no localhost:8888 Firebase Emulator, so the
-    // smoke method's navigation will error. We don't want that to
-    // fail the workflow — the diagnostic value is in parse/dispatch,
-    // not the smoke outcome. The `|| true` pattern is documented in
-    // the workflow comment.
-    expect(reusable).toMatch(/--smoke[^\n]{0,200}\|\|\s*true/);
+  test('--smoke step has `if: always()` for independent diagnostic', () => {
+    // Reviewer-flagged: without if: always(), GitHub Actions skips
+    // the --smoke step if --check-drivers above fails. Operator
+    // wants the smoke signal regardless — distinguishes
+    // bootstrap-only from method-level failures.
+    expect(reusable).toMatch(/--smoke[\s\S]{0,500}?if:\s*always\(\)/);
+  });
+
+  test('--smoke step selective-swallows ONLY localhost ECONNREFUSED (gap C1)', () => {
+    // Reviewer-flagged 2026-05-31 — naive `|| true` would silently
+    // mask CLI parser regressions, missing factories, renamed
+    // methods (all exit 1). Tightened to grep for the connection
+    // error specifically; any other exit-1 propagates.
+    expect(reusable).toMatch(/ECONNREFUSED/);
+    expect(reusable).toMatch(/net::ERR_CONNECTION_REFUSED/);
+    // Anti-pattern check: no bare `|| true` on the runner invocation.
+    expect(reusable).not.toMatch(/manual-qa-runner\.js[^\n]{0,200}\|\|\s*true/);
+    // Must surface non-connection errors with a clear ::error:: message.
+    expect(reusable).toMatch(/::error::--smoke failed with a NON-CONNECTION error/);
   });
 
   test('grants read-only contents permission', () => {

--- a/express-api/tests/scripts/qa-runner-driver-checks-pin.test.js
+++ b/express-api/tests/scripts/qa-runner-driver-checks-pin.test.js
@@ -73,6 +73,24 @@ describe('.github/workflows/qa-runner-driver-checks.yml', () => {
     expect(reusable).toMatch(/manual-qa-runner\.js\s+--check-drivers/);
   });
 
+  test('runs --smoke diagnostic (PR-gated subset, gap E3)', () => {
+    // Closes gap E3: PR-time subset uses --smoke (one method call
+    // per cell) instead of --matrix (full journey scenarios — would
+    // need PERSONAS_PASSWORD + burn Firebase quota).
+    expect(reusable).toMatch(/manual-qa-runner\.js\s+--smoke/);
+    // Scoped to chromium so PR CI overhead is ~30s, not minutes.
+    expect(reusable).toMatch(/--filter\s+chromium/);
+  });
+
+  test('--smoke step uses `|| true` to tolerate expected CI connection error', () => {
+    // In PR CI there's no localhost:8888 Firebase Emulator, so the
+    // smoke method's navigation will error. We don't want that to
+    // fail the workflow — the diagnostic value is in parse/dispatch,
+    // not the smoke outcome. The `|| true` pattern is documented in
+    // the workflow comment.
+    expect(reusable).toMatch(/--smoke[^\n]{0,200}\|\|\s*true/);
+  });
+
   test('grants read-only contents permission', () => {
     // No write needed — this workflow only runs tests + diagnostics.
     expect(reusable).toMatch(/permissions:[\s\S]{0,200}?contents:\s*read/);


### PR DESCRIPTION
## Summary

Closes gap **E3** ("PR-gated subset matrix"). Rather than a heavyweight
new \`--matrix\` workflow on PRs (requires secrets, burns Firebase
quota), extends the existing \`qa-runner-driver-checks.yml\` with a
\`--smoke chromium\` step. Adds ~30s to PR CI for driver-touching PRs.

## What it adds

\`\`\`yaml
- name: --smoke diagnostic — chromium (PR-gated subset, gap E3)
  run: node scripts/manual-qa-runner.js --smoke --target local --filter chromium || true
\`\`\`

| Diagnostic | Depth | PR CI cost |
|------------|-------|-----------|
| \`--check-drivers\` (existing) | Bootstrap + close | ~5s/cell |
| \`--smoke\` (new) | Bootstrap + ONE method call (webUiDump) + close | ~10s/cell |
| \`--matrix\` (E1, operator-dispatched) | Full journey scenarios | ~30min |

\`--smoke\` catches cells that bootstrap clean but can't service runtime
calls — broken page navigation, driver-method drift, browser silently
degraded.

## Trade-offs documented

- Target=local → smoke method navigation will hit ECONNREFUSED on
  localhost:8888 (no Firebase Emulator in CI). \`|| true\` tolerates
  this; the diagnostic value is in --smoke parse/dispatch surface.
- \`--filter chromium\` keeps PR CI cost minimal. Full matrix is
  operator-dispatched via E1 (PR #938).
- No cron schedule per [[feedback-avoid-crons-prefer-event-driven]].

## Test plan

- [x] 3 new tests in \`qa-runner-driver-checks-pin.test.js\`:
  - runs --smoke + --filter chromium
  - --smoke step uses \`|| true\` for expected CI connection error
- [x] actionlint clean
- [x] Tests: 24 (was 21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)