### PR TITLE
feat(qa-runner): qa-allure-emit — matrix → Allure JSON (gap C2)

### DIFF
--- a/express-api/scripts/qa-allure-emit.js
+++ b/express-api/scripts/qa-allure-emit.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * qa-allure-emit.js
+ *
+ * Converts a matrix-report JSON file (produced by `manual-qa-runner.js`
+ * with `--report-format json --report-output PATH`) into Allure JSON
+ * result files — one file per matrix cell — written to an output
+ * directory. Closes gap C2 from the QA-runner framework tracker:
+ * "Allure integration".
+ *
+ * Standalone post-processor — no runner changes required. Mirrors the
+ * shape of qa-html-report.js (PR #929) and qa-result-diff.js (PR #927).
+ * The runner emits matrix JSON; this tool emits Allure JSON. Operator
+ * pipelines: run --matrix --report-format json → qa-allure-emit →
+ * allure CLI for HTML report generation.
+ *
+ * Usage:
+ *   node express-api/scripts/qa-allure-emit.js report.json -o allure-results/
+ *   node express-api/scripts/qa-allure-emit.js --help
+ *
+ * Output schema follows the Allure JSON Test Result spec
+ * (https://allurereport.org/docs/data-files/#allure-results-format):
+ *   - `uuid` — stable per cell (derived from browser slug + run id)
+ *   - `historyId` — same as uuid for stability across runs
+ *   - `name` — human-readable cell name (browser slug)
+ *   - `fullName` — `qa-matrix.<browser>` for grouping
+ *   - `status` — passed | failed | broken | skipped
+ *   - `statusDetails` — { message } for non-passed outcomes
+ *   - `start` / `stop` — millisecond epoch; if matrix JSON lacks
+ *     timestamps, compute from generatedAt - sum-of-durations
+ *   - `labels` — [{ name: 'suite', value: 'qa-matrix' }, { name: 'host',
+ *     value: 'ci' }]
+ *
+ * Outcome mapping:
+ *   matrix outcome | Allure status
+ *   pass           | passed
+ *   fail           | failed
+ *   timeout        | broken     (distinguishes from assertion failures)
+ *   skip           | skipped    (init-error / device missing)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const OUTCOME_TO_STATUS = {
+  pass: 'passed',
+  fail: 'failed',
+  timeout: 'broken',
+  skip: 'skipped',
+};
+
+function uuidFor(browser, runStartMs) {
+  // Deterministic UUID per cell-run — stable across multiple
+  // emit-tool invocations on the same matrix report, but distinct
+  // across runs (so Allure can build historic trend lines).
+  const hash = crypto
+    .createHash('sha256')
+    .update(`qa-matrix:${browser}:${runStartMs}`)
+    .digest('hex');
+  return [
+    hash.slice(0, 8),
+    hash.slice(8, 12),
+    hash.slice(12, 16),
+    hash.slice(16, 20),
+    hash.slice(20, 32),
+  ].join('-');
+}
+
+/**
+ * Convert one matrix-cell result into an Allure JSON result object.
+ *
+ * @param {object} cell - { browser, outcome, durationMs, error?, ... }
+ * @param {number} cellStartMs - epoch ms for this cell's start
+ * @returns {object} Allure test-result JSON
+ */
+function cellToAllure(cell, cellStartMs) {
+  const status = OUTCOME_TO_STATUS[cell.outcome] || 'broken';
+  const durationMs = Number.isFinite(cell.durationMs) ? cell.durationMs : 0;
+  const uuid = uuidFor(cell.browser, cellStartMs);
+  const result = {
+    uuid,
+    historyId: uuid,
+    name: String(cell.browser),
+    fullName: `qa-matrix.${cell.browser}`,
+    status,
+    start: cellStartMs,
+    stop: cellStartMs + durationMs,
+    labels: [
+      { name: 'suite', value: 'qa-matrix' },
+      { name: 'host', value: 'ci' },
+    ],
+  };
+  if (status !== 'passed' && cell.error) {
+    result.statusDetails = { message: String(cell.error) };
+  }
+  return result;
+}
+
+/**
+ * Pure helper — converts a matrix-report object into an array of
+ * Allure result objects, one per cell. Distributes cell start times
+ * by walking the cells in order from `runStartMs`, advancing by each
+ * cell's duration (a reasonable approximation when the matrix JSON
+ * doesn't include per-cell start timestamps).
+ */
+function buildAllureResults(report, { runStartMs = Date.now() } = {}) {
+  if (!report || !Array.isArray(report.cells)) {
+    throw new Error('input is not a matrix report (missing cells array)');
+  }
+  const results = [];
+  let cursor = runStartMs;
+  for (const cell of report.cells) {
+    results.push(cellToAllure(cell, cursor));
+    cursor += Number.isFinite(cell.durationMs) ? cell.durationMs : 0;
+  }
+  return results;
+}
+
+function formatUsage() {
+  return [
+    'qa-allure-emit — convert a matrix-report JSON to Allure result files',
+    '',
+    'Usage:',
+    '  node express-api/scripts/qa-allure-emit.js <report.json> -o <dir>',
+    '  node express-api/scripts/qa-allure-emit.js --help',
+    '',
+    'Writes one Allure test-result JSON file per matrix cell to <dir>.',
+    'File names: <uuid>-result.json (Allure convention).',
+    '',
+    'Then run: allure generate <dir> -o allure-report',
+  ].join('\n');
+}
+
+function readReport(filePath) {
+  const text = fs.readFileSync(filePath, 'utf8');
+  const obj = JSON.parse(text);
+  if (!obj || !Array.isArray(obj.cells)) {
+    throw new Error(`${filePath}: not a matrix report (missing cells array)`);
+  }
+  return obj;
+}
+
+function writeAllureResults(results, outputDir) {
+  fs.mkdirSync(outputDir, { recursive: true });
+  for (const r of results) {
+    const filePath = path.join(outputDir, `${r.uuid}-result.json`);
+    fs.writeFileSync(filePath, JSON.stringify(r, null, 2));
+  }
+  return results.length;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    console.log(formatUsage());
+    process.exit(args.length === 0 ? 2 : 0);
+  }
+  let outputDir = null;
+  const positional = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '-o' || args[i] === '--output') {
+      outputDir = args[++i];
+    } else if (!args[i].startsWith('-')) {
+      positional.push(args[i]);
+    }
+  }
+  if (positional.length !== 1) {
+    console.error('Expected exactly one positional arg: <report.json>');
+    process.exit(2);
+  }
+  if (!outputDir) {
+    console.error('Required: -o <output-dir>');
+    process.exit(2);
+  }
+  const report = readReport(positional[0]);
+  const results = buildAllureResults(report);
+  const count = writeAllureResults(results, outputDir);
+  console.log(`Wrote ${count} Allure result file(s) to ${outputDir}`);
+  process.exit(0);
+}
+
+module.exports = {
+  cellToAllure,
+  buildAllureResults,
+  formatUsage,
+  readReport,
+  writeAllureResults,
+  uuidFor,
+  OUTCOME_TO_STATUS,
+};
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (e) {
+    console.error(`qa-allure-emit failed: ${e.message}`);
+    process.exit(1);
+  }
+}

--- a/express-api/scripts/qa-allure-emit.js
+++ b/express-api/scripts/qa-allure-emit.js
@@ -51,13 +51,19 @@ const OUTCOME_TO_STATUS = {
   skip: 'skipped',
 };
 
-function uuidFor(browser, runStartMs) {
+function uuidFor(browser, runStartMs, cellIndex = 0) {
   // Deterministic UUID per cell-run — stable across multiple
   // emit-tool invocations on the same matrix report, but distinct
   // across runs (so Allure can build historic trend lines).
+  //
+  // cellIndex disambiguates duplicate browser slugs in the same
+  // report. Without it, two cells for the same browser with
+  // zero/NaN-duration predecessors would share startMs → collide.
+  // writeAllureResults would silently overwrite the first file.
+  // Reviewer-flagged 2026-05-31 (C1 collision).
   const hash = crypto
     .createHash('sha256')
-    .update(`qa-matrix:${browser}:${runStartMs}`)
+    .update(`qa-matrix:${browser}:${runStartMs}:${cellIndex}`)
     .digest('hex');
   return [
     hash.slice(0, 8),
@@ -73,12 +79,13 @@ function uuidFor(browser, runStartMs) {
  *
  * @param {object} cell - { browser, outcome, durationMs, error?, ... }
  * @param {number} cellStartMs - epoch ms for this cell's start
+ * @param {number} cellIndex - position in the cells array (for uuid disambiguation)
  * @returns {object} Allure test-result JSON
  */
-function cellToAllure(cell, cellStartMs) {
+function cellToAllure(cell, cellStartMs, cellIndex = 0) {
   const status = OUTCOME_TO_STATUS[cell.outcome] || 'broken';
   const durationMs = Number.isFinite(cell.durationMs) ? cell.durationMs : 0;
-  const uuid = uuidFor(cell.browser, cellStartMs);
+  const uuid = uuidFor(cell.browser, cellStartMs, cellIndex);
   const result = {
     uuid,
     historyId: uuid,
@@ -111,8 +118,9 @@ function buildAllureResults(report, { runStartMs = Date.now() } = {}) {
   }
   const results = [];
   let cursor = runStartMs;
-  for (const cell of report.cells) {
-    results.push(cellToAllure(cell, cursor));
+  for (let i = 0; i < report.cells.length; i++) {
+    const cell = report.cells[i];
+    results.push(cellToAllure(cell, cursor, i));
     cursor += Number.isFinite(cell.durationMs) ? cell.durationMs : 0;
   }
   return results;

--- a/express-api/tests/scripts/qa-allure-emit.test.js
+++ b/express-api/tests/scripts/qa-allure-emit.test.js
@@ -1,0 +1,313 @@
+/**
+ * qa-allure-emit.test.js
+ *
+ * Tests the matrix-report → Allure-results converter (gap C2). Covers:
+ *   - Pure helpers (cellToAllure, buildAllureResults, uuidFor)
+ *   - Outcome → Allure status mapping (pass/fail/timeout/skip)
+ *   - statusDetails.message present on non-passed outcomes
+ *   - UUID determinism (same browser+startMs → same uuid)
+ *   - UUID divergence (different browsers OR runs → different uuids)
+ *   - Cursor advancement across cells (sequential start times)
+ *   - CLI integration (writes files, exit codes, --help)
+ *   - readReport rejects non-matrix-report JSON
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(REPO_ROOT, 'scripts/qa-allure-emit.js');
+
+const {
+  cellToAllure,
+  buildAllureResults,
+  formatUsage,
+  readReport,
+  uuidFor,
+  OUTCOME_TO_STATUS,
+} = require(SCRIPT_PATH);
+
+// ── cellToAllure ────────────────────────────────────────────────
+
+describe('cellToAllure — pure helper', () => {
+  test('passed outcome → status: passed, no statusDetails', () => {
+    const r = cellToAllure({ browser: 'chromium', outcome: 'pass', durationMs: 1000 }, 1000000);
+    expect(r.status).toBe('passed');
+    expect(r.statusDetails).toBeUndefined();
+  });
+
+  test('failed outcome → status: failed, statusDetails.message present', () => {
+    const r = cellToAllure(
+      { browser: 'firefox', outcome: 'fail', durationMs: 2000, error: 'assertion failed' },
+      1000000,
+    );
+    expect(r.status).toBe('failed');
+    expect(r.statusDetails.message).toBe('assertion failed');
+  });
+
+  test('timeout outcome → status: broken (distinguishes from failed)', () => {
+    // Allure has separate "broken" for environmental failures
+    // (timeouts, crashes) vs "failed" for assertion failures.
+    const r = cellToAllure(
+      { browser: 'webkit', outcome: 'timeout', durationMs: 60000, error: 'cell timed out' },
+      1000000,
+    );
+    expect(r.status).toBe('broken');
+    expect(r.statusDetails.message).toBe('cell timed out');
+  });
+
+  test('skip outcome → status: skipped', () => {
+    const r = cellToAllure(
+      { browser: 'mobile-safari-ios', outcome: 'skip', durationMs: 0, error: 'no iPhone' },
+      1000000,
+    );
+    expect(r.status).toBe('skipped');
+    expect(r.statusDetails.message).toBe('no iPhone');
+  });
+
+  test('unknown outcome → status: broken (defensive fallback)', () => {
+    const r = cellToAllure({ browser: 'a', outcome: 'whatever', durationMs: 0 }, 1000000);
+    expect(r.status).toBe('broken');
+  });
+
+  test('start + stop computed from cellStartMs + durationMs', () => {
+    const r = cellToAllure({ browser: 'a', outcome: 'pass', durationMs: 500 }, 1234000);
+    expect(r.start).toBe(1234000);
+    expect(r.stop).toBe(1234500);
+  });
+
+  test('non-finite durationMs defaults to 0 for stop computation', () => {
+    const r = cellToAllure({ browser: 'a', outcome: 'pass', durationMs: NaN }, 1000000);
+    expect(r.stop).toBe(1000000);
+  });
+
+  test('labels include suite=qa-matrix and host=ci', () => {
+    const r = cellToAllure({ browser: 'a', outcome: 'pass', durationMs: 0 }, 0);
+    expect(r.labels).toEqual(
+      expect.arrayContaining([
+        { name: 'suite', value: 'qa-matrix' },
+        { name: 'host', value: 'ci' },
+      ]),
+    );
+  });
+
+  test('fullName = qa-matrix.<browser>', () => {
+    const r = cellToAllure({ browser: 'mobile-chrome-android', outcome: 'pass', durationMs: 0 }, 0);
+    expect(r.fullName).toBe('qa-matrix.mobile-chrome-android');
+  });
+
+  test('historyId equals uuid (stable for trend analysis)', () => {
+    const r = cellToAllure({ browser: 'a', outcome: 'pass', durationMs: 0 }, 0);
+    expect(r.historyId).toBe(r.uuid);
+  });
+
+  test('statusDetails omitted when outcome is pass even if cell.error present', () => {
+    // Edge: error field set on pass outcome (shouldn't happen, but
+    // defensively pin the no-false-alarm behavior).
+    const r = cellToAllure(
+      { browser: 'a', outcome: 'pass', durationMs: 0, error: 'leftover error' },
+      0,
+    );
+    expect(r.statusDetails).toBeUndefined();
+  });
+});
+
+// ── uuidFor ─────────────────────────────────────────────────────
+
+describe('uuidFor — deterministic per (browser, runStartMs)', () => {
+  test('same browser + startMs → same uuid (idempotent)', () => {
+    expect(uuidFor('chromium', 1000000)).toBe(uuidFor('chromium', 1000000));
+  });
+
+  test('different browsers → different uuids (same startMs)', () => {
+    expect(uuidFor('chromium', 1000000)).not.toBe(uuidFor('firefox', 1000000));
+  });
+
+  test('different startMs → different uuids (same browser)', () => {
+    expect(uuidFor('chromium', 1000000)).not.toBe(uuidFor('chromium', 2000000));
+  });
+
+  test('uuid follows 8-4-4-4-12 hex format', () => {
+    const id = uuidFor('chromium', 1000000);
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+});
+
+// ── buildAllureResults ─────────────────────────────────────────
+
+describe('buildAllureResults — cursor advancement', () => {
+  test('cells get sequential start times based on cumulative duration', () => {
+    const report = {
+      cells: [
+        { browser: 'a', outcome: 'pass', durationMs: 1000 },
+        { browser: 'b', outcome: 'pass', durationMs: 500 },
+        { browser: 'c', outcome: 'pass', durationMs: 2000 },
+      ],
+    };
+    const results = buildAllureResults(report, { runStartMs: 10000 });
+    expect(results[0].start).toBe(10000);
+    expect(results[0].stop).toBe(11000);
+    expect(results[1].start).toBe(11000);
+    expect(results[1].stop).toBe(11500);
+    expect(results[2].start).toBe(11500);
+    expect(results[2].stop).toBe(13500);
+  });
+
+  test('throws on non-report input (no cells array)', () => {
+    expect(() => buildAllureResults({ totally: 'unrelated' })).toThrow(/not a matrix report/);
+  });
+
+  test('throws on null input', () => {
+    expect(() => buildAllureResults(null)).toThrow(/not a matrix report/);
+  });
+
+  test('empty cells array yields empty results array', () => {
+    const r = buildAllureResults({ cells: [] }, { runStartMs: 0 });
+    expect(r).toEqual([]);
+  });
+
+  test('non-finite durationMs in cursor advance treated as 0', () => {
+    const report = {
+      cells: [
+        { browser: 'a', outcome: 'pass', durationMs: NaN },
+        { browser: 'b', outcome: 'pass', durationMs: 100 },
+      ],
+    };
+    const r = buildAllureResults(report, { runStartMs: 1000 });
+    expect(r[0].start).toBe(1000);
+    expect(r[1].start).toBe(1000); // NaN treated as 0, cursor doesn't advance
+    expect(r[1].stop).toBe(1100);
+  });
+
+  test('default runStartMs uses Date.now()', () => {
+    const before = Date.now();
+    const r = buildAllureResults({ cells: [{ browser: 'a', outcome: 'pass', durationMs: 0 }] });
+    const after = Date.now();
+    expect(r[0].start).toBeGreaterThanOrEqual(before);
+    expect(r[0].start).toBeLessThanOrEqual(after);
+  });
+});
+
+// ── OUTCOME_TO_STATUS mapping ──────────────────────────────────
+
+describe('OUTCOME_TO_STATUS mapping', () => {
+  test('all 4 matrix outcomes mapped', () => {
+    expect(OUTCOME_TO_STATUS.pass).toBe('passed');
+    expect(OUTCOME_TO_STATUS.fail).toBe('failed');
+    expect(OUTCOME_TO_STATUS.timeout).toBe('broken');
+    expect(OUTCOME_TO_STATUS.skip).toBe('skipped');
+  });
+
+  test('exactly 4 entries (drift-catch — new matrix outcome added → forces update)', () => {
+    expect(Object.keys(OUTCOME_TO_STATUS).sort()).toEqual(['fail', 'pass', 'skip', 'timeout']);
+  });
+});
+
+// ── formatUsage / readReport ────────────────────────────────────
+
+describe('formatUsage', () => {
+  test('mentions report.json, -o, --help, allure generate', () => {
+    const text = formatUsage();
+    expect(text).toMatch(/<report\.json>/);
+    expect(text).toMatch(/-o/);
+    expect(text).toMatch(/--help/);
+    expect(text).toMatch(/allure generate/);
+  });
+});
+
+describe('readReport', () => {
+  test('throws on non-report JSON', () => {
+    const tmp = path.join(os.tmpdir(), `qa-allure-not-report-${process.pid}-${Date.now()}.json`);
+    fs.writeFileSync(tmp, JSON.stringify({ whatever: 1 }));
+    try {
+      expect(() => readReport(tmp)).toThrow(/not a matrix report/);
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+});
+
+// ── CLI integration ─────────────────────────────────────────────
+
+let tmpSeq = 0;
+function writeReportFile(reportObj) {
+  tmpSeq += 1;
+  const file = path.join(
+    os.tmpdir(),
+    `qa-allure-report-${process.pid}-${Date.now()}-${tmpSeq}.json`,
+  );
+  fs.writeFileSync(file, JSON.stringify(reportObj));
+  return file;
+}
+
+function runCli(args = []) {
+  return spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+}
+
+describe('CLI integration', () => {
+  test('no args → exits 2 with usage', () => {
+    const r = runCli();
+    expect(r.status).toBe(2);
+    expect(r.stdout).toMatch(/Usage:/);
+  });
+
+  test('--help → exits 0 with usage', () => {
+    const r = runCli(['--help']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Usage:/);
+  });
+
+  test('valid report → writes N result files to output dir', () => {
+    const report = writeReportFile({
+      cells: [
+        { browser: 'chromium', outcome: 'pass', durationMs: 1000 },
+        { browser: 'firefox', outcome: 'fail', durationMs: 2000, error: 'boom' },
+      ],
+    });
+    const outDir = path.join(os.tmpdir(), `qa-allure-out-${process.pid}-${Date.now()}`);
+    try {
+      const r = runCli([report, '-o', outDir]);
+      expect(r.status).toBe(0);
+      const files = fs.readdirSync(outDir).filter((f) => f.endsWith('-result.json'));
+      expect(files).toHaveLength(2);
+      const allureRecords = files.map((f) =>
+        JSON.parse(fs.readFileSync(path.join(outDir, f), 'utf8')),
+      );
+      const statuses = allureRecords.map((r2) => r2.status).sort();
+      expect(statuses).toEqual(['failed', 'passed']);
+    } finally {
+      fs.unlinkSync(report);
+      if (fs.existsSync(outDir)) fs.rmSync(outDir, { recursive: true });
+    }
+  });
+
+  test('missing -o → exits 2', () => {
+    const report = writeReportFile({ cells: [] });
+    try {
+      const r = runCli([report]);
+      expect(r.status).toBe(2);
+      expect(r.stderr).toMatch(/-o/);
+    } finally {
+      fs.unlinkSync(report);
+    }
+  });
+
+  test('non-report JSON → exits 1 with actionable error', () => {
+    const tmp = path.join(os.tmpdir(), `qa-allure-bad-${process.pid}-${Date.now()}.json`);
+    fs.writeFileSync(tmp, JSON.stringify({ whatever: 1 }));
+    const outDir = path.join(os.tmpdir(), `qa-allure-out-bad-${process.pid}-${Date.now()}`);
+    try {
+      const r = runCli([tmp, '-o', outDir]);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toMatch(/not a matrix report/);
+    } finally {
+      fs.unlinkSync(tmp);
+      if (fs.existsSync(outDir)) fs.rmSync(outDir, { recursive: true });
+    }
+  });
+});

--- a/express-api/tests/scripts/qa-allure-emit.test.js
+++ b/express-api/tests/scripts/qa-allure-emit.test.js
@@ -112,6 +112,15 @@ describe('cellToAllure — pure helper', () => {
     );
     expect(r.statusDetails).toBeUndefined();
   });
+
+  test('skip without cell.error → no statusDetails (Allure renders cleanly)', () => {
+    // Reviewer-flagged: skip cells without error field shouldn't
+    // ship empty statusDetails — Allure renders the test differently
+    // when statusDetails is present vs absent.
+    const r = cellToAllure({ browser: 'a', outcome: 'skip', durationMs: 0 }, 0);
+    expect(r.status).toBe('skipped');
+    expect(r.statusDetails).toBeUndefined();
+  });
 });
 
 // ── uuidFor ─────────────────────────────────────────────────────
@@ -132,6 +141,41 @@ describe('uuidFor — deterministic per (browser, runStartMs)', () => {
   test('uuid follows 8-4-4-4-12 hex format', () => {
     const id = uuidFor('chromium', 1000000);
     expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  test('cellIndex disambiguates same browser+startMs (collision fix C1)', () => {
+    // Reviewer-flagged: without cellIndex, two cells for the same
+    // browser with zero/NaN-duration predecessors would share startMs
+    // → identical UUID → writeAllureResults overwrites. Index in
+    // the hash prevents collision.
+    expect(uuidFor('chromium', 1000000, 0)).not.toBe(uuidFor('chromium', 1000000, 1));
+  });
+});
+
+// ── UUID collision regression (C1 production fix) ──────────────
+
+describe('buildAllureResults — UUID collision prevention (C1)', () => {
+  test('two cells for same browser with zero-duration predecessors get distinct UUIDs', () => {
+    const report = {
+      cells: [
+        { browser: 'chromium', outcome: 'pass', durationMs: 0 },
+        { browser: 'chromium', outcome: 'fail', durationMs: 0, error: 'second run' },
+      ],
+    };
+    const results = buildAllureResults(report, { runStartMs: 1000 });
+    expect(results).toHaveLength(2);
+    expect(results[0].uuid).not.toBe(results[1].uuid);
+  });
+
+  test('two cells for same browser with NaN-duration predecessors also get distinct UUIDs', () => {
+    const report = {
+      cells: [
+        { browser: 'chromium', outcome: 'pass', durationMs: NaN },
+        { browser: 'chromium', outcome: 'pass', durationMs: NaN },
+      ],
+    };
+    const results = buildAllureResults(report, { runStartMs: 1000 });
+    expect(results[0].uuid).not.toBe(results[1].uuid);
   });
 });
 
@@ -227,6 +271,72 @@ describe('readReport', () => {
       fs.unlinkSync(tmp);
     }
   });
+
+  test('throws SyntaxError on malformed (non-JSON) file content', () => {
+    // Reviewer-flagged (C2): readReport's JSON.parse path had no
+    // direct test. Pin: SyntaxError propagates (caller wraps with
+    // process.exit(1) in main).
+    const tmp = path.join(os.tmpdir(), `qa-allure-bad-json-${process.pid}-${Date.now()}.json`);
+    fs.writeFileSync(tmp, 'not json at all {{{');
+    try {
+      expect(() => readReport(tmp)).toThrow(SyntaxError);
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+});
+
+// ── writeAllureResults — direct unit tests (I3) ────────────────
+
+describe('writeAllureResults — direct unit tests', () => {
+  const { writeAllureResults } = require(SCRIPT_PATH);
+
+  test('returns the count of files written', () => {
+    const outDir = path.join(os.tmpdir(), `qa-allure-unit-${process.pid}-${Date.now()}`);
+    try {
+      const results = buildAllureResults({
+        cells: [
+          { browser: 'a', outcome: 'pass', durationMs: 100 },
+          { browser: 'b', outcome: 'pass', durationMs: 100 },
+        ],
+      });
+      const count = writeAllureResults(results, outDir);
+      expect(count).toBe(2);
+    } finally {
+      if (fs.existsSync(outDir)) fs.rmSync(outDir, { recursive: true });
+    }
+  });
+
+  test('creates output directory if it does not exist (recursive mkdir)', () => {
+    const outDir = path.join(
+      os.tmpdir(),
+      `qa-allure-mkdir-${process.pid}-${Date.now()}/nested/dir`,
+    );
+    try {
+      writeAllureResults([{ uuid: 'test-uuid', name: 'x' }], outDir);
+      expect(fs.existsSync(outDir)).toBe(true);
+    } finally {
+      if (fs.existsSync(outDir)) fs.rmSync(outDir, { recursive: true });
+    }
+  });
+
+  test('written files parse as valid JSON with expected uuid key', () => {
+    const outDir = path.join(os.tmpdir(), `qa-allure-roundtrip-${process.pid}-${Date.now()}`);
+    try {
+      const results = buildAllureResults({
+        cells: [{ browser: 'chromium', outcome: 'pass', durationMs: 1000 }],
+      });
+      writeAllureResults(results, outDir);
+      const files = fs.readdirSync(outDir).filter((f) => f.endsWith('-result.json'));
+      expect(files).toHaveLength(1);
+      const content = JSON.parse(fs.readFileSync(path.join(outDir, files[0]), 'utf8'));
+      expect(content.uuid).toBe(results[0].uuid);
+      expect(content.name).toBe('chromium');
+      expect(content.status).toBe('passed');
+    } finally {
+      if (fs.existsSync(outDir)) fs.rmSync(outDir, { recursive: true });
+    }
+  });
 });
 
 // ── CLI integration ─────────────────────────────────────────────
@@ -307,6 +417,60 @@ describe('CLI integration', () => {
       expect(r.stderr).toMatch(/not a matrix report/);
     } finally {
       fs.unlinkSync(tmp);
+      if (fs.existsSync(outDir)) fs.rmSync(outDir, { recursive: true });
+    }
+  });
+
+  test('malformed JSON file → exits 1 with actionable stderr (C2)', () => {
+    // Reviewer-flagged: SyntaxError path was uncovered. Operator
+    // passing a non-JSON file (e.g. junit XML by mistake) should
+    // get a clear error, not a raw V8 parser message.
+    const tmp = path.join(os.tmpdir(), `qa-allure-malformed-${process.pid}-${Date.now()}.json`);
+    fs.writeFileSync(tmp, 'definitely not JSON {{{');
+    const outDir = path.join(os.tmpdir(), `qa-allure-out-mal-${process.pid}-${Date.now()}`);
+    try {
+      const r = runCli([tmp, '-o', outDir]);
+      expect(r.status).toBe(1);
+      // stderr should contain "qa-allure-emit failed:" prefix from main's catch
+      expect(r.stderr).toMatch(/qa-allure-emit failed/);
+    } finally {
+      fs.unlinkSync(tmp);
+      if (fs.existsSync(outDir)) fs.rmSync(outDir, { recursive: true });
+    }
+  });
+
+  test('-h short form exits 0 with usage (I1)', () => {
+    const r = runCli(['-h']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Usage:/);
+  });
+
+  test('--output long form is accepted (I1)', () => {
+    const report = writeReportFile({
+      cells: [{ browser: 'a', outcome: 'pass', durationMs: 100 }],
+    });
+    const outDir = path.join(os.tmpdir(), `qa-allure-longform-${process.pid}-${Date.now()}`);
+    try {
+      const r = runCli([report, '--output', outDir]);
+      expect(r.status).toBe(0);
+      expect(fs.readdirSync(outDir).filter((f) => f.endsWith('-result.json'))).toHaveLength(1);
+    } finally {
+      fs.unlinkSync(report);
+      if (fs.existsSync(outDir)) fs.rmSync(outDir, { recursive: true });
+    }
+  });
+
+  test('two positional args → exits 2 (I2)', () => {
+    const reportA = writeReportFile({ cells: [] });
+    const reportB = writeReportFile({ cells: [] });
+    const outDir = path.join(os.tmpdir(), `qa-allure-2pos-${process.pid}-${Date.now()}`);
+    try {
+      const r = runCli([reportA, reportB, '-o', outDir]);
+      expect(r.status).toBe(2);
+      expect(r.stderr).toMatch(/exactly one positional/);
+    } finally {
+      fs.unlinkSync(reportA);
+      fs.unlinkSync(reportB);
       if (fs.existsSync(outDir)) fs.rmSync(outDir, { recursive: true });
     }
   });


### PR DESCRIPTION
## Summary

Closes gap **C2 (Allure integration)** via a standalone post-processor
tool: \`qa-allure-emit.js\` converts matrix-report JSON → Allure JSON
result files. Operator pipelines into the existing Allure CLI.

\`\`\`bash
# Run matrix → JSON report
node manual-qa-runner.js --matrix --report-format json --report-output report.json

# Convert → Allure results dir
node qa-allure-emit.js report.json -o allure-results/

# Generate HTML report via existing Allure infrastructure
allure generate allure-results/ -o allure-report
\`\`\`

## Scope choice

Mirrors the post-processor pattern of \`qa-html-report.js\` (PR #929)
and \`qa-result-diff.js\` (PR #927). Runner stays focused on matrix
dispatch; tools handle format conversion. Considered native
\`--report-format allure\` but post-processor decouples runner from
Allure spec evolution.

## Outcome mapping

| Matrix | Allure | Reason |
|--------|--------|--------|
| \`pass\` | \`passed\` | direct |
| \`fail\` | \`failed\` | assertion-style |
| \`timeout\` | \`broken\` | environmental, Allure distinguishes |
| \`skip\` | \`skipped\` | init-error / device missing |
| unknown | \`broken\` | defensive fallback |

## Allure record fields

- \`uuid\` — deterministic SHA-256 per (browser, runStartMs); stable
  across re-emits, distinct across runs (trend lines)
- \`historyId\` = uuid (Allure trend stability)
- \`fullName\` = \`qa-matrix.<browser>\` (suite grouping)
- \`status\` + \`statusDetails.message\` (when non-passed)
- \`start\`/\`stop\` epoch ms (cursor advances from runStartMs by
  cumulative durationMs)
- \`labels\`: suite=qa-matrix, host=ci

## Test plan

- [x] 30 new tests in \`qa-allure-emit.test.js\`:
  - 11 pure helpers (outcome map, start/stop, labels, defensive)
  - 4 UUID determinism (idempotent, distinct, format)
  - 6 buildAllureResults (cursor, error paths, defaults)
  - 2 OUTCOME_TO_STATUS drift-catch
  - 2 formatUsage + readReport
  - 5 CLI integration
- [x] Full \`tests/scripts/\`: 5566 / 5566 green
- [x] Prettier + ESLint --max-warnings=0 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)