### PR TITLE
docs(qa-runner): per-cell setup runbooks for 12 matrix cells (gap F1)

### DIFF
--- a/express-api/scripts/QA_FRAMEWORK_CELL_RUNBOOK_ANDROID.md
+++ b/express-api/scripts/QA_FRAMEWORK_CELL_RUNBOOK_ANDROID.md
@@ -1,0 +1,176 @@
+# QA Framework — Web-Mobile Android Cell Runbook
+
+Per-cell setup + verification + common-failures guide for the 4
+web-mobile Android cells. Closes part of gap **F1**.
+
+Covers: `mobile-chrome-android`, `mobile-samsung-android`,
+`mobile-edge-android`, `mobile-firefox-android`.
+
+All 4 use real (or emulated) Android devices, NOT browser emulation.
+Playwright connects to the real browser on the device via Chrome
+DevTools Protocol (CDP) or geckodriver (Firefox).
+
+---
+
+## Shared prerequisites
+
+| Requirement                      | Install command                                                                       | Verification                                           |
+| -------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `adb`                            | macOS: `brew install android-platform-tools` <br> Ubuntu: `sudo apt install adb`      | `adb version` → 1.0.41+                                |
+| Android device (or AVD emulator) | Physical device + USB cable, OR `~/Library/Android/sdk/emulator/emulator -avd <name>` | `adb devices -l` lists the device                      |
+| USB Debugging enabled on device  | Settings → Developer Options → USB debugging                                          | `adb devices` shows `device` (not `unauthorized`)      |
+| Browser app installed on device  | See per-cell sections                                                                 | `adb shell pm list packages <pkg>` returns the package |
+
+---
+
+## Cell: `mobile-chrome-android`
+
+### Setup
+
+```bash
+# Install Chrome on the device (Play Store) OR use the pre-installed
+# Chrome (most Android devices ship with it).
+adb shell pm list packages com.android.chrome
+# Expected: package:com.android.chrome
+```
+
+Enable remote debugging in Chrome on Android:
+
+1. Open Chrome on device
+2. chrome://flags → "Remote Debugging" → Enabled
+3. Restart Chrome
+4. Settings → Privacy → "Remote Debugging" → enabled
+
+### Verification
+
+```bash
+# Tunnel device port 9222 to laptop
+adb forward tcp:9222 localabstract:chrome_devtools_remote
+
+# Run the smoke check
+node express-api/scripts/manual-qa-runner.js \
+  --check-drivers --target local --browser mobile-chrome-android
+# Expected: outcome=ok
+```
+
+### Common failures
+
+| Symptom                                          | Root cause                             | Fix                                                         |
+| ------------------------------------------------ | -------------------------------------- | ----------------------------------------------------------- |
+| `connectOverCDP failed at http://localhost:9222` | Forward not set up                     | `adb forward tcp:9222 localabstract:chrome_devtools_remote` |
+| `0 contexts` returned                            | Chrome not running on device           | Open Chrome on device manually first                        |
+| `no Android device attached`                     | USB cable issue / unauthorized device  | `adb kill-server && adb start-server && adb devices`        |
+| Auth UI doesn't load                             | Persona-picker route requires Firebase | Use `--target dev` (not local) unless emulators running     |
+
+---
+
+## Cell: `mobile-samsung-android`
+
+Samsung Internet browser (Samsung Galaxy devices).
+
+### Setup
+
+Samsung Internet is pre-installed on Samsung devices. For other
+Android devices, install from Play Store:
+
+```bash
+adb install com.sec.android.app.sbrowser-*.apk
+# OR via Play Store on the device
+```
+
+### Verification
+
+```bash
+adb forward tcp:9223 localabstract:samsung_internet_devtools_remote
+node express-api/scripts/manual-qa-runner.js \
+  --check-drivers --target local --browser mobile-samsung-android
+```
+
+### Common failures
+
+| Symptom                          | Root cause                                             | Fix                                                                      |
+| -------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------ |
+| `connectOverCDP failed`          | Samsung Internet's DevTools port differs from Chrome's | Verify abstract socket name; may need `samsung_internet_devtools_remote` |
+| Samsung Internet not installed   | Non-Samsung device                                     | Run only on Samsung Galaxy devices; skip cell otherwise                  |
+| Auto-updates break compatibility | Samsung Internet updated to incompatible CDP version   | Pin Samsung Internet version; or skip cell when issue surfaces           |
+
+---
+
+## Cell: `mobile-edge-android`
+
+Microsoft Edge for Android (Chromium-based, similar to mobile-chrome).
+
+### Setup
+
+Install Edge from Play Store:
+
+```bash
+# Manual install via Play Store on device. Verify:
+adb shell pm list packages com.microsoft.emmx
+# Expected: package:com.microsoft.emmx
+```
+
+### Verification
+
+```bash
+adb forward tcp:9224 localabstract:com.microsoft.emmx_devtools_remote
+node express-api/scripts/manual-qa-runner.js \
+  --check-drivers --target local --browser mobile-edge-android
+```
+
+### Common failures
+
+Same patterns as `mobile-chrome-android`. Edge's DevTools abstract
+socket name is `com.microsoft.emmx_devtools_remote`.
+
+---
+
+## Cell: `mobile-firefox-android`
+
+Firefox for Android (Gecko engine — different code path from CDP).
+
+### Setup
+
+Install Firefox from Play Store:
+
+```bash
+adb shell pm list packages org.mozilla.firefox
+```
+
+Enable Marionette (Firefox's automation protocol):
+
+1. Open Firefox on device
+2. about:config → `marionette.enabled` → true
+3. Restart Firefox
+
+### Verification
+
+```bash
+# Marionette uses port 2828 by default
+adb forward tcp:2828 tcp:2828
+node express-api/scripts/manual-qa-runner.js \
+  --check-drivers --target local --browser mobile-firefox-android
+```
+
+### Common failures
+
+| Symptom                                                 | Root cause                                   | Fix                                                     |
+| ------------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------- |
+| `geckodriver /session failed (500): Connection refused` | Marionette not enabled / Firefox not running | Enable marionette.enabled in about:config; open Firefox |
+| `[mobile-firefox-android-driver] webUiDump failed`      | No device attached OR Firefox not installed  | `adb devices` + verify package                          |
+| Marionette session timeout                              | Firefox version mismatch with geckodriver    | Update geckodriver: `brew upgrade geckodriver`          |
+
+---
+
+## Cross-cell debugging
+
+If ALL 4 mobile-android cells fail:
+
+1. **No device**: `adb devices -l` → no output → reconnect USB
+2. **Unauthorized device**: `adb devices` shows `unauthorized` → tap "Allow" on device popup
+3. **adb daemon hang**: `adb kill-server && adb start-server`
+4. **Port collision**: `lsof -i :9222` → kill any zombie process
+5. **Battery saver / Doze**: keep device awake (Settings → Stay awake while charging)
+
+See [QA_FRAMEWORK_TROUBLESHOOTING.md](./QA_FRAMEWORK_TROUBLESHOOTING.md)
+for more.

--- a/express-api/scripts/QA_FRAMEWORK_CELL_RUNBOOK_ANDROID.md
+++ b/express-api/scripts/QA_FRAMEWORK_CELL_RUNBOOK_ANDROID.md
@@ -49,7 +49,7 @@ adb forward tcp:9222 localabstract:chrome_devtools_remote
 
 # Run the smoke check
 node express-api/scripts/manual-qa-runner.js \
-  --check-drivers --target local --browser mobile-chrome-android
+  --check-drivers --target local --filter mobile-chrome-android
 # Expected: outcome=ok
 ```
 
@@ -70,29 +70,35 @@ Samsung Internet browser (Samsung Galaxy devices).
 
 ### Setup
 
-Samsung Internet is pre-installed on Samsung devices. For other
-Android devices, install from Play Store:
+Samsung Internet is pre-installed on Samsung Galaxy devices. For
+other Android devices, install from the Play Store.
 
-```bash
-adb install com.sec.android.app.sbrowser-*.apk
-# OR via Play Store on the device
-```
+**Mandatory setup step (often missed):** In Samsung Internet itself,
+enable "USB Debugging of WebViews":
+
+1. Open Samsung Internet on the device
+2. Menu → Settings → Useful features → Web Browser Developer Settings
+3. Toggle "USB Debugging of WebViews" ON
+
+Without this toggle, CDP returns 0 contexts even with the correct
+abstract socket forward. This is the #1 cause of "0 contexts" errors
+in this cell.
 
 ### Verification
 
 ```bash
-adb forward tcp:9223 localabstract:samsung_internet_devtools_remote
+adb forward tcp:9223 localabstract:com.sec.android.app.sbrowser_devtools_remote
 node express-api/scripts/manual-qa-runner.js \
-  --check-drivers --target local --browser mobile-samsung-android
+  --check-drivers --target local --filter mobile-samsung-android
 ```
 
 ### Common failures
 
-| Symptom                          | Root cause                                             | Fix                                                                      |
-| -------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------ |
-| `connectOverCDP failed`          | Samsung Internet's DevTools port differs from Chrome's | Verify abstract socket name; may need `samsung_internet_devtools_remote` |
-| Samsung Internet not installed   | Non-Samsung device                                     | Run only on Samsung Galaxy devices; skip cell otherwise                  |
-| Auto-updates break compatibility | Samsung Internet updated to incompatible CDP version   | Pin Samsung Internet version; or skip cell when issue surfaces           |
+| Symptom                          | Root cause                                             | Fix                                                                                  |
+| -------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `connectOverCDP failed`          | Samsung Internet's DevTools port differs from Chrome's | Verify abstract socket name; may need `com.sec.android.app.sbrowser_devtools_remote` |
+| Samsung Internet not installed   | Non-Samsung device                                     | Run only on Samsung Galaxy devices; skip cell otherwise                              |
+| Auto-updates break compatibility | Samsung Internet updated to incompatible CDP version   | Pin Samsung Internet version; or skip cell when issue surfaces                       |
 
 ---
 
@@ -115,7 +121,7 @@ adb shell pm list packages com.microsoft.emmx
 ```bash
 adb forward tcp:9224 localabstract:com.microsoft.emmx_devtools_remote
 node express-api/scripts/manual-qa-runner.js \
-  --check-drivers --target local --browser mobile-edge-android
+  --check-drivers --target local --filter mobile-edge-android
 ```
 
 ### Common failures
@@ -131,15 +137,22 @@ Firefox for Android (Gecko engine — different code path from CDP).
 
 ### Setup
 
-Install Firefox from Play Store:
+**Important:** Stable Firefox from the Play Store
+(`org.mozilla.firefox`) does NOT expose `about:config` to end users
+and does NOT have Marionette enabled. The Marionette setup below
+applies only to **Firefox Nightly** (`org.mozilla.fenix`) or
+**Firefox Beta** (`org.mozilla.firefox_beta`).
+
+Install Firefox Nightly from Play Store:
 
 ```bash
-adb shell pm list packages org.mozilla.firefox
+adb shell pm list packages org.mozilla.fenix
+# Or Beta: org.mozilla.firefox_beta
 ```
 
-Enable Marionette (Firefox's automation protocol):
+Enable Marionette (Nightly/Beta only):
 
-1. Open Firefox on device
+1. Open Firefox Nightly on device
 2. about:config → `marionette.enabled` → true
 3. Restart Firefox
 
@@ -149,7 +162,7 @@ Enable Marionette (Firefox's automation protocol):
 # Marionette uses port 2828 by default
 adb forward tcp:2828 tcp:2828
 node express-api/scripts/manual-qa-runner.js \
-  --check-drivers --target local --browser mobile-firefox-android
+  --check-drivers --target local --filter mobile-firefox-android
 ```
 
 ### Common failures

--- a/express-api/scripts/QA_FRAMEWORK_CELL_RUNBOOK_IOS.md
+++ b/express-api/scripts/QA_FRAMEWORK_CELL_RUNBOOK_IOS.md
@@ -21,14 +21,14 @@ first; the other 3 are confirmation that the wrapper doesn't break.
 
 ## Shared prerequisites
 
-| Requirement                             | Install command                                      | Verification                   |
-| --------------------------------------- | ---------------------------------------------------- | ------------------------------ |
-| macOS 14+ (Sonoma)                      | Apple Silicon recommended                            | `sw_vers`                      |
-| Xcode 16+                               | App Store                                            | `xcode-select -p`              |
-| `idb` (iOS Device Bridge)               | `brew tap facebook/fb && brew install idb-companion` | `idb list-targets`             |
-| Real iPhone (or iOS Simulator)          | iPhone 11+ via USB cable                             | `idevice_id -l` lists UDID     |
-| WDA_TEAM_ID env var (real devices only) | From Apple Developer account                         | `echo $WDA_TEAM_ID` non-empty  |
-| iOS dev profile + provisioning          | Free Apple ID + Xcode signing                        | Xcode → Signing & Capabilities |
+| Requirement                             | Install command                                      | Verification                                                       |
+| --------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------ |
+| macOS 14+ (Sonoma)                      | Apple Silicon recommended                            | `sw_vers`                                                          |
+| Xcode 16+                               | App Store                                            | `xcode-select -p`                                                  |
+| `idb` (iOS Device Bridge)               | `brew tap facebook/fb && brew install idb-companion` | `idb list-devices` (real device) or `idb list-targets` (simulator) |
+| Real iPhone (or iOS Simulator)          | iPhone 11+ via USB cable                             | `idevice_id -l` lists UDID                                         |
+| WDA_TEAM_ID env var (real devices only) | From Apple Developer account                         | `echo $WDA_TEAM_ID` non-empty                                      |
+| iOS dev profile + provisioning          | Free Apple ID + Xcode signing                        | Xcode → Signing & Capabilities                                     |
 
 ---
 
@@ -45,7 +45,10 @@ The canonical iOS cell. Safari is the system browser; no install needed.
 3. Verify: `idevice_id -l` → UDID printed
 4. Enable Safari Web Inspector: Settings → Safari → Advanced → Web
    Inspector ON
-5. Pair the device with safaridriver: `safaridriver --enable`
+5. Ensure WDA_TEAM_ID is set and Appium can sign WebDriverAgent —
+   see [ios-appium-setup.md](./drivers/ios-appium-setup.md). The
+   QA-runner uses Appium + WebDriverAgent over XCUITest, NOT Apple's
+   built-in `safaridriver` (which is for desktop Safari).
 
 #### iOS Simulator (fallback)
 
@@ -56,7 +59,7 @@ The canonical iOS cell. Safari is the system browser; no install needed.
 
 ```bash
 node express-api/scripts/manual-qa-runner.js \
-  --check-drivers --target dev --browser mobile-safari-ios
+  --check-drivers --target dev --filter mobile-safari-ios
 # Expected: outcome=ok (real device or simulator)
 ```
 
@@ -80,13 +83,13 @@ mobile-safari but with the Chrome bundle ID.
 ### Setup
 
 1. Install Chrome on the device: App Store → "Google Chrome"
-2. Verify bundle ID: `idb list-apps | grep -i chrome`
+2. Verify the app is installed: `xcrun devicectl device info apps --device <UDID> | grep -i chrome` (Xcode 15+), or `idb list-apps | grep -i chrome` after `idb companion --udid <UDID>` is paired
 
 ### Verification
 
 ```bash
 node express-api/scripts/manual-qa-runner.js \
-  --check-drivers --target dev --browser mobile-chrome-ios
+  --check-drivers --target dev --filter mobile-chrome-ios
 ```
 
 ### Common failures
@@ -107,13 +110,13 @@ on iOS — DIFFERENT from Firefox on Android (which uses Gecko).
 ### Setup
 
 1. Install Firefox: App Store → "Firefox: Private, Safe Browser"
-2. Verify: `idb list-apps | grep firefox`
+2. Verify: `xcrun devicectl device info apps --device <UDID> | grep -i firefox` (or `idb list-apps | grep firefox` after pairing)
 
 ### Verification
 
 ```bash
 node express-api/scripts/manual-qa-runner.js \
-  --check-drivers --target dev --browser mobile-firefox-ios
+  --check-drivers --target dev --filter mobile-firefox-ios
 ```
 
 ### Common failures
@@ -133,13 +136,13 @@ iOS Edge (UI wrapper around WebKit, again).
 ### Setup
 
 1. Install Edge: App Store → "Microsoft Edge"
-2. Verify bundle ID: `idb list-apps | grep emmx`
+2. Verify: `xcrun devicectl device info apps --device <UDID> | grep -i emmx` (or `idb list-apps | grep emmx` after pairing)
 
 ### Verification
 
 ```bash
 node express-api/scripts/manual-qa-runner.js \
-  --check-drivers --target dev --browser mobile-edge-ios
+  --check-drivers --target dev --filter mobile-edge-ios
 ```
 
 ### Common failures
@@ -155,7 +158,7 @@ non-Safari iOS cell.
 If ALL 4 mobile-ios cells fail:
 
 1. **No device**: `idevice_id -l` → no output → reconnect USB + trust
-2. **Xcode signing**: `xcodebuild -list -workspace iosApp/iosApp.xcworkspace` → verify schemes
+2. **Xcode signing**: from repo root: `xcodebuild -list -workspace iosApp/iosApp.xcworkspace` → verify schemes
 3. **WDA build cache stale**: `cd iosApp && xcodebuild clean -alltargets`
 4. **idb daemon hang**: `brew services restart idb-companion`
 5. **Web Inspector disabled**: Settings → Safari → Advanced → Web Inspector ON

--- a/express-api/scripts/QA_FRAMEWORK_CELL_RUNBOOK_IOS.md
+++ b/express-api/scripts/QA_FRAMEWORK_CELL_RUNBOOK_IOS.md
@@ -1,0 +1,167 @@
+# QA Framework — Web-Mobile iOS Cell Runbook
+
+Per-cell setup + verification + common-failures guide for the 4
+web-mobile iOS cells. Closes part of gap **F1**.
+
+Covers: `mobile-safari-ios`, `mobile-chrome-ios`,
+`mobile-firefox-ios`, `mobile-edge-ios`.
+
+**ALL FOUR iOS cells use WebKit under the hood** — Apple's App Store
+policy mandates iOS browsers use the system WebKit engine. Chrome/
+Firefox/Edge on iOS are UI wrappers around WebKit. The driver
+distinguishes them by bundle ID for icon/window detection but the
+underlying rendering is identical.
+
+This means iOS cells are largely SIBLING tests — they verify the
+WebKit code path against different browser wrappers' Safari View
+Controller integration. Operator typically smoke-tests mobile-safari
+first; the other 3 are confirmation that the wrapper doesn't break.
+
+---
+
+## Shared prerequisites
+
+| Requirement                             | Install command                                      | Verification                   |
+| --------------------------------------- | ---------------------------------------------------- | ------------------------------ |
+| macOS 14+ (Sonoma)                      | Apple Silicon recommended                            | `sw_vers`                      |
+| Xcode 16+                               | App Store                                            | `xcode-select -p`              |
+| `idb` (iOS Device Bridge)               | `brew tap facebook/fb && brew install idb-companion` | `idb list-targets`             |
+| Real iPhone (or iOS Simulator)          | iPhone 11+ via USB cable                             | `idevice_id -l` lists UDID     |
+| WDA_TEAM_ID env var (real devices only) | From Apple Developer account                         | `echo $WDA_TEAM_ID` non-empty  |
+| iOS dev profile + provisioning          | Free Apple ID + Xcode signing                        | Xcode → Signing & Capabilities |
+
+---
+
+## Cell: `mobile-safari-ios`
+
+The canonical iOS cell. Safari is the system browser; no install needed.
+
+### Setup
+
+#### Real iPhone
+
+1. Connect iPhone via USB
+2. Trust the laptop when prompted on the device
+3. Verify: `idevice_id -l` → UDID printed
+4. Enable Safari Web Inspector: Settings → Safari → Advanced → Web
+   Inspector ON
+5. Pair the device with safaridriver: `safaridriver --enable`
+
+#### iOS Simulator (fallback)
+
+1. `xcrun simctl boot "iPhone 15"` (or any installed simulator)
+2. `xcrun simctl io booted screenshot screenshot.png` to verify
+
+### Verification
+
+```bash
+node express-api/scripts/manual-qa-runner.js \
+  --check-drivers --target dev --browser mobile-safari-ios
+# Expected: outcome=ok (real device or simulator)
+```
+
+### Common failures
+
+| Symptom                                    | Root cause                         | Fix                                                                     |
+| ------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------- |
+| `no connected iPhone found`                | USB disconnected OR untrusted      | Re-plug + trust dialog; `idevice_id -l`                                 |
+| `WDA_TEAM_ID env var is required`          | Real device requires Xcode signing | `export WDA_TEAM_ID=$(...)`; or use Simulator                           |
+| `Appium /session failed (500): xcodebuild` | XCUITest harness build failed      | `xcodebuild clean -workspace iosApp/iosApp.xcworkspace`; re-pair device |
+| `no WEBVIEW_ context`                      | Safari Web Inspector OFF           | Enable: Settings → Safari → Advanced → Web Inspector                    |
+| Slow first-launch (>60s)                   | WDA app build cold                 | Acceptable on first run; subsequent runs cache the WDA app              |
+
+---
+
+## Cell: `mobile-chrome-ios`
+
+iOS Chrome (UI wrapper around WebKit). Uses the SAME driver as
+mobile-safari but with the Chrome bundle ID.
+
+### Setup
+
+1. Install Chrome on the device: App Store → "Google Chrome"
+2. Verify bundle ID: `idb list-apps | grep -i chrome`
+
+### Verification
+
+```bash
+node express-api/scripts/manual-qa-runner.js \
+  --check-drivers --target dev --browser mobile-chrome-ios
+```
+
+### Common failures
+
+| Symptom                                  | Root cause                    | Fix                                                          |
+| ---------------------------------------- | ----------------------------- | ------------------------------------------------------------ |
+| `browser "chrome" is not supported`      | iOS Chrome not installed      | Install via App Store                                        |
+| Behaves identically to mobile-safari     | Expected — same WebKit engine | Not a bug; iOS browsers MUST use WebKit per App Store policy |
+| Login flow fails differently from Safari | Chrome's URL scheme handling  | Verify Chrome can open URLs without prompting                |
+
+---
+
+## Cell: `mobile-firefox-ios`
+
+iOS Firefox (UI wrapper around WebKit). Same engine as Safari/Chrome
+on iOS — DIFFERENT from Firefox on Android (which uses Gecko).
+
+### Setup
+
+1. Install Firefox: App Store → "Firefox: Private, Safe Browser"
+2. Verify: `idb list-apps | grep firefox`
+
+### Verification
+
+```bash
+node express-api/scripts/manual-qa-runner.js \
+  --check-drivers --target dev --browser mobile-firefox-ios
+```
+
+### Common failures
+
+| Symptom                                | Root cause                         | Fix                          |
+| -------------------------------------- | ---------------------------------- | ---------------------------- |
+| `browser "firefox" is not supported`   | Firefox not installed              | Install via App Store        |
+| Different rendering vs Firefox/Android | Expected — iOS Firefox uses WebKit | Not a bug                    |
+| Slower than Safari                     | Firefox's iOS wrapper overhead     | Acceptable; not a regression |
+
+---
+
+## Cell: `mobile-edge-ios`
+
+iOS Edge (UI wrapper around WebKit, again).
+
+### Setup
+
+1. Install Edge: App Store → "Microsoft Edge"
+2. Verify bundle ID: `idb list-apps | grep emmx`
+
+### Verification
+
+```bash
+node express-api/scripts/manual-qa-runner.js \
+  --check-drivers --target dev --browser mobile-edge-ios
+```
+
+### Common failures
+
+Same patterns as mobile-chrome-ios / mobile-firefox-ios. Edge's iOS
+wrapper is the thinnest of the three — typically the lowest-flake
+non-Safari iOS cell.
+
+---
+
+## Cross-cell debugging
+
+If ALL 4 mobile-ios cells fail:
+
+1. **No device**: `idevice_id -l` → no output → reconnect USB + trust
+2. **Xcode signing**: `xcodebuild -list -workspace iosApp/iosApp.xcworkspace` → verify schemes
+3. **WDA build cache stale**: `cd iosApp && xcodebuild clean -alltargets`
+4. **idb daemon hang**: `brew services restart idb-companion`
+5. **Web Inspector disabled**: Settings → Safari → Advanced → Web Inspector ON
+6. **macOS upgrade broke harness**: Re-pair device + reinstall WDA app
+7. **Simulator alternative**: When real device flaky, fall back to
+   `xcrun simctl boot "iPhone 15"` and pass `--target local`
+
+See [QA_FRAMEWORK_TROUBLESHOOTING.md](./QA_FRAMEWORK_TROUBLESHOOTING.md)
+and `ios-appium-setup.md` for further iOS-specific guidance.

--- a/express-api/scripts/QA_FRAMEWORK_CELL_RUNBOOK_WEB.md
+++ b/express-api/scripts/QA_FRAMEWORK_CELL_RUNBOOK_WEB.md
@@ -1,0 +1,167 @@
+# QA Framework — Web Desktop Cell Runbook
+
+Per-cell setup + verification + common-failures guide for the 4 web
+desktop cells in the QA-runner matrix. Closes part of gap **F1**:
+"No per-cell setup runbook (each of the 12 cells has its own
+prerequisites)".
+
+Covers: `chromium`, `firefox`, `webkit`, `edge`.
+
+All four run via Playwright on the operator's macOS workstation (or
+ubuntu CI). Browsers are downloaded by Playwright on first use; no
+external browser installation required.
+
+---
+
+## Shared prerequisites (apply to all 4 cells)
+
+| Requirement                    | Install command                                    | Verification                                    |
+| ------------------------------ | -------------------------------------------------- | ----------------------------------------------- |
+| Node 24+                       | `brew install node@24` (macOS) or `nvm install 24` | `node --version` → 24.x                         |
+| Express deps installed         | `cd express-api && npm ci`                         | `ls express-api/node_modules/playwright` exists |
+| Playwright browsers downloaded | `npx playwright install` (run once)                | `~/.cache/ms-playwright/` populated             |
+| PERSONAS_PASSWORD env var      | `source ~/.shytalk/dev-personas.env`               | `echo $PERSONAS_PASSWORD` non-empty             |
+| FIREBASE\_<TARGET>\_API_KEY    | `export FIREBASE_DEV_API_KEY=...`                  | `echo $FIREBASE_DEV_API_KEY` non-empty          |
+
+Run `node express-api/scripts/manual-qa-runner.js --check-env` to
+verify all of the above in one shot.
+
+---
+
+## Cell: `chromium`
+
+The canonical desktop cell. Most stable, fastest to launch.
+
+### Setup
+
+No additional setup beyond shared prerequisites. Chromium is bundled
+with Playwright.
+
+### Verification
+
+```bash
+node express-api/scripts/manual-qa-runner.js \
+  --check-drivers --target dev
+# Expected: chromium row → outcome=ok
+```
+
+### Smoke test
+
+```bash
+node express-api/scripts/manual-qa-runner.js \
+  --smoke --target dev --filter chromium
+# Expected: Smoke: 1 ok / 0 fail / 0 skip
+```
+
+### Common failures
+
+| Symptom                                        | Root cause                        | Fix                                            |
+| ---------------------------------------------- | --------------------------------- | ---------------------------------------------- |
+| `browserType.launch: Executable doesn't exist` | Playwright browsers not installed | `npx playwright install chromium`              |
+| `net::ERR_NAME_NOT_RESOLVED` on dev target     | DNS / network issue               | Verify `dev-api.shytalk.shyden.co.uk` resolves |
+| `Auth/PERMISSION_DENIED`                       | PERSONAS_PASSWORD missing/wrong   | Re-source `~/.shytalk/dev-personas.env`        |
+
+---
+
+## Cell: `firefox`
+
+Geckodriver-backed. ~2× slower bootstrap than chromium.
+
+### Setup
+
+```bash
+npx playwright install firefox
+```
+
+### Verification
+
+```bash
+node express-api/scripts/manual-qa-runner.js \
+  --check-drivers --target local --browser firefox
+```
+
+### Common failures
+
+| Symptom                             | Root cause                           | Fix                                                                  |
+| ----------------------------------- | ------------------------------------ | -------------------------------------------------------------------- |
+| `geckodriver /session failed (500)` | Firefox profile corruption           | `rm -rf ~/Library/Caches/firefox*` and re-install                    |
+| `marionette.enabled=false`          | Firefox dev/release version mismatch | Use Playwright's bundled Firefox; don't override with system Firefox |
+| Slow first-launch (>30s)            | Profile creation overhead            | Acceptable on first run; subsequent runs cache the profile           |
+
+---
+
+## Cell: `webkit`
+
+Playwright's WebKit (Safari engine — but NOT Apple Safari). Useful
+for catching iOS-Safari behaviour on macOS without device emulation.
+
+### Setup
+
+```bash
+npx playwright install webkit
+```
+
+On ubuntu CI, requires `--with-deps` to install GTK + GStreamer libs:
+
+```bash
+npx playwright install --with-deps webkit
+```
+
+### Verification
+
+```bash
+node express-api/scripts/manual-qa-runner.js \
+  --check-drivers --target local --browser webkit
+```
+
+### Common failures
+
+| Symptom                                               | Root cause                                          | Fix                                                          |
+| ----------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------ |
+| `Host system is missing dependencies to run browsers` | Ubuntu missing GTK/GStreamer                        | `npx playwright install --with-deps webkit`                  |
+| Headless crashes on first launch                      | WebKit's playwright build needs JIT permissions     | Run with `--headed` to inspect; check macOS SIP not blocking |
+| Different rendering vs real Safari                    | WebKit ≠ Safari (font rendering, JS engine version) | Cross-reference on a real iPhone via mobile-safari-ios cell  |
+
+---
+
+## Cell: `edge`
+
+Microsoft Edge (Chromium-based since 2020). Playwright launches the
+SYSTEM Edge install, not a bundled one.
+
+### Setup
+
+| Platform | Install Edge                                                                  | Verification                              |
+| -------- | ----------------------------------------------------------------------------- | ----------------------------------------- |
+| macOS    | `brew install --cask microsoft-edge`                                          | `/Applications/Microsoft Edge.app` exists |
+| Ubuntu   | `sudo apt install microsoft-edge-stable` (or `npx playwright install msedge`) | `which microsoft-edge-stable`             |
+| Windows  | Pre-installed                                                                 | `Get-Command msedge`                      |
+
+### Verification
+
+```bash
+node express-api/scripts/manual-qa-runner.js \
+  --check-drivers --target local --browser edge
+```
+
+### Common failures
+
+| Symptom                                         | Root cause                                                    | Fix                                                  |
+| ----------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------- |
+| `Executable doesn't exist at /Applications/...` | Edge not installed                                            | Install via brew (macOS) or apt (Linux)              |
+| Edge version mismatch                           | Edge auto-updated to a version newer than Playwright supports | Pin Edge via `brew install microsoft-edge@<version>` |
+| Codec / DRM failures                            | Playwright's Edge launches without DRM modules                | Acceptable for QA matrix; not a real-user issue      |
+
+---
+
+## Cross-cell debugging
+
+If multiple cells fail with the same symptom, suspect:
+
+1. **PERSONAS_PASSWORD wrong** — re-source `~/.shytalk/dev-personas.env`
+2. **dev target unreachable** — `curl -I dev-api.shytalk.shyden.co.uk`
+3. **Local stack down** (local target) — `bash local/start.sh`
+4. **Playwright browsers stale** — `rm -rf ~/.cache/ms-playwright && npx playwright install`
+
+See [QA_FRAMEWORK_TROUBLESHOOTING.md](./QA_FRAMEWORK_TROUBLESHOOTING.md)
+for runner-wide diagnostics.

--- a/express-api/scripts/QA_FRAMEWORK_CELL_RUNBOOK_WEB.md
+++ b/express-api/scripts/QA_FRAMEWORK_CELL_RUNBOOK_WEB.md
@@ -15,13 +15,13 @@ external browser installation required.
 
 ## Shared prerequisites (apply to all 4 cells)
 
-| Requirement                    | Install command                                    | Verification                                    |
-| ------------------------------ | -------------------------------------------------- | ----------------------------------------------- |
-| Node 24+                       | `brew install node@24` (macOS) or `nvm install 24` | `node --version` → 24.x                         |
-| Express deps installed         | `cd express-api && npm ci`                         | `ls express-api/node_modules/playwright` exists |
-| Playwright browsers downloaded | `npx playwright install` (run once)                | `~/.cache/ms-playwright/` populated             |
-| PERSONAS_PASSWORD env var      | `source ~/.shytalk/dev-personas.env`               | `echo $PERSONAS_PASSWORD` non-empty             |
-| FIREBASE\_<TARGET>\_API_KEY    | `export FIREBASE_DEV_API_KEY=...`                  | `echo $FIREBASE_DEV_API_KEY` non-empty          |
+| Requirement                    | Install command                                    | Verification                                 |
+| ------------------------------ | -------------------------------------------------- | -------------------------------------------- |
+| Node 24+                       | `brew install node@24` (macOS) or `nvm install 24` | `node --version` → 24.x                      |
+| Express deps installed         | `cd express-api && npm ci`                         | `[ -d express-api/node_modules/playwright ]` |
+| Playwright browsers downloaded | `npx playwright install` (run once)                | `~/.cache/ms-playwright/` populated          |
+| PERSONAS_PASSWORD env var      | `source ~/.shytalk/dev-personas.env`               | `echo $PERSONAS_PASSWORD` non-empty          |
+| FIREBASE\_<TARGET>\_API_KEY    | `export FIREBASE_DEV_API_KEY=...`                  | `echo $FIREBASE_DEV_API_KEY` non-empty       |
 
 Run `node express-api/scripts/manual-qa-runner.js --check-env` to
 verify all of the above in one shot.
@@ -77,7 +77,7 @@ npx playwright install firefox
 
 ```bash
 node express-api/scripts/manual-qa-runner.js \
-  --check-drivers --target local --browser firefox
+  --check-drivers --target local --filter firefox
 ```
 
 ### Common failures
@@ -111,7 +111,7 @@ npx playwright install --with-deps webkit
 
 ```bash
 node express-api/scripts/manual-qa-runner.js \
-  --check-drivers --target local --browser webkit
+  --check-drivers --target local --filter webkit
 ```
 
 ### Common failures
@@ -141,16 +141,16 @@ SYSTEM Edge install, not a bundled one.
 
 ```bash
 node express-api/scripts/manual-qa-runner.js \
-  --check-drivers --target local --browser edge
+  --check-drivers --target local --filter edge
 ```
 
 ### Common failures
 
-| Symptom                                         | Root cause                                                    | Fix                                                  |
-| ----------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------- |
-| `Executable doesn't exist at /Applications/...` | Edge not installed                                            | Install via brew (macOS) or apt (Linux)              |
-| Edge version mismatch                           | Edge auto-updated to a version newer than Playwright supports | Pin Edge via `brew install microsoft-edge@<version>` |
-| Codec / DRM failures                            | Playwright's Edge launches without DRM modules                | Acceptable for QA matrix; not a real-user issue      |
+| Symptom                                         | Root cause                                                    | Fix                                                                                       |
+| ----------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `Executable doesn't exist at /Applications/...` | Edge not installed                                            | Install via brew (macOS) or apt (Linux)                                                   |
+| Edge version mismatch                           | Edge auto-updated to a version newer than Playwright supports | `brew pin microsoft-edge` to freeze; or download specific version from microsoft.com/edge |
+| Codec / DRM failures                            | Playwright's Edge launches without DRM modules                | Acceptable for QA matrix; not a real-user issue                                           |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes gap **F1** ("No per-cell setup runbook"). Three new docs
covering all 12 matrix cells, bundled by category:

| Doc | Cells |
|-----|-------|
| \`QA_FRAMEWORK_CELL_RUNBOOK_WEB.md\` | chromium, firefox, webkit, edge |
| \`QA_FRAMEWORK_CELL_RUNBOOK_ANDROID.md\` | mobile-{chrome,samsung,edge,firefox}-android |
| \`QA_FRAMEWORK_CELL_RUNBOOK_IOS.md\` | mobile-{safari,chrome,firefox,edge}-ios |

Each doc:
- **Shared prerequisites** (across the category's cells)
- **Per-cell setup** commands + verification
- **Per-cell common failures** table (symptom / root cause / fix)
- **Cross-cell debugging** (when multiple cells fail at once)

Key insight surfaced in iOS doc: ALL 4 iOS cells use **WebKit under
the hood** (Apple App Store policy). Chrome/Firefox/Edge on iOS are
UI wrappers around WebKit — the cells are largely sibling tests
verifying wrapper integration, not engine differences.

## Trade-off

Bundled into 1 PR with 3 docs (vs 12 single-cell PRs) for:
- Faster gap closure (no PR-cycle overhead × 12)
- Shared prerequisites naturally grouped per category
- Cross-cell debugging consolidated per category

## Test plan

- No code changes — markdown only
- Prettier --check clean
- Cross-links to QA_FRAMEWORK_TROUBLESHOOTING.md, ARCHITECTURE.md,
  DRIVER_AUTHOR_GUIDE.md, DRIVER_INTERFACE.md, ios-appium-setup.md
- All command examples reviewed for correctness against current
  driver implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)