### PR TITLE
feat(qa-runner): per-cell screenshot on scenario failure (gap C3)

### DIFF
--- a/express-api/scripts/driver-surface-report.js
+++ b/express-api/scripts/driver-surface-report.js
@@ -28,7 +28,11 @@ const fs = require('fs');
 const path = require('path');
 
 const DRIVERS_DIR = path.join(__dirname, 'drivers');
-const HELPER_FILES = new Set(['android-cdp-helpers.js', 'ios-driver-loader.js']);
+const HELPER_FILES = new Set([
+  'android-cdp-helpers.js',
+  'ios-driver-loader.js',
+  'driver-screenshot-helper.js',
+]);
 
 function discoverDrivers() {
   return fs

--- a/express-api/scripts/drivers/driver-screenshot-helper.js
+++ b/express-api/scripts/drivers/driver-screenshot-helper.js
@@ -1,0 +1,68 @@
+/**
+ * driver-screenshot-helper.js
+ *
+ * Shared `takeScreenshot(pages, outputDir, slug)` for the web-playwright
+ * base driver + the 6 web-mobile wrapper drivers (gap C3 — per-cell
+ * screenshot capture on failure).
+ *
+ * Each driver maintains a `pages` Map (persona name → Playwright Page).
+ * This helper iterates the map and writes one PNG per persona to
+ * `outputDir`, named `screenshot-<slug>-<persona>.png`. The slug is
+ * the driver's matrix-cell slug (e.g. "chromium", "mobile-chrome-
+ * android", "mobile-firefox-ios") so artifacts from different cells
+ * don't collide in a shared report-dir.
+ *
+ * Best-effort semantics:
+ *   - Falsy outputDir → returns [] (operator didn't pass --report-dir)
+ *   - One persona's screenshot failure does NOT block the others
+ *   - Caller MUST call this BEFORE driver.close() (closed browsers
+ *     can't screenshot)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+async function takeScreenshotForPages(pages, outputDir, slug) {
+  if (!outputDir) return [];
+  fs.mkdirSync(outputDir, { recursive: true });
+  const saved = [];
+  for (const [name, page] of pages.entries()) {
+    try {
+      const filename = `screenshot-${slug}-${name}.png`;
+      const fullPath = path.join(outputDir, filename);
+      await page.screenshot({ path: fullPath, fullPage: true });
+      saved.push(fullPath);
+    } catch (_e) {
+      /* best-effort: one persona's failure doesn't block the others */
+    }
+  }
+  return saved;
+}
+
+/**
+ * Appium-flavoured screenshot. iOS wrappers (mobile-safari-ios,
+ * mobile-webkit-ios) drive via Appium's HTTP API, not Playwright
+ * pages — so they POST to `/session/<sid>/screenshot` and decode the
+ * base64 PNG response. One file per session (Appium doesn't expose
+ * a per-persona-page concept on iOS the way Playwright does).
+ */
+async function takeScreenshotViaAppium({ appiumBaseUrl, sessionId, fetchImpl, outputDir, slug }) {
+  if (!outputDir || !sessionId) return [];
+  fs.mkdirSync(outputDir, { recursive: true });
+  try {
+    const r = await fetchImpl(`${appiumBaseUrl}/session/${sessionId}/screenshot`);
+    if (!r.ok) return [];
+    const body = await r.json();
+    const base64 = body && body.value;
+    if (!base64) return [];
+    const filename = `screenshot-${slug}-default.png`;
+    const fullPath = path.join(outputDir, filename);
+    fs.writeFileSync(fullPath, Buffer.from(base64, 'base64'));
+    return [fullPath];
+  } catch (_e) {
+    /* best-effort */
+    return [];
+  }
+}
+
+module.exports = { takeScreenshotForPages, takeScreenshotViaAppium };

--- a/express-api/scripts/drivers/driver-screenshot-helper.js
+++ b/express-api/scripts/drivers/driver-screenshot-helper.js
@@ -12,23 +12,56 @@
  * android", "mobile-firefox-ios") so artifacts from different cells
  * don't collide in a shared report-dir.
  *
- * Best-effort semantics:
+ * Best-effort semantics — the function MUST NEVER throw:
  *   - Falsy outputDir → returns [] (operator didn't pass --report-dir)
+ *   - mkdir failure (EACCES, EROFS, disk full) → returns []
  *   - One persona's screenshot failure does NOT block the others
  *   - Caller MUST call this BEFORE driver.close() (closed browsers
  *     can't screenshot)
+ *
+ * Scenario-collision policy: the runner is responsible for passing a
+ * scenario-unique outputDir (e.g. `<reportDir>/scenario-<idx>/`) so
+ * multiple failing scenarios in the same feature don't overwrite each
+ * other's PNGs. This helper does not encode scenario index into the
+ * filename itself.
  */
 
 const fs = require('fs');
 const path = require('path');
 
+/**
+ * Defensive: persona keys come from driver-controlled `pages` Maps.
+ * In practice they're "Alice"/"Bob"/etc. from operator-written feature
+ * files, but `path.join(outputDir, untrustedKey)` resolves `..`
+ * segments and could escape outputDir if conventions change. Strip
+ * to a conservative filename-safe charset.
+ */
+function safeFilenamePart(s) {
+  return String(s).replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+/**
+ * Best-effort recursive mkdir. Returns true on success, false on any
+ * failure — never throws. Keeps the outer helpers' best-effort
+ * contract intact when EACCES/EROFS/disk-full hits before the
+ * per-iteration try/catch.
+ */
+function ensureDirSafe(outputDir) {
+  try {
+    fs.mkdirSync(outputDir, { recursive: true });
+    return true;
+  } catch (_e) {
+    return false;
+  }
+}
+
 async function takeScreenshotForPages(pages, outputDir, slug) {
   if (!outputDir) return [];
-  fs.mkdirSync(outputDir, { recursive: true });
+  if (!ensureDirSafe(outputDir)) return [];
   const saved = [];
   for (const [name, page] of pages.entries()) {
     try {
-      const filename = `screenshot-${slug}-${name}.png`;
+      const filename = `screenshot-${slug}-${safeFilenamePart(name)}.png`;
       const fullPath = path.join(outputDir, filename);
       await page.screenshot({ path: fullPath, fullPage: true });
       saved.push(fullPath);
@@ -40,21 +73,26 @@ async function takeScreenshotForPages(pages, outputDir, slug) {
 }
 
 /**
- * Appium-flavoured screenshot. iOS wrappers (mobile-safari-ios,
- * mobile-webkit-ios) drive via Appium's HTTP API, not Playwright
- * pages — so they POST to `/session/<sid>/screenshot` and decode the
- * base64 PNG response. One file per session (Appium doesn't expose
- * a per-persona-page concept on iOS the way Playwright does).
+ * W3C WebDriver HTTP screenshot. Used by:
+ *   - firefox-android via Geckodriver (port 4444)
+ *   - safari-ios + webkit-ios via Appium (port 4723)
+ *
+ * Both speak the same W3C `/session/<sid>/screenshot` endpoint and
+ * return `{value: <base64-png>}`. The name "ViaAppium" is historical
+ * — the helper works for any W3C-compliant HTTP driver.
+ *
+ * One file per session (W3C HTTP drivers don't expose a per-persona-
+ * page concept like Playwright does).
  */
 async function takeScreenshotViaAppium({ appiumBaseUrl, sessionId, fetchImpl, outputDir, slug }) {
   if (!outputDir || !sessionId) return [];
-  fs.mkdirSync(outputDir, { recursive: true });
+  if (!ensureDirSafe(outputDir)) return [];
   try {
     const r = await fetchImpl(`${appiumBaseUrl}/session/${sessionId}/screenshot`);
     if (!r.ok) return [];
     const body = await r.json();
     const base64 = body && body.value;
-    if (!base64) return [];
+    if (!base64 || typeof base64 !== 'string') return [];
     const filename = `screenshot-${slug}-default.png`;
     const fullPath = path.join(outputDir, filename);
     fs.writeFileSync(fullPath, Buffer.from(base64, 'base64'));
@@ -65,4 +103,9 @@ async function takeScreenshotViaAppium({ appiumBaseUrl, sessionId, fetchImpl, ou
   }
 }
 
-module.exports = { takeScreenshotForPages, takeScreenshotViaAppium };
+module.exports = {
+  takeScreenshotForPages,
+  takeScreenshotViaAppium,
+  safeFilenamePart,
+  ensureDirSafe,
+};

--- a/express-api/scripts/drivers/web-mobile-chrome-android-driver.js
+++ b/express-api/scripts/drivers/web-mobile-chrome-android-driver.js
@@ -194,6 +194,14 @@ async function createMobileChromeAndroidDriver({
     }
   };
 
+  // takeScreenshot — gap C3. Delegates to shared helper.
+  driver.takeScreenshot = async (outputDir) =>
+    require('./driver-screenshot-helper').takeScreenshotForPages(
+      pages,
+      outputDir,
+      'mobile-chrome-android',
+    );
+
   driver.close = async () => {
     for (const p of pages.values()) {
       try {
@@ -216,7 +224,7 @@ async function createMobileChromeAndroidDriver({
 // Canonical method surface — the runner-vocabulary methods this driver
 // implements (close() is intentionally excluded; it's lifecycle, not a
 // runner step-binding). Pinned by tests/scripts/drivers/driver-contract.test.js.
-const WEB_MOBILE_METHOD_NAMES = ['webRefreshRoomsList', 'webUiDump'];
+const WEB_MOBILE_METHOD_NAMES = ['webRefreshRoomsList', 'webUiDump', 'takeScreenshot'];
 
 function listMethods() {
   return [...new Set(WEB_MOBILE_METHOD_NAMES)].sort();

--- a/express-api/scripts/drivers/web-mobile-edge-android-driver.js
+++ b/express-api/scripts/drivers/web-mobile-edge-android-driver.js
@@ -139,6 +139,14 @@ async function createMobileEdgeAndroidDriver({
     }
   };
 
+  // takeScreenshot — gap C3. Delegates to shared helper.
+  driver.takeScreenshot = async (outputDir) =>
+    require('./driver-screenshot-helper').takeScreenshotForPages(
+      pages,
+      outputDir,
+      'mobile-edge-android',
+    );
+
   driver.close = async () => {
     for (const p of pages.values()) {
       try {
@@ -159,7 +167,7 @@ async function createMobileEdgeAndroidDriver({
 }
 
 // Canonical method surface — pinned by driver-contract.test.js.
-const WEB_MOBILE_METHOD_NAMES = ['webRefreshRoomsList', 'webUiDump'];
+const WEB_MOBILE_METHOD_NAMES = ['webRefreshRoomsList', 'webUiDump', 'takeScreenshot'];
 
 function listMethods() {
   return [...new Set(WEB_MOBILE_METHOD_NAMES)].sort();

--- a/express-api/scripts/drivers/web-mobile-firefox-android-driver.js
+++ b/express-api/scripts/drivers/web-mobile-firefox-android-driver.js
@@ -290,6 +290,19 @@ async function createMobileFirefoxAndroidDriver({
     }
   };
 
+  // takeScreenshot — gap C3. Geckodriver exposes the W3C
+  // /session/<sid>/screenshot endpoint (same shape as Appium), so we
+  // reuse takeScreenshotViaAppium (despite the name, the helper works
+  // for any W3C WebDriver HTTP impl that returns {value: <base64>}).
+  driver.takeScreenshot = async (outputDir) =>
+    require('./driver-screenshot-helper').takeScreenshotViaAppium({
+      appiumBaseUrl: `http://127.0.0.1:${port}`,
+      sessionId: _sessionId,
+      fetchImpl,
+      outputDir,
+      slug: 'mobile-firefox-android',
+    });
+
   driver.close = async () => {
     if (_sessionId) {
       try {
@@ -312,7 +325,7 @@ async function createMobileFirefoxAndroidDriver({
 }
 
 // Canonical method surface — pinned by driver-contract.test.js.
-const WEB_MOBILE_METHOD_NAMES = ['webRefreshRoomsList', 'webUiDump'];
+const WEB_MOBILE_METHOD_NAMES = ['webRefreshRoomsList', 'webUiDump', 'takeScreenshot'];
 
 function listMethods() {
   return [...new Set(WEB_MOBILE_METHOD_NAMES)].sort();

--- a/express-api/scripts/drivers/web-mobile-safari-ios-driver.js
+++ b/express-api/scripts/drivers/web-mobile-safari-ios-driver.js
@@ -206,6 +206,19 @@ async function createMobileSafariIosDriver({
     }
   };
 
+  // takeScreenshot — gap C3. Uses Appium's screenshot endpoint
+  // (POST /session/<sid>/screenshot returns base64 PNG). One file per
+  // session (Appium doesn't model multi-persona pages on iOS the way
+  // Playwright does on desktop).
+  driver.takeScreenshot = async (outputDir) =>
+    require('./driver-screenshot-helper').takeScreenshotViaAppium({
+      appiumBaseUrl,
+      sessionId: _sessionId,
+      fetchImpl,
+      outputDir,
+      slug: 'mobile-safari-ios',
+    });
+
   driver.close = async () => {
     if (!_sessionId) return;
     try {
@@ -220,7 +233,7 @@ async function createMobileSafariIosDriver({
 }
 
 // Canonical method surface — pinned by driver-contract.test.js.
-const WEB_MOBILE_METHOD_NAMES = ['webRefreshRoomsList', 'webUiDump'];
+const WEB_MOBILE_METHOD_NAMES = ['webRefreshRoomsList', 'webUiDump', 'takeScreenshot'];
 
 function listMethods() {
   return [...new Set(WEB_MOBILE_METHOD_NAMES)].sort();

--- a/express-api/scripts/drivers/web-mobile-samsung-android-driver.js
+++ b/express-api/scripts/drivers/web-mobile-samsung-android-driver.js
@@ -141,6 +141,14 @@ async function createMobileSamsungAndroidDriver({
     }
   };
 
+  // takeScreenshot — gap C3. Delegates to shared helper.
+  driver.takeScreenshot = async (outputDir) =>
+    require('./driver-screenshot-helper').takeScreenshotForPages(
+      pages,
+      outputDir,
+      'mobile-samsung-android',
+    );
+
   driver.close = async () => {
     for (const p of pages.values()) {
       try {
@@ -161,7 +169,7 @@ async function createMobileSamsungAndroidDriver({
 }
 
 // Canonical method surface — pinned by driver-contract.test.js.
-const WEB_MOBILE_METHOD_NAMES = ['webRefreshRoomsList', 'webUiDump'];
+const WEB_MOBILE_METHOD_NAMES = ['webRefreshRoomsList', 'webUiDump', 'takeScreenshot'];
 
 function listMethods() {
   return [...new Set(WEB_MOBILE_METHOD_NAMES)].sort();

--- a/express-api/scripts/drivers/web-mobile-webkit-ios-driver.js
+++ b/express-api/scripts/drivers/web-mobile-webkit-ios-driver.js
@@ -262,6 +262,18 @@ async function createMobileWebkitIosDriver({
     }
   };
 
+  // takeScreenshot — gap C3. Uses Appium's screenshot endpoint.
+  // Browser name is part of the slug (mobile-<browser>-ios) so each
+  // browser-app variant gets a distinct artifact filename.
+  driver.takeScreenshot = async (outputDir) =>
+    require('./driver-screenshot-helper').takeScreenshotViaAppium({
+      appiumBaseUrl,
+      sessionId: _sessionId,
+      fetchImpl,
+      outputDir,
+      slug: `mobile-${browser}-ios`,
+    });
+
   driver.close = async () => {
     if (!_sessionId) return;
     try {
@@ -277,7 +289,7 @@ async function createMobileWebkitIosDriver({
 }
 
 // Canonical method surface — pinned by driver-contract.test.js.
-const WEB_MOBILE_METHOD_NAMES = ['webRefreshRoomsList', 'webUiDump'];
+const WEB_MOBILE_METHOD_NAMES = ['webRefreshRoomsList', 'webUiDump', 'takeScreenshot'];
 
 function listMethods() {
   return [...new Set(WEB_MOBILE_METHOD_NAMES)].sort();

--- a/express-api/scripts/drivers/web-playwright-driver.js
+++ b/express-api/scripts/drivers/web-playwright-driver.js
@@ -139,6 +139,7 @@ const WEB_METHOD_NAMES = [
   // on the persona's tab; the matcher's `within 3000ms` polling
   // wraps the list population.
   'webRefreshRoomsList',
+  'takeScreenshot',
   // Append-only — add new method names as new matchers land.
 ];
 
@@ -443,6 +444,12 @@ async function createWebDriver({
       return false;
     }
   };
+
+  // takeScreenshot — capture all persona pages to `outputDir` (gap C3).
+  // Delegates to the shared helper so the 7 web drivers (this one + 6
+  // web-mobile wrappers) implement the screenshot contract identically.
+  driver.takeScreenshot = async (outputDir) =>
+    require('./driver-screenshot-helper').takeScreenshotForPages(pages, outputDir, browserName);
 
   driver.close = async () => {
     for (const p of pages.values()) {

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -14819,12 +14819,26 @@ async function runFeatureFile(filePath, ctx) {
         error: failed.result.error,
         code: failed.result.code || null,
       });
-      scenarioReports.push({
+      // Capture per-scenario failure screenshots (gap C3) BEFORE
+      // driver.close() tears down the browser. Best-effort: a screenshot
+      // failure must NEVER change the test outcome — the cell already
+      // failed; we're just preserving artifacts.
+      let screenshotPaths = [];
+      if (ctx.reportDir && ctx.webDriver && typeof ctx.webDriver.takeScreenshot === 'function') {
+        try {
+          screenshotPaths = (await ctx.webDriver.takeScreenshot(ctx.reportDir)) || [];
+        } catch (_e) {
+          /* swallow — screenshot capture is diagnostic, not test outcome */
+        }
+      }
+      const failReport = {
         file: fileName,
         scenario: scenario.name,
         status: 'fail',
         failedStep: failed.step.text,
-      });
+      };
+      if (screenshotPaths.length > 0) failReport.screenshots = screenshotPaths;
+      scenarioReports.push(failReport);
     } else {
       scenarioReports.push({
         file: fileName,
@@ -16330,6 +16344,10 @@ async function main() {
     uiDriver,
     liveKitDriver,
     testerDriver,
+    // reportDir attached for per-scenario-failure screenshot capture
+    // (gap C3). runFeatureFile calls webDriver.takeScreenshot(reportDir)
+    // when a scenario fails AND reportDir is set, BEFORE driver.close().
+    reportDir: opts.reportDir || null,
     _driverCleanup: driverCleanup,
   };
 

--- a/express-api/scripts/manual-qa-runner.js
+++ b/express-api/scripts/manual-qa-runner.js
@@ -14823,10 +14823,16 @@ async function runFeatureFile(filePath, ctx) {
       // driver.close() tears down the browser. Best-effort: a screenshot
       // failure must NEVER change the test outcome — the cell already
       // failed; we're just preserving artifacts.
+      //
+      // Per-failure subdir keeps multi-failure feature files from
+      // overwriting each other's PNGs: `<reportDir>/scenario-<N>/`
+      // where N is the failure ordinal (matches findings[N]).
       let screenshotPaths = [];
       if (ctx.reportDir && ctx.webDriver && typeof ctx.webDriver.takeScreenshot === 'function') {
         try {
-          screenshotPaths = (await ctx.webDriver.takeScreenshot(ctx.reportDir)) || [];
+          const scenarioDir = path.join(ctx.reportDir, `scenario-${findings.length - 1}`);
+          const raw = (await ctx.webDriver.takeScreenshot(scenarioDir)) || [];
+          screenshotPaths = raw.filter(Boolean);
         } catch (_e) {
           /* swallow — screenshot capture is diagnostic, not test outcome */
         }

--- a/express-api/tests/scripts/driver-surface-report.test.js
+++ b/express-api/tests/scripts/driver-surface-report.test.js
@@ -19,14 +19,15 @@ const { discoverDrivers, buildReport, formatTable, formatJson, formatUsage } = r
 // ── Pure helpers ───────────────────────────────────────────────────
 
 describe('discoverDrivers', () => {
-  test('returns at least the 11 expected drivers (13 files − 2 helpers)', () => {
+  test('returns >= 11 drivers; exact count pinned by EXPECTED_COUNTS (14 files − 3 helpers)', () => {
     expect(discoverDrivers().length).toBeGreaterThanOrEqual(11);
   });
 
-  test('excludes helper modules (android-cdp-helpers, ios-driver-loader)', () => {
+  test('excludes helper modules (android-cdp-helpers, ios-driver-loader, driver-screenshot-helper)', () => {
     const names = discoverDrivers().map((d) => d.name);
     expect(names).not.toContain('android-cdp-helpers');
     expect(names).not.toContain('ios-driver-loader');
+    expect(names).not.toContain('driver-screenshot-helper');
   });
 
   test('result entries have name + full (absolute path)', () => {

--- a/express-api/tests/scripts/drivers/driver-contract.test.js
+++ b/express-api/tests/scripts/drivers/driver-contract.test.js
@@ -54,7 +54,7 @@ function discoverDrivers() {
 // ── Discovery sanity ───────────────────────────────────────────────
 
 describe('Driver discovery', () => {
-  test('finds at least the 11 expected drivers (13 files − 2 helpers)', () => {
+  test('finds >= 11 drivers; exact count pinned by EXPECTED_COUNTS (14 files − 3 helpers)', () => {
     expect(discoverDrivers().length).toBeGreaterThanOrEqual(11);
   });
 

--- a/express-api/tests/scripts/drivers/driver-contract.test.js
+++ b/express-api/tests/scripts/drivers/driver-contract.test.js
@@ -20,7 +20,8 @@
  *      the other isn't.
  *
  * Excluded files: helper modules without a driver shape
- * (`android-cdp-helpers.js`, `ios-driver-loader.js`).
+ * (`android-cdp-helpers.js`, `ios-driver-loader.js`,
+ * `driver-screenshot-helper.js`).
  *
  * `describe.each` per discovered driver — adding a new driver requires
  * zero test edits; the new file is auto-tested.
@@ -35,7 +36,11 @@ const DRIVERS_DIR = path.resolve(__dirname, '../../../scripts/drivers');
 // not driver implementations). Exclusion list is intentional: every
 // addition here represents a conscious decision about what is/isn't a
 // driver.
-const HELPER_FILES = new Set(['android-cdp-helpers.js', 'ios-driver-loader.js']);
+const HELPER_FILES = new Set([
+  'android-cdp-helpers.js',
+  'ios-driver-loader.js',
+  'driver-screenshot-helper.js',
+]);
 
 function discoverDrivers() {
   return fs

--- a/express-api/tests/scripts/drivers/driver-interface-pin.test.js
+++ b/express-api/tests/scripts/drivers/driver-interface-pin.test.js
@@ -30,20 +30,21 @@ const path = require('path');
 
 const DRIVERS_DIR = path.resolve(__dirname, '../../../scripts/drivers');
 
-// EXPECTED method counts per driver. Updated 2026-05-31.
+// EXPECTED method counts per driver. Updated 2026-05-31 (PR #944 added
+// takeScreenshot to all 7 web drivers — gap C3).
 // Drift in EITHER direction surfaces a red test for deliberate review.
 const EXPECTED_COUNTS = {
-  'web-playwright-driver': 77,
+  'web-playwright-driver': 78,
   'android-adb-driver': 72,
   'ios-devicectl-driver': 66,
   'ios-simctl-driver': 66,
   'ios-appium-driver': 11,
-  'web-mobile-chrome-android-driver': 2,
-  'web-mobile-samsung-android-driver': 2,
-  'web-mobile-edge-android-driver': 2,
-  'web-mobile-firefox-android-driver': 2,
-  'web-mobile-safari-ios-driver': 2,
-  'web-mobile-webkit-ios-driver': 2,
+  'web-mobile-chrome-android-driver': 3,
+  'web-mobile-samsung-android-driver': 3,
+  'web-mobile-edge-android-driver': 3,
+  'web-mobile-firefox-android-driver': 3,
+  'web-mobile-safari-ios-driver': 3,
+  'web-mobile-webkit-ios-driver': 3,
 };
 
 /**

--- a/express-api/tests/scripts/drivers/driver-screenshot-delegation.test.js
+++ b/express-api/tests/scripts/drivers/driver-screenshot-delegation.test.js
@@ -1,0 +1,96 @@
+/**
+ * driver-screenshot-delegation.test.js
+ *
+ * Pins the C3 delegation contract: each of the 7 web/web-mobile
+ * drivers must wire `driver.takeScreenshot` to the shared helper.
+ *
+ * Why a static check?
+ *   driver-contract.test.js verifies `*_METHOD_NAMES` matches
+ *   listMethods(), and driver-interface-pin.test.js pins the per-driver
+ *   COUNT. Neither verifies that a name in the array corresponds to an
+ *   actual `driver.<name> = ...` line in the factory body. A regression
+ *   that drops the assignment but keeps the array intact would slip
+ *   through both pins. This file closes that gap for takeScreenshot
+ *   specifically — the runner's per-failure screenshot hook silently
+ *   becomes a no-op without it.
+ *
+ * Why not an instance test?
+ *   Building a real driver requires playwright/appium/adb mocks. A
+ *   source-text grep is bounded, fast, and catches the exact
+ *   regression the hook design depends on.
+ *
+ * Scope: only takeScreenshot. Generalizing to "every method in
+ * *_METHOD_NAMES has a driver.<name> assignment" is a separate
+ * framework gap and intentionally out of scope here.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DRIVERS_DIR = path.resolve(__dirname, '../../../scripts/drivers');
+
+// The 7 drivers that integrate with the C3 hook. Native drivers
+// (android-adb / ios-devicectl / ios-simctl / ios-appium) are NOT in
+// this list because they don't render web UIs and the C3 hook only
+// fires for ctx.webDriver. Adding them later would be a deliberate
+// expansion of the hook contract.
+const C3_INTEGRATED_DRIVERS = [
+  'web-playwright-driver.js',
+  'web-mobile-chrome-android-driver.js',
+  'web-mobile-samsung-android-driver.js',
+  'web-mobile-edge-android-driver.js',
+  'web-mobile-firefox-android-driver.js',
+  'web-mobile-safari-ios-driver.js',
+  'web-mobile-webkit-ios-driver.js',
+];
+
+describe('driver-screenshot delegation (C3) — every web driver wires takeScreenshot', () => {
+  for (const driverFile of C3_INTEGRATED_DRIVERS) {
+    test(`${driverFile} assigns driver.takeScreenshot`, () => {
+      const src = fs.readFileSync(path.join(DRIVERS_DIR, driverFile), 'utf8');
+      // The literal `driver.takeScreenshot` assignment marker. The
+      // regex is bounded (`{0,30}` between `driver.takeScreenshot` and
+      // `=`) to allow `driver.takeScreenshot = async ...` shape, and
+      // anchors to the assignment so a mere reference doesn't count.
+      expect(src).toMatch(/driver\.takeScreenshot\s{0,30}=/);
+    });
+
+    test(`${driverFile} requires the screenshot helper`, () => {
+      const src = fs.readFileSync(path.join(DRIVERS_DIR, driverFile), 'utf8');
+      // The helper is the single source of truth for the file-naming
+      // convention (`screenshot-<slug>-<persona>.png`). Drivers MUST
+      // delegate to it rather than rolling their own — otherwise the
+      // matrix-report parser can't reliably find artifacts by glob.
+      expect(src).toMatch(/['"]\.\/driver-screenshot-helper['"]/);
+    });
+
+    test(`${driverFile} includes takeScreenshot in WEB_*_METHOD_NAMES`, () => {
+      const src = fs.readFileSync(path.join(DRIVERS_DIR, driverFile), 'utf8');
+      // Drift-catch: if a future PR removes 'takeScreenshot' from the
+      // array but forgets to remove the assignment (or vice versa),
+      // listMethods() would lie about the driver's real surface.
+      expect(src).toMatch(/['"]takeScreenshot['"]/);
+    });
+  }
+});
+
+describe('driver-screenshot delegation (C3) — native drivers do NOT have takeScreenshot', () => {
+  // Invariant: takeScreenshot is web-only (ctx.webDriver hook). If a
+  // native driver adds it later, this test surfaces the divergence so
+  // the hook contract gets reviewed deliberately (it would need to
+  // also hook ctx.androidDriver / ctx.iosDriver).
+  const NATIVE_DRIVERS = [
+    'android-adb-driver.js',
+    'ios-devicectl-driver.js',
+    'ios-simctl-driver.js',
+    'ios-appium-driver.js',
+  ];
+
+  for (const driverFile of NATIVE_DRIVERS) {
+    test(`${driverFile} does NOT export takeScreenshot (web-hook only contract)`, () => {
+      const src = fs.readFileSync(path.join(DRIVERS_DIR, driverFile), 'utf8');
+      expect(src).not.toMatch(/['"]takeScreenshot['"]/);
+      expect(src).not.toMatch(/driver\.takeScreenshot\s{0,30}=/);
+    });
+  }
+});

--- a/express-api/tests/scripts/drivers/driver-screenshot-helper.test.js
+++ b/express-api/tests/scripts/drivers/driver-screenshot-helper.test.js
@@ -18,7 +18,12 @@ const path = require('path');
 const REPO_ROOT = path.resolve(__dirname, '../../..');
 const HELPER_PATH = path.join(REPO_ROOT, 'scripts/drivers/driver-screenshot-helper.js');
 
-const { takeScreenshotForPages, takeScreenshotViaAppium } = require(HELPER_PATH);
+const {
+  takeScreenshotForPages,
+  takeScreenshotViaAppium,
+  safeFilenamePart,
+  ensureDirSafe,
+} = require(HELPER_PATH);
 
 // Non-http scheme placeholder for tests — Appium's real base URL is
 // http://localhost:4723 but linting flags clear-text protocols, and our
@@ -128,6 +133,45 @@ describe('takeScreenshotForPages — Playwright pages map', () => {
       expect(screenshot).toHaveBeenCalledWith(
         expect.objectContaining({ fullPage: true, path: expect.any(String) }),
       );
+    } finally {
+      cleanup(outDir);
+    }
+  });
+
+  test('returns [] when fs.mkdirSync throws (EACCES / EROFS / disk-full) — never throws (C1)', async () => {
+    // Reviewer-flagged: mkdirSync was OUTSIDE the try/catch. JSDoc
+    // promises best-effort semantics — function must NEVER throw.
+    const originalMkdir = fs.mkdirSync;
+    fs.mkdirSync = jest.fn(() => {
+      throw Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+    });
+    try {
+      const r = await takeScreenshotForPages(
+        new Map([['Alice', { screenshot: jest.fn() }]]),
+        '/some/forbidden/dir',
+        'chromium',
+      );
+      expect(r).toEqual([]);
+    } finally {
+      fs.mkdirSync = originalMkdir;
+    }
+  });
+
+  test('sanitizes persona keys with path-traversal segments (P2)', async () => {
+    // Defense-in-depth: persona key comes from driver-controlled
+    // pages-Map. Path.join would resolve `..` segments and escape
+    // outputDir. The helper strips to a conservative charset before
+    // joining.
+    const outDir = tmpDir('persona-sanitize');
+    const screenshot = jest.fn(async ({ path: p }) => fs.writeFileSync(p, 'ok'));
+    const pages = new Map([['../../etc/shadow', { screenshot }]]);
+    try {
+      const r = await takeScreenshotForPages(pages, outDir, 'chromium');
+      expect(r).toHaveLength(1);
+      // ../../etc/shadow → ___..etc.shadow → all non-[a-zA-Z0-9_-] become _
+      expect(r[0]).toBe(path.join(outDir, 'screenshot-chromium-______etc_shadow.png'));
+      // Verify the file is INSIDE outDir, not escaped
+      expect(r[0].startsWith(outDir)).toBe(true);
     } finally {
       cleanup(outDir);
     }
@@ -285,6 +329,126 @@ describe('takeScreenshotViaAppium — Appium HTTP screenshot endpoint', () => {
       expect(fetchImpl).toHaveBeenCalledWith(`${MOCK_APPIUM_BASE}/session/abc-123/screenshot`);
     } finally {
       cleanup(outDir);
+    }
+  });
+
+  test('returns [] when r.json() throws — malformed response body (I3)', async () => {
+    // Distinct from the fetchImpl-throw case: the HTTP layer succeeds
+    // but the body is non-JSON (HTML error page, truncated stream,
+    // protocol mismatch). Helper must swallow + return [].
+    const outDir = tmpDir('appium-json-throw');
+    const fetchImpl = jest.fn(async () => ({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError('Unexpected token < in JSON at position 0');
+      },
+    }));
+    try {
+      const r = await takeScreenshotViaAppium({
+        appiumBaseUrl: MOCK_APPIUM_BASE,
+        sessionId: 'sid',
+        fetchImpl,
+        outputDir: outDir,
+        slug: 'mobile-safari-ios',
+      });
+      expect(r).toEqual([]);
+    } finally {
+      cleanup(outDir);
+    }
+  });
+
+  test('returns [] when body.value is a non-string truthy value (I4)', async () => {
+    // Buffer.from(42, 'base64') throws TypeError. The outer try/catch
+    // catches it in production, but the explicit typeof guard short-
+    // circuits without paying for the Buffer.from attempt and gives
+    // a cleaner contract.
+    const outDir = tmpDir('appium-non-string');
+    const fetchImpl = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ value: 42 }),
+    }));
+    try {
+      const r = await takeScreenshotViaAppium({
+        appiumBaseUrl: MOCK_APPIUM_BASE,
+        sessionId: 'sid',
+        fetchImpl,
+        outputDir: outDir,
+        slug: 'mobile-safari-ios',
+      });
+      expect(r).toEqual([]);
+    } finally {
+      cleanup(outDir);
+    }
+  });
+
+  test('returns [] when fs.mkdirSync throws — never throws (C1)', async () => {
+    // Reviewer-flagged: parity with the Playwright-side mkdirSync
+    // guard. Best-effort contract must hold for the Appium path too.
+    const originalMkdir = fs.mkdirSync;
+    fs.mkdirSync = jest.fn(() => {
+      throw Object.assign(new Error('EROFS: read-only file system'), { code: 'EROFS' });
+    });
+    try {
+      const r = await takeScreenshotViaAppium({
+        appiumBaseUrl: MOCK_APPIUM_BASE,
+        sessionId: 'sid',
+        fetchImpl: jest.fn(),
+        outputDir: '/readonly/dir',
+        slug: 'mobile-safari-ios',
+      });
+      expect(r).toEqual([]);
+    } finally {
+      fs.mkdirSync = originalMkdir;
+    }
+  });
+});
+
+// ── safeFilenamePart + ensureDirSafe (internals exposed for testing) ──
+
+describe('safeFilenamePart — persona-key sanitizer', () => {
+  test('strips path-traversal segments', () => {
+    expect(safeFilenamePart('../../etc/shadow')).toBe('______etc_shadow');
+  });
+
+  test('strips backslashes (Windows path-traversal)', () => {
+    expect(safeFilenamePart('..\\..\\Windows\\System32')).toBe('______Windows_System32');
+  });
+
+  test('preserves alphanumerics + underscore + hyphen', () => {
+    expect(safeFilenamePart('Alice-1_admin')).toBe('Alice-1_admin');
+  });
+
+  test('coerces non-string inputs via String()', () => {
+    expect(safeFilenamePart(42)).toBe('42');
+    expect(safeFilenamePart(null)).toBe('null');
+    expect(safeFilenamePart(undefined)).toBe('undefined');
+  });
+
+  test('strips embedded null bytes (defense against C-string truncation in downstream tools)', () => {
+    expect(safeFilenamePart('Alice\0evil')).toBe('Alice_evil');
+  });
+});
+
+describe('ensureDirSafe — never-throws mkdir wrapper', () => {
+  test('returns true on success', () => {
+    const dir = tmpDir('ensure-ok');
+    try {
+      expect(ensureDirSafe(dir)).toBe(true);
+      expect(fs.existsSync(dir)).toBe(true);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('returns false on mkdir failure (never throws)', () => {
+    const originalMkdir = fs.mkdirSync;
+    fs.mkdirSync = jest.fn(() => {
+      throw new Error('EACCES');
+    });
+    try {
+      expect(ensureDirSafe('/whatever')).toBe(false);
+    } finally {
+      fs.mkdirSync = originalMkdir;
     }
   });
 });

--- a/express-api/tests/scripts/drivers/driver-screenshot-helper.test.js
+++ b/express-api/tests/scripts/drivers/driver-screenshot-helper.test.js
@@ -1,0 +1,290 @@
+/**
+ * driver-screenshot-helper.test.js
+ *
+ * Tests the shared screenshot helpers (gap C3 — per-cell screenshot
+ * capture on failure). Covers:
+ *   - takeScreenshotForPages — Playwright-based drivers
+ *   - takeScreenshotViaAppium — Appium-based iOS drivers
+ *   - Best-effort: falsy outputDir / sessionId returns []
+ *   - One persona's failure doesn't block the others
+ *   - File naming: `screenshot-<slug>-<persona>.png`
+ *   - Directory creation (recursive mkdir)
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const HELPER_PATH = path.join(REPO_ROOT, 'scripts/drivers/driver-screenshot-helper.js');
+
+const { takeScreenshotForPages, takeScreenshotViaAppium } = require(HELPER_PATH);
+
+// Non-http scheme placeholder for tests — Appium's real base URL is
+// http://localhost:4723 but linting flags clear-text protocols, and our
+// fetchImpl is a jest.fn() that doesn't validate scheme. The endpoint
+// assertion still pins the path shape via `${base}/session/<sid>/screenshot`.
+const MOCK_APPIUM_BASE = 'mock://appium';
+
+function tmpDir(suffix) {
+  return path.join(os.tmpdir(), `qa-screenshot-${process.pid}-${Date.now()}-${suffix}`);
+}
+
+function cleanup(dir) {
+  if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ── takeScreenshotForPages ─────────────────────────────────────
+
+describe('takeScreenshotForPages — Playwright pages map', () => {
+  test('returns [] when outputDir is falsy (operator passed no --report-dir)', async () => {
+    const pages = new Map([['default', { screenshot: jest.fn() }]]);
+    expect(await takeScreenshotForPages(pages, null, 'chromium')).toEqual([]);
+    expect(await takeScreenshotForPages(pages, '', 'chromium')).toEqual([]);
+    expect(await takeScreenshotForPages(pages, undefined, 'chromium')).toEqual([]);
+  });
+
+  test('returns [] for empty pages map (driver had no persona tabs)', async () => {
+    const outDir = tmpDir('empty');
+    try {
+      expect(await takeScreenshotForPages(new Map(), outDir, 'chromium')).toEqual([]);
+    } finally {
+      cleanup(outDir);
+    }
+  });
+
+  test('writes one PNG per persona with naming "screenshot-<slug>-<persona>.png"', async () => {
+    const outDir = tmpDir('multi');
+    const screenshot = jest.fn(async ({ path: p }) => {
+      fs.writeFileSync(p, Buffer.from('fake-png'));
+    });
+    const pages = new Map([
+      ['Alice', { screenshot }],
+      ['Bob', { screenshot }],
+    ]);
+    try {
+      const saved = await takeScreenshotForPages(pages, outDir, 'chromium');
+      expect(saved).toHaveLength(2);
+      expect(saved).toContain(path.join(outDir, 'screenshot-chromium-Alice.png'));
+      expect(saved).toContain(path.join(outDir, 'screenshot-chromium-Bob.png'));
+      expect(fs.existsSync(saved[0])).toBe(true);
+      expect(fs.existsSync(saved[1])).toBe(true);
+    } finally {
+      cleanup(outDir);
+    }
+  });
+
+  test('one persona screenshot failure does NOT block the others', async () => {
+    const outDir = tmpDir('partial');
+    const goodScreenshot = jest.fn(async ({ path: p }) => fs.writeFileSync(p, 'ok'));
+    const badScreenshot = jest.fn(async () => {
+      throw new Error('page closed');
+    });
+    const pages = new Map([
+      ['Alice', { screenshot: goodScreenshot }],
+      ['Bob', { screenshot: badScreenshot }],
+      ['Carol', { screenshot: goodScreenshot }],
+    ]);
+    try {
+      const saved = await takeScreenshotForPages(pages, outDir, 'chromium');
+      expect(saved).toHaveLength(2); // Alice + Carol; Bob swallowed
+      expect(saved.some((p) => p.endsWith('Alice.png'))).toBe(true);
+      expect(saved.some((p) => p.endsWith('Carol.png'))).toBe(true);
+      expect(saved.some((p) => p.endsWith('Bob.png'))).toBe(false);
+    } finally {
+      cleanup(outDir);
+    }
+  });
+
+  test('creates outputDir recursively if it does not exist', async () => {
+    const nested = path.join(tmpDir('nested'), 'sub', 'dir');
+    const screenshot = jest.fn(async ({ path: p }) => fs.writeFileSync(p, 'ok'));
+    try {
+      await takeScreenshotForPages(new Map([['a', { screenshot }]]), nested, 'chromium');
+      expect(fs.existsSync(nested)).toBe(true);
+    } finally {
+      cleanup(nested.split('/sub')[0]);
+    }
+  });
+
+  test('slug + persona appear in filename (no collisions across cells)', async () => {
+    const outDir = tmpDir('slug');
+    const screenshot = jest.fn(async ({ path: p }) => fs.writeFileSync(p, 'ok'));
+    const pages = new Map([['default', { screenshot }]]);
+    try {
+      await takeScreenshotForPages(pages, outDir, 'mobile-chrome-android');
+      const files = fs.readdirSync(outDir);
+      expect(files).toContain('screenshot-mobile-chrome-android-default.png');
+    } finally {
+      cleanup(outDir);
+    }
+  });
+
+  test('uses fullPage: true (capture below-fold content)', async () => {
+    const outDir = tmpDir('fullpage');
+    const screenshot = jest.fn(async ({ path: p }) => fs.writeFileSync(p, 'ok'));
+    try {
+      await takeScreenshotForPages(new Map([['a', { screenshot }]]), outDir, 'chromium');
+      expect(screenshot).toHaveBeenCalledWith(
+        expect.objectContaining({ fullPage: true, path: expect.any(String) }),
+      );
+    } finally {
+      cleanup(outDir);
+    }
+  });
+});
+
+// ── takeScreenshotViaAppium ────────────────────────────────────
+
+describe('takeScreenshotViaAppium — Appium HTTP screenshot endpoint', () => {
+  test('returns [] when outputDir falsy', async () => {
+    const r = await takeScreenshotViaAppium({
+      appiumBaseUrl: MOCK_APPIUM_BASE,
+      sessionId: 'sid',
+      fetchImpl: jest.fn(),
+      outputDir: null,
+      slug: 'mobile-safari-ios',
+    });
+    expect(r).toEqual([]);
+  });
+
+  test('returns [] when sessionId falsy (Appium session not established)', async () => {
+    const outDir = tmpDir('no-sid');
+    try {
+      const r = await takeScreenshotViaAppium({
+        appiumBaseUrl: MOCK_APPIUM_BASE,
+        sessionId: null,
+        fetchImpl: jest.fn(),
+        outputDir: outDir,
+        slug: 'mobile-safari-ios',
+      });
+      expect(r).toEqual([]);
+    } finally {
+      cleanup(outDir);
+    }
+  });
+
+  test('decodes base64 PNG from Appium response + writes to file', async () => {
+    const outDir = tmpDir('appium-ok');
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]); // PNG magic
+    const base64 = pngBytes.toString('base64');
+    const fetchImpl = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ value: base64 }),
+    }));
+    try {
+      const r = await takeScreenshotViaAppium({
+        appiumBaseUrl: MOCK_APPIUM_BASE,
+        sessionId: 'sid-123',
+        fetchImpl,
+        outputDir: outDir,
+        slug: 'mobile-safari-ios',
+      });
+      expect(r).toHaveLength(1);
+      expect(r[0]).toBe(path.join(outDir, 'screenshot-mobile-safari-ios-default.png'));
+      const written = fs.readFileSync(r[0]);
+      expect(written).toEqual(pngBytes);
+    } finally {
+      cleanup(outDir);
+    }
+  });
+
+  test('returns [] on non-ok HTTP response', async () => {
+    const outDir = tmpDir('appium-fail');
+    const fetchImpl = jest.fn(async () => ({ ok: false, json: async () => ({}) }));
+    try {
+      const r = await takeScreenshotViaAppium({
+        appiumBaseUrl: MOCK_APPIUM_BASE,
+        sessionId: 'sid',
+        fetchImpl,
+        outputDir: outDir,
+        slug: 'mobile-safari-ios',
+      });
+      expect(r).toEqual([]);
+    } finally {
+      cleanup(outDir);
+    }
+  });
+
+  test('returns [] on missing value field in Appium response', async () => {
+    const outDir = tmpDir('appium-missing');
+    const fetchImpl = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        /* no value */
+      }),
+    }));
+    try {
+      const r = await takeScreenshotViaAppium({
+        appiumBaseUrl: MOCK_APPIUM_BASE,
+        sessionId: 'sid',
+        fetchImpl,
+        outputDir: outDir,
+        slug: 'mobile-safari-ios',
+      });
+      expect(r).toEqual([]);
+    } finally {
+      cleanup(outDir);
+    }
+  });
+
+  test('returns [] on fetchImpl throw (best-effort, never propagates)', async () => {
+    const outDir = tmpDir('appium-throw');
+    const fetchImpl = jest.fn(async () => {
+      throw new Error('network down');
+    });
+    try {
+      const r = await takeScreenshotViaAppium({
+        appiumBaseUrl: MOCK_APPIUM_BASE,
+        sessionId: 'sid',
+        fetchImpl,
+        outputDir: outDir,
+        slug: 'mobile-safari-ios',
+      });
+      expect(r).toEqual([]);
+    } finally {
+      cleanup(outDir);
+    }
+  });
+
+  test('slug appears in filename (per-cell uniqueness)', async () => {
+    const outDir = tmpDir('appium-slug');
+    const fetchImpl = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ value: Buffer.from('x').toString('base64') }),
+    }));
+    try {
+      await takeScreenshotViaAppium({
+        appiumBaseUrl: MOCK_APPIUM_BASE,
+        sessionId: 'sid',
+        fetchImpl,
+        outputDir: outDir,
+        slug: 'mobile-chrome-ios',
+      });
+      const files = fs.readdirSync(outDir);
+      expect(files).toContain('screenshot-mobile-chrome-ios-default.png');
+    } finally {
+      cleanup(outDir);
+    }
+  });
+
+  test('hits Appium /session/<sid>/screenshot endpoint', async () => {
+    const outDir = tmpDir('appium-endpoint');
+    const fetchImpl = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ value: Buffer.from('x').toString('base64') }),
+    }));
+    try {
+      await takeScreenshotViaAppium({
+        appiumBaseUrl: MOCK_APPIUM_BASE,
+        sessionId: 'abc-123',
+        fetchImpl,
+        outputDir: outDir,
+        slug: 'mobile-safari-ios',
+      });
+      expect(fetchImpl).toHaveBeenCalledWith(`${MOCK_APPIUM_BASE}/session/abc-123/screenshot`);
+    } finally {
+      cleanup(outDir);
+    }
+  });
+});

--- a/express-api/tests/scripts/drivers/web-mobile-chrome-android-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-mobile-chrome-android-driver.test.js
@@ -550,3 +550,47 @@ describe('createMobileChromeAndroidDriver', () => {
     await expect(driver.close()).resolves.toBeUndefined();
   });
 });
+
+// takeScreenshot — behavioral delegation (gap C3, reviewer I-NEW-1) ──
+
+describe('createMobileChromeAndroidDriver — takeScreenshot delegation', () => {
+  const helper = require(
+    path.join(REPO_ROOT, 'express-api/scripts/drivers/driver-screenshot-helper'),
+  );
+
+  test('routes to takeScreenshotForPages with the populated pages Map + slug', async () => {
+    const spy = jest
+      .spyOn(helper, 'takeScreenshotForPages')
+      .mockResolvedValue(['/mock/chrome-android.png']);
+    try {
+      const execFileSync = makeExecFileSyncMock({
+        devicesOutput: 'List of devices attached\nABC\tdevice\n',
+      });
+      const pages = makePagesByPersona(['Alice', 'Bob']);
+      const playwrightImpl = makePlaywrightConnectOverCDPMock(pages);
+      const driver = await createMobileChromeAndroidDriver({
+        execFileSync,
+        playwrightImpl,
+        pickPort: async () => 9333,
+      });
+      // Populate the pages Map through public API.
+      await driver.webRefreshRoomsList('Alice');
+      await driver.webRefreshRoomsList('Bob');
+
+      const result = await driver.takeScreenshot('/tmp/chrome-android-out');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [pagesArg, outputDirArg, slugArg] = spy.mock.calls[0];
+      expect(outputDirArg).toBe('/tmp/chrome-android-out');
+      expect(slugArg).toBe('mobile-chrome-android');
+      // Identity pin: pagesArg must be the SAME Map the driver populated.
+      expect(pagesArg instanceof Map).toBe(true);
+      expect(pagesArg.size).toBe(2);
+      expect(pagesArg.has('Alice')).toBe(true);
+      expect(pagesArg.has('Bob')).toBe(true);
+      expect(result).toEqual(['/mock/chrome-android.png']);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/express-api/tests/scripts/drivers/web-mobile-chrome-android-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-mobile-chrome-android-driver.test.js
@@ -593,4 +593,35 @@ describe('createMobileChromeAndroidDriver — takeScreenshot delegation', () => 
       spy.mockRestore();
     }
   });
+
+  test('takeScreenshot before any webRefreshRoomsList → forwards empty pages Map, returns []', async () => {
+    // Reviewer round-3 I-2 — pre-bootstrap case parallel to the
+    // webkit-ios null-sessionId test. driver.takeScreenshot must not
+    // crash if invoked before any persona page is populated; it should
+    // forward an EMPTY pages Map and pass through whatever the helper
+    // returns (which is `[]` for an empty Map per the helper's tested
+    // contract).
+    const spy = jest.spyOn(helper, 'takeScreenshotForPages').mockResolvedValue([]);
+    try {
+      const execFileSync = makeExecFileSyncMock({
+        devicesOutput: 'List of devices attached\nABC\tdevice\n',
+      });
+      const pages = makePagesByPersona(['Alice']);
+      const playwrightImpl = makePlaywrightConnectOverCDPMock(pages);
+      const driver = await createMobileChromeAndroidDriver({
+        execFileSync,
+        playwrightImpl,
+        pickPort: async () => 9333,
+      });
+      // NB: no webRefreshRoomsList call — pages Map is still empty.
+      const result = await driver.takeScreenshot('/tmp/empty-out');
+      expect(result).toEqual([]);
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [pagesArg] = spy.mock.calls[0];
+      expect(pagesArg instanceof Map).toBe(true);
+      expect(pagesArg.size).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });

--- a/express-api/tests/scripts/drivers/web-mobile-edge-android-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-mobile-edge-android-driver.test.js
@@ -330,4 +330,27 @@ describe('createMobileEdgeAndroidDriver — takeScreenshot delegation', () => {
       spy.mockRestore();
     }
   });
+
+  test('takeScreenshot before any webRefreshRoomsList → forwards empty pages Map, returns []', async () => {
+    // Reviewer round-3 I-2 — pre-bootstrap case.
+    const spy = jest.spyOn(helper, 'takeScreenshotForPages').mockResolvedValue([]);
+    try {
+      const execFileSync = makeExecFileSyncMock();
+      const pages = makePages(['Alice']);
+      const playwrightImpl = makePlaywrightMock(pages);
+      const driver = await createMobileEdgeAndroidDriver({
+        execFileSync,
+        playwrightImpl,
+        pickPort: async () => 9777,
+      });
+      const result = await driver.takeScreenshot('/tmp/empty-out');
+      expect(result).toEqual([]);
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [pagesArg] = spy.mock.calls[0];
+      expect(pagesArg instanceof Map).toBe(true);
+      expect(pagesArg.size).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });

--- a/express-api/tests/scripts/drivers/web-mobile-edge-android-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-mobile-edge-android-driver.test.js
@@ -293,3 +293,41 @@ describe('createMobileEdgeAndroidDriver', () => {
     await expect(driver.close()).resolves.toBeUndefined();
   });
 });
+
+// takeScreenshot — behavioral delegation (gap C3, reviewer I-NEW-1) ──
+
+describe('createMobileEdgeAndroidDriver — takeScreenshot delegation', () => {
+  const helper = require(
+    path.join(REPO_ROOT, 'express-api/scripts/drivers/driver-screenshot-helper'),
+  );
+
+  test('routes to takeScreenshotForPages with populated pages Map + slug', async () => {
+    const spy = jest.spyOn(helper, 'takeScreenshotForPages').mockResolvedValue(['/mock/edge.png']);
+    try {
+      const execFileSync = makeExecFileSyncMock();
+      const pages = makePages(['Alice', 'Bob']);
+      const playwrightImpl = makePlaywrightMock(pages);
+      const driver = await createMobileEdgeAndroidDriver({
+        execFileSync,
+        playwrightImpl,
+        pickPort: async () => 9777,
+      });
+      await driver.webRefreshRoomsList('Alice');
+      await driver.webRefreshRoomsList('Bob');
+
+      const result = await driver.takeScreenshot('/tmp/edge-out');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [pagesArg, outputDirArg, slugArg] = spy.mock.calls[0];
+      expect(outputDirArg).toBe('/tmp/edge-out');
+      expect(slugArg).toBe('mobile-edge-android');
+      expect(pagesArg instanceof Map).toBe(true);
+      expect(pagesArg.size).toBe(2);
+      expect(pagesArg.has('Alice')).toBe(true);
+      expect(pagesArg.has('Bob')).toBe(true);
+      expect(result).toEqual(['/mock/edge.png']);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/express-api/tests/scripts/drivers/web-mobile-firefox-android-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-mobile-firefox-android-driver.test.js
@@ -609,3 +609,67 @@ describe('close', () => {
     await expect(driver.close()).resolves.toBeUndefined();
   });
 });
+
+// takeScreenshot — behavioral delegation (gap C3, reviewer I2) ────────
+//
+// firefox-android uses Geckodriver's W3C WebDriver HTTP API — same
+// `/session/<sid>/screenshot` endpoint as Appium — so we delegate to
+// `takeScreenshotViaAppium` (helper is transport-correct for any W3C
+// driver despite the name). This test pins the wiring with the
+// correct Geckodriver port + slug.
+
+describe('createMobileFirefoxAndroidDriver — takeScreenshot delegation', () => {
+  const helper = require(
+    path.join(REPO_ROOT, 'express-api/scripts/drivers/driver-screenshot-helper'),
+  );
+
+  test('routes to takeScreenshotViaAppium with Geckodriver URL + session + slug', async () => {
+    const spy = jest
+      .spyOn(helper, 'takeScreenshotViaAppium')
+      .mockResolvedValue(['/mock/firefox.png']);
+    try {
+      const spawnImpl = makeSpawnMock();
+      const fetchImpl = makeFetchMock(defaultHandlers({ sessionId: 'sess-ff-789' }));
+      const driver = await createMobileFirefoxAndroidDriver({
+        geckodriverPath: '/opt/homebrew/bin/geckodriver',
+        spawnImpl,
+        fetchImpl,
+        pickPort: async () => 4444,
+        waitForReady: async () => true,
+      });
+      // Establish session via webRefreshRoomsList → navigateTo → ensureSession.
+      await driver.webRefreshRoomsList('Alice');
+
+      const result = await driver.takeScreenshot('/tmp/firefox-report');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [args] = spy.mock.calls[0];
+      // Geckodriver listens on 127.0.0.1:<chosenPort>; we forced 4444 above.
+      expect(args.appiumBaseUrl).toBe('http://127.0.0.1:4444');
+      expect(args.sessionId).toBe('sess-ff-789');
+      expect(args.fetchImpl).toBe(fetchImpl);
+      expect(args.outputDir).toBe('/tmp/firefox-report');
+      expect(args.slug).toBe('mobile-firefox-android');
+      expect(result).toEqual(['/mock/firefox.png']);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('sessionId reflects current _sessionId (null before any session call)', async () => {
+    const spy = jest.spyOn(helper, 'takeScreenshotViaAppium').mockResolvedValue([]);
+    try {
+      const driver = await createMobileFirefoxAndroidDriver({
+        geckodriverPath: '/opt/homebrew/bin/geckodriver',
+        spawnImpl: makeSpawnMock(),
+        fetchImpl: makeFetchMock([]),
+        pickPort: async () => 4444,
+        waitForReady: async () => true,
+      });
+      await driver.takeScreenshot('/tmp/out');
+      expect(spy.mock.calls[0][0].sessionId).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/express-api/tests/scripts/drivers/web-mobile-safari-ios-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-mobile-safari-ios-driver.test.js
@@ -401,3 +401,58 @@ describe('close', () => {
     expect(fetchImpl.calls.filter((c) => c.opts.method === 'DELETE')).toHaveLength(1);
   });
 });
+
+// takeScreenshot — behavioral delegation (gap C3, reviewer I2) ────────
+
+describe('createMobileSafariIosDriver — takeScreenshot delegation', () => {
+  const helperPath = path.join(REPO_ROOT, 'express-api/scripts/drivers/driver-screenshot-helper');
+  const helper = require(helperPath);
+
+  test('routes to takeScreenshotViaAppium with Appium URL + session + slug', async () => {
+    const spy = jest
+      .spyOn(helper, 'takeScreenshotViaAppium')
+      .mockResolvedValue(['/mock/safari.png']);
+    try {
+      const fetchImpl = makeFetchMock(defaultHandlers({ sessionId: 'sess-xyz' }));
+      const driver = await createMobileSafariIosDriver({
+        wdaTeamId: 'TEAM123',
+        selectUdidImpl: () => 'UDID',
+        fetchImpl,
+      });
+      // Establish session via a normal driver call so _sessionId is set.
+      await driver.webRefreshRoomsList('Alice');
+
+      const result = await driver.takeScreenshot('/tmp/report');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [args] = spy.mock.calls[0];
+      expect(args.appiumBaseUrl).toBe(DEFAULT_APPIUM_BASE_URL);
+      expect(args.sessionId).toBe('sess-xyz');
+      expect(args.fetchImpl).toBe(fetchImpl);
+      expect(args.outputDir).toBe('/tmp/report');
+      expect(args.slug).toBe('mobile-safari-ios');
+      expect(result).toEqual(['/mock/safari.png']);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('sessionId is null when called before session-establishment', async () => {
+    // Drift-catch: if a future refactor pre-establishes the session
+    // eagerly in the factory, this test fails — which is fine, the
+    // sessionId field will be set; but the assertion then needs an
+    // update. Today, _sessionId starts null until first method call.
+    const spy = jest.spyOn(helper, 'takeScreenshotViaAppium').mockResolvedValue([]);
+    try {
+      const driver = await createMobileSafariIosDriver({
+        wdaTeamId: 'TEAM123',
+        selectUdidImpl: () => 'UDID',
+        fetchImpl: makeFetchMock([]),
+      });
+      await driver.takeScreenshot('/tmp/out');
+      expect(spy.mock.calls[0][0].sessionId).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/express-api/tests/scripts/drivers/web-mobile-samsung-android-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-mobile-samsung-android-driver.test.js
@@ -353,4 +353,27 @@ describe('createMobileSamsungAndroidDriver — takeScreenshot delegation', () =>
       spy.mockRestore();
     }
   });
+
+  test('takeScreenshot before any webRefreshRoomsList → forwards empty pages Map, returns []', async () => {
+    // Reviewer round-3 I-2 — pre-bootstrap case.
+    const spy = jest.spyOn(helper, 'takeScreenshotForPages').mockResolvedValue([]);
+    try {
+      const execFileSync = makeExecFileSyncMock();
+      const pages = makePages(['Alice']);
+      const playwrightImpl = makePlaywrightMock(pages);
+      const driver = await createMobileSamsungAndroidDriver({
+        execFileSync,
+        playwrightImpl,
+        pickPort: async () => 9555,
+      });
+      const result = await driver.takeScreenshot('/tmp/empty-out');
+      expect(result).toEqual([]);
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [pagesArg] = spy.mock.calls[0];
+      expect(pagesArg instanceof Map).toBe(true);
+      expect(pagesArg.size).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });

--- a/express-api/tests/scripts/drivers/web-mobile-samsung-android-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-mobile-samsung-android-driver.test.js
@@ -314,3 +314,43 @@ describe('createMobileSamsungAndroidDriver', () => {
     await expect(driver.close()).resolves.toBeUndefined();
   });
 });
+
+// takeScreenshot — behavioral delegation (gap C3, reviewer I-NEW-1) ──
+
+describe('createMobileSamsungAndroidDriver — takeScreenshot delegation', () => {
+  const helper = require(
+    path.join(REPO_ROOT, 'express-api/scripts/drivers/driver-screenshot-helper'),
+  );
+
+  test('routes to takeScreenshotForPages with populated pages Map + slug', async () => {
+    const spy = jest
+      .spyOn(helper, 'takeScreenshotForPages')
+      .mockResolvedValue(['/mock/samsung.png']);
+    try {
+      const execFileSync = makeExecFileSyncMock();
+      const pages = makePages(['Alice', 'Bob']);
+      const playwrightImpl = makePlaywrightMock(pages);
+      const driver = await createMobileSamsungAndroidDriver({
+        execFileSync,
+        playwrightImpl,
+        pickPort: async () => 9555,
+      });
+      await driver.webRefreshRoomsList('Alice');
+      await driver.webRefreshRoomsList('Bob');
+
+      const result = await driver.takeScreenshot('/tmp/samsung-out');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [pagesArg, outputDirArg, slugArg] = spy.mock.calls[0];
+      expect(outputDirArg).toBe('/tmp/samsung-out');
+      expect(slugArg).toBe('mobile-samsung-android');
+      expect(pagesArg instanceof Map).toBe(true);
+      expect(pagesArg.size).toBe(2);
+      expect(pagesArg.has('Alice')).toBe(true);
+      expect(pagesArg.has('Bob')).toBe(true);
+      expect(result).toEqual(['/mock/samsung.png']);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/express-api/tests/scripts/drivers/web-mobile-webkit-ios-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-mobile-webkit-ios-driver.test.js
@@ -623,3 +623,80 @@ describe('close', () => {
     expect(sessionPosts).toHaveLength(2); // re-bootstrapped
   });
 });
+
+// takeScreenshot — behavioral delegation (gap C3, reviewer I-NEW-1) ──
+
+describe('createMobileWebkitIosDriver — takeScreenshot delegation', () => {
+  const helper = require(
+    path.join(REPO_ROOT, 'express-api/scripts/drivers/driver-screenshot-helper'),
+  );
+
+  test('routes to takeScreenshotViaAppium with Appium URL + slug=mobile-chrome-ios', async () => {
+    const spy = jest
+      .spyOn(helper, 'takeScreenshotViaAppium')
+      .mockResolvedValue(['/mock/webkit-chrome.png']);
+    try {
+      const fetchImpl = makeFetchMock(defaultHandlers({ sessionId: 'sess-webkit-chrome' }));
+      const driver = await createMobileWebkitIosDriver({
+        browser: 'chrome',
+        wdaTeamId: 'TEAM123',
+        selectUdidImpl: () => 'UDID',
+        fetchImpl,
+      });
+      // Establish session via webRefreshRoomsList → context switch + nav.
+      await driver.webRefreshRoomsList('Alice');
+
+      const result = await driver.takeScreenshot('/tmp/webkit-out');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [args] = spy.mock.calls[0];
+      expect(args.appiumBaseUrl).toBe(DEFAULT_APPIUM_BASE_URL);
+      expect(args.sessionId).toBe('sess-webkit-chrome');
+      expect(args.fetchImpl).toBe(fetchImpl);
+      expect(args.outputDir).toBe('/tmp/webkit-out');
+      // Slug interpolates the browser param — drift-catch for the
+      // dynamic template literal at the production wiring.
+      expect(args.slug).toBe('mobile-chrome-ios');
+      expect(result).toEqual(['/mock/webkit-chrome.png']);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('slug = mobile-firefox-ios when browser=firefox (different code path)', async () => {
+    // Distinct from the chrome variant: pins the slug interpolation
+    // against an alternate browser value. If a future refactor
+    // hardcodes the slug, this test fails.
+    const spy = jest.spyOn(helper, 'takeScreenshotViaAppium').mockResolvedValue([]);
+    try {
+      const fetchImpl = makeFetchMock(defaultHandlers({ sessionId: 'sess-webkit-ff' }));
+      const driver = await createMobileWebkitIosDriver({
+        browser: 'firefox',
+        wdaTeamId: 'TEAM123',
+        selectUdidImpl: () => 'UDID',
+        fetchImpl,
+      });
+      await driver.webRefreshRoomsList('Alice');
+      await driver.takeScreenshot('/tmp/ff-ios-out');
+      expect(spy.mock.calls[0][0].slug).toBe('mobile-firefox-ios');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('sessionId is null when called before any session-establishing call', async () => {
+    const spy = jest.spyOn(helper, 'takeScreenshotViaAppium').mockResolvedValue([]);
+    try {
+      const driver = await createMobileWebkitIosDriver({
+        browser: 'chrome',
+        wdaTeamId: 'TEAM123',
+        selectUdidImpl: () => 'UDID',
+        fetchImpl: makeFetchMock([]),
+      });
+      await driver.takeScreenshot('/tmp/out');
+      expect(spy.mock.calls[0][0].sessionId).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/express-api/tests/scripts/drivers/web-playwright-driver.test.js
+++ b/express-api/tests/scripts/drivers/web-playwright-driver.test.js
@@ -258,3 +258,64 @@ describe('web-playwright-driver — webRefreshRoomsList', () => {
     expect(ok).toBe(false);
   });
 });
+
+// takeScreenshot — behavioral delegation (gap C3, reviewer I2) ────────
+//
+// Distinct from the static source-text pin in
+// driver-screenshot-delegation.test.js — this test exercises the actual
+// runtime wiring by spying on the helper module and asserting the
+// driver's inline `require('./driver-screenshot-helper')` call
+// delegates with the closure-captured `pages` Map (not a fresh empty
+// Map or a stale reference).
+
+describe('web-playwright-driver — takeScreenshot delegation', () => {
+  const helperPath = path.join(REPO_ROOT, 'express-api/scripts/drivers/driver-screenshot-helper');
+  const helper = require(helperPath);
+
+  test('routes to takeScreenshotForPages with the populated pages Map + slug + outputDir', async () => {
+    const spy = jest
+      .spyOn(helper, 'takeScreenshotForPages')
+      .mockResolvedValue(['/mock/png-1.png', '/mock/png-2.png']);
+    try {
+      prepareMockPages({ Alice: makeMockPage(), Bob: makeMockPage() });
+      const driver = await createWebDriver({ baseURL: 'http://localhost:8888' });
+      // Populate the pages Map by exercising pageFor() through the
+      // driver's public API. Drives the closure's `pages` variable.
+      await driver.webRefreshRoomsList('Alice');
+      await driver.webRefreshRoomsList('Bob');
+
+      const result = await driver.takeScreenshot('/tmp/report-dir');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [pagesArg, outputDirArg, slugArg] = spy.mock.calls[0];
+      expect(outputDirArg).toBe('/tmp/report-dir');
+      expect(slugArg).toBe('chromium');
+      // CRITICAL: pagesArg must be the SAME Map instance that
+      // pageFor() populated. A regression that passes a fresh Map
+      // would silently produce 0 screenshots — this assertion catches it.
+      expect(pagesArg instanceof Map).toBe(true);
+      expect(pagesArg.size).toBe(2);
+      expect(pagesArg.has('Alice')).toBe(true);
+      expect(pagesArg.has('Bob')).toBe(true);
+      expect(result).toEqual(['/mock/png-1.png', '/mock/png-2.png']);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('slug reflects the configured browser (firefox path)', async () => {
+    const spy = jest.spyOn(helper, 'takeScreenshotForPages').mockResolvedValue([]);
+    try {
+      prepareMockPages({ Alice: makeMockPage() });
+      const driver = await createWebDriver({
+        baseURL: 'http://localhost:8888',
+        browser: 'firefox',
+      });
+      await driver.webRefreshRoomsList('Alice');
+      await driver.takeScreenshot('/tmp/out');
+      expect(spy.mock.calls[0][2]).toBe('firefox');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner-screenshot-on-fail.test.js
+++ b/express-api/tests/scripts/manual-qa-runner-screenshot-on-fail.test.js
@@ -268,11 +268,17 @@ describe('runFeatureFile screenshot-on-failure hook (C3)', () => {
     // Catches off-by-one regressions if a future refactor reorders the
     // findings.push vs screenshot block (the index is computed from
     // findings.length - 1).
-    const actualDirs = takeScreenshot.mock.calls.map((c) => c[0]).sort();
-    const expectedDirs = takeScreenshot.mock.calls
-      .map((_, idx) => `/tmp/qa-report/scenario-${idx}`)
-      .sort();
-    expect(actualDirs).toEqual(expectedDirs);
+    //
+    // Reviewer round-3 I-1 — pin per-CALL order, not just the set.
+    // sample-failures.feature scenarios run in Gherkin order; failure
+    // ordinal MUST match call ordinal so scenarioReports[i].screenshots
+    // points to the right scenario's artifacts. A future refactor that
+    // sorts failures (e.g. by severity) before screenshots would pass a
+    // set-equality assertion but break the correlation. The per-call
+    // pin catches that class of regression.
+    for (let i = 0; i < takeScreenshot.mock.calls.length; i++) {
+      expect(takeScreenshot.mock.calls[i][0]).toBe(`/tmp/qa-report/scenario-${i}`);
+    }
   });
 
   test('empty-string screenshot paths are filtered out (reviewer P3)', async () => {

--- a/express-api/tests/scripts/manual-qa-runner-screenshot-on-fail.test.js
+++ b/express-api/tests/scripts/manual-qa-runner-screenshot-on-fail.test.js
@@ -1,0 +1,241 @@
+/**
+ * manual-qa-runner-screenshot-on-fail.test.js
+ *
+ * Integration test for gap C3 — per-scenario-failure screenshot capture.
+ * Exercises the hook in runFeatureFile (~line 14826) end-to-end against
+ * the existing sample-failures.feature fixture.
+ *
+ * Hook contract (must hold for every code change):
+ *   1. Scenario fails AND ctx.reportDir set AND ctx.webDriver has
+ *      takeScreenshot → takeScreenshot is called with reportDir.
+ *   2. Returned paths are persisted on scenarioReports[].screenshots.
+ *   3. Scenario passes → takeScreenshot is NEVER called.
+ *   4. No reportDir → takeScreenshot is NEVER called.
+ *   5. No webDriver → no crash, no screenshots field.
+ *   6. webDriver lacks takeScreenshot → no crash, no screenshots field.
+ *   7. takeScreenshot throws → swallowed, scenario still reported as
+ *      fail with no screenshots field.
+ *   8. takeScreenshot returns [] → no empty screenshots field added.
+ *
+ * Best-effort guarantee: a failing screenshot must NEVER mask the
+ * scenario failure itself nor crash the runner.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const { runFeatureFile } = require(path.join(REPO_ROOT, 'scripts/manual-qa-runner.js'));
+
+const FIXTURE_DIR = path.join(__dirname, 'fixtures');
+const FAILURES_FIXTURE = path.join(FIXTURE_DIR, 'sample-failures.feature');
+
+/**
+ * Write a one-scenario passes-by-default fixture to a tmp path so the
+ * "pass → no screenshot call" assertion is hermetic — independent of
+ * sample-auth's multi-persona fetch contract.
+ */
+function writePassingFixture() {
+  const tmp = path.join(os.tmpdir(), `qa-passing-fixture-${process.pid}-${Date.now()}.feature`);
+  fs.writeFileSync(
+    tmp,
+    [
+      'Feature: Single passing scenario for screenshot hook test',
+      '',
+      '  Scenario: Healthcheck',
+      '    Given the local stack is healthy',
+      '',
+    ].join('\n'),
+  );
+  return tmp;
+}
+
+/**
+ * Minimal ctx — mirrors makeCtx() in manual-qa-runner.test.js but
+ * adds the C3-specific fields (reportDir + webDriver). Default fetch
+ * is a stub that returns enough to let the auth Given pass and the
+ * GET succeed; the assertion-mismatch is what drives the failure.
+ */
+function makeCtx(overrides = {}) {
+  return {
+    apiBase: 'https://dev-api.example',
+    firebaseApiKey: 'fake-key',
+    personasPassword: 'fake-pw-not-real-just-stub-fixture',
+    sessions: new Map(),
+    personaPlatforms: new Map(),
+    personaPaths: new Map(),
+    lastResponse: null,
+    locale: 'en',
+    fetch: jest.fn(async (url) => {
+      if (typeof url === 'string' && url.includes('signInWithPassword')) {
+        const claims = { uniqueId: 50000010, admin: false };
+        const idToken = 'h.' + Buffer.from(JSON.stringify(claims)).toString('base64url') + '.s';
+        return {
+          status: 200,
+          json: async () => ({ idToken, refreshToken: 'rt', localId: 'fb-1' }),
+        };
+      }
+      if (typeof url === 'string' && url.includes('/api/users/')) {
+        return {
+          status: 200,
+          text: async () => JSON.stringify({ uniqueId: 50000010, displayName: 'Alice' }),
+        };
+      }
+      return { status: 200, text: async () => '{}' };
+    }),
+    ...overrides,
+  };
+}
+
+describe('runFeatureFile screenshot-on-failure hook (C3)', () => {
+  test('failing scenario + reportDir + webDriver.takeScreenshot → screenshots captured', async () => {
+    const takeScreenshot = jest.fn(async () => ['/tmp/qa-report/screenshot-chromium-Alice.png']);
+    const ctx = makeCtx({
+      reportDir: '/tmp/qa-report',
+      webDriver: { takeScreenshot },
+    });
+    const { scenarioReports } = await runFeatureFile(FAILURES_FIXTURE, ctx);
+    const wrongStatus = scenarioReports.find(
+      (s) => s.scenario === 'Wrong status assertion produces a finding',
+    );
+    expect(wrongStatus.status).toBe('fail');
+    expect(wrongStatus.screenshots).toEqual(['/tmp/qa-report/screenshot-chromium-Alice.png']);
+    // The hook receives reportDir verbatim so the helper can mkdir + write.
+    expect(takeScreenshot).toHaveBeenCalledWith('/tmp/qa-report');
+    // Called once per failing scenario (sample-failures has 3, so ≥1).
+    expect(takeScreenshot).toHaveBeenCalled();
+  });
+
+  test('passing scenario → takeScreenshot is NEVER called (no wasted I/O on green path)', async () => {
+    const takeScreenshot = jest.fn(async () => ['unused.png']);
+    const ctx = makeCtx({
+      reportDir: '/tmp/qa-report',
+      webDriver: { takeScreenshot },
+    });
+    const passingFixture = writePassingFixture();
+    try {
+      const { scenarioReports } = await runFeatureFile(passingFixture, ctx);
+      expect(scenarioReports[0].status).toBe('pass');
+      // If a future runner change wrongly fires the hook on pass, this throws.
+      expect(takeScreenshot).not.toHaveBeenCalled();
+    } finally {
+      fs.unlinkSync(passingFixture);
+    }
+  });
+
+  test('no reportDir → takeScreenshot is NEVER called even on fail (operator opt-out)', async () => {
+    const takeScreenshot = jest.fn(async () => ['unused.png']);
+    const ctx = makeCtx({
+      // no reportDir
+      webDriver: { takeScreenshot },
+    });
+    const { scenarioReports } = await runFeatureFile(FAILURES_FIXTURE, ctx);
+    expect(takeScreenshot).not.toHaveBeenCalled();
+    // Still reports the failure normally — no screenshots field.
+    const wrongStatus = scenarioReports.find(
+      (s) => s.scenario === 'Wrong status assertion produces a finding',
+    );
+    expect(wrongStatus.status).toBe('fail');
+    expect(wrongStatus.screenshots).toBeUndefined();
+  });
+
+  test('no webDriver → no crash, scenario still reported as fail (native/headless cells)', async () => {
+    const ctx = makeCtx({
+      reportDir: '/tmp/qa-report',
+      // no webDriver — e.g. android-adb or ios-devicectl runs
+    });
+    const { scenarioReports, findings } = await runFeatureFile(FAILURES_FIXTURE, ctx);
+    const wrongStatus = scenarioReports.find(
+      (s) => s.scenario === 'Wrong status assertion produces a finding',
+    );
+    expect(wrongStatus.status).toBe('fail');
+    expect(wrongStatus.screenshots).toBeUndefined();
+    // Failure still classified normally.
+    expect(findings.some((f) => f.scenario === wrongStatus.scenario)).toBe(true);
+  });
+
+  test('webDriver without takeScreenshot method → no crash, no screenshots field (older driver versions)', async () => {
+    const ctx = makeCtx({
+      reportDir: '/tmp/qa-report',
+      webDriver: { close: async () => {} }, // driver predates C3
+    });
+    const { scenarioReports } = await runFeatureFile(FAILURES_FIXTURE, ctx);
+    const wrongStatus = scenarioReports.find(
+      (s) => s.scenario === 'Wrong status assertion produces a finding',
+    );
+    expect(wrongStatus.status).toBe('fail');
+    expect(wrongStatus.screenshots).toBeUndefined();
+  });
+
+  test('takeScreenshot throws → swallowed, scenario reported as fail without screenshots (best-effort)', async () => {
+    const takeScreenshot = jest.fn(async () => {
+      throw new Error('Playwright context closed');
+    });
+    const ctx = makeCtx({
+      reportDir: '/tmp/qa-report',
+      webDriver: { takeScreenshot },
+    });
+    const { scenarioReports, findings } = await runFeatureFile(FAILURES_FIXTURE, ctx);
+    expect(takeScreenshot).toHaveBeenCalled();
+    const wrongStatus = scenarioReports.find(
+      (s) => s.scenario === 'Wrong status assertion produces a finding',
+    );
+    // Critical invariant: a broken screenshot helper must NEVER mask the
+    // underlying test failure or crash the runner.
+    expect(wrongStatus.status).toBe('fail');
+    expect(wrongStatus.screenshots).toBeUndefined();
+    expect(findings.some((f) => f.scenario === wrongStatus.scenario)).toBe(true);
+  });
+
+  test('takeScreenshot returns [] → no empty screenshots field on report', async () => {
+    // Helper returns [] when outputDir is falsy or all per-persona
+    // captures error; mirror that here. Empty array MUST NOT be
+    // serialized as `screenshots: []` — it would pollute every report
+    // JSON with empty arrays.
+    const takeScreenshot = jest.fn(async () => []);
+    const ctx = makeCtx({
+      reportDir: '/tmp/qa-report',
+      webDriver: { takeScreenshot },
+    });
+    const { scenarioReports } = await runFeatureFile(FAILURES_FIXTURE, ctx);
+    const wrongStatus = scenarioReports.find(
+      (s) => s.scenario === 'Wrong status assertion produces a finding',
+    );
+    expect(wrongStatus.status).toBe('fail');
+    expect(wrongStatus.screenshots).toBeUndefined();
+  });
+
+  test('takeScreenshot returns null → no crash, no screenshots field', async () => {
+    // Defensive: future helper bug returning null shouldn't crash the
+    // `screenshotPaths.length` check. The hook coerces via `|| []`.
+    const takeScreenshot = jest.fn(async () => null);
+    const ctx = makeCtx({
+      reportDir: '/tmp/qa-report',
+      webDriver: { takeScreenshot },
+    });
+    const { scenarioReports } = await runFeatureFile(FAILURES_FIXTURE, ctx);
+    const wrongStatus = scenarioReports.find(
+      (s) => s.scenario === 'Wrong status assertion produces a finding',
+    );
+    expect(wrongStatus.status).toBe('fail');
+    expect(wrongStatus.screenshots).toBeUndefined();
+  });
+
+  test('multiple failing scenarios in one file → takeScreenshot called per failure', async () => {
+    // sample-failures has 3 failing scenarios; each should trigger the
+    // hook independently (one screenshot batch per failure).
+    const takeScreenshot = jest.fn(async () => ['shot.png']);
+    const ctx = makeCtx({
+      reportDir: '/tmp/qa-report',
+      webDriver: { takeScreenshot },
+    });
+    const { scenarioReports } = await runFeatureFile(FAILURES_FIXTURE, ctx);
+    const failingReports = scenarioReports.filter((s) => s.status === 'fail');
+    expect(failingReports.length).toBeGreaterThanOrEqual(2);
+    expect(takeScreenshot.mock.calls.length).toBe(failingReports.length);
+    for (const r of failingReports) {
+      expect(r.screenshots).toEqual(['shot.png']);
+    }
+  });
+});

--- a/express-api/tests/scripts/manual-qa-runner-screenshot-on-fail.test.js
+++ b/express-api/tests/scripts/manual-qa-runner-screenshot-on-fail.test.js
@@ -263,6 +263,16 @@ describe('runFeatureFile screenshot-on-failure hook (C3)', () => {
     for (const [dir] of takeScreenshot.mock.calls) {
       expect(dir).toMatch(/\/tmp\/qa-report\/scenario-\d+$/);
     }
+    // Reviewer I-NEW-2 — pin EXACT indices: failures form a contiguous
+    // zero-based sequence so screenshot dir N correlates with findings[N].
+    // Catches off-by-one regressions if a future refactor reorders the
+    // findings.push vs screenshot block (the index is computed from
+    // findings.length - 1).
+    const actualDirs = takeScreenshot.mock.calls.map((c) => c[0]).sort();
+    const expectedDirs = takeScreenshot.mock.calls
+      .map((_, idx) => `/tmp/qa-report/scenario-${idx}`)
+      .sort();
+    expect(actualDirs).toEqual(expectedDirs);
   });
 
   test('empty-string screenshot paths are filtered out (reviewer P3)', async () => {

--- a/express-api/tests/scripts/manual-qa-runner-screenshot-on-fail.test.js
+++ b/express-api/tests/scripts/manual-qa-runner-screenshot-on-fail.test.js
@@ -101,8 +101,12 @@ describe('runFeatureFile screenshot-on-failure hook (C3)', () => {
     );
     expect(wrongStatus.status).toBe('fail');
     expect(wrongStatus.screenshots).toEqual(['/tmp/qa-report/screenshot-chromium-Alice.png']);
-    // The hook receives reportDir verbatim so the helper can mkdir + write.
-    expect(takeScreenshot).toHaveBeenCalledWith('/tmp/qa-report');
+    // The hook passes a per-failure subdir `<reportDir>/scenario-<N>/`
+    // so multiple failures in the same feature don't overwrite each
+    // other's PNGs (reviewer I1 fix).
+    expect(takeScreenshot).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/tmp\/qa-report\/scenario-\d+$/),
+    );
     // Called once per failing scenario (sample-failures has 3, so ≥1).
     expect(takeScreenshot).toHaveBeenCalled();
   });
@@ -236,6 +240,61 @@ describe('runFeatureFile screenshot-on-failure hook (C3)', () => {
     expect(takeScreenshot.mock.calls.length).toBe(failingReports.length);
     for (const r of failingReports) {
       expect(r.screenshots).toEqual(['shot.png']);
+    }
+  });
+
+  test('multi-failure: each scenario gets a UNIQUE outputDir (collision-proof per reviewer I1)', async () => {
+    // Reviewer-flagged: prior helper-level filename pattern
+    // `screenshot-<slug>-<persona>.png` had no scenario qualifier, so
+    // a second failing scenario with the same persona would overwrite
+    // the first. Fix: runner passes `<reportDir>/scenario-<N>/` as the
+    // outputDir, where N is the failure ordinal. Helper writes inside
+    // that subdir → no collision possible.
+    const takeScreenshot = jest.fn(async (outputDir) => [`${outputDir}/shot.png`]);
+    const ctx = makeCtx({
+      reportDir: '/tmp/qa-report',
+      webDriver: { takeScreenshot },
+    });
+    await runFeatureFile(FAILURES_FIXTURE, ctx);
+    const uniqueDirs = new Set(takeScreenshot.mock.calls.map((c) => c[0]));
+    // If two failures shared an outputDir, set size would be < calls length.
+    expect(uniqueDirs.size).toBe(takeScreenshot.mock.calls.length);
+    // Each call gets a `scenario-N` suffix.
+    for (const [dir] of takeScreenshot.mock.calls) {
+      expect(dir).toMatch(/\/tmp\/qa-report\/scenario-\d+$/);
+    }
+  });
+
+  test('empty-string screenshot paths are filtered out (reviewer P3)', async () => {
+    // Defense-in-depth: if a future helper bug returned `['']`, the
+    // runner's `length > 0` guard would attach `screenshots: ['']` —
+    // a garbage path for any downstream artifact consumer. The
+    // `.filter(Boolean)` in the runner strips falsy entries first.
+    const takeScreenshot = jest.fn(async () => ['', '/real/path.png', '']);
+    const ctx = makeCtx({
+      reportDir: '/tmp/qa-report',
+      webDriver: { takeScreenshot },
+    });
+    const { scenarioReports } = await runFeatureFile(FAILURES_FIXTURE, ctx);
+    const failingReports = scenarioReports.filter((s) => s.status === 'fail');
+    for (const r of failingReports) {
+      expect(r.screenshots).toEqual(['/real/path.png']);
+    }
+  });
+
+  test('helper returns only empty strings → screenshots field NOT attached', async () => {
+    // Edge of P3: if every entry is falsy, the post-filter array is
+    // empty → length-check skips the .screenshots assignment entirely.
+    // No screenshots field is more honest than `screenshots: []`.
+    const takeScreenshot = jest.fn(async () => ['', '']);
+    const ctx = makeCtx({
+      reportDir: '/tmp/qa-report',
+      webDriver: { takeScreenshot },
+    });
+    const { scenarioReports } = await runFeatureFile(FAILURES_FIXTURE, ctx);
+    const failingReports = scenarioReports.filter((s) => s.status === 'fail');
+    for (const r of failingReports) {
+      expect(r.screenshots).toBeUndefined();
     }
   });
 });


### PR DESCRIPTION
## Summary

Closes gap **C3** from the QA-runner framework tracker — per-cell screenshot capture on scenario failure. Diagnostic artifact dropped into the operator's `--report-dir` whenever a Gherkin scenario fails, one PNG per persona-tab.

## What ships

- **New helper module**: `express-api/scripts/drivers/driver-screenshot-helper.js`
  - `takeScreenshotForPages(pages, outputDir, slug)` — Playwright pages-Map (chrome-android, samsung-android, edge-android, desktop Playwright)
  - `takeScreenshotViaAppium({appiumBaseUrl, sessionId, fetchImpl, outputDir, slug})` — W3C WebDriver HTTP API. Despite the name, works for ANY W3C-compliant driver returning `{value: <base64>}` — Geckodriver, Appium, future webdrivers. firefox-android (Geckodriver), safari-ios + webkit-ios (Appium) all share this endpoint shape.
- **7 web drivers wired** with `driver.takeScreenshot(outputDir)`:
  - `web-playwright-driver`, `web-mobile-chrome-android`, `web-mobile-samsung-android`, `web-mobile-edge-android` → Playwright path
  - `web-mobile-firefox-android` → Geckodriver HTTP path
  - `web-mobile-safari-ios`, `web-mobile-webkit-ios` → Appium HTTP path
- **Runner hook** in `runFeatureFile` — calls `ctx.webDriver.takeScreenshot(ctx.reportDir)` **before** `driver.close()` on scenario failure when `ctx.webDriver` AND `ctx.reportDir` are both set. Best-effort: any throw is swallowed and logged; it must never mask the original test outcome.
- **Native drivers (android-adb / ios-devicectl / ios-simctl / ios-appium) explicitly NOT wired** — the hook is web-only (`ctx.webDriver` triggers it). Expanding to native would be a deliberate contract change with its own gap.
- **File naming**: `screenshot-<driver-slug>-<persona>.png` — so the matrix report can glob artifacts by cell.

## Test coverage (49 new tests)

- **15 helper unit tests** (`driver-screenshot-helper.test.js`) — both helpers: falsy outputDir, empty pages, multi-persona naming, partial-failure resilience (one persona throwing doesn't block others), recursive mkdir, fullPage flag, base64 decode, endpoint shape, error-path returns `[]`
- **9 integration tests** (`manual-qa-runner-screenshot-on-fail.test.js`) — end-to-end via `runFeatureFile` + sample fixture: fail+capture, pass+skip, no `reportDir`, no `webDriver`, no `takeScreenshot` method, thrown error swallowed, empty array return, null return, multiple failures
- **25 delegation pin tests** (`driver-screenshot-delegation.test.js`) — static-text pins that each of 7 web drivers wires the assignment, requires the helper, and includes `'takeScreenshot'` in `*_METHOD_NAMES`; 4 native drivers tested for explicit absence (closes the assignment-vs-constant drift gap for this method)

All tests green; ESLint + Prettier clean; pre-commit + pre-push Sonar passed.

## Why C3 was deferred and is now closed

Original deferral (PR #908-era): C3 needed a stable driver-method contract + a shared file-naming convention before per-cell screenshots could be reliable. With B2 (`*_METHOD_NAMES`), B3 (driver-contract.test.js), B5 (driver-surface report) all landed (#937, #918, #925), the path-of-least-resistance was clear: one helper, two transport implementations, seven thin wirings.

## Pre-commit caught a real bug

I initially wired firefox-android with `takeScreenshotForPages(pages, ...)`, assuming the same Playwright pages-Map shape as chrome/samsung/edge-android. Pre-commit hook reported `'pages' is not defined`. Investigation revealed firefox-android uses **Geckodriver HTTP** (not Playwright) — entirely different transport. Fixed by switching to `takeScreenshotViaAppium` with the Geckodriver port. Per [feedback-think-like-qa-real-fixes] — real root-cause fix.

## Auto-merge intentionally DISABLED

Per [feedback-auto-merge-race-with-reviewer]. Will enable only after the code-reviewer agent reports ZERO findings.

## Test plan

- [x] All 4378+ Jest tests pass (`cd express-api && npm test`)
- [x] ESLint `--max-warnings=0` clean
- [x] Prettier clean
- [x] Pre-commit hook (lint-staged) passes
- [x] Pre-push Sonar quality gate passes
- [ ] Code-reviewer agent reports ZERO findings (next step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)