### PR TITLE
fix(ci): split ~/.konan cache restore+save so hung uploads don't strand the workflow

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -203,8 +203,23 @@ jobs:
       # Cache key uses the gradle versions-catalog hash so a Kotlin
       # version bump correctly invalidates; restore-keys provide
       # partial warmth on bumps.
-      - name: Cache Kotlin/Native (~/.konan)
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      #
+      # Split into restore (here) + save (at the END of the job, after
+      # the heavy build steps) instead of using the combined
+      # `actions/cache` step. Self-discovered 2026-06-01 on a hung
+      # 9858c4c run that stalled in "Post Cache Kotlin/Native"
+      # in_progress for 2h+ because actions/cache's synthetic POST
+      # step does NOT respect job-level `timeout-minutes: 90`. The
+      # split lets the save run as a regular step where the safety
+      # attributes (`timeout-minutes` + `continue-on-error: true`)
+      # actually apply. `~/.konan` is multi-GB and is the largest cache
+      # in the job — the smaller caches (SwiftPM/DerivedData/Pods/
+      # CocoaPods specs) all completed cleanly, so they keep using the
+      # combined action. Pinned by
+      # tests/scripts/ios-konan-cache-no-hang.test.js.
+      - name: Restore Kotlin/Native cache (~/.konan)
+        id: konan-cache-restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.konan
           key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
@@ -417,6 +432,34 @@ jobs:
           name: ios-test-bundle
           path: build/ios-derived-data/
           retention-days: 3
+
+      # Paired with the Restore Kotlin/Native cache step at the head
+      # of the job. Runs as a regular step (NOT a synthetic POST step
+      # like combined actions/cache) so the safety attributes below
+      # actually apply when GitHub's cache backend hangs mid-upload.
+      #
+      # `if:` skips re-uploading on cache-hit — the restored bundle
+      # is byte-identical so a save would be wasted bytes.
+      #
+      # `timeout-minutes: 10` bounds the blast radius. Real ~/.konan
+      # uploads complete in 1-3 min on a green network; 10 min is 3×
+      # the worst legitimate duration. A longer hang means the cache
+      # backend is the bottleneck and the job should bail rather than
+      # eat the runner's 6h budget.
+      #
+      # `continue-on-error: true` because the cache is a perf
+      # optimization, not a correctness gate. A failed/timed-out save
+      # means the NEXT cold-cache run pays the K/N-toolchain download
+      # tax (~hundreds of MB, ~2-3 min) — annoying but not blocking.
+      # Don't fail the iOS Build job for it.
+      - name: Save Kotlin/Native cache (~/.konan)
+        if: always() && steps.konan-cache-restore.outputs.cache-hit != 'true'
+        timeout-minutes: 10
+        continue-on-error: true
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.konan
+          key: ${{ steps.konan-cache-restore.outputs.cache-primary-key }}
 
     outputs:
       has_tests: ${{ steps.check-tests.outputs.has_tests }}

--- a/express-api/tests/scripts/ios-konan-cache-no-hang.test.js
+++ b/express-api/tests/scripts/ios-konan-cache-no-hang.test.js
@@ -1,0 +1,134 @@
+/**
+ * ios-tests.yml — ~/.konan cache must use restore + save split with
+ * bounded save step.
+ *
+ * Self-discovered 2026-06-01 on PR #950 (i18n translation PR that did
+ * not touch iOS code): the build-ios job's Post step "Cache
+ * Kotlin/Native (~/.konan)" hung in `in_progress` for 2+ hours,
+ * blocking the workflow's concurrency lock and stranding all
+ * subsequent PR Checks runs on the branch. The job-level
+ * `timeout-minutes: 90` did NOT enforce the kill — actions/cache
+ * post-steps that are mid-upload to GitHub's cache backend do not
+ * reliably respect timeout signals.
+ *
+ * Root cause: the combined `actions/cache@v5` step runs its save as
+ * a synthetic POST step appended to the job's teardown. Post steps
+ * cannot themselves be wrapped with `timeout-minutes` or
+ * `continue-on-error` (those attributes apply only at the regular
+ * step level). When the cache upload hangs (~.konan is multi-GB —
+ * the largest cache in the job; SwiftPM/DerivedData/Pods/CocoaPods
+ * all completed cleanly), the post step blocks indefinitely with no
+ * escape hatch.
+ *
+ * Fix: split the combined step into `actions/cache/restore@v5`
+ * (regular step at the head of the job) plus `actions/cache/save@v5`
+ * (regular step AFTER the heavy build steps complete). The save
+ * step gets:
+ *   - `timeout-minutes` so a hung upload bounds the blast radius
+ *   - `continue-on-error: true` so a hung/failed save doesn't fail
+ *     the job (cache is a perf optimization, not a correctness gate)
+ *   - `if:` guard that skips save on cache-hit (no point re-uploading
+ *     the identical bundle)
+ *
+ * Pin the resulting workflow shape here so a future refactor that
+ * regresses back to the combined `actions/cache` step is caught at
+ * PR time, not after another PR is blocked for hours.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const IOS_TESTS_YML = path.join(REPO_ROOT, '.github/workflows/ios-tests.yml');
+
+describe('ios-tests.yml — ~/.konan cache: restore + save split with bounded save', () => {
+  let yamlText;
+
+  beforeAll(() => {
+    yamlText = fs.readFileSync(IOS_TESTS_YML, 'utf8');
+  });
+
+  test('does NOT use the combined actions/cache step for ~/.konan (anti-pattern)', () => {
+    // Iterate over each `uses: actions/cache@<X>` line (combined
+    // action). The split actions/cache/restore + actions/cache/save
+    // won't match this prefix because of the slash after `cache`.
+    // For each combined-cache step, assert that the next 300
+    // characters don't include `path: ~/.konan` — i.e. no combined
+    // step targets this cache.
+    const combinedSteps = [...yamlText.matchAll(/uses: actions\/cache@\S+/g)];
+    for (const m of combinedSteps) {
+      const stepWindow = yamlText.substring(m.index, m.index + 300);
+      expect(stepWindow).not.toMatch(/path:\s*~\/\.konan/);
+    }
+  });
+
+  test('has an actions/cache/restore step for ~/.konan with id for save-guard', () => {
+    // The restore step must carry an `id:` so a later save step can
+    // gate on its cache-hit output. `id:` conventionally sits between
+    // `name:` and `uses:` in the step body — search for an `id:` line
+    // within ~200 chars BEFORE the `uses: actions/cache/restore@<X>`
+    // → `path: ~/.konan` pair.
+    const restoreWithId = yamlText.match(
+      /id:\s+\S+[\s\S]{0,200}?uses: actions\/cache\/restore@\S+[\s\S]{0,200}?path: ~\/\.konan/,
+    );
+    expect(restoreWithId).not.toBeNull();
+  });
+
+  // Locate the save step body once via index arithmetic — avoids
+  // unbounded-lazy regexes (`[^]*?`) that ESLint's sonarjs/slow-regex
+  // flags as catastrophic-backtracking-prone. The step's safety
+  // attributes (`if:`, `timeout-minutes:`, `continue-on-error:`) all
+  // appear in the ~10 lines immediately above the `uses:` line per
+  // YAML step convention.
+  function findSaveStepBlock() {
+    const usesPattern = /uses: actions\/cache\/save@\S+/;
+    const usesMatch = yamlText.match(usesPattern);
+    if (!usesMatch) return null;
+    // Walk backwards from the `uses:` line to the step's `- name:`
+    // header (bounded by 20 lines — far more than any real step).
+    const upToUses = yamlText.substring(0, usesMatch.index + usesMatch[0].length);
+    const lines = upToUses.split('\n');
+    const stepHeaderIdx = (() => {
+      for (let i = lines.length - 1; i >= Math.max(0, lines.length - 20); i--) {
+        if (/^ {6}- /.test(lines[i])) return i;
+      }
+      return -1;
+    })();
+    if (stepHeaderIdx === -1) return null;
+    // Walk forwards from `uses:` until the next step header or end.
+    const allLines = yamlText.split('\n');
+    let endIdx = allLines.length;
+    for (let i = lines.length; i < Math.min(allLines.length, lines.length + 20); i++) {
+      if (/^ {6}- /.test(allLines[i]) || /^ {4}\S/.test(allLines[i])) {
+        endIdx = i;
+        break;
+      }
+    }
+    return allLines.slice(stepHeaderIdx, endIdx).join('\n');
+  }
+
+  test('has an actions/cache/save step for ~/.konan', () => {
+    const block = findSaveStepBlock();
+    expect(block).not.toBeNull();
+    expect(block).toMatch(/uses: actions\/cache\/save@\S+/);
+    expect(block).toMatch(/path:\s*~\/\.konan/);
+  });
+
+  test('the save step has timeout-minutes (bounded blast radius)', () => {
+    const block = findSaveStepBlock();
+    expect(block).not.toBeNull();
+    expect(block).toMatch(/timeout-minutes:\s+\d+/);
+  });
+
+  test('the save step has continue-on-error: true (cache is not a correctness gate)', () => {
+    const block = findSaveStepBlock();
+    expect(block).not.toBeNull();
+    expect(block).toMatch(/continue-on-error:\s+true/);
+  });
+
+  test('the save step has an if-guard so it skips save on cache-hit', () => {
+    const block = findSaveStepBlock();
+    expect(block).not.toBeNull();
+    expect(block).toMatch(/if:[^\n]*cache-hit/);
+  });
+});

--- a/express-api/tests/scripts/ios-tests-build-cache.test.js
+++ b/express-api/tests/scripts/ios-tests-build-cache.test.js
@@ -237,7 +237,15 @@ describe('ios-tests.yml — build-ios job cold-cache survival', () => {
   beforeAll(() => {
     yamlText = fs.readFileSync(IOS_TESTS_PATH, 'utf8');
     buildIosJob = extractJob(yamlText, 'build-ios');
-    cacheStep = extractStep(yamlText, 'Cache Kotlin/Native (~/.konan)');
+    // Step renamed 2026-06-01: the combined actions/cache step was
+    // split into restore + save to bound the cache-save blast radius
+    // (the combined step's POST-job upload would hang for hours on
+    // ~/.konan's multi-GB payload, with job-level timeout-minutes
+    // unable to enforce a kill on the synthetic POST). The restore
+    // step carries the key + restore-keys + path that this suite
+    // pins; the save step's safety attributes are pinned separately
+    // by ios-konan-cache-no-hang.test.js.
+    cacheStep = extractStep(yamlText, 'Restore Kotlin/Native cache (~/.konan)');
     kmpBuildStep = extractStep(yamlText, 'Build shared KMP framework for iOS Simulator');
   });
 
@@ -259,11 +267,11 @@ describe('ios-tests.yml — build-ios job cold-cache survival', () => {
   // The full SHA string contains 'actions/cache' as a substring, so
   // asserting both would be redundant — a single assertion on the
   // pinned SHA covers both the action choice and the version pin.
-  test('Cache Kotlin/Native step pins actions/cache@v5.0.5 SHA (matches deploy-dev)', () => {
-    expect(cacheStep).toContain('actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae');
+  test('Restore Kotlin/Native step pins actions/cache/restore@v5.0.5 SHA (matches deploy-dev)', () => {
+    expect(cacheStep).toContain('actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae');
   });
 
-  test('Cache Kotlin/Native step targets ~/.konan', () => {
+  test('Restore Kotlin/Native step targets ~/.konan', () => {
     expect(cacheStep).toContain('~/.konan');
   });
 
@@ -292,8 +300,14 @@ describe('ios-tests.yml — build-ios job cold-cache survival', () => {
     // in the step that mentions `konan-` carries the `${{ runner.os }}`
     // scope. Guards a future PR that adds a second restore-key entry
     // with a bare `konan-` prefix (which the prior single-line check
-    // would silently miss). The `restore-keys:` literal itself is
-    // excluded — it's the keyword, not a cache key value.
+    // would silently miss).
+    //
+    // Exclusions (none of these are cache key values):
+    //   - `restore-keys:` — the keyword itself
+    //   - `id:` — step identifier (e.g. `id: konan-cache-restore`),
+    //     added 2026-06-01 when the cache step was split into
+    //     restore + save and the restore step gained an `id` so the
+    //     save step can gate on its cache-hit output.
     //
     // Filter-into-violations pattern (not forEach + nested expect):
     // when a forEach-with-expect fails, Jest reports only the offending
@@ -303,7 +317,10 @@ describe('ios-tests.yml — build-ios job cold-cache survival', () => {
     // the test in a debugger.
     const violations = lines.filter(
       (l) =>
-        l.includes('konan-') && !l.includes('restore-keys:') && !l.includes('${{ runner.os }}'),
+        l.includes('konan-') &&
+        !l.includes('restore-keys:') &&
+        !/^\s*id:\s+/.test(l) &&
+        !l.includes('${{ runner.os }}'),
     );
     expect(violations).toEqual([]);
   });
@@ -312,8 +329,14 @@ describe('ios-tests.yml — build-ios job cold-cache survival', () => {
   // (`      - name: …`), not the bare `- name: …` substring. A YAML
   // comment can never literally equal that prefix because comments
   // are introduced by `#`, not 6 spaces.
-  test('konan cache step appears before the Build shared KMP framework step', () => {
-    const cacheStepIdx = yamlText.indexOf('      - name: Cache Kotlin/Native (~/.konan)');
+  //
+  // Renamed 2026-06-01 from `Cache Kotlin/Native (~/.konan)` to the
+  // restore step (cache step split into restore + save). The ordering
+  // invariant remains the same: restore must happen before the
+  // KMP build step so the cache is warm when the build resolves
+  // K/N artifacts.
+  test('Restore Kotlin/Native cache step appears before the Build shared KMP framework step', () => {
+    const cacheStepIdx = yamlText.indexOf('      - name: Restore Kotlin/Native cache (~/.konan)');
     const kmpBuildIdx = yamlText.indexOf(
       '      - name: Build shared KMP framework for iOS Simulator',
     );


### PR DESCRIPTION
## Summary

Self-discovered on closed PR #950 (XML-only i18n PR that didn't touch iOS code): the `build-ios` job's POST step **`Cache Kotlin/Native (~/.konan)`** hung `in_progress` for 2h+, blocking the workflow's concurrency lock and stranding all subsequent PR Checks runs on the branch. Job-level `timeout-minutes: 90` did **NOT** enforce the kill — actions/cache's synthetic POST step does not reliably respect timeout signals when GitHub's cache backend hangs mid-upload.

## Root cause

The combined `actions/cache@v5` step runs save as a synthetic POST step appended to job teardown. POST steps cannot themselves carry `timeout-minutes` or `continue-on-error` attributes (those apply only at the regular-step level). `~/.konan` is multi-GB (the largest cache in the job — SwiftPM, DerivedData, Pods, CocoaPods spec repos all completed cleanly); when its upload hangs, the post step blocks indefinitely with no escape hatch.

## Fix

Split the combined step into `actions/cache/restore@v5` (head of job, unchanged location) + `actions/cache/save@v5` (tail of job, after the heavy build steps). The save step now carries:

- `timeout-minutes: 10` — 3× the worst-legitimate upload duration; longer = backend issue, job should bail
- `continue-on-error: true` — cache is a perf optimization, not a correctness gate; cold-cache next-run is ~2-3 min worth of K/N-toolchain re-download (annoying, not blocking)
- `if: always() && steps.konan-cache-restore.outputs.cache-hit != 'true'` — skip on cache-hit (byte-identical bundle)

## Test plan

- [x] New `ios-konan-cache-no-hang.test.js` (TDD red→green, 6 tests) — pins workflow shape: no combined `actions/cache` for `~/.konan`, restore step has `id` for save-guard, save step has all 3 safety attributes
- [x] Updated `ios-tests-build-cache.test.js` — looks for renamed `Restore Kotlin/Native cache` step, excludes `id:` from the konan-OS-scope scan
- [x] `npm test` in `express-api/` — 10,934 tests pass
- [x] `actionlint` clean on ios-tests.yml
- [x] eslint + prettier clean (sonarjs/slow-regex flags addressed via bounded regex + index-scan helper)
- [x] Pre-push Sonar quality gate — passed

Unblocks closed PR #950 — will be reopened with auto-merge re-armed once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)