### PR TITLE
fix(i18n): natural sign_out phrasing for es + it

### DIFF
--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -132,7 +132,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="about">Acerca de</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="sign_out">Desconectar</string>
+    <string name="sign_out">Cerrar sesión</string>
     <!-- google-translated 2026-05-04 -->
     <string name="sign_out_confirm">¿Estás seguro de que deseas cerrar sesión?</string>
 
@@ -1645,7 +1645,7 @@
     <!-- translated 2026-06-01 -->
     <string name="account_error_code_label">Código de error: %1$s</string>
     <!-- translated 2026-06-01 -->
-    <string name="account_error_sign_out">Desconectar</string>
+    <string name="account_error_sign_out">Cerrar sesión</string>
     <!-- translated 2026-06-01 -->
     <string name="age_restriction_needs_verification_title">Verifica tu edad</string>
     <!-- translated 2026-06-01 -->

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -132,7 +132,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="about">Di</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="sign_out">Disconnessione</string>
+    <string name="sign_out">Esci</string>
     <!-- google-translated 2026-05-04 -->
     <string name="sign_out_confirm">Sei sicuro di voler uscire?</string>
 
@@ -1645,7 +1645,7 @@
     <!-- translated 2026-06-01 -->
     <string name="account_error_code_label">Codice errore: %1$s</string>
     <!-- translated 2026-06-01 -->
-    <string name="account_error_sign_out">Disconnessione</string>
+    <string name="account_error_sign_out">Esci</string>
     <!-- translated 2026-06-01 -->
     <string name="age_restriction_needs_verification_title">Verifica la tua età</string>
     <!-- translated 2026-06-01 -->


### PR DESCRIPTION
## Summary

Follow-up to PR #950's code-reviewer round-1 finding that was intentionally out of #950's scope. Per `[[feedback-fix-pre-existing-and-new-same]]` (operator HARD RULE 2026-05-24): pre-existing translation-quality issues surfaced in review must be fixed in a follow-up PR **this session** — not deferred.

## Changes

| Locale | Key | Before | After | Why |
|---|---|---|---|---|
| es | `sign_out` (line 135) | `Desconectar` | `Cerrar sesión` | "Desconectar" literally means "disconnect" (network/cable). The file's own `sign_out_confirm` (line 137) already uses "cerrar sesión" — proving this is the established convention; the sign_out label was the outlier. |
| es | `account_error_sign_out` (line 1648) | `Desconectar` | `Cerrar sesión` | Mirrors the same fix on the dialog button #950 introduced (matched the existing-awkward convention at PR-#950 time). |
| it | `sign_out` (line 135) | `Disconnessione` | `Esci` | "Disconnessione" is a noun ("disconnection"). Italian buttons take imperative-verb form. Mirrors the file's existing `sign_out_confirm` (line 137) "Sei sicuro di voler uscire?" which uses the same verb root. |
| it | `account_error_sign_out` (line 1648) | `Disconnessione` | `Esci` | Same fix on the dialog button. |

## NOT changed

- `values-es/strings.xml:1050` `unlink` → `Desconectar` — legitimate literal "disconnect" for account-unlink action. Different surface, correct existing translation.

## Test plan

- [x] 62/62 `compose-resources-locale-parity` tests pass (key set unchanged, just value updates)
- [x] No other locale changes
- [x] No code-side string references — both keys consumed by existing `AccountErrorScreen.kt` + signed-in menu Compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)