### PR TITLE
fix(ci): apply ~/.konan restore+save split to deploy-dev + deploy-prod

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -486,8 +486,18 @@ jobs:
       # libs.versions.toml so a kotlin-version bump correctly invalidates.
       # restore-keys allows partial-match restore on minor differences
       # so we usually get a warm konan even when the exact key misses.
-      - name: Cache Kotlin/Native (~/.konan)
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      #
+      # Split into restore (here) + save (at the END of the job, after
+      # the heavy build steps) instead of the combined `actions/cache`
+      # step. Mirrors the fix landed in ios-tests.yml via PR #951 (and
+      # pinned by ios-konan-cache-no-hang.test.js): the combined step's
+      # synthetic POST upload of multi-GB ~/.konan can hang past the
+      # job-level timeout-minutes, stranding the workflow. The split
+      # makes save a regular step where timeout-minutes +
+      # continue-on-error apply.
+      - name: Restore Kotlin/Native cache (~/.konan)
+        id: konan-cache-restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.konan
           key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
@@ -758,6 +768,20 @@ jobs:
         uses: ./.github/actions/cleanup-ios-signing
         with:
           app-store-connect-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+
+      # Paired with the Restore Kotlin/Native cache step at the head
+      # of the job. Runs as a regular step (NOT a synthetic POST step
+      # like combined actions/cache) so the safety attributes below
+      # actually apply when GitHub's cache backend hangs mid-upload.
+      # See ios-tests.yml PR #951 for the original split rationale.
+      - name: Save Kotlin/Native cache (~/.konan)
+        if: always() && steps.konan-cache-restore.outputs.cache-hit != 'true'
+        timeout-minutes: 10
+        continue-on-error: true
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.konan
+          key: ${{ steps.konan-cache-restore.outputs.cache-primary-key }}
 
   sanity-check:
     name: Dev Sanity Check

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -436,8 +436,12 @@ jobs:
 
       # See deploy-dev.yml's matching step for rationale — ~/.konan is the
       # only big iOS-relevant cache that setup-gradle doesn't cover.
-      - name: Cache Kotlin/Native (~/.konan)
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      # Split into restore (here) + save (at job tail) per ios-tests.yml
+      # PR #951's pattern — combined actions/cache's synthetic POST save
+      # can hang past timeout-minutes when GitHub's cache backend is slow.
+      - name: Restore Kotlin/Native cache (~/.konan)
+        id: konan-cache-restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.konan
           key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
@@ -582,6 +586,20 @@ jobs:
         uses: ./.github/actions/cleanup-ios-signing
         with:
           app-store-connect-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+
+      # Paired with the Restore Kotlin/Native cache step at the head
+      # of the job. Regular step (NOT a synthetic POST) so timeout-
+      # minutes + continue-on-error actually apply when GitHub's cache
+      # backend hangs mid-upload. See ios-tests.yml PR #951 for full
+      # rationale.
+      - name: Save Kotlin/Native cache (~/.konan)
+        if: always() && steps.konan-cache-restore.outputs.cache-hit != 'true'
+        timeout-minutes: 10
+        continue-on-error: true
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.konan
+          key: ${{ steps.konan-cache-restore.outputs.cache-primary-key }}
 
   # ── Smoke tests (after deploys) ────────────────────────────
   # Smoke tests are split per-surface so the GitHub UI status reflects what
@@ -775,8 +793,11 @@ jobs:
       # Mirror of deploy-ios-prod's konan cache. ~/.konan isn't covered by
       # setup-gradle. Sharing the same cache key across all iOS jobs lets
       # them all hit the same warm cache once any of them has populated it.
-      - name: Cache Kotlin/Native (~/.konan)
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      # Split restore/save per ios-tests.yml PR #951 — combined POST save
+      # can hang past timeout-minutes.
+      - name: Restore Kotlin/Native cache (~/.konan)
+        id: konan-cache-restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.konan
           key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
@@ -864,6 +885,20 @@ jobs:
 
           echo "No crashes detected — iOS app boots successfully"
           xcrun simctl shutdown "$DEVICE_ID" || true
+
+      # Paired with the Restore Kotlin/Native cache step at the head
+      # of the job. Regular step (NOT a synthetic POST) so timeout-
+      # minutes + continue-on-error actually apply when GitHub's cache
+      # backend hangs mid-upload. See ios-tests.yml PR #951 for full
+      # rationale.
+      - name: Save Kotlin/Native cache (~/.konan)
+        if: always() && steps.konan-cache-restore.outputs.cache-hit != 'true'
+        timeout-minutes: 10
+        continue-on-error: true
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.konan
+          key: ${{ steps.konan-cache-restore.outputs.cache-primary-key }}
 
   # ── Alert on failure ───────────────────────────────────────
   alert-desync:

--- a/express-api/tests/scripts/ios-konan-cache-no-hang.test.js
+++ b/express-api/tests/scripts/ios-konan-cache-no-hang.test.js
@@ -132,3 +132,78 @@ describe('ios-tests.yml — ~/.konan cache: restore + save split with bounded sa
     expect(block).toMatch(/if:[^\n]*cache-hit/);
   });
 });
+
+// The same restore+save split MUST apply to deploy-dev.yml and
+// deploy-prod.yml — both contain iOS jobs that cache ~/.konan with
+// the identical multi-GB payload + same actions/cache version. Per
+// PR #951's reviewer note (pre-existing-systemic): a hung POST save
+// here would block a DEPLOY (worse than blocking a PR Gate). This
+// suite asserts the split was applied in all 3 workflows.
+const DEPLOY_DEV_YML = path.join(REPO_ROOT, '.github/workflows/deploy-dev.yml');
+const DEPLOY_PROD_YML = path.join(REPO_ROOT, '.github/workflows/deploy-prod.yml');
+
+describe.each([
+  ['deploy-dev.yml', DEPLOY_DEV_YML, 1],
+  ['deploy-prod.yml', DEPLOY_PROD_YML, 2],
+])('%s — ~/.konan cache split applied', (label, yamlPath, expectedSaveCount) => {
+  let yamlText;
+
+  beforeAll(() => {
+    yamlText = fs.readFileSync(yamlPath, 'utf8');
+  });
+
+  test(`${label} does NOT use combined actions/cache for ~/.konan`, () => {
+    const combinedSteps = [...yamlText.matchAll(/uses: actions\/cache@\S+/g)];
+    for (const m of combinedSteps) {
+      const stepWindow = yamlText.substring(m.index, m.index + 300);
+      expect(stepWindow).not.toMatch(/path:\s*~\/\.konan/);
+    }
+  });
+
+  test(`${label} has actions/cache/restore step(s) for ~/.konan with id for save-guard`, () => {
+    const restoreOccurrences = [
+      ...yamlText.matchAll(
+        /id:\s+\S+[\s\S]{0,300}?uses: actions\/cache\/restore@\S+[\s\S]{0,300}?path: ~\/\.konan/g,
+      ),
+    ];
+    expect(restoreOccurrences.length).toBe(expectedSaveCount);
+  });
+
+  test(`${label} has ${expectedSaveCount} actions/cache/save step(s) for ~/.konan`, () => {
+    const saveOccurrences = [...yamlText.matchAll(/uses: actions\/cache\/save@\S+/g)];
+    expect(saveOccurrences.length).toBe(expectedSaveCount);
+  });
+
+  test(`${label} every save step has timeout-minutes + continue-on-error + cache-hit if-guard`, () => {
+    // For each `uses: actions/cache/save@<X>`, walk back to the step
+    // header (`      - `) and forward to next sibling (~30 lines)
+    // to extract the step body. Assert all 3 safety attrs present.
+    const lines = yamlText.split('\n');
+    const saveStepLineNumbers = [];
+    for (let i = 0; i < lines.length; i++) {
+      if (/uses: actions\/cache\/save@\S+/.test(lines[i])) saveStepLineNumbers.push(i);
+    }
+    expect(saveStepLineNumbers.length).toBe(expectedSaveCount);
+    for (const lineNo of saveStepLineNumbers) {
+      let headerIdx = -1;
+      for (let j = lineNo; j >= Math.max(0, lineNo - 15); j--) {
+        if (/^ {6}- /.test(lines[j])) {
+          headerIdx = j;
+          break;
+        }
+      }
+      expect(headerIdx).toBeGreaterThanOrEqual(0);
+      let endIdx = Math.min(lines.length, lineNo + 15);
+      for (let j = lineNo + 1; j < Math.min(lines.length, lineNo + 15); j++) {
+        if (/^ {6}- /.test(lines[j]) || /^ {2}\S/.test(lines[j])) {
+          endIdx = j;
+          break;
+        }
+      }
+      const block = lines.slice(headerIdx, endIdx).join('\n');
+      expect(block).toMatch(/timeout-minutes:\s+\d+/);
+      expect(block).toMatch(/continue-on-error:\s+true/);
+      expect(block).toMatch(/if:[^\n]*cache-hit/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors PR #951's `~/.konan` cache split on `ios-tests.yml` across the **3 iOS jobs in the deploy workflows**. PR #951's reviewer flagged this as a pre-existing-systemic note ("same vulnerability class — applies identically") and per `[[feedback-fix-pre-existing-and-new-same]]` HARD RULE must be fixed this session.

## Jobs updated

All 3 use the identical `actions/cache@v5.0.5` SHA on `~/.konan` with the multi-GB payload that hung PR #950 for 2h+:

- `deploy-dev.yml::distribute-ios`
- `deploy-prod.yml::deploy-ios-prod`
- `deploy-prod.yml::smoke-test-ios`

## Pattern (per job)

| Step | Before | After |
|---|---|---|
| Cache | Combined `actions/cache@v5` step (synthetic POST save ignores `timeout-minutes`) | `actions/cache/restore@v5` (head, `id: konan-cache-restore`) + `actions/cache/save@v5` (tail) |
| Save safety | None | `timeout-minutes: 10`, `continue-on-error: true`, `if: cache-hit != 'true'` |

Failure mode unblocked: synthetic POST step that ignores `timeout-minutes` when GitHub's cache backend stalls mid-upload (deploy failure has higher impact than PR-gate failure).

## Test plan

- [x] `ios-konan-cache-no-hang.test.js` extended via `describe.each` to cover all 3 workflows (1 for deploy-dev, 2 for deploy-prod). Each workflow asserts: no combined cache step for `~/.konan`, correct count of restore steps with `id`, correct count of save steps, every save step has `timeout-minutes` + `continue-on-error` + cache-hit if-guard.
- [x] 14/14 tests pass (was 6 + 8 new = 14)
- [x] Pre-push Sonar quality gate passed
- [x] `actionlint` reports same counts BEFORE/AFTER my edits — no new findings

## Queued follow-up (separate PR per `[[feedback-fix-pre-existing-and-new-same]]`)

`actionlint` reports pre-existing `SC2086` (info-level shellcheck) warnings:
- 3 on `deploy-prod.yml` (lines 471 + 516)
- 6 on `deploy-dev.yml`

Verified BEFORE/AFTER this PR: counts unchanged. Will be cleaned up in a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)