### PR TITLE
fix(test): loosen setup-node version pin in manual-qa-matrix workflow test

### DIFF
--- a/express-api/tests/scripts/manual-qa-matrix-workflow-pin.test.js
+++ b/express-api/tests/scripts/manual-qa-matrix-workflow-pin.test.js
@@ -144,11 +144,20 @@ describe('manual-qa-matrix.yml — structural pin', () => {
     expect(yamlText).toMatch(/uses:\s*actions\/checkout/);
   });
 
-  test('setup-node@v4 with cache: npm + cache-dependency-path', () => {
+  test('setup-node@v4+ with cache: npm + cache-dependency-path', () => {
     // Pin the npm cache invariant — without cache-dependency-path,
     // setup-node defaults to repo-root package.json which doesn't
     // exist; cache would silently no-op and slow every PR.
-    expect(yamlText).toMatch(/uses:\s*actions\/setup-node@v4/);
+    //
+    // Loosened 2026-06-01 from `@v4` to `@v[4-9]` after the workflow
+    // was bumped to setup-node@v6 (current major) but this test stayed
+    // pinned to v4, breaking every push via the pre-push Jest hook
+    // (no PR could land regardless of its diff). Major bumps of
+    // setup-node have so far been backwards-compatible on the
+    // cache + cache-dependency-path inputs; allow v4-v9 so future
+    // maintenance bumps don't break the gate again. Pin a specific
+    // version separately if a real incompatibility appears.
+    expect(yamlText).toMatch(/uses:\s*actions\/setup-node@v[4-9]/);
     expect(yamlText).toMatch(/cache:\s*npm/);
     expect(yamlText).toMatch(/cache-dependency-path:\s*express-api\/package-lock\.json/);
   });


### PR DESCRIPTION
## Summary

Hot-fix for a pre-existing test failure on main that blocked **every push** via the pre-push Jest hook (no PR could land regardless of its diff).

## Root cause

`express-api/tests/scripts/manual-qa-matrix-workflow-pin.test.js:151` pinned `actions/setup-node@v4` while `.github/workflows/manual-qa-matrix.yml:74` was bumped to `setup-node@v6`. Mismatch → test fails → pre-push hook fails → push blocked.

## Fix

Loosened the regex from `setup-node@v4` to `setup-node@v[4-9]`. Major bumps of `setup-node` have so far been backwards-compatible on the `cache: npm` + `cache-dependency-path` inputs that the test actually cares about. If a real incompatibility ever appears, pin the specific version separately.

## Test plan

- [x] `npm test` in `express-api/` — 297/297 test suites pass, **11,012 tests pass, 0 failures** (was 1 failure before)
- [x] Pre-push hook passes (the very mechanism this PR is unblocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)