### PR TITLE
fix(ci): clear all 9 pre-existing shellcheck warnings in deploy workflows

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -123,7 +123,22 @@ jobs:
           # endpoint reads it back so the deploy verification can assert
           # the new code is actually serving (vs. stale pm2 process from
           # a prior tarball that didn't trigger restart correctly).
-          ssh ubuntu@145.241.224.13 "cd ~/express-api && tar xzf /tmp/api.tar.gz && echo '$DEPLOYED_SHA' > .deployed-sha && npm install --omit=dev && DEPLOYED_SHA='$DEPLOYED_SHA' pm2 restart shytalk-api --update-env"
+          #
+          # Build the remote-side deploy script LOCALLY (with the SHA
+          # baked in), then scp + exec. Splits the local-expansion from
+          # the ssh invocation so neither shellcheck SC2029 (client-side
+          # ssh-string expansion) nor SC2087 (heredoc expansion locale)
+          # fires — the local heredoc is the only place expansion
+          # happens, and that's exactly what local heredocs are for.
+          cat > /tmp/deploy-remote.sh <<EOF
+          set -e
+          cd ~/express-api && tar xzf /tmp/api.tar.gz
+          echo '${DEPLOYED_SHA}' > .deployed-sha
+          npm install --omit=dev
+          DEPLOYED_SHA='${DEPLOYED_SHA}' pm2 restart shytalk-api --update-env
+          EOF
+          scp /tmp/deploy-remote.sh ubuntu@145.241.224.13:/tmp/
+          ssh ubuntu@145.241.224.13 'bash /tmp/deploy-remote.sh'
 
       - name: Verify dev API health
         env:
@@ -668,7 +683,7 @@ jobs:
             -scheme iosApp \
             -sdk iphoneos \
             -configuration Release \
-            -archivePath $RUNNER_TEMP/iosApp.xcarchive \
+            -archivePath "$RUNNER_TEMP/iosApp.xcarchive" \
             -clonedSourcePackagesDirPath ../build/ios-spm-packages \
             -parallelizeTargets \
             DEVELOPMENT_TEAM=F3XX4PM3MF \
@@ -678,12 +693,12 @@ jobs:
           # Export IPA
           xcodebuild \
             -exportArchive \
-            -archivePath $RUNNER_TEMP/iosApp.xcarchive \
+            -archivePath "$RUNNER_TEMP/iosApp.xcarchive" \
             -exportOptionsPlist ExportOptions.plist \
-            -exportPath $RUNNER_TEMP/export \
+            -exportPath "$RUNNER_TEMP/export" \
             -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" \
-            -authenticationKeyID $APP_STORE_CONNECT_KEY_ID \
-            -authenticationKeyIssuerID $APP_STORE_CONNECT_ISSUER_ID
+            -authenticationKeyID "$APP_STORE_CONNECT_KEY_ID" \
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID"
           # Verify a single IPA was produced (catches `destination: upload` regressions
           # that uploaded silently and left no local artifact, breaking the next step)
           shopt -s nullglob

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -507,7 +507,7 @@ jobs:
             -scheme iosApp \
             -sdk iphoneos \
             -configuration Release \
-            -archivePath $RUNNER_TEMP/iosApp.xcarchive \
+            -archivePath "$RUNNER_TEMP/iosApp.xcarchive" \
             DEVELOPMENT_TEAM=F3XX4PM3MF \
             CURRENT_PROJECT_VERSION="${VERSION_CODE}" \
             MARKETING_VERSION="${VERSION_NAME}" \
@@ -522,9 +522,9 @@ jobs:
           cd iosApp
           xcodebuild \
             -exportArchive \
-            -archivePath $RUNNER_TEMP/iosApp.xcarchive \
+            -archivePath "$RUNNER_TEMP/iosApp.xcarchive" \
             -exportOptionsPlist ExportOptions.plist \
-            -exportPath $RUNNER_TEMP/export \
+            -exportPath "$RUNNER_TEMP/export" \
             -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" \
             -authenticationKeyID "$APP_STORE_CONNECT_KEY_ID" \
             -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID"


### PR DESCRIPTION
## Summary

Queued from PR #955 review per `[[feedback-fix-pre-existing-and-new-same]]` HARD RULE. All 9 warnings pre-existed on main (counted BEFORE/AFTER #955: unchanged).

Per `[[feedback-warnings-are-failures]]` HARD RULE — info-level shellcheck findings count as failures and must be cleared, not suppressed.

## Cleared findings

| File | Line | Code | Fix |
|---|---|---|---|
| deploy-dev.yml | 671, 681, 683, 685, 686 | SC2086 | Quote `$RUNNER_TEMP`, `$APP_STORE_CONNECT_KEY_ID`, `$APP_STORE_CONNECT_ISSUER_ID` |
| deploy-dev.yml | 126 | SC2029 | Refactored `ssh "long-string-with-vars"` into local heredoc + `scp` + `ssh 'bash /tmp/script'` |
| deploy-prod.yml | 510 | SC2086 | Quote `$RUNNER_TEMP` in `-archivePath` |
| deploy-prod.yml | 525, 527 | SC2086 | Quote `$RUNNER_TEMP` in `-archivePath` + `-exportPath` |

## SC2029 fix details (structural change)

The Express-API deploy step previously inlined the SHA + remote commands in one ssh argument with both `$DEPLOYED_SHA` expansions happening client-side. shellcheck warns (SC2029) about the local-vs-remote expansion ambiguity. Tried 2 in-place alternatives (env-pass + heredoc) — both surfaced SC2087 instead. Final fix splits the concerns cleanly: build the remote-side script LOCALLY via a heredoc (only place expansion happens), then `scp` + `ssh 'bash /tmp/script'`.

**Functional equivalence**: same commands execute in the same order with the same SHA value. Just splits the local-expansion from the ssh invocation so each tool does one job cleanly.

## Test plan

- [x] `actionlint .github/workflows/deploy-dev.yml deploy-prod.yml` → exit 0, **zero warnings** (was 9)
- [x] 11,012 express-api tests pass, 0 failures
- [x] Pre-push Sonar quality gate passed
- [x] No suppression comments anywhere per `[[feedback-never-suppress-fix-or-upgrade]]`

⚠️ The SC2029 fix touches the dev Express-API deploy path. Reviewer to validate command-semantics equivalence carefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
