### PR TITLE
fix(ci): remove last 2 shellcheck-disable suppressions in workflows

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -143,8 +143,16 @@ jobs:
           # First-parent walk on main; allowlist of feat/fix/perf
           # Conventional-Commits prefixes; reverts summarised separately.
           # See release.yml for the rationale on each filter choice.
-          # shellcheck disable=SC2086
-          ALL_LINES=$(git log $RANGE --first-parent --pretty=format:'%s')
+          #
+          # Use a bash array to pass RANGE: an unquoted `$RANGE` triggers
+          # SC2086, but a quoted `"$RANGE"` would pass an empty-string
+          # argument to git in the first-release-ever case (RANGE="") and
+          # confuse the rev parser. Array expands to ZERO args when
+          # RANGE is empty, ONE arg when set ("tag..HEAD"). See
+          # release.yml for the same pattern.
+          range_args=()
+          [ -n "$RANGE" ] && range_args=("$RANGE")
+          ALL_LINES=$(git log "${range_args[@]}" --first-parent --pretty=format:'%s')
           USER_FACING=$(echo "$ALL_LINES" \
             | { grep -E '^(feat|fix|perf)(\(.+\))?:' || [ $? -eq 1 ]; } \
             | sed -E 's/^[a-z]+(\([^)]*\))?: //')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,8 +248,16 @@ jobs:
           # `git log` failures (corrupt repo, bad RANGE) need to abort —
           # don't mask with `|| true`. We've validated RANGE above so a
           # failure here is genuinely exceptional.
-          # shellcheck disable=SC2086
-          ALL_LINES=$(git log $RANGE --first-parent --pretty=format:'%s')
+          #
+          # Use a bash array to pass RANGE: an unquoted `$RANGE` triggers
+          # SC2086, but a quoted `"$RANGE"` would pass an empty-string
+          # argument to git in the first-release-ever case (RANGE="") and
+          # confuse the rev parser. Array form expands to ZERO args when
+          # RANGE is empty (genuinely first release → all commits) and
+          # ONE arg when RANGE is set ("tag..HEAD" → range filter).
+          range_args=()
+          [ -n "$RANGE" ] && range_args=("$RANGE")
+          ALL_LINES=$(git log "${range_args[@]}" --first-parent --pretty=format:'%s')
           # `grep` returns exit 1 when there are no matches (legitimate
           # "no user-facing changes" case). Swallow ONLY that specific
           # exit so a real error from grep (regex compile, I/O) or sed


### PR DESCRIPTION
## Summary

PR #964's reviewer surfaced 2 pre-existing `# shellcheck disable=SC2086` suppressions in `release.yml` + `release-tag.yml`. Per `[[feedback-never-suppress-fix-or-upgrade]]` HARD RULE no suppression anywhere. Per `[[feedback-fix-pre-existing-and-new-same]]` HARD RULE pre-existing findings surfaced must be cleared THIS session.

## The suppression

Both files had the same pattern:

```bash
# shellcheck disable=SC2086
ALL_LINES=$(git log $RANGE --first-parent --pretty=format:'%s')
```

`RANGE` is either `${LAST_TAG}..HEAD` OR `""` (genuinely-first-release case). The unquoted `$RANGE` was deliberate: a quoted `"$RANGE"` would pass an empty-string argument to git in the first-release case and confuse the rev parser.

## Fix — bash array, no suppression

```bash
range_args=()
[ -n "$RANGE" ] && range_args=("$RANGE")
ALL_LINES=$(git log "${range_args[@]}" --first-parent --pretty=format:'%s')
```

| RANGE value | Expansion | git args |
|---|---|---|
| `"v1.2.3..HEAD"` | `range_args=("v1.2.3..HEAD")` → `"${range_args[@]}"` → one arg | `git log v1.2.3..HEAD --first-parent ...` |
| `""` (first release) | `range_args=()` → `"${range_args[@]}"` → ZERO args | `git log --first-parent ...` (default range = all commits) |

Functional equivalence with the original unquoted form, no shellcheck suppression needed.

## Test plan

- [x] `actionlint .github/workflows/release.yml release-tag.yml` → exit 0, zero warnings
- [x] `grep -r 'shellcheck disable' .github/workflows/` returns nothing (this PR removes the LAST 2 suppressions in the repo)
- [x] 11,012 express-api tests pass, 0 failures
- [x] Pre-push Sonar quality gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
