### PR TITLE
fix(i18n): ru sign_out verb form for sign_in parity

### DIFF
--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -132,7 +132,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="about">О</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="sign_out">Выход</string>
+    <string name="sign_out">Выйти</string>
     <!-- google-translated 2026-05-04 -->
     <string name="sign_out_confirm">Вы уверены, что хотите выйти?</string>
 


### PR DESCRIPTION
## Summary
- Russian `sign_out` button label was the noun `Выход` ("exit") — the **single outlier** in a file that already uses the verb form everywhere else (`sign_out_confirm` line 137: "...хотите выйти?", `account_error_sign_out` line 1648: "Выйти"). Restores verb/verb parity with `Войти` (sign_in).
- Aligns with every sister language's verb-style label (es "Cerrar sesión", it "Esci", uk "Вийти" — exact Russian cognate, pt "Sair", pl "Wyloguj się", etc.).
- Closes a pre-existing translation-quality finding deferred from PR #953's review — per `[[feedback-fix-pre-existing-and-new-same]]`, pre-existing bugs surfaced in review must be fixed in a follow-up PR same session, not deferred to "next time".

## Test plan
- [x] `compose-resources-locale-parity.test.js` — **62/62 passed** (key set unchanged; only one value updated)
- [x] Pre-push gates: SonarCloud quality gate passed, no gradle daemon held
- [ ] Code-reviewer agent — pending
- [ ] CI PR-Checks green
- [ ] Visual verification on Russian-locale device — deferred to dev-deploy smoke (parity test catches functional regression; visual is style only)

## Considered alternatives (per `[[feedback-quality-explore-alternatives-validate]]`)
| Option | Verdict |
|--------|---------|
| `Выход` (noun, current) | ✗ Breaks verb-parity with `Войти` |
| `Выйти` (verb infinitive) | ✓ **Chosen** — matches all sister languages, exact Ukrainian cognate, internal file consistency |
| `Выйти из аккаунта` ("Exit from account") | ✗ Breaks UI compactness; longer than other locales |
| `Выйти из системы` ("Exit from system") | ✗ Reads as formal Windows-style "log off" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)