### PR TITLE
fix(ci): deploy-prod ssh uses heredoc + scp pattern (mirror dev)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -243,7 +243,10 @@ jobs:
         run: ssh ubuntu@213.35.98.160 "cd ~/shytalk-api && tar czf /tmp/api-previous.tar.gz --exclude='node_modules' --exclude='.env' ."
 
       - name: Deploy Express API to Singapore (prod)
+        env:
+          DEPLOYED_SHA: ${{ needs.validate-release.outputs.commit-sha }}
         run: |
+          set -euo pipefail
           cd express-api
           tar czf /tmp/api.tar.gz --exclude='node_modules' --exclude='.env' .
           scp /tmp/api.tar.gz ubuntu@213.35.98.160:/tmp/
@@ -254,7 +257,23 @@ jobs:
           # time), which for branch/commit deploys is NOT the same as the
           # checked-out deploy ref — using it would write a misleading SHA to
           # .deployed-sha and pass the health check while serving different code.
-          ssh ubuntu@213.35.98.160 "cd ~/shytalk-api && tar xzf /tmp/api.tar.gz && echo '${{ needs.validate-release.outputs.commit-sha }}' > .deployed-sha && npm install --omit=dev && DEPLOYED_SHA='${{ needs.validate-release.outputs.commit-sha }}' pm2 restart shytalk-api --update-env"
+          #
+          # Build the remote-side deploy script LOCALLY (with the SHA baked
+          # in via the env-block expansion), then scp + exec. Mirrors
+          # deploy-dev.yml: splits local-expansion from the ssh invocation
+          # so neither shellcheck SC2029 (client-side ssh-string expansion)
+          # nor SC2087 (heredoc expansion locale) fires — the local heredoc
+          # is the only place expansion happens, which is exactly its
+          # purpose.
+          cat > /tmp/deploy-remote.sh <<EOF
+          set -e
+          cd ~/shytalk-api && tar xzf /tmp/api.tar.gz
+          echo '${DEPLOYED_SHA}' > .deployed-sha
+          npm install --omit=dev
+          DEPLOYED_SHA='${DEPLOYED_SHA}' pm2 restart shytalk-api --update-env
+          EOF
+          scp /tmp/deploy-remote.sh ubuntu@213.35.98.160:/tmp/
+          ssh ubuntu@213.35.98.160 'bash /tmp/deploy-remote.sh'
 
       - name: Verify prod API health
         run: |


### PR DESCRIPTION
## Summary
- `deploy-prod.yml:257` inline `ssh ubuntu@... "...${{ }}...${{ }}..."` pattern refactored to mirror `deploy-dev.yml`'s already-proven heredoc + scp + ssh pattern.
- Closes the **last** SC2029-equivalent in the deploy workflows (PR #964 cleaned the obvious cases; this was the residual one flagged in #964's review but deferred). Repo's `.github/` now has zero ssh-embedded `${{ }}` variable expansion.
- Per `[[feedback-fix-pre-existing-and-new-same]]` (operator HARD RULE): pre-existing bugs surfaced in review must be fixed in a follow-up PR same session, not deferred.

## Why this pattern (per `[[feedback-quality-explore-alternatives-validate]]`)
| Option | Verdict |
|--------|---------|
| Status quo (inline `${{ }}` in ssh `"..."`) | ✗ Reviewer-flagged; inconsistent with `deploy-dev.yml` |
| **Heredoc + scp + ssh** (this PR) | ✓ Mirrors sister workflow exactly; zero shellcheck noise |
| `ssh ... bash -s -- "$SHA" <<'REMOTE'` heredoc-via-stdin | ✗ Saves one scp roundtrip but diverges from `deploy-dev.yml` |
| `ssh -o SendEnv DEPLOYED_SHA` | ✗ Requires `sshd_config AcceptEnv` change on remote — out of scope |

Consistency with `deploy-dev.yml` is worth more than micro-optimizations — dev/prod workflow drift creates maintenance cliffs.

## Behavior
**Identical**: same SHA written to `.deployed-sha`, same `DEPLOYED_SHA` env propagated to `pm2 restart --update-env`. Only the transport layer changed — script-file scp'd instead of ssh-string-embedded.

## Test plan
- [x] `actionlint .github/workflows/deploy-prod.yml` — exit 0, zero findings
- [x] 105/105 deploy + workflow Jest tests pass (`deploy-prod|deploy-dev|reusable-workflow|workflow` test patterns)
- [x] YAML parses cleanly (python `yaml.safe_load`)
- [x] Diff verified against `deploy-dev.yml` lines 127-141 — same heredoc/scp/ssh structure
- [ ] Code-reviewer agent — pending
- [ ] CI PR-Checks green
- [ ] **Operational verification deferred**: per `[[feedback-workflow-verify-by-running]]` the only way to genuinely verify a prod-deploy workflow is to dispatch it, which is not appropriate for a refactor. Functional equivalence is verified by static comparison with `deploy-dev.yml`'s proven pattern; next operator-initiated prod deploy is the real end-to-end gate.

## Risk
**Low**. Workflow file change with no functional difference at the operational layer. Worst case if I got the heredoc quoting wrong: the next manual prod deploy would fail at the `Deploy Express API to Singapore (prod)` step BEFORE serving traffic (pm2 restart wouldn't fire). The Verify health check step (lines 259-279) is the safety net — it'd assert the SHA serving doesn't match expected, fail the deploy, and the operator would revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)