### PR TITLE
fix(web): re-entrancy guards across admin click handlers + finally symmetry

### DIFF
--- a/express-api/tests/scripts/admin-click-handler-reentrancy.test.js
+++ b/express-api/tests/scripts/admin-click-handler-reentrancy.test.js
@@ -1,22 +1,45 @@
 /**
- * Static guard for admin click-handler re-entrancy.
+ * Static guard for admin click-handler re-entrancy + finally symmetry.
  *
- * Every async click handler that opens confirm() and then calls apiCall()
- * / fetch() must bail when the button is already in-flight. Without the
- * guard, a double-tap (or Playwright auto-accepted confirm in tests)
- * races two handler invocations through the API call.
+ * Two invariants pinned here:
  *
- * PR #968 fixed direct-warn-btn (users.js:1305). This test pins the
- * codebase-wide invariant so future handlers can't regress.
+ * 1. **Re-entrancy guard** — every async click handler whose body opens
+ *    confirm() and then calls apiCall()/fetch() must bail when the
+ *    button is already in-flight. Without the guard, a double-tap (or
+ *    Playwright auto-accepted confirm in tests) races two handler
+ *    invocations through the API call. The same invariant applies to
+ *    handlers that set `btn.disabled = true` before an `await` — even
+ *    without confirm(), the gap between sync-disable-set and the await
+ *    yield is wide enough for two queued events to both pass the guard
+ *    check (see PR #968 direct-warn-btn for the original surface).
+ *
+ * 2. **Re-enable symmetry** — every handler that disables a button must
+ *    re-enable it in a `finally` block, so confirm-cancel, API errors,
+ *    or thrown exceptions inside `catch` all flow through to the same
+ *    re-enable. A bare `btn.disabled = false` after try/catch silently
+ *    leaks a stuck-disabled button when the catch itself throws.
  *
  * Guard shapes accepted (any of):
  *   if (someBtn.disabled) return;
  *   if (this.disabled) return;
- *   if (e.target.dataset.inflight) return;
+ *   if (this.disabled === true) return;       // === / !== variants
+ *   if (someFlagInFlight) return;             // module-level boolean
+ *   if (e.target.dataset.inflight) return;    // dataset alternative
  *
- * Detection lives at the AST level so renaming variables or reformatting
- * doesn't fool it — but the guard MATCH stays as a textual regex over the
- * handler body so the test owns a single, readable invariant.
+ * KNOWN LIMITATIONS (documented as accepted gaps, not bugs):
+ *   - Named-function references (`addEventListener("click", handleX)`
+ *     where handleX is declared elsewhere) are NOT resolved. Add a
+ *     direct test case for new exported handlers that fit this shape.
+ *   - Inline `onclick=` HTML attributes are NOT scanned. Functions
+ *     exposed via `window.X = X` for HTML onclick (e.g. resetPinLockout,
+ *     revokeBiometricKey in users.js) must carry their own module-level
+ *     in-flight flag — verified by separate test below.
+ *   - Nested function handlers inside the outer body share the body
+ *     text slice. The regex check on `bodyText` may false-positive if a
+ *     nested inner handler carries the guard while the outer doesn't,
+ *     or false-negative in the inverse case. For the current codebase
+ *     this is not a problem; revisit if `addEventListener` calls become
+ *     nested.
  */
 
 const fs = require('node:fs');
@@ -31,6 +54,36 @@ const SCAN_GLOBS = [
   path.join(REPO_ROOT, 'public/admin/**/*.js'),
   path.join(REPO_ROOT, 'public/js/**/*.js'),
 ];
+
+// Guard accepts: .disabled-check OR module-flag-check OR dataset.inflight.
+// `=== true|false`, `!== true|false` variants all allowed. Quantifiers are
+// bounded to keep the regex linear (no super-linear backtracking).
+const GUARD_PATTERNS = [
+  /if\s*\(\s*(?:this|\w{1,40})\.disabled\b[^)]{0,40}\)\s*return/i,
+  /if\s*\(\s*_?[a-z]\w{0,40}InFlight\b[^)]{0,5}\)\s*return/,
+  /dataset\.inflight/i,
+];
+
+function hasGuard(bodyText) {
+  return GUARD_PATTERNS.some((p) => p.test(bodyText));
+}
+
+// `disabled = true` followed (later) by an `await`. Either ordering of
+// confirm()/await inside try is fine — we just need the disable to land
+// before any yield point.
+function setsDisabledBeforeAwait(bodyText) {
+  if (!/\.\s*disabled\s*=\s*true/.test(bodyText)) return false;
+  return /\bawait\b/.test(bodyText);
+}
+
+// Re-enable must live inside a `finally` block to survive throws. The
+// finally-aware window keeps the regex bounded (no nested `[\s\S]*?`).
+function reEnablesInFinally(bodyText) {
+  const idx = bodyText.search(/\bfinally\s*\{/);
+  if (idx < 0) return false;
+  const win = bodyText.slice(idx, idx + 500);
+  return /\.\s*disabled\s*=\s*false/.test(win);
+}
 
 function collectClickHandlers(file) {
   const source = fs.readFileSync(file, 'utf-8');
@@ -57,13 +110,17 @@ function collectClickHandlers(file) {
       const bodyText = source.slice(body.start, body.end);
       const hasConfirm = /\bconfirm\s*\(/.test(bodyText);
       const hasApiCall = /\bapiCall\s*\(/.test(bodyText) || /\bfetch\s*\(/.test(bodyText);
-      if (!hasConfirm || !hasApiCall) return;
-      const guardPatterns = [/if\s*\([^)]*\.\s*disabled\s*\)\s*return/i, /dataset\.inflight/i];
-      const hasGuard = guardPatterns.some((p) => p.test(bodyText));
+      const racePattern = (hasConfirm && hasApiCall) || setsDisabledBeforeAwait(bodyText);
+      if (!racePattern) return;
       hits.push({
         file: path.relative(REPO_ROOT, file),
         line: node.loc.start.line,
-        hasGuard,
+        hasGuard: hasGuard(bodyText),
+        // `finally` only matters when the handler actually disables the
+        // button. Handlers using a module-level in-flight flag manage
+        // their own finally separately.
+        needsFinally: /\.\s*disabled\s*=\s*true/.test(bodyText),
+        hasFinally: reEnablesInFinally(bodyText),
       });
     },
   });
@@ -77,7 +134,7 @@ describe('admin click-handler re-entrancy', () => {
     expect(files.length).toBeGreaterThan(0);
   });
 
-  test('every confirm()+api click handler has a re-entrancy guard', () => {
+  test('every confirm()+api or disable+await click handler has a re-entrancy guard', () => {
     const allHits = [];
     for (const file of files) {
       allHits.push(...collectClickHandlers(file));
@@ -88,7 +145,45 @@ describe('admin click-handler re-entrancy', () => {
     const msg =
       `${missing.length} click handler(s) missing re-entrancy guard ` +
       `(must early-return when button is already in-flight — see PR #968 ` +
-      `direct-warn-btn pattern at users.js:1305):\n${detail}`;
+      `direct-warn-btn pattern in users.js, the original surface):\n${detail}`;
     throw new Error(msg);
+  });
+
+  test('every handler that disables a button re-enables in finally', () => {
+    const allHits = [];
+    for (const file of files) {
+      allHits.push(...collectClickHandlers(file));
+    }
+    const broken = allHits.filter((h) => h.needsFinally && !h.hasFinally);
+    if (broken.length === 0) return;
+    const detail = broken.map((m) => `  ${m.file}:${m.line}`).join('\n');
+    const msg =
+      `${broken.length} click handler(s) disable the button without a ` +
+      `'finally { btn.disabled = false }' re-enable — a throw inside catch ` +
+      `leaks a stuck-disabled button:\n${detail}`;
+    throw new Error(msg);
+  });
+
+  // Inline-onclick globals: confirm()+apiCall() functions exposed via
+  // `window.X = X` for HTML onclick=. The AST scan above doesn't see
+  // them (no addEventListener wrapper). Pin their in-flight discipline
+  // explicitly by name.
+  test('inline-onclick globals carry module-level in-flight flags', () => {
+    const usersJs = fs.readFileSync(path.join(REPO_ROOT, 'public/admin/js/tabs/users.js'), 'utf-8');
+    const targets = ['resetPinLockout', 'revokeBiometricKey'];
+    const missing = [];
+    for (const name of targets) {
+      // Each must declare a backing flag and check it on entry.
+      const flagDecl = new RegExp(`_${name}InFlight\\s*=\\s*false`);
+      const flagCheck = new RegExp(`if\\s*\\(\\s*_${name}InFlight\\s*\\)\\s*return`);
+      if (!flagDecl.test(usersJs) || !flagCheck.test(usersJs)) {
+        missing.push(name);
+      }
+    }
+    if (missing.length === 0) return;
+    throw new Error(
+      `Inline-onclick admin globals missing in-flight flag: ${missing.join(', ')}. ` +
+        `Each must declare \`let _<name>InFlight = false\` and check it on entry.`,
+    );
   });
 });

--- a/express-api/tests/scripts/admin-click-handler-reentrancy.test.js
+++ b/express-api/tests/scripts/admin-click-handler-reentrancy.test.js
@@ -240,6 +240,41 @@ describe('admin click-handler re-entrancy', () => {
     );
   });
 
+  // Multi-step wizard step-locks: nuclear-reset.js + sync-prod.js have
+  // a `let *StepLock = false` module-level flag that prevents step-1→2
+  // rapid double-tap from skipping the "last warning" UI. Without
+  // pinning by name, GUARD_PATTERN[0] (`btn.disabled`) is enough to
+  // pass the broader invariant — but a future refactor could silently
+  // remove the step-lock and re-introduce the UX-skip bug. Pin by
+  // name, structure, and the setTimeout-cleared release semantics.
+  test('multi-step wizard handlers carry a step-transition lock', () => {
+    const cases = [
+      { file: 'public/admin/js/nuclear-reset.js', name: 'nuclearStepLock' },
+      { file: 'public/admin/js/sync-prod.js', name: 'syncStepLock' },
+    ];
+    const issues = [];
+    for (const { file, name } of cases) {
+      const src = fs.readFileSync(path.join(REPO_ROOT, file), 'utf-8');
+      // Declaration: `let <name> = false`.
+      const declRe = new RegExp(`let\\s+${name}\\s*=\\s*false`);
+      // Entry check: `if (<name>) return`.
+      const checkRe = new RegExp(`if\\s*\\(\\s*${name}\\s*\\)\\s*return`);
+      // Set then schedule release on next macrotask:
+      //   <name> = true;
+      //   ...setTimeout(() => { <name> = false; }, 0)
+      const setRe = new RegExp(`${name}\\s*=\\s*true\\b`);
+      const releaseRe = new RegExp(`setTimeout\\([^,]+${name}\\s*=\\s*false[^,]+,\\s*0\\s*\\)`);
+      if (!declRe.test(src)) issues.push(`${file}: missing \`let ${name} = false\` declaration`);
+      if (!checkRe.test(src)) issues.push(`${file}: missing \`if (${name}) return\` entry check`);
+      if (!setRe.test(src)) issues.push(`${file}: missing \`${name} = true\` set`);
+      if (!releaseRe.test(src)) {
+        issues.push(`${file}: missing setTimeout(0) release of ${name}`);
+      }
+    }
+    if (issues.length === 0) return;
+    throw new Error(`Multi-step wizard step-lock invariants violated:\n  ${issues.join('\n  ')}`);
+  });
+
   // revokeWarning is a thin-wrapper handler: registered via
   // `() => revokeWarning(uid, w.id, w.gcsDeduction, rb)` so the AST
   // scan sees the arrow wrapper (no confirm/apiCall in the wrapper body

--- a/express-api/tests/scripts/admin-click-handler-reentrancy.test.js
+++ b/express-api/tests/scripts/admin-click-handler-reentrancy.test.js
@@ -262,6 +262,11 @@ describe('admin click-handler re-entrancy', () => {
       // Set then schedule release on next macrotask:
       //   <name> = true;
       //   ...setTimeout(() => { <name> = false; }, 0)
+      // The releaseRe assumes a single-line setTimeout shape with no
+      // commas in the body slice between `false` and the `, 0)` tail.
+      // A future refactor that adds commas inside the arrow body (e.g.
+      // a sequence expression) would false-negative — keep the shape
+      // simple, no comma operators in the release body.
       const setRe = new RegExp(`${name}\\s*=\\s*true\\b`);
       const releaseRe = new RegExp(`setTimeout\\([^,]+${name}\\s*=\\s*false[^,]+,\\s*0\\s*\\)`);
       if (!declRe.test(src)) issues.push(`${file}: missing \`let ${name} = false\` declaration`);

--- a/express-api/tests/scripts/admin-click-handler-reentrancy.test.js
+++ b/express-api/tests/scripts/admin-click-handler-reentrancy.test.js
@@ -1,0 +1,94 @@
+/**
+ * Static guard for admin click-handler re-entrancy.
+ *
+ * Every async click handler that opens confirm() and then calls apiCall()
+ * / fetch() must bail when the button is already in-flight. Without the
+ * guard, a double-tap (or Playwright auto-accepted confirm in tests)
+ * races two handler invocations through the API call.
+ *
+ * PR #968 fixed direct-warn-btn (users.js:1305). This test pins the
+ * codebase-wide invariant so future handlers can't regress.
+ *
+ * Guard shapes accepted (any of):
+ *   if (someBtn.disabled) return;
+ *   if (this.disabled) return;
+ *   if (e.target.dataset.inflight) return;
+ *
+ * Detection lives at the AST level so renaming variables or reformatting
+ * doesn't fool it — but the guard MATCH stays as a textual regex over the
+ * handler body so the test owns a single, readable invariant.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const parser = require('@babel/parser');
+const traverseModule = require('@babel/traverse');
+const traverse = traverseModule.default || traverseModule;
+const glob = require('glob');
+
+const REPO_ROOT = path.join(__dirname, '..', '..', '..');
+const SCAN_GLOBS = [
+  path.join(REPO_ROOT, 'public/admin/**/*.js'),
+  path.join(REPO_ROOT, 'public/js/**/*.js'),
+];
+
+function collectClickHandlers(file) {
+  const source = fs.readFileSync(file, 'utf-8');
+  let ast;
+  try {
+    ast = parser.parse(source, { sourceType: 'module' });
+  } catch (_e) {
+    ast = parser.parse(source, { sourceType: 'script' });
+  }
+  const hits = [];
+  traverse(ast, {
+    CallExpression(nodePath) {
+      const node = nodePath.node;
+      if (node.callee.type !== 'MemberExpression') return;
+      if (node.callee.property.name !== 'addEventListener') return;
+      if (node.arguments.length < 2) return;
+      const arg0 = node.arguments[0];
+      if (arg0.type !== 'StringLiteral' || arg0.value !== 'click') return;
+      const handler = node.arguments[1];
+      if (handler.type !== 'ArrowFunctionExpression' && handler.type !== 'FunctionExpression') {
+        return;
+      }
+      const body = handler.body;
+      const bodyText = source.slice(body.start, body.end);
+      const hasConfirm = /\bconfirm\s*\(/.test(bodyText);
+      const hasApiCall = /\bapiCall\s*\(/.test(bodyText) || /\bfetch\s*\(/.test(bodyText);
+      if (!hasConfirm || !hasApiCall) return;
+      const guardPatterns = [/if\s*\([^)]*\.\s*disabled\s*\)\s*return/i, /dataset\.inflight/i];
+      const hasGuard = guardPatterns.some((p) => p.test(bodyText));
+      hits.push({
+        file: path.relative(REPO_ROOT, file),
+        line: node.loc.start.line,
+        hasGuard,
+      });
+    },
+  });
+  return hits;
+}
+
+describe('admin click-handler re-entrancy', () => {
+  const files = SCAN_GLOBS.flatMap((g) => glob.sync(g));
+
+  test('discovers at least one click handler (sanity)', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  test('every confirm()+api click handler has a re-entrancy guard', () => {
+    const allHits = [];
+    for (const file of files) {
+      allHits.push(...collectClickHandlers(file));
+    }
+    const missing = allHits.filter((h) => !h.hasGuard);
+    if (missing.length === 0) return;
+    const detail = missing.map((m) => `  ${m.file}:${m.line}`).join('\n');
+    const msg =
+      `${missing.length} click handler(s) missing re-entrancy guard ` +
+      `(must early-return when button is already in-flight — see PR #968 ` +
+      `direct-warn-btn pattern at users.js:1305):\n${detail}`;
+    throw new Error(msg);
+  });
+});

--- a/express-api/tests/scripts/admin-click-handler-reentrancy.test.js
+++ b/express-api/tests/scripts/admin-click-handler-reentrancy.test.js
@@ -28,8 +28,10 @@
  *
  * KNOWN LIMITATIONS (documented as accepted gaps, not bugs):
  *   - Named-function references (`addEventListener("click", handleX)`
- *     where handleX is declared elsewhere) are NOT resolved. Add a
- *     direct test case for new exported handlers that fit this shape.
+ *     where handleX is a FunctionDeclaration or const-arrow IN THE SAME
+ *     FILE) ARE now resolved via collectFunctionDecls(). Cross-file
+ *     imports are NOT resolved — if a future handler is imported from
+ *     another module, add a hard-coded pin test.
  *   - Inline `onclick=` HTML attributes are NOT scanned. Functions
  *     exposed via `window.X = X` for HTML onclick (e.g. resetPinLockout,
  *     revokeBiometricKey in users.js) must carry their own module-level
@@ -40,6 +42,12 @@
  *     or false-negative in the inverse case. For the current codebase
  *     this is not a problem; revisit if `addEventListener` calls become
  *     nested.
+ *   - Guard regex `[^)]{0,40}` after `.disabled\b` terminates at the
+ *     first `)`. A guard with a nested-call condition like
+ *     `if (btn.disabled && helper() === true) return;` would prematurely
+ *     terminate and not match. No such pattern exists today; document
+ *     the bound here so future developers know to use simple guard
+ *     conditions.
  */
 
 const fs = require('node:fs');
@@ -85,6 +93,42 @@ function reEnablesInFinally(bodyText) {
   return /\.\s*disabled\s*=\s*false/.test(win);
 }
 
+// Collect every FunctionDeclaration in the file keyed by name. Used to
+// resolve `addEventListener("click", namedFn)` to its actual body so the
+// invariants apply to named-function refs, not just inline arrows.
+function collectFunctionDecls(ast, source) {
+  const map = new Map();
+  traverse(ast, {
+    FunctionDeclaration(p) {
+      if (!p.node.id?.name) return;
+      map.set(p.node.id.name, source.slice(p.node.body.start, p.node.body.end));
+    },
+    VariableDeclarator(p) {
+      const init = p.node.init;
+      if (!init || !p.node.id?.name) return;
+      if (init.type !== 'ArrowFunctionExpression' && init.type !== 'FunctionExpression') return;
+      const bodyNode = init.body;
+      map.set(p.node.id.name, source.slice(bodyNode.start, bodyNode.end));
+    },
+  });
+  return map;
+}
+
+function analyseBody(bodyText) {
+  const hasConfirm = /\bconfirm\s*\(/.test(bodyText);
+  const hasApiCall = /\bapiCall\s*\(/.test(bodyText) || /\bfetch\s*\(/.test(bodyText);
+  const racePattern = (hasConfirm && hasApiCall) || setsDisabledBeforeAwait(bodyText);
+  if (!racePattern) return null;
+  return {
+    hasGuard: hasGuard(bodyText),
+    // `finally` only matters when the handler actually disables the
+    // button. Handlers using a module-level in-flight flag manage
+    // their own finally separately.
+    needsFinally: /\.\s*disabled\s*=\s*true/.test(bodyText),
+    hasFinally: reEnablesInFinally(bodyText),
+  };
+}
+
 function collectClickHandlers(file) {
   const source = fs.readFileSync(file, 'utf-8');
   let ast;
@@ -93,6 +137,7 @@ function collectClickHandlers(file) {
   } catch (_e) {
     ast = parser.parse(source, { sourceType: 'script' });
   }
+  const fnDecls = collectFunctionDecls(ast, source);
   const hits = [];
   traverse(ast, {
     CallExpression(nodePath) {
@@ -103,24 +148,22 @@ function collectClickHandlers(file) {
       const arg0 = node.arguments[0];
       if (arg0.type !== 'StringLiteral' || arg0.value !== 'click') return;
       const handler = node.arguments[1];
-      if (handler.type !== 'ArrowFunctionExpression' && handler.type !== 'FunctionExpression') {
+      let bodyText;
+      if (handler.type === 'ArrowFunctionExpression' || handler.type === 'FunctionExpression') {
+        bodyText = source.slice(handler.body.start, handler.body.end);
+      } else if (handler.type === 'Identifier' && fnDecls.has(handler.name)) {
+        // `addEventListener("click", namedFn)` — resolve to the
+        // function body declared in the same file.
+        bodyText = fnDecls.get(handler.name);
+      } else {
         return;
       }
-      const body = handler.body;
-      const bodyText = source.slice(body.start, body.end);
-      const hasConfirm = /\bconfirm\s*\(/.test(bodyText);
-      const hasApiCall = /\bapiCall\s*\(/.test(bodyText) || /\bfetch\s*\(/.test(bodyText);
-      const racePattern = (hasConfirm && hasApiCall) || setsDisabledBeforeAwait(bodyText);
-      if (!racePattern) return;
+      const analysis = analyseBody(bodyText);
+      if (!analysis) return;
       hits.push({
         file: path.relative(REPO_ROOT, file),
         line: node.loc.start.line,
-        hasGuard: hasGuard(bodyText),
-        // `finally` only matters when the handler actually disables the
-        // button. Handlers using a module-level in-flight flag manage
-        // their own finally separately.
-        needsFinally: /\.\s*disabled\s*=\s*true/.test(bodyText),
-        hasFinally: reEnablesInFinally(bodyText),
+        ...analysis,
       });
     },
   });
@@ -167,7 +210,9 @@ describe('admin click-handler re-entrancy', () => {
   // Inline-onclick globals: confirm()+apiCall() functions exposed via
   // `window.X = X` for HTML onclick=. The AST scan above doesn't see
   // them (no addEventListener wrapper). Pin their in-flight discipline
-  // explicitly by name.
+  // explicitly by name. Convention: exactly `let _<name>InFlight = false`
+  // (no `_is` prefix variation); a future global must follow this
+  // convention so the regex pin stays consistent with the guard pattern.
   test('inline-onclick globals carry module-level in-flight flags', () => {
     const usersJs = fs.readFileSync(path.join(REPO_ROOT, 'public/admin/js/tabs/users.js'), 'utf-8');
     const targets = ['resetPinLockout', 'revokeBiometricKey'];
@@ -183,7 +228,34 @@ describe('admin click-handler re-entrancy', () => {
     if (missing.length === 0) return;
     throw new Error(
       `Inline-onclick admin globals missing in-flight flag: ${missing.join(', ')}. ` +
-        `Each must declare \`let _<name>InFlight = false\` and check it on entry.`,
+        `Each must declare exactly \`let _<name>InFlight = false\` (no _is prefix) ` +
+        `and check it on entry.`,
     );
+  });
+
+  // revokeWarning is a thin-wrapper handler: registered via
+  // `() => revokeWarning(uid, w.id, w.gcsDeduction, rb)` so the AST
+  // scan sees the arrow wrapper (no confirm/apiCall in the wrapper body
+  // — both live inside revokeWarning itself). Pin its discipline
+  // explicitly: must carry a `btn.disabled` guard at the top. Success
+  // path destroys the button via list re-render, so finally-symmetry
+  // does NOT apply — the catch-only re-enable is intentional.
+  test('revokeWarning carries the entry guard', () => {
+    const usersJs = fs.readFileSync(path.join(REPO_ROOT, 'public/admin/js/tabs/users.js'), 'utf-8');
+    // Match the function header + the next ~200 chars; assert the guard
+    // lands before the first `confirm(`.
+    const fnIdx = usersJs.search(/export\s+async\s+function\s+revokeWarning\s*\(/);
+    if (fnIdx < 0) {
+      throw new Error('revokeWarning function not found in users.js — refactor may have moved it');
+    }
+    const window = usersJs.slice(fnIdx, fnIdx + 400);
+    const guardIdx = window.search(/if\s*\(\s*btn\.disabled\s*\)\s*return/);
+    const confirmIdx = window.search(/\bconfirm\s*\(/);
+    if (guardIdx < 0) {
+      throw new Error('revokeWarning is missing the `if (btn.disabled) return;` guard at the top');
+    }
+    if (confirmIdx >= 0 && guardIdx > confirmIdx) {
+      throw new Error('revokeWarning guard must come BEFORE the confirm() — same race as PR #968');
+    }
   });
 });

--- a/express-api/tests/scripts/admin-click-handler-reentrancy.test.js
+++ b/express-api/tests/scripts/admin-click-handler-reentrancy.test.js
@@ -48,6 +48,13 @@
  *     terminate and not match. No such pattern exists today; document
  *     the bound here so future developers know to use simple guard
  *     conditions.
+ *   - MemberExpression handler arguments (e.g. `addEventListener("click",
+ *     obj.method)` or `addEventListener("click", this.fn.bind(this))`)
+ *     are NOT resolved — they fall through to the silent `return` at the
+ *     end of the CallExpression visitor. No such pattern exists in the
+ *     admin or shared JS today; if a future class-based module appears,
+ *     add a hard-coded pin test for it like the inline-onclick globals
+ *     and revokeWarning sections below.
  */
 
 const fs = require('node:fs');

--- a/public/admin/js/main.js
+++ b/public/admin/js/main.js
@@ -389,6 +389,7 @@ loginBtn.addEventListener('click', async (e) => {
   // (Enter key) — preventDefault here too to keep the chain idempotent
   // even if the form-level handler is removed.
   e.preventDefault?.();
+  if (loginBtn.disabled) return;
   loginError.textContent = '';
   const email = loginEmail.value.trim();
   const pass = loginPassword.value;
@@ -407,8 +408,9 @@ loginBtn.addEventListener('click', async (e) => {
     } else {
       loginError.textContent = err.message;
     }
+  } finally {
+    loginBtn.disabled = false;
   }
-  loginBtn.disabled = false;
 });
 
 loginPassword.addEventListener('keydown', (e) => { if (e.key === 'Enter') loginBtn.click(); });

--- a/public/admin/js/nuclear-reset.js
+++ b/public/admin/js/nuclear-reset.js
@@ -247,6 +247,11 @@ async function handleNuclearProceed() {
   const proceedBtn = document.getElementById('nuclear-proceed');
   const confirmInput = document.getElementById('nuclear-confirm-input');
 
+  // Re-entrancy guard: blocks a queued second click after step 2
+  // disables the button for input gating, AND after step 3 disables
+  // the button before awaiting executeNuclearReset.
+  if (proceedBtn.disabled) return;
+
   if (step === 1) {
     step = 2;
     document.getElementById('nuclear-step-label').textContent = 'Step 2 of 3';
@@ -269,7 +274,16 @@ async function handleNuclearProceed() {
   }
   if (step === 3) {
     if (confirmInput.value !== CONFIRM_PHRASE) return;
-    await executeNuclearReset();
+    // Disable BEFORE the await so a queued second click hits the
+    // guard above. `finally` re-enables for retry on error; the
+    // success path destroys the dialog (proceedBtn becomes hidden),
+    // making the re-enable a harmless no-op.
+    proceedBtn.disabled = true;
+    try {
+      await executeNuclearReset();
+    } finally {
+      proceedBtn.disabled = false;
+    }
   }
 }
 

--- a/public/admin/js/nuclear-reset.js
+++ b/public/admin/js/nuclear-reset.js
@@ -62,6 +62,13 @@ const CONFIRM_PHRASE = 'RESET EVERYTHING';
 let step = 0;
 let executing = false;
 let soundMuted = false;
+// Cleared on the next macrotask after a step transition so the visible
+// "Step 2 of 3 / last warning" screen can't be skipped by a rapid
+// double-tap at step 1. Without it, two queued clicks both enter the
+// handler synchronously, click 1 advances step 1→2 and returns,
+// click 2 reads step === 2 and advances to step 3 — bypassing the
+// "last warning" UI without changing the typing-gate security.
+let nuclearStepLock = false;
 
 // ── Web Audio: warning beep (confirmation steps) ──────────────────
 
@@ -251,6 +258,12 @@ async function handleNuclearProceed() {
   // disables the button for input gating, AND after step 3 disables
   // the button before awaiting executeNuclearReset.
   if (proceedBtn.disabled) return;
+  // Step-transition lock: prevents step 1→2 double-tap from skipping
+  // the "last warning" screen by burning click 2 in the same
+  // macrotask as click 1. Cleared on next tick.
+  if (nuclearStepLock) return;
+  nuclearStepLock = true;
+  setTimeout(() => { nuclearStepLock = false; }, 0);
 
   if (step === 1) {
     step = 2;

--- a/public/admin/js/sync-prod.js
+++ b/public/admin/js/sync-prod.js
@@ -70,6 +70,10 @@ const SYNC_PHRASE = 'SYNC';
 let syncStep = 0;
 let syncExecuting = false;
 let syncMuted = false;
+// See nuclear-reset.js for rationale. Step-transition lock cleared on
+// next macrotask; blocks step 1→2 double-tap from skipping the "this
+// will overwrite everything" warning screen.
+let syncStepLock = false;
 
 // ── Web Audio: digital pulse (confirmation steps) ─────────────────
 
@@ -206,6 +210,11 @@ async function handleSyncProceed() {
   // disables the button for input gating, AND after step 3 disables
   // the button before awaiting executeSyncFromProd.
   if (proceedBtn.disabled) return;
+  // Step-transition lock: blocks step 1→2 double-tap from skipping
+  // the "this will overwrite everything" warning. Cleared next tick.
+  if (syncStepLock) return;
+  syncStepLock = true;
+  setTimeout(() => { syncStepLock = false; }, 0);
 
   if (syncStep === 1) {
     syncStep = 2;

--- a/public/admin/js/sync-prod.js
+++ b/public/admin/js/sync-prod.js
@@ -202,6 +202,11 @@ async function handleSyncProceed() {
   const proceedBtn = document.getElementById('sync-proceed');
   const confirmInput = document.getElementById('sync-confirm-input');
 
+  // Re-entrancy guard: blocks a queued second click after step 2
+  // disables the button for input gating, AND after step 3 disables
+  // the button before awaiting executeSyncFromProd.
+  if (proceedBtn.disabled) return;
+
   if (syncStep === 1) {
     syncStep = 2;
     document.getElementById('sync-step-label').textContent = 'Step 2 of 3';
@@ -231,7 +236,16 @@ async function handleSyncProceed() {
   }
   if (syncStep === 3) {
     if (confirmInput.value !== SYNC_PHRASE) return;
-    await executeSyncFromProd();
+    // Disable BEFORE the await so a queued second click hits the
+    // guard above. `finally` re-enables for retry on error; the
+    // success path destroys the dialog (proceedBtn becomes hidden),
+    // making the re-enable a harmless no-op.
+    proceedBtn.disabled = true;
+    try {
+      await executeSyncFromProd();
+    } finally {
+      proceedBtn.disabled = false;
+    }
   }
 }
 

--- a/public/admin/js/tabs/appeals.js
+++ b/public/admin/js/tabs/appeals.js
@@ -68,6 +68,7 @@ async function load(status) {
     // Bind resolve buttons
     for (const btn of list.querySelectorAll('[data-resolve]')) {
       btn.addEventListener('click', async () => {
+        if (btn.disabled) return;
         const appealId = btn.dataset.resolve;
         const newStatus = btn.dataset.status;
         const noteInput = list.querySelector(
@@ -84,8 +85,9 @@ async function load(status) {
           load(currentFilter);
         } catch (err) {
           showToast(err.message, 'error');
+        } finally {
+          btn.disabled = false;
         }
-        btn.disabled = false;
       });
     }
 

--- a/public/admin/js/tabs/backups.js
+++ b/public/admin/js/tabs/backups.js
@@ -200,6 +200,7 @@ async function restoreBackup(date, mode) {
 
 async function triggerBackup() {
   const btn = document.getElementById('backup-trigger-btn');
+  if (btn.disabled) return;
   btn.disabled = true;
   btn.textContent = 'Backing up...';
   try {
@@ -223,6 +224,7 @@ async function triggerBackup() {
 async function recoverPhotos() {
   const btn = document.getElementById('backup-recover-photos-btn');
   if (!btn) return;
+  if (btn.disabled) return;
   if (!confirm('Recover missing profile/cover photos from R2 storage?'))
     return;
   btn.disabled = true;

--- a/public/admin/js/tabs/banners.js
+++ b/public/admin/js/tabs/banners.js
@@ -280,13 +280,17 @@ function renderList() {
     deleteBtn.style.cssText =
       'padding:6px 14px;background:var(--danger);color:#fff;border:none;border-radius:5px;cursor:pointer;font-size:13px;';
     deleteBtn.addEventListener('click', async () => {
+      if (deleteBtn.disabled) return;
       if (!confirm('Delete this banner? This cannot be undone.')) return;
+      deleteBtn.disabled = true;
       try {
         await apiCall('DELETE', `/api/admin/banners/${b.id}`);
         showToast('Banner deleted');
         await loadBanners();
       } catch (err) {
         showToast('Delete failed: ' + err.message, 'error');
+      } finally {
+        deleteBtn.disabled = false;
       }
     });
     actions.appendChild(deleteBtn);

--- a/public/admin/js/tabs/banners.js
+++ b/public/admin/js/tabs/banners.js
@@ -387,6 +387,7 @@ function closeDialog() {
 
 async function saveDialog() {
   const saveBtnEl = document.getElementById('banner-dialog-save');
+  if (saveBtnEl.disabled) return;
   saveBtnEl.disabled = true;
   saveBtnEl.textContent = 'Saving...';
 

--- a/public/admin/js/tabs/economy-config.js
+++ b/public/admin/js/tabs/economy-config.js
@@ -329,6 +329,7 @@ function collectMilestoneRewards() {
 async function save() {
   const btn = $('#eco-save-btn');
   const info = $('#eco-save-info');
+  if (btn.disabled) return;
   btn.disabled = true;
   btn.textContent = 'Saving...';
 
@@ -398,8 +399,8 @@ async function save() {
     info.textContent = err.message;
     info.style.color = 'var(--danger)';
     showToast(err.message, 'error');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Save Economy Config';
   }
-
-  btn.disabled = false;
-  btn.textContent = 'Save Economy Config';
 }

--- a/public/admin/js/tabs/fun-facts.js
+++ b/public/admin/js/tabs/fun-facts.js
@@ -181,13 +181,17 @@ function renderList() {
     deleteBtn.style.cssText =
       'padding:6px 14px;background:var(--danger);color:#fff;border:none;border-radius:5px;cursor:pointer;font-size:13px;';
     deleteBtn.addEventListener('click', async () => {
+      if (deleteBtn.disabled) return;
       if (!confirm('Delete this fun fact? This cannot be undone.')) return;
+      deleteBtn.disabled = true;
       try {
         await apiCall('DELETE', `/api/admin/fun-facts/${f.id}`);
         showToast('Fun fact deleted');
         await loadFunFacts();
       } catch (err) {
         showToast('Delete failed: ' + err.message, 'error');
+      } finally {
+        deleteBtn.disabled = false;
       }
     });
     actions.appendChild(deleteBtn);

--- a/public/admin/js/tabs/fun-facts.js
+++ b/public/admin/js/tabs/fun-facts.js
@@ -218,13 +218,14 @@ function closeDialog() {
 }
 
 async function saveDialog() {
+  const saveBtnEl = document.getElementById('funfact-dialog-save');
+  if (saveBtnEl.disabled) return;
   const text = textInput.value.trim();
   if (!text) {
     showToast('Fact text is required', 'error');
     return;
   }
 
-  const saveBtnEl = document.getElementById('funfact-dialog-save');
   saveBtnEl.disabled = true;
   saveBtnEl.textContent = 'Saving...';
 

--- a/public/admin/js/tabs/gifts.js
+++ b/public/admin/js/tabs/gifts.js
@@ -319,6 +319,7 @@ function showConfirmation() {
 async function applyChanges() {
   const submitBtn = $('#gift-confirm-submit');
   const cancelBtn = $('#gift-confirm-cancel');
+  if (submitBtn.disabled) return;
   submitBtn.disabled = true;
   cancelBtn.disabled = true;
   submitBtn.textContent = 'Applying...';
@@ -348,9 +349,9 @@ async function applyChanges() {
         ' \u2014 pending changes kept for retry',
       'error',
     );
+  } finally {
+    submitBtn.disabled = false;
+    cancelBtn.disabled = false;
+    submitBtn.textContent = 'Confirm';
   }
-
-  submitBtn.disabled = false;
-  cancelBtn.disabled = false;
-  submitBtn.textContent = 'Confirm';
 }

--- a/public/admin/js/tabs/maintenance.js
+++ b/public/admin/js/tabs/maintenance.js
@@ -90,6 +90,7 @@ async function runAction(btnId, resultId, endpoint, confirmMsg) {
   const btn = document.getElementById(btnId);
   const result = document.getElementById(resultId);
   if (!btn || !result) return;
+  if (btn.disabled) return;
   if (!confirm(confirmMsg)) return;
 
   btn.disabled = true;
@@ -118,9 +119,10 @@ async function runAction(btnId, resultId, endpoint, confirmMsg) {
     result.className = 'maintenance-result error';
     result.textContent = err.message;
     result.style.display = 'block';
+  } finally {
+    btn.disabled = false;
+    btn.textContent = btn.dataset.label || 'Run';
   }
-  btn.disabled = false;
-  btn.textContent = btn.dataset.label || 'Run';
 }
 
 function formatBytes(bytes) {
@@ -133,6 +135,7 @@ function formatBytes(bytes) {
 async function auditStorage() {
   const btn = document.getElementById('audit-storage-btn');
   const result = document.getElementById('storage-result');
+  if (btn.disabled) return;
   btn.disabled = true;
   btn.textContent = 'Auditing...';
   result.className = 'maintenance-result';
@@ -161,14 +164,16 @@ async function auditStorage() {
     result.className = 'maintenance-result error';
     result.textContent = err.message;
     result.style.display = 'block';
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Audit Storage';
   }
-  btn.disabled = false;
-  btn.textContent = 'Audit Storage';
 }
 
 async function purgeStorage() {
   const btn = document.getElementById('purge-storage-btn');
   const result = document.getElementById('storage-result');
+  if (btn.disabled) return;
   const folders = ['pm_images/', 'stickers/', 'report_evidence/'];
   if (
     !confirm(
@@ -201,7 +206,8 @@ async function purgeStorage() {
     result.className = 'maintenance-result error';
     result.textContent = err.message;
     result.style.display = 'block';
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Purge Orphaned Files';
   }
-  btn.disabled = false;
-  btn.textContent = 'Purge Orphaned Files';
 }

--- a/public/admin/js/tabs/reports.js
+++ b/public/admin/js/tabs/reports.js
@@ -164,6 +164,7 @@ export function init(deps) {
 
   if (exportCsvBtn) {
     exportCsvBtn.addEventListener('click', async () => {
+      if (exportCsvBtn.disabled) return;
       if (!exportFrom.value || !exportTo.value) {
         showToast('Select a date range', 'error');
         return;

--- a/public/admin/js/tabs/spin-monitor.js
+++ b/public/admin/js/tabs/spin-monitor.js
@@ -610,6 +610,7 @@ async function loadGuaranteeStatus() {
 }
 
 async function handleGuaranteeSet() {
+  if (guaranteeSetBtn.disabled) return;
   if (!monitorUid) {
     showToast("Start monitoring a user first", "error");
     return;
@@ -622,8 +623,8 @@ async function handleGuaranteeSet() {
   const selectedText = guaranteeGiftSelect.options[guaranteeGiftSelect.selectedIndex].textContent;
   if (!confirm(`Set guaranteed next pull to "${selectedText}" for the monitored user?`)) return;
 
+  guaranteeSetBtn.disabled = true;
   try {
-    guaranteeSetBtn.disabled = true;
     const result = await apiCall("POST", `/api/users/${monitorUid}/guarantee-next-pull`, { giftId });
     showToast(`Guarantee set: ${result.giftName} (${result.coinValue} coins)`);
     await loadGuaranteeStatus();
@@ -635,11 +636,12 @@ async function handleGuaranteeSet() {
 }
 
 async function handleGuaranteeRevoke() {
+  if (guaranteeRevokeBtn.disabled) return;
   if (!monitorUid) return;
   if (!confirm("Revoke the guaranteed next pull for this user?")) return;
 
+  guaranteeRevokeBtn.disabled = true;
   try {
-    guaranteeRevokeBtn.disabled = true;
     await apiCall("DELETE", `/api/users/${monitorUid}/guarantee-next-pull`);
     showToast("Guarantee revoked");
     await loadGuaranteeStatus();

--- a/public/admin/js/tabs/starting-screens.js
+++ b/public/admin/js/tabs/starting-screens.js
@@ -780,6 +780,7 @@ function renderDeletedScreenCard(screenId, screen) {
   card
     .querySelector('.permanent-delete-btn')
     .addEventListener('click', async function () {
+      if (this.disabled) return;
       if (
         !confirm(
           'Permanently delete screen "' +

--- a/public/admin/js/tabs/starting-screens.js
+++ b/public/admin/js/tabs/starting-screens.js
@@ -761,6 +761,7 @@ function renderDeletedScreenCard(screenId, screen) {
   card
     .querySelector('.restore-screen-btn')
     .addEventListener('click', async function () {
+      if (this.disabled) return;
       this.disabled = true;
       try {
         await apiCall(
@@ -773,8 +774,9 @@ function renderDeletedScreenCard(screenId, screen) {
         load();
       } catch (err) {
         showToast('Failed to restore: ' + err.message, 'error');
+      } finally {
+        this.disabled = false;
       }
-      this.disabled = false;
     });
 
   card
@@ -804,8 +806,9 @@ function renderDeletedScreenCard(screenId, screen) {
           'Failed to permanently delete: ' + err.message,
           'error',
         );
+      } finally {
+        this.disabled = false;
       }
-      this.disabled = false;
     });
 
   return card;

--- a/public/admin/js/tabs/users.js
+++ b/public/admin/js/tabs/users.js
@@ -1083,6 +1083,7 @@ function renderWarningItem(w, uid) {
 }
 
 export async function revokeWarning(uid, warningId, deduction, btn) {
+  if (btn.disabled) return;
   if (!confirm(window.tAdminFmt("confirm_revoke_warning", { deduction }))) return;
   btn.disabled = true; btn.textContent = "...";
   try {
@@ -1091,6 +1092,9 @@ export async function revokeWarning(uid, warningId, deduction, btn) {
     const data = await apiCall("GET", "/api/user/" + uid);
     populateGcsSection(data);
     loadWarningHistory(uid, false);
+    // Success path rerenders the list (loadWarningHistory) destroying
+    // `btn` — no re-enable needed. Only the catch branch needs to
+    // re-enable so the admin can retry the revoke after an error.
   } catch (err) { showToast(err.message, "error"); btn.disabled = false; btn.textContent = window.tAdmin("btn_revoke"); }
 }
 
@@ -1214,25 +1218,43 @@ export async function loadSecurityPanel() {
   }
 }
 
+// Module-level in-flight flags for functions called via inline `onclick=`
+// in admin/index.html (exposed via wireSecurityGlobals). Unlike the
+// addEventListener handlers below, these have no `btn` reference, so the
+// `if (btn.disabled) return;` pattern from PR #968 doesn't apply. The
+// flag closes the same race window: blocking-`confirm()` resolves
+// instantly under Playwright auto-accept, both calls pass the flag check
+// before either sets it, so the flag must be set BEFORE the first `await`.
+let _resetPinLockoutInFlight = false;
+let _revokeBiometricKeyInFlight = false;
+
 export async function resetPinLockout() {
+  if (_resetPinLockoutInFlight) return;
   if (!currentUid || !confirm(window.tAdmin("confirm_reset_pin_lockout"))) return;
+  _resetPinLockoutInFlight = true;
   try {
     await apiCall("POST", `/api/user/${currentUid}/reset-pin-lockout`);
     showToast(window.tAdmin("toast_pin_lockout_reset"));
     loadSecurityPanel();
   } catch (err) {
     showToast(window.tAdminFmt("toast_action_failed", { error: err.message }), "error");
+  } finally {
+    _resetPinLockoutInFlight = false;
   }
 }
 
 export async function revokeBiometricKey(uniqueId, deviceId) {
+  if (_revokeBiometricKeyInFlight) return;
   if (!confirm(window.tAdminFmt("confirm_revoke_biometric", { deviceId }))) return;
+  _revokeBiometricKeyInFlight = true;
   try {
     await apiCall("DELETE", `/api/user/${uniqueId}/biometric-keys/${deviceId}`);
     showToast(window.tAdmin("toast_biometric_revoked"));
     loadSecurityPanel();
   } catch (err) {
     showToast(window.tAdminFmt("toast_action_failed", { error: err.message }), "error");
+  } finally {
+    _revokeBiometricKeyInFlight = false;
   }
 }
 
@@ -1247,6 +1269,7 @@ export function wireModerationListeners() {
   // Suspend
   const suspendBtn = $("#suspend-btn");
   if (suspendBtn) suspendBtn.addEventListener("click", async () => {
+    if (suspendBtn.disabled) return;
     const reason = $("#suspend-reason")?.value?.trim();
     if (!reason) { showToast(window.tAdmin("toast_reason_required"), "error"); return; }
     const endDateVal = $("#suspend-end-date")?.value;
@@ -1259,7 +1282,7 @@ export function wireModerationListeners() {
       const data = await apiCall("GET", `/api/user/${currentUid}`);
       await populateFormFull(data);
     } catch (err) { showToast(err.message, "error"); }
-    suspendBtn.disabled = false;
+    finally { suspendBtn.disabled = false; }
   });
   // Unsuspend
   const unsuspendBtn = $("#unsuspend-btn");
@@ -1276,7 +1299,7 @@ export function wireModerationListeners() {
       const data = await apiCall("GET", `/api/user/${currentUid}`);
       await populateFormFull(data);
     } catch (err) { showToast(err.message, "error"); }
-    unsuspendBtn.disabled = false;
+    finally { unsuspendBtn.disabled = false; }
   });
   // Duration presets
   for (const btn of document.querySelectorAll(".duration-presets button")) {
@@ -1503,7 +1526,7 @@ function showClearAllConfirmation() {
   const confirmBtn = document.createElement("button"); confirmBtn.style.cssText = "padding:8px 20px;background:var(--danger);color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:14px;opacity:0.5;"; confirmBtn.disabled = true;
   let countdown = 5; confirmBtn.textContent = window.tAdminFmt("btn_confirming", { countdown });
   const timer = setInterval(function() { countdown--; if (countdown <= 0) { clearInterval(timer); confirmBtn.disabled = false; confirmBtn.style.opacity = "1"; confirmBtn.textContent = window.tAdmin("btn_confirm_clear_all"); } else { confirmBtn.textContent = window.tAdminFmt("btn_confirming", { countdown }); } }, 1000);
-  confirmBtn.addEventListener("click", async function() { if (confirmBtn.disabled) return; clearInterval(timer); confirmBtn.disabled = true; confirmBtn.textContent = window.tAdmin("btn_clearing"); await clearAllBackpack(); document.body.removeChild(overlay); });
+  confirmBtn.addEventListener("click", async function() { if (confirmBtn.disabled) return; clearInterval(timer); confirmBtn.disabled = true; confirmBtn.textContent = window.tAdmin("btn_clearing"); try { await clearAllBackpack(); document.body.removeChild(overlay); } finally { confirmBtn.disabled = false; } });
   btnRow.appendChild(confirmBtn); dialog.appendChild(btnRow); overlay.appendChild(dialog);
   overlay.addEventListener("click", function(e) { if (e.target === overlay) { clearInterval(timer); document.body.removeChild(overlay); } });
   document.body.appendChild(overlay);

--- a/public/admin/js/tabs/users.js
+++ b/public/admin/js/tabs/users.js
@@ -156,6 +156,7 @@ export function switchUserSubtab(subtab) {
 // ── Search ─────────────────────────────────────────────────────────
 
 async function doSearchFinal() {
+  if (searchBtnEl.disabled) return;
   const q = searchUidEl.value.trim();
   if (!q) return;
   await _flushNotifications();
@@ -172,9 +173,10 @@ async function doSearchFinal() {
     if (err.name === "AbortError") return;
     showToast(err.message, "error");
     sessionStorage.removeItem("admin_user_search");
+  } finally {
+    searchBtnEl.disabled = false;
+    searchBtnEl.textContent = window.tAdmin("btn_search");
   }
-  searchBtnEl.disabled = false;
-  searchBtnEl.textContent = window.tAdmin("btn_search");
 }
 
 /**

--- a/public/admin/js/tabs/users.js
+++ b/public/admin/js/tabs/users.js
@@ -1267,6 +1267,7 @@ export function wireModerationListeners() {
     // Symmetry with every other destructive admin action (kick, GCS reset,
     // schedule deletion, IP ban) — one accidental click on a suspended
     // user's profile previously lifted the suspension immediately.
+    if (unsuspendBtn.disabled) return;
     if (!confirm(window.tAdmin("confirm_unsuspend_user"))) return;
     unsuspendBtn.disabled = true;
     try {
@@ -1291,6 +1292,7 @@ export function wireModerationListeners() {
   // GCS reset
   const resetGcsBtn = $("#reset-gcs-btn");
   if (resetGcsBtn) resetGcsBtn.addEventListener("click", async () => {
+    if (resetGcsBtn.disabled) return;
     if (!currentUid || !confirm(window.tAdmin("confirm_reset_gcs"))) return;
     resetGcsBtn.disabled = true;
     try { await apiCall("POST", `/api/user/${currentUid}/reset-gcs`); showToast(window.tAdmin("toast_gcs_reset_100")); const data = await apiCall("GET", `/api/user/${currentUid}`); populateGcsSection(data); }
@@ -1334,20 +1336,27 @@ export function wireModerationListeners() {
   // Account deletion
   const scheduleDeletionBtn = $("#schedule-deletion-btn");
   if (scheduleDeletionBtn) scheduleDeletionBtn.addEventListener("click", async () => {
+    if (scheduleDeletionBtn.disabled) return;
     const reason = prompt(window.tAdmin("prompt_deletion_reason")); if (reason === null) return;
     if (!confirm(window.tAdmin("confirm_schedule_deletion"))) return;
+    scheduleDeletionBtn.disabled = true;
     try { await apiCall("POST", `/api/user/${currentUid}/delete`, { reason }); alert(window.tAdmin("alert_deletion_scheduled")); const freshData = await apiCall("GET", `/api/user/${currentUid}`); populateDeletionSection(freshData); }
     catch (err) { alert(window.tAdminFmt("alert_schedule_deletion_failed", { error: err.message || err })); }
+    finally { scheduleDeletionBtn.disabled = false; }
   });
   const cancelDeletionBtn = $("#cancel-deletion-btn");
   if (cancelDeletionBtn) cancelDeletionBtn.addEventListener("click", async () => {
+    if (cancelDeletionBtn.disabled) return;
     if (!confirm(window.tAdmin("confirm_cancel_deletion"))) return;
+    cancelDeletionBtn.disabled = true;
     try { await apiCall("POST", `/api/user/${currentUid}/cancel-delete`); alert(window.tAdmin("alert_deletion_cancelled")); const freshData = await apiCall("GET", `/api/user/${currentUid}`); populateDeletionSection(freshData); }
     catch (err) { alert(window.tAdminFmt("alert_cancel_deletion_failed", { error: err.message || err })); }
+    finally { cancelDeletionBtn.disabled = false; }
   });
   // Reset device binding
   const resetDeviceBtn = document.getElementById("reset-device-binding-btn");
   if (resetDeviceBtn) resetDeviceBtn.addEventListener("click", async () => {
+    if (resetDeviceBtn.disabled) return;
     if (!currentUid) { showToast(window.tAdmin("toast_no_user_loaded"), "error"); return; }
     if (!confirm(window.tAdmin("confirm_remove_all_device_bindings"))) return;
     resetDeviceBtn.disabled = true; resetDeviceBtn.textContent = window.tAdmin("btn_resetting");
@@ -1661,13 +1670,13 @@ export async function populateBansSection(uid) {
     const deviceBans = bansData.deviceBans || [];
     if (bansDeviceList) {
       if (deviceBans.length === 0) { bansDeviceList.innerHTML = '<div style="color:var(--text2);font-size:12px;font-style:italic;">No device bans</div>'; }
-      else { bansDeviceList.textContent = ""; deviceBans.forEach(b => { const item = document.createElement("div"); item.className = "ban-item"; item.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:8px;"; const info = document.createElement("div"); info.className = "ban-item-info"; info.style.flex = "1"; const idSpan = document.createElement("span"); idSpan.textContent = b.deviceId || b.id; const detailSpan = document.createElement("span"); detailSpan.className = "ban-item-type"; detailSpan.textContent = (b.reason || "No reason") + " | " + (b.duration || "permanent") + (b.autoApplied ? " (auto)" : ""); info.appendChild(idSpan); info.appendChild(detailSpan); item.appendChild(info); const removeBtn = document.createElement("button"); removeBtn.textContent = "Remove"; removeBtn.style.cssText = "padding:4px 10px;border:none;border-radius:4px;cursor:pointer;font-size:11px;font-weight:600;background:var(--danger);color:#fff;white-space:nowrap;"; removeBtn.addEventListener("click", async () => { if (!confirm(window.tAdmin("confirm_remove_device_ban"))) return; try { await apiCall("DELETE", "/api/admin/bans/device/" + encodeURIComponent(b.deviceId || b.id)); showToast("Device ban removed", "success"); populateBansSection(currentUid); } catch (err) { showToast(err.message, "error"); } }); item.appendChild(removeBtn); bansDeviceList.appendChild(item); }); }
+      else { bansDeviceList.textContent = ""; deviceBans.forEach(b => { const item = document.createElement("div"); item.className = "ban-item"; item.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:8px;"; const info = document.createElement("div"); info.className = "ban-item-info"; info.style.flex = "1"; const idSpan = document.createElement("span"); idSpan.textContent = b.deviceId || b.id; const detailSpan = document.createElement("span"); detailSpan.className = "ban-item-type"; detailSpan.textContent = (b.reason || "No reason") + " | " + (b.duration || "permanent") + (b.autoApplied ? " (auto)" : ""); info.appendChild(idSpan); info.appendChild(detailSpan); item.appendChild(info); const removeBtn = document.createElement("button"); removeBtn.textContent = "Remove"; removeBtn.style.cssText = "padding:4px 10px;border:none;border-radius:4px;cursor:pointer;font-size:11px;font-weight:600;background:var(--danger);color:#fff;white-space:nowrap;"; removeBtn.addEventListener("click", async () => { if (removeBtn.disabled) return; if (!confirm(window.tAdmin("confirm_remove_device_ban"))) return; removeBtn.disabled = true; try { await apiCall("DELETE", "/api/admin/bans/device/" + encodeURIComponent(b.deviceId || b.id)); showToast("Device ban removed", "success"); populateBansSection(currentUid); } catch (err) { showToast(err.message, "error"); } finally { removeBtn.disabled = false; } }); item.appendChild(removeBtn); bansDeviceList.appendChild(item); }); }
     }
     // Network bans
     const networkBans = bansData.networkBans || [];
     if (bansNetworkList) {
       if (networkBans.length === 0) { bansNetworkList.innerHTML = '<div style="color:var(--text2);font-size:12px;font-style:italic;">No network bans</div>'; }
-      else { bansNetworkList.textContent = ""; networkBans.forEach(b => { const item = document.createElement("div"); item.className = "ban-item"; item.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:8px;"; const info = document.createElement("div"); info.className = "ban-item-info"; info.style.flex = "1"; const valSpan = document.createElement("span"); valSpan.textContent = (b.value || b.id) + " (" + (b.type || "ip") + ")"; const detailSpan = document.createElement("span"); detailSpan.className = "ban-item-type"; detailSpan.textContent = (b.reason || "No reason") + " | " + (b.duration || "permanent") + (b.autoApplied ? " (auto)" : ""); info.appendChild(valSpan); info.appendChild(detailSpan); item.appendChild(info); const removeBtn = document.createElement("button"); removeBtn.textContent = "Remove"; removeBtn.style.cssText = "padding:4px 10px;border:none;border-radius:4px;cursor:pointer;font-size:11px;font-weight:600;background:var(--danger);color:#fff;white-space:nowrap;"; removeBtn.addEventListener("click", async () => { if (!confirm(window.tAdmin("confirm_remove_network_ban"))) return; try { await apiCall("DELETE", "/api/admin/bans/network/" + encodeURIComponent(b.id)); showToast("Network ban removed", "success"); populateBansSection(currentUid); } catch (err) { showToast(err.message, "error"); } }); item.appendChild(removeBtn); bansNetworkList.appendChild(item); }); }
+      else { bansNetworkList.textContent = ""; networkBans.forEach(b => { const item = document.createElement("div"); item.className = "ban-item"; item.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:8px;"; const info = document.createElement("div"); info.className = "ban-item-info"; info.style.flex = "1"; const valSpan = document.createElement("span"); valSpan.textContent = (b.value || b.id) + " (" + (b.type || "ip") + ")"; const detailSpan = document.createElement("span"); detailSpan.className = "ban-item-type"; detailSpan.textContent = (b.reason || "No reason") + " | " + (b.duration || "permanent") + (b.autoApplied ? " (auto)" : ""); info.appendChild(valSpan); info.appendChild(detailSpan); item.appendChild(info); const removeBtn = document.createElement("button"); removeBtn.textContent = "Remove"; removeBtn.style.cssText = "padding:4px 10px;border:none;border-radius:4px;cursor:pointer;font-size:11px;font-weight:600;background:var(--danger);color:#fff;white-space:nowrap;"; removeBtn.addEventListener("click", async () => { if (removeBtn.disabled) return; if (!confirm(window.tAdmin("confirm_remove_network_ban"))) return; removeBtn.disabled = true; try { await apiCall("DELETE", "/api/admin/bans/network/" + encodeURIComponent(b.id)); showToast("Network ban removed", "success"); populateBansSection(currentUid); } catch (err) { showToast(err.message, "error"); } finally { removeBtn.disabled = false; } }); item.appendChild(removeBtn); bansNetworkList.appendChild(item); }); }
     }
     // Bound devices
     const devices = devicesData.devices || [];
@@ -1796,32 +1805,39 @@ export function wireBansListeners() {
     bansDevicesBoundList.addEventListener("click", async (e) => {
       const btn = e.target.closest("[data-ban-action]");
       if (!btn) return;
+      if (btn.disabled) return;
       const action = btn.dataset.banAction;
       const deviceId = btn.dataset.deviceId;
       if (action === "ban") {
         const reasonInput = btn.closest(".device-card-body")?.querySelector(".ban-reason-input");
         const durationSelect = btn.closest(".device-card-body")?.querySelector(".ban-duration-select");
+        btn.disabled = true;
         try {
           // Returns pms: { failed, total } per admin-bans.js POST /admin/bans/device.
           const result = await apiCall("POST", "/api/admin/bans/device", { deviceId, reason: reasonInput?.value?.trim() || null, duration: durationSelect?.value || null, linkedUniqueId: currentUid });
           window.PartialFailureToast?.showResultToast(showToast, result, "Device banned");
           populateBansSection(currentUid);
         } catch (err) { showToast(err.message, "error"); }
+        finally { btn.disabled = false; }
       } else if (action === "unban") {
         if (!confirm(window.tAdmin("confirm_unban_device"))) return;
+        btn.disabled = true;
         try {
           await apiCall("DELETE", `/api/admin/bans/device/${deviceId}`);
           showToast("Device unbanned", "success");
           populateBansSection(currentUid);
         } catch (err) { showToast(err.message, "error"); }
+        finally { btn.disabled = false; }
       }
     });
   }
   const banAllBtn = $("#bans-ban-all-devices");
   if (banAllBtn) banAllBtn.addEventListener("click", async () => {
+    if (banAllBtn.disabled) return;
     if (!currentUid) return;
     if (!confirm(window.tAdmin("confirm_ban_all_devices"))) return;
     const reason = prompt(window.tAdmin("prompt_ban_reason")) || "";
+    banAllBtn.disabled = true;
     try {
       const devicesData = await apiCall("GET", `/api/admin/devices/user/${currentUid}`);
       const devices = devicesData.devices || [];
@@ -1857,10 +1873,13 @@ export function wireBansListeners() {
       }
       populateBansSection(currentUid);
     } catch (err) { showToast(window.tAdminFmt("toast_action_failed", { error: err.message }), "error"); }
+    finally { banAllBtn.disabled = false; }
   });
   const banIpBtn = $("#bans-ban-last-ip");
   if (banIpBtn) banIpBtn.addEventListener("click", async () => {
+    if (banIpBtn.disabled) return;
     if (!currentUid) return;
+    banIpBtn.disabled = true;
     try {
       const devicesData = await apiCall("GET", `/api/admin/devices/user/${currentUid}`);
       const devices = devicesData.devices || [];
@@ -1873,24 +1892,28 @@ export function wireBansListeners() {
       window.PartialFailureToast?.showResultToast(showToast, result, window.tAdmin("toast_ip_banned"));
       populateBansSection(currentUid);
     } catch (err) { showToast(window.tAdminFmt("toast_action_failed", { error: err.message }), "error"); }
+    finally { banIpBtn.disabled = false; }
   });
   const unbanAllBtn = $("#bans-unban-all");
   if (unbanAllBtn) unbanAllBtn.addEventListener("click", async () => {
+    if (unbanAllBtn.disabled) return;
     if (!currentUid) return;
     if (!confirm(window.tAdmin("confirm_remove_all_bans"))) return;
+    unbanAllBtn.disabled = true;
     try {
       const result = await apiCall("POST", `/api/admin/bans/unban-all/${currentUid}`);
       window.PartialFailureToast?.showResultToast(showToast, result, window.tAdminFmt("toast_removed_n_bans", { count: result.removed || 0 }));
       populateBansSection(currentUid);
     } catch (err) { showToast(window.tAdminFmt("toast_action_failed", { error: err.message }), "error"); }
+    finally { unbanAllBtn.disabled = false; }
   });
   const viewLogsBtn = $("#bans-view-logs");
   if (viewLogsBtn) viewLogsBtn.addEventListener("click", () => { if (!currentUid) return; const logsUserFilter = $("#log-filter-userId"); if (logsUserFilter) logsUserFilter.value = currentUid; _switchTab("logs"); });
   // Identity graph suspend/unsuspend (tabular version)
   const igSuspendBtn = $("#ig-suspend-btn");
-  if (igSuspendBtn) igSuspendBtn.addEventListener("click", async () => { if (!currentUid) return; const duration = $("#ig-duration-picker")?.value; const scope = $("#ig-scope-picker")?.value; if (!confirm(window.tAdminFmt("confirm_suspend_identity_graph", { duration, scope }))) return; try { await apiCall("PUT", `/api/admin/bans/graph/${currentUid}`, { action: "suspend", duration, scope }); showToast(window.tAdmin("toast_identity_graph_suspended"), "success"); populateBansSection(currentUid); } catch (err) { showToast(err.message, "error"); } });
+  if (igSuspendBtn) igSuspendBtn.addEventListener("click", async () => { if (igSuspendBtn.disabled) return; if (!currentUid) return; const duration = $("#ig-duration-picker")?.value; const scope = $("#ig-scope-picker")?.value; if (!confirm(window.tAdminFmt("confirm_suspend_identity_graph", { duration, scope }))) return; igSuspendBtn.disabled = true; try { await apiCall("PUT", `/api/admin/bans/graph/${currentUid}`, { action: "suspend", duration, scope }); showToast(window.tAdmin("toast_identity_graph_suspended"), "success"); populateBansSection(currentUid); } catch (err) { showToast(err.message, "error"); } finally { igSuspendBtn.disabled = false; } });
   const igUnsuspendBtn = $("#ig-unsuspend-btn");
-  if (igUnsuspendBtn) igUnsuspendBtn.addEventListener("click", async () => { if (!currentUid) return; if (!confirm(window.tAdmin("confirm_unsuspend_identity_graph"))) return; try { await apiCall("PUT", `/api/admin/bans/graph/${currentUid}`, { action: "unsuspend" }); showToast(window.tAdmin("toast_identity_graph_unsuspended"), "success"); populateBansSection(currentUid); } catch (err) { showToast(err.message, "error"); } });
+  if (igUnsuspendBtn) igUnsuspendBtn.addEventListener("click", async () => { if (igUnsuspendBtn.disabled) return; if (!currentUid) return; if (!confirm(window.tAdmin("confirm_unsuspend_identity_graph"))) return; igUnsuspendBtn.disabled = true; try { await apiCall("PUT", `/api/admin/bans/graph/${currentUid}`, { action: "unsuspend" }); showToast(window.tAdmin("toast_identity_graph_unsuspended"), "success"); populateBansSection(currentUid); } catch (err) { showToast(err.message, "error"); } finally { igUnsuspendBtn.disabled = false; } });
 }
 
 export function wireTempIdListeners() {
@@ -1899,7 +1922,7 @@ export function wireTempIdListeners() {
   const applyBtn = document.getElementById("temp-id-apply");
   if (applyBtn) applyBtn.addEventListener("click", async () => { if (!currentUid) return; const id = parseInt(document.getElementById("temp-id-input")?.value); const expiryVal = document.getElementById("temp-id-expiry")?.value; if (!id || id < 10000000) { showToast("ID must be at least 10000000", "error"); return; } if (!expiryVal) { showToast("Set an expiry date", "error"); return; } const expiryDate = new Date(expiryVal).getTime(); if (expiryDate <= Date.now()) { showToast("Expiry must be in the future", "error"); return; } try { await apiCall("POST", `/api/admin/users/${currentUid}/temp-id`, { tempUniqueId: id, expiryDate }); showToast("Temporary ID applied", "success"); const currentEl = document.getElementById("temp-id-current"); if (currentEl) currentEl.innerHTML = "Active temp ID: <strong>" + escapeHtml(String(id)) + "</strong> (expires " + escapeHtml(new Date(expiryDate).toLocaleString()) + ")"; const resultEl = document.getElementById("temp-id-check-result"); if (resultEl) resultEl.textContent = ""; } catch (err) { showToast(err.message || "Failed to apply temp ID", "error"); } });
   const clearBtn = document.getElementById("temp-id-clear");
-  if (clearBtn) clearBtn.addEventListener("click", async () => { if (!currentUid) return; if (!confirm(window.tAdmin("confirm_clear_temp_id"))) return; try { await apiCall("DELETE", `/api/admin/users/${currentUid}/temp-id`); showToast("Temporary ID cleared", "success"); const inputEl = document.getElementById("temp-id-input"); if (inputEl) inputEl.value = ""; const expiryEl = document.getElementById("temp-id-expiry"); if (expiryEl) expiryEl.value = ""; const currentEl = document.getElementById("temp-id-current"); if (currentEl) currentEl.textContent = "No temporary ID set"; const resultEl = document.getElementById("temp-id-check-result"); if (resultEl) resultEl.textContent = ""; } catch (err) { showToast(err.message || "Failed to clear temp ID", "error"); } });
+  if (clearBtn) clearBtn.addEventListener("click", async () => { if (clearBtn.disabled) return; if (!currentUid) return; if (!confirm(window.tAdmin("confirm_clear_temp_id"))) return; clearBtn.disabled = true; try { await apiCall("DELETE", `/api/admin/users/${currentUid}/temp-id`); showToast("Temporary ID cleared", "success"); const inputEl = document.getElementById("temp-id-input"); if (inputEl) inputEl.value = ""; const expiryEl = document.getElementById("temp-id-expiry"); if (expiryEl) expiryEl.value = ""; const currentEl = document.getElementById("temp-id-current"); if (currentEl) currentEl.textContent = "No temporary ID set"; const resultEl = document.getElementById("temp-id-check-result"); if (resultEl) resultEl.textContent = ""; } catch (err) { showToast(err.message || "Failed to clear temp ID", "error"); } finally { clearBtn.disabled = false; } });
 }
 
 export function wirePreviewListeners() {

--- a/tests/web/admin-maintenance.spec.ts
+++ b/tests/web/admin-maintenance.spec.ts
@@ -351,7 +351,36 @@ test.describe('Admin Maintenance Tab', () => {
     await expect(overlay).not.toHaveClass(/visible/);
   });
 
-  // ── Test 16: Mute toggle ──
+  // ── Test 16: Step-transition lock — rapid double-tap at step 1
+  //            cannot skip the "last warning" UI ──
+  test('rapid double-tap at step 1 does not skip step 2', async ({ page }) => {
+    // Open nuclear dialog
+    await page.locator('#reset-all-btn').click();
+    const overlay = page.locator('#nuclear-overlay');
+    await expect(overlay).toHaveClass(/visible/);
+
+    // Dispatch two synchronous click events on #nuclear-proceed in the
+    // same browser-side macrotask. JavaScript is single-threaded, so
+    // both events queue before either handler runs. Without the
+    // `nuclearStepLock` flag, both handlers would advance `step`
+    // synchronously: click 1 sets step=2, click 2 reads step===2 and
+    // skips straight to step 3 — bypassing the "last warning" screen.
+    await page.evaluate(() => {
+      const btn = document.getElementById('nuclear-proceed')!;
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // Must be at Step 2 (not Step 3) — step-lock blocked the second click.
+    await expect(page.locator('#nuclear-step-label')).toHaveText('Step 2 of 3');
+    await expect(page.locator('#nuclear-title')).toContainText('last warning');
+
+    // Cancel to clean up
+    await page.locator('#nuclear-cancel').click();
+    await expect(overlay).not.toHaveClass(/visible/);
+  });
+
+  // ── Test 17: Mute toggle ──
   test('mute button toggles mute state during nuclear dialog', async ({ page }) => {
     // Open nuclear dialog
     await page.locator('#reset-all-btn').click();

--- a/tests/web/admin-maintenance.spec.ts
+++ b/tests/web/admin-maintenance.spec.ts
@@ -380,7 +380,44 @@ test.describe('Admin Maintenance Tab', () => {
     await expect(overlay).not.toHaveClass(/visible/);
   });
 
-  // ── Test 17: Mute toggle ──
+  // ── Test 17: Sync-prod step-transition lock ──
+  // Mirror of test 16 for the sync-prod wizard. The migrate-prod-card
+  // is only shown when apiBase contains "dev-api" (local stack runs
+  // on localhost so the card is hidden by default) — force it visible
+  // before clicking so the test runs in any environment.
+  test('sync-prod rapid double-tap at step 1 does not skip step 2', async ({ page }) => {
+    // Force-show the sync card and open the wizard
+    await page.evaluate(() => {
+      const card = document.getElementById('migrate-prod-card');
+      if (card) card.style.display = '';
+    });
+    await page.locator('#migrate-prod-btn').click();
+    const overlay = page.locator('#sync-overlay');
+    await expect(overlay).toHaveClass(/visible/);
+    await expect(page.locator('#sync-step-label')).toHaveText('Step 1 of 3');
+
+    // Dispatch two synchronous click events on #sync-proceed in the
+    // same browser-side macrotask. Without `syncStepLock`, click 1
+    // advances syncStep=2 + returns; click 2 reads syncStep===2 and
+    // skips to step 3 — bypassing the "this will overwrite
+    // everything" warning. Lock blocks click 2 on the entry check.
+    await page.evaluate(() => {
+      const btn = document.getElementById('sync-proceed')!;
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // Must be at Step 2 (not Step 3) — step-lock blocked the second click.
+    await expect(page.locator('#sync-step-label')).toHaveText('Step 2 of 3');
+    await expect(page.locator('#sync-title')).toContainText('overwrite everything');
+
+    // Cancel to clean up — both for state hygiene and to silence the
+    // sync-beep audio that openSyncOverlay started.
+    await page.locator('#sync-cancel').click();
+    await expect(overlay).not.toHaveClass(/visible/);
+  });
+
+  // ── Test 18: Mute toggle ──
   test('mute button toggles mute state during nuclear dialog', async ({ page }) => {
     // Open nuclear dialog
     await page.locator('#reset-all-btn').click();

--- a/tests/web/admin-users-moderation.spec.ts
+++ b/tests/web/admin-users-moderation.spec.ts
@@ -25,10 +25,13 @@ test.describe('Admin Users - Moderation Subtab', () => {
   // admin-users-deletion) that suspend or otherwise touch the worker
   // user can leave the score below 100 — making the
   // "issue warning → expect 85" assertion intermittently fail when the
-  // start state was already below 15. Idempotent API call.
+  // start state was already below 15. Idempotent API call. We let the
+  // setup throw rather than silently swallowing — a failed reset
+  // produces a clear "beforeAll failed" message instead of test 1
+  // failing with "Expected 85, Received <something else>".
   test.beforeAll(async ({ testData }) => {
     const uid = String(testData.user.uniqueId);
-    await testData.api.post(`/api/user/${uid}/reset-gcs`, {}).catch(() => {});
+    await testData.api.post(`/api/user/${uid}/reset-gcs`, {});
   });
 
   test.beforeEach(async ({ page, testData }) => {

--- a/tests/web/admin-users-moderation.spec.ts
+++ b/tests/web/admin-users-moderation.spec.ts
@@ -19,6 +19,18 @@ async function reloadAndNavigateToModeration(
 test.describe('Admin Users - Moderation Subtab', () => {
   test.describe.configure({ mode: 'serial' });
 
+  // Defensive isolation: tests in this file assert against a known
+  // baseline (gcsScore === 100, no leftover warnings). Without this
+  // reset, alphabetically-earlier test files (admin-appeals,
+  // admin-users-deletion) that suspend or otherwise touch the worker
+  // user can leave the score below 100 — making the
+  // "issue warning → expect 85" assertion intermittently fail when the
+  // start state was already below 15. Idempotent API call.
+  test.beforeAll(async ({ testData }) => {
+    const uid = String(testData.user.uniqueId);
+    await testData.api.post(`/api/user/${uid}/reset-gcs`, {}).catch(() => {});
+  });
+
   test.beforeEach(async ({ page, testData }) => {
     // Auto-accept all confirm() and prompt() dialogs
     page.on('dialog', async (dialog) => {


### PR DESCRIPTION
## Summary

PR #968's commit explicitly punted: "Same pattern (confirm-then-disable) exists in ~10 sibling handlers — left for a separate sweep PR". This closes that sweep, then extends the invariant codebase-wide.

- **18+ production handlers fixed** across `users.js`, `appeals.js`, `reports.js`, `main.js`, `starting-screens.js`, `fun-facts.js`, `banners.js`, `spin-monitor.js`, `gifts.js`, `backups.js`, `maintenance.js`, `economy-config.js`, `nuclear-reset.js`, `sync-prod.js` — every async click handler that opens `confirm()+apiCall()` OR sets `btn.disabled=true` before an `await` now carries `if (btn.disabled) return;` at entry + `finally { btn.disabled = false; }`. Multi-step wizards (nuclear-reset, sync-prod) gained a `*StepLock` flag to prevent step-1→2 double-tap from skipping the "last warning" screen.
- **Inline-onclick globals** (`resetPinLockout`, `revokeBiometricKey` — exposed via `wireSecurityGlobals` for HTML `onclick=`) gained module-level `_<name>InFlight` flags. `revokeWarning` (called via thin-arrow wrapper) gained the entry guard; success path destroys the button via list re-render, documented in the test.
- **Static gate** at `express-api/tests/scripts/admin-click-handler-reentrancy.test.js` — AST-resolves named-function refs (`addEventListener("click", handleX)`), pins the inline-onclick globals + revokeWarning + step-locks by name. 6 tests cover: invariant discovery, guard presence, `finally` symmetry, inline globals, `revokeWarning` ordering, step-lock structure.
- **Playwright regression tests** in `admin-maintenance.spec.ts`: synchronous double-dispatch on `#nuclear-proceed` and `#sync-proceed` confirms the step-lock blocks the second click.
- **Test isolation** (defensive [[feedback-test-isolation-no-leaks]]): `admin-users-moderation.spec.ts` `beforeAll` resets `gcsScore` so the worker-shared user starts at 100 regardless of upstream file state.

Reviewer loop: 6 rounds, every finding addressed (Critical/Important/Minor). Final round: zero findings.

## Test plan
- [x] All 6 new static tests green (Jest)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] 18/18 admin-maintenance.spec.ts pass (incl. new test 16/17 double-tap regressions)
- [x] 122/123 broader admin Playwright sweep pass (1 known PR #968 residual — admin-funfacts active-toggle Firestore emulator query lag, unrelated to this PR's edited handlers)
- [x] Pre-push: 1301/1301 chromium pass (4 flaky-pass-on-retry are the PR #968 admin-keyboard residuals, documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)