### PR TITLE
fix(web+test): close PR #968 D-shortcut residual flake + workflow pin tests

### DIFF
--- a/express-api/tests/scripts/manual-qa-matrix-workflow-pin.test.js
+++ b/express-api/tests/scripts/manual-qa-matrix-workflow-pin.test.js
@@ -179,7 +179,7 @@ describe('manual-qa-matrix.yml — structural pin', () => {
   test('Playwright browser cache keyed on resolved version', () => {
     // [[feedback-ci-cache-downloads-version-aware]] — cache must
     // invalidate when Playwright version bumps.
-    expect(yamlText).toMatch(/actions\/cache@v4/);
+    expect(yamlText).toMatch(/actions\/cache@v5/);
     expect(yamlText).toMatch(
       /playwright-\$\{\{ runner\.os \}\}-\$\{\{ steps\.pw\.outputs\.version \}\}/,
     );
@@ -191,7 +191,7 @@ describe('manual-qa-matrix.yml — structural pin', () => {
   });
 
   test('upload-artifact uses if: always() (uploads on failure too)', () => {
-    expect(yamlText).toMatch(/uses:\s*actions\/upload-artifact@v4/);
+    expect(yamlText).toMatch(/uses:\s*actions\/upload-artifact@v7/);
     expect(yamlText).toMatch(/if:\s*always\(\)/);
   });
 

--- a/express-api/tests/scripts/qa-runner-driver-checks-pin.test.js
+++ b/express-api/tests/scripts/qa-runner-driver-checks-pin.test.js
@@ -55,7 +55,7 @@ describe('.github/workflows/qa-runner-driver-checks.yml', () => {
     // [[feedback-ci-cache-downloads-version-aware]] — newer Playwright
     // must bust the cache automatically. The key must reference the
     // resolved version (steps.pw.outputs.version), not just runner.os.
-    expect(reusable).toMatch(/uses:\s*actions\/cache@v4/);
+    expect(reusable).toMatch(/uses:\s*actions\/cache@v5/);
     expect(reusable).toMatch(
       /key:\s*playwright-\$\{\{\s*runner\.os\s*\}\}-\$\{\{\s*steps\.pw\.outputs\.version\s*\}\}/,
     );

--- a/public/admin/js/tabs/reports.js
+++ b/public/admin/js/tabs/reports.js
@@ -114,6 +114,16 @@ export function init(deps) {
       void btn.offsetHeight; // Force layout flush for WebKit
       currentReportFilter = btn.dataset.reportFilter;
       sessionStorage.setItem('admin_report_filter', currentReportFilter);
+      // Reset selection — the new view's cards are unrelated to the old.
+      // Without this, the keyboard-shortcut handler reads a stale
+      // `selectedCardIndex` from the prior filter and a subsequent
+      // ArrowDown lands on the wrong card. Tests 18→19 (W then D) used
+      // to flake when test 18 left selectedCardIndex=0 and test 19's
+      // ArrowDown incremented to 1 instead of selecting 0. The
+      // periodic 15s poll path (line ~340) intentionally preserves
+      // selectedCardIndex so a user reviewing reports isn't yanked
+      // out of their selection mid-task.
+      selectedCardIndex = -1;
       loadReports();
     });
   }
@@ -125,6 +135,9 @@ export function init(deps) {
     reportSearchBtn.addEventListener('click', () => {
       reportSearchQuery = reportSearchInput.value.trim();
       sessionStorage.setItem('admin_report_search', reportSearchQuery);
+      // See filter-button click handler — search re-scopes the list,
+      // so the prior selection has no referent in the new view.
+      selectedCardIndex = -1;
       loadReports();
     });
   }
@@ -133,6 +146,7 @@ export function init(deps) {
       if (e.key === 'Enter') {
         reportSearchQuery = reportSearchInput.value.trim();
         sessionStorage.setItem('admin_report_search', reportSearchQuery);
+        selectedCardIndex = -1;
         loadReports();
       }
     });

--- a/public/admin/js/tabs/reports.js
+++ b/public/admin/js/tabs/reports.js
@@ -643,8 +643,12 @@ function wireUpReportCards() {
         const ok = await acquireLock(uid);
         if (ok) {
           showToast('Review taken over');
-          // Takeover refreshes the whole list — the API contract doesn't
-          // guarantee order parity, so any prior selection is unreliable.
+          // Same rationale as activate()/filter/search above: the
+          // refresh rebuilds reportCards[] and the API contract doesn't
+          // guarantee order parity, so any prior selectedCardIndex is
+          // stale. The periodic poll path (line ~340) deliberately
+          // does NOT reset here — that's a background render where
+          // yanking the user out of their selection would be jarring.
           selectedCardIndex = -1;
           loadReports();
         }

--- a/public/admin/js/tabs/reports.js
+++ b/public/admin/js/tabs/reports.js
@@ -278,6 +278,10 @@ export function init(deps) {
 
 /** Called every time the Reports tab is activated. */
 export function activate() {
+  // Tab re-entry is a "new view" event — any selection from a prior
+  // session is stale because reportCards[] is about to be rebuilt.
+  // Same rationale as the filter/search click handlers above.
+  selectedCardIndex = -1;
   loadReports();
   loadReportStats();
 }
@@ -639,6 +643,9 @@ function wireUpReportCards() {
         const ok = await acquireLock(uid);
         if (ok) {
           showToast('Review taken over');
+          // Takeover refreshes the whole list — the API contract doesn't
+          // guarantee order parity, so any prior selection is unreliable.
+          selectedCardIndex = -1;
           loadReports();
         }
       } catch (err) {

--- a/tests/web/admin-keyboard.spec.ts
+++ b/tests/web/admin-keyboard.spec.ts
@@ -126,6 +126,58 @@ test.describe('Admin Keyboard Shortcuts', () => {
     await expect(actionSelect).toHaveValue('dismiss');
   });
 
+  // ── Test 3b: Reports — D key after tab re-entry resets stale index ──
+  // Regression guard for the `activate()` reset added to
+  // public/admin/js/tabs/reports.js. Without that reset, an admin who
+  // selected card N in Reports, switched to Users, then switched back,
+  // would press ArrowDown and land on card N+1 (not 0) because
+  // `selectedCardIndex` survived the deactivate/activate round trip
+  // and the rebuilt `reportCards[]` was still indexed against the
+  // stale value. A future commit that removes the `activate()` reset
+  // would leave the basic D test (test 3) green because beforeEach's
+  // adminLogin triggers a full page load — only this round-trip path
+  // surfaces the bug.
+  test('D key after Users→Reports round-trip selects first card', async ({ page }) => {
+    await navigateToTab(page, 'Reports');
+    await waitForReportsLoaded(page);
+    await filterReports(page, 'pending');
+
+    const firstCard = page.locator('.report-card').first();
+    if (await firstCard.count() === 0) {
+      test.skip(true, 'No pending reports for keyboard shortcuts');
+      return;
+    }
+
+    // Establish a stale selectedCardIndex by selecting card 0 first
+    await selectFirstReportCard(page);
+
+    // Round-trip: leave Reports → return to Reports. deactivate() does
+    // not reset selectedCardIndex; activate() must.
+    await navigateToTab(page, 'Users');
+    await navigateToTab(page, 'Reports');
+    await waitForReportsLoaded(page);
+    await filterReports(page, 'pending');
+
+    // Re-locate the first card after the rebuild
+    const firstCardAfter = page.locator('.report-card').first();
+    if (await firstCardAfter.count() === 0) {
+      test.skip(true, 'No pending reports after round-trip');
+      return;
+    }
+
+    // ArrowDown should land on card 0 — proving selectedCardIndex was
+    // reset on tab re-entry, not preserved from the prior selection.
+    await page.evaluate(() => (document.activeElement as HTMLElement)?.blur?.());
+    await page.keyboard.press('ArrowDown');
+    await expect(firstCardAfter).toHaveClass(/selected/, { timeout: 5_000 });
+
+    // D on the freshly selected card 0 sets its action-select to dismiss
+    const uid = await firstCardAfter.getAttribute('data-uid');
+    const actionSelect = firstCardAfter.locator(`select[data-action-select="${uid}"]`);
+    await page.keyboard.press('d');
+    await expect(actionSelect).toHaveValue('dismiss');
+  });
+
   // ── Test 4: Reports — Enter key triggers resolve ──
   test('Enter key triggers resolve on selected report', async ({ page, testData }) => {
     await navigateToTab(page, 'Reports');

--- a/tests/web/admin-reports.spec.ts
+++ b/tests/web/admin-reports.spec.ts
@@ -591,20 +591,20 @@ test.describe('Admin Reports', () => {
       return;
     }
 
+    // Use the same selection helper as the W test (real Playwright
+    // keyboard.press) — synthetic `document.dispatchEvent(new
+    // KeyboardEvent(...))` calls don't dispatch through the same
+    // dispatch path as user input and miss the report tab handler in
+    // some build configurations. The selectFirstReportCard helper
+    // awaits `.selected` so the handler has actually run before we
+    // proceed.
+    await selectFirstReportCard(page);
+
     const uid = await firstCard.getAttribute('data-uid');
     const actionSelect = firstCard.locator(`select[data-action-select="${uid}"]`);
 
-    // Do the select-card + press-D atomically in one browser-side
-    // function so the 15s poll cannot fire between the ArrowDown
-    // (sets selectedCardIndex + .selected) and the D press (handler
-    // checks selectedCardIndex). Same pattern as
-    // admin-cross-tab.spec.ts atomic radio-set+resolve.
-    await page.evaluate(() => {
-      const e1 = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
-      document.dispatchEvent(e1);
-      const e2 = new KeyboardEvent('keydown', { key: 'd', bubbles: true });
-      document.dispatchEvent(e2);
-    });
+    // Press D — real keyboard event, matches the W test's mechanism.
+    await page.keyboard.press('d');
 
     // Verify "dismiss" is selected
     await expect(actionSelect).toHaveValue('dismiss');


### PR DESCRIPTION
## Summary

Two related fixes in one PR:

### 1. D-shortcut flake (admin-reports.spec.ts:584)
PR #968 documented this as "practical fix budget exhausted". Two compounding root causes, both closed:

**Production fix**: filter/search clicks now reset `selectedCardIndex = -1` before calling `loadReports()`. The 15s poll path intentionally preserves the index (so a user reviewing reports isn't yanked out of their selection mid-task), but a filter/search click is a deliberate "new view" action and should drop the carry-over. Pre-fix: pressing W in test 18 left `selectedCardIndex=0`; test 19's filterReports preserved it; ArrowDown incremented to 1 instead of selecting 0; the test's "first card" locator pointed at one card while the handler mutated a different card's action-select.

**Test fix**: replaced synthetic `document.dispatchEvent(new KeyboardEvent(...))` with the same `selectFirstReportCard` helper + `page.keyboard.press('d')` that the W test uses. The synthetic dispatch missed some browser dispatch path empirically.

5/5 isolated full-suite runs pass with 0 flaky after the fix.

### 2. Workflow pin tests (express-api/tests/scripts/*.js)
Self-inflicted regression — I merged PR #959 (cache 4→5) and PR #961 (upload-artifact 4→7) earlier this session without updating the corresponding pin tests. Main has been red on `npm test` since 22:30 BST.

## Test plan
- [x] 5/5 full admin-reports.spec.ts runs (chromium) pass — 0 flaky
- [x] 49/49 pin tests pass after version bumps
- [x] Pre-push (Sonar + Playwright chromium) clean — 1292 passed, 35 skipped, 4 known PR #968 keyboard residuals retry-pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)