### PR TITLE
fix(server): GDPR account-deletion cascade for suggestions footprint

### DIFF
--- a/express-api/src/cron/accountDeletion.js
+++ b/express-api/src/cron/accountDeletion.js
@@ -215,6 +215,152 @@ async function cleanupReportsAndAppeals(uniqueId) {
   }
 }
 
+/**
+ * Step 6b: Suggestions-content cleanup (GDPR right-to-erasure cascade).
+ *
+ * The original hardDeleteAccount sequence omitted the suggestions footprint
+ * entirely, leaving deleted users still identifiable across the corpus via
+ * submitterUid / voterId / authorUid. This step closes that gap:
+ *
+ *   1. Anonymise own suggestions (preserve community value, redact identity)
+ *   2. Delete own votes via collectionGroup + decrement parent voteCount
+ *   3. Anonymise own comments via collectionGroup (preserve thread structure)
+ *   4. Delete subscription preferences doc
+ *   5. Delete inbox notifications
+ *
+ * Each sub-step is independently try/wrapped so a single failure does not
+ * abort the wider cron. Defensive parent-id check on collectionGroup hits
+ * future-proofs against unrelated `votes` / `comments` subcollections.
+ *
+ * Uses an anonymous sentinel of `submitterUid: 0` (no real user has uniqueId
+ * 0 — the floor is ≥1, with Officia=1) plus an explicit `submitterDeleted`
+ * flag so read-side code can distinguish anonymisation from a legitimate
+ * never-existed user.
+ */
+async function cleanupSuggestionsContent(uniqueId) {
+  const numericUid = Number(uniqueId);
+  const ANON = { uid: 0, deletedAt: now() };
+
+  try {
+    const sugSnap = await db
+      .collection('suggestions')
+      .where('submitterUid', '==', numericUid)
+      .get();
+    if (sugSnap.docs && sugSnap.docs.length > 0) {
+      let batch = db.batch();
+      let count = 0;
+      for (const doc of sugSnap.docs) {
+        batch.update(doc.ref, {
+          submitterUid: ANON.uid,
+          submitterDeleted: true,
+          submitterDeletedAt: ANON.deletedAt,
+        });
+        count++;
+        if (count === 500) {
+          await batch.commit();
+          batch = db.batch();
+          count = 0;
+        }
+      }
+      if (count > 0) await batch.commit();
+    }
+  } catch (err) {
+    log.error('cron', 'Failed to anonymise own suggestions', {
+      uniqueId,
+      error: err.message,
+    });
+  }
+
+  try {
+    const votesSnap = await db.collectionGroup('votes').where('voterId', '==', numericUid).get();
+    let batch = db.batch();
+    let count = 0;
+    for (const voteDoc of votesSnap.docs || []) {
+      const suggestionRef = voteDoc.ref.parent?.parent;
+      if (!suggestionRef || suggestionRef.parent?.id !== 'suggestions') continue;
+      const vote = voteDoc.data().vote;
+      const delta = vote === 'up' ? -1 : vote === 'down' ? 1 : 0;
+      batch.delete(voteDoc.ref);
+      if (delta !== 0) {
+        batch.update(suggestionRef, { voteCount: FieldValue.increment(delta) });
+      }
+      count++;
+      if (count >= 250) {
+        await batch.commit();
+        batch = db.batch();
+        count = 0;
+      }
+    }
+    if (count > 0) await batch.commit();
+  } catch (err) {
+    log.error('cron', 'Failed to delete suggestion votes', {
+      uniqueId,
+      error: err.message,
+    });
+  }
+
+  try {
+    const commentsSnap = await db
+      .collectionGroup('comments')
+      .where('authorUid', '==', numericUid)
+      .get();
+    let batch = db.batch();
+    let count = 0;
+    for (const commentDoc of commentsSnap.docs || []) {
+      const suggestionRef = commentDoc.ref.parent?.parent;
+      if (!suggestionRef || suggestionRef.parent?.id !== 'suggestions') continue;
+      batch.update(commentDoc.ref, {
+        authorUid: ANON.uid,
+        authorDeleted: true,
+        authorDeletedAt: ANON.deletedAt,
+        text: '[Comment from deleted user]',
+      });
+      count++;
+      if (count === 500) {
+        await batch.commit();
+        batch = db.batch();
+        count = 0;
+      }
+    }
+    if (count > 0) await batch.commit();
+  } catch (err) {
+    log.error('cron', 'Failed to anonymise suggestion comments', {
+      uniqueId,
+      error: err.message,
+    });
+  }
+
+  try {
+    await db.doc(`subscriptions/${uniqueId}`).delete();
+  } catch (err) {
+    log.error('cron', 'Failed to delete subscription preferences', {
+      uniqueId,
+      error: err.message,
+    });
+  }
+
+  try {
+    const notifSnap = await db.collection('notifications').where('uid', '==', numericUid).get();
+    let batch = db.batch();
+    let count = 0;
+    for (const notifDoc of notifSnap.docs || []) {
+      batch.delete(notifDoc.ref);
+      count++;
+      if (count === 500) {
+        await batch.commit();
+        batch = db.batch();
+        count = 0;
+      }
+    }
+    if (count > 0) await batch.commit();
+  } catch (err) {
+    log.error('cron', 'Failed to delete notification inbox', {
+      uniqueId,
+      error: err.message,
+    });
+  }
+}
+
 /** Step 7: Auth-related cleanup */
 async function cleanupAuthData(user, uniqueId) {
   try {
@@ -329,6 +475,7 @@ async function hardDeleteAccount(userDoc) {
   await cleanupFollowerFollowing(uniqueId);
   await cleanupGiftRankings(uniqueId);
   await cleanupReportsAndAppeals(uniqueId);
+  await cleanupSuggestionsContent(uniqueId);
   await cleanupAuthData(user, uniqueId);
   await deleteUserDocAndSubcollections(uniqueId);
   await softDeleteIdentityMap(user, uniqueId);
@@ -354,6 +501,11 @@ async function hardDeleteAccount(userDoc) {
       'r2',
       'reports',
       'appeals',
+      'suggestions',
+      'votes',
+      'comments',
+      'subscriptions',
+      'notifications',
       'auth',
       'identity',
       'deviceBindings',

--- a/express-api/src/cron/accountDeletion.js
+++ b/express-api/src/cron/accountDeletion.js
@@ -340,10 +340,21 @@ async function cleanupSuggestionsContent(uniqueId) {
   }
 
   try {
-    const notifSnap = await db.collection('notifications').where('uid', '==', numericUid).get();
+    // Notifications today set both `uid` and `recipientUid` to the same value
+    // on every write path. Querying both fields and deduplicating by ref makes
+    // erasure forward-safe: if a future path writes only `recipientUid`, that
+    // record still gets deleted instead of silently surviving the cascade.
+    const [byUid, byRecipient] = await Promise.all([
+      db.collection('notifications').where('uid', '==', numericUid).get(),
+      db.collection('notifications').where('recipientUid', '==', numericUid).get(),
+    ]);
+    const seen = new Set();
     let batch = db.batch();
     let count = 0;
-    for (const notifDoc of notifSnap.docs || []) {
+    for (const notifDoc of [...(byUid.docs || []), ...(byRecipient.docs || [])]) {
+      const path = notifDoc.ref.path;
+      if (seen.has(path)) continue;
+      seen.add(path);
       batch.delete(notifDoc.ref);
       count++;
       if (count === 500) {

--- a/express-api/src/routes/suggestions.js
+++ b/express-api/src/routes/suggestions.js
@@ -275,8 +275,11 @@ router.get('/suggestions/:id', async (req, res) => {
       commentCount: commentsSnap.size,
     };
 
-    // Admin view: include submitter's other suggestions
-    if (isAdmin && data.submitterUid) {
+    // Admin view: include submitter's other suggestions. Skip for anonymised
+    // (GDPR-deleted) submitters — the `submitterDeleted` flag is canonical;
+    // do not rely on the `submitterUid: 0` sentinel being falsy because a
+    // future sentinel change would silently break this guard.
+    if (isAdmin && !data.submitterDeleted && data.submitterUid) {
       try {
         const otherSnap = await db
           .collection('suggestions')
@@ -878,7 +881,12 @@ async function notifySubscribers(suggestionData, eventType, extraData = {}) {
     const subscribers = suggestionData.subscribers || [];
     const submitterUid = suggestionData.submitterUid;
     const uidsToNotify = new Set(subscribers);
-    if (submitterUid) uidsToNotify.add(submitterUid);
+    // Skip notifying a GDPR-deleted submitter. The `submitterDeleted` flag is
+    // canonical here, not the sentinel value of `submitterUid` — `0` happens
+    // to be falsy today but the contract should not depend on that.
+    if (submitterUid && !suggestionData.submitterDeleted) {
+      uidsToNotify.add(submitterUid);
+    }
 
     let notified = 0;
     const failedUids = [];

--- a/express-api/tests/cron/accountDeletion.test.js
+++ b/express-api/tests/cron/accountDeletion.test.js
@@ -16,6 +16,7 @@
  *   Step 5: Follower/following array cleanup
  *   Step 5b: Gift rankings cleanup
  *   Step 6: Reports & appeals deletion
+ *   Step 6b: Suggestions-content cleanup (GDPR right-to-erasure cascade)
  *   Step 7: Auth-related cleanup (biometricKeys, otpCodes, emailMetrics)
  *   Step 8: User doc + subcollections deletion
  *   Step 9: Identity map soft-delete
@@ -52,6 +53,9 @@ const mockDoc = jest.fn((path) => ({
 const mockWhere = jest.fn();
 const mockLimit = jest.fn();
 const mockCollection = jest.fn();
+const mockCollectionGroup = jest.fn();
+
+let mockLastQueried = { type: null, name: null };
 
 jest.mock('../../src/utils/firebase', () => {
   const chain = {
@@ -63,14 +67,24 @@ jest.mock('../../src/utils/firebase', () => {
       mockLimit(...args);
       return chain;
     },
-    get: () => mockCollectionGet(),
+    // Pass the most-recent collection/collectionGroup target into get(). Existing
+    // Once-chain tests ignore the arg and still work; new tests can use
+    // mockImplementation(({type, name}) => …) to dispatch by target instead of
+    // counting prior get() calls.
+    get: () => mockCollectionGet({ ...mockLastQueried }),
   };
 
   return {
     db: {
       doc: (...args) => mockDoc(...args),
-      collection: (...args) => {
-        mockCollection(...args);
+      collection: (name, ...rest) => {
+        mockLastQueried = { type: 'col', name };
+        mockCollection(name, ...rest);
+        return chain;
+      },
+      collectionGroup: (name, ...rest) => {
+        mockLastQueried = { type: 'cg', name };
+        mockCollectionGroup(name, ...rest);
         return chain;
       },
       batch: jest.fn(() => ({
@@ -91,6 +105,7 @@ jest.mock('../../src/utils/firebase', () => {
     },
     FieldValue: {
       arrayRemove: jest.fn((...args) => `arrayRemove(${args})`),
+      increment: jest.fn((n) => `increment(${n})`),
     },
   };
 });
@@ -418,6 +433,226 @@ describe('hardDeleteAccount', () => {
     expect(mockCollection).toHaveBeenCalledWith('suspensionAppeals');
   });
 
+  // ── Step 6b: suggestions-content cleanup (GDPR cascade) ────────
+  //
+  // hardDeleteAccount must also wipe the user's suggestions footprint:
+  //   - Anonymise own suggestions (preserve community value, redact identity)
+  //   - Delete own votes + decrement parent voteCount per up/down
+  //   - Anonymise own comments (preserve thread structure)
+  //   - Delete subscription preferences doc
+  //   - Delete inbox notifications
+  //
+  // Without this, a deleted user's submitterUid/voterId/authorUid still
+  // identifies them across suggestions — a GDPR right-to-erasure gap.
+  // The tests below assert the contract; the implementation lives in
+  // src/cron/accountDeletion.js#cleanupSuggestionsContent.
+
+  function makeSuggestionDoc(id, data = {}) {
+    return {
+      id,
+      ref: { path: `suggestions/${id}`, _isSuggestion: true },
+      data: () => ({ submitterUid: 10000001, ...data }),
+    };
+  }
+
+  function makeVoteDoc(suggestionId, voterId, vote = 'up') {
+    const suggestionRef = {
+      path: `suggestions/${suggestionId}`,
+      parent: { id: 'suggestions' },
+    };
+    return {
+      ref: {
+        path: `suggestions/${suggestionId}/votes/${voterId}`,
+        parent: { parent: suggestionRef },
+      },
+      data: () => ({ voterId, vote, votedAt: 1717000000000 }),
+    };
+  }
+
+  function makeCommentDoc(suggestionId, commentId, authorUid) {
+    const suggestionRef = {
+      path: `suggestions/${suggestionId}`,
+      parent: { id: 'suggestions' },
+    };
+    return {
+      ref: {
+        path: `suggestions/${suggestionId}/comments/${commentId}`,
+        parent: { parent: suggestionRef },
+      },
+      data: () => ({ authorUid, text: 'original text' }),
+    };
+  }
+
+  // Dispatch helper: returns mockImplementation that switches by query target.
+  // Avoids brittle call-order counting given Steps 3–6 already make ~12 queries
+  // before our Step 6b runs. Unmatched targets fall through to empty.
+  function dispatchByTarget(map) {
+    return ({ type, name }) => {
+      const key = type === 'cg' ? `cg:${name}` : `col:${name}`;
+      if (Object.prototype.hasOwnProperty.call(map, key)) return Promise.resolve(map[key]);
+      return Promise.resolve({ docs: [], empty: true });
+    };
+  }
+
+  test('Step 6b: anonymises own suggestions by submitterUid', async () => {
+    mockDocGet.mockResolvedValue({ exists: false, data: () => null });
+    mockCollectionGet.mockImplementation(
+      dispatchByTarget({
+        'col:suggestions': {
+          docs: [makeSuggestionDoc('sug-1'), makeSuggestionDoc('sug-2')],
+          empty: false,
+        },
+      }),
+    );
+
+    await hardDeleteAccount(testUser);
+
+    expect(mockCollection).toHaveBeenCalledWith('suggestions');
+    expect(mockWhere).toHaveBeenCalledWith('submitterUid', '==', 10000001);
+    expect(mockBatchUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ _isSuggestion: true }),
+      expect.objectContaining({
+        submitterUid: 0,
+        submitterDeleted: true,
+      }),
+    );
+  });
+
+  test('Step 6b: deletes votes via collectionGroup and decrements parent voteCount', async () => {
+    mockDocGet.mockResolvedValue({ exists: false, data: () => null });
+
+    const upVote = makeVoteDoc('sug-A', 10000001, 'up');
+    const downVote = makeVoteDoc('sug-B', 10000001, 'down');
+
+    mockCollectionGet.mockImplementation(
+      dispatchByTarget({
+        'cg:votes': { docs: [upVote, downVote], empty: false },
+      }),
+    );
+
+    await hardDeleteAccount(testUser);
+
+    expect(mockCollectionGroup).toHaveBeenCalledWith('votes');
+    expect(mockWhere).toHaveBeenCalledWith('voterId', '==', 10000001);
+    expect(mockBatchDelete).toHaveBeenCalledWith(upVote.ref);
+    expect(mockBatchDelete).toHaveBeenCalledWith(downVote.ref);
+    expect(mockBatchUpdate).toHaveBeenCalledWith(upVote.ref.parent.parent, {
+      voteCount: 'increment(-1)',
+    });
+    expect(mockBatchUpdate).toHaveBeenCalledWith(downVote.ref.parent.parent, {
+      voteCount: 'increment(1)',
+    });
+  });
+
+  test('Step 6b: anonymises comments via collectionGroup by authorUid', async () => {
+    mockDocGet.mockResolvedValue({ exists: false, data: () => null });
+
+    const comment = makeCommentDoc('sug-C', 'comment-1', 10000001);
+
+    mockCollectionGet.mockImplementation(
+      dispatchByTarget({
+        'cg:comments': { docs: [comment], empty: false },
+      }),
+    );
+
+    await hardDeleteAccount(testUser);
+
+    expect(mockCollectionGroup).toHaveBeenCalledWith('comments');
+    expect(mockWhere).toHaveBeenCalledWith('authorUid', '==', 10000001);
+    expect(mockBatchUpdate).toHaveBeenCalledWith(
+      comment.ref,
+      expect.objectContaining({
+        authorUid: 0,
+        authorDeleted: true,
+        text: '[Comment from deleted user]',
+      }),
+    );
+  });
+
+  test('Step 6b: deletes subscription preferences doc', async () => {
+    mockDocGet.mockResolvedValue({ exists: false, data: () => null });
+    mockCollectionGet.mockResolvedValue({ docs: [], empty: true });
+
+    await hardDeleteAccount(testUser);
+
+    expect(mockDocDelete).toHaveBeenCalledWith('subscriptions/10000001');
+  });
+
+  test('Step 6b: deletes notifications inbox by uid', async () => {
+    mockDocGet.mockResolvedValue({ exists: false, data: () => null });
+
+    const notif1 = { id: 'notif-1', ref: { path: 'notifications/notif-1' } };
+    const notif2 = { id: 'notif-2', ref: { path: 'notifications/notif-2' } };
+
+    mockCollectionGet.mockImplementation(
+      dispatchByTarget({
+        'col:notifications': { docs: [notif1, notif2], empty: false },
+      }),
+    );
+
+    await hardDeleteAccount(testUser);
+
+    expect(mockCollection).toHaveBeenCalledWith('notifications');
+    expect(mockWhere).toHaveBeenCalledWith('uid', '==', 10000001);
+    expect(mockBatchDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ path: 'notifications/notif-1' }),
+    );
+    expect(mockBatchDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ path: 'notifications/notif-2' }),
+    );
+  });
+
+  test('Step 6b: skips collectionGroup hits whose parent is not "suggestions"', async () => {
+    // Defensive: future feature could introduce another `votes` subcollection
+    // (e.g. polls/{id}/votes/...). The cron must ignore those.
+    mockDocGet.mockResolvedValue({ exists: false, data: () => null });
+
+    const goodVote = makeVoteDoc('sug-X', 10000001, 'up');
+    const strayVote = {
+      ref: {
+        path: 'polls/p1/votes/10000001',
+        parent: { parent: { parent: { id: 'polls' } } },
+      },
+      data: () => ({ voterId: 10000001, vote: 'up' }),
+    };
+
+    mockCollectionGet.mockImplementation(
+      dispatchByTarget({
+        'cg:votes': { docs: [goodVote, strayVote], empty: false },
+      }),
+    );
+
+    await hardDeleteAccount(testUser);
+
+    expect(mockBatchDelete).toHaveBeenCalledWith(goodVote.ref);
+    expect(mockBatchDelete).not.toHaveBeenCalledWith(strayVote.ref);
+  });
+
+  test('Step 6b: error in one substep does not abort hardDeleteAccount', async () => {
+    mockDocGet.mockResolvedValue({ exists: false, data: () => null });
+
+    // The suggestions query throws — cron must log + continue past Step 6b.
+    mockCollectionGet.mockImplementation(({ type, name }) => {
+      if (type === 'col' && name === 'suggestions') {
+        return Promise.reject(new Error('suggestions query failed'));
+      }
+      return Promise.resolve({ docs: [], empty: true });
+    });
+
+    await hardDeleteAccount(testUser);
+
+    // Subsequent steps still happen — Firebase Auth deletion is Step 11.
+    expect(auth.deleteUser).toHaveBeenCalled();
+    expect(log.error).toHaveBeenCalledWith(
+      'cron',
+      expect.stringContaining('suggestion'),
+      // uniqueId is logged as a string because hardDeleteAccount derives it
+      // from userDoc.id (always a string), even though Firestore queries
+      // convert to Number for type-safety against the schema.
+      expect.objectContaining({ uniqueId: '10000001' }),
+    );
+  });
+
   test('Step 7: deletes auth-related data', async () => {
     mockDocGet.mockResolvedValue({ exists: false, data: () => null });
 
@@ -511,7 +746,17 @@ describe('hardDeleteAccount', () => {
         reason: 'self',
         triggeredBy: 'system',
         standing: 'clean',
-        dataDeleted: expect.arrayContaining(['user', 'conversations', 'rooms', 'r2']),
+        dataDeleted: expect.arrayContaining([
+          'user',
+          'conversations',
+          'rooms',
+          'r2',
+          'suggestions',
+          'votes',
+          'comments',
+          'subscriptions',
+          'notifications',
+        ]),
       }),
     );
 

--- a/express-api/tests/cron/accountDeletion.test.js
+++ b/express-api/tests/cron/accountDeletion.test.js
@@ -653,6 +653,94 @@ describe('hardDeleteAccount', () => {
     );
   });
 
+  test('Step 6b: vote with null vote field deletes without voteCount update', async () => {
+    // Defensive against malformed vote docs (no `vote: up|down`). Production
+    // code computes `delta = 0` for unknown vote shapes; the vote MUST still
+    // be deleted (PII erasure) but the parent voteCount MUST NOT be touched
+    // (no way to know which direction to adjust).
+    mockDocGet.mockResolvedValue({ exists: false, data: () => null });
+
+    const malformedVote = makeVoteDoc('sug-Z', 10000001, null);
+    mockCollectionGet.mockImplementation(
+      dispatchByTarget({
+        'cg:votes': { docs: [malformedVote], empty: false },
+      }),
+    );
+
+    await hardDeleteAccount(testUser);
+
+    expect(mockBatchDelete).toHaveBeenCalledWith(malformedVote.ref);
+    expect(mockBatchUpdate).not.toHaveBeenCalledWith(
+      malformedVote.ref.parent.parent,
+      expect.objectContaining({ voteCount: expect.anything() }),
+    );
+  });
+
+  test('Step 6b: subscription-doc deletion failure logs but does not abort', async () => {
+    mockDocGet.mockResolvedValue({ exists: false, data: () => null });
+    mockCollectionGet.mockResolvedValue({ docs: [], empty: true });
+    mockDocDelete.mockImplementation((path) => {
+      if (path === 'subscriptions/10000001') {
+        return Promise.reject(new Error('subscriptions delete failed'));
+      }
+      return Promise.resolve();
+    });
+
+    await hardDeleteAccount(testUser);
+
+    expect(auth.deleteUser).toHaveBeenCalled();
+    expect(log.error).toHaveBeenCalledWith(
+      'cron',
+      expect.stringContaining('subscription'),
+      expect.objectContaining({ uniqueId: '10000001' }),
+    );
+  });
+
+  test('Step 6b: notifications query failure logs but does not abort', async () => {
+    mockDocGet.mockResolvedValue({ exists: false, data: () => null });
+    mockCollectionGet.mockImplementation(({ type, name }) => {
+      if (type === 'col' && name === 'notifications') {
+        return Promise.reject(new Error('notifications query failed'));
+      }
+      return Promise.resolve({ docs: [], empty: true });
+    });
+
+    await hardDeleteAccount(testUser);
+
+    expect(auth.deleteUser).toHaveBeenCalled();
+    expect(log.error).toHaveBeenCalledWith(
+      'cron',
+      expect.stringContaining('notification'),
+      expect.objectContaining({ uniqueId: '10000001' }),
+    );
+  });
+
+  test('Step 6b: notifications cleanup queries BOTH uid and recipientUid, dedupes by ref', async () => {
+    // The cron runs two queries in parallel and dedupes results by ref.path —
+    // a notification matching BOTH fields (today's invariant) must be deleted
+    // exactly once, not twice.
+    mockDocGet.mockResolvedValue({ exists: false, data: () => null });
+
+    const dualMatch = { id: 'n-1', ref: { path: 'notifications/n-1' } };
+    mockCollectionGet.mockImplementation(({ type, name }) => {
+      if (type === 'col' && name === 'notifications') {
+        // Both queries return the same doc (since today both fields equal uid)
+        return Promise.resolve({ docs: [dualMatch], empty: false });
+      }
+      return Promise.resolve({ docs: [], empty: true });
+    });
+
+    await hardDeleteAccount(testUser);
+
+    expect(mockWhere).toHaveBeenCalledWith('uid', '==', 10000001);
+    expect(mockWhere).toHaveBeenCalledWith('recipientUid', '==', 10000001);
+    // Despite appearing in BOTH result sets, deleted exactly once.
+    const deleteCallsForN1 = mockBatchDelete.mock.calls.filter(
+      ([ref]) => ref?.path === 'notifications/n-1',
+    );
+    expect(deleteCallsForN1).toHaveLength(1);
+  });
+
   test('Step 7: deletes auth-related data', async () => {
     mockDocGet.mockResolvedValue({ exists: false, data: () => null });
 
@@ -746,17 +834,25 @@ describe('hardDeleteAccount', () => {
         reason: 'self',
         triggeredBy: 'system',
         standing: 'clean',
-        dataDeleted: expect.arrayContaining([
+        // Exact-match assertion — the audit-log contract is a public surface
+        // (admin feed), so adding/removing entries is a deliberate decision
+        // that should force this test to update, not silently pass.
+        dataDeleted: [
           'user',
           'conversations',
           'rooms',
           'r2',
+          'reports',
+          'appeals',
           'suggestions',
           'votes',
           'comments',
           'subscriptions',
           'notifications',
-        ]),
+          'auth',
+          'identity',
+          'deviceBindings',
+        ],
       }),
     );
 

--- a/express-api/tests/routes/suggestions-integration-a-flows.test.js
+++ b/express-api/tests/routes/suggestions-integration-a-flows.test.js
@@ -624,19 +624,10 @@ describe('11.72 — GDPR Data Export & Account Deletion', () => {
   // path is integration-tested.
   test.skip('TODO: data export includes user votes', async () => {});
   test.skip('TODO: data export includes user comments', async () => {});
-  // ── Account-deletion cascade — TODO group ───────────────────────
-  // These tests currently set up mocks but assert nothing meaningful
-  // (`expect(true).toBe(true)` or `expect(mockX).toBeDefined()`).
-  // Marked test.skip to surface honestly that the cascade behaviour
-  // is NOT covered, rather than passing falsely. Implement properly
-  // when the suggestions cascade logic is hardened, OR migrate to
-  // the integration framework (cron #8 pattern in PR #514) which
-  // exercises real Firestore + the cron.
-  test.skip('TODO: account deletion cascade: user suggestions anonymized or deleted', async () => {});
-  test.skip('TODO: account deletion cascade: user votes removed and counts decremented', async () => {});
-  test.skip('TODO: account deletion cascade: user comments anonymized', async () => {});
-  test.skip('TODO: account deletion cascade: subscription preferences removed', async () => {});
-  test.skip('TODO: account deletion cascade: notification inbox cleared', async () => {});
+  // Account-deletion cascade is now covered by the cron-level integration
+  // pattern in tests/cron/accountDeletion.test.js (Step 6b group). That is
+  // the right home for it — these route-level mocks cannot exercise the
+  // cron's collectionGroup queries or batch-update fan-out faithfully.
   test('GDPR export: suspended user can still request data export', async () => {
     const res = await request(createApp({ uniqueId: 1001, isSuspended: true })).get(
       '/api/suggestions/mine',

--- a/express-api/tests/routes/suggestions-integration-b.test.js
+++ b/express-api/tests/routes/suggestions-integration-b.test.js
@@ -868,7 +868,7 @@ describe('11.115b — GDPR-Deleted Submitter Guards', () => {
     expect(pmTargetedSubmitter).toBe(true);
   });
 
-  test('GET /suggestions/:id (admin) skips submitterOtherSuggestions when submitterDeleted', async () => {
+  test('GET /suggestions/:id (admin) skips submitterOtherSuggestions when submitterDeleted (uid=0)', async () => {
     setupDocMocks({
       'suggestions/sug-3': makeSuggestionDoc('sug-3', {
         status: 'accepted',
@@ -881,13 +881,31 @@ describe('11.115b — GDPR-Deleted Submitter Guards', () => {
       '/api/suggestions/sug-3',
     );
 
-    // Either the field is absent, or it is an empty array — what we MUST
-    // NOT see is a populated list of suggestions for a deleted user.
-    if (res.body.submitterOtherSuggestions !== undefined) {
-      expect(res.body.submitterOtherSuggestions).toEqual([]);
-    } else {
-      expect(res.body).not.toHaveProperty('submitterOtherSuggestions');
-    }
+    // Field MUST be either absent or an empty array — what we MUST NOT see
+    // is a populated list for a deleted user. `field || []` normalises both
+    // null and undefined to the same empty-array contract.
+    expect(res.body.submitterOtherSuggestions || []).toEqual([]);
+  });
+
+  test('GET /suggestions/:id (admin) skips submitterOtherSuggestions when submitterDeleted with NON-ZERO uid', async () => {
+    // Pins the load-bearing condition: the `!data.submitterDeleted` check is
+    // the canonical gate, not the `submitterUid: 0` sentinel happening to be
+    // falsy. If a future refactor reorders the conditions or someone
+    // anonymises by setting `submitterDeleted: true` without zeroing the uid,
+    // this test catches the regression. (Round-2 reviewer N2.)
+    setupDocMocks({
+      'suggestions/sug-4': makeSuggestionDoc('sug-4', {
+        status: 'accepted',
+        submitterUid: 1001, // intentionally non-zero
+        submitterDeleted: true, // but flag says deleted
+      }),
+    });
+
+    const res = await request(createApp({ uniqueId: 9999, isAdmin: true })).get(
+      '/api/suggestions/sug-4',
+    );
+
+    expect(res.body.submitterOtherSuggestions || []).toEqual([]);
   });
 });
 

--- a/express-api/tests/routes/suggestions-integration-b.test.js
+++ b/express-api/tests/routes/suggestions-integration-b.test.js
@@ -811,6 +811,87 @@ describe('11.115 — Error Recovery Flows', () => {
 });
 
 // =============================================================================
+// 11.115b — GDPR-Deleted Submitter Guards
+// =============================================================================
+//
+// Verifies the explicit `submitterDeleted` guards on:
+//   - notifySubscribers (suggestions.js:879-887) — must NOT FCM/SystemPm the
+//     anonymised submitter when admin changes status on their suggestion
+//   - GET /suggestions/:id admin sidebar (suggestions.js:279) — must NOT
+//     query "other suggestions" by submitterUid=0 when submitterDeleted=true
+//
+// Both guards previously relied on `submitterUid: 0` being JavaScript-falsy.
+// That is correct behaviour today but breaks silently if the sentinel value
+// ever changes — these tests force the contract to be load-bearing.
+
+describe('11.115b — GDPR-Deleted Submitter Guards', () => {
+  test('admin status-change on anonymised suggestion does NOT notify uid=0', async () => {
+    setupDocMocks({
+      'suggestions/sug-1': makeSuggestionDoc('sug-1', {
+        status: 'pending',
+        submitterUid: 0,
+        submitterDeleted: true,
+        subscribers: [], // no other subscribers either
+      }),
+    });
+
+    await request(createApp({ uniqueId: 9999, isAdmin: true }))
+      .put('/api/admin/suggestions/sug-1/status')
+      .send({ status: 'accepted' });
+
+    // No FCM / system-PM should target the anonymised submitter
+    const fcmTargetedUid0 = sendFcmToTokens.mock.calls.some(
+      ([tokens]) => Array.isArray(tokens) && tokens.includes(0),
+    );
+    expect(fcmTargetedUid0).toBe(false);
+    const pmTargetedUid0 = sendSystemPm.mock.calls.some(([uid]) => uid === 0);
+    expect(pmTargetedUid0).toBe(false);
+  });
+
+  test('admin status-change on live submitter DOES notify them (regression guard)', async () => {
+    // Counterpart to the above — confirms the guard fires only for deleted
+    // submitters, not as a blanket suppression.
+    setupDocMocks({
+      'suggestions/sug-2': makeSuggestionDoc('sug-2', {
+        status: 'pending',
+        submitterUid: 1001,
+        subscribers: [],
+      }),
+      'users/1001': makeUserDoc(1001),
+    });
+
+    await request(createApp({ uniqueId: 9999, isAdmin: true }))
+      .put('/api/admin/suggestions/sug-2/status')
+      .send({ status: 'accepted' });
+
+    const pmTargetedSubmitter = sendSystemPm.mock.calls.some(([uid]) => uid === 1001);
+    expect(pmTargetedSubmitter).toBe(true);
+  });
+
+  test('GET /suggestions/:id (admin) skips submitterOtherSuggestions when submitterDeleted', async () => {
+    setupDocMocks({
+      'suggestions/sug-3': makeSuggestionDoc('sug-3', {
+        status: 'accepted',
+        submitterUid: 0,
+        submitterDeleted: true,
+      }),
+    });
+
+    const res = await request(createApp({ uniqueId: 9999, isAdmin: true })).get(
+      '/api/suggestions/sug-3',
+    );
+
+    // Either the field is absent, or it is an empty array — what we MUST
+    // NOT see is a populated list of suggestions for a deleted user.
+    if (res.body.submitterOtherSuggestions !== undefined) {
+      expect(res.body.submitterOtherSuggestions).toEqual([]);
+    } else {
+      expect(res.body).not.toHaveProperty('submitterOtherSuggestions');
+    }
+  });
+});
+
+// =============================================================================
 // 11.116 — Cross-Feature Interactions
 // =============================================================================
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -233,5 +233,22 @@
       ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "votes",
+      "fieldPath": "voterId",
+      "indexes": [
+        { "queryScope": "COLLECTION", "order": "ASCENDING" },
+        { "queryScope": "COLLECTION_GROUP", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "comments",
+      "fieldPath": "authorUid",
+      "indexes": [
+        { "queryScope": "COLLECTION", "order": "ASCENDING" },
+        { "queryScope": "COLLECTION_GROUP", "order": "ASCENDING" }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Closes the suggestions-footprint gap in `hardDeleteAccount` — deleted users were still identifiable via `submitterUid` / `voterId` / `authorUid` (real right-to-erasure gap, not just test coverage).
- Adds **Step 6b: `cleanupSuggestionsContent(uniqueId)`** between reports/appeals and auth cleanup: anonymise own suggestions, delete own votes + decrement parent voteCount, anonymise own comments, delete subscription preferences doc, delete inbox notifications.
- Extends audit log `dataDeleted` with `suggestions`, `votes`, `comments`, `subscriptions`, `notifications`.

## Design notes

- **Anonymisation sentinel**: `submitterUid: 0` + `submitterDeleted: true` flag. Safe because the real-user floor is ≥1 (Officia uses uniqueId=1 per j04 journey test). Flag is the canonical signal for UI; the sentinel happens to also make admin "other suggestions" lookup skip naturally (`if (data.submitterUid)` is falsy).
- **Vote semantics**: each vote deletion reverses its contribution to `voteCount` (`-1` for up, `+1` for down) via `FieldValue.increment`. Atomic per-batch.
- **Defensive parent-id check** on `collectionGroup('votes')` / `collectionGroup('comments')` so unrelated future subcollections (e.g. `polls/{id}/votes/...`) are skipped.
- **Per-substep try/catch**: a single failure logs + continues; Steps 7–12 still run.

## Test infra change

The cron's firebase mock gains `collectionGroup` + `FieldValue.increment`. The `chain.get()` now passes the most-recent `{type, name}` into `mockCollectionGet` — new Step 6b tests use `mockImplementation` to dispatch by target name instead of fragile call-order counting. Existing `.mockResolvedValueOnce` chains still work (they ignore the arg).

Removed 5 obsolete `test.skip` stubs in `suggestions-integration-a-flows.test.js` that the prior author honestly flagged as "passing falsely with no real assertions" — the cron-level tests are the proper home.

## Indexes

`firestore.indexes.json` gains COLLECTION_GROUP `fieldOverrides` for `votes.voterId` and `comments.authorUid`. Side effect: also unblocks the pre-existing `data-export-builder` votes-export query that silently assumed the override existed.

## Test plan

- [x] 11,123 express tests passing (3 skipped — exactly the 5 cascade stubs removed minus 2 retained data-export TODOs)
- [x] ESLint `--max-warnings=0` clean
- [x] Prettier clean
- [x] Pre-push SonarCloud quality gate passed
- [ ] Code-reviewer agent: zero findings
- [ ] CI: green
- [ ] Manual emulator verification (deferred to dev-deploy verification post-merge)

## Follow-ups not in scope

- `[Comment from deleted user]` placeholder is English; client UI should drive localisation via the `authorDeleted` flag (separate UI PR).
- Data-export comments inclusion (the 2 retained `test.skip` stubs) — separate data-export PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)