### PR TITLE
feat(express-api): close GDPR data-export gap for user suggestion comments

### DIFF
--- a/express-api/src/utils/data-export-builder.js
+++ b/express-api/src/utils/data-export-builder.js
@@ -44,7 +44,88 @@ const STRIP_FIELDS = [
   '_testRun',
 ];
 
+/**
+ * Walk a collection-group snapshot and keep only docs whose grandparent is
+ * the top-level `suggestions` collection. Pulled out of the votes + comments
+ * loops because (a) the defensive grandparent-id guard is the load-bearing
+ * privacy invariant — any rogue subcollection with the same leaf name (e.g.
+ * a future `posts/{id}/comments`) must NOT leak into a user's export — and
+ * (b) inline, the guard's behavior could only be tested by decoding the
+ * compressed ZIP buffer (no unzip lib is on the project's dep tree). As an
+ * exported helper it can be unit-tested directly with mixed-legit-and-rogue
+ * inputs, which is the only shape that actually pins `continue` as
+ * filter-not-pass-all. The `mapper` lets each caller shape its own payload
+ * (votes spread voteDoc.data(); comments also expose `id` because comment
+ * doc IDs are auto-generated and meaningful to users, unlike vote doc IDs
+ * which are just the voterId).
+ *
+ * @param {Array<{ref: {parent: {parent: {id: string, parent: {id: string}}}}, data: () => object, id?: string}>} docs
+ * @param {(suggestionId: string, doc: object) => object} mapper
+ * @returns {Array<object>}
+ */
+function collectSuggestionScopedEntries(docs, mapper) {
+  const result = [];
+  for (const doc of docs) {
+    const suggestionRef = doc.ref.parent.parent;
+    // Three failure modes to short-circuit BEFORE the `.parent.id` deref:
+    //   (1) `suggestionRef === null` — top-level collection-group hit
+    //       (a root-level `comments`/`votes` collection, if Firestore
+    //       ever permits one).
+    //   (2) `suggestionRef.parent === null` — pathologically deep nesting
+    //       where the grandparent doc exists but its containing collection
+    //       has no parent. Cannot happen in current Firestore semantics
+    //       (every doc has a parent collection) but a malformed test
+    //       fixture or an Admin-SDK version drift could surface it; the
+    //       guard prevents a TypeError in either case.
+    //   (3) The grandparent collection's name isn't `suggestions` — this
+    //       is the actual privacy guard: any sibling subcollection with
+    //       the same leaf name (e.g. `posts/{id}/comments`) must NOT leak.
+    if (!suggestionRef || !suggestionRef.parent || suggestionRef.parent.id !== 'suggestions') {
+      continue;
+    }
+    result.push(mapper(suggestionRef.id, doc));
+  }
+  return result;
+}
+
+// Per-section mappers, extracted as module-level constants so the test
+// suite can pin each one's payload shape directly (the previous inline
+// arrow functions made `id: commentDoc.id` propagation only testable
+// through the compressed ZIP buffer, which has no unzip lib on the dep
+// tree).
+//
+// Votes: doc ID is the voter's uniqueId (path `votes/{voterId}`), so
+//   it's redundant with the `voterId` field in the payload — no `id:`.
+// Comments: doc ID is `generateId()`-derived (path `comments/{auto}`),
+//   so it's the ONLY stable identifier the user can use to correlate
+//   an exported comment with one cited in a moderation appeal — `id:`
+//   is required.
+//
+// Spread order: payload spread FIRST, explicit fields LAST. The trusted
+// values (`suggestionId` from the doc-path, `id` from the doc-ref) must
+// win over any same-named field that might end up in the payload — a
+// future schema or a malicious write storing `id: '<spoofed>'` or
+// `suggestionId: '<wrong>'` in the data must NOT be able to misattribute
+// the entry in a user's GDPR export.
+const _suggestionVoteMapper = (suggestionId, voteDoc) => ({
+  ...voteDoc.data(),
+  suggestionId,
+});
+const _suggestionCommentMapper = (suggestionId, commentDoc) => ({
+  ...commentDoc.data(),
+  suggestionId,
+  id: commentDoc.id,
+});
+
 async function buildDataExport(uniqueId) {
+  // Single numeric coercion shared by every Firestore equality query in
+  // this function — the function previously did this seven times inline
+  // (and once as a separately-named `numericId` local in the conversations
+  // block). `parseInt` is safe to call before any awaits; if the input is
+  // non-numeric the result is NaN and the downstream `where(...==..., NaN)`
+  // returns an empty set, matching Firestore's strict-equality semantics.
+  const numericUid = Number.parseInt(uniqueId, 10);
+
   // Track every section's outcome so the manifest + caller can see exactly
   // which subcollection queries succeeded. Insertion order matches the order
   // of section reads below — useful for debugging which doc is failing on
@@ -142,9 +223,8 @@ async function buildDataExport(uniqueId) {
   try {
     const convSnap = await db
       .collection('conversations')
-      .where('participantIds', 'array-contains', Number.parseInt(uniqueId, 10))
+      .where('participantIds', 'array-contains', numericUid)
       .get();
-    const numericId = Number.parseInt(uniqueId, 10);
     conversations = convSnap.docs.map((d) => {
       const data = d.data();
       return {
@@ -154,7 +234,7 @@ async function buildDataExport(uniqueId) {
         updatedAt: data.updatedAt,
         participantCount: data.participantIds ? data.participantIds.length : undefined,
         userRole: data.roles ? data.roles[uniqueId] : undefined,
-        isUserOwner: data.ownerId === numericId,
+        isUserOwner: data.ownerId === numericUid,
       };
     });
 
@@ -216,10 +296,7 @@ async function buildDataExport(uniqueId) {
   // Identity
   let identity = [];
   try {
-    const idSnap = await db
-      .collection('identityMap')
-      .where('uniqueId', '==', Number.parseInt(uniqueId, 10))
-      .get();
+    const idSnap = await db.collection('identityMap').where('uniqueId', '==', numericUid).get();
     identity = idSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
   } catch (err) {
     recordFailure('identity', err);
@@ -230,7 +307,7 @@ async function buildDataExport(uniqueId) {
   try {
     const bindSnap = await db
       .collection('deviceBindings')
-      .where('uniqueId', '==', Number.parseInt(uniqueId, 10))
+      .where('uniqueId', '==', numericUid)
       .get();
     deviceBindings = bindSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
   } catch (err) {
@@ -242,7 +319,7 @@ async function buildDataExport(uniqueId) {
   try {
     const sugSnap = await db
       .collection('suggestions')
-      .where('submitterUid', '==', Number.parseInt(uniqueId, 10))
+      .where('submitterUid', '==', numericUid)
       .get();
     suggestions = sugSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
   } catch (err) {
@@ -256,22 +333,40 @@ async function buildDataExport(uniqueId) {
   // become routine. The collection-group query reads ONLY the docs where
   // `voterId === uniqueId` — at most ~hundreds per user. Requires a
   // collection-group composite index on `votes.voterId` (added in firestore.indexes.json).
-  const suggestionVotes = [];
+  let suggestionVotes = [];
   try {
-    const numericUid = Number.parseInt(uniqueId, 10);
     const votesSnap = await db.collectionGroup('votes').where('voterId', '==', numericUid).get();
-    for (const voteDoc of votesSnap.docs) {
-      // votes are stored at suggestions/{suggestionId}/votes/{voterId}, so the
-      // suggestion ID is the parent's parent (the votes subcollection's parent
-      // doc, which is the suggestion). Defensive null check in case a future
-      // collection-group expansion introduces a different `votes` subcollection
-      // at another nesting level.
-      const suggestionRef = voteDoc.ref.parent.parent;
-      if (!suggestionRef || suggestionRef.parent.id !== 'suggestions') continue;
-      suggestionVotes.push({ suggestionId: suggestionRef.id, ...voteDoc.data() });
-    }
+    // Votes live at `suggestions/{suggestionId}/votes/{voterId}` — the doc
+    // ID is the voter's uniqueId so it's redundant with `voterId` in the
+    // payload (no `id:` in the mapper, unlike comments). The grandparent-id
+    // guard inside `collectSuggestionScopedEntries` rejects any rogue
+    // `votes` subcollection at a different nesting level.
+    suggestionVotes = collectSuggestionScopedEntries(votesSnap.docs, _suggestionVoteMapper);
   } catch (err) {
     recordFailure('suggestionVotes', err);
+  }
+
+  // Suggestion comments authored by this user — same collection-group shape
+  // as votes above, same quota motivation. Comments live at
+  // `suggestions/{suggestionId}/comments/{commentId}` with `authorUid` as the
+  // user FK, so the index override is on `comments.authorUid` (added in
+  // firestore.indexes.json alongside the votes override). The mapper exposes
+  // `id: commentDoc.id` because comment doc IDs are auto-generated (not
+  // derived from any payload field) and are the only stable identifier a
+  // user can use to correlate an exported comment with one cited in a
+  // moderation appeal or admin response.
+  let suggestionComments = [];
+  try {
+    const commentsSnap = await db
+      .collectionGroup('comments')
+      .where('authorUid', '==', numericUid)
+      .get();
+    suggestionComments = collectSuggestionScopedEntries(
+      commentsSnap.docs,
+      _suggestionCommentMapper,
+    );
+  } catch (err) {
+    recordFailure('suggestionComments', err);
   }
 
   // Subscription preferences
@@ -286,10 +381,7 @@ async function buildDataExport(uniqueId) {
   // Notification history
   let notificationHistory = [];
   try {
-    const notifSnap = await db
-      .collection('notifications')
-      .where('uid', '==', Number.parseInt(uniqueId, 10))
-      .get();
+    const notifSnap = await db.collection('notifications').where('uid', '==', numericUid).get();
     notificationHistory = notifSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
   } catch (err) {
     recordFailure('notifications', err);
@@ -324,6 +416,7 @@ async function buildDataExport(uniqueId) {
       deviceBindings: failedSections.includes('deviceBindings') ? 'failed' : 'ok',
       suggestions: failedSections.includes('suggestions') ? 'failed' : 'ok',
       suggestionVotes: failedSections.includes('suggestionVotes') ? 'failed' : 'ok',
+      suggestionComments: failedSections.includes('suggestionComments') ? 'failed' : 'ok',
       subscriptionPrefs: failedSections.includes('subscriptionPrefs') ? 'failed' : 'ok',
       notifications: failedSections.includes('notifications') ? 'failed' : 'ok',
     },
@@ -384,6 +477,7 @@ async function buildDataExport(uniqueId) {
       '  reports/          — Reports you filed and appeals',
       '  devices/          — Your device bindings',
       '  moderation/       — Your warning history',
+      '  suggestions/      — Suggestions you submitted, votes & comments you made, your subscription preferences, and notifications you received',
     );
     const readme = readmeLines.join('\n');
 
@@ -439,6 +533,9 @@ async function buildDataExport(uniqueId) {
     archive.append(JSON.stringify(suggestionVotes, null, 2), {
       name: 'suggestions/votes.json',
     });
+    archive.append(JSON.stringify(suggestionComments, null, 2), {
+      name: 'suggestions/comments.json',
+    });
     if (subscriptionPrefs) {
       archive.append(JSON.stringify(subscriptionPrefs, null, 2), {
         name: 'suggestions/subscription-preferences.json',
@@ -455,3 +552,12 @@ async function buildDataExport(uniqueId) {
 }
 
 module.exports = buildDataExport;
+// Exposed for direct unit testing of the privacy-critical grandparent-id
+// guard with mixed-legit-and-rogue inputs (the only assertion shape that
+// actually pins the guard's behavior — see test file for the rationale).
+// The per-section mappers are also exported so each one's payload shape
+// (notably `id: commentDoc.id` for comments) can be pinned without
+// decoding the compressed ZIP buffer.
+module.exports._collectSuggestionScopedEntries = collectSuggestionScopedEntries;
+module.exports._suggestionVoteMapper = _suggestionVoteMapper;
+module.exports._suggestionCommentMapper = _suggestionCommentMapper;

--- a/express-api/tests/routes/suggestions-integration-a-flows.test.js
+++ b/express-api/tests/routes/suggestions-integration-a-flows.test.js
@@ -618,12 +618,11 @@ describe('11.72 — GDPR Data Export & Account Deletion', () => {
       expect(res.body).toBeDefined();
     }
   });
-  // Both of these placeholder tests asserted only that the mock
-  // collection helper exists (always true), not that the data export
-  // actually included votes/comments. Honest TODO until the export
-  // path is integration-tested.
-  test.skip('TODO: data export includes user votes', async () => {});
-  test.skip('TODO: data export includes user comments', async () => {});
+  // Data-export votes & comments coverage lives in
+  // `tests/utils/data-export-builder.test.js` (the unit boundary where
+  // the collection-group queries actually fire). The prior placeholders
+  // here asserted only that the mock-collection helper exists (always
+  // true) — they were honest TODOs, now resolved by the builder tests.
   // Account-deletion cascade is now covered by the cron-level integration
   // pattern in tests/cron/accountDeletion.test.js (Step 6b group). That is
   // the right home for it — these route-level mocks cannot exercise the

--- a/express-api/tests/utils/data-export-builder.test.js
+++ b/express-api/tests/utils/data-export-builder.test.js
@@ -16,7 +16,12 @@ const mockDocGet = jest.fn();
 const mockCollectionGet = jest.fn();
 // Collection-group queries (Phase 2A finding #1) — separate mock so tests
 // can return votes-subset without polluting normal collection queries.
+// Routed by collection-group name so the votes vs. comments paths are
+// independently controllable: a votes-only test must not have to pre-stuff
+// a comments response (and vice versa). Default mock (mockCollectionGroupGet)
+// catches any name not in the routing table.
 const mockCollectionGroupGet = jest.fn();
+const mockCollectionGroupCommentsGet = jest.fn();
 
 jest.mock('../../src/utils/firebase', () => ({
   db: {
@@ -33,12 +38,12 @@ jest.mock('../../src/utils/firebase', () => ({
       };
       return chain;
     }),
-    collectionGroup: jest.fn(() => {
+    collectionGroup: jest.fn((name) => {
       const chain = {
         where: jest.fn().mockImplementation(() => chain),
         orderBy: jest.fn().mockImplementation(() => chain),
         limit: jest.fn().mockImplementation(() => chain),
-        get: mockCollectionGroupGet,
+        get: name === 'comments' ? mockCollectionGroupCommentsGet : mockCollectionGroupGet,
       };
       return chain;
     }),
@@ -64,6 +69,10 @@ beforeEach(() => {
   // Default: no votes for the user — tests that exercise the votes path
   // override with mockCollectionGroupGet.mockResolvedValueOnce(...).
   mockCollectionGroupGet.mockResolvedValue({ docs: [], empty: true });
+  // Default: no comments by the user — comments-path tests override with
+  // mockCollectionGroupCommentsGet.mockResolvedValueOnce(...). Mirror of the
+  // votes default so all non-comments tests stay simple.
+  mockCollectionGroupCommentsGet.mockResolvedValue({ docs: [], empty: true });
   // Reset the db.collection implementation between tests — `clearAllMocks`
   // clears call history but not `.mockImplementation(...)` overrides, so
   // a test that selectively rejects (e.g., `name === 'reports' ? throw`)
@@ -709,6 +718,128 @@ describe('buildDataExport', () => {
       'Failed to query suggestionVotes',
       expect.objectContaining({ uniqueId: '10000001' }),
     );
+    // Partial-failure contract assertions (parity with the comments error
+    // path test below): a regression that silently swallowed the error
+    // and left partial=false would pass without these.
+    expect(result.partial).toBe(true);
+    expect(result.failedSections).toContain('suggestionVotes');
+  });
+
+  // --- Suggestion comments scanning -----------------------------------------
+  // Mirrors the votes path: comments live at suggestions/{id}/comments/{cid}
+  // with authorUid as the FK, so collectionGroup('comments').where('authorUid')
+  // is the same quota-safe shape. Index override exists in firestore.indexes.json
+  // (added with the GDPR account-deletion cascade work). Tests pin three things:
+  //   (1) the query shape is the collection-group entry, not an N+1 scan
+  //   (2) a defensive grandparent-id guard rejects rogue `comments` subcollections
+  //   (3) failures are recorded as a partial-export section, not silently dropped
+
+  test('collects suggestion comments via collection-group query', async () => {
+    mockDocGet.mockResolvedValue({ exists: true, data: () => testUser });
+    queryDocs.mockResolvedValue([]);
+
+    // Comments doc ref shape mirrors Firestore exactly:
+    //   suggestions/{suggestionId}/comments/{commentId}
+    // so `.parent` is the comments subcollection, `.parent.parent` is the
+    // parent suggestion doc, and `.parent.parent.parent` is the suggestions
+    // collection. The export reads `.parent.parent` (the suggestion doc) and
+    // pushes its id alongside the comment payload.
+    function makeSuggestionsCollection() {
+      return { id: 'suggestions' };
+    }
+    function makeCommentDoc(suggestionId, commentData) {
+      const suggestionsCol = makeSuggestionsCollection();
+      const suggestionDoc = { id: suggestionId, parent: suggestionsCol };
+      const commentsCol = { id: 'comments', parent: suggestionDoc };
+      return {
+        ref: { parent: commentsCol },
+        data: () => commentData,
+      };
+    }
+    mockCollectionGroupCommentsGet.mockResolvedValueOnce({
+      docs: [
+        makeCommentDoc('sug-1', {
+          authorUid: 10000001,
+          text: 'Great idea',
+          isPublic: true,
+          createdAt: 1700000000000,
+        }),
+        makeCommentDoc('sug-4', {
+          authorUid: 10000001,
+          text: 'Already shipped — see release notes',
+          isPublic: true,
+          createdAt: 1700000000200,
+        }),
+      ],
+    });
+
+    const result = await buildDataExport('10000001');
+    expect(result.buffer).toBeInstanceOf(Buffer);
+
+    // The collection-group entry point was used for `comments` — verifies
+    // the quota-safe shape is real and not silently regressed to a
+    // per-suggestion subcollection scan.
+    const { db } = require('../../src/utils/firebase');
+    expect(db.collectionGroup).toHaveBeenCalledWith('comments');
+    // Confirm we don't load individual comment docs (no N+1 fallback)
+    expect(db.doc).not.toHaveBeenCalledWith(expect.stringMatching(/^suggestions\/.+\/comments\//));
+  });
+
+  test('skips collection-group comment entries whose grandparent is NOT the suggestions collection', async () => {
+    // Defensive guard parallel to the votes path: if a future schema adds
+    // another `comments` subcollection under a different parent collection
+    // (e.g. `posts/{id}/comments`), the export must not leak those entries
+    // — they're not suggestion comments and would constitute a privacy
+    // bleed (a stranger's post-comment showing up in this user's export
+    // because the authorUid happens to match).
+    mockDocGet.mockResolvedValue({ exists: true, data: () => testUser });
+    queryDocs.mockResolvedValue([]);
+
+    function makeRogueCommentDoc() {
+      const otherCol = { id: 'posts' };
+      const otherDoc = { id: 'post-1', parent: otherCol };
+      const commentsCol = { id: 'comments', parent: otherDoc };
+      return {
+        ref: { parent: commentsCol },
+        data: () => ({ authorUid: 10000001, text: 'rogue' }),
+      };
+    }
+    mockCollectionGroupCommentsGet.mockResolvedValueOnce({ docs: [makeRogueCommentDoc()] });
+
+    const result = await buildDataExport('10000001');
+    expect(result.buffer).toBeInstanceOf(Buffer);
+    // Pass condition: the rogue comment was filtered (no crash on the
+    // grandparent-id check). A regression that removes the guard would
+    // throw or leak the rogue entry into the export. The PRIMARY pin for
+    // the guard's filter-vs-pass-all behavior lives in the dedicated
+    // `collectSuggestionScopedEntries` describe block below, where the
+    // helper is unit-tested directly with mixed-legit-and-rogue inputs.
+  });
+
+  test('handles suggestion comments query error gracefully', async () => {
+    // Index-missing is the realistic failure mode here — the collection-group
+    // query needs the `comments.authorUid` field override, and a future
+    // firestore.indexes.json rewrite could drop it. The export must continue
+    // (other sections still ship) and the failure must surface in
+    // failedSections so the user knows.
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => testUser,
+    });
+    queryDocs.mockResolvedValue([]);
+    mockCollectionGroupCommentsGet.mockRejectedValueOnce(new Error('CG comments index missing'));
+
+    const result = await buildDataExport('10000001');
+    expect(result.buffer).toBeInstanceOf(Buffer);
+
+    const log = require('../../src/utils/log');
+    expect(log.error).toHaveBeenCalledWith(
+      'data-export',
+      'Failed to query suggestionComments',
+      expect.objectContaining({ uniqueId: '10000001' }),
+    );
+    expect(result.partial).toBe(true);
+    expect(result.failedSections).toContain('suggestionComments');
   });
 
   // --- Empty data defaults --------------------------------------------------
@@ -865,6 +996,275 @@ describe('buildDataExport', () => {
       // user gets SOMETHING back, not an empty error response).
       expect(result.buffer).toBeInstanceOf(Buffer);
       expect(result.buffer.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── collectSuggestionScopedEntries (privacy-critical grandparent guard) ───
+  // The buildDataExport-level rogue tests above can only assert "the buffer
+  // still builds" because the ZIP is `level: 9` compressed and there's no
+  // unzip lib on the dep tree to decode the result. That's a weak pin: it
+  // passes even if the guard is deleted and the rogue leaks into the export.
+  // The guard is privacy-critical (any future schema with a sibling
+  // `comments`/`votes` subcollection at a different nesting level — e.g.
+  // posts/{id}/comments — must NOT leak into a user's export), so it
+  // deserves a load-bearing test. The production helper is exported as
+  // `_collectSuggestionScopedEntries` for that purpose. These tests pin:
+  //   (1) filter-not-pass-all: mixed legitimate + rogue → only legitimate
+  //   (2) filter-not-skip-all: all-legitimate batch → all pass through
+  //   (3) null grandparent (top-level collection-group hit) doesn't crash
+  //   (4) null grandparent-parent (pathological nesting) doesn't crash
+  //   (5) empty input returns []
+  //   (6) the mapper actually shapes the output per caller's contract
+  describe('collectSuggestionScopedEntries (privacy guard)', () => {
+    const {
+      _collectSuggestionScopedEntries: helper,
+    } = require('../../src/utils/data-export-builder');
+
+    // Synthetic doc shape that models the relevant slice of the Firestore
+    // Admin SDK's `DocumentSnapshot`. `ref` carries `id`, `path`, and
+    // `parent` because the helper currently only touches `.ref.parent`
+    // but any natural extension (logging `ref.path` on a rogue doc,
+    // exposing `ref.id` to the mapper) should not silently no-op against
+    // the fixture — including all three matches the SDK's minimum shape.
+    function makeDoc(
+      grandparentId,
+      suggestionId,
+      payload,
+      leafColName = 'comments',
+      docId = undefined,
+    ) {
+      const grandparentCol = { id: grandparentId };
+      const grandparentDoc = { id: suggestionId, parent: grandparentCol };
+      const leafCol = { id: leafColName, parent: grandparentDoc };
+      const refPath = `${grandparentId}/${suggestionId}/${leafColName}/${docId ?? '_'}`;
+      return {
+        id: docId,
+        ref: { id: docId, path: refPath, parent: leafCol },
+        data: () => payload,
+      };
+    }
+
+    test('keeps only docs whose grandparent is the suggestions collection (mixed batch)', () => {
+      const docs = [
+        makeDoc('suggestions', 'sug-1', { authorUid: 1, text: 'legitimate-1' }, 'comments', 'c1'),
+        makeDoc('posts', 'post-1', { authorUid: 1, text: 'rogue-from-posts' }, 'comments', 'c2'),
+        makeDoc('suggestions', 'sug-2', { authorUid: 1, text: 'legitimate-2' }, 'comments', 'c3'),
+        makeDoc('events', 'evt-1', { authorUid: 1, text: 'rogue-from-events' }, 'comments', 'c4'),
+      ];
+
+      const result = helper(docs, (suggestionId, doc) => ({
+        suggestionId,
+        id: doc.id,
+        ...doc.data(),
+      }));
+
+      // Exactly 2 legitimate entries pass through; rogue entries are filtered.
+      // The negative assertion is the load-bearing one — without it, a
+      // regression where the helper returns ALL docs would still produce
+      // a non-empty array and the positive `expect(length).toBe(2)`
+      // would catch it, but the explicit `not.toContainEqual` makes
+      // the privacy contract self-documenting.
+      expect(result).toHaveLength(2);
+      expect(result).toEqual([
+        { suggestionId: 'sug-1', id: 'c1', authorUid: 1, text: 'legitimate-1' },
+        { suggestionId: 'sug-2', id: 'c3', authorUid: 1, text: 'legitimate-2' },
+      ]);
+      expect(result).not.toContainEqual(expect.objectContaining({ text: 'rogue-from-posts' }));
+      expect(result).not.toContainEqual(expect.objectContaining({ text: 'rogue-from-events' }));
+    });
+
+    test('passes through every doc when ALL grandparents are suggestions (no false drops)', () => {
+      const docs = [
+        makeDoc('suggestions', 'sug-1', { voterId: 1, direction: 'up' }, 'votes'),
+        makeDoc('suggestions', 'sug-2', { voterId: 1, direction: 'down' }, 'votes'),
+        makeDoc('suggestions', 'sug-3', { voterId: 1, direction: 'up' }, 'votes'),
+      ];
+
+      const result = helper(docs, (suggestionId, doc) => ({
+        suggestionId,
+        ...doc.data(),
+      }));
+
+      // Pins the inverse failure mode: a regression where the guard
+      // accidentally rejects valid suggestion-scoped docs (e.g. a typo
+      // changing `=== 'suggestions'` to `!== 'suggestions'`) would
+      // produce an empty array. This test makes that immediately visible.
+      expect(result).toHaveLength(3);
+    });
+
+    test('skips doc whose grandparent is null (top-level collection-group hit)', () => {
+      // Edge case: a collection-group query may return docs whose
+      // `.parent.parent` is null (a root-level collection at the same
+      // leaf name, if Firestore ever permits that). The guard must
+      // short-circuit on `!suggestionRef` before dereferencing `.parent.id`.
+      const orphanLeafCol = { id: 'comments', parent: null };
+      const orphanDoc = {
+        ref: { parent: orphanLeafCol },
+        data: () => ({ authorUid: 1, text: 'orphan' }),
+      };
+      const result = helper([orphanDoc], (suggestionId, doc) => ({ suggestionId, ...doc.data() }));
+      // No crash + orphan filtered.
+      expect(result).toEqual([]);
+    });
+
+    test('skips doc whose grandparent-parent is null (pathologically shallow nesting)', () => {
+      // Second guard branch: `suggestionRef` is truthy but
+      // `suggestionRef.parent` is null. Cannot happen in current Firestore
+      // semantics (every doc has a parent collection) but a malformed
+      // fixture or Admin-SDK version drift could surface it. Without the
+      // `!suggestionRef.parent` short-circuit the helper would throw
+      // `TypeError: Cannot read properties of null (reading 'id')`.
+      const grandparentDoc = { id: 'sug-1', parent: null };
+      const leafCol = { id: 'comments', parent: grandparentDoc };
+      const pathologicalDoc = {
+        id: 'c-x',
+        ref: { id: 'c-x', path: '?/sug-1/comments/c-x', parent: leafCol },
+        data: () => ({ authorUid: 1, text: 'pathological' }),
+      };
+      const result = helper([pathologicalDoc], (suggestionId, doc) => ({
+        suggestionId,
+        ...doc.data(),
+      }));
+      expect(result).toEqual([]);
+    });
+
+    test('returns empty array for empty input (no off-by-one)', () => {
+      // Pins that an empty snapshot returns `[]`, not `undefined`.
+      // The buildDataExport-level code spreads/serialises this directly
+      // into the manifest, so a regression returning `undefined` would
+      // produce malformed JSON in the export ZIP.
+      expect(helper([], () => ({}))).toEqual([]);
+    });
+
+    test('mapper receives suggestionId and the full doc object', () => {
+      // Pins the helper's contract with the mapper. Both call sites need
+      // the suggestion ID extracted from `.parent.parent.id`, and the
+      // comments call site needs `doc.id` (Firestore auto-ID) which the
+      // helper must hand through unmodified. A regression that handed
+      // `doc.data()` instead of `doc` would break the comments mapper's
+      // `doc.id` access silently.
+      const mockMapper = jest.fn((suggestionId, doc) => ({ suggestionId, _id: doc.id }));
+      const docs = [makeDoc('suggestions', 'sug-1', { x: 1 }, 'comments', 'auto-id-abc')];
+
+      const result = helper(docs, mockMapper);
+
+      expect(mockMapper).toHaveBeenCalledTimes(1);
+      expect(mockMapper).toHaveBeenCalledWith(
+        'sug-1',
+        expect.objectContaining({ id: 'auto-id-abc' }),
+      );
+      expect(result).toEqual([{ suggestionId: 'sug-1', _id: 'auto-id-abc' }]);
+    });
+  });
+
+  // ─── Per-section mapper contracts ──────────────────────────────────────
+  // Pin each section mapper's exact output shape. These run against the
+  // production-exported mapper constants (not inline arrow lambdas) so a
+  // regression deleting e.g. `id: commentDoc.id` from the comments mapper
+  // fails here directly, without needing to decode the ZIP.
+  describe('section mappers', () => {
+    const {
+      _suggestionVoteMapper: voteMapper,
+      _suggestionCommentMapper: commentMapper,
+    } = require('../../src/utils/data-export-builder');
+
+    test('vote mapper: spreads voteDoc.data() and prepends suggestionId (no id field)', () => {
+      // Vote doc IDs are the voterId — already in the payload as `voterId`.
+      // Pinning the absence of an `id:` here prevents a future "consistency"
+      // refactor from adding it (which would expose Firestore's internal
+      // doc-key, a privacy-tangential leak even if cosmetically harmless).
+      const fakeVoteDoc = {
+        id: '10000001',
+        data: () => ({ voterId: 10000001, direction: 'up', votedAt: 1700000000000 }),
+      };
+      const result = voteMapper('sug-7', fakeVoteDoc);
+      expect(result).toEqual({
+        suggestionId: 'sug-7',
+        voterId: 10000001,
+        direction: 'up',
+        votedAt: 1700000000000,
+      });
+      expect(result).not.toHaveProperty('id');
+    });
+
+    test('comment mapper: propagates commentDoc.id (auto-generated, otherwise unrecoverable)', () => {
+      // The load-bearing assertion for R1-I2: the auto-generated Firestore
+      // doc ID MUST appear in the exported payload because it's the only
+      // stable identifier a user can use to correlate an exported comment
+      // with one cited in a moderation appeal or admin response. Deleting
+      // `id: commentDoc.id` from the mapper fails this test directly.
+      const fakeCommentDoc = {
+        id: 'auto-id-firestore-7xyz',
+        data: () => ({
+          authorUid: 10000001,
+          text: 'pinned by the mapper test',
+          isPublic: true,
+          createdAt: 1700000000000,
+        }),
+      };
+      const result = commentMapper('sug-42', fakeCommentDoc);
+      expect(result).toEqual({
+        suggestionId: 'sug-42',
+        id: 'auto-id-firestore-7xyz',
+        authorUid: 10000001,
+        text: 'pinned by the mapper test',
+        isPublic: true,
+        createdAt: 1700000000000,
+      });
+    });
+
+    test('comment mapper: trusted explicit fields win over same-named payload fields (privacy invariant)', () => {
+      // The mapper's explicit `suggestionId` (from the doc path) and `id`
+      // (from the doc ref) are TRUSTED — they come from the storage layer
+      // and identify the entry's true location in the corpus. The payload
+      // is UNTRUSTED user-or-future-schema data. If a comment payload
+      // ever stores fields named `suggestionId` or `id`, those must NOT
+      // be able to override the trusted values — otherwise an export
+      // could misattribute a comment, breaking the user's ability to
+      // correlate the entry with a real comment in the system.
+      // Production code achieves this by ordering the spread BEFORE the
+      // explicit fields in the mapper's object literal. This test pins
+      // that ordering as a privacy invariant.
+      const fakeCommentDoc = {
+        id: 'real-comment-id',
+        data: () => ({
+          // Adversarial payload: tries to claim a different identity
+          suggestionId: 'rogue-suggestion-id',
+          id: 'rogue-comment-id',
+          authorUid: 1,
+          text: 'attempted override',
+        }),
+      };
+      const result = commentMapper('sug-true', fakeCommentDoc);
+      // Trusted values win
+      expect(result.suggestionId).toBe('sug-true');
+      expect(result.id).toBe('real-comment-id');
+      // Other payload fields still pass through
+      expect(result.authorUid).toBe(1);
+      expect(result.text).toBe('attempted override');
+    });
+
+    test('vote mapper: trusted suggestionId wins over same-named payload field (privacy invariant)', () => {
+      // Pre-existing path with the same concern: if a vote payload ever
+      // stores a `suggestionId` field, it must NOT override the trusted
+      // value from the doc path. The bug existed in the pre-extraction
+      // inline mapper but was only surfaced by the comments-mapper test
+      // architecture — fixed in the same PR per the project's
+      // "fix pre-existing and new findings the same way" rule.
+      const fakeVoteDoc = {
+        id: '10000001',
+        data: () => ({
+          // Adversarial payload: tries to claim a different suggestion
+          suggestionId: 'rogue-suggestion-id',
+          voterId: 10000001,
+          direction: 'up',
+          votedAt: 1700000000000,
+        }),
+      };
+      const result = voteMapper('sug-real', fakeVoteDoc);
+      expect(result.suggestionId).toBe('sug-real');
+      expect(result.voterId).toBe(10000001);
+      expect(result.direction).toBe('up');
     });
   });
 });


### PR DESCRIPTION
## Summary
- New `suggestionComments` section in `data-export-builder.js` — mirrors the votes-export `collectionGroup` shape, closing a documented GDPR right-of-access gap (PR #974 cleaned up comments on deletion but the export path had no equivalent).
- Extracted `collectSuggestionScopedEntries` helper and per-section mapper constants so the privacy-critical grandparent guard and `id:` field propagation are directly testable (the ZIP is `level: 9` compressed and no unzip lib is on the dep tree).
- Fixed pre-existing spread-order bug in BOTH vote and comment mappers: payload fields could override trusted `suggestionId`/`id` values, letting a malicious or future-schema payload spoof its identity in the export. Trusted fields now win.

## Other cleanups in scope
- Hoisted `numericUid` to a single declaration (was 7 inline `parseInt` calls + 1 separately-named `numericId` local).
- Added defensive null guard for `suggestionRef.parent` (pathological nesting current Firestore doesn't produce but a fixture or SDK drift could).
- Added the missing `suggestions/` README listing — the ZIP has shipped 4 files there since the suggestions-export work landed but the README never mentioned them.
- Removed two obsolete `test.skip` stubs in `suggestions-integration-a-flows.test.js` (honest TODOs for votes/comments export coverage that now live in the data-export-builder unit suite where they belong).

## Review loop
4 rounds with `code-reviewer` agent:
- R1: 2 Critical + 3 Important (schema mismatch body→text, vacuous rogue-guard test, numericUid hoist incomplete, missing commentDoc.id, mixed-batch test gap). All fixed.
- R2: 1 Critical + 4 Important (numericUid hoist still incomplete — 5 inline sites + `numericId` local missed; integration coverage for `id:` propagation; makeDoc fragility; null `suggestionRef.parent` crash path). All fixed. R2 surfaced the spread-order bug as a side effect of writing adversarial mapper tests.
- R3: 1 Important (votes error test missing `partial`/`failedSections` parity with comments test). Fixed.
- R4: Zero findings.

## Test plan
- [x] 11,144 express tests pass, 1 skipped
- [x] 13 new unit tests across helper + mapper + integration surfaces (43 builder tests total, was 30)
- [x] Prettier + ESLint clean
- [x] Pre-push SonarCloud quality gate passed
- [x] Firestore index override for `comments.authorUid` already in place (PR #974)

🤖 Generated with [Claude Code](https://claude.com/claude-code)