### PR TITLE
fix(express-api): spread-order safety in roadmap-auth + firestore-helpers

### DIFF
--- a/express-api/src/routes/roadmap-auth.js
+++ b/express-api/src/routes/roadmap-auth.js
@@ -66,8 +66,11 @@ router.get('/roadmap/me', async (req, res) => {
 
           const userDoc = await db.doc(`users/${idData.uniqueId}`).get();
           if (userDoc.exists) {
-            // Same identity-pinning as the direct path above.
-            userData = { ...userDoc.data(), uniqueId: idData.uniqueId };
+            // Same identity-pinning + numeric coercion as the direct path
+            // above. `Number(...)` keeps the response shape consistent
+            // across both auth paths (identityMap may legacy-store the FK
+            // as a string).
+            userData = { ...userDoc.data(), uniqueId: Number(idData.uniqueId) };
             break;
           }
         }

--- a/express-api/src/routes/roadmap-auth.js
+++ b/express-api/src/routes/roadmap-auth.js
@@ -45,7 +45,9 @@ router.get('/roadmap/me', async (req, res) => {
     if (req.auth.uniqueId) {
       const userDoc = await db.doc(`users/${req.auth.uniqueId}`).get();
       if (userDoc.exists) {
-        userData = { uniqueId: Number(req.auth.uniqueId), ...userDoc.data() };
+        // Trust the authenticated uniqueId, NOT whatever the user-doc payload
+        // claims — payload spread comes first so the trusted value wins.
+        userData = { ...userDoc.data(), uniqueId: Number(req.auth.uniqueId) };
       }
     }
 
@@ -64,7 +66,8 @@ router.get('/roadmap/me', async (req, res) => {
 
           const userDoc = await db.doc(`users/${idData.uniqueId}`).get();
           if (userDoc.exists) {
-            userData = { uniqueId: idData.uniqueId, ...userDoc.data() };
+            // Same identity-pinning as the direct path above.
+            userData = { ...userDoc.data(), uniqueId: idData.uniqueId };
             break;
           }
         }

--- a/express-api/src/utils/firestore-helpers.js
+++ b/express-api/src/utils/firestore-helpers.js
@@ -1,27 +1,25 @@
 /**
  * Shared Firestore helper functions.
  *
- * Extracted from users.js, reports.js, banners.js, config.js, etc. to eliminate duplication.
+ * Extracted from users.js, reports.js, banners.js, config.js, etc. to
+ * eliminate duplication.
+ *
+ * Spread-order invariant (both helpers): the payload is spread BEFORE the
+ * trusted `id` so a legacy or adversarially-shaped `id` field on the doc
+ * body cannot override the storage-layer key. See the "spread-order safety"
+ * tests in firestore-helpers.test.js for the failing-without-the-fix proof.
  */
 
 const { db } = require('./firebase');
 
-/**
- * Get a single Firestore document by path.
- * Returns { id, ...data } or null if the document doesn't exist.
- */
 async function getDoc(path) {
   const snap = await db.doc(path).get();
-  return snap.exists ? { id: snap.id, ...snap.data() } : null;
+  return snap.exists ? { ...snap.data(), id: snap.id } : null;
 }
 
-/**
- * Execute a Firestore query reference and return all matching documents
- * as an array of { id, ...data } objects.
- */
 async function queryDocs(ref) {
   const snap = await ref.get();
-  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+  return snap.docs.map((d) => ({ ...d.data(), id: d.id }));
 }
 
 module.exports = { getDoc, queryDocs };

--- a/express-api/src/utils/firestore-helpers.js
+++ b/express-api/src/utils/firestore-helpers.js
@@ -4,10 +4,11 @@
  * Extracted from users.js, reports.js, banners.js, config.js, etc. to
  * eliminate duplication.
  *
- * Spread-order invariant (both helpers): the payload is spread BEFORE the
- * trusted `id` so a legacy or adversarially-shaped `id` field on the doc
- * body cannot override the storage-layer key. See the "spread-order safety"
- * tests in firestore-helpers.test.js for the failing-without-the-fix proof.
+ * Spread-order invariant (`getDoc` and `queryDocs`): the payload is spread
+ * BEFORE the trusted `id` so a legacy or adversarially-shaped `id` field on
+ * the doc body cannot override the storage-layer key. See the "spread-order
+ * safety" tests in firestore-helpers.test.js for the failing-without-the-fix
+ * proof.
  */
 
 const { db } = require('./firebase');

--- a/express-api/tests/routes/roadmap-auth.test.js
+++ b/express-api/tests/routes/roadmap-auth.test.js
@@ -533,6 +533,77 @@ describe('GET /api/roadmap/me', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════
+// GET /api/roadmap/me — spread-order safety (identity invariant)
+// ═══════════════════════════════════════════════════════════════
+//
+// `uniqueId` is the authoritative identity for the authenticated request —
+// either copied from `req.auth.uniqueId` (verified by upstream auth middleware
+// against the Firebase token) or sourced from the identityMap lookup. The
+// user doc payload is treated as untrusted: even though Firestore rules deny
+// client writes to the `uniqueId` field today, a future schema migration,
+// admin-tool write, or rule-drift could persist a rogue value. If the user
+// doc's payload ever overrode the trusted uniqueId, /roadmap/me would return
+// a profile under the *wrong* numeric identity — the strongest possible
+// identity-spoofing shape for an authenticated endpoint.
+//
+// Pins the spread-order contract: `{ ...userDoc.data(), uniqueId: <trusted> }`.
+
+describe('GET /api/roadmap/me — spread-order safety (identity invariant)', () => {
+  test('direct uniqueId path: payload uniqueId cannot override authenticated uniqueId', async () => {
+    mockDocGet.mockImplementation((path) => {
+      if (path && path.includes('users/1001')) {
+        // Adversarial: user doc payload tries to claim a different identity.
+        return Promise.resolve({
+          exists: true,
+          data: () => ({
+            uniqueId: 9999,
+            displayName: 'AuthenticatedUser',
+            avatarUrl: 'https://example.com/a.png',
+            profilePhotoUrl: 'https://example.com/p.png',
+          }),
+        });
+      }
+      return Promise.resolve({ exists: false });
+    });
+    const app = createApp({ uid: 'firebase-uid-1', uniqueId: 1001 });
+    const res = await request(app).get('/api/roadmap/me').expect(200);
+    expect(res.body.uniqueId).toBe(1001);
+    expect(res.body.displayName).toBe('AuthenticatedUser');
+  });
+
+  test('identityMap fallback path: payload uniqueId cannot override identityMap-resolved uniqueId', async () => {
+    mockCollectionGet.mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'google:linked@gmail.com',
+          data: () => ({ uniqueId: 2002, firebaseUid: 'firebase-uid-fallback' }),
+        },
+      ],
+    });
+    mockDocGet.mockImplementation((path) => {
+      if (path && path.includes('users/2002')) {
+        // Adversarial: user doc payload tries to claim a different identity.
+        return Promise.resolve({
+          exists: true,
+          data: () => ({
+            uniqueId: 9999,
+            displayName: 'FallbackUser',
+            avatarUrl: 'https://example.com/a.png',
+            profilePhotoUrl: 'https://example.com/p.png',
+          }),
+        });
+      }
+      return Promise.resolve({ exists: false });
+    });
+    const app = createApp({ uid: 'firebase-uid-fallback', uniqueId: null });
+    const res = await request(app).get('/api/roadmap/me').expect(200);
+    expect(res.body.uniqueId).toBe(2002);
+    expect(res.body.displayName).toBe('FallbackUser');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
 // GET /api/roadmap/me — Auth edge cases
 // ═══════════════════════════════════════════════════════════════
 

--- a/express-api/tests/routes/roadmap-auth.test.js
+++ b/express-api/tests/routes/roadmap-auth.test.js
@@ -334,7 +334,13 @@ describe('GET /api/roadmap/me', () => {
     expect(typeof res.body.displayName).toBe('string');
   });
 
-  test('response time under 500ms for cached users', async () => {
+  // Replaces the prior `response time under 500ms` test (non-load-bearing on
+  // a synchronous mock — could never fail in CI, could only flake). Pin the
+  // request-shape invariant instead: when `req.auth.uniqueId` is set, the
+  // route makes exactly one direct `users/{id}` read and SKIPS the
+  // identityMap fallback query — a regression that always ran the fallback
+  // would double the Firestore RPC count on every authenticated request.
+  test('direct-uniqueId path makes exactly one users-doc read and skips identityMap', async () => {
     mockDocGet.mockImplementation((path) => {
       if (path && path.includes('users/')) {
         return Promise.resolve(makeUserDoc(1001));
@@ -342,10 +348,9 @@ describe('GET /api/roadmap/me', () => {
       return Promise.resolve({ exists: false });
     });
     const app = createApp();
-    const start = Date.now();
     await request(app).get('/api/roadmap/me').expect(200);
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeLessThan(500);
+    expect(mockDocGet).toHaveBeenCalledTimes(1);
+    expect(mockCollectionGet).not.toHaveBeenCalled();
   });
 
   test('multiple rapid requests return same data (idempotent)', async () => {
@@ -451,6 +456,12 @@ describe('GET /api/roadmap/me', () => {
     const res = await request(app).get('/api/roadmap/me').expect(200);
     expect(res.body.uniqueId).toBe(4002);
     expect(res.body.displayName).toBe('LinkedUser');
+    // Strong pin: the unlinked entry's user doc must NEVER be fetched. A
+    // "fetch all then pick last" regression that happened to land on 4002
+    // would pass the toBe-4002 assertion above — this negative assertion
+    // closes that gap.
+    expect(mockDocGet).not.toHaveBeenCalledWith('users/4001');
+    expect(mockDocGet).toHaveBeenCalledWith('users/4002');
   });
 
   // ─── New tests: type safety ────────────────────────────────────
@@ -684,12 +695,14 @@ describe('GET /api/roadmap/me — Auth edge cases', () => {
     expect([200, 404]).toContain(res.status);
   });
 
-  test('auth with empty string uid returns 404 (no user found)', async () => {
+  test('auth with empty string uid returns 401 (requireAuth rejects falsy uid)', async () => {
     mockDocGet.mockResolvedValue({ exists: false });
     mockCollectionGet.mockResolvedValue({ empty: true, docs: [] });
     const app = createApp({ uid: '', uniqueId: null });
     const res = await request(app).get('/api/roadmap/me');
-    expect([401, 404]).toContain(res.status);
+    // Empty string is falsy, so requireAuth's `!req.auth.uid && !req.auth.uniqueId`
+    // guard fires deterministically — pin 401, not a disjunctive [401, 404].
+    expect(res.status).toBe(401);
   });
 });
 

--- a/express-api/tests/routes/roadmap-auth.test.js
+++ b/express-api/tests/routes/roadmap-auth.test.js
@@ -686,13 +686,32 @@ describe('GET /api/roadmap/me — Auth edge cases', () => {
     expect(res.status).toBe(401);
   });
 
-  test('auth with uid but no uniqueId still attempts identity lookup', async () => {
+  test('auth with uid but no uniqueId falls through identityMap and returns 404 when empty', async () => {
     mockCollectionGet.mockResolvedValue({ empty: true, docs: [] });
     mockDocGet.mockResolvedValue({ exists: false });
     const app = createApp({ uid: 'uid-no-unique', uniqueId: null });
     const res = await request(app).get('/api/roadmap/me');
-    // Should either find via identityMap or return 404 — not crash
-    expect([200, 404]).toContain(res.status);
+    // requireAuth passes (uid is truthy), direct path skipped (uniqueId null
+    // is falsy), identityMap fallback finds nothing → deterministic 404. Pin
+    // exact status, not a disjunctive [200, 404] that would also accept
+    // a successful resolution that shouldn't happen against this mock.
+    expect(res.status).toBe(404);
+  });
+
+  // Pre-existing falsy-guard analysis: requireAuth's `!req.auth.uniqueId`
+  // treats 0 the same as null/undefined. With a truthy uid the guard does
+  // NOT fire on uniqueId=0; the route falls through to the identityMap
+  // fallback. This test pins that current behavior so a future "tighten the
+  // guard" refactor (e.g. switching to `req.auth.uniqueId == null`) doesn't
+  // change the response shape unintentionally. ShyTalk uniqueIds are
+  // demonstrably positive integers (provisioning never assigns 0), so this
+  // is a regression pin, not a real-world bug surface.
+  test('uniqueId of 0 with truthy uid falls through to identityMap (returns 404 when empty)', async () => {
+    mockCollectionGet.mockResolvedValue({ empty: true, docs: [] });
+    mockDocGet.mockResolvedValue({ exists: false });
+    const app = createApp({ uid: 'uid-zero', uniqueId: 0 });
+    const res = await request(app).get('/api/roadmap/me');
+    expect(res.status).toBe(404);
   });
 
   test('auth with empty string uid returns 401 (requireAuth rejects falsy uid)', async () => {

--- a/express-api/tests/routes/roadmap-auth.test.js
+++ b/express-api/tests/routes/roadmap-auth.test.js
@@ -219,6 +219,7 @@ describe('GET /api/roadmap/me', () => {
     });
     const app = createApp();
     const res = await request(app).get('/api/roadmap/me').expect(200);
+    expect(res.body).not.toHaveProperty('isSuspended');
     expect(res.body).not.toHaveProperty('suspensionReason');
   });
 
@@ -412,9 +413,11 @@ describe('GET /api/roadmap/me', () => {
     });
     const app = createApp({ uid: 'firebase-uid-multi', uniqueId: null });
     const res = await request(app).get('/api/roadmap/me').expect(200);
-    // Should pick the first matched entry
-    expect(res.body.displayName).toBeDefined();
-    expect([3001, 3002]).toContain(res.body.uniqueId);
+    // The route loops idSnap.docs in iteration order and `break`s on the
+    // first existing user doc — pin the determinism (first entry: 3001).
+    // A regression that picked a different entry would otherwise pass.
+    expect(res.body.uniqueId).toBe(3001);
+    expect(res.body.displayName).toBe('FirstEntry');
   });
 
   test('identityMap with unlinked entry (unlinked: true) skipped', async () => {
@@ -431,20 +434,23 @@ describe('GET /api/roadmap/me', () => {
         },
       ],
     });
+    // Both user docs EXIST with distinguishable displayNames so the
+    // assertion truly pins "unlinked entry skipped". A regression that
+    // failed to skip would resolve to 4001 first and return UnlinkedUser
+    // instead of LinkedUser.
     mockDocGet.mockImplementation((path) => {
+      if (path && path.includes('users/4001')) {
+        return Promise.resolve(makeUserDoc(4001, { displayName: 'UnlinkedUser' }));
+      }
       if (path && path.includes('users/4002')) {
         return Promise.resolve(makeUserDoc(4002, { displayName: 'LinkedUser' }));
       }
       return Promise.resolve({ exists: false });
     });
     const app = createApp({ uid: 'uid-unlinked', uniqueId: null });
-    const res = await request(app).get('/api/roadmap/me');
-    // Should skip the unlinked entry and use the linked one, or 404 if not handled
-    if (res.status === 200) {
-      expect(res.body.uniqueId).toBe(4002);
-    } else {
-      expect(res.status).toBe(404);
-    }
+    const res = await request(app).get('/api/roadmap/me').expect(200);
+    expect(res.body.uniqueId).toBe(4002);
+    expect(res.body.displayName).toBe('LinkedUser');
   });
 
   // ─── New tests: type safety ────────────────────────────────────
@@ -600,6 +606,34 @@ describe('GET /api/roadmap/me — spread-order safety (identity invariant)', () 
     const res = await request(app).get('/api/roadmap/me').expect(200);
     expect(res.body.uniqueId).toBe(2002);
     expect(res.body.displayName).toBe('FallbackUser');
+  });
+
+  // Type-shape parity between the two auth paths: the direct path coerces
+  // `req.auth.uniqueId` to Number via `Number(...)`; the fallback must do
+  // the same so legacy identityMap docs that store the FK as a string don't
+  // produce a string `uniqueId` in the response. Without the coercion, a
+  // single API contract leaks two different runtime types for the same
+  // field, depending on which auth path resolved the request.
+  test('identityMap fallback path: string uniqueId in identityMap is coerced to number in response', async () => {
+    mockCollectionGet.mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: 'google:legacy@gmail.com',
+          data: () => ({ uniqueId: '5005', firebaseUid: 'firebase-uid-legacy' }),
+        },
+      ],
+    });
+    mockDocGet.mockImplementation((path) => {
+      if (path && path.includes('users/5005')) {
+        return Promise.resolve(makeUserDoc(5005, { displayName: 'LegacyString' }));
+      }
+      return Promise.resolve({ exists: false });
+    });
+    const app = createApp({ uid: 'firebase-uid-legacy', uniqueId: null });
+    const res = await request(app).get('/api/roadmap/me').expect(200);
+    expect(typeof res.body.uniqueId).toBe('number');
+    expect(res.body.uniqueId).toBe(5005);
   });
 });
 

--- a/express-api/tests/routes/roadmap-auth.test.js
+++ b/express-api/tests/routes/roadmap-auth.test.js
@@ -334,12 +334,9 @@ describe('GET /api/roadmap/me', () => {
     expect(typeof res.body.displayName).toBe('string');
   });
 
-  // Replaces the prior `response time under 500ms` test (non-load-bearing on
-  // a synchronous mock — could never fail in CI, could only flake). Pin the
-  // request-shape invariant instead: when `req.auth.uniqueId` is set, the
-  // route makes exactly one direct `users/{id}` read and SKIPS the
-  // identityMap fallback query — a regression that always ran the fallback
-  // would double the Firestore RPC count on every authenticated request.
+  // Pin the request-shape invariant: the direct-uniqueId path makes one
+  // users-doc read and skips the identityMap query. A regression that always
+  // ran the fallback would double the Firestore RPC count per authed request.
   test('direct-uniqueId path makes exactly one users-doc read and skips identityMap', async () => {
     mockDocGet.mockImplementation((path) => {
       if (path && path.includes('users/')) {
@@ -456,10 +453,8 @@ describe('GET /api/roadmap/me', () => {
     const res = await request(app).get('/api/roadmap/me').expect(200);
     expect(res.body.uniqueId).toBe(4002);
     expect(res.body.displayName).toBe('LinkedUser');
-    // Strong pin: the unlinked entry's user doc must NEVER be fetched. A
-    // "fetch all then pick last" regression that happened to land on 4002
-    // would pass the toBe-4002 assertion above — this negative assertion
-    // closes that gap.
+    // Closes the "fetch all, pick last" regression: a route that fetched
+    // users/4001 anyway would pass the toBe(4002) above but fail here.
     expect(mockDocGet).not.toHaveBeenCalledWith('users/4001');
     expect(mockDocGet).toHaveBeenCalledWith('users/4002');
   });
@@ -553,17 +548,11 @@ describe('GET /api/roadmap/me', () => {
 // GET /api/roadmap/me — spread-order safety (identity invariant)
 // ═══════════════════════════════════════════════════════════════
 //
-// `uniqueId` is the authoritative identity for the authenticated request —
-// either copied from `req.auth.uniqueId` (verified by upstream auth middleware
-// against the Firebase token) or sourced from the identityMap lookup. The
-// user doc payload is treated as untrusted: even though Firestore rules deny
-// client writes to the `uniqueId` field today, a future schema migration,
-// admin-tool write, or rule-drift could persist a rogue value. If the user
-// doc's payload ever overrode the trusted uniqueId, /roadmap/me would return
-// a profile under the *wrong* numeric identity — the strongest possible
-// identity-spoofing shape for an authenticated endpoint.
-//
-// Pins the spread-order contract: `{ ...userDoc.data(), uniqueId: <trusted> }`.
+// Pins the spread-order contract `{ ...userDoc.data(), uniqueId: <trusted> }`
+// on both auth paths. A rogue `uniqueId` field in the user doc payload (from
+// schema drift, admin-tool write, or rule drift) must not override the
+// trusted authenticated value — that is the strongest identity-spoofing
+// shape on an authenticated endpoint.
 
 describe('GET /api/roadmap/me — spread-order safety (identity invariant)', () => {
   test('direct uniqueId path: payload uniqueId cannot override authenticated uniqueId', async () => {
@@ -698,14 +687,10 @@ describe('GET /api/roadmap/me — Auth edge cases', () => {
     expect(res.status).toBe(404);
   });
 
-  // Pre-existing falsy-guard analysis: requireAuth's `!req.auth.uniqueId`
-  // treats 0 the same as null/undefined. With a truthy uid the guard does
-  // NOT fire on uniqueId=0; the route falls through to the identityMap
-  // fallback. This test pins that current behavior so a future "tighten the
-  // guard" refactor (e.g. switching to `req.auth.uniqueId == null`) doesn't
-  // change the response shape unintentionally. ShyTalk uniqueIds are
-  // demonstrably positive integers (provisioning never assigns 0), so this
-  // is a regression pin, not a real-world bug surface.
+  // requireAuth's `!req.auth.uniqueId` treats 0 like null/undefined — with a
+  // truthy uid, the guard does NOT fire and the route falls through to the
+  // identityMap path. Pin that contract so a future "tighten the guard"
+  // refactor (e.g. switching to `== null`) doesn't change the response shape.
   test('uniqueId of 0 with truthy uid falls through to identityMap (returns 404 when empty)', async () => {
     mockCollectionGet.mockResolvedValue({ empty: true, docs: [] });
     mockDocGet.mockResolvedValue({ exists: false });

--- a/express-api/tests/utils/firestore-helpers.test.js
+++ b/express-api/tests/utils/firestore-helpers.test.js
@@ -64,3 +64,40 @@ describe('queryDocs', () => {
     expect(results).toEqual([]);
   });
 });
+
+// The Firestore doc reference's `.id` is the authoritative storage-layer key.
+// The payload (`snap.data()`) is untrusted because user-writable Firestore
+// rules can let an `id` field be persisted on the doc body (legacy schema,
+// migration drift, adversarial write). If the helper ever lets the payload's
+// `id` win over the doc's own `id`, every caller of getDoc/queryDocs is
+// silently mis-attributing records — IDs flowing into authorization checks,
+// admin UIs, exports, and analytics would be wrong-but-plausible.
+//
+// Pins the spread-order contract: `{ ...snap.data(), id: snap.id }`.
+describe('spread-order safety (privacy invariant)', () => {
+  test('getDoc: trusted snap.id wins over payload.id', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      id: 'real-doc-id',
+      data: () => ({ id: 'rogue-payload-id', name: 'spoofed' }),
+    });
+
+    const result = await getDoc('collection/real-doc-id');
+    expect(result.id).toBe('real-doc-id');
+    expect(result.name).toBe('spoofed');
+  });
+
+  test('queryDocs: trusted d.id wins over payload.id for every result', async () => {
+    const mockRef = { get: mockQueryGet };
+    mockQueryGet.mockResolvedValue({
+      docs: [
+        { id: 'real-a', data: () => ({ id: 'rogue-a', name: 'Alice' }) },
+        { id: 'real-b', data: () => ({ id: 'rogue-b', name: 'Bob' }) },
+      ],
+    });
+
+    const results = await queryDocs(mockRef);
+    expect(results.map((r) => r.id)).toEqual(['real-a', 'real-b']);
+    expect(results.map((r) => r.name)).toEqual(['Alice', 'Bob']);
+  });
+});

--- a/express-api/tests/utils/firestore-helpers.test.js
+++ b/express-api/tests/utils/firestore-helpers.test.js
@@ -118,4 +118,23 @@ describe('spread-order safety (privacy invariant)', () => {
     const result = await getDoc('collection/doc-undef');
     expect(result).toEqual({ id: 'doc-undef' });
   });
+
+  // Same `{ ...undefined } -> {}` invariant for queryDocs: a single
+  // undefined-payload doc must not poison the entire result array nor crash
+  // the spread; neighbouring well-formed docs must still pass through. Pins
+  // the queryDocs side of the contract symmetrically with the getDoc case
+  // above so a future spread-shape refactor can't regress one without
+  // failing both.
+  test('queryDocs: data() returning undefined on one doc yields { id } only, others unaffected', async () => {
+    const mockRef = { get: mockQueryGet };
+    mockQueryGet.mockResolvedValue({
+      docs: [
+        { id: 'normal', data: () => ({ name: 'Alice' }) },
+        { id: 'undef', data: () => undefined },
+      ],
+    });
+
+    const results = await queryDocs(mockRef);
+    expect(results).toEqual([{ id: 'normal', name: 'Alice' }, { id: 'undef' }]);
+  });
 });

--- a/express-api/tests/utils/firestore-helpers.test.js
+++ b/express-api/tests/utils/firestore-helpers.test.js
@@ -138,3 +138,21 @@ describe('spread-order safety (privacy invariant)', () => {
     expect(results).toEqual([{ id: 'normal', name: 'Alice' }, { id: 'undef' }]);
   });
 });
+
+// The helpers do not try/catch — they let Firestore rejections propagate to
+// the caller, which is the documented contract every consumer depends on for
+// upstream error handling. Pin both rejection paths so a future "defensive"
+// wrapper (e.g. swallowing errors and returning null/[]) cannot silently
+// turn every consumer's catch block into dead code.
+describe('error propagation', () => {
+  test('getDoc: rejects unmodified when snap.get() rejects', async () => {
+    mockDocGet.mockRejectedValue(new Error('DEADLINE_EXCEEDED'));
+    await expect(getDoc('collection/anything')).rejects.toThrow('DEADLINE_EXCEEDED');
+  });
+
+  test('queryDocs: rejects unmodified when ref.get() rejects', async () => {
+    const mockRef = { get: mockQueryGet };
+    mockQueryGet.mockRejectedValue(new Error('PERMISSION_DENIED'));
+    await expect(queryDocs(mockRef)).rejects.toThrow('PERMISSION_DENIED');
+  });
+});

--- a/express-api/tests/utils/firestore-helpers.test.js
+++ b/express-api/tests/utils/firestore-helpers.test.js
@@ -100,4 +100,22 @@ describe('spread-order safety (privacy invariant)', () => {
     expect(results.map((r) => r.id)).toEqual(['real-a', 'real-b']);
     expect(results.map((r) => r.name)).toEqual(['Alice', 'Bob']);
   });
+
+  // ECMAScript spread of `undefined` produces `{}` silently. A mocked or
+  // legacy-tier Firestore snap that reports `exists: true` but whose `data()`
+  // returns `undefined` would therefore pass through the helper as
+  // `{ id: snap.id }` — the trusted id still wins, no crash, payload is empty.
+  // Pinning this avoids a future "defensive" refactor (e.g. wrapping
+  // `snap.data() ?? {}` then changing spread order again) silently regressing
+  // the contract or introducing a TypeError on the spread.
+  test('getDoc: data() returning undefined on an existing doc yields { id } (no crash)', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      id: 'doc-undef',
+      data: () => undefined,
+    });
+
+    const result = await getDoc('collection/doc-undef');
+    expect(result).toEqual({ id: 'doc-undef' });
+  });
 });


### PR DESCRIPTION
## Summary

Defense-in-depth fix for the object-literal spread-order vulnerability pattern PR #975 closed in the suggestion vote/comment mappers — same shape, different files, same fix.

- **`roadmap-auth.js`** — `/roadmap/me` direct-uniqueId AND identityMap-fallback paths spread the user-doc payload BEFORE writing the trusted `uniqueId`. A rogue `uniqueId` field in the payload (from schema drift / admin-tool write / rule drift) can no longer impersonate a different account on the authenticated endpoint. The identityMap fallback also now coerces `Number(idData.uniqueId)` for type parity with the direct path.
- **`firestore-helpers.js`** — `getDoc` and `queryDocs` spread payload before the trusted doc-reference `id`. The 10 caller modules (banners, fun-facts, config, users, admin-users, admin-cleanup, reports, evict-suspended-user, data-export-builder, accountDeletion) inherit the fix automatically.

Firestore rules at `firestore.rules:43+` deny client writes to `uniqueId` today, so this isn't an exploitable bug at HEAD — it's defense-in-depth against the same class PR #975 closed, applied consistently across the next two highest-risk surfaces.

## Review cycle

5 rounds to ZERO findings:

| Round | Findings | Addressed in commit |
|---|---|---|
| R1 | 1 Critical + 3 Important + 2 Minor | 2 (pre-existing test weaknesses + numeric-coercion asymmetry) |
| R2 | 0C + 2I + 1M + 1 gap | 3 (negative-assertion on unlinked, exact-401 pin, single-read invariant, queryDocs undefined-data) |
| R3 | 0C + 1I + 1M | 4 (uniqueId=0 regression pin, tightened disjunctive) |
| R4 | 0C + 1I advisory + 1 follow-up condition | 5 (rejection-propagation tests + comment trim) — both bundled per `[[feedback-fix-pre-existing-and-new-same]]` |
| R5 | **0C + 0I + 0M — safe to merge** | — |

## Test plan

- [x] `firestore-helpers.test.js`: spread-order safety (getDoc + queryDocs), undefined-data on existing doc, rejection propagation
- [x] `roadmap-auth.test.js`: identity-invariant spread on both auth paths, numeric coercion of identityMap FK, single-read invariant, strengthened unlinked skip with negative assertion, exact-401 empty-uid, uniqueId=0 fallthrough regression pin, deterministic multiple-entry break
- [x] Full express-api suite: 300 suites, **11,154 passing**, 1 skipped (+10 since baseline)
- [x] ESLint `--max-warnings=0` + Prettier `--check` clean (pre-commit hooks)
- [x] Pre-push: SonarCloud quality gate passed locally
- [ ] CI green
- [ ] Auto-merge fires when required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)