### PR TITLE
fix(express-api): spread-order safety on conversations message routes

### DIFF
--- a/express-api/src/routes/conversations.js
+++ b/express-api/src/routes/conversations.js
@@ -234,7 +234,13 @@ router.get('/conversations/:id/messages', async (req, res) => {
       .limit(limit)
       .get();
 
-    const messages = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    // Spread the payload BEFORE writing the trusted doc-ref id, so that a
+    // same-named `id` field in the stored message data (whether from a
+    // future schema migration or an adversarial Firestore write) cannot
+    // override the doc's true identity in the response. buildMessage
+    // below reads `doc.id`, so a payload-supplied id would otherwise
+    // propagate all the way to the JSON sent to the client.
+    const messages = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     // Return in chronological order (oldest first)
     return res.json(messages.toReversed().map(buildMessage));
@@ -384,8 +390,14 @@ router.post('/conversations/:id/messages', async (req, res) => {
       }),
     );
 
+    // Spread msgData BEFORE the trusted server-generated `id` so that
+    // an `id` field never wins from the spread side — defensive
+    // ordering for the day msgData gains an `id` field via a future
+    // schema migration. `replyToMessageId` is also written last so it
+    // overrides msgData.replyToMessageId if present (the explicit
+    // rewrite from `replyToId` is the canonical name).
     return res.json(
-      buildMessage({ id: messageId, ...msgData, replyToMessageId: msgData.replyToId }),
+      buildMessage({ ...msgData, id: messageId, replyToMessageId: msgData.replyToId }),
     );
   } catch (err) {
     log.error('conversations', 'Failed to send message', {

--- a/express-api/tests/routes/conversations.test.js
+++ b/express-api/tests/routes/conversations.test.js
@@ -142,6 +142,56 @@ describe('GET /api/conversations/:id/messages', () => {
     const app = createApp('user-A');
     await request(app).get('/api/conversations/conv-1/messages').expect(403);
   });
+
+  test('payload id in stored doc does NOT override doc-ref id in response (spread-order privacy invariant)', async () => {
+    // Adversarial: a stored message doc has `id: 'rogue-spoofed-id'` in
+    // its payload (from a future schema migration or a malicious write
+    // to Firestore). The response's `id` MUST be the doc-ref id
+    // ('real-doc-id'), not the payload value — otherwise an attacker
+    // could misattribute message identity in the API response, breaking
+    // user-side correlation with audit/moderation refs that cite the
+    // real doc id. Same defense-in-depth pattern as the data-export-
+    // builder mappers (PR #977) and the firestore-helpers queryDocs
+    // fix (PR #976).
+    mockDocGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ participantIds: ['user-A', 'user-B'] }),
+    });
+
+    const { db } = require('../../src/utils/firebase');
+    db.collection.mockReturnValueOnce({
+      orderBy: jest.fn(() => ({
+        limit: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue({
+            docs: [
+              {
+                id: 'real-doc-id',
+                data: () => ({
+                  id: 'rogue-spoofed-id',
+                  senderId: 'user-A',
+                  text: 'attempted spoof',
+                  createdAt: 1700000000000,
+                }),
+              },
+            ],
+          }),
+        })),
+      })),
+    });
+
+    const app = createApp();
+    const res = await request(app).get('/api/conversations/conv-1/messages').expect(200);
+
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].id).toBe('real-doc-id');
+    expect(res.body[0].id).not.toBe('rogue-spoofed-id');
+    // buildMessage also emits messageId = doc.id; the same spread-order
+    // protection must keep both id fields trusted.
+    expect(res.body[0].messageId).toBe('real-doc-id');
+    // Sanity: other payload fields still flow through unchanged.
+    expect(res.body[0].text).toBe('attempted spoof');
+    expect(res.body[0].senderId).toBe('user-A');
+  });
 });
 
 describe('POST /api/conversations/:id/messages', () => {


### PR DESCRIPTION
## Summary

Continuation of the adversarial-spread-order audit cluster. Fixes 2 inline object-literal sites in `express-api/src/routes/conversations.js` where trusted fields were placed BEFORE the payload spread, letting a same-named field in the payload override.

- **Read path (line 237)**: `snap.docs.map((d) => ({ id: d.id, ...d.data() }))` — payload `id` propagated through `buildMessage(doc)` to `res.json`. **Exploitable today**: any stored message doc with `id` in its payload misattributed the entry in the GET response.
- **Send path (line 388)**: `buildMessage({ id: messageId, ...msgData, ... })` — defense-in-depth; `msgData` has no current `id` input vector (server-built from cherry-picked body fields), but the order would activate if a future schema migration added one.

Both sites now spread first, trusted fields last — same defense-in-depth pattern as PR #975/#976/#977.

## Tests

- 1 new integration test (GET) asserts a payload-supplied `id: 'rogue-spoofed-id'` does NOT override the doc-ref id in the response (covers both `res.body[0].id` and `res.body[0].messageId` — buildMessage emits both from `doc.id`).
- Send-path's contract was already pinned at line 201 (`res.body.id === 'msg-123'` generateId mock value) — that test continues to pass after the order flip.
- Test count: 11182 → 11183.

## Test plan

- [x] \`cd express-api && npm test\` — 11183 passed, 1 skipped, 300/300 suites
- [x] \`npx prettier --check\` clean on changed files
- [x] \`npx eslint\` clean on changed files
- [x] Pre-push SonarCloud quality gate passed (after \`./gradlew --stop\`)
- [ ] CI status checks
- [ ] Auto-merge

## Open follow-ups (next session)

- Single-callsite read paths in `suggestions.js`, `identity-graph.js`, etc. (\~18 remaining in the open-follow-up group)
- \`admin-*\` routes sweep (\~40 callsites, lower-risk admin-only reads)
- \`economy.js\` (\~10 callsites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)