### PR TITLE
fix(express-api): spread-order safety in 23 sites (suggestions/identity-graph/economy)

### DIFF
--- a/express-api/src/routes/economy.js
+++ b/express-api/src/routes/economy.js
@@ -212,9 +212,14 @@ async function updateGiftWall(recipientId, giftId, senderId, quantity, senderCoh
  * Write a transaction record.
  */
 async function writeTransaction(userId, txId, data) {
+  // Defensive spread order: place the caller-supplied `data` BEFORE the
+  // trusted server-generated txId so that an accidental or malicious
+  // `id` field in `data` cannot override the canonical transaction id
+  // written to Firestore. Same defense-in-depth pattern as PR
+  // #975/#976/#977/#978.
   await db.doc(`users/${userId}/transactions/${txId}`).set({
-    id: txId,
     ...data,
+    id: txId,
     timestamp: data.timestamp || now(),
   });
 }
@@ -590,7 +595,7 @@ router.post('/economy/gacha', async (req, res) => {
       .orderBy('order')
       .limit(16)
       .get();
-    const allGifts = giftsSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const allGifts = giftsSnap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     if (allGifts.length === 0) return res.status(500).json({ error: 'No winnable gifts' });
 
@@ -779,7 +784,7 @@ router.post('/economy/gift', async (req, res) => {
       db.doc(`users/${recipientId}`).get(),
     ]);
 
-    const gift = giftSnap.exists ? { id: giftSnap.id, ...giftSnap.data() } : null;
+    const gift = giftSnap.exists ? { ...giftSnap.data(), id: giftSnap.id } : null;
     const bpItem = bpSnap.exists ? bpSnap.data() : null;
     const sender = senderSnap.exists ? senderSnap.data() : null;
     const recipient = recipientSnap.exists ? recipientSnap.data() : null;
@@ -934,7 +939,7 @@ router.post('/economy/gift-direct', async (req, res) => {
       db.doc(`users/${recipientId}`).get(),
     ]);
 
-    const gift = giftSnap.exists ? { id: giftSnap.id, ...giftSnap.data() } : null;
+    const gift = giftSnap.exists ? { ...giftSnap.data(), id: giftSnap.id } : null;
     const sender = senderSnap.exists ? senderSnap.data() : null;
     const recipient = recipientSnap.exists ? recipientSnap.data() : null;
 
@@ -1080,7 +1085,7 @@ router.post('/economy/gift-batch', async (req, res) => {
 
     const giftSnap = await db.doc(`gifts/${giftId}`).get();
     if (!giftSnap.exists) return res.status(404).json({ error: 'Gift not found' });
-    const gift = { id: giftSnap.id, ...giftSnap.data() };
+    const gift = { ...giftSnap.data(), id: giftSnap.id };
 
     const senderSnap = await db.doc(`users/${uniqueId}`).get();
     if (!senderSnap.exists) return res.status(404).json({ error: 'Sender not found' });
@@ -1293,7 +1298,7 @@ router.post('/economy/backpack-send', async (req, res) => {
 
     // Get backpack items (excluding trial items)
     const backpackSnap = await db.collection(`users/${uniqueId}/backpack`).get();
-    const backpackItems = backpackSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const backpackItems = backpackSnap.docs.map((d) => ({ ...d.data(), id: d.id }));
     const sendableItems = backpackItems.filter(
       (item) => item.giftId !== 'super_shy_trial' && (item.quantity || 0) > 0,
     );
@@ -1916,7 +1921,7 @@ router.get('/economy/transactions', async (req, res) => {
     query = query.orderBy('timestamp', 'desc').limit(limit);
 
     const snap = await query.get();
-    const results = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const results = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
     res.json(results);
   } catch (err) {
     log.error('economy', 'GET /economy/transactions failed', { error: err.message });
@@ -1932,7 +1937,7 @@ router.get('/users/:uniqueId/backpack', async (req, res) => {
       return res.status(403).json({ error: "Cannot access another user's backpack" });
     }
     const snap = await db.collection(`users/${req.params.uniqueId}/backpack`).get();
-    const results = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const results = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
     res.json(results);
   } catch (err) {
     log.error('economy', 'GET /users/:uniqueId/backpack failed', { error: err.message });
@@ -1961,7 +1966,7 @@ router.get('/users/:uniqueId/gift-wall', async (req, res) => {
     }
 
     const snap = await db.collection(`users/${req.params.uniqueId}/giftWall`).get();
-    const results = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const results = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
     res.json(results);
   } catch (err) {
     log.error('economy', 'GET /users/:uniqueId/gift-wall failed', { error: err.message });

--- a/express-api/src/routes/identity-graph.js
+++ b/express-api/src/routes/identity-graph.js
@@ -90,7 +90,11 @@ router.get('/admin/bans/graph/:id', async (req, res) => {
     const doc = await db.doc(`identityGraphs/${req.params.id}`).get();
     if (!doc.exists) return res.status(404).json({ error: 'Identity graph not found' });
 
-    res.json({ id: doc.id, ...doc.data() });
+    // Spread payload BEFORE doc-ref id so a same-named `id` field in the
+    // stored identityGraph data cannot override the doc's true identity.
+    // Admin-only endpoint, so currently low exploitability, but follows
+    // the canonical defense-in-depth pattern (PR #975/#976/#977/#978).
+    res.json({ ...doc.data(), id: doc.id });
   } catch (err) {
     log.error('identity-graph', 'Failed to get graph', { error: err.message });
     res.status(500).json({ error: 'Internal server error' });

--- a/express-api/src/routes/suggestions.js
+++ b/express-api/src/routes/suggestions.js
@@ -141,7 +141,7 @@ router.get('/suggestions/mine', async (req, res) => {
       .orderBy('createdAt', 'desc')
       .get();
 
-    const suggestions = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const suggestions = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
     res.json({ suggestions });
   } catch (err) {
     log.error('suggestions', 'Failed to list own suggestions', { error: err.message });
@@ -180,7 +180,7 @@ router.get('/suggestions/search', async (req, res) => {
 
     const query = q.toLowerCase().trim();
     const matches = snap.docs
-      .map((d) => ({ id: d.id, ...d.data() }))
+      .map((d) => ({ ...d.data(), id: d.id }))
       .filter((s) => {
         const title = (s.title || '').toLowerCase();
         const desc = (s.description || '').toLowerCase();
@@ -207,7 +207,7 @@ router.get('/suggestions/blocked', async (req, res) => {
 
     const snap = await db.collection('blockedTopics').get();
     const topics = snap.docs
-      .map((d) => ({ id: d.id, ...d.data() }))
+      .map((d) => ({ ...d.data(), id: d.id }))
       .filter((t) => similarity(q, t.title) >= SIMILARITY_THRESHOLD * 0.75);
 
     const matches = topics.map((t) => ({
@@ -262,14 +262,21 @@ router.get('/suggestions/:id', async (req, res) => {
       .orderBy('createdAt', 'asc')
       .get();
 
-    let comments = commentsSnap.docs.map((c) => ({ id: c.id, ...c.data() }));
+    let comments = commentsSnap.docs.map((c) => ({ ...c.data(), id: c.id }));
     if (!isAdmin) {
       comments = comments.filter((c) => c.isPublic !== false);
     }
 
+    // Spread the doc payload BEFORE the trusted doc-ref id so that a
+    // same-named `id` field in the stored suggestion data — whether from
+    // a future schema migration or an adversarial Firestore write —
+    // cannot override the doc's true identity in the response. Same
+    // defense-in-depth pattern as conversations.js (PR #978),
+    // data-export-builder mappers (PR #977), firestore-helpers
+    // queryDocs (PR #976), and roadmap-auth (PR #975).
     const result = {
-      id: doc.id,
       ...data,
+      id: doc.id,
       netScore: (data.upvotes || 0) - (data.downvotes || 0),
       comments,
       commentCount: commentsSnap.size,
@@ -287,7 +294,7 @@ router.get('/suggestions/:id', async (req, res) => {
           .get();
         result.submitterOtherSuggestions = otherSnap.docs
           .filter((d) => d.id !== id)
-          .map((d) => ({ id: d.id, ...d.data() }));
+          .map((d) => ({ ...d.data(), id: d.id }));
       } catch {
         result.submitterOtherSuggestions = [];
       }
@@ -330,7 +337,7 @@ router.get('/suggestions', async (req, res) => {
     }
 
     const snap = await query.get();
-    let suggestions = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    let suggestions = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     // Enforce status filter client-side (Firestore where may not filter in all environments)
     if (!status) {
@@ -844,7 +851,12 @@ router.post('/suggestions/:id/comments', async (req, res) => {
     };
 
     await db.doc(`suggestions/${id}/comments/${commentId}`).set(comment);
-    res.status(201).json({ id: commentId, ...comment });
+    // Defensive spread order: even though `comment` is server-built from
+    // cherry-picked body fields (authorUid, text, isPublic, createdAt) and
+    // therefore has no current `id` input vector, place the spread BEFORE
+    // the trusted commentId so the order would still hold if the comment
+    // shape ever gains an `id` field via a future schema migration.
+    res.status(201).json({ ...comment, id: commentId });
   } catch (err) {
     log.error('suggestions', 'Failed to add comment', { error: err.message });
     res.status(500).json({ error: 'Internal server error' });
@@ -953,7 +965,7 @@ router.get('/admin/suggestions/disputes', async (req, res) => {
       .orderBy('createdAt', 'desc')
       .get();
 
-    const disputes = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const disputes = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
     res.json({ disputes });
   } catch (err) {
     log.error('admin-suggestions', 'Failed to list disputes', { error: err.message });
@@ -1040,7 +1052,7 @@ router.get('/admin/suggestions', async (req, res) => {
 
     const { q, status } = req.query;
     const snap = await db.collection('suggestions').get();
-    let suggestions = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    let suggestions = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     // Apply status filter if provided (11.92 badge count test depends on this).
     if (status) {
@@ -1590,7 +1602,7 @@ router.get('/admin/suggestions/:id', async (req, res) => {
     const { id } = req.params;
     const doc = await db.doc(`suggestions/${id}`).get();
     if (!doc.exists) return res.status(404).json({ error: 'Suggestion not found' });
-    res.json({ id: doc.id, ...doc.data() });
+    res.json({ ...doc.data(), id: doc.id });
   } catch (err) {
     log.error('admin-suggestions', 'Get single failed', { error: err.message });
     res.status(500).json({ error: 'Internal server error' });
@@ -1744,7 +1756,7 @@ router.get('/admin/notifications', async (req, res) => {
     if (await requireAdmin(req, res)) return;
     const { userId, type } = req.query;
     const snap = await db.collection('notifications').get();
-    let notifications = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    let notifications = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
     if (userId) {
       notifications = notifications.filter(
         (n) =>
@@ -1819,7 +1831,7 @@ router.get('/admin/suggestions/:id/history', async (req, res) => {
       return map[raw] || raw;
     }
     const events = uniqueDocs
-      .map((d) => ({ id: d.id, ...d.data() }))
+      .map((d) => ({ ...d.data(), id: d.id }))
       .sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0))
       .map((e) => ({
         action: normaliseAction(e),

--- a/express-api/tests/routes/suggestions-read.test.js
+++ b/express-api/tests/routes/suggestions-read.test.js
@@ -453,6 +453,35 @@ describe('GET /api/suggestions/:id — Get single', () => {
     const res = await request(app).get('/api/suggestions/sug1').expect(200);
     expect(res.body.rejectReason).toBe('Too vague');
   });
+
+  test('payload id in stored doc does NOT override doc-ref id (spread-order privacy invariant)', async () => {
+    // Adversarial: a stored suggestion doc has `id: 'rogue-spoofed-id'`
+    // inside its data payload — e.g. from a future schema migration that
+    // denormalised an id field, or from a malicious direct Firestore
+    // write by a user with write access to their own suggestion doc.
+    // The response's top-level `id` MUST be the doc-ref id
+    // ('real-doc-id'), not the payload value, otherwise an attacker
+    // could misattribute suggestion identity in the API response and
+    // break user-side correlation with audit/moderation/dispute refs
+    // that cite the real doc id. Same defense-in-depth pattern as
+    // conversations.js read path (PR #978), data-export-builder mappers
+    // (PR #977), firestore-helpers queryDocs (PR #976), and
+    // roadmap-auth (PR #975).
+    mockDocGet.mockImplementation((path) => {
+      if (path && path.includes('suggestions/')) {
+        return Promise.resolve(makeSuggestionDoc('real-doc-id', { id: 'rogue-spoofed-id' }));
+      }
+      return Promise.resolve({ exists: false });
+    });
+    mockCollectionGet.mockResolvedValueOnce({ empty: true, docs: [], size: 0 }); // comments
+    const app = createApp();
+    const res = await request(app).get('/api/suggestions/real-doc-id').expect(200);
+    expect(res.body.id).toBe('real-doc-id');
+    expect(res.body.id).not.toBe('rogue-spoofed-id');
+    // Sanity: other payload fields still flow through unchanged.
+    expect(res.body.title).toBe('Test suggestion');
+    expect(res.body.status).toBe('accepted');
+  });
 });
 
 describe('GET /api/suggestions/mine — Own submissions', () => {


### PR DESCRIPTION
## Summary

- Continues the adversarial-spread-order audit cluster (PR #975/#976/#977/#978).
- 23 vulnerable `{ id: trustedId, ...untrustedPayload }` sites flipped across 3 files.
- Most-exploitable site is the user-facing `GET /suggestions/:id` result block (suggestions.js line 271 pre-fix) — a stored `id` payload would have misattributed suggestion identity in the response.

## Inventory

| File | Sites | Notes |
|---|---|---|
| `src/routes/suggestions.js` | 13 | 12 read-path maps + 1 multi-line `result` block; mix of user-facing public API + admin moderation routes |
| `src/routes/identity-graph.js` | 1 | admin-only `/admin/bans/graph/:id`; pattern-consistent, low exploitability |
| `src/routes/economy.js` | 9 | 8 read paths (gacha gift list, 3 single-doc gift reads, backpack-send, GET transactions, GET backpack, GET gift-wall) + 1 defensive write path (`writeTransaction`) |

The 4 mutation entry points in economy.js that use explicit field literals (`addBroadcast`, `writeRoomGiftMessage`) are NOT vulnerable — they list each field by name rather than spreading caller data, so they're unchanged.

`writeTransaction` caller analysis: all 17 callers pass server-derived data with no `id` field today — the write-path flip is purely defense-in-depth against future schema migrations.

## Test plan

- [ ] +1 integration test in `suggestions-read.test.js` asserts `GET /suggestions/:id` returns the doc-ref id (not a rogue payload `id`) and that non-id fields (title, status) flow through unchanged
- [ ] 11183 → 11184 tests passing (full express-api suite green, 300 suites, 1 pre-existing skip)
- [ ] Zero self-review findings; same defense-in-depth pattern as PR #978 / #977 / #976 / #975

🤖 Generated with [Claude Code](https://claude.com/claude-code)