### PR TITLE
fix(express-api): spread-order safety in 13 admin-cleanup sites

### DIFF
--- a/express-api/src/routes/admin-cleanup.js
+++ b/express-api/src/routes/admin-cleanup.js
@@ -136,7 +136,7 @@ router.post('/cleanup/system-conversations', async (req, res) => {
       .collection('conversations')
       .where('participantIds', 'array-contains', 'SHYTALK_SYSTEM')
       .get();
-    const systemConvs = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const systemConvs = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     let deleted = 0;
     const seen = new Map(); // recipientUid → first conversation id
@@ -178,7 +178,7 @@ router.post('/cleanup/all-system-conversations', async (req, res) => {
       .collection('conversations')
       .where('participantIds', 'array-contains', 'SHYTALK_SYSTEM')
       .get();
-    const systemConvs = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const systemConvs = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     for (const conv of systemConvs) {
       await deleteConversation(conv.id);
@@ -272,7 +272,7 @@ router.post('/cleanup/all-backpacks', async (req, res) => {
     log.info('admin-cleanup', 'Clearing all backpacks', { adminId: req.auth.uniqueId });
 
     const usersSnap = await db.collection('users').orderBy('uid').get();
-    const users = usersSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const users = usersSnap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     let deleted = 0;
     for (const user of users) {
@@ -304,7 +304,7 @@ router.post('/cleanup/all-giftwalls', async (req, res) => {
     log.info('admin-cleanup', 'Clearing all gift walls', { adminId: req.auth.uniqueId });
 
     const usersSnap = await db.collection('users').orderBy('uid').get();
-    const users = usersSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const users = usersSnap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     let deleted = 0;
     for (const user of users) {
@@ -395,7 +395,7 @@ router.post('/cleanup/all-spin-history', async (req, res) => {
 
     // Delete GACHA_PULL transactions from every user's transactions subcollection
     const usersSnap = await db.collection('users').orderBy('uid').get();
-    const users = usersSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const users = usersSnap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     let txDeleted = 0;
     for (const user of users) {
@@ -458,7 +458,7 @@ router.post('/cleanup/all-transactions', async (req, res) => {
     log.info('admin-cleanup', 'Deleting all transactions', { adminId: req.auth.uniqueId });
 
     const usersSnap = await db.collection('users').orderBy('uid').get();
-    const users = usersSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const users = usersSnap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     let deleted = 0;
     for (const user of users) {
@@ -513,7 +513,7 @@ router.post('/cleanup/backfill-user-type', async (req, res) => {
     log.info('admin-cleanup', 'Backfilling userType', { adminId: req.auth.uniqueId });
 
     const snap = await db.collection('users').limit(5000).get();
-    const users = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const users = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
     const missing = users.filter((u) => !u.userType && !u.user_type);
 
     if (missing.length === 0) {
@@ -564,7 +564,7 @@ router.post('/cleanup/all-private-messages', async (req, res) => {
     log.info('admin-cleanup', 'Deleting all private messages', { adminId: req.auth.uniqueId });
 
     const snap = await db.collection('conversations').limit(5000).get();
-    const allConvs = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const allConvs = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
     const pms = allConvs.filter((c) => !c.isGroup);
 
     if (pms.length === 0) {
@@ -601,7 +601,7 @@ router.post('/cleanup/all-group-chats', async (req, res) => {
       .where('isGroup', '==', true)
       .limit(5000)
       .get();
-    const allConvs = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const allConvs = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     if (allConvs.length === 0) {
       return res.json({
@@ -646,7 +646,7 @@ router.post('/cleanup/all-rooms', async (req, res) => {
     log.info('admin-cleanup', 'Deleting all closed rooms', { adminId: req.auth.uniqueId });
 
     const snap = await db.collection('rooms').where('state', '==', 'CLOSED').limit(200).get();
-    const closedRooms = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const closedRooms = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     if (closedRooms.length === 0) {
       return res.json({ success: true, deleted: 0, message: 'No closed rooms found' });
@@ -734,7 +734,7 @@ router.post('/cleanup/destroyed-users', async (req, res) => {
     });
 
     const snap = await db.collection('users').limit(5000).get();
-    const users = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const users = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     const destroyed = users.filter((u) => !u.createdAt);
     const intact = users.length - destroyed.length;
@@ -902,7 +902,7 @@ async function collectReferencedR2Keys(CDN_PREFIX) {
 
   // Conversations
   const convsSnap = await db.collection('conversations').limit(2000).get();
-  const convs = convsSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+  const convs = convsSnap.docs.map((doc) => ({ ...doc.data(), id: doc.id }));
   for (const conv of convs) {
     const key = extractR2Key(conv.groupPhotoUrl ?? conv.group_photo_url, CDN_PREFIX);
     if (key) referencedKeys.add(key);
@@ -911,7 +911,7 @@ async function collectReferencedR2Keys(CDN_PREFIX) {
   // Collect image keys from messages (conversations + rooms)
   await collectImageMessageKeys(convs.slice(0, 30), 'conversations', CDN_PREFIX, referencedKeys);
   const roomsSnap = await db.collection('rooms').limit(200).get();
-  const rooms = roomsSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+  const rooms = roomsSnap.docs.map((doc) => ({ ...doc.data(), id: doc.id }));
   await collectImageMessageKeys(rooms.slice(0, 30), 'rooms', CDN_PREFIX, referencedKeys);
 
   // Reports + archive

--- a/express-api/tests/routes/admin-cleanup-user.test.js
+++ b/express-api/tests/routes/admin-cleanup-user.test.js
@@ -492,6 +492,43 @@ describe('POST /api/cleanup/system-conversations', () => {
     expect(res.status).toBe(500);
     expect(res.body.error).toBeDefined();
   });
+
+  test('uses trusted doc.id (not payload id) when a duplicate doc carries an attacker-controlled id field', async () => {
+    const { queryDocs } = require('../../src/utils/firestore-helpers');
+    queryDocs.mockResolvedValue([]);
+
+    // Both docs share participantIds ['user-1', 'SHYTALK_SYSTEM']; canonical id is
+    // 'SHYTALK_SYSTEM_user-1' (uppercase S < lowercase u under localeCompare).
+    // The duplicate's REAL doc id is 'dup-rogue-id', but its data() injects a
+    // payload `id` matching the canonical id. With the unsafe spread order
+    // `{ id: d.id, ...d.data() }` the payload wins, the route mistakes the
+    // duplicate for canonical, and it survives (deleted: 0). With the safe
+    // order `{ ...d.data(), id: d.id }` the trusted doc.id wins, the route
+    // identifies the duplicate correctly, and deletes it (deleted: 1).
+    mockCollectionSnap = {
+      empty: false,
+      docs: [
+        {
+          id: 'SHYTALK_SYSTEM_user-1',
+          data: () => ({ participantIds: ['user-1', 'SHYTALK_SYSTEM'] }),
+        },
+        {
+          id: 'dup-rogue-id',
+          data: () => ({
+            id: 'SHYTALK_SYSTEM_user-1',
+            participantIds: ['user-1', 'SHYTALK_SYSTEM'],
+          }),
+        },
+      ],
+    };
+
+    const app = createApp(true);
+    const res = await request(app).post('/api/cleanup/system-conversations');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.deleted).toBe(1);
+  });
 });
 
 // ── POST /cleanup/all-system-conversations ──────────────────────


### PR DESCRIPTION
## Summary

- Reorder all 13 `{ id: doc.id, ...doc.data() }` mappers in `express-api/src/routes/admin-cleanup.js` to `{ ...doc.data(), id: doc.id }` so a payload `id` field can never override the trusted Firestore doc id.
- Without the fix, an adversarial `data()` payload could mislead downstream operations keyed off `id` — notably `deleteConversation(conv.id)` at `POST /cleanup/system-conversations` (could fool the canonical-vs-duplicate decision and either over- or under-delete) and `db.collection(\`users/\${uid}/<sub>\`)` paths on the user-iteration cleanup routes (could redirect deletes to the wrong user's subcollection).
- Write paths in this file (`batch.update(doc.ref, { shyCoins: 0 })` / `{ shyBeans: 0 }` / `{ pityCounter: 0 }` / `{ userType: 'MEMBER' }`) take no spread of user data, so **no companion write-path fix is required here** (unlike economy.js's `writeTransaction` defense-in-depth in #979).
- Continues the cluster: #975 → #976 → #977 → #978 → #979 → **this PR**.

## Sites fixed (13 / 1 file)

| Route | Lines |
|---|---|
| `POST /cleanup/system-conversations` (dedup) | 139 |
| `POST /cleanup/all-system-conversations` | 181 |
| `POST /cleanup/all-backpacks` | 275 |
| `POST /cleanup/all-giftwalls` | 307 |
| `POST /cleanup/all-spin-history` | 398 |
| `POST /cleanup/all-transactions` | 461 |
| `POST /cleanup/backfill-user-type` | 516 |
| `POST /cleanup/all-private-messages` | 567 |
| `POST /cleanup/all-group-chats` | 604 |
| `POST /cleanup/all-rooms` | 649 |
| `POST /cleanup/destroyed-users` | 737 |
| `GET /storage/audit` (collectReferencedR2Keys) | 905, 914 |

All single-line patterns — applied via 2 `replace_all` calls (one per `d`/`doc` variant). Zero residual unsafe patterns confirmed via grep.

## Tests

- **+1 integration test** in `admin-cleanup-user.test.js` exercising the dedup logic of `POST /cleanup/system-conversations`. The duplicate doc's `data()` injects an `id` matching the canonical id; without the fix the duplicate looks canonical and survives (`deleted: 0`); with the fix the trusted doc.id wins and the duplicate is correctly removed (`deleted: 1`). Confirmed **RED on unfixed code → GREEN on fixed code**.
- `11184 → 11185` passing. 300 suites green, 1 pre-existing skip.

## Test plan

- [x] Adversarial test fails on unfixed code (verified red): `Received: 0, Expected: 1`
- [x] Adversarial test passes after fix (verified green)
- [x] All 118 admin-cleanup-* tests pass
- [x] Full express-api suite passes (11185 / 11186, 1 pre-existing skip)
- [x] Pre-push SonarCloud quality gate passed (3m 24s)
- [x] Grep confirms zero residual unsafe `{ id: doc.id, ...doc.data() }` patterns in `admin-cleanup.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)