### PR TITLE
fix(express-api): spread-order safety in 14 remaining admin-* sites

### DIFF
--- a/express-api/src/routes/admin-age-verification.js
+++ b/express-api/src/routes/admin-age-verification.js
@@ -143,7 +143,7 @@ router.get('/admin/age-verification/pending', async (req, res) => {
       .where('status', '==', 'pending')
       .orderBy('submittedAt', 'asc')
       .get();
-    const submissions = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const submissions = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
     return res.json({ submissions });
   } catch (err) {
     log.error('admin-age-verification', 'list pending failed', { error: err?.message });

--- a/express-api/src/routes/admin-alerts.js
+++ b/express-api/src/routes/admin-alerts.js
@@ -38,7 +38,7 @@ router.get('/admin/alerts', async (req, res) => {
     query = query.limit(limit);
 
     const snapshot = await query.get();
-    const alerts = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    const alerts = snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id }));
 
     res.json({ alerts });
   } catch (err) {
@@ -89,7 +89,7 @@ router.get('/admin/alerts/:alertId', async (req, res) => {
       return res.status(404).json({ error: 'Alert not found' });
     }
 
-    res.json({ id: snap.id, ...snap.data() });
+    res.json({ ...snap.data(), id: snap.id });
   } catch (err) {
     log.error('admin-alerts', 'Error getting alert', {
       alertId: req.params.alertId,

--- a/express-api/src/routes/admin-audit-log.js
+++ b/express-api/src/routes/admin-audit-log.js
@@ -88,7 +88,7 @@ router.get('/admin/audit-log', async (req, res) => {
     for (const d of [...adminSnap.docs, ...auditSnap.docs, ...modSnap.docs]) {
       if (seen.has(d.id)) continue;
       seen.add(d.id);
-      merged.push({ id: d.id, ...d.data() });
+      merged.push({ ...d.data(), id: d.id });
     }
     merged.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
 

--- a/express-api/src/routes/admin-bans.js
+++ b/express-api/src/routes/admin-bans.js
@@ -51,11 +51,11 @@ router.get('/admin/bans', async (req, res) => {
     const nowMs = Date.now();
 
     const deviceBans = deviceSnap.docs
-      .map((d) => ({ id: d.id, ...d.data() }))
+      .map((d) => ({ ...d.data(), id: d.id }))
       .filter((b) => !b.expiresAt || new Date(b.expiresAt).getTime() > nowMs);
 
     const networkBans = networkSnap.docs
-      .map((d) => ({ id: d.id, ...d.data() }))
+      .map((d) => ({ ...d.data(), id: d.id }))
       .filter((b) => !b.expiresAt || new Date(b.expiresAt).getTime() > nowMs);
 
     res.json({ deviceBans, networkBans });
@@ -316,7 +316,7 @@ router.get('/admin/bans/user/:uniqueId', async (req, res) => {
       for (const d of snap.docs) {
         if (!seenDevice.has(d.id)) {
           seenDevice.add(d.id);
-          deviceBans.push({ id: d.id, ...d.data() });
+          deviceBans.push({ ...d.data(), id: d.id });
         }
       }
     }
@@ -327,7 +327,7 @@ router.get('/admin/bans/user/:uniqueId', async (req, res) => {
       for (const d of snap.docs) {
         if (!seenNetwork.has(d.id)) {
           seenNetwork.add(d.id);
-          networkBans.push({ id: d.id, ...d.data() });
+          networkBans.push({ ...d.data(), id: d.id });
         }
       }
     }

--- a/express-api/src/routes/admin-devices.js
+++ b/express-api/src/routes/admin-devices.js
@@ -26,7 +26,7 @@ router.get('/admin/devices', async (req, res) => {
     const offset = Math.max(Number.parseInt(req.query.offset, 10) || 0, 0);
 
     const snap = await db.collection('deviceBindings').get();
-    let devices = snap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    let devices = snap.docs.map((doc) => ({ ...doc.data(), id: doc.id }));
 
     // In-memory search (Firestore doesn't support full-text search)
     if (searchQuery) {
@@ -96,7 +96,7 @@ router.get('/admin/devices/user/:uniqueId', async (req, res) => {
     const uniqueId = Number(req.params.uniqueId);
     const snap = await db.collection('deviceBindings').where('uniqueId', '==', uniqueId).get();
 
-    const devices = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const devices = snap.docs.map((d) => ({ ...d.data(), id: d.id }));
 
     res.json({ devices });
   } catch (err) {
@@ -121,7 +121,7 @@ router.get('/admin/devices/:deviceId', async (req, res) => {
       return res.status(404).json({ error: 'Device binding not found' });
     }
 
-    res.json({ id: snap.id, ...snap.data() });
+    res.json({ ...snap.data(), id: snap.id });
   } catch (err) {
     log.error('admin-devices', 'Error fetching device binding', {
       deviceId: req.params.deviceId,

--- a/express-api/src/routes/admin-economy.js
+++ b/express-api/src/routes/admin-economy.js
@@ -290,7 +290,7 @@ router.get('/users/:uniqueId/transactions', async (req, res) => {
     query = query.limit(limit);
 
     const snapshot = await query.get();
-    const results = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+    const results = snapshot.docs.map((d) => ({ ...d.data(), id: d.id }));
     results.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
 
     res.json(results);

--- a/express-api/src/routes/admin-logs.js
+++ b/express-api/src/routes/admin-logs.js
@@ -55,7 +55,7 @@ router.get('/admin/logs', async (req, res) => {
 
     const snapshot = await query.get();
 
-    let logs = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    let logs = snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id }));
 
     // Client-side filters (can't be compound-queried in Firestore)
     if (route) {
@@ -93,7 +93,7 @@ router.get('/admin/logs/trace/:traceId', async (req, res) => {
       .limit(MAX_TRACE_LIMIT)
       .get();
 
-    const logs = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    const logs = snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id }));
 
     res.json({ logs });
   } catch (err) {

--- a/express-api/tests/routes/admin-devices.test.js
+++ b/express-api/tests/routes/admin-devices.test.js
@@ -185,6 +185,29 @@ describe('GET /api/admin/devices/:deviceId', () => {
 
     expect(res.body.error).toBe('Device binding not found');
   });
+
+  test('uses trusted snap.id (not payload id) when device doc data contains an attacker-controlled id field', async () => {
+    // Adversarial: the doc's REAL id is 'dev-001', but data() injects an `id`
+    // field that an attacker would have written to the deviceBindings doc.
+    // With the unsafe spread order `{ id: snap.id, ...snap.data() }` the
+    // payload id overrides the trusted doc id; with the safe order
+    // `{ ...snap.data(), id: snap.id }` the trusted doc.id wins.
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      id: 'dev-001',
+      data: () => ({
+        id: 'rogue-device-id',
+        userId: 'u1',
+        manufacturer: 'Samsung',
+        model: 'Galaxy S21',
+      }),
+    });
+
+    const app = createApp();
+    const res = await request(app).get('/api/admin/devices/dev-001').expect(200);
+
+    expect(res.body.id).toBe('dev-001');
+  });
 });
 
 describe('GET /api/admin/devices/user/:uniqueId', () => {


### PR DESCRIPTION
## Summary

Sweeping fix completing the adversarial-spread-order safety cluster. **8th and final PR** (#975 → #976 → #977 → #978 → #979 → #980 → #982 → **this**) — total 39 spread-order sites resolved across 11 files.

- Reorder all 14 `{ id: <ref>.id, ...<ref>.data() }` patterns in the 7 remaining admin-* route files to `{ ...<ref>.data(), id: <ref>.id }` so a payload `id` field on a Firestore doc can never override the trusted doc id.
- Three variable variants (`d`, `doc`, `snap`) covered by 3 mechanical `replace_all` calls.
- +1 adversarial integration test in `admin-devices.test.js` proves RED→GREEN on the most-exploitable site (single-doc direct `res.json`).

## Sites fixed (14 / 7 files)

| File | Lines | Variant | Route(s) |
|---|---|---|---|
| admin-devices.js | 29, 99, 124 | doc, d, snap | GET /admin/devices, /devices/user/:uid, /devices/:deviceId |
| admin-bans.js | 54, 58, 319, 330 | d | GET /admin/bans (deviceBans + networkBans), /bans/graph push |
| admin-logs.js | 58, 96 | doc | admin log listings |
| admin-alerts.js | 41, 92 | doc, snap | GET /admin/alerts, /alerts/:alertId |
| admin-economy.js | 293 | d | admin economy lookup |
| admin-audit-log.js | 91 | d | cross-collection merged.push |
| admin-age-verification.js | 146 | d | pending submissions list |

## Tests

- **+1 adversarial integration test** in `admin-devices.test.js` exercising `GET /admin/devices/:deviceId` with `snap.id='dev-001'` + `data().id='rogue-device-id'`. Without fix: `res.body.id === 'rogue-device-id'` (RED). With fix: `res.body.id === 'dev-001'` (GREEN). **RED→GREEN verified.**
- All existing admin-devices/bans/logs/alerts/economy/audit-log/age-verification tests continue to pass (52 + 36 + sub-counts).
- 11186 → **11187 passing**. 300 suites green. 1 pre-existing skip.

The fix is mechanically uniform across all 14 sites (3 `replace_all` patterns), so one adversarial test against the most-exploitable site (single-doc direct `res.json`) anchors the principle — same shape as PRs #978-#982 in the cluster.

## Write-path analysis

Verified across all 7 files: write payloads are either **allowlist-constructed** (`bindingData` in admin-devices, `alertData` in admin-alerts — both built from named destructured `req.body` fields with explicit coercion, never `...req.body`) or **object literals with hardcoded server-controlled fields** (auditLog entries, `batch.update` with named field projections, `tx.update` with explicit field extraction). No spread of attacker-controlled data into writes. **No companion write-path fix required**, same as PR #980/#982 (vs economy.js's writeTransaction defense-in-depth in PR #979).

## Review

- **Pre-self-review**: zero residual unsafe patterns via grep, all 14 fixes mechanically uniform, test isolation verified (`beforeEach` + `jest.clearAllMocks` + per-test `mockResolvedValue` overrides — no state leaks).
- **`feature-dev:code-reviewer` agent dispatched** (per operator directive "properly reviewed"): **ZERO findings at actionable confidence (≥80)**. All claimed sites verified in safe order, write-path analysis confirmed correct, adversarial test catches the regression deterministically.

## Carry-forward (not in this PR)

Reviewer surfaced one pre-existing Minor (confidence 55, below actionable threshold) worth tracking: `POST /admin/alerts` writes `status` from `req.body` to Firestore without an allowlist check, allowing admin callers to persist arbitrary status strings bypassing the PATCH-endpoint state machine. Logged as a follow-up; not scope-creeping this spread-order PR.

## Test plan

- [x] Adversarial test fails on unfixed code (RED): `Received: "rogue-device-id", Expected: "dev-001"`
- [x] Adversarial test passes after fix (GREEN)
- [x] All admin-devices/bans/logs/alerts/economy/audit-log/age-verification tests pass
- [x] Full express-api suite passes (11187 / 11188, 1 pre-existing skip)
- [x] Pre-push SonarCloud quality gate passed (3m 34s)
- [x] Grep confirms 14/14 sites fixed across 7 files, zero residual unsafe patterns
- [x] Code-reviewer agent: ZERO findings at actionable confidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)