### PR TITLE
fix(ci): auto-retry sonarcloud when only sonar fails (AWS-IP 403 class)

### DIFF
--- a/.github/workflows/sonarcloud-auto-retry.yml
+++ b/.github/workflows/sonarcloud-auto-retry.yml
@@ -1,0 +1,133 @@
+name: SonarCloud Auto-Retry
+
+# Auto-retry the SonarCloud Analysis job when it 403s on
+# api.sonarcloud.io endpoints (`/analysis/jres`, `/analysis/engine`)
+# because the GitHub Actions runner's IP is on an AWS reputation block.
+# SonarSource confirmed in their community forum that some GitHub-hosted
+# runner IPs are intermittently blocked at AWS's edge — see
+# https://community.sonarsource.com/t/138939. The block is per-IP and
+# persists for the job lifetime, so within-job retries on the same
+# runner don't help. Re-triggering failed jobs gives a fresh runner
+# with a different IP and almost always clears the failure.
+#
+# PR #981 landed `systemProp.sonar.scanner.skipJreProvisioning=true`
+# which eliminated the `/analysis/jres` request. PR #983 then hit the
+# same 403 class on the `/analysis/engine` endpoint (the scanner-engine
+# bootstrap can't be skipped — it IS the scanner). This workflow is the
+# defensive remediation: when only sonarcloud failed (signal of the AWS
+# IP class), auto re-run failed jobs once. Anything more than one
+# auto-retry is bounded out — persistent failures still surface to the
+# operator instead of being masked.
+#
+# Filter logic ("only sonar failed"):
+#   - sonarcloud / SonarCloud Analysis failed
+#   - PR Gate failed (it's downstream of sonarcloud — always co-fails)
+#   - Every OTHER required check (lint, test-backend, integration-tests,
+#     Analyze JavaScript, Detect Changes) either succeeded or was
+#     skipped (skip is fine — pr-checks.yml's Detect Changes job
+#     intentionally skips paths based on diff)
+#
+# Bound: github.event.workflow_run.run_attempt < 2 → exactly one
+# auto-retry. If retry also fails, the workflow stays red and the
+# operator (or a separate manual rerun) takes over.
+
+on:
+  workflow_run:
+    workflows: ['PR Checks']
+    types: [completed]
+
+permissions:
+  actions: write    # gh run rerun
+  contents: read
+
+jobs:
+  auto-retry-sonar:
+    name: Auto-retry sonarcloud when only sonar failed
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 2
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Identify failed jobs in the run
+        id: classify
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          # Enumerate all jobs in this run with their conclusions.
+          # --paginate covers runs with >100 jobs (matrix-heavy E2E).
+          # We need names + conclusions only, hence the lean jq projection.
+          JOBS_JSON=$(gh api --paginate \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+            --jq '[.jobs[] | {name, conclusion}]')
+
+          # Failed jobs (failure or cancelled — treat cancelled like failed
+          # because GitHub may cancel downstream jobs when an upstream
+          # fails, and we still want to differentiate from a clean skip).
+          FAILED=$(echo "$JOBS_JSON" | jq -r '
+            map(select(.conclusion == "failure" or .conclusion == "cancelled"))
+            | map(.name) | .[]
+          ')
+
+          echo "Failed jobs:"
+          echo "$FAILED"
+          echo "---"
+
+          # The signal we auto-retry on: sonarcloud is among the failed,
+          # AND every failed job is in the allowlist of sonar-related names.
+          # PR Gate fails downstream of sonarcloud — it's an expected co-fail.
+          # Anything outside this allowlist means a real code/test failure
+          # that retries won't fix.
+          ALLOWLIST_REGEX='^(sonarcloud / SonarCloud Analysis|PR Gate|auto-merge)$'
+
+          SONAR_FAILED=$(echo "$FAILED" | grep -cxE 'sonarcloud / SonarCloud Analysis' || true)
+          NON_ALLOWLISTED=$(echo "$FAILED" | grep -vxE "$ALLOWLIST_REGEX" | grep -c . || true)
+
+          echo "sonar_failed=$SONAR_FAILED"
+          echo "non_allowlisted_failed=$NON_ALLOWLISTED"
+
+          if [ "$SONAR_FAILED" -ge 1 ] && [ "$NON_ALLOWLISTED" -eq 0 ]; then
+            echo "should_retry=true" >> "$GITHUB_OUTPUT"
+            echo "Decision: auto-retry (sonar-only failure pattern matches)"
+          else
+            echo "should_retry=false" >> "$GITHUB_OUTPUT"
+            echo "Decision: skip (non-sonar failures present or sonar not failed)"
+          fi
+
+      - name: Re-run failed jobs
+        if: steps.classify.outputs.should_retry == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          PREV_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          set -euo pipefail
+          NEXT_ATTEMPT=$((PREV_ATTEMPT + 1))
+          echo "Re-running failed jobs on run ${RUN_ID} (auto-retry attempt ${NEXT_ATTEMPT})"
+          gh run rerun "${RUN_ID}" --failed --repo "${GITHUB_REPOSITORY}"
+
+      - name: Summary
+        if: always()
+        env:
+          DECISION: ${{ steps.classify.outputs.should_retry }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          {
+            echo "### SonarCloud Auto-Retry Decision"
+            echo ""
+            echo "- Source run: \`${RUN_ID}\` (attempt ${ATTEMPT})"
+            echo "- Head SHA: \`${HEAD_SHA}\`"
+            echo "- Decision: \`${DECISION}\`"
+            echo ""
+            if [ "${DECISION}" = "true" ]; then
+              echo "Triggered \`gh run rerun --failed\` to get a fresh runner IP."
+              echo "If the failure persists on the next attempt, manual investigation is required (workflow re-runs are bounded at 1)."
+            else
+              echo "No retry triggered. Either sonarcloud passed, the failure mix included a real code/test failure that retries won't fix, or this is already the second attempt."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/sonarcloud-auto-retry.yml` — listens for `PR Checks` completion, detects the "only sonarcloud failed" pattern, and auto-runs `gh run rerun --failed` to get a fresh runner with a different IP.

Companion to PR #981 (skipJreProvisioning) — together they cover the two known 403 manifestations of the same AWS-IP root cause:
- **PR #981**: removes `/analysis/jres` from the failure surface
- **This PR**: auto-retries when the unavoidable `/analysis/engine` (or any other sonarcloud endpoint) 403s

## Why

Empirical pattern across PR cluster #975-#983:
| PR | First-attempt sonar | Re-run sonar |
|---|---|---|
| #980 | FAILURE — `/analysis/jres` 403 | SUCCESS (different runner) |
| #981, #982 | SUCCESS first try | n/a |
| #983 | FAILURE — `/analysis/engine` 403 | SUCCESS (different runner) |

SonarSource staff confirmed in [community thread #138939](https://community.sonarsource.com/t/github-ci-cd-getting-inconsistent-403-errors-on-jre-metadata/138939) that some GitHub-hosted runner IPs sit on AWS's reputation blocklist. The block is **per-IP**, **persistent for the job's lifetime**. Within-job retries on the same runner cannot clear it. Re-triggering the failed job gives a fresh runner with a different IP — empirically ~100% recovery rate.

## How

1. **Trigger**: `workflow_run` on `PR Checks` completion, runs only when `conclusion == 'failure'`.
2. **Identify failed jobs**: `gh api .../jobs` enumerates failures; applies allowlist `^(sonarcloud / SonarCloud Analysis|PR Gate|auto-merge)$`. PR Gate is downstream of sonarcloud (always co-fails); auto-merge is similarly downstream.
3. **Decision**: auto-retry only if `sonarcloud / SonarCloud Analysis` failed AND every other failed job is in the allowlist. Any real code/test failure (lint, test-backend, integration-tests, e2e) outside the allowlist blocks auto-retry — surfaces as normal failure.
4. **Bound**: `github.event.workflow_run.run_attempt < 2` — exactly one auto-retry. If the retry also fails, the workflow stays red and the operator takes over. Persistent failures are NOT masked.
5. **Action**: `gh run rerun ${RUN_ID} --failed` re-queues only the failed jobs (not the whole workflow). GitHub assigns fresh runners.
6. **Audit**: every decision (retry or skip) writes to `GITHUB_STEP_SUMMARY` for visibility.

## Security

Per the [GitHub Actions workflow injection guide](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/):
- **All workflow-expression interpolation moved to `env:` blocks** before run-scripts use the values. Zero `${{ ... }}` inside run-script bodies.
- **Permissions minimal**: `actions: write` (for `gh run rerun`), `contents: read` (for `gh api`). No `pull-requests`, no `checks`.
- Allowlist regex uses anchored matching (`grep -xE`) to prevent name-injection in failed-job names.

## Alternatives rejected

| Option | Why rejected |
|---|---|
| `nick-fields/retry` wrapping the gradle sonar step | Same runner, same IP — empirically ineffective against AWS-IP blocks |
| Multiple auto-retries (>1) | Risks masking real failures behind retry loops |
| Log-content pattern matching (grep "403 Forbidden") | More precise but requires log download. Allowlist filter is sufficient — only AWS-IP 403 produces "sonar fails alone" |
| Skip scanner engine bootstrap | Not a documented Sonar property — engine bootstrap is required |

## Test plan

- [x] actionlint passes at pre-push (validates YAML + embedded shellcheck on run-script bodies)
- [x] YAML syntax validated via `python3 -c yaml.safe_load`
- [x] `workflow_run` trigger only fires when the listened workflow runs on the default branch — verified per [GitHub docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run). Means this workflow is dormant on feature branches; activates only after merge to main.
- [ ] **Live validation post-merge**: the FIRST PR that triggers a sonarcloud 403 after this lands should be auto-retried within ~30s of the PR Checks workflow finishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)