### PR TITLE
feat(express-api): /api/system/health endpoint, replace serverHealth cron

### DIFF
--- a/express-api/src/cron/index.js
+++ b/express-api/src/cron/index.js
@@ -11,7 +11,6 @@ const orphanedStorage = require('./orphanedStorage');
 const rotateLogs = require('./rotateLogs');
 const expireBans = require('./expireBans');
 const expireTempIds = require('./expireTempIds');
-const serverHealth = require('./serverHealth');
 const accountDeletion = require('./accountDeletion');
 const expireDataExports = require('./expireDataExports');
 const alertManager = require('../utils/alertManagerInstance');
@@ -96,13 +95,6 @@ function startCronJobs() {
     log.info('cron', 'Running expireDataExports');
     expireDataExports().catch((err) =>
       log.error('cron', 'expireDataExports failed', { error: err.message }),
-    );
-  });
-
-  // Server health check — every 5 minutes
-  cron.schedule('*/5 * * * *', () => {
-    serverHealth(alertManager).catch((err) =>
-      log.error('cron', 'serverHealth failed', { error: err.message }),
     );
   });
 

--- a/express-api/src/cron/serverHealth.js
+++ b/express-api/src/cron/serverHealth.js
@@ -1,17 +1,43 @@
 /**
- * Server health check cron — monitors memory usage and PM2 restarts.
+ * Server health metrics check — memory usage + PM2 restart detection.
  *
- * Runs every 5 minutes. Creates alerts when thresholds are exceeded.
+ * Originally a 5-min in-process cron; now invoked by the Better Stack
+ * heartbeat endpoint at GET /api/system/health. The in-flight guard
+ * below ensures concurrent heartbeat hits don't double-fire the PM2
+ * check or race on `lastRestartCounts` (which would emit duplicate
+ * alerts because alertManager has no dedup of its own).
  */
 
 const { execFile } = require('node:child_process');
 const os = require('node:os');
 const log = require('../utils/log');
 
-// Track last-known restart counts to only alert on NEW restarts
+// Track last-known restart counts to only alert on NEW restarts. Now
+// shared across HTTP-triggered invocations; the in-flight guard below
+// keeps the read-then-write race window single-threaded.
 const lastRestartCounts = {};
 
+// Concurrent-invocation guard. Multiple Better Stack hits (or a future
+// secondary monitor) firing during a slow `pm2 jlist` (10s timeout)
+// would otherwise overlap, double-counting restarts and forking
+// duplicate child processes. A boolean flag is enough — JavaScript's
+// single-threaded model means the read+write in the guard is atomic.
+let inFlight = false;
+
 async function serverHealth(alertManager) {
+  if (inFlight) {
+    log.debug('server-health', 'check already in flight — skipping concurrent invocation');
+    return;
+  }
+  inFlight = true;
+  try {
+    return await runHealthCheck(alertManager);
+  } finally {
+    inFlight = false;
+  }
+}
+
+async function runHealthCheck(alertManager) {
   // Check memory usage — RSS vs system total (not V8 heap ratio, which is
   // misleadingly high because V8 keeps heapTotal close to heapUsed)
   const mem = process.memoryUsage();

--- a/express-api/src/index.js
+++ b/express-api/src/index.js
@@ -98,7 +98,15 @@ app.use('/api', require('./routes/legal-versions'));
 // GitHub Actions scheduled workflows that replace internal node-cron.
 // Mounted before the Firebase auth middleware so all /system/* routes
 // bypass the user-auth flow.
-app.use('/api', require('./routes/system'));
+//
+// `generalLimiter` is applied INLINE on the mount (not relying on the
+// downstream block at line ~137) because routes/system.js responds
+// synchronously inside its handler, so a downstream `app.use(...,
+// generalLimiter)` block never runs. Without this guard, /system/health
+// would be an unauthenticated DoS path into the alertManager — every
+// hit triggers serverHealth() async-fire, which can write Firestore
+// docs and dispatch FCM messages.
+app.use('/api', generalLimiter, require('./routes/system'));
 
 // Auth middleware for all /api routes (except health, log-config, auth, and pre-auth endpoints)
 app.use('/api', (req, res, next) => {

--- a/express-api/src/index.js
+++ b/express-api/src/index.js
@@ -91,6 +91,15 @@ app.use('/api', require('./routes/auth'));
 // for the rationale on why versions are hardcoded.
 app.use('/api', require('./routes/legal-versions'));
 
+// System endpoints for external schedulers and uptime monitoring.
+// `/system/health` is public for Better Stack heartbeat pings.
+// `/system/sweep-*` endpoints (added in subsequent cron-cluster PRs)
+// apply requireSystemAuth internally — bearer-token guarded for the
+// GitHub Actions scheduled workflows that replace internal node-cron.
+// Mounted before the Firebase auth middleware so all /system/* routes
+// bypass the user-auth flow.
+app.use('/api', require('./routes/system'));
+
 // Auth middleware for all /api routes (except health, log-config, auth, and pre-auth endpoints)
 app.use('/api', (req, res, next) => {
   if (

--- a/express-api/src/middleware/system-auth.js
+++ b/express-api/src/middleware/system-auth.js
@@ -14,15 +14,29 @@
  *
  * Per the same-secret-many-callers model, each scheduled workflow (and
  * any other ops-only tooling) configures the same value via repo
- * secrets / Better Stack monitor headers / etc. Rotation is
- * coordinated by updating the Express API env first, then the callers.
+ * secrets / Better Stack monitor headers / etc. Rotation is coordinated
+ * by updating the Express API env first, then the callers.
  *
- * Comparison uses `crypto.timingSafeEqual` so a token-guessing attacker
- * can't infer the secret one character at a time from response timing.
+ * Verification uses an HMAC-of-HMAC comparison rather than a direct
+ * `timingSafeEqual` of the bytes. Both HMACs are always 32 bytes
+ * regardless of the provided token's length, so the work done by the
+ * comparison is identical in EVERY rejection path — same-length wrong
+ * token, wrong-length token, and matching token all execute the same
+ * sequence of allocations + a 32-byte timing-safe compare. This
+ * eliminates the byte-length side channel that the naive
+ * `if (expectedBuf.length !== providedBuf.length) return 401` pattern
+ * leaks (because `Buffer.from(provided, 'utf8')` is O(provided.length),
+ * an attacker can binary-search the secret's byte length by measuring
+ * the response delta between the fast-path length-mismatch and the
+ * slower constant-time compare).
+ *
+ * Reference: https://www.synopsys.com/blogs/software-security/timing-attacks-explained/
  */
 
 const crypto = require('node:crypto');
 const log = require('../utils/log');
+
+const BEARER_PREFIX = 'Bearer ';
 
 function requireSystemAuth(req, res, next) {
   const expected = process.env.SYSTEM_SHARED_SECRET;
@@ -38,31 +52,30 @@ function requireSystemAuth(req, res, next) {
   }
 
   const header = req.get('authorization') || '';
-  // Prefix-check avoids regex backtracking risk on pathological inputs
-  // (e.g. `Authorization: Bearer ` + 10kb of whitespace would force a
-  // greedy regex to backtrack). The case-insensitive prefix check +
-  // index slice does the same job as `/^Bearer\s+(.+)$/i` in
-  // bounded time.
-  const PREFIX_LEN = 'Bearer '.length;
-  if (header.length <= PREFIX_LEN || header.slice(0, PREFIX_LEN).toLowerCase() !== 'bearer ') {
+  // Prefix-check + slice avoids regex backtracking on pathological
+  // inputs (e.g. `Authorization: Bearer ` + 10kb of whitespace would
+  // force `/^Bearer\s+(.+)$/i` to backtrack). The slice + trimStart
+  // accepts RFC-6750-compliant whitespace after `Bearer`.
+  if (
+    header.length <= BEARER_PREFIX.length ||
+    header.slice(0, BEARER_PREFIX.length).toLowerCase() !== BEARER_PREFIX.toLowerCase()
+  ) {
     return res.status(401).json({ error: 'Missing bearer token' });
   }
-  const provided = header.slice(PREFIX_LEN).trimStart();
+  const provided = header.slice(BEARER_PREFIX.length).trimStart();
   if (!provided) {
     return res.status(401).json({ error: 'Missing bearer token' });
   }
-  const expectedBuf = Buffer.from(expected, 'utf8');
-  const providedBuf = Buffer.from(provided, 'utf8');
 
-  // timingSafeEqual requires equal-length buffers. Reject length
-  // mismatch up-front to avoid the throw — that branch is constant
-  // time regardless of secret contents because we don't compare
-  // anything beyond the length check.
-  if (expectedBuf.length !== providedBuf.length) {
-    return res.status(401).json({ error: 'Invalid bearer token' });
-  }
-
-  if (!crypto.timingSafeEqual(expectedBuf, providedBuf)) {
+  // HMAC both the expected and the provided string under a shared key
+  // (the expected secret itself) so both digests are always 32 bytes
+  // regardless of input length. timingSafeEqual then compares two
+  // fixed-length buffers in constant time. No length-mismatch branch
+  // is needed at all — wrong-length, wrong-content, and right tokens
+  // all take the same code path.
+  const referenceDigest = crypto.createHmac('sha256', expected).update(expected).digest();
+  const providedDigest = crypto.createHmac('sha256', expected).update(provided).digest();
+  if (!crypto.timingSafeEqual(referenceDigest, providedDigest)) {
     return res.status(401).json({ error: 'Invalid bearer token' });
   }
 

--- a/express-api/src/middleware/system-auth.js
+++ b/express-api/src/middleware/system-auth.js
@@ -1,0 +1,72 @@
+/**
+ * System-endpoint authentication.
+ *
+ * Protects `/api/system/*` endpoints called by external schedulers
+ * (GitHub Actions scheduled workflows replacing the in-process node-cron
+ * jobs). The endpoints are publicly reachable URLs, so they need a
+ * shared-secret guard separate from the Firebase Auth flow used by
+ * end-users.
+ *
+ * The secret is held in `SYSTEM_SHARED_SECRET` env var. The caller
+ * passes it as a bearer token:
+ *
+ *     Authorization: Bearer <SYSTEM_SHARED_SECRET>
+ *
+ * Per the same-secret-many-callers model, each scheduled workflow (and
+ * any other ops-only tooling) configures the same value via repo
+ * secrets / Better Stack monitor headers / etc. Rotation is
+ * coordinated by updating the Express API env first, then the callers.
+ *
+ * Comparison uses `crypto.timingSafeEqual` so a token-guessing attacker
+ * can't infer the secret one character at a time from response timing.
+ */
+
+const crypto = require('node:crypto');
+const log = require('../utils/log');
+
+function requireSystemAuth(req, res, next) {
+  const expected = process.env.SYSTEM_SHARED_SECRET;
+
+  if (!expected) {
+    // Configuration error: deny by default so a misconfigured deploy
+    // can't accidentally expose the sweep endpoints. Logged once per
+    // request so ops can spot the gap without flooding.
+    log.error('system-auth', 'SYSTEM_SHARED_SECRET not configured — denying request', {
+      path: req.path,
+    });
+    return res.status(503).json({ error: 'System authentication not configured' });
+  }
+
+  const header = req.get('authorization') || '';
+  // Prefix-check avoids regex backtracking risk on pathological inputs
+  // (e.g. `Authorization: Bearer ` + 10kb of whitespace would force a
+  // greedy regex to backtrack). The case-insensitive prefix check +
+  // index slice does the same job as `/^Bearer\s+(.+)$/i` in
+  // bounded time.
+  const PREFIX_LEN = 'Bearer '.length;
+  if (header.length <= PREFIX_LEN || header.slice(0, PREFIX_LEN).toLowerCase() !== 'bearer ') {
+    return res.status(401).json({ error: 'Missing bearer token' });
+  }
+  const provided = header.slice(PREFIX_LEN).trimStart();
+  if (!provided) {
+    return res.status(401).json({ error: 'Missing bearer token' });
+  }
+  const expectedBuf = Buffer.from(expected, 'utf8');
+  const providedBuf = Buffer.from(provided, 'utf8');
+
+  // timingSafeEqual requires equal-length buffers. Reject length
+  // mismatch up-front to avoid the throw — that branch is constant
+  // time regardless of secret contents because we don't compare
+  // anything beyond the length check.
+  if (expectedBuf.length !== providedBuf.length) {
+    return res.status(401).json({ error: 'Invalid bearer token' });
+  }
+
+  if (!crypto.timingSafeEqual(expectedBuf, providedBuf)) {
+    return res.status(401).json({ error: 'Invalid bearer token' });
+  }
+
+  next();
+}
+
+module.exports = { requireSystemAuth };

--- a/express-api/src/routes/system.js
+++ b/express-api/src/routes/system.js
@@ -1,0 +1,42 @@
+/**
+ * System endpoints for external schedulers + health monitoring.
+ *
+ * GET  /api/system/health            — public (rate-limited), Better Stack heartbeat.
+ *                                      Returns 200 immediately, async-fires
+ *                                      the serverHealth() metrics check
+ *                                      (memory + PM2 restart detection).
+ *
+ * Future endpoints (added per cron-cluster migration):
+ * POST /api/system/sweep-account-deletions  — requires bearer
+ * POST /api/system/sweep-bans               — requires bearer
+ * POST /api/system/dispatch-notifications   — requires bearer
+ *
+ * Architecture: replaces what was an in-process node-cron every-5-min
+ * schedule for serverHealth with an externally-triggered ping. Better
+ * Stack's free-tier 3-min interval is faster than the previous 5-min
+ * cron AND provides external uptime detection that an internal cron
+ * can't (a hung Node process can't alert about itself).
+ *
+ * The handler returns 200 BEFORE invoking the metrics check so a slow
+ * `pm2 jlist` call (10-sec timeout) doesn't cause Better Stack to mark
+ * the monitor down on a healthy server.
+ */
+
+const router = require('express').Router();
+const log = require('../utils/log');
+const serverHealth = require('../cron/serverHealth');
+const alertManager = require('../utils/alertManagerInstance');
+
+router.get('/system/health', (req, res) => {
+  // Respond immediately so the external monitor sees a fast 200. The
+  // metrics check (memory threshold + PM2 restart detection) runs
+  // fire-and-forget — a failure there is logged but doesn't affect
+  // the heartbeat response.
+  res.json({ status: 'ok' });
+
+  serverHealth(alertManager).catch((err) => {
+    log.error('system', 'serverHealth metrics check failed', { error: err.message });
+  });
+});
+
+module.exports = router;

--- a/express-api/tests/cron/index.test.js
+++ b/express-api/tests/cron/index.test.js
@@ -30,7 +30,6 @@ jest.mock('../../src/cron/orphanedStorage', () => jest.fn());
 jest.mock('../../src/cron/rotateLogs', () => jest.fn());
 jest.mock('../../src/cron/expireBans', () => jest.fn());
 jest.mock('../../src/cron/expireTempIds', () => jest.fn());
-jest.mock('../../src/cron/serverHealth', () => jest.fn());
 jest.mock('../../src/cron/accountDeletion', () => jest.fn());
 jest.mock('../../src/cron/expireDataExports', () => jest.fn());
 jest.mock('../../src/cron/notification-dispatch', () => jest.fn());
@@ -48,7 +47,6 @@ const orphanedStorage = require('../../src/cron/orphanedStorage');
 const rotateLogs = require('../../src/cron/rotateLogs');
 const expireBans = require('../../src/cron/expireBans');
 const expireTempIds = require('../../src/cron/expireTempIds');
-const serverHealth = require('../../src/cron/serverHealth');
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -121,10 +119,10 @@ describe('startCronJobs', () => {
       // ageVerificationAuditReconcile — daily 05:00 UTC
       expect(schedules).toContain('0 5 * * *');
 
-      // Total: 12 schedules in production (staleRooms + serverHealth share */5,
-      // + accountDeletion, + expireDataExports, + notification-dispatch,
-      // + ageVerificationAuditReconcile)
-      expect(mockSchedule).toHaveBeenCalledTimes(12);
+      // Total: 11 schedules in production. serverHealth was migrated to
+      // an externally-triggered ping (Better Stack heartbeat hits
+      // /api/system/health) so it no longer appears as a node-cron job.
+      expect(mockSchedule).toHaveBeenCalledTimes(11);
     });
 
     test('does not register testDataCleanup in production', () => {
@@ -139,7 +137,9 @@ describe('startCronJobs', () => {
       startCronJobs();
 
       const fiveMinCalls = mockSchedule.mock.calls.filter((c) => c[0] === '*/5 * * * *');
-      expect(fiveMinCalls.length).toBe(2); // staleRooms + serverHealth
+      // staleRooms is the only remaining */5 schedule after serverHealth
+      // was migrated to the Better Stack heartbeat endpoint.
+      expect(fiveMinCalls.length).toBe(1);
 
       fiveMinCalls[0][1]();
       expect(staleRooms).toHaveBeenCalled();
@@ -154,19 +154,6 @@ describe('startCronJobs', () => {
 
       expireCall[1]();
       expect(expireBans).toHaveBeenCalled();
-    });
-
-    test('serverHealth callback invokes the job with alertManager', () => {
-      serverHealth.mockResolvedValue(undefined);
-      startCronJobs();
-
-      const fiveMinCalls = mockSchedule.mock.calls.filter((c) => c[0] === '*/5 * * * *');
-      // serverHealth is the second */5 schedule
-      fiveMinCalls[1][1]();
-
-      expect(serverHealth).toHaveBeenCalled();
-      const alertManager = require('../../src/utils/alertManagerInstance');
-      expect(serverHealth).toHaveBeenCalledWith(alertManager);
     });
 
     test('rotateLogs uses hourly schedule in production', () => {

--- a/express-api/tests/cron/rotateLogs.test.js
+++ b/express-api/tests/cron/rotateLogs.test.js
@@ -161,6 +161,13 @@ describe('rotateLogs', () => {
     mockGet.mockResolvedValueOnce({ exists: true, data: () => ({ retentionHours: 48 }) });
     mockGet.mockResolvedValueOnce({ empty: true, docs: [] });
 
+    // Pin "now" so the recent/old boundary is deterministic regardless
+    // of wall clock — without this, the test goes flaky as `recentKey`
+    // (originally written 2026-03-06) drifts past the 90-day window
+    // with calendar progression. Pre-existing flake surfaced on PR #988.
+    const FIXED_NOW = new Date('2026-04-01T00:00:00Z').getTime();
+    jest.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
+
     // Set up old and recent R2 keys
     const oldKey = 'logs/2025/01/01/12-1234567890.ndjson';
     const recentKey = `logs/2026/03/06/10-9999999999.ndjson`;
@@ -173,6 +180,8 @@ describe('rotateLogs', () => {
     const deletedKeys = r2.deleteObjects.mock.calls.flatMap((c) => c[0]);
     expect(deletedKeys).toContain(oldKey);
     expect(deletedKeys).not.toContain(recentKey);
+
+    Date.now.mockRestore();
   });
 
   test('handles missing config doc gracefully (uses default 48h)', async () => {

--- a/express-api/tests/cron/serverHealth.test.js
+++ b/express-api/tests/cron/serverHealth.test.js
@@ -579,4 +579,70 @@ describe('serverHealth', () => {
       expect.objectContaining({ error: 'Alert DB down' }),
     );
   });
+
+  test('in-flight guard: concurrent invocations do not double-fire the metrics check', async () => {
+    // Heartbeat-class endpoint can be hit multiple times during a slow
+    // PM2 jlist (10s timeout). The module-level inFlight guard ensures
+    // only one run reaches createAlert per overlap window — otherwise
+    // duplicate PM2-restart alerts emit because alertManager has no
+    // dedup. Restarts (1) crossing the threshold (0) would create one
+    // alert per concurrent caller without the guard.
+    const createAlert = jest.fn().mockResolvedValue(undefined);
+    const mockManager = {
+      getConfig: () => ({
+        serverMemoryWarningPercent: 30,
+        pm2RestartAlert: true,
+      }),
+      createAlert,
+    };
+
+    mockMemory(100, 8000);
+
+    // Hold the PM2 jlist callback so the first invocation stays
+    // in-flight while the second starts.
+    let releasePm2;
+    execFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      releasePm2 = () => {
+        callback(null, JSON.stringify([{ name: 'api', pm2_env: { restart_time: 5 } }]));
+      };
+    });
+
+    // Prime baseline with a synchronous run (sets lastRestartCounts).
+    execFile.mockImplementationOnce((_cmd, _args, _opts, callback) => {
+      callback(null, JSON.stringify([{ name: 'api', pm2_env: { restart_time: 1 } }]));
+    });
+    await serverHealth(mockManager);
+    jest.clearAllMocks();
+
+    // Re-establish the held mock for the overlap test.
+    execFile.mockImplementation((_cmd, _args, _opts, callback) => {
+      releasePm2 = () => {
+        callback(null, JSON.stringify([{ name: 'api', pm2_env: { restart_time: 5 } }]));
+      };
+    });
+
+    // Start TWO concurrent invocations. The second sees inFlight === true
+    // and returns immediately without entering the body.
+    const first = serverHealth(mockManager);
+    const second = serverHealth(mockManager);
+
+    // Second invocation resolves immediately (guard hit) while the
+    // first is still awaiting the PM2 callback.
+    await second;
+    expect(createAlert).not.toHaveBeenCalled();
+
+    // Release PM2 so the first invocation completes.
+    releasePm2();
+    await first;
+
+    // Only one alert was created across both invocations.
+    expect(createAlert).toHaveBeenCalledTimes(1);
+    expect(createAlert).toHaveBeenCalledWith(
+      'pm2_restart',
+      'warning',
+      expect.stringContaining('api'),
+      expect.any(String),
+      expect.objectContaining({ processName: 'api' }),
+    );
+  });
 });

--- a/express-api/tests/middleware/system-auth.test.js
+++ b/express-api/tests/middleware/system-auth.test.js
@@ -1,0 +1,125 @@
+const { requireSystemAuth } = require('../../src/middleware/system-auth');
+
+describe('requireSystemAuth', () => {
+  let req;
+  let res;
+  let next;
+  let originalSecret;
+
+  beforeEach(() => {
+    originalSecret = process.env.SYSTEM_SHARED_SECRET;
+    req = {
+      path: '/system/sweep-account-deletions',
+      get: jest.fn().mockReturnValue(''),
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    next = jest.fn();
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.SYSTEM_SHARED_SECRET;
+    } else {
+      process.env.SYSTEM_SHARED_SECRET = originalSecret;
+    }
+  });
+
+  test('returns 503 when SYSTEM_SHARED_SECRET is not configured', () => {
+    delete process.env.SYSTEM_SHARED_SECRET;
+
+    requireSystemAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'System authentication not configured',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 401 when Authorization header is missing', () => {
+    process.env.SYSTEM_SHARED_SECRET = 'correct-secret';
+    req.get.mockReturnValue('');
+
+    requireSystemAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Missing bearer token' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 401 when Authorization header is not a Bearer token', () => {
+    process.env.SYSTEM_SHARED_SECRET = 'correct-secret';
+    req.get.mockReturnValue('Basic dXNlcjpwYXNz');
+
+    requireSystemAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Missing bearer token' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 401 when bearer token length differs from secret', () => {
+    process.env.SYSTEM_SHARED_SECRET = 'correct-secret';
+    req.get.mockReturnValue('Bearer too-short');
+
+    requireSystemAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid bearer token' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 401 when bearer token matches length but not value', () => {
+    process.env.SYSTEM_SHARED_SECRET = 'correct-secret';
+    req.get.mockReturnValue('Bearer wrong-secret!');
+
+    requireSystemAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid bearer token' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('calls next() when bearer token matches secret exactly', () => {
+    process.env.SYSTEM_SHARED_SECRET = 'correct-secret';
+    req.get.mockReturnValue('Bearer correct-secret');
+
+    requireSystemAuth(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('accepts case-insensitive Bearer prefix', () => {
+    process.env.SYSTEM_SHARED_SECRET = 'correct-secret';
+    req.get.mockReturnValue('bearer correct-secret');
+
+    requireSystemAuth(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test('uses Authorization header lookup (not auth)', () => {
+    process.env.SYSTEM_SHARED_SECRET = 'correct-secret';
+    req.get.mockImplementation((header) =>
+      header === 'authorization' || header === 'Authorization' ? 'Bearer correct-secret' : '',
+    );
+
+    requireSystemAuth(req, res, next);
+
+    expect(req.get).toHaveBeenCalledWith('authorization');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test('handles non-ASCII secrets correctly', () => {
+    process.env.SYSTEM_SHARED_SECRET = 'sécret-with-unicodé';
+    req.get.mockReturnValue('Bearer sécret-with-unicodé');
+
+    requireSystemAuth(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/express-api/tests/middleware/system-auth.test.js
+++ b/express-api/tests/middleware/system-auth.test.js
@@ -61,9 +61,23 @@ describe('requireSystemAuth', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  test('returns 401 when bearer token length differs from secret', () => {
+  test('returns 401 when bearer token is shorter than secret', () => {
     process.env.SYSTEM_SHARED_SECRET = 'correct-secret';
     req.get.mockReturnValue('Bearer too-short');
+
+    requireSystemAuth(req, res, next);
+
+    // HMAC compare path means no length-mismatch fast-exit: both
+    // wrong-length and wrong-content tokens go through the same
+    // constant-time compare and end here.
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid bearer token' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 401 when bearer token is longer than secret', () => {
+    process.env.SYSTEM_SHARED_SECRET = 'correct-secret';
+    req.get.mockReturnValue('Bearer correct-secret-with-extra-bytes-appended');
 
     requireSystemAuth(req, res, next);
 
@@ -102,10 +116,13 @@ describe('requireSystemAuth', () => {
     expect(next).toHaveBeenCalledTimes(1);
   });
 
-  test('uses Authorization header lookup (not auth)', () => {
+  test('uses lowercase "authorization" header lookup (Express normalises)', () => {
     process.env.SYSTEM_SHARED_SECRET = 'correct-secret';
+    // Pin the lowercase-only invariant — if the source switches to
+    // 'Authorization', this mock returns '' (the default) and the test
+    // will fail.
     req.get.mockImplementation((header) =>
-      header === 'authorization' || header === 'Authorization' ? 'Bearer correct-secret' : '',
+      header === 'authorization' ? 'Bearer correct-secret' : '',
     );
 
     requireSystemAuth(req, res, next);
@@ -117,6 +134,15 @@ describe('requireSystemAuth', () => {
   test('handles non-ASCII secrets correctly', () => {
     process.env.SYSTEM_SHARED_SECRET = 'sécret-with-unicodé';
     req.get.mockReturnValue('Bearer sécret-with-unicodé');
+
+    requireSystemAuth(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test('tolerates extra whitespace after Bearer', () => {
+    process.env.SYSTEM_SHARED_SECRET = 'correct-secret';
+    req.get.mockReturnValue('Bearer    correct-secret');
 
     requireSystemAuth(req, res, next);
 

--- a/express-api/tests/routes/system.test.js
+++ b/express-api/tests/routes/system.test.js
@@ -13,12 +13,16 @@ jest.mock('../../src/utils/alertManagerInstance', () => ({
   createAlert: jest.fn().mockResolvedValue(undefined),
 }));
 
-jest.mock('../../src/utils/log', () => ({
+// Mock log at module scope (used by both production code under test
+// and the assertion in test 3). Lifting the require out of the test
+// body avoids the sonarjs/no-require-or-internal-modules pattern.
+const mockLog = {
   debug: jest.fn(),
   info: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),
-}));
+};
+jest.mock('../../src/utils/log', () => mockLog);
 
 const systemRouter = require('../../src/routes/system');
 
@@ -54,7 +58,6 @@ describe('GET /api/system/health', () => {
   });
 
   test('returns 200 even when serverHealth rejects (logged, not surfaced)', async () => {
-    const log = require('../../src/utils/log');
     mockServerHealth.mockRejectedValueOnce(new Error('PM2 unavailable'));
 
     const app = createApp();
@@ -66,34 +69,38 @@ describe('GET /api/system/health', () => {
     // Flush the microtask + macrotask queue so the catch handler runs.
     await new Promise((resolve) => setImmediate(resolve));
 
-    expect(log.error).toHaveBeenCalledWith(
+    expect(mockLog.error).toHaveBeenCalledWith(
       'system',
       'serverHealth metrics check failed',
       expect.objectContaining({ error: 'PM2 unavailable' }),
     );
   });
 
-  test('responds quickly without awaiting serverHealth', async () => {
-    // Simulate a slow serverHealth (e.g., PM2 jlist hanging at the
-    // 10-sec timeout). Heartbeat should still return promptly.
+  test('responds before awaiting serverHealth (structural fire-and-forget assertion)', async () => {
+    // Replace wall-clock timing with a structural check: the heartbeat
+    // response must complete BEFORE the metrics check resolves. A
+    // pending Promise that we hold open simulates a slow PM2 jlist
+    // (10-sec timeout). The response should arrive while that Promise
+    // is still pending; the metrics check is only OBSERVABLY called
+    // after we let the event loop flush, but the response has long
+    // since been sent.
     let resolveSlowCheck;
-    mockServerHealth.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveSlowCheck = resolve;
-      }),
-    );
+    const slowMetricsPromise = new Promise((resolve) => {
+      resolveSlowCheck = resolve;
+    });
+    mockServerHealth.mockReturnValueOnce(slowMetricsPromise);
 
     const app = createApp();
-    const start = Date.now();
     const res = await request(app).get('/api/system/health');
-    const elapsed = Date.now() - start;
 
+    // The supertest await resolved → response was sent. The metrics
+    // check is still pending. If the handler awaited serverHealth, the
+    // supertest await would not have resolved yet.
     expect(res.status).toBe(200);
-    // The endpoint should not block on the metrics check — 100ms is a
-    // generous bound for a local supertest call.
-    expect(elapsed).toBeLessThan(100);
+    expect(res.body).toEqual({ status: 'ok' });
 
-    // Cleanup so the pending Promise doesn't dangle.
+    // Cleanup the dangling Promise so Jest doesn't warn about open handles.
     resolveSlowCheck();
+    await slowMetricsPromise;
   });
 });

--- a/express-api/tests/routes/system.test.js
+++ b/express-api/tests/routes/system.test.js
@@ -1,0 +1,99 @@
+const express = require('express');
+const request = require('supertest');
+
+// Mock the serverHealth cron-style worker so we can assert it was
+// invoked async without actually exercising PM2 / system memory.
+const mockServerHealth = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../src/cron/serverHealth', () => mockServerHealth);
+
+// Mock alertManager — its real init touches Firestore which we don't
+// need for the heartbeat endpoint's contract.
+jest.mock('../../src/utils/alertManagerInstance', () => ({
+  send: jest.fn(),
+  createAlert: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../src/utils/log', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const systemRouter = require('../../src/routes/system');
+
+function createApp() {
+  const app = express();
+  app.use('/api', systemRouter);
+  return app;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockServerHealth.mockResolvedValue(undefined);
+});
+
+describe('GET /api/system/health', () => {
+  test('returns 200 with status ok', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/system/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+
+  test('async-fires the serverHealth metrics check', async () => {
+    const app = createApp();
+    await request(app).get('/api/system/health');
+
+    // Heartbeat returns 200 before the metrics check resolves; flush
+    // the microtask queue so the fire-and-forget invocation is observed.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockServerHealth).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns 200 even when serverHealth rejects (logged, not surfaced)', async () => {
+    const log = require('../../src/utils/log');
+    mockServerHealth.mockRejectedValueOnce(new Error('PM2 unavailable'));
+
+    const app = createApp();
+    const res = await request(app).get('/api/system/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+
+    // Flush the microtask + macrotask queue so the catch handler runs.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(log.error).toHaveBeenCalledWith(
+      'system',
+      'serverHealth metrics check failed',
+      expect.objectContaining({ error: 'PM2 unavailable' }),
+    );
+  });
+
+  test('responds quickly without awaiting serverHealth', async () => {
+    // Simulate a slow serverHealth (e.g., PM2 jlist hanging at the
+    // 10-sec timeout). Heartbeat should still return promptly.
+    let resolveSlowCheck;
+    mockServerHealth.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSlowCheck = resolve;
+      }),
+    );
+
+    const app = createApp();
+    const start = Date.now();
+    const res = await request(app).get('/api/system/health');
+    const elapsed = Date.now() - start;
+
+    expect(res.status).toBe(200);
+    // The endpoint should not block on the metrics check — 100ms is a
+    // generous bound for a local supertest call.
+    expect(elapsed).toBeLessThan(100);
+
+    // Cleanup so the pending Promise doesn't dangle.
+    resolveSlowCheck();
+  });
+});


### PR DESCRIPTION
## Summary

PR #2 of the cron-cluster refactor — externalises the every-5-min `serverHealth` cron with a public heartbeat endpoint that Better Stack pings every 3 min.

Net effect:
- External uptime detection (Better Stack alerts on response timeout — a hung Node process couldn't alert about itself when serverHealth was internal)
- Metrics still collected (memory + PM2 restart): the handler async-fires `serverHealth(alertManager)` so existing alerts continue with the same alertManager wiring
- Faster polling (3 min vs 5 min, free tier)
- One fewer in-process node-cron schedule (13 → 12 after PR #987 → 11 after this PR)

Also lands the `requireSystemAuth` middleware (HMAC-SHA256 timing-safe Bearer auth) for the cron-cluster's upcoming sweep-* endpoints in PRs #3/#4/#5.

## Code review

`feature-dev:code-reviewer` agent surfaced 2 Critical + several Important/Minor findings on the initial commit; all addressed in the fix-up commit before merge per the operator's quality bar:

- **Critical 1**: `/api/system/health` had no rate limiting (downstream `generalLimiter` block never runs because the handler responds synchronously). Fix: mount `generalLimiter` INLINE on the system router.
- **Critical 2**: `Buffer.from(provided, 'utf8')` is O(n), so the length-mismatch fast-exit in `requireSystemAuth` leaked the secret's byte length via timing. Fix: HMAC-of-HMAC comparison so both digests are always 32 bytes and `timingSafeEqual` always compares fixed-length buffers.
- **Important**: serverHealth's shared `lastRestartCounts` could double-emit alerts on concurrent invocations. Fix: module-level `inFlight` guard + regression test.
- **Minor**: tightened test casing pin (lowercase `'authorization'` invariant), replaced wall-clock test with structural fire-and-forget assertion, lifted `require()` out of test body, added whitespace-after-Bearer tolerance test.

## Files

- ADD `express-api/src/middleware/system-auth.js` (HMAC-SHA256 Bearer auth, backtracking-safe prefix-check parse)
- ADD `express-api/src/routes/system.js` (GET /api/system/health → 200 + async metrics)
- `src/index.js`: mount system router pre-auth-middleware with `generalLimiter` inline
- `src/cron/serverHealth.js`: in-flight guard for concurrent invocations
- `src/cron/index.js`: drop serverHealth import + schedule
- `tests/cron/index.test.js`: drop mock + assertion + callback test (cron count 12 → 11; */5 schedule count 2 → 1)
- ADD `tests/middleware/system-auth.test.js` (11 tests)
- ADD `tests/routes/system.test.js` (4 tests)
- `tests/cron/serverHealth.test.js`: +1 in-flight guard regression test

## Verification

- Full express-api suite: 301 / 11198 passed (was 299 / 11183 after PR #987)
- 1 pre-existing skip preserved
- Pre-push SonarCloud quality gate will run on push

## Better Stack monitor setup (operator action, post-merge)

1. Create Better Stack account (free tier; no credit card)
2. Add HTTP(S) monitor:
   - URL: `https://api.shytalk.shyden.co.uk/api/system/health`
   - Method: GET
   - Expected status: 200
   - Expected body fragment: `"status":"ok"`
   - Interval: 3 minutes (free-tier max)
3. Configure escalation (Slack/email/webhook) on monitor down
4. Optional: public status page exposing the monitor

`SYSTEM_SHARED_SECRET` env var is NOT used by /system/health (public); will be added when PRs #3/#4/#5 land their sweep endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)