### PR TITLE
feat(cron): migrate dispatchNotifications to GH Actions + factory refactor

### DIFF
--- a/.github/workflows/cron-dispatch-notifications.yml
+++ b/.github/workflows/cron-dispatch-notifications.yml
@@ -1,0 +1,95 @@
+name: Cron — Dispatch Notifications
+
+# External replacement for the in-process node-cron schedule that used
+# to run `dispatchNotifications()` every 2 minutes inside the Express
+# API process. The function itself still lives in
+# `express-api/src/cron/notification-dispatch.js`; this workflow only
+# changes the trigger from `node-cron` to `gh actions schedule`.
+#
+# Cadence changed from every-2-min (in-process) to every-5-min in the
+# move — operator-approved relaxation to keep total cron-cluster
+# minutes low across the cluster's 4 GH-Actions cron workflows. Worst-
+# case notification dispatch latency rises from 2 min to 5 min, plus
+# the GH Actions ~10-min schedule-trigger delay envelope. Suggestion-
+# board users won't notice — the surfaces that consume these
+# notifications (inApp badge, email digest) are not latency-sensitive
+# at sub-15-min resolution.
+#
+# Companion endpoint:
+#   POST /api/system/dispatch-notifications
+#   Headers: Authorization: Bearer ${{ secrets.SYSTEM_SHARED_SECRET }}
+#   Body:    (empty)
+#
+# Deploy steps (operator action, ONCE PER REPO):
+# Same as cron-account-deletion.yml — sets `SYSTEM_SHARED_SECRET` repo
+# secret + matching env var on the production Express API. Reuses the
+# secret from PR #989; no new setup once that landed.
+#
+# Failure behaviour: if the endpoint returns 5xx, the workflow fails
+# visibly. The next */5 tick picks up the work the failed run would
+# have done (dispatchNotifications paginates by `firedAt` queue
+# position). A 409 response is treated as success (in-flight sweep
+# will complete; next tick handles new entries).
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Target environment (prod is the only valid choice today; dev does not run crons)'
+        type: choice
+        options: [prod]
+        default: 'prod'
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: POST /api/system/dispatch-notifications
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Invoke dispatch endpoint
+        env:
+          API_URL: https://api.shytalk.shyden.co.uk/api/system/dispatch-notifications
+          SYSTEM_SHARED_SECRET: ${{ secrets.SYSTEM_SHARED_SECRET }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SYSTEM_SHARED_SECRET}" ]; then
+            echo "::error::SYSTEM_SHARED_SECRET secret is not configured on this repo"
+            exit 1
+          fi
+
+          # --max-time 240 leaves a 60s buffer before the */5 cadence
+          # tick fires the next scheduled run. With --max-time 300 the
+          # curl exit would land right at the next-tick boundary,
+          # making overlap essentially guaranteed at production scale.
+          # The 60s buffer doesn't eliminate overlap (server-side sweep
+          # may still be running for up to 20 min — that's the 409-as-
+          # success path), but it removes the trivial case where two
+          # curls are in-flight against the SAME endpoint simultaneously.
+          HTTP_CODE=$(curl -sS -o /tmp/sweep-response.txt -w "%{http_code}" \
+            -X POST "${API_URL}" \
+            -H "Authorization: Bearer ${SYSTEM_SHARED_SECRET}" \
+            -H "Content-Length: 0" \
+            --max-time 240)
+
+          echo "Server status: ${HTTP_CODE}"
+          echo "Server body:"
+          cat /tmp/sweep-response.txt
+          echo
+
+          case "${HTTP_CODE}" in
+            200)
+              echo "✓ dispatch completed successfully"
+              ;;
+            409)
+              echo "✓ dispatch already in flight on the server — treating as success"
+              ;;
+            *)
+              echo "::error::dispatch failed with status ${HTTP_CODE}"
+              exit 1
+              ;;
+          esac

--- a/express-api/src/cron/index.js
+++ b/express-api/src/cron/index.js
@@ -12,7 +12,6 @@ const rotateLogs = require('./rotateLogs');
 const expireTempIds = require('./expireTempIds');
 const expireDataExports = require('./expireDataExports');
 const alertManager = require('../utils/alertManagerInstance');
-const dispatchNotifications = require('./notification-dispatch');
 const ageVerificationAuditReconcile = require('./ageVerificationAuditReconcile');
 
 function startCronJobs() {
@@ -91,12 +90,13 @@ function startCronJobs() {
     );
   });
 
-  // Dispatch queued suggestion notifications — every 2 minutes
-  cron.schedule('*/2 * * * *', () => {
-    dispatchNotifications().catch((err) =>
-      log.error('cron', 'notification-dispatch failed', { error: err.message }),
-    );
-  });
+  // dispatchNotifications migrated to GitHub Actions scheduled workflow
+  // (.github/workflows/cron-dispatch-notifications.yml) which POSTs to
+  // /api/system/dispatch-notifications every 5 minutes. The cadence was
+  // relaxed from every-2-min (in-process cron) to every-5-min in the GH
+  // Actions move to keep total cron-cluster minutes low; notification
+  // dispatch latency rises from 2-min worst case to 5-min worst case,
+  // operator-approved. Function lives in src/cron/notification-dispatch.js.
 
   // Age-verification audit-log reconciliation — daily 05:00 UTC.
   // Back-fills missing audit entries for decisions whose post-commit

--- a/express-api/src/routes/system.js
+++ b/express-api/src/routes/system.js
@@ -21,8 +21,18 @@
  *                                             .github/workflows/
  *                                             cron-expire-bans.yml.
  *
- * Future endpoints (added per cron-cluster migration):
- * POST /api/system/dispatch-notifications   — requires Bearer
+ * POST /api/system/dispatch-notifications   — requires Bearer auth.
+ *                                             Synchronously runs
+ *                                             dispatchNotifications() —
+ *                                             every-5-min sweep scheduled
+ *                                             by .github/workflows/
+ *                                             cron-dispatch-notifications.yml.
+ *                                             Was every 2 min in the
+ *                                             in-process cron; cadence
+ *                                             relaxed to every 5 min in
+ *                                             the GH Actions move to keep
+ *                                             total cluster minutes low
+ *                                             (operator-approved).
  *
  * Architecture: replaces in-process node-cron schedules with either
  * external monitors (Better Stack for serverHealth) or GitHub Actions
@@ -36,6 +46,7 @@ const log = require('../utils/log');
 const serverHealth = require('../cron/serverHealth');
 const accountDeletion = require('../cron/accountDeletion');
 const expireBans = require('../cron/expireBans');
+const dispatchNotifications = require('../cron/notification-dispatch');
 const alertManager = require('../utils/alertManagerInstance');
 const { requireSystemAuth } = require('../middleware/system-auth');
 
@@ -51,29 +62,6 @@ router.get('/system/health', (req, res) => {
   });
 });
 
-// In-flight guards prevent concurrent sweeps from racing on the same
-// page of work. The GH Actions scheduled workflow runs once per cron
-// tick, but a hand-triggered re-dispatch or a delayed first run
-// overlapping the next scheduled run would otherwise pick up the same
-// rows. The guard returns 409 so the caller sees a clean rejection
-// rather than a partial double-execution.
-//
-// Each sweep has its own flag so a hung `accountDeletion` sweep doesn't
-// block an unrelated `bans` sweep, and vice versa.
-//
-// Paired with a hard timeout (SWEEP_TIMEOUT): if the underlying sweep
-// hangs forever (Firestore unreachable, R2 retry-loop, Auth SDK stuck),
-// the timeout races the sweep and forces the handler to respond 500.
-// Without this, the in-flight flag would stay `true` forever and the
-// GH Actions 409-as-success path would mask the wedge from the Actions
-// UI — operator only finds out a week later when the queue hasn't
-// drained. The 20-min bound is well inside the workflow's `timeout-
-// minutes: 30` and the curl `--max-time 600` (10 min) — curl times out
-// first so the workflow sees a hard failure, then the server's own
-// timeout clears the flag so the NEXT scheduled run can proceed
-// without manual intervention.
-let accountDeletionInFlight = false;
-let bansInFlight = false;
 const SWEEP_TIMEOUT_DEFAULT_MS = 20 * 60 * 1000;
 
 // Read the sweep timeout per-request so tests can inject a short
@@ -89,66 +77,96 @@ function getSweepTimeoutMs() {
   return SWEEP_TIMEOUT_DEFAULT_MS;
 }
 
-router.post('/system/sweep-account-deletions', requireSystemAuth, async (req, res) => {
-  if (accountDeletionInFlight) {
-    return res.status(409).json({ error: 'sweep already in flight' });
-  }
-  accountDeletionInFlight = true;
-  let timeoutHandle;
-  try {
-    const timeoutMs = getSweepTimeoutMs();
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(
-        () => reject(new Error(`sweep timed out after ${timeoutMs}ms`)),
-        timeoutMs,
-      );
-    });
-    await Promise.race([accountDeletion(), timeoutPromise]);
-    res.json({ status: 'ok' });
-  } catch (err) {
-    log.error('system', 'sweep-account-deletions failed', { error: err.message });
-    res.status(500).json({ error: 'sweep failed' });
-  } finally {
-    if (timeoutHandle) clearTimeout(timeoutHandle);
-    accountDeletionInFlight = false;
-  }
-});
+/**
+ * Factory for sweep-style endpoint handlers.
+ *
+ * Each sweep endpoint shares the same shape: bearer-auth (applied
+ * upstream by the route mounting), reject-if-in-flight with 409,
+ * Promise.race with a hard timeout, error → 500 + log, and a
+ * try/finally that guarantees the in-flight flag is cleared and the
+ * timeout handle released.
+ *
+ * Returning a closure-captured handler gives each sweep its OWN
+ * in-flight flag (independent of other sweeps), and exposes a
+ * `_reset()` method behind a NODE_ENV=test guard so the test suite can
+ * scrub any leaked flag from a Jest-aborted test without exposing the
+ * mutation to production callers. Per the operator's
+ * `[[feedback-test-isolation-no-leaks]]` directive.
+ *
+ * The factory is the "three similar lines" refactor of PRs #989, #990,
+ * and this PR — by the time we have three sweep endpoints with
+ * identical wrapping logic, the abstraction pays for itself in: (a)
+ * one place to audit auth / timeout / error-handling semantics; (b)
+ * the in-flight independence test only needs to assert per-endpoint
+ * flag closure; (c) future sweep endpoints (e.g. PR #6's voice-room
+ * scrap once RTDB onDisconnect lands) get the same defenses for free.
+ *
+ * @param {string} name short identifier used in log messages, e.g.
+ *   'sweep-bans', 'sweep-account-deletions'.
+ * @param {() => Promise<unknown>} sweepFn the underlying worker that
+ *   does the actual sweep — typically a function from src/cron/*.
+ * @returns Express handler.
+ */
+function createSweepHandler(name, sweepFn) {
+  let inFlight = false;
 
-router.post('/system/sweep-bans', requireSystemAuth, async (req, res) => {
-  if (bansInFlight) {
-    return res.status(409).json({ error: 'sweep already in flight' });
+  const handler = async (req, res) => {
+    if (inFlight) {
+      return res.status(409).json({ error: 'sweep already in flight' });
+    }
+    inFlight = true;
+    let timeoutHandle;
+    try {
+      const timeoutMs = getSweepTimeoutMs();
+      const timeoutPromise = new Promise((_, reject) => {
+        timeoutHandle = setTimeout(
+          () => reject(new Error(`sweep timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      });
+      await Promise.race([sweepFn(), timeoutPromise]);
+      res.json({ status: 'ok' });
+    } catch (err) {
+      log.error('system', `${name} failed`, { error: err.message });
+      res.status(500).json({ error: 'sweep failed' });
+    } finally {
+      // Clear the timer first so a successful sweep doesn't leak the
+      // pending setTimeout (the Promise.race winner ignores the loser
+      // but the loser's setTimeout is still scheduled and would keep
+      // Node alive past the response).
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      inFlight = false;
+    }
+  };
+
+  if (process.env.NODE_ENV === 'test') {
+    handler._reset = () => {
+      inFlight = false;
+    };
   }
-  bansInFlight = true;
-  let timeoutHandle;
-  try {
-    const timeoutMs = getSweepTimeoutMs();
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(
-        () => reject(new Error(`sweep timed out after ${timeoutMs}ms`)),
-        timeoutMs,
-      );
-    });
-    await Promise.race([expireBans(), timeoutPromise]);
-    res.json({ status: 'ok' });
-  } catch (err) {
-    log.error('system', 'sweep-bans failed', { error: err.message });
-    res.status(500).json({ error: 'sweep failed' });
-  } finally {
-    if (timeoutHandle) clearTimeout(timeoutHandle);
-    bansInFlight = false;
-  }
-});
+
+  return handler;
+}
+
+const sweepAccountDeletions = createSweepHandler('sweep-account-deletions', accountDeletion);
+const sweepBans = createSweepHandler('sweep-bans', expireBans);
+const dispatchNotificationsHandler = createSweepHandler(
+  'dispatch-notifications',
+  dispatchNotifications,
+);
+
+router.post('/system/sweep-account-deletions', requireSystemAuth, sweepAccountDeletions);
+router.post('/system/sweep-bans', requireSystemAuth, sweepBans);
+router.post('/system/dispatch-notifications', requireSystemAuth, dispatchNotificationsHandler);
 
 // Test-only reset hook. Exported behind a NODE_ENV guard so production
-// code can't accidentally clobber the in-flight flags — the consumer
-// (system.test.js afterEach) calls this to scrub any leaked state from
-// a Jest-timeout-aborted test that held a Promise open without
-// resolving it. Per the operator's `[[feedback-test-isolation-no-leaks]]`
-// directive: tests must be isolated, no leaked state across cases.
+// code can't accidentally clobber the in-flight flags. Calls each
+// sweep handler's `_reset()` closure so all flags scrub in one go.
 if (process.env.NODE_ENV === 'test') {
   router._resetInFlightForTesting = () => {
-    accountDeletionInFlight = false;
-    bansInFlight = false;
+    sweepAccountDeletions._reset();
+    sweepBans._reset();
+    dispatchNotificationsHandler._reset();
   };
 }
 

--- a/express-api/tests/cron/index.test.js
+++ b/express-api/tests/cron/index.test.js
@@ -30,7 +30,6 @@ jest.mock('../../src/cron/orphanedStorage', () => jest.fn());
 jest.mock('../../src/cron/rotateLogs', () => jest.fn());
 jest.mock('../../src/cron/expireTempIds', () => jest.fn());
 jest.mock('../../src/cron/expireDataExports', () => jest.fn());
-jest.mock('../../src/cron/notification-dispatch', () => jest.fn());
 jest.mock('../../src/cron/ageVerificationAuditReconcile', () => jest.fn());
 const { startCronJobs } = require('../../src/cron/index');
 const log = require('../../src/utils/log');
@@ -45,7 +44,6 @@ const orphanedStorage = require('../../src/cron/orphanedStorage');
 const rotateLogs = require('../../src/cron/rotateLogs');
 const expireTempIds = require('../../src/cron/expireTempIds');
 const expireDataExports = require('../../src/cron/expireDataExports');
-const dispatchNotifications = require('../../src/cron/notification-dispatch');
 const ageVerificationAuditReconcile = require('../../src/cron/ageVerificationAuditReconcile');
 beforeEach(() => {
   jest.clearAllMocks();
@@ -120,12 +118,13 @@ describe('startCronJobs', () => {
       // ageVerificationAuditReconcile — daily 05:00 UTC
       expect(schedules).toContain('0 5 * * *');
 
-      // Total: 9 schedules in production. serverHealth migrated to
-      // Better Stack (PR #988); accountDeletion migrated to GitHub
-      // Actions (PR #989); expireBans migrated to GitHub Actions
-      // (this PR's .github/workflows/cron-expire-bans.yml POSTs to
-      // /api/system/sweep-bans at */15 * * * *).
-      expect(mockSchedule).toHaveBeenCalledTimes(9);
+      // Total: 8 schedules in production. serverHealth migrated to
+      // Better Stack (PR #988); accountDeletion → GH Actions (PR #989);
+      // expireBans → GH Actions (PR #990); dispatchNotifications → GH
+      // Actions (this PR — every 5 min via
+      // .github/workflows/cron-dispatch-notifications.yml POSTs to
+      // /api/system/dispatch-notifications).
+      expect(mockSchedule).toHaveBeenCalledTimes(8);
     });
 
     test('does not register testDataCleanup in production', () => {
@@ -201,16 +200,11 @@ describe('startCronJobs', () => {
       expect(expireDataExports).toHaveBeenCalled();
     });
 
-    test('dispatchNotifications callback invokes the job on every 2 minutes', () => {
-      dispatchNotifications.mockResolvedValue(undefined);
-      startCronJobs();
-
-      const twoMinCall = mockSchedule.mock.calls.find((c) => c[0] === '*/2 * * * *');
-      expect(twoMinCall).toBeDefined();
-
-      twoMinCall[1]();
-      expect(dispatchNotifications).toHaveBeenCalled();
-    });
+    // dispatchNotifications callback test removed — migrated to GH
+    // Actions scheduled workflow (*/5 in workflow vs */2 in-process,
+    // operator-approved cadence relaxation). The endpoint is exercised
+    // by tests in tests/routes/system.test.js + the workflow at
+    // .github/workflows/cron-dispatch-notifications.yml.
 
     test('ageVerificationAuditReconcile callback invokes the job', () => {
       ageVerificationAuditReconcile.mockResolvedValue(undefined);

--- a/express-api/tests/routes/system.test.js
+++ b/express-api/tests/routes/system.test.js
@@ -16,6 +16,13 @@ jest.mock('../../src/cron/accountDeletion', () => mockAccountDeletion);
 const mockExpireBans = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../src/cron/expireBans', () => mockExpireBans);
 
+// Mock the notification-dispatch worker the same way — dispatch-
+// notifications endpoint awaits this synchronously. Also avoids
+// touching the firebase init chain in notification-dispatch.js's
+// require tree.
+const mockDispatchNotifications = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../src/cron/notification-dispatch', () => mockDispatchNotifications);
+
 // Mock alertManager — its real init touches Firestore which we don't
 // need for the heartbeat endpoint's contract.
 jest.mock('../../src/utils/alertManagerInstance', () => ({
@@ -65,6 +72,7 @@ beforeEach(() => {
   mockServerHealth.mockResolvedValue(undefined);
   mockAccountDeletion.mockResolvedValue(undefined);
   mockExpireBans.mockResolvedValue(undefined);
+  mockDispatchNotifications.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -505,5 +513,168 @@ describe('POST /api/system/sweep-bans', () => {
     const { err, res: accountRes } = await accountResponse;
     expect(err).toBeNull();
     expect(accountRes.status).toBe(200);
+  });
+});
+
+describe('POST /api/system/dispatch-notifications', () => {
+  test('returns 401 without bearer token', async () => {
+    const app = createApp();
+    const res = await request(app).post('/api/system/dispatch-notifications');
+
+    expect(res.status).toBe(401);
+    expect(mockDispatchNotifications).not.toHaveBeenCalled();
+  });
+
+  test('returns 401 with wrong bearer token', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/system/dispatch-notifications')
+      .set('Authorization', 'Bearer wrong-secret');
+
+    expect(res.status).toBe(401);
+    expect(mockDispatchNotifications).not.toHaveBeenCalled();
+  });
+
+  test('returns 200 and invokes dispatchNotifications with correct secret', async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/system/dispatch-notifications')
+      .set('Authorization', `Bearer ${TEST_SECRET}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+    expect(mockDispatchNotifications).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns 500 when dispatchNotifications throws', async () => {
+    mockDispatchNotifications.mockRejectedValueOnce(new Error('FCM unavailable'));
+
+    const app = createApp();
+    const res = await request(app)
+      .post('/api/system/dispatch-notifications')
+      .set('Authorization', `Bearer ${TEST_SECRET}`);
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'sweep failed' });
+    expect(mockDispatchNotifications).toHaveBeenCalledTimes(1);
+    expect(mockLog.error).toHaveBeenCalledWith(
+      'system',
+      'dispatch-notifications failed',
+      expect.objectContaining({ error: 'FCM unavailable' }),
+    );
+  });
+
+  test('returns 409 when a concurrent dispatch is in flight', async () => {
+    let resolveFirst;
+    const firstPromise = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockDispatchNotifications.mockReturnValueOnce(firstPromise);
+
+    const app = createApp();
+
+    let captureFirstResponse;
+    const firstResponse = new Promise((resolve) => {
+      captureFirstResponse = resolve;
+    });
+    request(app)
+      .post('/api/system/dispatch-notifications')
+      .set('Authorization', `Bearer ${TEST_SECRET}`)
+      .end((err, res) => captureFirstResponse({ err, res }));
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const secondRes = await request(app)
+      .post('/api/system/dispatch-notifications')
+      .set('Authorization', `Bearer ${TEST_SECRET}`);
+
+    expect(secondRes.status).toBe(409);
+    expect(secondRes.body).toEqual({ error: 'sweep already in flight' });
+    expect(mockDispatchNotifications).toHaveBeenCalledTimes(1);
+
+    resolveFirst();
+    const { err, res: firstRes } = await firstResponse;
+    expect(err).toBeNull();
+    expect(firstRes.status).toBe(200);
+  });
+
+  test('times out and returns 500 if dispatchNotifications hangs forever', async () => {
+    mockDispatchNotifications.mockReturnValueOnce(new Promise(() => {}));
+    process.env.SWEEP_TIMEOUT_MS_OVERRIDE = '50';
+
+    try {
+      const app = createApp();
+      const res = await request(app)
+        .post('/api/system/dispatch-notifications')
+        .set('Authorization', `Bearer ${TEST_SECRET}`);
+
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({ error: 'sweep failed' });
+      expect(mockLog.error).toHaveBeenCalledWith(
+        'system',
+        'dispatch-notifications failed',
+        expect.objectContaining({ error: expect.stringContaining('timed out') }),
+      );
+
+      // Flag cleared → next dispatch works.
+      mockDispatchNotifications.mockResolvedValueOnce(undefined);
+      const next = await request(app)
+        .post('/api/system/dispatch-notifications')
+        .set('Authorization', `Bearer ${TEST_SECRET}`);
+      expect(next.status).toBe(200);
+    } finally {
+      delete process.env.SWEEP_TIMEOUT_MS_OVERRIDE;
+    }
+  });
+
+  test('dispatch-notifications guard is INDEPENDENT from sweep-bans and sweep-account-deletions', async () => {
+    // All three sweeps have their own closure-captured flag from the
+    // createSweepHandler factory. A hung dispatch must not block bans
+    // or account-deletions, and vice versa.
+    //
+    // Hold dispatch via a manually-resolvable Promise (not a timeout
+    // override) so the dispatch sweep stays in-flight for the FULL
+    // duration of the bans + account-deletion assertions. A timeout
+    // approach would clear the dispatch flag mid-test, defeating the
+    // structural guarantee the test is meant to prove (reviewer's
+    // Important #1 on PR #5).
+    let resolveDispatch;
+    const dispatchHeld = new Promise((resolve) => {
+      resolveDispatch = resolve;
+    });
+    mockDispatchNotifications.mockReturnValueOnce(dispatchHeld);
+
+    const app = createApp();
+
+    let captureDispatch;
+    const dispatchResponse = new Promise((resolve) => {
+      captureDispatch = resolve;
+    });
+    request(app)
+      .post('/api/system/dispatch-notifications')
+      .set('Authorization', `Bearer ${TEST_SECRET}`)
+      .end((err, res) => captureDispatch({ err, res }));
+
+    // Yield so the dispatch handler enters and sets its inFlight flag.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // The dispatch is now genuinely in-flight (no timeout fallback).
+    // sweep-bans must proceed because its flag is INDEPENDENT.
+    const bansRes = await request(app)
+      .post('/api/system/sweep-bans')
+      .set('Authorization', `Bearer ${TEST_SECRET}`);
+    expect(bansRes.status).toBe(200);
+
+    // sweep-account-deletions must also proceed — also INDEPENDENT.
+    const accountRes = await request(app)
+      .post('/api/system/sweep-account-deletions')
+      .set('Authorization', `Bearer ${TEST_SECRET}`);
+    expect(accountRes.status).toBe(200);
+
+    // Release the dispatch and confirm it completes cleanly.
+    resolveDispatch();
+    const { err, res: dispatchRes } = await dispatchResponse;
+    expect(err).toBeNull();
+    expect(dispatchRes.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary

PR #5 of the cron-cluster refactor. Two things in one PR (third sweep endpoint = the "three similar lines" abstraction threshold per CLAUDE.md):

1. **Refactor `src/routes/system.js`** to use a `createSweepHandler(name, sweepFn)` factory. Each call returns a closure-captured handler with its own in-flight flag, `Promise.race` timeout, error-logging, and `finally` cleanup. `sweep-account-deletions`, `sweep-bans`, and the new `dispatch-notifications` all route through the factory.

2. **New endpoint `POST /api/system/dispatch-notifications`** + `cron-dispatch-notifications.yml` workflow that POSTs to it every 5 minutes (relaxed from in-process every-2-min — operator-approved cadence change to keep total cron-cluster minutes low).

## Reviewer findings (all addressed)

`feature-dev:code-reviewer` agent flagged 0 Critical + 2 Important.

| Finding | Confidence | Status |
|---|---|---|
| Independence test used 500ms timeout that could clear the dispatch in-flight flag before bans/account-deletion assertions complete (test would pass even against a broken shared-flag implementation) | 82 (Important) | Fixed via manually-resolvable Promise pattern matching `system.test.js:481` |
| Workflow `--max-time 300` == `*/5` cadence with no buffer | 80 (Important) | Tightened to `--max-time 240` (60s buffer before next tick) |

Reviewer confirmed at confidence >= 80: factory closure correctness, test-only hook security (NODE_ENV=test gating), existing test compatibility (no behavioral regression for sweep-account-deletions or sweep-bans), workflow security (env-scoped secret, no `${{ }}` in run body), cadence change documentation, sonar cleanliness.

## Files

- `src/routes/system.js`: factory refactor + new dispatch-notifications endpoint via the factory; existing two endpoints route through it too
- ADD `.github/workflows/cron-dispatch-notifications.yml` — `schedule: '*/5 * * * *'` + `workflow_dispatch`, `--max-time 240` curl
- `src/cron/index.js`: drop dispatchNotifications import + `*/2` schedule; migration-note comment explaining the cadence change
- `tests/cron/index.test.js`: drop mock + callback test; total cron schedule count `9 → 8`
- `tests/routes/system.test.js`: +6 dispatch-notifications tests (auth/success/error/409/timeout/INDEPENDENT) + mock for notification-dispatch (avoids touching firebase init chain)

## Verification

- Affected tests: 3 suites / 58 passed
- Full express-api suite: 301 / 11223 passed (was 301 / 11217 after PR #990, +6 from this PR)
- 1 pre-existing skip preserved
- actionlint + SonarCloud pre-push gates passed

## Deploy steps (operator)

**NO additional deploy steps** — `SYSTEM_SHARED_SECRET` was set up for PR #989 and reused by #990 and this PR. The new workflow becomes active on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)