### PR TITLE
feat(gdpr): locale-aware README architecture in data-export ZIP

### DIFF
--- a/express-api/src/utils/data-export-builder.js
+++ b/express-api/src/utils/data-export-builder.js
@@ -27,6 +27,7 @@ const zipArchivePromise = import('archiver').then((m) => m.ZipArchive);
 const { db } = require('./firebase');
 const { queryDocs } = require('./firestore-helpers');
 const log = require('./log');
+const { buildReadme } = require('./data-export-readme-i18n');
 
 // Fields to strip from the profile (internal/sensitive)
 const STRIP_FIELDS = [
@@ -456,54 +457,19 @@ async function buildDataExport(uniqueId) {
     archive.on('end', () => resolve(Buffer.concat(chunks)));
     archive.on('error', reject);
 
-    const readmeLines = [
-      'ShyTalk Data Export',
-      '===================',
-      '',
-      `User ID: ${uniqueId}`,
-      `Export date: ${new Date().toISOString()}`,
-      '',
-    ];
-    if (partial) {
-      // Surface partial-export state explicitly in the README so the user
-      // sees it without parsing manifest.json. The list of failed sections
-      // tells them exactly what they're missing.
-      readmeLines.push(
-        '⚠️  PARTIAL EXPORT',
-        '',
-        'This export is incomplete. The following sections could not be',
-        'retrieved due to a transient backend failure:',
-        '',
-        ...failedSections.map((s) => `  - ${s}`),
-        '',
-        'You can request a fresh export in 24 hours. We apologise for the',
-        'inconvenience — this is a compliance issue we take seriously.',
-        '',
-      );
-    } else {
-      readmeLines.push(
-        'This ZIP contains all personal data associated with your ShyTalk account.',
-        '',
-      );
-    }
-    readmeLines.push(
-      'Files:',
-      '  manifest.json     — Section-by-section status of this export',
-      '  profile.json      — Your profile information',
-      '  settings.json     — Your privacy and notification settings',
-      '  identity.json     — Your linked sign-in providers',
-      '  followers.json    — Your followers and following lists',
-      '  blocked.json      — Your blocked users list',
-      '  economy/          — Your coins, beans, transactions, and backpack',
-      '  gifts/            — Your gift wall',
-      '  conversations/    — Your conversation metadata and messages',
-      '  rooms/            — Rooms you own',
-      '  reports/          — Reports you filed and appeals',
-      '  devices/          — Your device bindings',
-      '  moderation/       — Your warning history',
-      '  suggestions/      — Suggestions you submitted, votes & comments you made, your subscription preferences, and notifications you received',
-    );
-    const readme = readmeLines.join('\n');
+    // README.txt is rendered via the locale-aware builder. The owner's
+    // language preference is on the user doc (set by the in-app
+    // language picker). Untranslated locales fall back to English
+    // automatically — see src/utils/data-export-readme-i18n.js for
+    // the translation table and the contributor guidance for adding
+    // a new locale.
+    const readme = buildReadme({
+      language: userData.language,
+      uniqueId,
+      exportDateIso: new Date().toISOString(),
+      partial,
+      failedSections,
+    });
 
     archive.append(readme, { name: 'README.txt' });
     archive.append(JSON.stringify(manifest, null, 2), { name: 'manifest.json' });

--- a/express-api/src/utils/data-export-readme-i18n.js
+++ b/express-api/src/utils/data-export-readme-i18n.js
@@ -1,0 +1,176 @@
+/**
+ * Locale-aware translation table for the README.txt that ships inside
+ * every GDPR data-export ZIP. The table is structured for per-locale
+ * override + automatic fallback to English:
+ *
+ *   buildReadme('en', ...)   → en strings
+ *   buildReadme('fr', ...)   → en strings (no 'fr' override yet)
+ *   buildReadme('en-US', ...) → en strings (region tag stripped)
+ *
+ * To add a new locale, add a key to STRINGS keyed by the 2-letter
+ * ISO-639-1 code (matching the values written to user.language by the
+ * client's language picker). Each locale entry must have the same
+ * shape as `STRINGS.en` — see the `en` block for the required keys
+ * and their semantics. Untranslated keys fall through to en.
+ *
+ * Architecture-only scope (the operator's "Architecture-only, en stays"
+ * choice on the GDPR README i18n carry-forward): ship the
+ * infrastructure with en-only translations. Translations for the 19
+ * other ShyTalk locales should be PR'd by native speakers, not
+ * machine-generated, because the README contains legal-leaning text
+ * (GDPR Article 20 reference, compliance language) where mistranslation
+ * could create regulatory exposure.
+ */
+
+const STRINGS = {
+  en: {
+    title: 'ShyTalk Data Export',
+    titleUnderline: '===================',
+    userIdLabel: 'User ID',
+    exportDateLabel: 'Export date',
+    partialWarning: '⚠️  PARTIAL EXPORT',
+    partialIntroLine1: 'This export is incomplete. The following sections could not be',
+    partialIntroLine2: 'retrieved due to a transient backend failure:',
+    partialOutro: [
+      'You can request a fresh export in 24 hours. We apologise for the',
+      'inconvenience — this is a compliance issue we take seriously.',
+    ],
+    fullIntro: 'This ZIP contains all personal data associated with your ShyTalk account.',
+    filesHeader: 'Files:',
+    fileEntries: [
+      ['manifest.json    ', 'Section-by-section status of this export'],
+      ['profile.json     ', 'Your profile information'],
+      ['settings.json    ', 'Your privacy and notification settings'],
+      ['identity.json    ', 'Your linked sign-in providers'],
+      ['followers.json   ', 'Your followers and following lists'],
+      ['blocked.json     ', 'Your blocked users list'],
+      ['economy/         ', 'Your coins, beans, transactions, and backpack'],
+      ['gifts/           ', 'Your gift wall'],
+      ['conversations/   ', 'Your conversation metadata and messages'],
+      ['rooms/           ', 'Rooms you own'],
+      ['reports/         ', 'Reports you filed and appeals'],
+      ['devices/         ', 'Your device bindings'],
+      ['moderation/      ', 'Your warning history'],
+      [
+        'suggestions/     ',
+        'Suggestions you submitted, votes & comments you made, your subscription preferences, and notifications you received',
+      ],
+    ],
+  },
+};
+
+const FALLBACK_LANGUAGE = 'en';
+
+/**
+ * Look up a translation key with locale + en fallback.
+ *
+ * Fallback rules — in priority order:
+ *   1. Locale value missing → fall back to en.
+ *   2. Locale value present but wrong type vs en → fall back to en.
+ *      (Guards a contributor who writes `partialOutro: 'one line'`
+ *      when en has it as an array — without this, the string would be
+ *      character-spread into the README.)
+ *   3. Locale value is an empty array where en has a non-empty array
+ *      → fall back to en. (Guards a contributor who writes
+ *      `fileEntries: []` as a placeholder — without this, the README
+ *      would render `Files:` with no entries underneath.)
+ *
+ * @param {string|undefined} language - 2-letter ISO-639-1 code
+ *   (case-insensitive, region tag stripped); undefined → fallback.
+ * @param {string} key - One of the keys in STRINGS.en (see the en
+ *   block for the canonical set).
+ * @returns {string|string[]} the translated value, or the en value
+ *   if the locale doesn't have a usable override for this key.
+ */
+function t(language, key) {
+  const normalized = normaliseLanguage(language);
+  const localeTable = STRINGS[normalized] || {};
+  if (key in localeTable) {
+    const val = localeTable[key];
+    const enVal = STRINGS[FALLBACK_LANGUAGE][key];
+    // Type-match guard: if the en value is an array but the locale
+    // override isn't (or vice versa), fall back to en. Prevents the
+    // character-spread bug when a contributor writes a string for an
+    // array key.
+    if (Array.isArray(enVal) !== Array.isArray(val)) return enVal;
+    // Non-empty guard: if en has a non-empty array but the locale
+    // override is empty, fall back to en. Prevents the empty-section
+    // bug when a contributor leaves an array key as `[]`.
+    if (Array.isArray(val) && val.length === 0 && enVal.length > 0) return enVal;
+    return val;
+  }
+  return STRINGS[FALLBACK_LANGUAGE][key];
+}
+
+/**
+ * Strip region tags (`en-US` → `en`) + lower-case (`EN` → `en`) so
+ * the locale picker handles whatever shape the client writes to the
+ * user doc. Returns FALLBACK_LANGUAGE if the input is missing or
+ * unparseable.
+ */
+function normaliseLanguage(language) {
+  if (typeof language !== 'string' || !language.trim()) {
+    return FALLBACK_LANGUAGE;
+  }
+  return language.trim().toLowerCase().split(/[-_]/)[0];
+}
+
+/**
+ * Build the README.txt body for a GDPR data export.
+ *
+ * @param {object} args
+ * @param {string|undefined} args.language - The owner's preferred
+ *   locale from `user.language`. Falls back to en when absent or
+ *   when the locale has no override.
+ * @param {string} args.uniqueId - The owner's uniqueId.
+ * @param {string} args.exportDateIso - ISO-8601 timestamp for the
+ *   export.
+ * @param {boolean} args.partial - Whether the export is partial
+ *   (failed sections were omitted).
+ * @param {string[]} args.failedSections - Section names that failed
+ *   to be exported. Used only when `partial` is true.
+ * @returns {string} The README.txt body as a newline-joined string.
+ */
+function buildReadme({ language, uniqueId, exportDateIso, partial, failedSections }) {
+  const lines = [
+    t(language, 'title'),
+    t(language, 'titleUnderline'),
+    '',
+    `${t(language, 'userIdLabel')}: ${uniqueId}`,
+    `${t(language, 'exportDateLabel')}: ${exportDateIso}`,
+    '',
+  ];
+
+  if (partial) {
+    lines.push(
+      t(language, 'partialWarning'),
+      '',
+      t(language, 'partialIntroLine1'),
+      t(language, 'partialIntroLine2'),
+      '',
+      ...failedSections.map((s) => `  - ${s}`),
+      '',
+      ...t(language, 'partialOutro'),
+      '',
+    );
+  } else {
+    lines.push(t(language, 'fullIntro'), '');
+  }
+
+  lines.push(t(language, 'filesHeader'));
+  for (const [filename, description] of t(language, 'fileEntries')) {
+    lines.push(`  ${filename} — ${description}`);
+  }
+
+  return lines.join('\n');
+}
+
+module.exports = {
+  buildReadme,
+  // Exported for tests + future contributors who want to add a
+  // locale: confirm the en table is the source-of-truth shape, then
+  // add a parallel entry.
+  STRINGS,
+  FALLBACK_LANGUAGE,
+  normaliseLanguage,
+};

--- a/express-api/tests/utils/data-export-readme-i18n.test.js
+++ b/express-api/tests/utils/data-export-readme-i18n.test.js
@@ -1,0 +1,292 @@
+const {
+  buildReadme,
+  STRINGS,
+  FALLBACK_LANGUAGE,
+  normaliseLanguage,
+} = require('../../src/utils/data-export-readme-i18n');
+
+describe('normaliseLanguage', () => {
+  test('strips region tags and lower-cases', () => {
+    expect(normaliseLanguage('en-US')).toBe('en');
+    expect(normaliseLanguage('FR')).toBe('fr');
+    expect(normaliseLanguage('zh-Hans-CN')).toBe('zh');
+    expect(normaliseLanguage('pt_BR')).toBe('pt');
+  });
+
+  test('returns fallback for missing / empty / non-string input', () => {
+    expect(normaliseLanguage(undefined)).toBe(FALLBACK_LANGUAGE);
+    expect(normaliseLanguage(null)).toBe(FALLBACK_LANGUAGE);
+    expect(normaliseLanguage('')).toBe(FALLBACK_LANGUAGE);
+    expect(normaliseLanguage('   ')).toBe(FALLBACK_LANGUAGE);
+    expect(normaliseLanguage(42)).toBe(FALLBACK_LANGUAGE);
+  });
+});
+
+describe('STRINGS table shape', () => {
+  test('every locale entry has the same shape as the en source-of-truth', () => {
+    const enKeys = Object.keys(STRINGS.en).sort();
+    for (const [locale, table] of Object.entries(STRINGS)) {
+      if (locale === FALLBACK_LANGUAGE) continue;
+      const localeKeys = Object.keys(table).sort();
+      // Each non-en locale may have a SUBSET of keys (untranslated
+      // keys fall back to en), but every key it DOES have must exist
+      // in en. This catches typos like 'titleUnderlne' that would
+      // silently miss the en fallback because the key is wrong.
+      for (const key of localeKeys) {
+        expect(enKeys).toContain(key);
+        // Type-match guard: if en has an array, the locale override
+        // must also be an array (and non-empty). Without this check,
+        // a contributor writing `partialOutro: 'one sentence'` would
+        // pass the key-existence test, then fail at runtime by
+        // character-spreading the string into the README.
+        if (Array.isArray(STRINGS.en[key])) {
+          expect(Array.isArray(table[key])).toBe(true);
+          expect(table[key].length).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  test('STRINGS.en defines all the keys that buildReadme references', () => {
+    // Calling buildReadme with an unsupported locale exercises every
+    // fallback path; if buildReadme references a key that en doesn't
+    // have, this would throw or produce undefined-joined strings.
+    const en = STRINGS.en;
+    expect(en.title).toBe('ShyTalk Data Export');
+    expect(en.titleUnderline).toBeDefined();
+    expect(en.userIdLabel).toBeDefined();
+    expect(en.exportDateLabel).toBeDefined();
+    expect(en.partialWarning).toBeDefined();
+    expect(en.partialIntroLine1).toBeDefined();
+    expect(en.partialIntroLine2).toBeDefined();
+    expect(Array.isArray(en.partialOutro)).toBe(true);
+    expect(en.fullIntro).toBeDefined();
+    expect(en.filesHeader).toBeDefined();
+    expect(Array.isArray(en.fileEntries)).toBe(true);
+    expect(en.fileEntries.length).toBeGreaterThan(0);
+    for (const entry of en.fileEntries) {
+      expect(Array.isArray(entry)).toBe(true);
+      expect(entry.length).toBe(2);
+    }
+  });
+});
+
+describe('buildReadme', () => {
+  const baseArgs = {
+    language: 'en',
+    uniqueId: '12345678',
+    exportDateIso: '2026-06-04T03:30:00.000Z',
+    partial: false,
+    failedSections: [],
+  };
+
+  test('en full export contains expected sections', () => {
+    const readme = buildReadme(baseArgs);
+
+    expect(readme).toContain('ShyTalk Data Export');
+    expect(readme).toContain('===================');
+    expect(readme).toContain('User ID: 12345678');
+    expect(readme).toContain('Export date: 2026-06-04T03:30:00.000Z');
+    expect(readme).toContain('This ZIP contains all personal data');
+    expect(readme).toContain('Files:');
+    expect(readme).toContain('profile.json');
+    expect(readme).toContain('manifest.json');
+    // Full exports do NOT have the partial warning.
+    expect(readme).not.toContain('PARTIAL EXPORT');
+  });
+
+  test('en partial export surfaces the warning + failed sections', () => {
+    const readme = buildReadme({
+      ...baseArgs,
+      partial: true,
+      failedSections: ['conversations', 'rooms'],
+    });
+
+    expect(readme).toContain('PARTIAL EXPORT');
+    expect(readme).toContain('This export is incomplete');
+    expect(readme).toContain('  - conversations');
+    expect(readme).toContain('  - rooms');
+    expect(readme).toContain('You can request a fresh export in 24 hours');
+    // Partial exports do NOT have the "all personal data" intro.
+    expect(readme).not.toContain('This ZIP contains all personal data');
+  });
+
+  test('missing language defaults to en', () => {
+    const enReadme = buildReadme(baseArgs);
+    const undefinedReadme = buildReadme({ ...baseArgs, language: undefined });
+    const emptyReadme = buildReadme({ ...baseArgs, language: '' });
+    const nullReadme = buildReadme({ ...baseArgs, language: null });
+
+    expect(undefinedReadme).toBe(enReadme);
+    expect(emptyReadme).toBe(enReadme);
+    expect(nullReadme).toBe(enReadme);
+  });
+
+  test('unsupported language falls back to en', () => {
+    const enReadme = buildReadme(baseArgs);
+    const klingonReadme = buildReadme({ ...baseArgs, language: 'tlh' });
+
+    expect(klingonReadme).toBe(enReadme);
+  });
+
+  test('region tags are stripped before lookup', () => {
+    const enReadme = buildReadme(baseArgs);
+    const enUsReadme = buildReadme({ ...baseArgs, language: 'en-US' });
+    const upperEnReadme = buildReadme({ ...baseArgs, language: 'EN' });
+
+    expect(enUsReadme).toBe(enReadme);
+    expect(upperEnReadme).toBe(enReadme);
+  });
+
+  test('partial export with no failed sections still renders cleanly', () => {
+    const readme = buildReadme({ ...baseArgs, partial: true, failedSections: [] });
+
+    expect(readme).toContain('PARTIAL EXPORT');
+    expect(readme).not.toContain('  - ');
+  });
+
+  test('file entries are formatted as `  <name> — <description>`', () => {
+    const readme = buildReadme(baseArgs);
+    // Spot-check one entry to pin the format. The leading two spaces
+    // come from the template literal; the padding spaces between the
+    // filename column and the em-dash come from the STRINGS table's
+    // trailing-space padding so all file entries align vertically.
+    expect(readme).toMatch(/ {2}profile\.json {6}— Your profile information/);
+  });
+});
+
+describe('contributor-footgun guards (reviewer Important findings on PR)', () => {
+  test('wrong-type override falls back to en (string-where-array expected)', () => {
+    // A contributor writes `partialOutro: 'Vous pouvez...'` (a string)
+    // for a locale that needs only a single-sentence outro. Without
+    // the type-match guard, `...t(language, 'partialOutro')` would
+    // character-spread the string into the README. With the guard,
+    // we fall back to en's array form so the output stays sane.
+    const originalEs = STRINGS.es;
+    STRINGS.es = {
+      partialOutro: 'Single sentence wrongly typed as a string',
+    };
+
+    try {
+      const readme = buildReadme({
+        language: 'es',
+        uniqueId: '12345678',
+        exportDateIso: '2026-06-04T03:30:00.000Z',
+        partial: true,
+        failedSections: ['conversations'],
+      });
+
+      // The en outro is used (two lines), not the locale's string.
+      expect(readme).toContain('You can request a fresh export in 24 hours');
+      // No characters from the wrong-type string leak in.
+      expect(readme).not.toContain('Single sentence wrongly typed');
+      // No character-spread evidence: should NOT contain a line that's
+      // just one character (which would happen if the string spread).
+      const lines = readme.split('\n');
+      const singleCharLines = lines.filter((l) => l.length === 1);
+      expect(singleCharLines).toHaveLength(0);
+    } finally {
+      if (originalEs === undefined) delete STRINGS.es;
+      else STRINGS.es = originalEs;
+    }
+  });
+
+  test('empty-array override falls back to en (fileEntries: [] placeholder)', () => {
+    // A contributor leaves `fileEntries: []` as a TODO placeholder.
+    // Without the empty-guard, the README would render `Files:` with
+    // no entries — silently empty. With the guard, we fall back to
+    // en's populated array so the user sees the file list.
+    const originalEs = STRINGS.es;
+    STRINGS.es = {
+      fileEntries: [],
+    };
+
+    try {
+      const readme = buildReadme({
+        language: 'es',
+        uniqueId: '12345678',
+        exportDateIso: '2026-06-04T03:30:00.000Z',
+        partial: false,
+        failedSections: [],
+      });
+
+      // The en fileEntries are used, not the empty array.
+      expect(readme).toContain('profile.json');
+      expect(readme).toContain('manifest.json');
+      expect(readme).toContain('conversations/');
+    } finally {
+      if (originalEs === undefined) delete STRINGS.es;
+      else STRINGS.es = originalEs;
+    }
+  });
+
+  test('array-where-string expected falls back to en (inverse type mismatch)', () => {
+    // Mirror of the wrong-type guard: if a contributor writes
+    // `title: ['ShyTalk', 'Data Export']` (an array) for a key that
+    // en has as a string, fall back to en. Without the guard, the
+    // string concatenation `${t(...)}: ${...}` would produce
+    // `ShyTalk,Data Export: ...` (JS array-to-string coercion).
+    const originalEs = STRINGS.es;
+    STRINGS.es = {
+      title: ['Wrong', 'Type', 'Override'],
+    };
+
+    try {
+      const readme = buildReadme({
+        language: 'es',
+        uniqueId: '12345678',
+        exportDateIso: '2026-06-04T03:30:00.000Z',
+        partial: false,
+        failedSections: [],
+      });
+
+      // The en title is used, not the array.
+      expect(readme).toContain('ShyTalk Data Export');
+      expect(readme).not.toContain('Wrong,Type,Override');
+    } finally {
+      if (originalEs === undefined) delete STRINGS.es;
+      else STRINGS.es = originalEs;
+    }
+  });
+});
+
+describe('contributor flow — adding a new locale', () => {
+  // The README-i18n module is structured so a future PR can add a
+  // locale by dropping an entry into STRINGS keyed by the 2-letter
+  // code. This test simulates the contributor pattern to ensure the
+  // mechanics work end-to-end without needing to actually ship 19
+  // translations in this PR.
+  test('locale-specific override is used when present', () => {
+    // Temporarily monkey-patch STRINGS for the duration of the test.
+    const originalEs = STRINGS.es;
+    STRINGS.es = {
+      title: 'Exportación de datos de ShyTalk',
+      // Other keys deliberately omitted to exercise the per-key
+      // fallback to en.
+    };
+
+    try {
+      const readme = buildReadme({
+        language: 'es',
+        uniqueId: '12345678',
+        exportDateIso: '2026-06-04T03:30:00.000Z',
+        partial: false,
+        failedSections: [],
+      });
+
+      // Spanish title is used.
+      expect(readme).toContain('Exportación de datos de ShyTalk');
+      // English files header is used (no Spanish override).
+      expect(readme).toContain('Files:');
+      // English file entries are used (no Spanish override).
+      expect(readme).toContain('profile.json');
+    } finally {
+      // Restore so this test doesn't leak state into other tests.
+      if (originalEs === undefined) {
+        delete STRINGS.es;
+      } else {
+        STRINGS.es = originalEs;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Splits the hardcoded English README out of `data-export-builder.js` into a dedicated translation module (`data-export-readme-i18n.js`) keyed by `user.language` with automatic per-key fallback to en. Ships en-only translations per the operator's "Architecture-only, en stays" choice on this carry-forward.

Translations for the 19 other ShyTalk locales (ar/de/es/fr/hi/id/it/ja/km/ko/nl/pl/pt/ru/sv/th/tr/uk/vi/zh) should be added by native-speaker contributors in follow-up PRs — the README contains legal-leaning text (GDPR Article 20 references, compliance language) where machine-translated content could create regulatory exposure.

## Reviewer findings (all addressed)

`feature-dev:code-reviewer` agent flagged 0 Critical + 2 Important:

| Finding | Confidence | Status |
|---|---|---|
| Empty-array locale override (`fileEntries: []`) silently bypasses the en fallback — TODO placeholder would render a README with `Files:` header but zero entries | 88 | Fixed via runtime guard in `t()` (treats empty arrays as absent) + complementary test guard in the shape-validation test |
| Wrong-type locale override (e.g., `partialOutro` written as a string instead of an array) would character-spread the string into the README | 85 | Fixed via type-match guard in `t()` (falls back to en when `Array.isArray` differs) + 2 regression tests covering wrong-type and inverse-type cases |

## Files

- ADD `express-api/src/utils/data-export-readme-i18n.js` — translation table with `STRINGS.en` as source-of-truth, `buildReadme()` + `normaliseLanguage()` helpers, type-match + non-empty-array guards in `t()`
- `express-api/src/utils/data-export-builder.js` — refactor: delegate README construction to `buildReadme()`, pass `userData.language`. Lines 459-505 collapse from 47 hardcoded lines to a 7-line `buildReadme` call.
- ADD `express-api/tests/utils/data-export-readme-i18n.test.js` — 15 tests: normaliseLanguage edge cases (4), STRINGS shape validation incl. array-type guard (2), buildReadme behaviour (7), contributor-footgun guards (3 — wrong-type / empty-array / inverse-type)

## Verification

- Affected tests: 1 suite / 15 passed
- Full express-api suite: 302 / 11243 passed (was 301 / 11228 after PR #992 — +1 new suite, +15 new tests)
- 1 pre-existing skip preserved
- SonarCloud pre-push quality gate passed

## Adding a new locale (contributor guide)

1. Drop an entry into `STRINGS` keyed by the 2-letter ISO-639-1 code (e.g. `'fr'`, matching the values written to `user.language` by the in-app language picker).
2. Translate any subset of the en keys — untranslated keys fall back to en automatically.
3. Array-valued keys (`partialOutro`, `fileEntries`) must remain arrays; the `t()` runtime guard + the shape-validation test enforce this.
4. Add a `buildReadme` test demonstrating the locale's title or other distinctive string appears in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)