### PR TITLE
refactor(rooms): lazy reap stale rooms inline at mutation chokepoint (server piece)

### DIFF
--- a/express-api/src/routes/room-mutations.js
+++ b/express-api/src/routes/room-mutations.js
@@ -108,8 +108,9 @@ async function inRoomTransaction(req, roomId, mutate) {
     // OWNER_AWAY → ACTIVE transition, not a close — so the predicate
     // takes callerId and short-circuits when caller === ownerId.
     const callerId = req.auth ? String(req.auth.uniqueId) : null;
-    if (shouldReapStaleRoom(room, Date.now(), callerId)) {
-      room = reapStaleRoomTx(t, roomRef, room, Date.now());
+    const nowMs = Date.now();
+    if (shouldReapStaleRoom(room, nowMs, callerId)) {
+      room = reapStaleRoomTx(t, roomRef, room, nowMs);
     }
     return mutate(room, t, roomRef);
   });

--- a/express-api/src/routes/room-mutations.js
+++ b/express-api/src/routes/room-mutations.js
@@ -39,6 +39,7 @@ const {
   MAX_SEATS,
   OWNER_SEAT_INDEX,
 } = require('../utils/room-auth');
+const { shouldReapStaleRoom, reapStaleRoomTx } = require('../utils/stale-room-reap');
 const log = require('../utils/log');
 
 // Mirrors the client room-name input cap (CreateRoomDialog: length <= 50).
@@ -92,9 +93,23 @@ async function inRoomTransaction(req, roomId, mutate) {
   return db.runTransaction(async (t) => {
     const snap = await t.get(roomRef);
     if (!snap.exists) return { status: 404, body: { error: 'Room not found' } };
-    const room = snap.data();
+    let room = snap.data();
     if (cohortFromClaim(req) !== (room.cohort ?? 'minor')) {
       return { status: 404, body: { error: 'Not found' } };
+    }
+    // Lazy reap: if the room has been OWNER_AWAY long enough that the
+    // staleRooms cron would have closed it on its next tick, close it
+    // inline within this same transaction. The mutate() callback below
+    // sees the post-close room shape and returns its standard "room is
+    // closed" 409. The cron stays running as the safety net for
+    // abandoned rooms (zero participant traffic post-departure).
+    //
+    // The owner returning never triggers reap — that path is the
+    // OWNER_AWAY → ACTIVE transition, not a close — so the predicate
+    // takes callerId and short-circuits when caller === ownerId.
+    const callerId = req.auth ? String(req.auth.uniqueId) : null;
+    if (shouldReapStaleRoom(room, Date.now(), callerId)) {
+      room = reapStaleRoomTx(t, roomRef, room, Date.now());
     }
     return mutate(room, t, roomRef);
   });

--- a/express-api/src/utils/stale-room-reap.js
+++ b/express-api/src/utils/stale-room-reap.js
@@ -1,0 +1,117 @@
+/**
+ * Stale-room lazy reap — server-side replacement for the staleRooms cron's
+ * close-decision path.
+ *
+ * When a room enters OWNER_AWAY state (owner gracefully or ungracefully
+ * disconnects), the room must eventually close. The staleRooms cron polls
+ * every 5 minutes (~288 Firestore reads/day baseline). This module lets
+ * any participant-triggered room mutation reap the stale room inline as
+ * part of the transaction — no polling needed for the active-traffic case.
+ *
+ * Scope of this PR:
+ *  - The cron stays running for abandoned-rooms safety (rooms with zero
+ *    further participant traffic after owner leaves). Future PRs add
+ *    RTDB onDisconnect client-side to catch those, and the cron is then
+ *    deleted entirely.
+ *  - User-doc currentRoomId clears are NOT done here — the cron handles
+ *    them within 5 minutes. After RTDB onDisconnect lands, this module
+ *    will take that over too.
+ *
+ * The close-decision MUST match the cron's predicate so behaviour stays
+ * consistent during the transition:
+ *   - state === 'OWNER_AWAY'
+ *   - AND (no non-owner seated || ownerLeftAt < (now - timeout))
+ */
+
+const { hasNonOwnerSeated } = require('./room-auth');
+
+// Matches src/cron/staleRooms.js's tenMinutesAgo computation. Aligns the
+// lazy-reap upper bound with what the cron would have done, so a room
+// closed by lazy reap and a room closed by the cron use the same
+// `ownerLeftAt` cutoff.
+const STALE_ROOM_TIMEOUT_MS = 10 * 60 * 1000;
+
+// Grace window for the "no holdouts" case. The cron has an effective
+// 0-5 min grace because it only runs every 5 minutes — a room with no
+// non-owner seated stays OWNER_AWAY until the next cron tick. Lazy reap
+// has no tick rate (fires on every access), so without an explicit
+// grace it would close instantly on the first access — even the owner
+// returning or a user joining within the natural 5-min window. The
+// grace preserves owner-can-return-quickly and join-during-grace UX.
+const STALE_ROOM_NO_HOLDOUTS_GRACE_MS = 5 * 60 * 1000;
+
+const MAX_SEAT_INDEX = 8;
+
+/**
+ * Should this room be reaped right now?
+ *
+ * Semantics (matches the staleRooms cron's effective in-production
+ * behaviour with the cron's tick-rate grace expressed explicitly):
+ *  - state must be OWNER_AWAY and ownerLeftAt must be set
+ *  - the owner calling is never reaped (they're reclaiming the room
+ *    via /owner-returned or any other mutation — the close-on-access
+ *    pattern must NOT fight the state machine's OWNER_AWAY → ACTIVE
+ *    transition)
+ *  - "no holdouts" branch waits the grace window first (so a join in
+ *    the first few minutes after owner leaves still succeeds, matching
+ *    cron-tick behaviour)
+ *  - "holdouts present" branch waits the full timeout
+ *
+ * @param {object} room
+ * @param {number} nowMs - current time in ms-since-epoch
+ * @param {string|number|null} [callerId] - the participant whose
+ *   mutation triggered this check; the owner is never reaped against
+ * @returns {boolean}
+ */
+function shouldReapStaleRoom(room, nowMs, callerId = null) {
+  if (!room || room.state !== 'OWNER_AWAY') return false;
+  if (!room.ownerLeftAt) return false;
+  if (callerId !== null && callerId !== undefined && String(callerId) === String(room.ownerId)) {
+    return false;
+  }
+  const ageMs = nowMs - Number(room.ownerLeftAt);
+  if (!hasNonOwnerSeated(room)) {
+    return ageMs >= STALE_ROOM_NO_HOLDOUTS_GRACE_MS;
+  }
+  return ageMs >= STALE_ROOM_TIMEOUT_MS;
+}
+
+/**
+ * Build the close payload that staleRooms.js writes — same shape so the
+ * room transitions identically whether the cron or the lazy reap fires.
+ */
+function buildClosePayload(nowMs) {
+  const emptySeat = { userId: null, state: 'EMPTY', isMuted: false };
+  const emptySeats = {};
+  for (let i = 0; i < MAX_SEAT_INDEX; i++) emptySeats[String(i)] = { ...emptySeat };
+  return {
+    state: 'CLOSED',
+    closedAt: nowMs,
+    seats: emptySeats,
+    participantIds: [],
+  };
+}
+
+/**
+ * Apply the close to the room within a Firestore transaction.
+ *
+ * @param {FirebaseFirestore.Transaction} t
+ * @param {FirebaseFirestore.DocumentReference} roomRef
+ * @param {object} room - current room data (used only to confirm we're
+ *   acting on the right state; the close payload is independent)
+ * @param {number} nowMs
+ * @returns {object} the post-close room shape (same shape mutate() will see)
+ */
+function reapStaleRoomTx(t, roomRef, room, nowMs) {
+  const payload = buildClosePayload(nowMs);
+  t.update(roomRef, payload);
+  return { ...room, ...payload };
+}
+
+module.exports = {
+  STALE_ROOM_TIMEOUT_MS,
+  STALE_ROOM_NO_HOLDOUTS_GRACE_MS,
+  shouldReapStaleRoom,
+  reapStaleRoomTx,
+  buildClosePayload,
+};

--- a/express-api/src/utils/stale-room-reap.js
+++ b/express-api/src/utils/stale-room-reap.js
@@ -23,7 +23,7 @@
  *   - AND (no non-owner seated || ownerLeftAt < (now - timeout))
  */
 
-const { hasNonOwnerSeated } = require('./room-auth');
+const { hasNonOwnerSeated, MAX_SEATS } = require('./room-auth');
 
 // Matches src/cron/staleRooms.js's tenMinutesAgo computation. Aligns the
 // lazy-reap upper bound with what the cron would have done, so a room
@@ -39,8 +39,6 @@ const STALE_ROOM_TIMEOUT_MS = 10 * 60 * 1000;
 // returning or a user joining within the natural 5-min window. The
 // grace preserves owner-can-return-quickly and join-during-grace UX.
 const STALE_ROOM_NO_HOLDOUTS_GRACE_MS = 5 * 60 * 1000;
-
-const MAX_SEAT_INDEX = 8;
 
 /**
  * Should this room be reaped right now?
@@ -83,12 +81,17 @@ function shouldReapStaleRoom(room, nowMs, callerId = null) {
 function buildClosePayload(nowMs) {
   const emptySeat = { userId: null, state: 'EMPTY', isMuted: false };
   const emptySeats = {};
-  for (let i = 0; i < MAX_SEAT_INDEX; i++) emptySeats[String(i)] = { ...emptySeat };
+  for (let i = 0; i < MAX_SEATS; i++) emptySeats[String(i)] = { ...emptySeat };
+  // `ownerLeftAt: null` matches both staleRooms.js and the /close
+  // endpoint's payload. Without it, a reaped room would carry a
+  // stale OWNER_AWAY timestamp on a CLOSED row, diverging from
+  // every other close path.
   return {
     state: 'CLOSED',
     closedAt: nowMs,
     seats: emptySeats,
     participantIds: [],
+    ownerLeftAt: null,
   };
 }
 

--- a/express-api/tests/utils/stale-room-reap.test.js
+++ b/express-api/tests/utils/stale-room-reap.test.js
@@ -73,7 +73,7 @@ describe('shouldReapStaleRoom', () => {
       expect(shouldReapStaleRoom(baseRoom, pastGrace, 'other-1')).toBe(true);
     });
 
-    test('returns false at exactly ownerLeftAt + grace (strict greater-than-or-equal)', () => {
+    test('returns true at exactly ownerLeftAt + grace boundary (>=)', () => {
       // Predicate uses >= so AT grace boundary, returns true.
       const exactBoundary = baseRoom.ownerLeftAt + STALE_ROOM_NO_HOLDOUTS_GRACE_MS;
       expect(shouldReapStaleRoom(baseRoom, exactBoundary, 'other-1')).toBe(true);
@@ -144,7 +144,7 @@ describe('shouldReapStaleRoom', () => {
 });
 
 describe('buildClosePayload', () => {
-  test('returns shape matching staleRooms.js close payload', () => {
+  test('returns shape matching staleRooms.js + /close endpoint close payload', () => {
     const payload = buildClosePayload(1700000000000);
 
     expect(payload).toEqual({
@@ -152,7 +152,15 @@ describe('buildClosePayload', () => {
       closedAt: 1700000000000,
       seats: expect.any(Object),
       participantIds: [],
+      ownerLeftAt: null,
     });
+  });
+
+  test('clears ownerLeftAt to null (must match /close + cron payload)', () => {
+    // Reaped rooms must not carry the stale OWNER_AWAY timestamp on a
+    // CLOSED row — every other close path writes `ownerLeftAt: null`.
+    const payload = buildClosePayload(0);
+    expect(payload.ownerLeftAt).toBeNull();
   });
 
   test('emits all 8 seats as EMPTY', () => {
@@ -223,6 +231,8 @@ describe('reapStaleRoomTx', () => {
     expect(result.state).toBe('CLOSED');
     expect(result.closedAt).toBe(5000);
     expect(result.participantIds).toEqual([]);
+    // ownerLeftAt is explicitly cleared (matches /close + cron payload).
+    expect(result.ownerLeftAt).toBeNull();
   });
 });
 

--- a/express-api/tests/utils/stale-room-reap.test.js
+++ b/express-api/tests/utils/stale-room-reap.test.js
@@ -1,0 +1,233 @@
+const {
+  STALE_ROOM_TIMEOUT_MS,
+  STALE_ROOM_NO_HOLDOUTS_GRACE_MS,
+  shouldReapStaleRoom,
+  reapStaleRoomTx,
+  buildClosePayload,
+} = require('../../src/utils/stale-room-reap');
+
+describe('shouldReapStaleRoom', () => {
+  const baseRoom = {
+    state: 'OWNER_AWAY',
+    ownerId: 'owner-1',
+    ownerLeftAt: 1700000000000,
+    seats: {},
+  };
+  const wellPastTimeout = baseRoom.ownerLeftAt + STALE_ROOM_TIMEOUT_MS + 1000;
+  const pastGrace = baseRoom.ownerLeftAt + STALE_ROOM_NO_HOLDOUTS_GRACE_MS + 1000;
+
+  describe('state-machine preconditions', () => {
+    test('returns false when room is null/undefined', () => {
+      expect(shouldReapStaleRoom(null, wellPastTimeout)).toBe(false);
+      expect(shouldReapStaleRoom(undefined, wellPastTimeout)).toBe(false);
+    });
+
+    test('returns false when state is ACTIVE', () => {
+      expect(shouldReapStaleRoom({ ...baseRoom, state: 'ACTIVE' }, wellPastTimeout)).toBe(false);
+    });
+
+    test('returns false when state is CLOSED', () => {
+      expect(shouldReapStaleRoom({ ...baseRoom, state: 'CLOSED' }, wellPastTimeout)).toBe(false);
+    });
+
+    test('returns false when ownerLeftAt is missing/zero', () => {
+      expect(shouldReapStaleRoom({ ...baseRoom, ownerLeftAt: undefined }, wellPastTimeout)).toBe(
+        false,
+      );
+      expect(shouldReapStaleRoom({ ...baseRoom, ownerLeftAt: null }, wellPastTimeout)).toBe(false);
+      expect(shouldReapStaleRoom({ ...baseRoom, ownerLeftAt: 0 }, wellPastTimeout)).toBe(false);
+    });
+  });
+
+  describe('owner-caller short-circuit', () => {
+    test('returns false when callerId is the owner (returning), even past timeout', () => {
+      expect(shouldReapStaleRoom(baseRoom, wellPastTimeout, 'owner-1')).toBe(false);
+    });
+
+    test('returns false for owner caller even with numeric/string-id mismatch', () => {
+      const room = { ...baseRoom, ownerId: 42 };
+      expect(shouldReapStaleRoom(room, wellPastTimeout, '42')).toBe(false);
+      expect(shouldReapStaleRoom(room, wellPastTimeout, 42)).toBe(false);
+    });
+
+    test('returns true when callerId is a non-owner past timeout', () => {
+      // Other user trying to mutate well after timeout — reap.
+      expect(shouldReapStaleRoom(baseRoom, wellPastTimeout, 'other-1')).toBe(true);
+    });
+
+    test('returns true when callerId is null (system call, no caller)', () => {
+      // No caller info — fall back to reap-by-state-only.
+      expect(shouldReapStaleRoom(baseRoom, wellPastTimeout, null)).toBe(true);
+    });
+  });
+
+  describe('no-holdouts branch (grace window)', () => {
+    test('returns false when no holdouts and within grace window (owner can still return)', () => {
+      // Room is OWNER_AWAY, no non-owner seated, but within the grace.
+      // The owner-returned endpoint or a join-during-grace must still succeed.
+      const justAfterOwnerLeft = baseRoom.ownerLeftAt + 1000;
+      expect(shouldReapStaleRoom(baseRoom, justAfterOwnerLeft, 'other-1')).toBe(false);
+    });
+
+    test('returns true when no holdouts and past grace window', () => {
+      expect(shouldReapStaleRoom(baseRoom, pastGrace, 'other-1')).toBe(true);
+    });
+
+    test('returns false at exactly ownerLeftAt + grace (strict greater-than-or-equal)', () => {
+      // Predicate uses >= so AT grace boundary, returns true.
+      const exactBoundary = baseRoom.ownerLeftAt + STALE_ROOM_NO_HOLDOUTS_GRACE_MS;
+      expect(shouldReapStaleRoom(baseRoom, exactBoundary, 'other-1')).toBe(true);
+    });
+
+    test('returns false at just-before grace boundary', () => {
+      const justBefore = baseRoom.ownerLeftAt + STALE_ROOM_NO_HOLDOUTS_GRACE_MS - 1;
+      expect(shouldReapStaleRoom(baseRoom, justBefore, 'other-1')).toBe(false);
+    });
+
+    test('owner-seated stale record counts as "no holdouts" (matches cron)', () => {
+      // Owner has a stale seat record but is the only seated user.
+      const roomWithOwnerSeat = {
+        ...baseRoom,
+        seats: { 0: { userId: 'owner-1', state: 'OCCUPIED' } },
+      };
+      expect(shouldReapStaleRoom(roomWithOwnerSeat, pastGrace, 'other-1')).toBe(true);
+    });
+  });
+
+  describe('holdouts branch (full timeout)', () => {
+    test('returns false when non-owner seated and within timeout', () => {
+      const room = {
+        ...baseRoom,
+        seats: { 1: { userId: 'other-1', state: 'OCCUPIED' } },
+      };
+      const withinTimeout = room.ownerLeftAt + STALE_ROOM_TIMEOUT_MS - 1;
+      expect(shouldReapStaleRoom(room, withinTimeout, 'other-2')).toBe(false);
+    });
+
+    test('returns true when non-owner seated AND ownerLeftAt past timeout', () => {
+      const room = {
+        ...baseRoom,
+        seats: { 1: { userId: 'other-1', state: 'OCCUPIED' } },
+      };
+      expect(shouldReapStaleRoom(room, wellPastTimeout, 'other-2')).toBe(true);
+    });
+
+    test('returns true at exactly ownerLeftAt + timeout (>=)', () => {
+      const room = {
+        ...baseRoom,
+        seats: { 1: { userId: 'other-1', state: 'OCCUPIED' } },
+      };
+      const exactBoundary = room.ownerLeftAt + STALE_ROOM_TIMEOUT_MS;
+      expect(shouldReapStaleRoom(room, exactBoundary, 'other-2')).toBe(true);
+    });
+
+    test('returns false at just-before timeout boundary', () => {
+      const room = {
+        ...baseRoom,
+        seats: { 1: { userId: 'other-1', state: 'OCCUPIED' } },
+      };
+      const justBefore = room.ownerLeftAt + STALE_ROOM_TIMEOUT_MS - 1;
+      expect(shouldReapStaleRoom(room, justBefore, 'other-2')).toBe(false);
+    });
+  });
+
+  describe('type tolerance', () => {
+    test('treats string ownerLeftAt as numeric (mirrors staleRooms cron)', () => {
+      const room = {
+        ...baseRoom,
+        ownerLeftAt: String(baseRoom.ownerLeftAt),
+        seats: { 1: { userId: 'other-1', state: 'OCCUPIED' } },
+      };
+      expect(shouldReapStaleRoom(room, wellPastTimeout, 'other-2')).toBe(true);
+    });
+  });
+});
+
+describe('buildClosePayload', () => {
+  test('returns shape matching staleRooms.js close payload', () => {
+    const payload = buildClosePayload(1700000000000);
+
+    expect(payload).toEqual({
+      state: 'CLOSED',
+      closedAt: 1700000000000,
+      seats: expect.any(Object),
+      participantIds: [],
+    });
+  });
+
+  test('emits all 8 seats as EMPTY', () => {
+    const payload = buildClosePayload(0);
+
+    expect(Object.keys(payload.seats)).toEqual(['0', '1', '2', '3', '4', '5', '6', '7']);
+    for (let i = 0; i < 8; i++) {
+      expect(payload.seats[String(i)]).toEqual({
+        userId: null,
+        state: 'EMPTY',
+        isMuted: false,
+      });
+    }
+  });
+
+  test('each seat is an independent object (no shared reference)', () => {
+    const payload = buildClosePayload(0);
+    // Mutating one seat must not leak into another.
+    payload.seats['0'].userId = 'leaked';
+    expect(payload.seats['1'].userId).toBeNull();
+  });
+});
+
+describe('reapStaleRoomTx', () => {
+  test('calls t.update with the close payload', () => {
+    const mockUpdate = jest.fn();
+    const t = { update: mockUpdate };
+    const roomRef = { _id: 'roomRef' };
+    const room = {
+      state: 'OWNER_AWAY',
+      ownerId: 'o',
+      ownerLeftAt: 1000,
+      seats: { 0: { userId: 'o', state: 'OCCUPIED' } },
+      participantIds: ['o', 'p'],
+    };
+
+    reapStaleRoomTx(t, roomRef, room, 2000);
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      roomRef,
+      expect.objectContaining({
+        state: 'CLOSED',
+        closedAt: 2000,
+        participantIds: [],
+      }),
+    );
+  });
+
+  test('returns the room shape merged with the close payload', () => {
+    const t = { update: jest.fn() };
+    const roomRef = {};
+    const room = {
+      state: 'OWNER_AWAY',
+      ownerId: 'owner',
+      ownerLeftAt: 1000,
+      name: 'My room',
+      seats: { 0: { userId: 'owner', state: 'OCCUPIED' } },
+      participantIds: ['owner'],
+    };
+
+    const result = reapStaleRoomTx(t, roomRef, room, 5000);
+
+    // Preserved fields from the input room
+    expect(result.ownerId).toBe('owner');
+    expect(result.name).toBe('My room');
+    // Overwritten by the close payload
+    expect(result.state).toBe('CLOSED');
+    expect(result.closedAt).toBe(5000);
+    expect(result.participantIds).toEqual([]);
+  });
+});
+
+describe('STALE_ROOM_TIMEOUT_MS', () => {
+  test('is 10 minutes (matches staleRooms cron tenMinutesAgo computation)', () => {
+    expect(STALE_ROOM_TIMEOUT_MS).toBe(10 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
## Summary

**First of a multi-PR sweep-stale-rooms cron elimination** per operator's design pick (RTDB onDisconnect + lazy reap, incremental). Hooks the staleRooms cron's close-decision logic into `inRoomTransaction` — the single chokepoint every room mutation passes through. When a participant mutation touches a room that's been OWNER_AWAY past the threshold, close it inline within the same transaction.

## State-machine framing (operator-aligned)

Operator's framing from this session: "mark room as OWNER_AWAY; ACTIVE if return, CLOSED if not within the timeframe. is this reliable?" — YES, that's the existing state machine. The cron's only job is the OWNER_AWAY → CLOSED trigger; this PR moves that trigger from polling to lazy access while preserving the timeframe semantics.

## Why this PR is server-only (multi-PR plan)

Per `[[feedback-continuous-review-loop-workflow]]` + operator's "incremental, leave current crons running":

- **This PR**: server-side lazy reap. No client changes. The cron STAYS running as the safety net for abandoned rooms (zero participant traffic post-departure).
- **Next PRs**: RTDB onDisconnect on Android (#997), iOS (#998), Web (#999).
- **Final PR**: delete the cron + workflow + sweep endpoint once all platforms catch abandoned-room cases.

Server-first is defensible under CLAUDE.md tri-platform policy because lazy-reap is invisible backend behavior, not a user-facing feature parity gap.

## Behavior preservation (the subtle part)

The naive lazy-reap "close on every access" fired too aggressively and broke two existing tests:
- `POST /owner-returned`: owner reclaiming their room got closed instead
- `POST /join`: user joining a freshly-OWNER_AWAY room got closed instead

The fix preserves the cron's effective in-production behavior:

| Case | Cron behavior | Lazy reap behavior |
|---|---|---|
| Owner returning | Always works (owner-returned writes ACTIVE) | Same — caller-aware short-circuit when callerId === ownerId |
| No holdouts, 0-5 min after owner left | Cron hasn't ticked yet → no close | Within 5-min grace → no close |
| No holdouts, >5 min after owner left | Next cron tick closes | Lazy reap closes on access |
| Holdouts present, <10 min | No close | No close |
| Holdouts present, >10 min | Cron closes | Lazy reap closes on access |

The grace window mirrors the cron's effective 0-5 min window (which exists *because* the cron only runs every 5 min). Lazy-reap has no tick rate, so the grace is explicit.

## Files

**New**: `src/utils/stale-room-reap.js` (predicate + close payload + transactional close)
**Modified**: `src/routes/room-mutations.js` `inRoomTransaction` (hooks reap before mutate())
**New**: `tests/utils/stale-room-reap.test.js` (24 tests — state preconditions, owner-caller short-circuit, grace boundaries, timeout boundaries, type tolerance)

Net **+365 LOC** (additive — no deletions until later PRs).

## Test plan
- [x] `npm test` (express-api) — 11,243 pass / 1 pre-existing skip
- [x] `npm run lint` — clean
- [x] `npx prettier --check .` — clean
- [x] Pre-push SonarCloud quality gate — passed
- [x] 24 new unit tests + 2 previously-failing room-mutations tests now pass
- [ ] Post-deploy: confirm room states transition as expected on dev

## Operator alignment

Per `[[feedback-avoid-crons-prefer-event-driven]]` — incremental elimination. Per `[[feedback-think-like-qa-real-fixes]]` — the grace-window fix is a real semantic correction, not a test-skip plaster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)