### PR TITLE
feat(rooms): event-driven owner-left handler (server piece)

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -34,6 +34,12 @@
         }
       }
     },
+    "ownerLeft": {
+      "$roomId": {
+        ".write": "auth != null && (!newData.exists() || newData.val() === auth.uid)",
+        ".validate": "newData.isString() || !newData.exists()"
+      }
+    },
     ".read": false,
     ".write": false
   }

--- a/database.rules.json
+++ b/database.rules.json
@@ -36,7 +36,7 @@
     },
     "ownerLeft": {
       "$roomId": {
-        ".write": "auth != null && (!newData.exists() || newData.val() === auth.uid)",
+        ".write": "auth != null && ((!newData.exists() && data.val() === auth.uid) || newData.val() === auth.uid)",
         ".validate": "newData.isString() || !newData.exists()"
       }
     },

--- a/express-api/src/index.js
+++ b/express-api/src/index.js
@@ -14,7 +14,9 @@ const {
 const portalRoutes = require('./routes/portal');
 const { portalLimiter, recoveryLimiter } = require('./middleware/rateLimit');
 const { startCronJobs } = require('./cron');
-require('./utils/firebase'); // Initialize Firebase before routes
+const { db, rtdb } = require('./utils/firebase'); // Initialize Firebase before routes
+const log = require('./utils/log');
+const { startEventListeners } = require('./utils/event-listeners');
 const { patchConsole } = require('./utils/consoleLogger');
 
 // Route all console.log/warn/error through structured logger
@@ -293,4 +295,5 @@ app.listen(PORT, () => {
   // eslint-disable-next-line no-console
   console.log(`ShyTalk API listening on port ${PORT}`);
   startCronJobs();
+  startEventListeners({ db, rtdb, log });
 });

--- a/express-api/src/index.js
+++ b/express-api/src/index.js
@@ -17,6 +17,7 @@ const { startCronJobs } = require('./cron');
 const { db, rtdb } = require('./utils/firebase'); // Initialize Firebase before routes
 const log = require('./utils/log');
 const { startEventListeners } = require('./utils/event-listeners');
+const { wireProcessShutdown } = require('./utils/process-shutdown');
 const { patchConsole } = require('./utils/consoleLogger');
 
 // Route all console.log/warn/error through structured logger
@@ -295,5 +296,10 @@ app.listen(PORT, () => {
   // eslint-disable-next-line no-console
   console.log(`ShyTalk API listening on port ${PORT}`);
   startCronJobs();
-  startEventListeners({ db, rtdb, log });
+  const stopEventListeners = startEventListeners({ db, rtdb, log });
+  // PM2 sends SIGTERM on graceful restart; without explicit wiring the RTDB
+  // listener detaches abruptly mid-processing, leaving signal entries in
+  // ambiguous state. Wire AFTER startEventListeners so the captured stop
+  // function is invoked on shutdown.
+  wireProcessShutdown({ proc: process, stopFns: [stopEventListeners], log });
 });

--- a/express-api/src/utils/event-listeners.js
+++ b/express-api/src/utils/event-listeners.js
@@ -1,0 +1,58 @@
+/**
+ * Event-listener wiring — boots all event-driven listeners that should run
+ * for the lifetime of the Express process. Today: the owner-left RTDB
+ * listener. Future event-driven additions plug in here so src/index.js
+ * stays a thin call-site.
+ *
+ * Architectural notes:
+ *  - The presence checker is constructed here (not inside the listener) so
+ *    the listener's contract stays platform-neutral and the path is
+ *    centralised. The checker PROPAGATES errors (unlike the route-handler
+ *    `isUserPresent` which fail-safes to "present") because the listener
+ *    relies on errors to preserve the signal entry for retry.
+ *  - Returns a stop() that detaches all listeners — used by tests and
+ *    process shutdown hooks.
+ */
+
+const { registerOwnerLeftListener } = require('./owner-left-listener');
+
+/**
+ * Build a presence checker that reads `rooms/{roomId}/presence/{userId}` and
+ * THROWS on RTDB read errors. The owner-left orchestrator catches the throw
+ * and rejects up to the listener, which leaves the signal entry in place
+ * for retry on next signal-fire or restart-scan.
+ */
+function buildPresenceChecker(rtdb) {
+  return async function presenceChecker(roomId, userId) {
+    const snap = await rtdb.ref(`rooms/${roomId}/presence/${userId}`).get();
+    return snap.exists();
+  };
+}
+
+/**
+ * Start all event listeners. Returns a stop() that detaches each.
+ *
+ * @param {object} args
+ * @param {object} args.db - firebase-admin Firestore
+ * @param {object} args.rtdb - firebase-admin Realtime Database
+ * @param {object} args.log - logger
+ * @returns {() => void}
+ */
+function startEventListeners({ db, rtdb, log }) {
+  const detachOwnerLeft = registerOwnerLeftListener({
+    db,
+    rtdb,
+    log,
+    presenceChecker: buildPresenceChecker(rtdb),
+  });
+
+  return function stop() {
+    detachOwnerLeft();
+  };
+}
+
+module.exports = {
+  startEventListeners,
+  // Exported for direct testing.
+  buildPresenceChecker,
+};

--- a/express-api/src/utils/event-listeners.js
+++ b/express-api/src/utils/event-listeners.js
@@ -11,7 +11,12 @@
  *    `isUserPresent` which fail-safes to "present") because the listener
  *    relies on errors to preserve the signal entry for retry.
  *  - Returns a stop() that detaches all listeners — used by tests and
- *    process shutdown hooks.
+ *    process shutdown hooks (`wireProcessShutdown` in process-shutdown.js).
+ *  - INTENTIONALLY unconditional (not gated on NODE_ENV === 'production')
+ *    despite `startCronJobs` being prod-only: event-driven RTDB listeners
+ *    cost no Firestore quota (no polling), and they MUST run in local/dev
+ *    so journey tests can exercise the full owner-disconnect flow against
+ *    Firebase emulators. The asymmetry with crons is deliberate.
  */
 
 const { registerOwnerLeftListener } = require('./owner-left-listener');

--- a/express-api/src/utils/owner-left-handler.js
+++ b/express-api/src/utils/owner-left-handler.js
@@ -1,0 +1,89 @@
+/**
+ * Owner-left handler — server-side event-driven response to the
+ * `ownerLeft/{roomId}` RTDB signal (armed by the owner client via
+ * `onDisconnect().setValue(...)` when entering an ACTIVE room).
+ *
+ * Replaces the staleRooms cron's role in detecting and acting on owner
+ * disconnects. The cron polled every 5 minutes; this handler reacts within
+ * RTDB's onDisconnect latency (seconds). The operator's refined state machine
+ * (2026-06-04) determines the action:
+ *
+ *   - if the owner is still present somewhere (multi-device, reconnect within
+ *     the handler's processing window) — NOOP
+ *   - if the room is no longer ACTIVE (already AWAY/CLOSED via a concurrent
+ *     path) — NOOP
+ *   - if ACTIVE and at least one non-owner is OCCUPIED on a seat — transition
+ *     to OWNER_AWAY (the existing client-driven countdown will then close it)
+ *   - if ACTIVE and no non-owner is seated — close the room IMMEDIATELY
+ *     (the cron's "no holdouts" branch would have closed it; we just don't
+ *     wait the 5-minute tick)
+ *
+ * The decision is pure (`decideOwnerLeftAction`), the application is the
+ * transactional wrapper (`applyOwnerLeftTx`). The orchestrator (which performs
+ * the RTDB presence re-check, opens the Firestore transaction, applies the
+ * action, and clears the signal) lives in the listener module.
+ */
+
+const { hasNonOwnerSeated } = require('./room-auth');
+const { reapStaleRoomTx } = require('./stale-room-reap');
+
+const OWNER_LEFT_ACTION = Object.freeze({
+  NOOP: 'NOOP',
+  OWNER_AWAY: 'OWNER_AWAY',
+  CLOSE_IMMEDIATE: 'CLOSE_IMMEDIATE',
+});
+
+/**
+ * Decide what to do given the room's current Firestore shape + whether the
+ * owner is still present in RTDB (re-checked by the caller AFTER the signal
+ * fired, to close the TOCTOU window where the owner reconnects between
+ * signal arrival and handler execution, or is present on another device).
+ *
+ * @param {object|null|undefined} room - the room doc (from Firestore.get())
+ * @param {boolean} ownerStillPresent - result of the post-signal isUserPresent
+ *   re-check; if true, do nothing
+ * @returns {string} one of OWNER_LEFT_ACTION values
+ */
+function decideOwnerLeftAction(room, ownerStillPresent) {
+  if (ownerStillPresent) return OWNER_LEFT_ACTION.NOOP;
+  if (!room || !room.state) return OWNER_LEFT_ACTION.NOOP;
+  if (room.state !== 'ACTIVE') return OWNER_LEFT_ACTION.NOOP;
+  if (hasNonOwnerSeated(room)) return OWNER_LEFT_ACTION.OWNER_AWAY;
+  return OWNER_LEFT_ACTION.CLOSE_IMMEDIATE;
+}
+
+/**
+ * Apply the decided action inside a Firestore transaction.
+ *
+ * NOOP / unknown actions are intentionally a no-op write (zero t.update calls)
+ * so the caller can safely invoke this for every signal event without branching
+ * on the action upstream.
+ *
+ * @param {FirebaseFirestore.Transaction} t
+ * @param {FirebaseFirestore.DocumentReference} roomRef
+ * @param {object} room - the pre-transition room shape (from t.get())
+ * @param {string} action - one of OWNER_LEFT_ACTION values
+ * @param {number} nowMs - server time at the start of this transaction
+ * @returns {object} the post-transition room shape (room merged with the patch)
+ */
+function applyOwnerLeftTx(t, roomRef, room, action, nowMs) {
+  if (action === OWNER_LEFT_ACTION.OWNER_AWAY) {
+    const patch = { state: 'OWNER_AWAY', ownerLeftAt: nowMs };
+    t.update(roomRef, patch);
+    return { ...room, ...patch };
+  }
+  if (action === OWNER_LEFT_ACTION.CLOSE_IMMEDIATE) {
+    // Reuse the close payload + write through reapStaleRoomTx so the close
+    // shape stays a single source of truth (ownerLeftAt: null invariant from
+    // PR #996's reviewer-Critical finding lives in buildClosePayload).
+    return reapStaleRoomTx(t, roomRef, room, nowMs);
+  }
+  // NOOP or unknown — return the room as-is, no write.
+  return room;
+}
+
+module.exports = {
+  OWNER_LEFT_ACTION,
+  decideOwnerLeftAction,
+  applyOwnerLeftTx,
+};

--- a/express-api/src/utils/owner-left-listener.js
+++ b/express-api/src/utils/owner-left-listener.js
@@ -59,9 +59,17 @@ function registerOwnerLeftListener({
       return;
     }
 
+    // The signal entry's value is the uid of the client that armed the
+    // onDisconnect. The RTDB rule for `ownerLeft/{roomId}` forces
+    // `newData.val() === auth.uid`, so an authenticated writer can only sign
+    // with their own uid. The orchestrator additionally verifies the writer
+    // is the room's owner — closing the "attacker writes ownerLeft for
+    // victim's room" forgery vector.
+    const writerUid = snap && typeof snap.val === 'function' ? snap.val() : undefined;
+
     let result;
     try {
-      result = await handleSignal({ db, presenceChecker, roomId });
+      result = await handleSignal({ db, presenceChecker, roomId, writerUid });
     } catch (err) {
       // Orchestrator failed — leave the signal entry in place so a later
       // restart-scan or duplicate fire can retry.

--- a/express-api/src/utils/owner-left-listener.js
+++ b/express-api/src/utils/owner-left-listener.js
@@ -1,0 +1,105 @@
+/**
+ * Owner-left RTDB listener — attaches a `child_added` listener to the
+ * `ownerLeft` ref, delegates each fired child to the owner-left orchestrator,
+ * and clears the signal entry on success.
+ *
+ * Wiring contract:
+ *   1. Client (owner) arms `ownerLeft/{roomId}` onDisconnect on room entry
+ *      (PR #998 Android, #999 iOS).
+ *   2. RTDB writes the entry when the owner disconnects.
+ *   3. This listener picks up the `child_added` event in Express.
+ *   4. Orchestrator decides + applies the Firestore mutation.
+ *   5. Listener clears the RTDB signal entry on success.
+ *
+ * Restart resilience: Firebase admin SDK's `.on('child_added', cb)` fires
+ * synchronously for every existing child at attach time. That gives us a
+ * free startup-scan — any signals written during Express downtime are
+ * processed on next boot without any explicit catch-up code.
+ *
+ * The handler is intentionally crash-safe: orchestrator failures are caught
+ * and logged, never rethrown. The signal entry is preserved on failure so a
+ * later signal-fire or restart-scan can retry.
+ */
+
+const { handleOwnerLeftSignal: defaultHandleSignal } = require('./owner-left-orchestrator');
+
+/** Conservative cap matching Firebase RTDB / Firestore reasonable id sizes. */
+const MAX_ROOM_ID_LENGTH = 256;
+const SAFE_ROOM_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+function isValidRoomId(roomId) {
+  if (typeof roomId !== 'string') return false;
+  if (roomId.length === 0 || roomId.length > MAX_ROOM_ID_LENGTH) return false;
+  return SAFE_ROOM_ID_PATTERN.test(roomId);
+}
+
+/**
+ * @param {object} args
+ * @param {object} args.rtdb - firebase-admin Realtime Database instance
+ * @param {object} args.db - firebase-admin Firestore instance
+ * @param {(roomId: string, userId: string) => Promise<boolean>} args.presenceChecker
+ * @param {object} args.log - logger with .warn / .error
+ * @param {Function} [args.handleSignal] - injectable for tests; defaults to
+ *   the real orchestrator
+ * @returns {() => void} detach function (calls .off on the listener)
+ */
+function registerOwnerLeftListener({
+  rtdb,
+  db,
+  presenceChecker,
+  log,
+  handleSignal = defaultHandleSignal,
+}) {
+  const ownerLeftRef = rtdb.ref('ownerLeft');
+
+  async function onChildAdded(snap) {
+    const roomId = snap && snap.key;
+    if (!isValidRoomId(roomId)) {
+      log.warn('owner-left-listener', 'Ignoring signal with invalid roomId', { roomId });
+      return;
+    }
+
+    let result;
+    try {
+      result = await handleSignal({ db, presenceChecker, roomId });
+    } catch (err) {
+      // Orchestrator failed — leave the signal entry in place so a later
+      // restart-scan or duplicate fire can retry.
+      log.error('owner-left-listener', 'Processing failed; signal retained', {
+        roomId,
+        error: err && err.message,
+      });
+      return;
+    }
+
+    // Success path (incl. NOOP outcomes): clear the signal so we don't
+    // re-process it on restart. A NOOP would just NOOP again, so there's
+    // no value in retaining it.
+    try {
+      await snap.ref.remove();
+    } catch (err) {
+      log.error('owner-left-listener', 'Failed to clear signal after success', {
+        roomId,
+        action: result && result.action,
+        error: err && err.message,
+      });
+    }
+  }
+
+  ownerLeftRef.on('child_added', onChildAdded);
+
+  let detached = false;
+  return function detach() {
+    if (detached) return;
+    detached = true;
+    ownerLeftRef.off('child_added', onChildAdded);
+  };
+}
+
+module.exports = {
+  registerOwnerLeftListener,
+  // Exported for direct re-use by future listeners that need the same
+  // safe-key allowlist (defense-in-depth for any RTDB → Firestore path
+  // interpolation). Not currently used outside this module.
+  isValidRoomId,
+};

--- a/express-api/src/utils/owner-left-orchestrator.js
+++ b/express-api/src/utils/owner-left-orchestrator.js
@@ -28,12 +28,21 @@ const {
  * interpolation share the same defensive shape. Defends against `ownerId`
  * values from corrupt Firestore docs containing `/`, `.`, `#`, `$`, `[`,
  * `]`, whitespace, or being missing entirely.
+ *
+ * Type-strict: accepts ONLY `string` and finite `number` primitives. The
+ * schema stores ownerId as either (see `accountDeletion.js:148`'s
+ * `String(roomDoc.data().ownerId)` normalisation pattern), but anything
+ * else — boolean, object, array, function, NaN, Infinity — is corruption.
+ * Without the strict typeof check, `String(true)` / `String(false)` /
+ * `String(NaN)` yield strings that pass the alphanumeric regex.
  */
 const MAX_OWNER_ID_LENGTH = 256;
 const SAFE_OWNER_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 function isValidOwnerId(ownerId) {
-  if (ownerId === null || ownerId === undefined) return false;
+  const t = typeof ownerId;
+  if (t !== 'string' && t !== 'number') return false;
+  if (t === 'number' && !Number.isFinite(ownerId)) return false;
   const s = String(ownerId);
   if (s.length === 0 || s.length > MAX_OWNER_ID_LENGTH) return false;
   return SAFE_OWNER_ID_PATTERN.test(s);

--- a/express-api/src/utils/owner-left-orchestrator.js
+++ b/express-api/src/utils/owner-left-orchestrator.js
@@ -1,0 +1,74 @@
+/**
+ * Owner-left orchestrator — composes the room read, the RTDB presence
+ * re-check, and the Firestore-transactional decide+apply, returning the
+ * action result so the caller (an RTDB listener wrapper) can decide whether
+ * to clear the `ownerLeft/{roomId}` signal entry.
+ *
+ * Separation of concerns:
+ *   - Pure decision: `decideOwnerLeftAction` (owner-left-handler.js)
+ *   - Pure application: `applyOwnerLeftTx` (owner-left-handler.js)
+ *   - Composition + transactional read: THIS module
+ *   - Signal-lifecycle (RTDB add/remove): the listener wrapper
+ *
+ * The orchestrator THROWS on infrastructure errors (Firestore read/txn
+ * failure, RTDB presence read failure via the injected presenceChecker) so
+ * the caller can leave the signal in place for a retry; it returns a result
+ * object on success.
+ */
+
+const {
+  OWNER_LEFT_ACTION,
+  decideOwnerLeftAction,
+  applyOwnerLeftTx,
+} = require('./owner-left-handler');
+
+/**
+ * Process an owner-left signal for `roomId`.
+ *
+ * @param {object} args
+ * @param {FirebaseFirestore.Firestore} args.db
+ * @param {(roomId: string, userId: string) => Promise<boolean>} args.presenceChecker
+ *   Async; resolves to true if the user is present in RTDB right now. Should
+ *   THROW on read errors so the caller can decide whether to retry — do not
+ *   fail-safe-to-true inside the checker for this code path.
+ * @param {string} args.roomId
+ * @param {number} [args.nowMs] - server time captured by caller; defaults to
+ *   Date.now() at the start of the transaction
+ * @returns {Promise<{action: string, reason?: string, postRoom?: object}>}
+ */
+async function handleOwnerLeftSignal({ db, presenceChecker, roomId, nowMs }) {
+  const roomRef = db.doc(`rooms/${roomId}`);
+
+  // Pre-txn read to extract the authoritative ownerId. We deliberately do NOT
+  // trust an ownerId passed in via the signal payload — clients write to the
+  // RTDB signal path and could forge a different ownerId. The Firestore room
+  // doc is the source of truth.
+  const preSnap = await roomRef.get();
+  if (!preSnap.exists) {
+    return { action: OWNER_LEFT_ACTION.NOOP, reason: 'room-missing' };
+  }
+  const preRoom = preSnap.data();
+
+  // TOCTOU re-check: the signal may be stale by the time we process it (owner
+  // reconnected on a second device, or the same device finished a transient
+  // disconnect). The checker is the authoritative gate; it throws on read
+  // failure so the caller can preserve the signal for a later retry.
+  const ownerStillPresent = await presenceChecker(roomId, preRoom.ownerId);
+
+  const effectiveNowMs = nowMs ?? Date.now();
+
+  return db.runTransaction(async (t) => {
+    const snap = await t.get(roomRef);
+    if (!snap.exists) {
+      return { action: OWNER_LEFT_ACTION.NOOP, reason: 'room-missing-in-txn' };
+    }
+    const room = snap.data();
+    const action = decideOwnerLeftAction(room, ownerStillPresent);
+    const postRoom = applyOwnerLeftTx(t, roomRef, room, action, effectiveNowMs);
+    return { action, postRoom };
+  });
+}
+
+module.exports = {
+  handleOwnerLeftSignal,
+};

--- a/express-api/src/utils/owner-left-orchestrator.js
+++ b/express-api/src/utils/owner-left-orchestrator.js
@@ -23,6 +23,23 @@ const {
 } = require('./owner-left-handler');
 
 /**
+ * Path-safe identifier allowlist for RTDB path components. Mirrors the
+ * roomId allowlist in owner-left-listener.js so both ends of the path
+ * interpolation share the same defensive shape. Defends against `ownerId`
+ * values from corrupt Firestore docs containing `/`, `.`, `#`, `$`, `[`,
+ * `]`, whitespace, or being missing entirely.
+ */
+const MAX_OWNER_ID_LENGTH = 256;
+const SAFE_OWNER_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+function isValidOwnerId(ownerId) {
+  if (ownerId === null || ownerId === undefined) return false;
+  const s = String(ownerId);
+  if (s.length === 0 || s.length > MAX_OWNER_ID_LENGTH) return false;
+  return SAFE_OWNER_ID_PATTERN.test(s);
+}
+
+/**
  * Process an owner-left signal for `roomId`.
  *
  * @param {object} args
@@ -32,11 +49,20 @@ const {
  *   THROW on read errors so the caller can decide whether to retry — do not
  *   fail-safe-to-true inside the checker for this code path.
  * @param {string} args.roomId
+ * @param {string} [args.writerUid] - the uid stored in the RTDB signal entry
+ *   (snap.val()) — the client that armed the onDisconnect. The RTDB rule
+ *   forces this to equal `auth.uid` at write time; here we additionally
+ *   verify it matches the room's authoritative ownerId. An attacker who
+ *   writes `ownerLeft/{victim-room} = attacker-uid` would land at this
+ *   mismatch branch and the listener clears the signal without invoking
+ *   presenceChecker for the victim — preventing presence-probing as well.
+ *   Omit for direct callers that don't have an attesting writer.
  * @param {number} [args.nowMs] - server time captured by caller; defaults to
- *   Date.now() at the start of the transaction
+ *   Date.now() once, BEFORE `runTransaction` opens. Reused across SDK retry
+ *   attempts so the OWNER_AWAY timestamp is stable.
  * @returns {Promise<{action: string, reason?: string, postRoom?: object}>}
  */
-async function handleOwnerLeftSignal({ db, presenceChecker, roomId, nowMs }) {
+async function handleOwnerLeftSignal({ db, presenceChecker, roomId, writerUid, nowMs }) {
   const roomRef = db.doc(`rooms/${roomId}`);
 
   // Pre-txn read to extract the authoritative ownerId. We deliberately do NOT
@@ -49,10 +75,41 @@ async function handleOwnerLeftSignal({ db, presenceChecker, roomId, nowMs }) {
   }
   const preRoom = preSnap.data();
 
+  // Defense in depth: `ownerId` becomes an RTDB path segment via
+  // presenceChecker(roomId, ownerId). A corrupt room doc with ownerId
+  // null/undefined/empty/containing path-separators would either silently
+  // produce a false-absent (wrong path → snap.exists() = false → "absent" →
+  // spurious close) or open the path-traversal door. Reject early.
+  if (!isValidOwnerId(preRoom.ownerId)) {
+    return { action: OWNER_LEFT_ACTION.NOOP, reason: 'owner-id-missing-or-invalid' };
+  }
+
+  // Writer-attestation check: the client that armed the RTDB onDisconnect
+  // signs the entry value with their own uid (enforced by the rule
+  // `newData.val() === auth.uid`). Here we additionally verify the writer
+  // is the room's owner — closes the "attacker writes ownerLeft for victim's
+  // room" forgery. Omitted writerUid is accepted for direct (non-listener)
+  // callers that don't have an attesting writer.
+  if (
+    writerUid !== undefined &&
+    writerUid !== null &&
+    String(writerUid) !== String(preRoom.ownerId)
+  ) {
+    return { action: OWNER_LEFT_ACTION.NOOP, reason: 'writer-not-owner' };
+  }
+
   // TOCTOU re-check: the signal may be stale by the time we process it (owner
   // reconnected on a second device, or the same device finished a transient
   // disconnect). The checker is the authoritative gate; it throws on read
   // failure so the caller can preserve the signal for a later retry.
+  //
+  // NOTE on Firestore txn retries: ownerStillPresent is captured BEFORE the
+  // txn opens and is REUSED across every retry attempt. That is intentional —
+  // RTDB reads cannot run inside a Firestore transaction, so re-checking
+  // inside the callback is not an option. An owner who reconnects DURING
+  // the txn-retry window (typically sub-second on Firebase) will trigger a
+  // spurious OWNER_AWAY which self-heals via /owner-returned. Matches the
+  // /owner-away endpoint's documented residual TOCTOU window.
   const ownerStillPresent = await presenceChecker(roomId, preRoom.ownerId);
 
   const effectiveNowMs = nowMs ?? Date.now();
@@ -71,4 +128,5 @@ async function handleOwnerLeftSignal({ db, presenceChecker, roomId, nowMs }) {
 
 module.exports = {
   handleOwnerLeftSignal,
+  isValidOwnerId,
 };

--- a/express-api/src/utils/process-shutdown.js
+++ b/express-api/src/utils/process-shutdown.js
@@ -9,22 +9,29 @@
  * listener detaches cleanly so in-flight signals either complete or are
  * left for the next process boot to pick up via the startup-scan.
  *
+ * Async stops ARE supported — the handler awaits every stop (in parallel
+ * via Promise.allSettled) before calling proc.exit. Sync stops work
+ * unchanged. Errors from any individual stop are caught + logged but do
+ * not prevent other stops or the final exit.
+ *
  * Dependencies are injected to keep this unit-testable without mocking
  * the global `process` object.
  */
 
 function wireProcessShutdown({ proc, stopFns, log }) {
-  const handler = (signal) => {
+  const handler = async (signal) => {
     log.info('process-shutdown', `Received ${signal}, stopping listeners`, { signal });
-    for (const stop of stopFns) {
-      try {
-        stop();
-      } catch (err) {
-        log.warn('process-shutdown', 'stop function threw during shutdown', {
-          error: err && err.message,
-        });
-      }
-    }
+    await Promise.allSettled(
+      stopFns.map(async (stop) => {
+        try {
+          await stop();
+        } catch (err) {
+          log.warn('process-shutdown', 'stop function threw during shutdown', {
+            error: err && err.message,
+          });
+        }
+      }),
+    );
     proc.exit(0);
   };
 

--- a/express-api/src/utils/process-shutdown.js
+++ b/express-api/src/utils/process-shutdown.js
@@ -1,0 +1,37 @@
+/**
+ * Wire process-level SIGTERM/SIGINT to a shared shutdown handler that
+ * invokes every supplied `stop` function (e.g. event-listener detach
+ * functions) before calling `process.exit(0)`.
+ *
+ * Without this wiring, PM2's graceful-restart SIGTERM kills the Node
+ * process mid-RTDB-listener-processing, leaving signal entries in RTDB
+ * in an ambiguous "did the Firestore txn commit?" state. With it, the
+ * listener detaches cleanly so in-flight signals either complete or are
+ * left for the next process boot to pick up via the startup-scan.
+ *
+ * Dependencies are injected to keep this unit-testable without mocking
+ * the global `process` object.
+ */
+
+function wireProcessShutdown({ proc, stopFns, log }) {
+  const handler = (signal) => {
+    log.info('process-shutdown', `Received ${signal}, stopping listeners`, { signal });
+    for (const stop of stopFns) {
+      try {
+        stop();
+      } catch (err) {
+        log.warn('process-shutdown', 'stop function threw during shutdown', {
+          error: err && err.message,
+        });
+      }
+    }
+    proc.exit(0);
+  };
+
+  proc.on('SIGTERM', handler);
+  proc.on('SIGINT', handler);
+}
+
+module.exports = {
+  wireProcessShutdown,
+};

--- a/express-api/tests/rtdb-rules/owner-left-rules.test.js
+++ b/express-api/tests/rtdb-rules/owner-left-rules.test.js
@@ -45,15 +45,27 @@ describe('database.rules.json — ownerLeft rule', () => {
     expect(ownerLeftRule['.write']).toContain('auth != null');
   });
 
-  test('.write forces value to equal auth.uid OR be a removal (set null)', () => {
+  test('.write forces SET value to equal auth.uid (signed entries only)', () => {
     // The writer must SIGN the entry with their own uid (cannot forge
-    // a different uid into the signal). Removals (newData.exists() === false)
-    // are allowed so a graceful client-side cancel of the onDisconnect
-    // can clean up the path.
+    // a different uid into the signal).
     const write = ownerLeftRule['.write'];
     expect(write).toContain('newData.val()');
     expect(write).toContain('auth.uid');
-    expect(write).toContain('newData.exists()');
+  });
+
+  test('.write restricts REMOVAL to the original writer (data.val() === auth.uid) — R2 C1', () => {
+    // R2 reviewer finding C1: without this check, ANY authenticated user
+    // could delete another room's onDisconnect signal during the Express
+    // restart window. Now the removal branch requires `data.val() ===
+    // auth.uid` so only the original writer can clear their own arm.
+    // Admin SDK bypasses rules so server-side `snap.ref.remove()` after
+    // processing still works.
+    const write = ownerLeftRule['.write'];
+    expect(write).toContain('data.val()');
+    expect(write).toContain('!newData.exists()');
+    // Sanity: the removal branch (newData.exists() == false) must be
+    // conjoined with the data.val() === auth.uid check, not standalone.
+    expect(write).toMatch(/!newData\.exists\(\)\s*&&\s*data\.val\(\)\s*===\s*auth\.uid/);
   });
 
   test('.validate constrains the value to a string', () => {

--- a/express-api/tests/rtdb-rules/owner-left-rules.test.js
+++ b/express-api/tests/rtdb-rules/owner-left-rules.test.js
@@ -1,0 +1,89 @@
+/**
+ * Tests for the RTDB security rule on `ownerLeft/{roomId}` introduced
+ * alongside the event-driven owner-left handler (PR #997).
+ *
+ * Mirrors the structural-rule-grep convention used in
+ * `tests/firestore-rules/room-rules.test.js` — parses the rules file and
+ * asserts the expected structure WITHOUT spinning up an emulator. Full
+ * emulator-based rule testing via `@firebase/rules-unit-testing` is a
+ * worthwhile follow-up but a separate scope.
+ *
+ * The rule shape we are asserting:
+ *
+ *   "ownerLeft": {
+ *     "$roomId": {
+ *       ".write":    "auth != null && (!newData.exists() || newData.val() === auth.uid)",
+ *       ".validate": "newData.isString() || !newData.exists()"
+ *     }
+ *   }
+ *
+ * Security semantics:
+ *   - Only authenticated users can write.
+ *   - Writers must SIGN the entry with their own auth.uid (server-side
+ *     orchestrator additionally enforces writer === room.ownerId; the rule
+ *     alone is not sufficient).
+ *   - Removal (set null) is allowed; the validate skips on null per RTDB.
+ *   - Reads are denied by the root `.read: false` rule (no need to repeat).
+ */
+
+const { readFileSync } = require('fs');
+const { join } = require('path');
+
+const RULES = JSON.parse(
+  readFileSync(join(__dirname, '..', '..', '..', 'database.rules.json'), 'utf8'),
+);
+
+describe('database.rules.json — ownerLeft rule', () => {
+  const ownerLeftRule = RULES?.rules?.ownerLeft?.$roomId;
+
+  test('ownerLeft.$roomId stanza exists', () => {
+    expect(ownerLeftRule).toBeDefined();
+    expect(typeof ownerLeftRule).toBe('object');
+  });
+
+  test('.write requires authenticated session', () => {
+    expect(ownerLeftRule['.write']).toContain('auth != null');
+  });
+
+  test('.write forces value to equal auth.uid OR be a removal (set null)', () => {
+    // The writer must SIGN the entry with their own uid (cannot forge
+    // a different uid into the signal). Removals (newData.exists() === false)
+    // are allowed so a graceful client-side cancel of the onDisconnect
+    // can clean up the path.
+    const write = ownerLeftRule['.write'];
+    expect(write).toContain('newData.val()');
+    expect(write).toContain('auth.uid');
+    expect(write).toContain('newData.exists()');
+  });
+
+  test('.validate constrains the value to a string', () => {
+    // The value is the writer's auth.uid (a string). Reject objects,
+    // arrays, numbers, booleans. Allow null (removal) per RTDB semantics
+    // (.validate skips when newData is null) — but assert intent in the
+    // rule for documentation.
+    expect(ownerLeftRule['.validate']).toContain('newData.isString()');
+  });
+
+  test('does NOT expose a default .read (root .read: false denies)', () => {
+    // The root-level `.read: false` denies reads by default. ownerLeft
+    // does not need a .read rule of its own — clients have no business
+    // reading other rooms' onDisconnect signals.
+    expect(ownerLeftRule['.read']).toBeUndefined();
+  });
+
+  test('rule sits under the top-level "rules" object (NOT under "rooms")', () => {
+    // ownerLeft is a SEPARATE top-level path from rooms/* — keeps the
+    // listener's RTDB ref clean and the security boundary explicit.
+    expect(RULES.rules.ownerLeft).toBeDefined();
+    expect(RULES.rules.rooms.ownerLeft).toBeUndefined();
+  });
+
+  test('rule does not accidentally widen reads/writes on adjacent paths', () => {
+    // Pin the existing structure so this PR did not regress the presence
+    // or events rules on rooms/{roomId}.
+    expect(RULES.rules.rooms.$roomId.presence.$userId['.write']).toContain('auth.uid == $userId');
+    expect(RULES.rules.rooms.$roomId.events.lastEvent['.write']).toBe(false);
+    expect(RULES.rules['.read']).toBe(false);
+    expect(RULES.rules['.write']).toBe(false);
+  });
+});

--- a/express-api/tests/utils/event-listeners.test.js
+++ b/express-api/tests/utils/event-listeners.test.js
@@ -1,0 +1,116 @@
+// Test the wiring layer between Express boot and the owner-left listener.
+// startEventListeners() is the single seam we wire from src/index.js — it
+// builds the presence checker closure (so callers don't need to know the RTDB
+// path) and delegates to registerOwnerLeftListener.
+
+jest.mock('../../src/utils/owner-left-listener', () => ({
+  registerOwnerLeftListener: jest.fn(),
+}));
+
+const { registerOwnerLeftListener } = require('../../src/utils/owner-left-listener');
+const { startEventListeners } = require('../../src/utils/event-listeners');
+
+function makeRtdbMock({ presenceExists = true, throwOnGet = false } = {}) {
+  const get = jest.fn().mockImplementation(async () => {
+    if (throwOnGet) throw new Error('rtdb unreachable');
+    return { exists: () => presenceExists };
+  });
+  const ref = jest.fn(() => ({ get }));
+  return { ref, get };
+}
+
+const log = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+const db = { __sentinel: 'firestore' };
+
+beforeEach(() => {
+  registerOwnerLeftListener.mockReset();
+  registerOwnerLeftListener.mockReturnValue(() => {});
+});
+
+describe('startEventListeners — wiring', () => {
+  test('calls registerOwnerLeftListener exactly once', () => {
+    const rtdb = makeRtdbMock().ref;
+    startEventListeners({ db, rtdb: { ref: rtdb }, log });
+    expect(registerOwnerLeftListener).toHaveBeenCalledTimes(1);
+  });
+
+  test('passes db / rtdb / log straight through', () => {
+    const rtdb = { ref: jest.fn() };
+    startEventListeners({ db, rtdb, log });
+    const arg = registerOwnerLeftListener.mock.calls[0][0];
+    expect(arg.db).toBe(db);
+    expect(arg.rtdb).toBe(rtdb);
+    expect(arg.log).toBe(log);
+  });
+
+  test('builds a presenceChecker function (not undefined)', () => {
+    startEventListeners({ db, rtdb: { ref: jest.fn() }, log });
+    const arg = registerOwnerLeftListener.mock.calls[0][0];
+    expect(typeof arg.presenceChecker).toBe('function');
+  });
+
+  test('returns a stop function that detaches the listener', () => {
+    const detach = jest.fn();
+    registerOwnerLeftListener.mockReturnValue(detach);
+    const stop = startEventListeners({ db, rtdb: { ref: jest.fn() }, log });
+    expect(typeof stop).toBe('function');
+    stop();
+    expect(detach).toHaveBeenCalledTimes(1);
+  });
+
+  test('stop is idempotent', () => {
+    const detach = jest.fn();
+    registerOwnerLeftListener.mockReturnValue(detach);
+    const stop = startEventListeners({ db, rtdb: { ref: jest.fn() }, log });
+    stop();
+    stop();
+    // detach is called every time (the listener wrapper itself handles
+    // its own idempotency). What we care about: no exceptions.
+    expect(() => stop()).not.toThrow();
+  });
+});
+
+describe('startEventListeners — presenceChecker closure behavior', () => {
+  test('reads from the canonical rooms/{roomId}/presence/{userId} RTDB path', async () => {
+    const rtdb = makeRtdbMock({ presenceExists: true });
+    startEventListeners({ db, rtdb, log });
+    const presenceChecker = registerOwnerLeftListener.mock.calls[0][0].presenceChecker;
+    await presenceChecker('room-X', 'user-Y');
+    expect(rtdb.ref).toHaveBeenCalledWith('rooms/room-X/presence/user-Y');
+  });
+
+  test('returns true when snapshot exists', async () => {
+    const rtdb = makeRtdbMock({ presenceExists: true });
+    startEventListeners({ db, rtdb, log });
+    const presenceChecker = registerOwnerLeftListener.mock.calls[0][0].presenceChecker;
+    expect(await presenceChecker('room-1', 'user-1')).toBe(true);
+  });
+
+  test('returns false when snapshot does not exist', async () => {
+    const rtdb = makeRtdbMock({ presenceExists: false });
+    startEventListeners({ db, rtdb, log });
+    const presenceChecker = registerOwnerLeftListener.mock.calls[0][0].presenceChecker;
+    expect(await presenceChecker('room-1', 'user-1')).toBe(false);
+  });
+
+  test('PROPAGATES errors (does NOT fail-safe to true) so the listener can preserve the signal for retry', async () => {
+    // Compare with isUserPresent in room-mutations.js which fails-safe-to-true
+    // for use INSIDE a request handler (forging owner-away is the worse
+    // outcome). For the listener path, retry-on-error is preferable to
+    // silent-loss-of-event-on-error.
+    const rtdb = makeRtdbMock({ throwOnGet: true });
+    startEventListeners({ db, rtdb, log });
+    const presenceChecker = registerOwnerLeftListener.mock.calls[0][0].presenceChecker;
+    await expect(presenceChecker('room-1', 'user-1')).rejects.toThrow('rtdb unreachable');
+  });
+
+  test('escapes/forwards roomId and userId verbatim into the path (no transformation)', async () => {
+    // The orchestrator passes ownerId from the Firestore room doc (trusted
+    // source). Verify the closure doesn't accidentally mangle it.
+    const rtdb = makeRtdbMock({ presenceExists: true });
+    startEventListeners({ db, rtdb, log });
+    const presenceChecker = registerOwnerLeftListener.mock.calls[0][0].presenceChecker;
+    await presenceChecker('room_with-mixed.chars', 'user-42');
+    expect(rtdb.ref).toHaveBeenCalledWith('rooms/room_with-mixed.chars/presence/user-42');
+  });
+});

--- a/express-api/tests/utils/owner-left-handler.test.js
+++ b/express-api/tests/utils/owner-left-handler.test.js
@@ -1,0 +1,340 @@
+const {
+  OWNER_LEFT_ACTION,
+  decideOwnerLeftAction,
+  applyOwnerLeftTx,
+} = require('../../src/utils/owner-left-handler');
+const { buildClosePayload } = require('../../src/utils/stale-room-reap');
+
+// The handler implements the operator's refined state machine for owner
+// disconnect (2026-06-04):
+//   - On owner disconnect (signalled via RTDB onDisconnect), the server
+//     decides per the ROOM's current shape:
+//       * if owner is still present somewhere else (multi-device, reconnect
+//         within the listener's processing window) — NOOP
+//       * if room is not ACTIVE (already AWAY/CLOSED) — NOOP (idempotent)
+//       * if ACTIVE and no non-owner seated — CLOSE_IMMEDIATELY
+//       * if ACTIVE and at least one non-owner seated — OWNER_AWAY
+//     The cron is NOT involved in any branch.
+
+const baseActiveRoom = {
+  state: 'ACTIVE',
+  ownerId: 'owner-1',
+  ownerLeftAt: null,
+  participantIds: ['owner-1', 'user-2'],
+  seats: {
+    0: { userId: 'owner-1', state: 'OCCUPIED', isMuted: false },
+    1: { userId: null, state: 'EMPTY', isMuted: false },
+  },
+};
+
+const activeWithNonOwnerSeated = {
+  ...baseActiveRoom,
+  seats: {
+    0: { userId: 'owner-1', state: 'OCCUPIED', isMuted: false },
+    1: { userId: 'user-2', state: 'OCCUPIED', isMuted: false },
+  },
+};
+
+describe('OWNER_LEFT_ACTION', () => {
+  test('exports NOOP, OWNER_AWAY, CLOSE_IMMEDIATE constants', () => {
+    expect(OWNER_LEFT_ACTION.NOOP).toBeDefined();
+    expect(OWNER_LEFT_ACTION.OWNER_AWAY).toBeDefined();
+    expect(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE).toBeDefined();
+    // All three must be distinct strings so callers can switch/branch reliably.
+    const values = [
+      OWNER_LEFT_ACTION.NOOP,
+      OWNER_LEFT_ACTION.OWNER_AWAY,
+      OWNER_LEFT_ACTION.CLOSE_IMMEDIATE,
+    ];
+    expect(new Set(values).size).toBe(3);
+  });
+});
+
+describe('decideOwnerLeftAction', () => {
+  describe('TOCTOU presence re-check (ownerStillPresent === true)', () => {
+    // The RTDB signal can fire on a transient disconnect, but the owner may
+    // already have reconnected by the time the listener processes the event,
+    // or the owner may be present on a SECOND device that never disconnected.
+    // The presence re-check is the authoritative gate — if the owner is
+    // present anywhere, do nothing.
+    test('returns NOOP when owner still present on ACTIVE room with non-owner seated', () => {
+      expect(decideOwnerLeftAction(activeWithNonOwnerSeated, true)).toBe(OWNER_LEFT_ACTION.NOOP);
+    });
+
+    test('returns NOOP when owner still present on ACTIVE room without non-owner seated', () => {
+      expect(decideOwnerLeftAction(baseActiveRoom, true)).toBe(OWNER_LEFT_ACTION.NOOP);
+    });
+
+    test('returns NOOP when owner still present on OWNER_AWAY room', () => {
+      const room = { ...baseActiveRoom, state: 'OWNER_AWAY', ownerLeftAt: 1700000000000 };
+      expect(decideOwnerLeftAction(room, true)).toBe(OWNER_LEFT_ACTION.NOOP);
+    });
+
+    test('returns NOOP when owner still present on CLOSED room', () => {
+      const room = { ...baseActiveRoom, state: 'CLOSED' };
+      expect(decideOwnerLeftAction(room, true)).toBe(OWNER_LEFT_ACTION.NOOP);
+    });
+  });
+
+  describe('input guards (ownerStillPresent === false)', () => {
+    test('returns NOOP when room is null', () => {
+      expect(decideOwnerLeftAction(null, false)).toBe(OWNER_LEFT_ACTION.NOOP);
+    });
+
+    test('returns NOOP when room is undefined', () => {
+      expect(decideOwnerLeftAction(undefined, false)).toBe(OWNER_LEFT_ACTION.NOOP);
+    });
+
+    test('returns NOOP when room.state is missing', () => {
+      const room = { ...baseActiveRoom };
+      delete room.state;
+      expect(decideOwnerLeftAction(room, false)).toBe(OWNER_LEFT_ACTION.NOOP);
+    });
+
+    test('returns NOOP when room.state is null', () => {
+      const room = { ...baseActiveRoom, state: null };
+      expect(decideOwnerLeftAction(room, false)).toBe(OWNER_LEFT_ACTION.NOOP);
+    });
+  });
+
+  describe('idempotency (state is not ACTIVE)', () => {
+    // If state is OWNER_AWAY, the client-driven path already detected and
+    // transitioned the room — the listener's job is done, signal should
+    // just be cleared. Same for CLOSED rooms.
+    test('returns NOOP when state is OWNER_AWAY (already transitioned)', () => {
+      const room = { ...baseActiveRoom, state: 'OWNER_AWAY', ownerLeftAt: 1700000000000 };
+      expect(decideOwnerLeftAction(room, false)).toBe(OWNER_LEFT_ACTION.NOOP);
+    });
+
+    test('returns NOOP when state is CLOSED', () => {
+      const room = { ...baseActiveRoom, state: 'CLOSED' };
+      expect(decideOwnerLeftAction(room, false)).toBe(OWNER_LEFT_ACTION.NOOP);
+    });
+
+    test('returns NOOP when state is an unrecognised string', () => {
+      const room = { ...baseActiveRoom, state: 'UNKNOWN_STATE' };
+      expect(decideOwnerLeftAction(room, false)).toBe(OWNER_LEFT_ACTION.NOOP);
+    });
+  });
+
+  describe('CLOSE_IMMEDIATE branch (ACTIVE + no non-owner seated)', () => {
+    test('returns CLOSE_IMMEDIATE when only owner is seated', () => {
+      // Owner on seat 0, all other seats empty.
+      expect(decideOwnerLeftAction(baseActiveRoom, false)).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+    });
+
+    test('returns CLOSE_IMMEDIATE when no one is seated', () => {
+      const room = {
+        ...baseActiveRoom,
+        seats: {
+          0: { userId: null, state: 'EMPTY', isMuted: false },
+          1: { userId: null, state: 'EMPTY', isMuted: false },
+        },
+      };
+      expect(decideOwnerLeftAction(room, false)).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+    });
+
+    test('returns CLOSE_IMMEDIATE when seats object is empty', () => {
+      const room = { ...baseActiveRoom, seats: {} };
+      expect(decideOwnerLeftAction(room, false)).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+    });
+
+    test('returns CLOSE_IMMEDIATE when seats object is missing', () => {
+      const room = { ...baseActiveRoom };
+      delete room.seats;
+      expect(decideOwnerLeftAction(room, false)).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+    });
+
+    test('returns CLOSE_IMMEDIATE when a non-owner is seated but state is RESERVED, not OCCUPIED', () => {
+      // A user with a pending seat-request that hasn't fully occupied yet
+      // doesn't count as "seated" — hasNonOwnerSeated requires OCCUPIED.
+      const room = {
+        ...baseActiveRoom,
+        seats: {
+          0: { userId: 'owner-1', state: 'OCCUPIED', isMuted: false },
+          1: { userId: 'user-2', state: 'RESERVED', isMuted: false },
+        },
+      };
+      expect(decideOwnerLeftAction(room, false)).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+    });
+  });
+
+  describe('OWNER_AWAY branch (ACTIVE + non-owner seated)', () => {
+    test('returns OWNER_AWAY when one non-owner is seated', () => {
+      expect(decideOwnerLeftAction(activeWithNonOwnerSeated, false)).toBe(
+        OWNER_LEFT_ACTION.OWNER_AWAY,
+      );
+    });
+
+    test('returns OWNER_AWAY when multiple non-owners are seated', () => {
+      const room = {
+        ...baseActiveRoom,
+        seats: {
+          0: { userId: 'owner-1', state: 'OCCUPIED', isMuted: false },
+          1: { userId: 'user-2', state: 'OCCUPIED', isMuted: false },
+          2: { userId: 'user-3', state: 'OCCUPIED', isMuted: false },
+        },
+      };
+      expect(decideOwnerLeftAction(room, false)).toBe(OWNER_LEFT_ACTION.OWNER_AWAY);
+    });
+
+    test('returns OWNER_AWAY when only a non-owner is seated (owner not on a seat)', () => {
+      // Owner has departed their seat but the room is still ACTIVE because
+      // there are seated non-owners. This is a transient state during the
+      // owner's normal leave flow — the lazy-reap or client-driven path
+      // would normally have flipped state by now, but if we get here, the
+      // safe action is the standard OWNER_AWAY transition.
+      const room = {
+        ...baseActiveRoom,
+        seats: {
+          0: { userId: null, state: 'EMPTY', isMuted: false },
+          1: { userId: 'user-2', state: 'OCCUPIED', isMuted: false },
+        },
+      };
+      expect(decideOwnerLeftAction(room, false)).toBe(OWNER_LEFT_ACTION.OWNER_AWAY);
+    });
+  });
+
+  describe('owner-id normalization', () => {
+    // hasNonOwnerSeated already normalises ownerId via String(); the decision
+    // function must honour that so a numeric ownerId in Firestore doesn't
+    // confuse the predicate.
+    test('treats numeric ownerId vs string userId as the same identity (owner alone)', () => {
+      const room = {
+        ...baseActiveRoom,
+        ownerId: 42,
+        seats: {
+          0: { userId: '42', state: 'OCCUPIED', isMuted: false },
+        },
+      };
+      expect(decideOwnerLeftAction(room, false)).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+    });
+
+    test('treats string ownerId vs numeric userId as the same identity (owner alone)', () => {
+      const room = {
+        ...baseActiveRoom,
+        ownerId: '42',
+        seats: {
+          0: { userId: 42, state: 'OCCUPIED', isMuted: false },
+        },
+      };
+      expect(decideOwnerLeftAction(room, false)).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+    });
+  });
+});
+
+describe('applyOwnerLeftTx', () => {
+  // applyOwnerLeftTx is the transactional applier — given an action decided
+  // upstream, it issues the appropriate t.update call. Returning the
+  // post-transition room shape mirrors reapStaleRoomTx so callers (txn
+  // mutators) can read the new state without an extra t.get().
+
+  let mockTx;
+  let roomRef;
+  const nowMs = 1700000000000;
+
+  beforeEach(() => {
+    mockTx = { update: jest.fn() };
+    roomRef = { path: 'rooms/room-1' };
+  });
+
+  describe('NOOP', () => {
+    test('does not call t.update', () => {
+      applyOwnerLeftTx(mockTx, roomRef, baseActiveRoom, OWNER_LEFT_ACTION.NOOP, nowMs);
+      expect(mockTx.update).not.toHaveBeenCalled();
+    });
+
+    test('returns the room unchanged', () => {
+      const result = applyOwnerLeftTx(
+        mockTx,
+        roomRef,
+        baseActiveRoom,
+        OWNER_LEFT_ACTION.NOOP,
+        nowMs,
+      );
+      expect(result).toEqual(baseActiveRoom);
+    });
+  });
+
+  describe('OWNER_AWAY', () => {
+    test('updates state to OWNER_AWAY and stamps ownerLeftAt', () => {
+      applyOwnerLeftTx(
+        mockTx,
+        roomRef,
+        activeWithNonOwnerSeated,
+        OWNER_LEFT_ACTION.OWNER_AWAY,
+        nowMs,
+      );
+      expect(mockTx.update).toHaveBeenCalledWith(roomRef, {
+        state: 'OWNER_AWAY',
+        ownerLeftAt: nowMs,
+      });
+    });
+
+    test('does NOT touch seats or participants (still ACTIVE-shape data)', () => {
+      applyOwnerLeftTx(
+        mockTx,
+        roomRef,
+        activeWithNonOwnerSeated,
+        OWNER_LEFT_ACTION.OWNER_AWAY,
+        nowMs,
+      );
+      const updatePayload = mockTx.update.mock.calls[0][1];
+      expect(updatePayload).not.toHaveProperty('seats');
+      expect(updatePayload).not.toHaveProperty('participantIds');
+      expect(updatePayload).not.toHaveProperty('closedAt');
+    });
+
+    test('returns the room with state and ownerLeftAt patched', () => {
+      const result = applyOwnerLeftTx(
+        mockTx,
+        roomRef,
+        activeWithNonOwnerSeated,
+        OWNER_LEFT_ACTION.OWNER_AWAY,
+        nowMs,
+      );
+      expect(result.state).toBe('OWNER_AWAY');
+      expect(result.ownerLeftAt).toBe(nowMs);
+      expect(result.seats).toEqual(activeWithNonOwnerSeated.seats);
+    });
+  });
+
+  describe('CLOSE_IMMEDIATE', () => {
+    test('updates room to the standard close payload (matches buildClosePayload)', () => {
+      applyOwnerLeftTx(mockTx, roomRef, baseActiveRoom, OWNER_LEFT_ACTION.CLOSE_IMMEDIATE, nowMs);
+      const expectedPayload = buildClosePayload(nowMs);
+      expect(mockTx.update).toHaveBeenCalledWith(roomRef, expectedPayload);
+    });
+
+    test('payload includes ownerLeftAt: null (matches /close + lazy-reap contract)', () => {
+      applyOwnerLeftTx(mockTx, roomRef, baseActiveRoom, OWNER_LEFT_ACTION.CLOSE_IMMEDIATE, nowMs);
+      const updatePayload = mockTx.update.mock.calls[0][1];
+      // Invariant: every close path must set ownerLeftAt: null so a closed
+      // room never carries a stale OWNER_AWAY timestamp. This is the
+      // PR #996 reviewer-Critical-finding contract.
+      expect(updatePayload).toHaveProperty('ownerLeftAt', null);
+    });
+
+    test('returns the post-close room shape', () => {
+      const result = applyOwnerLeftTx(
+        mockTx,
+        roomRef,
+        baseActiveRoom,
+        OWNER_LEFT_ACTION.CLOSE_IMMEDIATE,
+        nowMs,
+      );
+      expect(result.state).toBe('CLOSED');
+      expect(result.closedAt).toBe(nowMs);
+      expect(result.ownerLeftAt).toBeNull();
+      expect(result.participantIds).toEqual([]);
+    });
+  });
+
+  describe('unknown action', () => {
+    test('does not call t.update and returns the room unchanged', () => {
+      const result = applyOwnerLeftTx(mockTx, roomRef, baseActiveRoom, 'BOGUS_ACTION', nowMs);
+      expect(mockTx.update).not.toHaveBeenCalled();
+      expect(result).toEqual(baseActiveRoom);
+    });
+  });
+});

--- a/express-api/tests/utils/owner-left-listener.test.js
+++ b/express-api/tests/utils/owner-left-listener.test.js
@@ -425,6 +425,19 @@ describe('registerOwnerLeftListener — adversarial: race / re-fire / concurrenc
     const childRef = mock.getChildRef('ownerLeft/room-remove-fails');
     childRef.remove.mockRejectedValueOnce(new Error('rtdb unreachable'));
     await expect(mock.fireChildAdded('room-remove-fails')).resolves.not.toThrow();
+    // The error MUST be logged with the roomId, the action taken (so the
+    // operator knows the Firestore mutation HAS committed even though the
+    // signal entry is still around), and the error message — per the I4
+    // review finding.
+    expect(log.error).toHaveBeenCalledWith(
+      'owner-left-listener',
+      'Failed to clear signal after success',
+      expect.objectContaining({
+        roomId: 'room-remove-fails',
+        action: OWNER_LEFT_ACTION.OWNER_AWAY,
+        error: 'rtdb unreachable',
+      }),
+    );
     // After the failed remove, the next signal must still be processable
     await mock.fireChildAdded('room-after');
     expect(handleSignal).toHaveBeenCalledTimes(2);
@@ -447,5 +460,57 @@ describe('registerOwnerLeftListener — dependency injection', () => {
         // handleSignal omitted on purpose — should fall back to the real one
       }),
     ).not.toThrow();
+  });
+});
+
+describe('registerOwnerLeftListener — writer-uid forwarding (C2 + spoof prevention)', () => {
+  test('passes snap.val() to handleSignal as writerUid', async () => {
+    const handleSignal = jest.fn().mockResolvedValue({ action: OWNER_LEFT_ACTION.OWNER_AWAY });
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal,
+    });
+    await mock.fireChildAdded('room-w1', 'owner-uid-99');
+    expect(handleSignal).toHaveBeenCalledWith(
+      expect.objectContaining({ roomId: 'room-w1', writerUid: 'owner-uid-99' }),
+    );
+  });
+
+  test('forwards a numeric writerUid verbatim (string normalisation happens downstream)', async () => {
+    const handleSignal = jest.fn().mockResolvedValue({ action: OWNER_LEFT_ACTION.OWNER_AWAY });
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal,
+    });
+    await mock.fireChildAdded('room-w2', 42);
+    expect(handleSignal).toHaveBeenCalledWith(
+      expect.objectContaining({ roomId: 'room-w2', writerUid: 42 }),
+    );
+  });
+
+  test('forwards undefined writerUid when snap has no value (legacy / cancel arm)', async () => {
+    const handleSignal = jest.fn().mockResolvedValue({ action: OWNER_LEFT_ACTION.NOOP });
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal,
+    });
+    await mock.fireChildAdded('room-w3', null);
+    // null becomes null on the wire; the orchestrator treats null and
+    // undefined as "no attestation" and falls back to ownerStillPresent.
+    expect(handleSignal).toHaveBeenCalledWith(
+      expect.objectContaining({ roomId: 'room-w3', writerUid: null }),
+    );
   });
 });

--- a/express-api/tests/utils/owner-left-listener.test.js
+++ b/express-api/tests/utils/owner-left-listener.test.js
@@ -1,0 +1,451 @@
+const { registerOwnerLeftListener } = require('../../src/utils/owner-left-listener');
+const { OWNER_LEFT_ACTION } = require('../../src/utils/owner-left-handler');
+
+// `registerOwnerLeftListener` attaches a `child_added` listener to the RTDB
+// `ownerLeft` ref. Each fired child is a signal that an owner's onDisconnect
+// fired for some room. The listener:
+//   - validates the roomId (rejects empty/structurally-invalid keys)
+//   - delegates to handleOwnerLeftSignal (the orchestrator) for the actual
+//     room mutation + decision
+//   - clears the signal entry on SUCCESS only (so a failure preserves the
+//     signal for a later retry or restart-scan)
+//   - never throws into the listener — errors are logged
+//   - returns a `detach` function for shutdown / test cleanup
+//
+// The orchestrator is INJECTED so tests don't need a real Firestore — we
+// substitute a jest.fn() and assert on it.
+
+/**
+ * RTDB mock matching the firebase-admin Reference shape the listener uses:
+ *   rtdb.ref('ownerLeft').on('child_added', cb)
+ *   rtdb.ref('ownerLeft').off('child_added', cb)
+ *   rtdb.ref(`ownerLeft/${roomId}`).remove()
+ *
+ * `.on('child_added', cb)` synchronously fires for any existing children at
+ * the moment of attach — mirrors Firebase admin SDK behavior. This is what
+ * gives us "free" restart-scan: existing signals get processed on listener
+ * boot without any explicit catch-up code.
+ */
+function makeMockRtdb({ initialChildren = {} } = {}) {
+  let children = { ...initialChildren };
+  const childRefs = new Map();
+  const listeners = [];
+
+  function getChildRef(path) {
+    if (!childRefs.has(path)) {
+      childRefs.set(path, {
+        path,
+        remove: jest.fn().mockImplementation(async () => {
+          const m = path.match(/^ownerLeft\/(.+)$/);
+          if (m) delete children[m[1]];
+        }),
+      });
+    }
+    return childRefs.get(path);
+  }
+
+  function makeSnap(roomId, value) {
+    return {
+      key: roomId,
+      val: () => value,
+      exists: () => value !== undefined && value !== null,
+      ref: getChildRef(`ownerLeft/${roomId}`),
+    };
+  }
+
+  const ownerLeftRef = {
+    path: 'ownerLeft',
+    on: jest.fn((eventType, callback) => {
+      listeners.push({ eventType, callback });
+      if (eventType === 'child_added') {
+        for (const [key, value] of Object.entries(children)) {
+          // Fire synchronously; tests await via the promise the callback returns
+          callback(makeSnap(key, value));
+        }
+      }
+    }),
+    off: jest.fn((eventType, callback) => {
+      const idx = listeners.findIndex((l) => l.eventType === eventType && l.callback === callback);
+      if (idx !== -1) listeners.splice(idx, 1);
+    }),
+  };
+
+  const rtdb = {
+    ref: jest.fn((path) => (path === 'ownerLeft' ? ownerLeftRef : getChildRef(path))),
+  };
+
+  return {
+    rtdb,
+    ownerLeftRef,
+    fireChildAdded: async (roomId, value = true) => {
+      const childAdded = listeners.find((l) => l.eventType === 'child_added');
+      if (!childAdded) throw new Error('No child_added listener attached');
+      await childAdded.callback(makeSnap(roomId, value));
+      return getChildRef(`ownerLeft/${roomId}`);
+    },
+    getChildren: () => ({ ...children }),
+    getChildRef,
+  };
+}
+
+function makeLog() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+}
+
+// Stable args used across many tests.
+const dummyDb = { __sentinel: 'firestore' };
+const dummyPresenceChecker = jest.fn();
+
+describe('registerOwnerLeftListener — attach / detach', () => {
+  test('attaches a child_added listener to the ownerLeft ref on construction', () => {
+    const { rtdb, ownerLeftRef } = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal: jest.fn(),
+    });
+    expect(rtdb.ref).toHaveBeenCalledWith('ownerLeft');
+    expect(ownerLeftRef.on).toHaveBeenCalledWith('child_added', expect.any(Function));
+  });
+
+  test('returns a detach function that removes the listener', () => {
+    const { rtdb, ownerLeftRef } = makeMockRtdb();
+    const detach = registerOwnerLeftListener({
+      rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal: jest.fn(),
+    });
+    expect(typeof detach).toBe('function');
+    detach();
+    expect(ownerLeftRef.off).toHaveBeenCalledWith('child_added', expect.any(Function));
+    // Confirm the function passed to off matches the one passed to on (so
+    // detachment actually targets our listener, not a stray reference).
+    const onArgs = ownerLeftRef.on.mock.calls[0];
+    const offArgs = ownerLeftRef.off.mock.calls[0];
+    expect(offArgs[1]).toBe(onArgs[1]);
+  });
+
+  test('detach is idempotent (calling twice does not throw)', () => {
+    const { rtdb } = makeMockRtdb();
+    const detach = registerOwnerLeftListener({
+      rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal: jest.fn(),
+    });
+    detach();
+    expect(() => detach()).not.toThrow();
+  });
+});
+
+describe('registerOwnerLeftListener — signal processing', () => {
+  test('invokes handleSignal with the roomId extracted from snap.key', async () => {
+    const handleSignal = jest.fn().mockResolvedValue({ action: OWNER_LEFT_ACTION.OWNER_AWAY });
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal,
+    });
+    await mock.fireChildAdded('room-abc-123', 1700000000000);
+    expect(handleSignal).toHaveBeenCalledTimes(1);
+    const callArgs = handleSignal.mock.calls[0][0];
+    expect(callArgs.roomId).toBe('room-abc-123');
+    expect(callArgs.db).toBe(dummyDb);
+    expect(callArgs.presenceChecker).toBe(dummyPresenceChecker);
+  });
+
+  test('removes the signal entry after successful processing', async () => {
+    const handleSignal = jest.fn().mockResolvedValue({ action: OWNER_LEFT_ACTION.CLOSE_IMMEDIATE });
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal,
+    });
+    const childRef = await mock.fireChildAdded('room-1');
+    expect(childRef.remove).toHaveBeenCalledTimes(1);
+  });
+
+  test('removes the signal entry even on NOOP outcome (idempotency drives cleanup)', async () => {
+    // If the orchestrator decided NOOP (room missing, already CLOSED, etc.),
+    // the signal still needs clearing — a retry would just NOOP again.
+    const handleSignal = jest.fn().mockResolvedValue({
+      action: OWNER_LEFT_ACTION.NOOP,
+      reason: 'room-missing',
+    });
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal,
+    });
+    const childRef = await mock.fireChildAdded('room-2');
+    expect(childRef.remove).toHaveBeenCalledTimes(1);
+  });
+
+  test('does NOT throw out of the listener when handleSignal rejects', async () => {
+    const handleSignal = jest.fn().mockRejectedValue(new Error('firestore down'));
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal,
+    });
+    // No unhandled rejection — the fire should resolve normally
+    await expect(mock.fireChildAdded('room-3')).resolves.not.toThrow();
+  });
+
+  test('PRESERVES the signal entry on handleSignal failure (retry on next signal-fire)', async () => {
+    const handleSignal = jest.fn().mockRejectedValue(new Error('firestore down'));
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal,
+    });
+    const childRef = await mock.fireChildAdded('room-4');
+    expect(childRef.remove).not.toHaveBeenCalled();
+  });
+
+  test('logs an error message on handleSignal failure with roomId + error', async () => {
+    const log = makeLog();
+    const handleSignal = jest.fn().mockRejectedValue(new Error('firestore down'));
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log,
+      handleSignal,
+    });
+    await mock.fireChildAdded('room-5');
+    expect(log.error).toHaveBeenCalled();
+    const errorPayload = log.error.mock.calls[0];
+    // The error payload should include the roomId so an operator can find it
+    expect(JSON.stringify(errorPayload)).toContain('room-5');
+    expect(JSON.stringify(errorPayload)).toContain('firestore down');
+  });
+});
+
+describe('registerOwnerLeftListener — startup-scan (existing children at attach)', () => {
+  test('processes EVERY existing child at .on() time (free restart-scan)', async () => {
+    const handleSignal = jest.fn().mockResolvedValue({ action: OWNER_LEFT_ACTION.OWNER_AWAY });
+    const mock = makeMockRtdb({
+      initialChildren: {
+        'room-a': 1700000000001,
+        'room-b': 1700000000002,
+        'room-c': 1700000000003,
+      },
+    });
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal,
+    });
+    // Allow microtasks to drain — synchronous callback invocation returns
+    // a promise; we need to flush.
+    await new Promise((r) => setImmediate(r));
+    const roomIds = handleSignal.mock.calls.map((c) => c[0].roomId);
+    expect(roomIds.sort()).toEqual(['room-a', 'room-b', 'room-c']);
+  });
+});
+
+describe('registerOwnerLeftListener — adversarial: malicious / malformed keys', () => {
+  test('ignores empty-string roomId', async () => {
+    const log = makeLog();
+    const handleSignal = jest.fn();
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log,
+      handleSignal,
+    });
+    await mock.fireChildAdded('', 1700000000000);
+    expect(handleSignal).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalled();
+  });
+
+  test('ignores null/undefined roomId', async () => {
+    const handleSignal = jest.fn();
+    const log = makeLog();
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log,
+      handleSignal,
+    });
+    await mock.fireChildAdded(null, 1700000000000);
+    await mock.fireChildAdded(undefined, 1700000000000);
+    expect(handleSignal).not.toHaveBeenCalled();
+  });
+
+  test('ignores a roomId that violates the safe-key character allowlist', async () => {
+    // RTDB itself disallows `/`, `.`, `#`, `$`, `[`, `]` in keys, so most of
+    // these "shouldn't happen". Defense-in-depth: the listener validates
+    // anyway, in case Firebase rules slip or a future SDK exposes raw keys.
+    const log = makeLog();
+    const handleSignal = jest.fn();
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log,
+      handleSignal,
+    });
+    const malicious = ['../../foo', 'a/b', 'a.b', 'a#b', 'a$b', 'a[b]', 'a b', 'a\tb', 'a\nb'];
+    for (const key of malicious) {
+      await mock.fireChildAdded(key, 1700000000000);
+    }
+    expect(handleSignal).not.toHaveBeenCalled();
+  });
+
+  test('accepts standard room-id shapes (alphanumeric + dash + underscore)', async () => {
+    const handleSignal = jest.fn().mockResolvedValue({ action: OWNER_LEFT_ACTION.OWNER_AWAY });
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal,
+    });
+    const validKeys = [
+      'room-1',
+      'ROOM_2',
+      'a1b2c3',
+      'abc-def-123_xyz',
+      // Long but plausible Firestore-style ID
+      'abcDEF0123456789xyzABCdef0123456789',
+    ];
+    for (const key of validKeys) {
+      await mock.fireChildAdded(key, 1700000000000);
+    }
+    expect(handleSignal).toHaveBeenCalledTimes(validKeys.length);
+  });
+
+  test('rejects roomId longer than the safe maximum (DoS / abuse prevention)', async () => {
+    const log = makeLog();
+    const handleSignal = jest.fn();
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log,
+      handleSignal,
+    });
+    // A pathologically long key shouldn't crash anything but doesn't match
+    // a real Firestore document id (max 1500 bytes path; we choose 256
+    // chars as a comfortable cap that still allows long IDs).
+    const tooLong = 'a'.repeat(257);
+    await mock.fireChildAdded(tooLong, 1700000000000);
+    expect(handleSignal).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerOwnerLeftListener — adversarial: race / re-fire / concurrency', () => {
+  test('second signal for the same roomId is processed independently (idempotent at handler layer)', async () => {
+    // Even if RTDB somehow re-fires for the same key, the handler should
+    // safely NOOP via decideOwnerLeftAction's state-machine guards. The
+    // listener should NOT swallow the duplicate — it should pass it through.
+    const handleSignal = jest.fn().mockResolvedValue({ action: OWNER_LEFT_ACTION.NOOP });
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal,
+    });
+    await mock.fireChildAdded('room-X');
+    await mock.fireChildAdded('room-X');
+    expect(handleSignal).toHaveBeenCalledTimes(2);
+  });
+
+  test('a failing signal does NOT prevent subsequent signals from being processed', async () => {
+    const handleSignal = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('transient failure'))
+      .mockResolvedValueOnce({ action: OWNER_LEFT_ACTION.CLOSE_IMMEDIATE });
+    const mock = makeMockRtdb();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log: makeLog(),
+      handleSignal,
+    });
+    await mock.fireChildAdded('room-fail');
+    await mock.fireChildAdded('room-ok');
+    expect(handleSignal).toHaveBeenCalledTimes(2);
+  });
+
+  test('a remove() failure after success does not break the listener (logs + continues)', async () => {
+    // If RTDB rejects the .remove(), we lose the cleanup but the room state
+    // is already correct in Firestore. Listener should log and keep going.
+    const handleSignal = jest.fn().mockResolvedValue({ action: OWNER_LEFT_ACTION.OWNER_AWAY });
+    const mock = makeMockRtdb();
+    const log = makeLog();
+    registerOwnerLeftListener({
+      rtdb: mock.rtdb,
+      db: dummyDb,
+      presenceChecker: dummyPresenceChecker,
+      log,
+      handleSignal,
+    });
+    // Make the next .remove() fail
+    const childRef = mock.getChildRef('ownerLeft/room-remove-fails');
+    childRef.remove.mockRejectedValueOnce(new Error('rtdb unreachable'));
+    await expect(mock.fireChildAdded('room-remove-fails')).resolves.not.toThrow();
+    // After the failed remove, the next signal must still be processable
+    await mock.fireChildAdded('room-after');
+    expect(handleSignal).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('registerOwnerLeftListener — dependency injection', () => {
+  test('uses the injected handleSignal (default exposes the real orchestrator)', () => {
+    // The signature accepts handleSignal so tests can swap it out — but the
+    // default must be the real orchestrator so wiring "just works" in prod.
+    // This test asserts the module exposes a sane default by attempting
+    // registration without handleSignal injected.
+    const mock = makeMockRtdb();
+    expect(() =>
+      registerOwnerLeftListener({
+        rtdb: mock.rtdb,
+        db: dummyDb,
+        presenceChecker: dummyPresenceChecker,
+        log: makeLog(),
+        // handleSignal omitted on purpose — should fall back to the real one
+      }),
+    ).not.toThrow();
+  });
+});

--- a/express-api/tests/utils/owner-left-listener.test.js
+++ b/express-api/tests/utils/owner-left-listener.test.js
@@ -496,7 +496,11 @@ describe('registerOwnerLeftListener — writer-uid forwarding (C2 + spoof preven
     );
   });
 
-  test('forwards undefined writerUid when snap has no value (legacy / cancel arm)', async () => {
+  test('forwards null writerUid when snap.val() returns null (removal / cancel arm)', async () => {
+    // RTDB child_added with a null value can occur in narrow edge cases
+    // (e.g. arming with explicit null, or test fixtures). The orchestrator
+    // treats null and undefined as "no attestation" and falls back to the
+    // ownerStillPresent check.
     const handleSignal = jest.fn().mockResolvedValue({ action: OWNER_LEFT_ACTION.NOOP });
     const mock = makeMockRtdb();
     registerOwnerLeftListener({
@@ -507,8 +511,6 @@ describe('registerOwnerLeftListener — writer-uid forwarding (C2 + spoof preven
       handleSignal,
     });
     await mock.fireChildAdded('room-w3', null);
-    // null becomes null on the wire; the orchestrator treats null and
-    // undefined as "no attestation" and falls back to ownerStillPresent.
     expect(handleSignal).toHaveBeenCalledWith(
       expect.objectContaining({ roomId: 'room-w3', writerUid: null }),
     );

--- a/express-api/tests/utils/owner-left-orchestrator.test.js
+++ b/express-api/tests/utils/owner-left-orchestrator.test.js
@@ -1,0 +1,333 @@
+const { OWNER_LEFT_ACTION } = require('../../src/utils/owner-left-handler');
+const { handleOwnerLeftSignal } = require('../../src/utils/owner-left-orchestrator');
+
+// `handleOwnerLeftSignal` is the orchestrator wired to the RTDB `ownerLeft/{roomId}`
+// signal. Given a roomId, it:
+//   1. Reads the room from Firestore (pre-txn) to obtain ownerId.
+//   2. Re-checks RTDB presence for the owner (TOCTOU window — owner may have
+//      reconnected on a second device between signal fire and processing).
+//   3. Inside a Firestore transaction: re-reads the room, decides the action
+//      via `decideOwnerLeftAction`, applies via `applyOwnerLeftTx`.
+//   4. Returns `{ action, ...details }` for the caller (the RTDB listener
+//      wrapper) to decide whether to clear the signal entry.
+//
+// The orchestrator does NOT touch the RTDB signal entry itself — that's the
+// listener wrapper's job. Separation of concerns lets the wrapper retain the
+// signal on error (so a later signal-fire or restart-scan can retry).
+
+const baseActiveRoom = {
+  state: 'ACTIVE',
+  ownerId: 'owner-1',
+  ownerLeftAt: null,
+  participantIds: ['owner-1', 'user-2'],
+  seats: {
+    0: { userId: 'owner-1', state: 'OCCUPIED', isMuted: false },
+    1: { userId: null, state: 'EMPTY', isMuted: false },
+  },
+};
+
+const activeWithSeatedUser = {
+  ...baseActiveRoom,
+  seats: {
+    0: { userId: 'owner-1', state: 'OCCUPIED', isMuted: false },
+    1: { userId: 'user-2', state: 'OCCUPIED', isMuted: false },
+  },
+};
+
+/**
+ * Build a mock `db` matching the firebase-admin Firestore shape used by the
+ * orchestrator: `db.doc(path)` returns a stable ref; `db.runTransaction(cb)`
+ * supplies a transaction object with `t.get(ref)` and `t.update(ref, patch)`.
+ *
+ * The factory exposes the captured mocks so tests can assert against them.
+ */
+function makeMockDb({ initialRoom }) {
+  const roomRef = { __ref: true };
+  let currentRoom = initialRoom; // may be null/undefined to simulate missing
+  const docFn = jest.fn(() => roomRef);
+
+  const preGetMock = jest
+    .fn()
+    .mockImplementation(async () => ({ exists: !!currentRoom, data: () => currentRoom }));
+  roomRef.get = preGetMock;
+
+  const txMock = {
+    get: jest
+      .fn()
+      .mockImplementation(async () => ({ exists: !!currentRoom, data: () => currentRoom })),
+    update: jest.fn().mockImplementation((ref, patch) => {
+      // Apply the patch locally so subsequent t.get calls inside the same
+      // test (rare but possible) see the post-update shape.
+      currentRoom = { ...currentRoom, ...patch };
+    }),
+  };
+
+  const runTransaction = jest.fn().mockImplementation(async (callback) => callback(txMock));
+
+  return { db: { doc: docFn, runTransaction }, roomRef, txMock, preGetMock };
+}
+
+describe('handleOwnerLeftSignal', () => {
+  const nowMs = 1700000000000;
+  let presenceChecker;
+
+  beforeEach(() => {
+    presenceChecker = jest.fn();
+  });
+
+  describe('room missing (pre-txn read)', () => {
+    test('returns NOOP with reason room-missing and never queries presence', async () => {
+      const { db } = makeMockDb({ initialRoom: null });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('room-missing');
+      expect(presenceChecker).not.toHaveBeenCalled();
+    });
+
+    test('does not open a transaction when room is missing', async () => {
+      const { db } = makeMockDb({ initialRoom: null });
+      await handleOwnerLeftSignal({ db, presenceChecker, roomId: 'room-1', nowMs });
+      expect(db.runTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('owner still present (TOCTOU re-check returns true)', () => {
+    test('returns NOOP without applying a txn update', async () => {
+      const { db, txMock } = makeMockDb({ initialRoom: baseActiveRoom });
+      presenceChecker.mockResolvedValue(true);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(presenceChecker).toHaveBeenCalledWith('room-1', 'owner-1');
+      expect(txMock.update).not.toHaveBeenCalled();
+    });
+
+    test('still opens the transaction (to atomically observe state, even if no-op)', async () => {
+      // The txn is the only safe place to make the decision atomically with
+      // any concurrent client mutations — the TOCTOU re-check inside the txn
+      // sees the latest room state.
+      const { db } = makeMockDb({ initialRoom: baseActiveRoom });
+      presenceChecker.mockResolvedValue(true);
+      await handleOwnerLeftSignal({ db, presenceChecker, roomId: 'room-1', nowMs });
+      expect(db.runTransaction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('owner absent + ACTIVE + non-owner seated → OWNER_AWAY', () => {
+    test('applies OWNER_AWAY patch inside transaction', async () => {
+      const { db, txMock, roomRef } = makeMockDb({ initialRoom: activeWithSeatedUser });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.OWNER_AWAY);
+      expect(txMock.update).toHaveBeenCalledTimes(1);
+      expect(txMock.update).toHaveBeenCalledWith(roomRef, {
+        state: 'OWNER_AWAY',
+        ownerLeftAt: nowMs,
+      });
+    });
+
+    test('returns the post-transition room shape', async () => {
+      const { db } = makeMockDb({ initialRoom: activeWithSeatedUser });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+
+      expect(result.postRoom.state).toBe('OWNER_AWAY');
+      expect(result.postRoom.ownerLeftAt).toBe(nowMs);
+    });
+  });
+
+  describe('owner absent + ACTIVE + no non-owner seated → CLOSE_IMMEDIATE', () => {
+    test('applies the close payload inside transaction', async () => {
+      const { db, txMock, roomRef } = makeMockDb({ initialRoom: baseActiveRoom });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+      const updateArgs = txMock.update.mock.calls[0];
+      expect(updateArgs[0]).toBe(roomRef);
+      expect(updateArgs[1]).toMatchObject({
+        state: 'CLOSED',
+        closedAt: nowMs,
+        ownerLeftAt: null,
+        participantIds: [],
+      });
+    });
+
+    test('returns the closed room with participantIds cleared', async () => {
+      const { db } = makeMockDb({ initialRoom: baseActiveRoom });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+
+      expect(result.postRoom.state).toBe('CLOSED');
+      expect(result.postRoom.participantIds).toEqual([]);
+    });
+  });
+
+  describe('idempotent (room already transitioned)', () => {
+    test('returns NOOP when room is already OWNER_AWAY (no double-stamp)', async () => {
+      const alreadyAway = {
+        ...activeWithSeatedUser,
+        state: 'OWNER_AWAY',
+        ownerLeftAt: nowMs - 1000,
+      };
+      const { db, txMock } = makeMockDb({ initialRoom: alreadyAway });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(txMock.update).not.toHaveBeenCalled();
+    });
+
+    test('returns NOOP when room is already CLOSED', async () => {
+      const closed = { ...baseActiveRoom, state: 'CLOSED' };
+      const { db, txMock } = makeMockDb({ initialRoom: closed });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(txMock.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('room disappears between pre-snap and txn (race)', () => {
+    test('returns NOOP with reason room-missing-in-txn', async () => {
+      const { db, txMock, preGetMock } = makeMockDb({ initialRoom: baseActiveRoom });
+      // Pre-snap sees the room, but the txn sees it deleted.
+      preGetMock.mockResolvedValueOnce({ exists: true, data: () => baseActiveRoom });
+      txMock.get.mockResolvedValueOnce({ exists: false, data: () => undefined });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('room-missing-in-txn');
+      expect(txMock.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error propagation', () => {
+    test('throws when presenceChecker throws (caller decides whether to clear signal)', async () => {
+      const { db } = makeMockDb({ initialRoom: baseActiveRoom });
+      const boom = new Error('rtdb read failed');
+      presenceChecker.mockRejectedValue(boom);
+
+      await expect(
+        handleOwnerLeftSignal({ db, presenceChecker, roomId: 'room-1', nowMs }),
+      ).rejects.toThrow('rtdb read failed');
+    });
+
+    test('throws when Firestore runTransaction throws', async () => {
+      const { db } = makeMockDb({ initialRoom: baseActiveRoom });
+      const boom = new Error('firestore unavailable');
+      db.runTransaction.mockRejectedValue(boom);
+      presenceChecker.mockResolvedValue(false);
+
+      await expect(
+        handleOwnerLeftSignal({ db, presenceChecker, roomId: 'room-1', nowMs }),
+      ).rejects.toThrow('firestore unavailable');
+    });
+
+    test('throws when pre-snap roomRef.get throws', async () => {
+      const { db, preGetMock } = makeMockDb({ initialRoom: baseActiveRoom });
+      const boom = new Error('firestore read failed');
+      preGetMock.mockRejectedValue(boom);
+
+      await expect(
+        handleOwnerLeftSignal({ db, presenceChecker, roomId: 'room-1', nowMs }),
+      ).rejects.toThrow('firestore read failed');
+    });
+  });
+
+  describe('ownerId trust boundary', () => {
+    test('reads ownerId from the Firestore room doc, not from caller args', async () => {
+      // A malicious or buggy caller could pass a forged ownerId. The
+      // orchestrator must ignore that and use the authoritative Firestore
+      // value. We assert this by giving presenceChecker the chance to
+      // observe what ownerId was passed and checking it matches the doc.
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: 'real-owner' } });
+      presenceChecker.mockResolvedValue(true); // pretend present so we can read invocation args
+
+      await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+        ownerIdFromSignal: 'attacker-id', // ignored
+      });
+
+      expect(presenceChecker).toHaveBeenCalledWith('room-1', 'real-owner');
+    });
+  });
+
+  describe('default nowMs', () => {
+    test('uses Date.now() when nowMs is omitted', async () => {
+      const { db, txMock } = makeMockDb({ initialRoom: activeWithSeatedUser });
+      presenceChecker.mockResolvedValue(false);
+      const realNow = Date.now;
+      const fakeNow = 1234567890;
+      Date.now = jest.fn(() => fakeNow);
+      try {
+        await handleOwnerLeftSignal({ db, presenceChecker, roomId: 'room-1' });
+        expect(txMock.update).toHaveBeenCalledWith(expect.anything(), {
+          state: 'OWNER_AWAY',
+          ownerLeftAt: fakeNow,
+        });
+      } finally {
+        Date.now = realNow;
+      }
+    });
+  });
+});

--- a/express-api/tests/utils/owner-left-orchestrator.test.js
+++ b/express-api/tests/utils/owner-left-orchestrator.test.js
@@ -330,4 +330,256 @@ describe('handleOwnerLeftSignal', () => {
       }
     });
   });
+
+  describe('ownerId path-safety guard (C2 + I2)', () => {
+    // C2: ownerId from Firestore is interpolated into an RTDB path; it MUST
+    // be validated as path-safe BEFORE it crosses module boundaries.
+    // I2:  ownerId may be missing/null/undefined in a corrupt-but-present
+    // room doc; without a guard the orchestrator silently closes the room.
+    test('returns NOOP with reason owner-id-missing-or-invalid when ownerId is null', async () => {
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: null } });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('owner-id-missing-or-invalid');
+      expect(presenceChecker).not.toHaveBeenCalled();
+    });
+
+    test('returns NOOP when ownerId is undefined', async () => {
+      const room = { ...baseActiveRoom };
+      delete room.ownerId;
+      const { db } = makeMockDb({ initialRoom: room });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('owner-id-missing-or-invalid');
+      expect(presenceChecker).not.toHaveBeenCalled();
+    });
+
+    test('returns NOOP when ownerId is an empty string', async () => {
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: '' } });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('owner-id-missing-or-invalid');
+      expect(presenceChecker).not.toHaveBeenCalled();
+    });
+
+    test('returns NOOP when ownerId contains a forward slash (path traversal attempt)', async () => {
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: '../../etc' } });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('owner-id-missing-or-invalid');
+      expect(presenceChecker).not.toHaveBeenCalled();
+    });
+
+    test('returns NOOP when ownerId contains RTDB-illegal chars (., #, $, [, ])', async () => {
+      const illegalIds = ['a.b', 'a#b', 'a$b', 'a[b]', 'a b', 'a\nb', ' '];
+      for (const ownerId of illegalIds) {
+        const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId } });
+        const result = await handleOwnerLeftSignal({
+          db,
+          presenceChecker,
+          roomId: 'room-1',
+          nowMs,
+        });
+        expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+        expect(result.reason).toBe('owner-id-missing-or-invalid');
+      }
+      expect(presenceChecker).not.toHaveBeenCalled();
+    });
+
+    test('returns NOOP when ownerId exceeds the safe length cap', async () => {
+      const { db } = makeMockDb({
+        initialRoom: { ...baseActiveRoom, ownerId: 'a'.repeat(257) },
+      });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('owner-id-missing-or-invalid');
+      expect(presenceChecker).not.toHaveBeenCalled();
+    });
+
+    test('accepts ownerId with standard alphanumeric + dash + underscore shapes', async () => {
+      const validIds = ['owner-1', 'OWNER_2', '42', 'a1b2-c3_d4', 'abcDEF0123456789'];
+      for (const ownerId of validIds) {
+        presenceChecker.mockClear();
+        presenceChecker.mockResolvedValue(true); // present → NOOP, no txn write
+        const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId } });
+        const result = await handleOwnerLeftSignal({
+          db,
+          presenceChecker,
+          roomId: 'room-1',
+          nowMs,
+        });
+        expect(result.reason).not.toBe('owner-id-missing-or-invalid');
+        expect(presenceChecker).toHaveBeenCalledWith('room-1', ownerId);
+      }
+    });
+  });
+
+  describe('writer-uid spoof prevention', () => {
+    // Without this check, an attacker can write `ownerLeft/{victim-room} = attacker-uid`
+    // (allowed by the RTDB rule `newData.val() === auth.uid`); the listener fires;
+    // the server reads room.ownerId = victim; presenceChecker for victim returns
+    // false if victim has a brief network blip — and the room is illegitimately
+    // closed or transitioned to OWNER_AWAY. The writerUid arg is the value at
+    // the RTDB signal entry (snap.val()) — it MUST match the room owner.
+    test('returns NOOP when writerUid does not match preRoom.ownerId', async () => {
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: 'owner-1' } });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: 'attacker-uid',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('writer-not-owner');
+      // Critical: presenceChecker was NOT called — attacker can't even probe
+      // the victim's presence state via this signal-spam.
+      expect(presenceChecker).not.toHaveBeenCalled();
+    });
+
+    test('proceeds when writerUid matches preRoom.ownerId', async () => {
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: 'owner-1' } });
+      presenceChecker.mockResolvedValue(false);
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: 'owner-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+      expect(presenceChecker).toHaveBeenCalledWith('room-1', 'owner-1');
+    });
+
+    test('writerUid omitted (undefined) is accepted — backward compat for direct callers', async () => {
+      // The orchestrator can be called from contexts other than the RTDB
+      // listener; when no writer attestation is available, the existing
+      // ownerStillPresent / state-machine guards still apply.
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: 'owner-1' } });
+      presenceChecker.mockResolvedValue(false);
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+    });
+
+    test('writerUid normalisation handles string vs numeric ownerId', async () => {
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: 42 } });
+      presenceChecker.mockResolvedValue(true);
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: '42',
+        nowMs,
+      });
+      // Match by string-normalised compare — should NOT be writer-not-owner.
+      expect(result.reason).not.toBe('writer-not-owner');
+    });
+  });
+
+  describe('transaction retry on contention (I3)', () => {
+    // Firestore Admin SDK retries the transaction callback on contention.
+    // ownerStillPresent is captured BEFORE the txn opens and re-used across
+    // every retry — that's intentional (the presence read can't run inside
+    // the txn). This test pins that semantic so a future refactor that
+    // tries to re-read presence inside the callback (which would deadlock
+    // or block) is caught.
+    test('does not re-invoke presenceChecker on transaction retry', async () => {
+      const { db, txMock } = makeMockDb({ initialRoom: activeWithSeatedUser });
+      presenceChecker.mockResolvedValue(false);
+      // Force the runTransaction mock to invoke the callback twice (simulating
+      // a contention-retry from the SDK).
+      let invocations = 0;
+      db.runTransaction.mockImplementation(async (callback) => {
+        invocations += 1;
+        const first = await callback(txMock);
+        if (invocations === 1) {
+          // Pretend the first attempt was retried by the SDK (contention).
+          return callback(txMock);
+        }
+        return first;
+      });
+
+      await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+
+      // presenceChecker is called exactly once even though the txn callback
+      // ran twice — captured outside, by design.
+      expect(presenceChecker).toHaveBeenCalledTimes(1);
+    });
+
+    test('reuses the same effectiveNowMs across transaction retries', async () => {
+      // Simulate Firestore SDK contention-retry: the same callback runs
+      // twice. In real Firestore, between attempts the SDK rolls back the
+      // first attempt's writes and re-reads the data, so attempt 2 sees the
+      // original (pre-attempt-1) room state. The mock replays that by
+      // returning the SAME pre-mutation room shape from t.get() on every
+      // call, regardless of how many t.update calls fired earlier.
+      const { db, roomRef } = makeMockDb({ initialRoom: activeWithSeatedUser });
+      presenceChecker.mockResolvedValue(false);
+
+      let invocations = 0;
+      const constantTxMock = {
+        get: jest.fn().mockResolvedValue({
+          exists: true,
+          data: () => activeWithSeatedUser,
+        }),
+        update: jest.fn(),
+      };
+      db.runTransaction.mockImplementation(async (callback) => {
+        invocations += 1;
+        const first = await callback(constantTxMock);
+        if (invocations === 1) return callback(constantTxMock);
+        return first;
+      });
+
+      await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+
+      // Both callback invocations should have called update with the same
+      // OWNER_AWAY patch — same nowMs reused across retries.
+      expect(constantTxMock.update.mock.calls.length).toBe(2);
+      for (const call of constantTxMock.update.mock.calls) {
+        expect(call[0]).toBe(roomRef);
+        expect(call[1]).toEqual({ state: 'OWNER_AWAY', ownerLeftAt: nowMs });
+      }
+    });
+  });
 });

--- a/express-api/tests/utils/owner-left-orchestrator.test.js
+++ b/express-api/tests/utils/owner-left-orchestrator.test.js
@@ -1,5 +1,8 @@
 const { OWNER_LEFT_ACTION } = require('../../src/utils/owner-left-handler');
-const { handleOwnerLeftSignal } = require('../../src/utils/owner-left-orchestrator');
+const {
+  handleOwnerLeftSignal,
+  isValidOwnerId,
+} = require('../../src/utils/owner-left-orchestrator');
 
 // `handleOwnerLeftSignal` is the orchestrator wired to the RTDB `ownerLeft/{roomId}`
 // signal. Given a roomId, it:
@@ -436,6 +439,189 @@ describe('handleOwnerLeftSignal', () => {
         expect(result.reason).not.toBe('owner-id-missing-or-invalid');
         expect(presenceChecker).toHaveBeenCalledWith('room-1', ownerId);
       }
+    });
+
+    // R2 finding I1: boolean primitives silently passed the original guard
+    // because String(true)/String(false) yield alphanumeric strings.
+    test('returns NOOP when ownerId is the boolean true (data corruption)', async () => {
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: true } });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('owner-id-missing-or-invalid');
+      expect(presenceChecker).not.toHaveBeenCalled();
+    });
+
+    test('returns NOOP when ownerId is the boolean false (data corruption)', async () => {
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: false } });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('owner-id-missing-or-invalid');
+      expect(presenceChecker).not.toHaveBeenCalled();
+    });
+
+    test('returns NOOP when ownerId is NaN', async () => {
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: NaN } });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('owner-id-missing-or-invalid');
+    });
+
+    test('returns NOOP when ownerId is Infinity', async () => {
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: Infinity } });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('owner-id-missing-or-invalid');
+    });
+
+    test('returns NOOP when ownerId is an object', async () => {
+      const { db } = makeMockDb({
+        initialRoom: { ...baseActiveRoom, ownerId: { uniqueId: 42 } },
+      });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('owner-id-missing-or-invalid');
+    });
+
+    test('returns NOOP when ownerId is an array', async () => {
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: ['42'] } });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('owner-id-missing-or-invalid');
+    });
+
+    // ShyTalk's accountDeletion.js:148 calls `String(roomDoc.data().ownerId)`
+    // for comparison, which means the schema legitimately stores ownerId as
+    // either a string or a finite number. The guard MUST accept both.
+    test('accepts a finite number ownerId (e.g. uniqueId stored as int)', async () => {
+      presenceChecker.mockResolvedValue(true);
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: 42 } });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.reason).not.toBe('owner-id-missing-or-invalid');
+      expect(presenceChecker).toHaveBeenCalledWith('room-1', 42);
+    });
+
+    test('accepts numeric 0 (path-safe, single-char id)', async () => {
+      presenceChecker.mockResolvedValue(true);
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: 0 } });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.reason).not.toBe('owner-id-missing-or-invalid');
+      expect(presenceChecker).toHaveBeenCalledWith('room-1', 0);
+    });
+
+    test('accepts ownerId at exactly the 256-char boundary (inclusive)', async () => {
+      presenceChecker.mockResolvedValue(true);
+      const at256 = 'a'.repeat(256);
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: at256 } });
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+      expect(result.reason).not.toBe('owner-id-missing-or-invalid');
+    });
+  });
+
+  describe('isValidOwnerId — direct unit tests (path-safety primitive)', () => {
+    // Direct tests on the exported guard so future callers can rely on
+    // documented behaviour without inferring it from integration paths.
+    test('returns false for null + undefined', () => {
+      expect(isValidOwnerId(null)).toBe(false);
+      expect(isValidOwnerId(undefined)).toBe(false);
+    });
+
+    test('returns false for booleans', () => {
+      expect(isValidOwnerId(true)).toBe(false);
+      expect(isValidOwnerId(false)).toBe(false);
+    });
+
+    test('returns false for empty string', () => {
+      expect(isValidOwnerId('')).toBe(false);
+    });
+
+    test('returns true for valid strings', () => {
+      expect(isValidOwnerId('owner-1')).toBe(true);
+      expect(isValidOwnerId('A')).toBe(true);
+      expect(isValidOwnerId('abc_DEF-123')).toBe(true);
+    });
+
+    test('returns true for finite numbers', () => {
+      expect(isValidOwnerId(42)).toBe(true);
+      expect(isValidOwnerId(0)).toBe(true);
+      expect(isValidOwnerId(1e9)).toBe(true);
+    });
+
+    test('returns false for non-finite numbers', () => {
+      expect(isValidOwnerId(NaN)).toBe(false);
+      expect(isValidOwnerId(Infinity)).toBe(false);
+      expect(isValidOwnerId(-Infinity)).toBe(false);
+    });
+
+    test('returns false for strings with RTDB-illegal chars', () => {
+      const bad = ['a/b', 'a.b', 'a#b', 'a$b', 'a[b]', 'a b', 'a\tb', '../../foo'];
+      for (const id of bad) expect(isValidOwnerId(id)).toBe(false);
+    });
+
+    test('returns false for objects + arrays + functions', () => {
+      expect(isValidOwnerId({})).toBe(false);
+      expect(isValidOwnerId([])).toBe(false);
+      expect(isValidOwnerId(['a'])).toBe(false);
+      expect(isValidOwnerId(() => 'fn')).toBe(false);
+    });
+
+    test('boundary: exactly 256 chars is accepted, 257 is rejected', () => {
+      expect(isValidOwnerId('a'.repeat(256))).toBe(true);
+      expect(isValidOwnerId('a'.repeat(257))).toBe(false);
+    });
+
+    test('returns false for negative numbers (dash is not interpreted in the regex)', () => {
+      // String(-1) = "-1"; "-1" contains a dash, which IS in the allowlist
+      // pattern [A-Za-z0-9_-]. So negative numbers DO pass the regex when
+      // string-normalised. This test documents that behaviour explicitly so
+      // a future reviewer doesn't misread "should be rejected".
+      // ShyTalk's uniqueIds are non-negative, but the path-safety guard is
+      // schema-agnostic; negative numbers are valid RTDB path components.
+      expect(isValidOwnerId(-1)).toBe(true);
     });
   });
 

--- a/express-api/tests/utils/owner-left-orchestrator.test.js
+++ b/express-api/tests/utils/owner-left-orchestrator.test.js
@@ -585,6 +585,12 @@ describe('handleOwnerLeftSignal', () => {
       expect(isValidOwnerId('abc_DEF-123')).toBe(true);
     });
 
+    test('returns true for string "0" (path-safe single-char digit, distinct from numeric 0)', () => {
+      // R3 I2: pins the string-zero boundary so a future regex tightening
+      // (e.g. requiring leading non-digit) doesn't silently break valid IDs.
+      expect(isValidOwnerId('0')).toBe(true);
+    });
+
     test('returns true for finite numbers', () => {
       expect(isValidOwnerId(42)).toBe(true);
       expect(isValidOwnerId(0)).toBe(true);
@@ -689,6 +695,25 @@ describe('handleOwnerLeftSignal', () => {
       });
       // Match by string-normalised compare — should NOT be writer-not-owner.
       expect(result.reason).not.toBe('writer-not-owner');
+    });
+
+    // R3 I1: the listener forwards `null` as writerUid when snap.val() is
+    // null. The orchestrator's `writerUid !== null && writerUid !== undefined`
+    // guard treats both as "no attestation" — but null and undefined exit
+    // the check at DIFFERENT short-circuit conditions, so test both paths.
+    test('writerUid explicitly null is accepted — treated as no attestation', async () => {
+      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: 'owner-1' } });
+      presenceChecker.mockResolvedValue(false);
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: null,
+        nowMs,
+      });
+      expect(result.reason).not.toBe('writer-not-owner');
+      expect(result.action).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+      expect(presenceChecker).toHaveBeenCalledWith('room-1', 'owner-1');
     });
   });
 

--- a/express-api/tests/utils/process-shutdown.test.js
+++ b/express-api/tests/utils/process-shutdown.test.js
@@ -15,10 +15,12 @@ function makeMockProcess() {
   };
   return {
     proc,
+    // Returns the handler's promise so tests can await async cleanup chains
+    // without race conditions. Sync tests can ignore the return value.
     fire: (signal) => {
       const h = handlers.get(signal);
       if (!h) throw new Error(`No handler registered for ${signal}`);
-      h(signal);
+      return h(signal);
     },
     getHandler: (signal) => handlers.get(signal),
   };
@@ -50,29 +52,29 @@ describe('wireProcessShutdown', () => {
     expect(getHandler('SIGTERM')).toBe(getHandler('SIGINT'));
   });
 
-  test('SIGTERM invokes every stop function in order', () => {
+  test('SIGTERM invokes every stop function in order', async () => {
     const calls = [];
     const stopA = jest.fn(() => calls.push('A'));
     const stopB = jest.fn(() => calls.push('B'));
     const stopC = jest.fn(() => calls.push('C'));
     const { proc, fire } = makeMockProcess();
     wireProcessShutdown({ proc, stopFns: [stopA, stopB, stopC], log: makeLog() });
-    fire('SIGTERM');
+    await fire('SIGTERM');
     expect(calls).toEqual(['A', 'B', 'C']);
   });
 
-  test('SIGTERM calls proc.exit(0) after stops complete', () => {
+  test('SIGTERM calls proc.exit(0) after stops complete', async () => {
     const stopA = jest.fn();
     const { proc, fire } = makeMockProcess();
     wireProcessShutdown({ proc, stopFns: [stopA], log: makeLog() });
-    fire('SIGTERM');
+    await fire('SIGTERM');
     expect(stopA).toHaveBeenCalledTimes(1);
     expect(proc.exit).toHaveBeenCalledWith(0);
     // exit must come AFTER stops finish — assert call order via mock call counts.
     expect(stopA.mock.invocationCallOrder[0]).toBeLessThan(proc.exit.mock.invocationCallOrder[0]);
   });
 
-  test('error in a stop function does not prevent subsequent stops or exit', () => {
+  test('error in a sync stop function does not prevent subsequent stops or exit', async () => {
     const stopA = jest.fn(() => {
       throw new Error('boom');
     });
@@ -80,7 +82,7 @@ describe('wireProcessShutdown', () => {
     const log = makeLog();
     const { proc, fire } = makeMockProcess();
     wireProcessShutdown({ proc, stopFns: [stopA, stopB], log });
-    fire('SIGTERM');
+    await fire('SIGTERM');
     expect(stopA).toHaveBeenCalled();
     expect(stopB).toHaveBeenCalled();
     expect(proc.exit).toHaveBeenCalledWith(0);
@@ -91,18 +93,18 @@ describe('wireProcessShutdown', () => {
     );
   });
 
-  test('logs an info entry on signal receipt with the signal name', () => {
+  test('logs an info entry on signal receipt with the signal name', async () => {
     const log = makeLog();
     const { proc, fire } = makeMockProcess();
     wireProcessShutdown({ proc, stopFns: [], log });
-    fire('SIGTERM');
+    await fire('SIGTERM');
     const firstCall = log.info.mock.calls.find((c) =>
       c.some((arg) => String(arg).includes('SIGTERM')),
     );
     expect(firstCall).toBeDefined();
   });
 
-  test('all stops fail → proc.exit is STILL called', () => {
+  test('all stops fail → proc.exit is STILL called', async () => {
     const stopA = jest.fn(() => {
       throw new Error('boom A');
     });
@@ -111,23 +113,115 @@ describe('wireProcessShutdown', () => {
     });
     const { proc, fire } = makeMockProcess();
     wireProcessShutdown({ proc, stopFns: [stopA, stopB], log: makeLog() });
-    fire('SIGTERM');
+    await fire('SIGTERM');
     expect(proc.exit).toHaveBeenCalledWith(0);
   });
 
-  test('stopFns empty array works (no-op then exit)', () => {
+  test('stopFns empty array works (no-op then exit)', async () => {
     const { proc, fire } = makeMockProcess();
     wireProcessShutdown({ proc, stopFns: [], log: makeLog() });
-    fire('SIGTERM');
+    await fire('SIGTERM');
     expect(proc.exit).toHaveBeenCalledWith(0);
   });
 
-  test('SIGINT fires the same shutdown flow', () => {
+  test('SIGINT fires the same shutdown flow', async () => {
     const stopA = jest.fn();
     const { proc, fire } = makeMockProcess();
     wireProcessShutdown({ proc, stopFns: [stopA], log: makeLog() });
-    fire('SIGINT');
+    await fire('SIGINT');
     expect(stopA).toHaveBeenCalledTimes(1);
     expect(proc.exit).toHaveBeenCalledWith(0);
+  });
+
+  describe('async stop functions (R2 I2)', () => {
+    // Sync stops are the common case (e.g. detaching an RTDB listener is
+    // immediate). But the contract must support async stops too — a future
+    // queue drainer, pending Firestore txn awaiter, etc. — without losing
+    // the cleanup.
+    test('awaits an async stop function before calling proc.exit', async () => {
+      const cleanupOrder = [];
+      const asyncStop = jest.fn().mockImplementation(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+        cleanupOrder.push('async-done');
+      });
+      const { proc, fire } = makeMockProcess();
+      wireProcessShutdown({ proc, stopFns: [asyncStop], log: makeLog() });
+      proc.exit.mockImplementation(() => cleanupOrder.push('exit'));
+      await fire('SIGTERM');
+      // Async stop completed BEFORE exit was called.
+      expect(cleanupOrder).toEqual(['async-done', 'exit']);
+    });
+
+    test('awaits all async stops in parallel (Promise.allSettled semantics)', async () => {
+      const done = [];
+      const stopA = jest.fn().mockImplementation(async () => {
+        await new Promise((r) => setTimeout(r, 30));
+        done.push('A');
+      });
+      const stopB = jest.fn().mockImplementation(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+        done.push('B');
+      });
+      const stopC = jest.fn().mockImplementation(async () => {
+        await new Promise((r) => setTimeout(r, 20));
+        done.push('C');
+      });
+      const { proc, fire } = makeMockProcess();
+      wireProcessShutdown({ proc, stopFns: [stopA, stopB, stopC], log: makeLog() });
+      await fire('SIGTERM');
+      // All three completed before exit — Promise.allSettled ordering means
+      // the actual completion order is by their delay (B, C, A).
+      expect(done.sort()).toEqual(['A', 'B', 'C']);
+      expect(proc.exit).toHaveBeenCalledWith(0);
+    });
+
+    test('async stop that throws does not prevent other stops or exit', async () => {
+      const stopA = jest.fn().mockRejectedValue(new Error('boom-A'));
+      const stopB = jest.fn().mockResolvedValue(undefined);
+      const log = makeLog();
+      const { proc, fire } = makeMockProcess();
+      wireProcessShutdown({ proc, stopFns: [stopA, stopB], log });
+      await fire('SIGTERM');
+      expect(stopA).toHaveBeenCalled();
+      expect(stopB).toHaveBeenCalled();
+      expect(proc.exit).toHaveBeenCalledWith(0);
+      expect(log.warn).toHaveBeenCalledWith(
+        'process-shutdown',
+        expect.stringMatching(/threw|fail/i),
+        expect.objectContaining({ error: 'boom-A' }),
+      );
+    });
+
+    test('mixed sync + async stops both complete before exit', async () => {
+      const done = [];
+      const syncStop = jest.fn(() => done.push('sync'));
+      const asyncStop = jest.fn().mockImplementation(async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        done.push('async');
+      });
+      const { proc, fire } = makeMockProcess();
+      proc.exit.mockImplementation(() => done.push('exit'));
+      wireProcessShutdown({ proc, stopFns: [syncStop, asyncStop], log: makeLog() });
+      await fire('SIGTERM');
+      // Sync completes first (synchronous push), async after the await,
+      // exit last.
+      expect(done).toEqual(['sync', 'async', 'exit']);
+    });
+  });
+
+  describe('multiple calls (R2 I2 follow-on)', () => {
+    // Documents the current behaviour: multiple wireProcessShutdown calls
+    // on the same proc register multiple handlers. This is intentional —
+    // each subsystem can register its own shutdown hook independently.
+    test('two wireProcessShutdown calls register two handlers on the same proc', () => {
+      const { proc } = makeMockProcess();
+      wireProcessShutdown({ proc, stopFns: [], log: makeLog() });
+      wireProcessShutdown({ proc, stopFns: [], log: makeLog() });
+      // 2 calls × 2 signals = 4 registrations.
+      const sigtermCount = proc.on.mock.calls.filter((c) => c[0] === 'SIGTERM').length;
+      const sigintCount = proc.on.mock.calls.filter((c) => c[0] === 'SIGINT').length;
+      expect(sigtermCount).toBe(2);
+      expect(sigintCount).toBe(2);
+    });
   });
 });

--- a/express-api/tests/utils/process-shutdown.test.js
+++ b/express-api/tests/utils/process-shutdown.test.js
@@ -52,7 +52,28 @@ describe('wireProcessShutdown', () => {
     expect(getHandler('SIGTERM')).toBe(getHandler('SIGINT'));
   });
 
-  test('SIGTERM invokes every stop function in order', async () => {
+  test('SIGTERM invokes EVERY stop function', async () => {
+    // The handler runs all stops via Promise.allSettled, which provides
+    // NO completion-order guarantee for async stops. This test only
+    // asserts each stop was called exactly once.
+    const stopA = jest.fn();
+    const stopB = jest.fn();
+    const stopC = jest.fn();
+    const { proc, fire } = makeMockProcess();
+    wireProcessShutdown({ proc, stopFns: [stopA, stopB, stopC], log: makeLog() });
+    await fire('SIGTERM');
+    expect(stopA).toHaveBeenCalledTimes(1);
+    expect(stopB).toHaveBeenCalledTimes(1);
+    expect(stopC).toHaveBeenCalledTimes(1);
+  });
+
+  test('SIGTERM sync stops run in stopFns iteration order (specifically for sync)', async () => {
+    // R3 I3 clarification: ONLY for synchronous stop functions, the
+    // invocation order matches the stopFns array order. This is because
+    // `stopFns.map(async (stop) => { await stop(); ... })` calls the
+    // synchronous body of `stop()` before yielding at the await. For
+    // ASYNC stops, completion order depends on each stop's resolution
+    // time — see the async-parallel test below for that semantic.
     const calls = [];
     const stopA = jest.fn(() => calls.push('A'));
     const stopB = jest.fn(() => calls.push('B'));

--- a/express-api/tests/utils/process-shutdown.test.js
+++ b/express-api/tests/utils/process-shutdown.test.js
@@ -1,0 +1,133 @@
+const { wireProcessShutdown } = require('../../src/utils/process-shutdown');
+
+// `wireProcessShutdown` registers SIGTERM + SIGINT handlers that call every
+// supplied stop function (event listeners, cron loops, etc.) in order, then
+// call process.exit(0). Designed for testability: the `proc` and `log` are
+// injected so jest can mock both.
+
+function makeMockProcess() {
+  const handlers = new Map(); // signal → handler fn
+  const proc = {
+    on: jest.fn((signal, handler) => {
+      handlers.set(signal, handler);
+    }),
+    exit: jest.fn(),
+  };
+  return {
+    proc,
+    fire: (signal) => {
+      const h = handlers.get(signal);
+      if (!h) throw new Error(`No handler registered for ${signal}`);
+      h(signal);
+    },
+    getHandler: (signal) => handlers.get(signal),
+  };
+}
+
+const makeLog = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+describe('wireProcessShutdown', () => {
+  test('registers a SIGTERM handler', () => {
+    const { proc } = makeMockProcess();
+    wireProcessShutdown({ proc, stopFns: [], log: makeLog() });
+    expect(proc.on).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+  });
+
+  test('registers a SIGINT handler', () => {
+    const { proc } = makeMockProcess();
+    wireProcessShutdown({ proc, stopFns: [], log: makeLog() });
+    expect(proc.on).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+  });
+
+  test('SIGTERM + SIGINT handlers are the same function (one shared shutdown path)', () => {
+    const { proc, getHandler } = makeMockProcess();
+    wireProcessShutdown({ proc, stopFns: [], log: makeLog() });
+    expect(getHandler('SIGTERM')).toBe(getHandler('SIGINT'));
+  });
+
+  test('SIGTERM invokes every stop function in order', () => {
+    const calls = [];
+    const stopA = jest.fn(() => calls.push('A'));
+    const stopB = jest.fn(() => calls.push('B'));
+    const stopC = jest.fn(() => calls.push('C'));
+    const { proc, fire } = makeMockProcess();
+    wireProcessShutdown({ proc, stopFns: [stopA, stopB, stopC], log: makeLog() });
+    fire('SIGTERM');
+    expect(calls).toEqual(['A', 'B', 'C']);
+  });
+
+  test('SIGTERM calls proc.exit(0) after stops complete', () => {
+    const stopA = jest.fn();
+    const { proc, fire } = makeMockProcess();
+    wireProcessShutdown({ proc, stopFns: [stopA], log: makeLog() });
+    fire('SIGTERM');
+    expect(stopA).toHaveBeenCalledTimes(1);
+    expect(proc.exit).toHaveBeenCalledWith(0);
+    // exit must come AFTER stops finish — assert call order via mock call counts.
+    expect(stopA.mock.invocationCallOrder[0]).toBeLessThan(proc.exit.mock.invocationCallOrder[0]);
+  });
+
+  test('error in a stop function does not prevent subsequent stops or exit', () => {
+    const stopA = jest.fn(() => {
+      throw new Error('boom');
+    });
+    const stopB = jest.fn();
+    const log = makeLog();
+    const { proc, fire } = makeMockProcess();
+    wireProcessShutdown({ proc, stopFns: [stopA, stopB], log });
+    fire('SIGTERM');
+    expect(stopA).toHaveBeenCalled();
+    expect(stopB).toHaveBeenCalled();
+    expect(proc.exit).toHaveBeenCalledWith(0);
+    expect(log.warn).toHaveBeenCalledWith(
+      'process-shutdown',
+      expect.stringMatching(/threw|fail/i),
+      expect.objectContaining({ error: 'boom' }),
+    );
+  });
+
+  test('logs an info entry on signal receipt with the signal name', () => {
+    const log = makeLog();
+    const { proc, fire } = makeMockProcess();
+    wireProcessShutdown({ proc, stopFns: [], log });
+    fire('SIGTERM');
+    const firstCall = log.info.mock.calls.find((c) =>
+      c.some((arg) => String(arg).includes('SIGTERM')),
+    );
+    expect(firstCall).toBeDefined();
+  });
+
+  test('all stops fail → proc.exit is STILL called', () => {
+    const stopA = jest.fn(() => {
+      throw new Error('boom A');
+    });
+    const stopB = jest.fn(() => {
+      throw new Error('boom B');
+    });
+    const { proc, fire } = makeMockProcess();
+    wireProcessShutdown({ proc, stopFns: [stopA, stopB], log: makeLog() });
+    fire('SIGTERM');
+    expect(proc.exit).toHaveBeenCalledWith(0);
+  });
+
+  test('stopFns empty array works (no-op then exit)', () => {
+    const { proc, fire } = makeMockProcess();
+    wireProcessShutdown({ proc, stopFns: [], log: makeLog() });
+    fire('SIGTERM');
+    expect(proc.exit).toHaveBeenCalledWith(0);
+  });
+
+  test('SIGINT fires the same shutdown flow', () => {
+    const stopA = jest.fn();
+    const { proc, fire } = makeMockProcess();
+    wireProcessShutdown({ proc, stopFns: [stopA], log: makeLog() });
+    fire('SIGINT');
+    expect(stopA).toHaveBeenCalledTimes(1);
+    expect(proc.exit).toHaveBeenCalledWith(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the `staleRooms` cron's owner-disconnect detection with an RTDB event-driven path: on owner force-quit, the room transitions to `OWNER_AWAY` if non-owners are seated OR closes IMMEDIATELY if no non-owner is seated. No cron in the loop.
- Server-only foundation. Clients (Android #998, iOS #999) will arm `ownerLeft/{roomId}` onDisconnect on room entry; the listener processes the signal via the orchestrator (read room → check presence → decide → apply). Free restart-scan via Firebase `child_added` semantics handles Express downtime gaps.
- Net structure: pure decision + apply in `owner-left-handler.js` (delegates CLOSE_IMMEDIATE to existing `reapStaleRoomTx` so the close payload stays one source of truth); composition in `owner-left-orchestrator.js`; RTDB listener in `owner-left-listener.js`; boot wiring in `event-listeners.js`; SIGTERM/SIGINT shutdown hook in new `process-shutdown.js`; RTDB rule in `database.rules.json`.

## Test plan
- [x] **Unit (jest)** — 147 tests across handler / orchestrator / listener / wiring / shutdown / RTDB rules. Adversarial coverage: TOCTOU window, owner multi-device, path-injection via `roomId` + `ownerId`, writer-uid spoof prevention, async stop, multi-call shutdown, listener restart-scan, etc.
- [x] **RTDB rule structural test** — pins the auth + writer-attestation + removal-restriction constraints.
- [x] **Full express suite** — 308 suites / 11,381 passing.
- [x] **Prettier + ESLint + SonarCloud** — clean (zero warnings).
- [ ] **Manual prod verification** — deferred to operator post-deploy; this PR only ships the server piece. Listener will sit idle until client PRs land.

## Review history
- R1: 6 findings (2 Critical + 4 Important) — all addressed in commit `9bf09afff1e`.
- R2: 4 findings (1 Critical + 3 Important) — all addressed in commit `ce1c0b7c986`.
- R3: 3 Important findings (test-quality only) — all addressed in commit `e642bf059fc`.
- R4: **ZERO findings**. Reviewer confirmed 100% line + branch coverage on new production code.

## Deployment note
- RTDB rule (`database.rules.json` `ownerLeft` stanza) must deploy before or with this Express PR. Until then, the listener attaches but no client writes to `ownerLeft/{roomId}` — harmless idle state.
- Cron remains live as the safety net until Android #998 + iOS #999 ship and a follow-up PR (#1000) removes `staleRooms.js`, the workflow, and the sweep endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)