### PR TITLE
feat(admin): ban cascade marks suspended user's suggestions for review

### DIFF
--- a/express-api/src/routes/admin-users.js
+++ b/express-api/src/routes/admin-users.js
@@ -1212,11 +1212,32 @@ router.post('/user/:uniqueId/suspend', async (req, res) => {
       cascade = buildCascadeFailure(err, 'cascade_failed');
     }
 
+    // Suggestion cascade is independent of room cascade — partial failure of one
+    // must not skip the other. Awaited (not fire-and-forget) so admin response
+    // reflects whether the flagging actually committed.
+    let suggestionsCascade;
+    try {
+      suggestionsCascade = await flagSuspendedUserSuggestions(req.params.uniqueId, req.auth.uid);
+    } catch (err) {
+      log.error('admin-users', 'Failed to flag suspended user suggestions', {
+        uniqueId: req.params.uniqueId,
+        error: err.message,
+      });
+      suggestionsCascade = {
+        flaggedCount: 0,
+        skippedCount: 0,
+        partial: true,
+        failedSuggestionIds: [],
+        error: err && err.message ? err.message : 'cascade_failed',
+      };
+    }
+
     // pms shape matches partial-failure-toast.js (failed, total). Single PM
     // for the suspension reason; either delivered or not.
     res.json({
       success: true,
       cascade,
+      suggestionsCascade,
       pms: { failed: pmFailed ? 1 : 0, total: 1 },
     });
   } catch (err) {
@@ -1294,6 +1315,27 @@ router.post('/user/:uniqueId/unsuspend', async (req, res) => {
       }),
     );
 
+    // Reverse the suggestion ban-cascade: clear `flaggedForReview` on suggestions
+    // whose flag was set by the matching suspension. Only `submitter_suspended`
+    // flags are cleared — unrelated manual admin flags (different reason) are
+    // preserved. Awaited so the admin response reports partial failures.
+    let suggestionsCascade;
+    try {
+      suggestionsCascade = await unflagUnsuspendedUserSuggestions(req.params.uniqueId);
+    } catch (err) {
+      log.error('admin-users', 'Failed to unflag suspended user suggestions', {
+        uniqueId: req.params.uniqueId,
+        error: err.message,
+      });
+      suggestionsCascade = {
+        unflaggedCount: 0,
+        skippedCount: 0,
+        partial: true,
+        failedSuggestionIds: [],
+        error: err && err.message ? err.message : 'cascade_failed',
+      };
+    }
+
     // Send system PM about unsuspension — track failure so admin UI can
     // surface that the user wasn't informed about being unsuspended.
     let pmFailed = false;
@@ -1307,6 +1349,7 @@ router.post('/user/:uniqueId/unsuspend', async (req, res) => {
     clearSuspensionCache(Number(req.params.uniqueId));
     res.json({
       success: true,
+      suggestionsCascade,
       pms: { failed: pmFailed ? 1 : 0, total: 1 },
     });
   } catch (err) {
@@ -1510,6 +1553,15 @@ async function liftAutoAppliedBans(uniqueId, adminUid) {
 // (Pass-17: previously two literals omitted rtdbEventsFailed and used a stale
 // 'cascade_failed' string token, drifting from the resolve routes).
 const { evictSuspendedUser, buildCascadeFailure } = require('../utils/evict-suspended-user');
+
+// Ban-cascade for the suggestions surface: a suspended user's live (accepted/planned)
+// suggestions get a `flaggedForReview` sticky note so an admin can decide case-by-case
+// whether they stay on the roadmap. Status is preserved, so unsuspend cleanly reverses
+// by clearing the flag fields. See utils/flag-suspended-user-suggestions.js for design.
+const {
+  flagSuspendedUserSuggestions,
+  unflagUnsuspendedUserSuggestions,
+} = require('../utils/flag-suspended-user-suggestions');
 
 // ═══════════════════════════════════════════════════════════════════
 // Admin Auth Management (PIN lockout, biometric keys, OTP metrics)

--- a/express-api/src/utils/flag-suspended-user-suggestions.js
+++ b/express-api/src/utils/flag-suspended-user-suggestions.js
@@ -1,0 +1,217 @@
+/**
+ * Ban-cascade for the suggestions surface.
+ *
+ * When an admin suspends a user, their existing "live" suggestions
+ * (status === 'accepted' or 'planned') get a `flaggedForReview: true`
+ * sticky note so an admin can decide case-by-case whether the suggestion
+ * stays on the roadmap. Suggestion status is left untouched — this preserves
+ * voter/subscriber state and lets unsuspend cleanly reverse the cascade by
+ * just clearing the flag fields.
+ *
+ * Why not change `status`?
+ *   - `planned` -> `pending` would silently rip items off the public roadmap
+ *     mid-flight, surprising voters/subscribers who are watching them.
+ *   - Adding an `under_review` status would force changes to every transition
+ *     guard in suggestions.js (lines 949-953) plus FE badges + 20 locales.
+ *   - A flag is reversible by symmetry on unsuspend; status changes need a
+ *     `priorStatus` stash to revert cleanly.
+ *
+ * Why not filter by status server-side?
+ *   - `where('submitterUid','==',uid).where('status','in',[...])` needs a
+ *     composite index. We expect <5 suggestions per typical user, so the
+ *     single-field query + in-JS status filter avoids the index entirely.
+ *
+ * Idempotency:
+ *   - flag: skip docs already carrying `flaggedReason === 'submitter_suspended'`.
+ *   - unflag: only clear docs whose `flaggedReason === 'submitter_suspended'`
+ *     (leaves unrelated manual admin flags alone).
+ *
+ * Contract mirrors evict-suspended-user.js for consistency across cascade utilities.
+ */
+
+const { db } = require('./firebase');
+const { now } = require('./helpers');
+const log = require('./log');
+
+const FLAGGABLE_STATUSES = new Set(['accepted', 'planned']);
+const FLAG_REASON = 'submitter_suspended';
+
+/**
+ * `submitterUid` is stored numerically (sourced from `req.auth.uniqueId`)
+ * but suspension callers pass `req.params.uniqueId` (always a string).
+ * Firestore equality is strict, so the string form silently matches nothing —
+ * normalize once at the boundary.
+ *
+ * Edge-case behaviour (all routed to "silently match nothing" rather than
+ * coercing to 0 or crashing — Firestore strict equality is the loud signal):
+ *   - `42`           → `42`        (already numeric, passthrough)
+ *   - `'42'`         → `42`        (integer string, normalized)
+ *   - `'-7'`         → `-7`        (negative integer string, normalized)
+ *   - `'7.5'`        → `'7.5'`     (float string, regex rejects, passthrough)
+ *   - `'abc'`        → `'abc'`     (non-numeric string, passthrough)
+ *   - `''`           → `''`        (empty string, passthrough)
+ *   - `NaN`          → `NaN`       (typeof 'number' passthrough; matches nothing in Firestore)
+ *   - `null`/`undef` → original    (typeof neither 'number' nor 'string', passthrough)
+ *
+ * For `NaN` specifically: Firestore equality treats NaN strictly, so a NaN-uid
+ * query returns empty rather than throwing. That is "match nothing" not "throw",
+ * which keeps the cascade route safe (admin response surfaces flaggedCount: 0)
+ * but means a buggy upstream sending NaN would not loudly fail at this layer —
+ * a worth-knowing limitation for future debugging.
+ */
+function normalizeUid(uid) {
+  if (typeof uid === 'number') return uid;
+  if (typeof uid === 'string' && uid !== '' && /^-?\d+$/.test(uid)) {
+    const n = Number(uid);
+    if (Number.isFinite(n)) return n;
+  }
+  return uid;
+}
+
+async function flagSuspendedUserSuggestions(uid, adminUid) {
+  const normalizedUid = normalizeUid(uid);
+  const snap = await db.collection('suggestions').where('submitterUid', '==', normalizedUid).get();
+
+  if (!snap || snap.empty) {
+    return {
+      flaggedCount: 0,
+      skippedCount: 0,
+      partial: false,
+      failedSuggestionIds: [],
+      error: null,
+    };
+  }
+
+  const flaggedAt = now();
+  const toFlag = [];
+  let skippedCount = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    if (!FLAGGABLE_STATUSES.has(data.status)) {
+      skippedCount += 1;
+      continue;
+    }
+    if (data.flaggedForReview === true && data.flaggedReason === FLAG_REASON) {
+      skippedCount += 1;
+      continue;
+    }
+    toFlag.push(doc);
+  }
+
+  if (toFlag.length === 0) {
+    return {
+      flaggedCount: 0,
+      skippedCount,
+      partial: false,
+      failedSuggestionIds: [],
+      error: null,
+    };
+  }
+
+  const payload = {
+    flaggedForReview: true,
+    flaggedReason: FLAG_REASON,
+    flaggedAt,
+    flaggedBy: adminUid,
+  };
+
+  return commitChunked(toFlag, payload, 'flag', skippedCount);
+}
+
+async function unflagUnsuspendedUserSuggestions(uid) {
+  const normalizedUid = normalizeUid(uid);
+  const snap = await db.collection('suggestions').where('submitterUid', '==', normalizedUid).get();
+
+  if (!snap || snap.empty) {
+    return {
+      unflaggedCount: 0,
+      skippedCount: 0,
+      partial: false,
+      failedSuggestionIds: [],
+      error: null,
+    };
+  }
+
+  const toClear = [];
+  let skippedCount = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    if (data.flaggedForReview === true && data.flaggedReason === FLAG_REASON) {
+      toClear.push(doc);
+    } else {
+      skippedCount += 1;
+    }
+  }
+
+  if (toClear.length === 0) {
+    return {
+      unflaggedCount: 0,
+      skippedCount,
+      partial: false,
+      failedSuggestionIds: [],
+      error: null,
+    };
+  }
+
+  const payload = {
+    flaggedForReview: false,
+    flaggedReason: null,
+    flaggedAt: null,
+    flaggedBy: null,
+  };
+
+  return commitChunked(toClear, payload, 'unflag', skippedCount);
+}
+
+async function commitChunked(docs, payload, mode, skippedCount = 0) {
+  const failedSuggestionIds = [];
+  let firstError = null;
+
+  for (let i = 0; i < docs.length; i += 500) {
+    const chunk = docs.slice(i, i + 500);
+    const batch = db.batch();
+    for (const doc of chunk) {
+      batch.update(doc.ref, payload);
+    }
+    try {
+      await batch.commit();
+    } catch (err) {
+      log.error('flag-suspended-user-suggestions', `Batch ${mode} commit failed`, {
+        chunkStart: i,
+        chunkSize: chunk.length,
+        error: err && err.message,
+      });
+      for (const doc of chunk) failedSuggestionIds.push(doc.id);
+      if (!firstError) firstError = err && err.message ? err.message : String(err);
+    }
+  }
+
+  const successCount = docs.length - failedSuggestionIds.length;
+  const partial = failedSuggestionIds.length > 0;
+
+  if (mode === 'flag') {
+    return {
+      flaggedCount: successCount,
+      skippedCount,
+      partial,
+      failedSuggestionIds,
+      error: firstError,
+    };
+  }
+  return {
+    unflaggedCount: successCount,
+    skippedCount,
+    partial,
+    failedSuggestionIds,
+    error: firstError,
+  };
+}
+
+module.exports = {
+  flagSuspendedUserSuggestions,
+  unflagUnsuspendedUserSuggestions,
+  FLAG_REASON,
+  FLAGGABLE_STATUSES,
+};

--- a/express-api/tests/admin-client/partial-failure-toast.test.js
+++ b/express-api/tests/admin-client/partial-failure-toast.test.js
@@ -62,6 +62,50 @@ describe('buildPartialFailureMessage — single-flag rendering', () => {
     expect(msg).toContain('3 room(s) need manual cleanup');
   });
 
+  it('suggestionsCascade.partial with failed suggestions', () => {
+    const msg = buildPartialFailureMessage({
+      success: true,
+      suggestionsCascade: {
+        partial: true,
+        failedSuggestionIds: ['sug-1', 'sug-2'],
+        error: 'Firestore unavailable',
+      },
+    });
+    expect(msg).toContain('suggestion cascade partial');
+    expect(msg).toContain('2 suggestion(s) need manual cleanup');
+  });
+
+  it('suggestionsCascade.partial with empty failedSuggestionIds (cascade utility threw)', () => {
+    const msg = buildPartialFailureMessage({
+      success: true,
+      suggestionsCascade: {
+        partial: true,
+        failedSuggestionIds: [],
+        error: 'cascade_failed',
+      },
+    });
+    expect(msg).toContain('suggestion cascade partial');
+    // Falls back to a generic "manual cleanup" hint when the failed list
+    // is empty (utility threw before populating failedSuggestionIds).
+    expect(msg).toContain('manual cleanup');
+  });
+
+  it('suggestionsCascade.partial=false does NOT render even with non-empty failedSuggestionIds', () => {
+    // Defensive: protects against a state contradiction where a future code path
+    // sets failedSuggestionIds without flipping `partial: true`. The toast must
+    // gate on `partial`, not on failed-list length, so a fully-committed cascade
+    // never produces a misleading "partial" toast.
+    const result = buildPartialFailureMessage({
+      success: true,
+      suggestionsCascade: {
+        partial: false,
+        failedSuggestionIds: ['sug-this-should-not-render'],
+        error: null,
+      },
+    });
+    expect(result).toBeNull();
+  });
+
   it('cascade.rtdbEventsFailed (Pass-13 L2)', () => {
     const msg = buildPartialFailureMessage({
       success: true,
@@ -277,7 +321,11 @@ describe('buildPartialFailureMessage — ordering invariants', () => {
   it('full chain order locked: every branch fires in canonical order (Pass-15 fix)', () => {
     // Pass-15 test-analyzer criticality 7: a refactor moving `pms` ahead of
     // `auditLog` (e.g. for "delivery first" UX) would silently change the
-    // admin-facing message order. Lock all 7 positions with one fixture.
+    // admin-facing message order. Lock all positions with one fixture.
+    //
+    // Reviewer-flagged 2026-06-04: the suggestions ban-cascade (slot 4, between
+    // room cascade and RTDB events) was added without being represented here,
+    // so the fixture didn't lock its position. Now included.
     const msg = buildPartialFailureMessage({
       success: true,
       warning: { failed: true, error: 'warning_create_failed' },
@@ -288,6 +336,11 @@ describe('buildPartialFailureMessage — ordering invariants', () => {
         failedRoomIds: ['r1', 'r2'],
         rtdbEventsFailed: 3,
       },
+      suggestionsCascade: {
+        partial: true,
+        failedSuggestionIds: ['sug-1'],
+        error: 'Firestore unavailable',
+      },
       reports: { committed: 2, failed: 1, total: 3, error: 'reports_commit_failed' },
       auditLog: { failed: true, error: 'audit_write_failed' },
       lockRelease: { failed: true },
@@ -297,6 +350,7 @@ describe('buildPartialFailureMessage — ordering invariants', () => {
       'warning was NOT applied',
       'suspension was NOT applied',
       'room cascade partial',
+      'suggestion cascade partial',
       "RTDB event(s) didn't deliver",
       'reports did not commit',
       'audit log failed — escalate to ops',
@@ -309,8 +363,8 @@ describe('buildPartialFailureMessage — ordering invariants', () => {
       expect(idx).toBeGreaterThan(lastIdx);
       lastIdx = idx;
     }
-    // Verify exactly 8 semicolon-separated parts (the 8 positions above).
-    expect(msg.split('; ').length).toBe(8);
+    // Verify exactly 9 semicolon-separated parts (the 9 positions above).
+    expect(msg.split('; ').length).toBe(9);
   });
 });
 

--- a/express-api/tests/routes/admin-users-write.test.js
+++ b/express-api/tests/routes/admin-users-write.test.js
@@ -1079,6 +1079,330 @@ describe('POST /api/user/:uniqueId/suspend --- room eviction', () => {
   });
 });
 
+// --- Suspend / unsuspend --- suggestion ban-cascade wiring ------------------
+//
+// Defence-in-depth alongside the unit tests in
+// tests/routes/suggestions-integration-a-submission.test.js: those prove the
+// cascade utility flags the right docs; these prove the suspend/unsuspend
+// routes actually CALL it and surface the result in the response.
+
+describe('POST /api/user/:uniqueId/suspend --- suggestion cascade', () => {
+  let app;
+
+  beforeEach(() => {
+    app = createApp();
+    jest.clearAllMocks();
+  });
+
+  it('flags accepted/planned suggestions of the suspended user and reports cascade in response', async () => {
+    const { db } = require('../../src/utils/firebase');
+    const futureDate = new Date(Date.now() + 86400000).toISOString();
+
+    const flagBatchUpdate = jest.fn();
+    const flagBatchCommit = jest.fn().mockResolvedValue();
+    db.batch.mockReturnValue({
+      set: jest.fn(),
+      update: flagBatchUpdate,
+      commit: flagBatchCommit,
+    });
+
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      id: '5151',
+      data: () => ({ displayName: 'Banned User', gcsScore: 50 }),
+    });
+
+    db.collection.mockImplementation((name) => {
+      if (name === 'suggestions') {
+        return {
+          where: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnThis(),
+            get: jest.fn().mockResolvedValue({
+              empty: false,
+              size: 2,
+              docs: [
+                {
+                  id: 'sug-A',
+                  ref: { _path: 'suggestions/sug-A', update: jest.fn() },
+                  data: () => ({ status: 'accepted', submitterUid: 5151 }),
+                },
+                {
+                  id: 'sug-B',
+                  ref: { _path: 'suggestions/sug-B', update: jest.fn() },
+                  data: () => ({ status: 'planned', submitterUid: 5151 }),
+                },
+              ],
+            }),
+          }),
+        };
+      }
+      // Rooms / deviceBindings / other collections → empty (no other cascade work).
+      const chain = {
+        where: jest.fn().mockImplementation(() => chain),
+        orderBy: jest.fn().mockImplementation(() => chain),
+        limit: jest.fn().mockImplementation(() => chain),
+        get: jest.fn().mockResolvedValue({ empty: true, docs: [] }),
+      };
+      return chain;
+    });
+
+    const res = await request(app)
+      .post('/api/user/5151/suspend')
+      .send({ reason: 'Repeated harassment', canAppeal: true, endDate: futureDate });
+
+    expect(res.status).toBe(200);
+    expect(res.body.suggestionsCascade).toBeDefined();
+    expect(res.body.suggestionsCascade.flaggedCount).toBe(2);
+    expect(res.body.suggestionsCascade.partial).toBe(false);
+    expect(res.body.suggestionsCascade.error).toBeNull();
+
+    // Batch update payload: confirms route-level wiring actually fanned out.
+    expect(flagBatchUpdate).toHaveBeenCalledTimes(2);
+    const samplePayload = flagBatchUpdate.mock.calls[0][1];
+    expect(samplePayload.flaggedForReview).toBe(true);
+    expect(samplePayload.flaggedReason).toBe('submitter_suspended');
+    expect(samplePayload.flaggedBy).toBe('admin-1');
+  });
+
+  it('returns partial=true in suggestionsCascade when the cascade utility throws', async () => {
+    const { db } = require('../../src/utils/firebase');
+    const futureDate = new Date(Date.now() + 86400000).toISOString();
+
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      id: '5252',
+      data: () => ({ displayName: 'Banned User', gcsScore: 50 }),
+    });
+
+    db.collection.mockImplementation((name) => {
+      if (name === 'suggestions') {
+        return {
+          where: jest.fn().mockReturnValue({
+            get: jest.fn().mockRejectedValue(new Error('Firestore unavailable')),
+          }),
+        };
+      }
+      const chain = {
+        where: jest.fn().mockImplementation(() => chain),
+        orderBy: jest.fn().mockImplementation(() => chain),
+        limit: jest.fn().mockImplementation(() => chain),
+        get: jest.fn().mockResolvedValue({ empty: true, docs: [] }),
+      };
+      return chain;
+    });
+
+    const res = await request(app)
+      .post('/api/user/5252/suspend')
+      .send({ reason: 'Spam', canAppeal: false, endDate: futureDate });
+
+    // Suspension itself MUST still succeed even when the cascade fails — admin
+    // must always be able to ban. Cascade failure is reported, not blocking.
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.suggestionsCascade.partial).toBe(true);
+    expect(res.body.suggestionsCascade.error).toBe('Firestore unavailable');
+  });
+
+  it('surfaces utility-returned partial=true (batch failed without throw) without entering route catch', async () => {
+    // The route's try/catch only fires when the utility ITSELF throws. The
+    // commitChunked path catches batch failures internally and returns
+    // partial:true normally — that path must still surface in the response.
+    //
+    // Content-aware batch mock: autoApplyBans (fire-and-forget on the suspend
+    // path) ALSO calls db.batch(); a blanket `mockRejectedValueOnce` would
+    // consume the rejection on the wrong batch. Reject only when the batch's
+    // first update carries the `flaggedForReview` payload signature.
+    const { db } = require('../../src/utils/firebase');
+    const futureDate = new Date(Date.now() + 86400000).toISOString();
+
+    db.batch.mockImplementation(() => {
+      let isFlagBatch = false;
+      return {
+        set: jest.fn(),
+        update: jest.fn((_ref, payload) => {
+          if (payload && payload.flaggedForReview !== undefined) {
+            isFlagBatch = true;
+          }
+        }),
+        commit: jest.fn(() => {
+          if (isFlagBatch) {
+            return Promise.reject(new Error('Firestore batch commit blocked by quota'));
+          }
+          return Promise.resolve();
+        }),
+      };
+    });
+
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      id: '5454',
+      data: () => ({ displayName: 'Banned User', gcsScore: 50 }),
+    });
+
+    db.collection.mockImplementation((name) => {
+      if (name === 'suggestions') {
+        return {
+          where: jest.fn().mockReturnValue({
+            get: jest.fn().mockResolvedValue({
+              empty: false,
+              size: 1,
+              docs: [
+                {
+                  id: 'sug-Q',
+                  ref: { _path: 'suggestions/sug-Q', update: jest.fn() },
+                  data: () => ({ status: 'accepted', submitterUid: 5454 }),
+                },
+              ],
+            }),
+          }),
+        };
+      }
+      const chain = {
+        where: jest.fn().mockImplementation(() => chain),
+        orderBy: jest.fn().mockImplementation(() => chain),
+        limit: jest.fn().mockImplementation(() => chain),
+        get: jest.fn().mockResolvedValue({ empty: true, docs: [] }),
+      };
+      return chain;
+    });
+
+    const res = await request(app)
+      .post('/api/user/5454/suspend')
+      .send({ reason: 'Spam', canAppeal: false, endDate: futureDate });
+
+    expect(res.status).toBe(200);
+    expect(res.body.suggestionsCascade.partial).toBe(true);
+    expect(res.body.suggestionsCascade.flaggedCount).toBe(0);
+    expect(res.body.suggestionsCascade.failedSuggestionIds).toEqual(['sug-Q']);
+    expect(res.body.suggestionsCascade.error).toBe('Firestore batch commit blocked by quota');
+  });
+});
+
+describe('POST /api/user/:uniqueId/unsuspend --- suggestion cascade', () => {
+  let app;
+
+  beforeEach(() => {
+    app = createApp();
+    jest.clearAllMocks();
+  });
+
+  it("clears submitter_suspended flags from the user's suggestions on unsuspend", async () => {
+    const { db } = require('../../src/utils/firebase');
+
+    const clearBatchUpdate = jest.fn();
+    const clearBatchCommit = jest.fn().mockResolvedValue();
+    db.batch.mockReturnValue({
+      set: jest.fn(),
+      update: clearBatchUpdate,
+      commit: clearBatchCommit,
+    });
+
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      id: '5151',
+      data: () => ({
+        displayName: 'Reformed User',
+        isSuspended: true,
+        preSuspensionDisplayName: 'Reformed User',
+      }),
+    });
+
+    db.collection.mockImplementation((name) => {
+      if (name === 'suggestions') {
+        return {
+          where: jest.fn().mockReturnValue({
+            get: jest.fn().mockResolvedValue({
+              empty: false,
+              size: 2,
+              docs: [
+                {
+                  id: 'sug-X',
+                  ref: { _path: 'suggestions/sug-X', update: jest.fn() },
+                  data: () => ({
+                    status: 'accepted',
+                    submitterUid: 5151,
+                    flaggedForReview: true,
+                    flaggedReason: 'submitter_suspended',
+                  }),
+                },
+                {
+                  id: 'sug-Y',
+                  ref: { _path: 'suggestions/sug-Y', update: jest.fn() },
+                  data: () => ({
+                    status: 'accepted',
+                    submitterUid: 5151,
+                    flaggedForReview: true,
+                    flaggedReason: 'manual_admin_flag',
+                  }),
+                },
+              ],
+            }),
+          }),
+        };
+      }
+      const chain = {
+        where: jest.fn().mockImplementation(() => chain),
+        orderBy: jest.fn().mockImplementation(() => chain),
+        limit: jest.fn().mockImplementation(() => chain),
+        get: jest.fn().mockResolvedValue({ empty: true, docs: [] }),
+      };
+      return chain;
+    });
+
+    const res = await request(app).post('/api/user/5151/unsuspend');
+
+    expect(res.status).toBe(200);
+    expect(res.body.suggestionsCascade).toBeDefined();
+    expect(res.body.suggestionsCascade.unflaggedCount).toBe(1);
+
+    // Only sug-X (submitter_suspended) is cleared; sug-Y (manual_admin_flag) is preserved.
+    expect(clearBatchUpdate).toHaveBeenCalledTimes(1);
+    const clearedPayload = clearBatchUpdate.mock.calls[0][1];
+    expect(clearedPayload.flaggedForReview).toBe(false);
+    expect(clearedPayload.flaggedReason).toBeNull();
+  });
+
+  it('returns partial=true in suggestionsCascade when the unflag utility throws', async () => {
+    // Pair with the suspend-route throw test: the unsuspend route's outer
+    // catch for unflagUnsuspendedUserSuggestions is otherwise uncovered.
+    const { db } = require('../../src/utils/firebase');
+
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      id: '5353',
+      data: () => ({
+        displayName: 'Reformed User',
+        isSuspended: true,
+      }),
+    });
+
+    db.collection.mockImplementation((name) => {
+      if (name === 'suggestions') {
+        return {
+          where: jest.fn().mockReturnValue({
+            get: jest.fn().mockRejectedValue(new Error('Firestore unavailable on unflag')),
+          }),
+        };
+      }
+      const chain = {
+        where: jest.fn().mockImplementation(() => chain),
+        orderBy: jest.fn().mockImplementation(() => chain),
+        limit: jest.fn().mockImplementation(() => chain),
+        get: jest.fn().mockResolvedValue({ empty: true, docs: [] }),
+      };
+      return chain;
+    });
+
+    const res = await request(app).post('/api/user/5353/unsuspend');
+
+    // Unsuspension must still succeed — cascade failure is reported, not blocking.
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.suggestionsCascade.partial).toBe(true);
+    expect(res.body.suggestionsCascade.error).toBe('Firestore unavailable on unflag');
+  });
+});
+
 // --- Suspend --- suspension-match duration for timed bans -------------------
 
 describe('POST /api/user/:uniqueId/suspend --- timed ban duration', () => {

--- a/express-api/tests/routes/suggestions-integration-a-submission.test.js
+++ b/express-api/tests/routes/suggestions-integration-a-submission.test.js
@@ -605,11 +605,258 @@ describe('11.31 — Integration Tests Full Flows', () => {
         .send(VALID_SUGGESTION);
       expect(res.status).toBe(403);
     });
-    // The ban cascade behaviour (user-ban → existing-suggestions
-    // re-flagged for review) is not asserted here. Marked skip until
-    // implemented properly, rather than passing falsely on a check
-    // that the mock helper exists.
-    test.skip('TODO: ban cascade: user ban marks their suggestions for review', async () => {});
+
+    // The ban cascade flags a suspended user's live (accepted/planned) suggestions for
+    // admin re-review rather than mutating their status — see [[feedback-fill-gaps-always-no-skip]]
+    // and ADR in src/utils/flag-suspended-user-suggestions.js. Terminal-state suggestions
+    // (rejected/completed) and already-pending ones are left untouched.
+    describe('user ban marks their accepted/planned suggestions for review', () => {
+      const {
+        flagSuspendedUserSuggestions,
+        unflagUnsuspendedUserSuggestions,
+      } = require('../../src/utils/flag-suspended-user-suggestions');
+
+      function suggestionDoc(id, status, submitterUid, extra = {}) {
+        const path = `suggestions/${id}`;
+        return {
+          id,
+          ref: { _path: path, update: (...args) => mockDocUpdate(path, ...args) },
+          data: () => ({ status, submitterUid, ...extra }),
+        };
+      }
+
+      test('accepted and planned suggestions get flagged; pending/rejected/completed are left alone', async () => {
+        mockCollectionGet.mockResolvedValueOnce({
+          empty: false,
+          size: 5,
+          docs: [
+            suggestionDoc('sug-acc', 'accepted', 7777),
+            suggestionDoc('sug-pln', 'planned', 7777),
+            suggestionDoc('sug-pen', 'pending', 7777),
+            suggestionDoc('sug-rej', 'rejected', 7777),
+            suggestionDoc('sug-cmp', 'completed', 7777),
+          ],
+        });
+
+        const result = await flagSuspendedUserSuggestions(7777, 'admin-uid-1');
+
+        expect(result.flaggedCount).toBe(2);
+        expect(result.partial).toBe(false);
+        expect(result.error).toBeNull();
+
+        const flaggedPaths = mockBatchUpdate.mock.calls.map((c) => c[0]._path);
+        expect(flaggedPaths).toEqual(
+          expect.arrayContaining(['suggestions/sug-acc', 'suggestions/sug-pln']),
+        );
+        expect(flaggedPaths).not.toEqual(
+          expect.arrayContaining([
+            'suggestions/sug-pen',
+            'suggestions/sug-rej',
+            'suggestions/sug-cmp',
+          ]),
+        );
+
+        const flagPayloads = mockBatchUpdate.mock.calls.map((c) => c[1]);
+        for (const payload of flagPayloads) {
+          expect(payload.flaggedForReview).toBe(true);
+          expect(payload.flaggedReason).toBe('submitter_suspended');
+          expect(payload.flaggedBy).toBe('admin-uid-1');
+          expect(typeof payload.flaggedAt).toBe('number');
+        }
+      });
+
+      test('returns zero-counts shape when user has no suggestions', async () => {
+        mockCollectionGet.mockResolvedValueOnce({ empty: true, size: 0, docs: [] });
+
+        const result = await flagSuspendedUserSuggestions(8888, 'admin-uid-1');
+
+        expect(result).toEqual({
+          flaggedCount: 0,
+          skippedCount: 0,
+          partial: false,
+          failedSuggestionIds: [],
+          error: null,
+        });
+        expect(mockBatchCommit).not.toHaveBeenCalled();
+      });
+
+      test('does not re-flag suggestions already marked submitter_suspended (idempotent)', async () => {
+        mockCollectionGet.mockResolvedValueOnce({
+          empty: false,
+          size: 1,
+          docs: [
+            suggestionDoc('sug-already', 'accepted', 9999, {
+              flaggedForReview: true,
+              flaggedReason: 'submitter_suspended',
+            }),
+          ],
+        });
+
+        const result = await flagSuspendedUserSuggestions(9999, 'admin-uid-2');
+
+        expect(result.flaggedCount).toBe(0);
+        expect(result.skippedCount).toBe(1);
+        expect(mockBatchUpdate).not.toHaveBeenCalled();
+      });
+
+      test('unsuspend reversal clears only flags whose reason is submitter_suspended', async () => {
+        mockCollectionGet.mockResolvedValueOnce({
+          empty: false,
+          size: 3,
+          docs: [
+            suggestionDoc('sug-ban', 'accepted', 7777, {
+              flaggedForReview: true,
+              flaggedReason: 'submitter_suspended',
+            }),
+            suggestionDoc('sug-other', 'accepted', 7777, {
+              flaggedForReview: true,
+              flaggedReason: 'manual_admin_flag',
+            }),
+            suggestionDoc('sug-also-ban', 'planned', 7777, {
+              flaggedForReview: true,
+              flaggedReason: 'submitter_suspended',
+            }),
+          ],
+        });
+
+        const result = await unflagUnsuspendedUserSuggestions(7777);
+
+        expect(result.unflaggedCount).toBe(2);
+        // Pin the "doc skipped because its reason wasn't submitter_suspended" branch.
+        // sug-other carries reason 'manual_admin_flag' — must not be cleared, must
+        // contribute to skippedCount. Without this assertion the else-branch on the
+        // unflag path is uncovered.
+        expect(result.skippedCount).toBe(1);
+        const clearedPaths = mockBatchUpdate.mock.calls.map((c) => c[0]._path);
+        expect(clearedPaths).toEqual(
+          expect.arrayContaining(['suggestions/sug-ban', 'suggestions/sug-also-ban']),
+        );
+        expect(clearedPaths).not.toContain('suggestions/sug-other');
+      });
+
+      test('string uid from URL params is normalized to number for Firestore equality', async () => {
+        // Regression: submitterUid is stored numerically (req.auth.uniqueId);
+        // callers pass req.params.uniqueId (string). Without normalization the
+        // where('==') silently matches nothing and the cascade is a no-op.
+        mockCollectionGet.mockResolvedValueOnce({ empty: true, size: 0, docs: [] });
+
+        await flagSuspendedUserSuggestions('7777', 'admin-uid-1');
+
+        const submitterEqCall = mockWhere.mock.calls.find(
+          (c) => c[0] === 'submitterUid' && c[1] === '==',
+        );
+        expect(submitterEqCall).toBeDefined();
+        expect(submitterEqCall[2]).toBe(7777);
+        expect(typeof submitterEqCall[2]).toBe('number');
+      });
+
+      test('numeric uid passes through normalizeUid unchanged', async () => {
+        mockCollectionGet.mockResolvedValueOnce({ empty: true, size: 0, docs: [] });
+
+        await flagSuspendedUserSuggestions(7777, 'admin-uid-1');
+
+        const submitterEqCall = mockWhere.mock.calls.find(
+          (c) => c[0] === 'submitterUid' && c[1] === '==',
+        );
+        expect(submitterEqCall[2]).toBe(7777);
+        expect(typeof submitterEqCall[2]).toBe('number');
+      });
+
+      test('negative integer string is normalized (test uniqueIds can be negative for system actors)', async () => {
+        mockCollectionGet.mockResolvedValueOnce({ empty: true, size: 0, docs: [] });
+
+        await flagSuspendedUserSuggestions('-42', 'admin-uid-1');
+
+        const submitterEqCall = mockWhere.mock.calls.find(
+          (c) => c[0] === 'submitterUid' && c[1] === '==',
+        );
+        expect(submitterEqCall[2]).toBe(-42);
+        expect(typeof submitterEqCall[2]).toBe('number');
+      });
+
+      test('float string and non-numeric string pass through unchanged (Firestore will match nothing)', async () => {
+        // Defensive: a caller sending a malformed uid must not silently coerce
+        // to integer 7 (Number('7.5') === 7.5 — pre-empt; 'abc' → NaN — pre-empt).
+        // Both must surface as the original value so Firestore strict-eq matches nothing.
+        mockCollectionGet.mockResolvedValue({ empty: true, size: 0, docs: [] });
+
+        await flagSuspendedUserSuggestions('7.5', 'admin-uid-1');
+        await flagSuspendedUserSuggestions('abc', 'admin-uid-1');
+
+        const eqCalls = mockWhere.mock.calls.filter(
+          (c) => c[0] === 'submitterUid' && c[1] === '==',
+        );
+        expect(eqCalls[0][2]).toBe('7.5');
+        expect(eqCalls[1][2]).toBe('abc');
+      });
+
+      test('chunked commit (unflag): >500 docs split across 2 batches; partial failure in chunk 2 leaves chunk 1 cleared', async () => {
+        // Mirror of the flag-path chunk-boundary test below — commitChunked is
+        // shared between flag and unflag modes, so the unflag path needs an
+        // equivalent pin against the same refactor regressions.
+        const docs = Array.from({ length: 501 }, (_, i) =>
+          suggestionDoc(`sug-${i}`, 'accepted', 6666, {
+            flaggedForReview: true,
+            flaggedReason: 'submitter_suspended',
+          }),
+        );
+        mockCollectionGet.mockResolvedValueOnce({ empty: false, size: 501, docs });
+
+        mockBatchCommit
+          .mockResolvedValueOnce(undefined)
+          .mockRejectedValueOnce(new Error('Firestore unavailable on unflag chunk 2'));
+
+        const result = await unflagUnsuspendedUserSuggestions(6666);
+
+        expect(result.unflaggedCount).toBe(500);
+        expect(result.partial).toBe(true);
+        expect(result.failedSuggestionIds).toEqual(['sug-500']);
+        expect(result.error).toBe('Firestore unavailable on unflag chunk 2');
+        expect(mockBatchCommit).toHaveBeenCalledTimes(2);
+      });
+
+      test('chunked commit: >500 docs split across 2 batches; partial failure in chunk 2 leaves chunk 1 committed', async () => {
+        // Pins the chunk-boundary branch of commitChunked. Without this, a future
+        // refactor of the batching loop (e.g. wrong slice arithmetic, missed
+        // try/catch per chunk) regresses silently because all existing tests
+        // fit in a single chunk.
+        const docs = Array.from({ length: 501 }, (_, i) =>
+          suggestionDoc(`sug-${i}`, 'accepted', 8888),
+        );
+        mockCollectionGet.mockResolvedValueOnce({ empty: false, size: 501, docs });
+
+        // First chunk (500) commits, second chunk (1) fails.
+        mockBatchCommit
+          .mockResolvedValueOnce(undefined)
+          .mockRejectedValueOnce(new Error('Firestore unavailable on chunk 2'));
+
+        const result = await flagSuspendedUserSuggestions(8888, 'admin-uid-1');
+
+        expect(result.flaggedCount).toBe(500);
+        expect(result.partial).toBe(true);
+        expect(result.failedSuggestionIds).toEqual(['sug-500']);
+        expect(result.error).toBe('Firestore unavailable on chunk 2');
+        // Pin that TWO DISTINCT batch.commit() calls were made — not one batch
+        // object reused twice (which would silently double-write chunk-1 docs
+        // in production while still matching the output-shape assertions above).
+        expect(mockBatchCommit).toHaveBeenCalledTimes(2);
+      });
+
+      test('batch commit failure surfaces partial=true and failedSuggestionIds', async () => {
+        mockCollectionGet.mockResolvedValueOnce({
+          empty: false,
+          size: 1,
+          docs: [suggestionDoc('sug-fail', 'accepted', 4444)],
+        });
+        mockBatchCommit.mockRejectedValueOnce(new Error('Firestore unavailable'));
+
+        const result = await flagSuspendedUserSuggestions(4444, 'admin-uid-1');
+
+        expect(result.partial).toBe(true);
+        expect(result.failedSuggestionIds).toContain('sug-fail');
+        expect(result.error).toBe('Firestore unavailable');
+      });
+    });
   });
 
   describe('Multi-account flow', () => {

--- a/public/admin/js/lib/partial-failure-toast.js
+++ b/public/admin/js/lib/partial-failure-toast.js
@@ -39,6 +39,17 @@
         : (result.cascade.failedRoomIds || []).length + ' room(s) need manual cleanup';
       parts.push('room cascade partial — ' + detail);
     }
+    // Ban cascade for the suggestions surface — admin suspend/unsuspend routes
+    // expose suggestionsCascade.partial when the flag/unflag batch couldn't
+    // commit. failedSuggestionIds is empty when the cascade utility threw
+    // before populating it (e.g. the initial query failed), so fall back to a
+    // generic "manual cleanup" hint rather than rendering "0 suggestion(s)".
+    if (result.suggestionsCascade && result.suggestionsCascade.partial) {
+      const failed = (result.suggestionsCascade.failedSuggestionIds || []).length;
+      const detail =
+        failed > 0 ? failed + ' suggestion(s) need manual cleanup' : 'manual cleanup needed';
+      parts.push('suggestion cascade partial — ' + detail);
+    }
     // Number.isFinite rejects NaN, ±Infinity, AND non-numbers — stricter than
     // typeof === 'number' which admits NaN. A misimplemented backend sending
     // `failed: NaN` would otherwise coerce `NaN > 0` → false and silently


### PR DESCRIPTION
## Summary

- When an admin suspends a user, their existing `accepted`/`planned` suggestions get a `flaggedForReview` sticky-note (preserving status) so admins can decide case-by-case whether each suggestion stays on the roadmap.
- Unsuspend symmetrically clears only the flags whose reason is `submitter_suspended` — manual admin flags from other code paths are preserved.
- Replaces the `test.skip` at `suggestions-integration-a-submission.test.js:612` per [[feedback-fill-gaps-always-no-skip]].

## Design

| Decision | Rationale |
|---|---|
| Boolean flag + metadata (not status change) | Preserves voter/subscriber state; unsuspend cleanly reverses by clearing 4 fields. Avoids changing every status-transition guard. |
| Single-field query + JS status filter | No composite Firestore index needed; typical N < 5. |
| `normalizeUid()` boundary normalization | `submitterUid` stored numerically; `req.params.uniqueId` is a string. Strict equality would silently match nothing. |
| Cascade utility mirrors `evict-suspended-user.js` shape | `partial` / `failedSuggestionIds` / `error` fields, batches chunked at 500. |
| Toast renderer extended for `suggestionsCascade.partial` | Admin UI surfaces cascade failures alongside existing room-cascade failure rendering. |
| Cascade failure NEVER blocks suspend/unsuspend HTTP response | Admin must always be able to act. Failures reported via `suggestionsCascade.partial`. |

## Routes wired

- `POST /admin/user/:uniqueId/suspend` → flag the user's live suggestions
- `POST /admin/user/:uniqueId/unsuspend` → clear only `submitter_suspended` flags

## Tests (12 new across 3 files)

- **11 cascade-utility unit tests**: status filter, idempotency, unflag reason-precision, chunked-commit (>500 docs, both flag + unflag paths), uid normalization (numeric / negative-int-string / float-string / non-numeric).
- **4 route-level integration tests**: suspend success + cascade-throws, unsuspend success + cascade-throws, batch-partial via content-aware batch mock (autoApplyBans shares `db.batch()`).
- **3 toast renderer tests**: rendering, empty `failedSuggestionIds` fallback, `partial: false` defensive (does NOT render with non-empty `failedSuggestionIds`), position locked in the full-chain ordering fixture.

## Review history

- **R1**: 3 Important + 1 Minor → fixed
- **R2**: 1 Important (chunked-commit call-count pin) → fixed
- **R3**: 2 Important (1 in-scope unflag-path symmetry → fixed; 1 pre-existing `admin-bans.js pms` shape → queued for follow-up PR)
- **R4**: ZERO findings ([[feedback-100-percent-clean-reviews]] gate met)

## Test plan

- [x] Express-api full suite: 11,347 passing, 0 regressions
- [x] Prettier + ESLint zero warnings on all touched files
- [x] Pre-push Sonar gate passed locally (3m 48s)
- [x] 4 sequential code-review cycles converged to zero findings
- [ ] CI: `lint / Lint`, `test-backend / Test Backend`, `integration-tests / Integration Tests`, `sonarcloud / SonarCloud Analysis`, `PR Gate` (will fire on push)
- [ ] CodeQL (path-filtered, expected NEUTRAL for express-only change)

## Follow-up PRs queued this session

1. Fix pre-existing `data-export-builder.js:26` dynamic `import('archiver')` failing Jest without `--experimental-vm-modules` (36 failures on main).
2. Add `pms` response-shape assertions to `tests/routes/admin-bans.test.js` (R3 pre-existing finding I3).
3. Roadmap update + 20-locale i18n for the ban-cascade-suggestions feature (preserved scope hygiene by separating this from the technical PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)