### PR TITLE
fix(rooms): attest owner-left signals against ownerFirebaseUid (denormalised)

### DIFF
--- a/app/src/androidTest/java/com/shyden/shytalk/fake/FakeRoomRepository.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/fake/FakeRoomRepository.kt
@@ -23,13 +23,16 @@ class FakeRoomRepository : RoomRepository {
     override suspend fun createRoom(
         name: String,
         ownerId: String,
+        ownerFirebaseUid: String,
         cohort: String,
     ): Resource<String> {
         // `cohort` is stamped on the Firestore room doc by the real
         // impl and bound to the caller's JWT claim by firestore.rules.
-        // The fake doesn't model the cohort gate (E2E tests are
-        // single-cohort by construction) — accept the arg to satisfy
-        // the interface and discard.
+        // `ownerFirebaseUid` is similarly stamped and read by the
+        // owner-left RTDB listener for signal attestation. The fake
+        // doesn't model either gate (E2E tests use a single
+        // authenticated identity) — accept the args to satisfy the
+        // interface and discard.
         val newRoom = ChatRoom(roomId = "room-new", name = name, ownerId = ownerId)
         rooms.value = rooms.value + newRoom
         return Resource.Success("room-new")

--- a/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/repository/RoomRepositoryImpl.kt
@@ -92,6 +92,7 @@ class RoomRepositoryImpl(
     override suspend fun createRoom(
         name: String,
         ownerId: String,
+        ownerFirebaseUid: String,
         cohort: String,
     ): Resource<String> =
         firebaseCall("Failed to create room") {
@@ -108,6 +109,13 @@ class RoomRepositoryImpl(
                     "id" to roomId,
                     "name" to name,
                     "ownerId" to ownerId,
+                    // Cron-elim PR A0 — denormalised Firebase Auth uid of
+                    // the room owner. Bound to request.auth.uid by the
+                    // firestore.rules rooms-create rule and read by the
+                    // owner-left RTDB listener to attest signals. Two
+                    // identity namespaces exist for every user; ownerId is
+                    // the Firestore uniqueId, this is the Firebase Auth uid.
+                    "ownerFirebaseUid" to ownerFirebaseUid,
                     "state" to "ACTIVE",
                     "createdAt" to timestamp,
                     "participantIds" to listOf(ownerId),

--- a/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/repository/RoomRepositoryImplTest.kt
@@ -91,7 +91,7 @@ class RoomRepositoryImplTest {
     @Test
     fun `createRoom returns Success with roomId`() =
         runTest {
-            val result = repo.createRoom("My Room", "owner-1", "adult")
+            val result = repo.createRoom("My Room", "owner-1", "owner-fuid-1", "adult")
             assertTrue(result is Resource.Success)
         }
 
@@ -100,7 +100,7 @@ class RoomRepositoryImplTest {
         runTest {
             every { mockDocRef.set(any()) } returns Tasks.forException(RuntimeException("Network error"))
 
-            val result = repo.createRoom("My Room", "owner-1", "adult")
+            val result = repo.createRoom("My Room", "owner-1", "owner-fuid-1", "adult")
             assertTrue(result is Resource.Error)
         }
 
@@ -117,7 +117,7 @@ class RoomRepositoryImplTest {
             val captured = slot<Map<String, Any?>>()
             every { mockDocRef.set(capture(captured)) } returns Tasks.forResult(null)
 
-            repo.createRoom("My Room", "owner-1", "adult")
+            repo.createRoom("My Room", "owner-1", "owner-fuid-1", "adult")
             assertTrue(captured.captured["cohort"] == "adult")
         }
 
@@ -127,8 +127,44 @@ class RoomRepositoryImplTest {
             val captured = slot<Map<String, Any?>>()
             every { mockDocRef.set(capture(captured)) } returns Tasks.forResult(null)
 
-            repo.createRoom("Kids Room", "owner-2", "minor")
+            repo.createRoom("Kids Room", "owner-2", "owner-fuid-2", "minor")
             assertTrue(captured.captured["cohort"] == "minor")
+        }
+
+    @Test
+    fun `createRoom stamps ownerFirebaseUid on the room doc`() =
+        runTest {
+            // Cron-elim PR A0 — firestore.rules binds
+            // `ownerFirebaseUid` to `request.auth.uid` when present. The
+            // owner-left RTDB listener attests signals against this field
+            // (Firebase Auth uid namespace, not the Firestore uniqueId
+            // namespace used by `ownerId`). Without this stamp the
+            // orchestrator falls back to a per-signal user-doc lookup,
+            // which works during transition but defeats the denormalisation
+            // goal. Pin the stamp so future refactors can't silently drop
+            // the fast-path field.
+            val captured = slot<Map<String, Any?>>()
+            every { mockDocRef.set(capture(captured)) } returns Tasks.forResult(null)
+
+            repo.createRoom("My Room", "owner-1", "owner-fuid-XYZ", "adult")
+            assertTrue(captured.captured["ownerFirebaseUid"] == "owner-fuid-XYZ")
+        }
+
+    @Test
+    fun `createRoom does not conflate ownerId and ownerFirebaseUid`() =
+        runTest {
+            // Regression guard for the two-namespace bug class. If a
+            // refactor accidentally passes ownerId in both positions, the
+            // stamp passes the rules-layer (defaults match auth.uid) but
+            // breaks owner-left signal attestation in production. The
+            // captured payload must show DIFFERENT values for the two
+            // fields when DIFFERENT values were passed.
+            val captured = slot<Map<String, Any?>>()
+            every { mockDocRef.set(capture(captured)) } returns Tasks.forResult(null)
+
+            repo.createRoom("My Room", "10000005", "abcDEF123XYZ", "adult")
+            assertTrue(captured.captured["ownerId"] == "10000005")
+            assertTrue(captured.captured["ownerFirebaseUid"] == "abcDEF123XYZ")
         }
 
     // endregion

--- a/app/src/test/java/com/shyden/shytalk/feature/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/home/HomeViewModelTest.kt
@@ -48,11 +48,20 @@ class HomeViewModelTest {
     private val roomsFlow = MutableSharedFlow<List<ChatRoom>>()
     private val currentUserId = "current-user"
 
+    // Cron-elim PR A0 — currentUserId (Firestore uniqueId) and
+    // currentFirebaseUid (Firebase Auth uid) live in different identity
+    // namespaces. The HomeViewModel must pass BOTH to createRoom — uniqueId
+    // as ownerId and firebaseUid as ownerFirebaseUid. The two values are
+    // deliberately distinct in tests so a bug that swaps them surfaces
+    // as a coVerify mismatch.
+    private val currentFirebaseUid = "current-firebase-uid"
+
     private val activeViewModels = mutableListOf<HomeViewModel>()
 
     @Before
     fun setup() {
         every { authRepository.currentUserId } returns currentUserId
+        every { authRepository.currentFirebaseUid } returns currentFirebaseUid
         every { roomRepository.getActiveRooms() } returns roomsFlow
         every { userRepository.userUpdates } returns MutableSharedFlow()
         coEvery { userRepository.getBlockedUserIds(currentUserId) } returns Resource.Success(emptySet())
@@ -145,13 +154,13 @@ class HomeViewModelTest {
                 Resource.Success(TestData.createTestUser(uid = currentUserId).copy(cohort = "adult"))
             val vm = createViewModel()
             advanceUntilIdle()
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Success("new-room-id")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("new-room-id")
 
             vm.createRoom("My Room")
             advanceUntilIdle()
 
             coVerify(exactly = 0) { roomRepository.closeAllRoomsByOwner(any()) }
-            coVerify { roomRepository.createRoom("My Room", currentUserId, "adult") }
+            coVerify { roomRepository.createRoom("My Room", currentUserId, currentFirebaseUid, "adult") }
             assertEquals("new-room-id", vm.uiState.value.createdRoomId)
         }
 
@@ -162,7 +171,7 @@ class HomeViewModelTest {
                 Resource.Success(TestData.createTestUser(uid = currentUserId))
             val vm = createViewModel()
             advanceUntilIdle()
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Error("failed")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Error("failed")
 
             vm.createRoom("My Room")
             advanceUntilIdle()
@@ -178,7 +187,7 @@ class HomeViewModelTest {
                 Resource.Success(TestData.createTestUser(uid = currentUserId))
             val vm = createViewModel()
             advanceUntilIdle()
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Success("new-room")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("new-room")
             vm.createRoom("Room")
             advanceUntilIdle()
 
@@ -194,7 +203,7 @@ class HomeViewModelTest {
                 Resource.Success(TestData.createTestUser(uid = currentUserId))
             val vm = createViewModel()
             advanceUntilIdle()
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Error("err")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Error("err")
             vm.createRoom("Room")
             advanceUntilIdle()
 
@@ -216,12 +225,12 @@ class HomeViewModelTest {
                 Resource.Success(TestData.createTestUser(uid = currentUserId).copy(cohort = "minor"))
             val vm = createViewModel()
             advanceUntilIdle()
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Success("rid")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("rid")
 
             vm.createRoom("Kids Room")
             advanceUntilIdle()
 
-            coVerify { roomRepository.createRoom("Kids Room", currentUserId, "minor") }
+            coVerify { roomRepository.createRoom("Kids Room", currentUserId, currentFirebaseUid, "minor") }
         }
 
     @Test
@@ -233,12 +242,12 @@ class HomeViewModelTest {
             coEvery { userRepository.getUser(currentUserId) } returns Resource.Error("rpc timeout")
             val vm = createViewModel()
             advanceUntilIdle()
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Success("rid")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("rid")
 
             vm.createRoom("Fallback Room")
             advanceUntilIdle()
 
-            coVerify { roomRepository.createRoom("Fallback Room", currentUserId, "minor") }
+            coVerify { roomRepository.createRoom("Fallback Room", currentUserId, currentFirebaseUid, "minor") }
         }
 
     @Test
@@ -260,12 +269,85 @@ class HomeViewModelTest {
                 )
             val vm = createViewModel()
             advanceUntilIdle()
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Success("rid")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("rid")
 
             vm.createRoom("Override Room")
             advanceUntilIdle()
 
-            coVerify { roomRepository.createRoom("Override Room", currentUserId, "adult") }
+            coVerify { roomRepository.createRoom("Override Room", currentUserId, currentFirebaseUid, "adult") }
+        }
+
+    @Test
+    fun `createRoom passes Firebase Auth uid as ownerFirebaseUid, not uniqueId`() =
+        runTest {
+            // Cron-elim PR A0 regression guard for the two-namespace bug
+            // class. AuthRepository exposes BOTH:
+            //   - currentUserId (Firestore uniqueId, e.g. "10000005")
+            //   - currentFirebaseUid (Firebase Auth uid, e.g. "abc123XYZ")
+            // The RTDB owner-left signal rule forces writerUid to equal
+            // `auth.uid`; the orchestrator attests it against
+            // room.ownerFirebaseUid. If the ViewModel accidentally passes
+            // currentUserId in BOTH positions, the rules-layer create-bind
+            // (which has a `.get(field, request.auth.uid)` default) might
+            // still let the write through, but the room would carry the
+            // wrong value and every owner-left signal would fail
+            // attestation. Pin DIFFERENT values for the two namespaces and
+            // assert each one lands in its own slot.
+            coEvery { userRepository.getUser(currentUserId) } returns
+                Resource.Success(TestData.createTestUser(uid = currentUserId).copy(cohort = "adult"))
+            val vm = createViewModel()
+            advanceUntilIdle()
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("rid")
+
+            vm.createRoom("Namespace Room")
+            advanceUntilIdle()
+
+            // Strict positional verification: the 2nd arg is the uniqueId,
+            // the 3rd is the firebaseUid. A swap would put firebaseUid in
+            // position 2 (where rules check ownerId == callerUniqueId) and
+            // PERMISSION_DENIED — but the mock has no rules-layer, so the
+            // test must catch the swap by positional pinning.
+            coVerify {
+                roomRepository.createRoom(
+                    "Namespace Room",
+                    currentUserId,
+                    currentFirebaseUid,
+                    "adult",
+                )
+            }
+            // Negative pin: the firebaseUid must NOT equal the uniqueId
+            // (otherwise the regression guard above is vacuous).
+            assertTrue(currentUserId != currentFirebaseUid)
+        }
+
+    @Test
+    fun `createRoom passes empty ownerFirebaseUid when AuthRepository returns null`() =
+        runTest {
+            // Defensive: if currentFirebaseUid is somehow null (impossible
+            // when authenticated — but defend in case AuthRepository's
+            // implementation introduces a transient null window), the
+            // ViewModel substitutes empty string. The Firestore rule's
+            // `.get('ownerFirebaseUid', request.auth.uid)` default makes
+            // this still pass create-side; the orchestrator's user-doc
+            // fallback covers signal attestation.
+            every { authRepository.currentFirebaseUid } returns null
+            coEvery { userRepository.getUser(currentUserId) } returns
+                Resource.Success(TestData.createTestUser(uid = currentUserId).copy(cohort = "adult"))
+            val vm = createViewModel()
+            advanceUntilIdle()
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("rid")
+
+            vm.createRoom("Null Firebase Uid Room")
+            advanceUntilIdle()
+
+            coVerify {
+                roomRepository.createRoom(
+                    "Null Firebase Uid Room",
+                    currentUserId,
+                    "",
+                    "adult",
+                )
+            }
         }
 
     @Test
@@ -284,12 +366,12 @@ class HomeViewModelTest {
                 )
             val vm = createViewModel()
             advanceUntilIdle()
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Success("rid")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("rid")
 
             vm.createRoom("Corrupt Override Room")
             advanceUntilIdle()
 
-            coVerify { roomRepository.createRoom("Corrupt Override Room", currentUserId, "adult") }
+            coVerify { roomRepository.createRoom("Corrupt Override Room", currentUserId, currentFirebaseUid, "adult") }
         }
 
     @Test
@@ -384,7 +466,7 @@ class HomeViewModelTest {
         runTest {
             val vm = createViewModel()
             advanceUntilIdle()
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Success("new-room-id")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("new-room-id")
 
             vm.createRoom("My Cool Room")
             advanceUntilIdle()
@@ -528,7 +610,7 @@ class HomeViewModelTest {
             vm.createRoom("My Room")
             advanceUntilIdle()
 
-            coVerify(exactly = 0) { roomRepository.createRoom(any(), any(), any()) }
+            coVerify(exactly = 0) { roomRepository.createRoom(any(), any(), any(), any()) }
         }
 
     // ===== createRoom - persists lastRoomName via updateProfile =====
@@ -538,7 +620,7 @@ class HomeViewModelTest {
         runTest {
             val vm = createViewModel()
             advanceUntilIdle()
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Success("new-id")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("new-id")
 
             vm.createRoom("Persisted Room")
             advanceUntilIdle()
@@ -707,12 +789,12 @@ class HomeViewModelTest {
         runTest {
             val vm = createViewModel()
             advanceUntilIdle()
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Error("first error")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Error("first error")
             vm.createRoom("Room1")
             advanceUntilIdle()
             assertNotNull(vm.uiState.value.error)
 
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Success("room-2")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("room-2")
             vm.createRoom("Room2")
             advanceUntilIdle()
 
@@ -735,7 +817,7 @@ class HomeViewModelTest {
             // Should show confirmation instead of creating or showing error
             assertTrue(vm.uiState.value.showReplaceRoomConfirmation)
             assertEquals("New Room", vm.uiState.value.pendingRoomName)
-            coVerify(exactly = 0) { roomRepository.createRoom(any(), any(), any()) }
+            coVerify(exactly = 0) { roomRepository.createRoom(any(), any(), any(), any()) }
         }
 
     @Test
@@ -744,12 +826,12 @@ class HomeViewModelTest {
             val vm = createViewModel()
             advanceUntilIdle()
             coEvery { roomRepository.findActiveRoomByOwner(currentUserId) } returns null
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Success("new-room-id")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("new-room-id")
 
             vm.createRoom("New Room")
             advanceUntilIdle()
 
-            coVerify { roomRepository.createRoom("New Room", currentUserId, any()) }
+            coVerify { roomRepository.createRoom("New Room", currentUserId, currentFirebaseUid, any()) }
             assertEquals("new-room-id", vm.uiState.value.createdRoomId)
         }
 
@@ -759,7 +841,7 @@ class HomeViewModelTest {
             val vm = createViewModel()
             advanceUntilIdle()
             coEvery { roomRepository.findActiveRoomByOwner(currentUserId) } returns "existing-room-id"
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Success("new-id")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("new-id")
 
             // First, createRoom shows confirmation
             vm.createRoom("New Room")
@@ -775,7 +857,7 @@ class HomeViewModelTest {
 
             coVerifyOrder {
                 roomRepository.closeAllRoomsByOwner(currentUserId)
-                roomRepository.createRoom("New Room", currentUserId, any())
+                roomRepository.createRoom("New Room", currentUserId, currentFirebaseUid, any())
             }
             assertFalse(vm.uiState.value.showReplaceRoomConfirmation)
             assertEquals("new-id", vm.uiState.value.createdRoomId)
@@ -952,11 +1034,11 @@ class HomeViewModelTest {
                 )
             val vm = createViewModel()
             advanceUntilIdle()
-            coEvery { roomRepository.createRoom(any(), any(), any()) } returns Resource.Success("rid")
+            coEvery { roomRepository.createRoom(any(), any(), any(), any()) } returns Resource.Success("rid")
 
             vm.createRoom("My Room")
             advanceUntilIdle()
 
-            coVerify { roomRepository.createRoom("My Room", currentUserId, "minor") }
+            coVerify { roomRepository.createRoom("My Room", currentUserId, currentFirebaseUid, "minor") }
         }
 }

--- a/express-api/src/utils/owner-left-orchestrator.js
+++ b/express-api/src/utils/owner-left-orchestrator.js
@@ -49,6 +49,34 @@ function isValidOwnerId(ownerId) {
 }
 
 /**
+ * Resolves the Firebase Auth uid the room owner should be attested under.
+ *
+ * Fast path: the room doc carries the denormalised `ownerFirebaseUid`
+ * (written at create-time, enforced unspoofable by the Firestore rule
+ * `request.resource.data.ownerFirebaseUid == request.auth.uid`). Returns it
+ * verbatim, no extra read.
+ *
+ * Fallback path (legacy rooms created before the denormalisation landed):
+ * looks up the owner's user doc at `users/{ownerId}` and reads
+ * `.firebaseUid`. Same lookup direction as `middleware/auth.js` but reversed
+ * — we have the uniqueId (room.ownerId) and need the firebaseUid.
+ *
+ * Returns null if neither path produces a non-empty string. The caller must
+ * treat null as a failed attestation (NOOP `writer-not-owner`) — silently
+ * defaulting to "accept" would re-open the forgery vector the attestation
+ * exists to close.
+ */
+async function resolveOwnerFirebaseUid(preRoom, db) {
+  if (typeof preRoom.ownerFirebaseUid === 'string' && preRoom.ownerFirebaseUid.length > 0) {
+    return preRoom.ownerFirebaseUid;
+  }
+  const userSnap = await db.doc(`users/${preRoom.ownerId}`).get();
+  if (!userSnap.exists) return null;
+  const fuid = userSnap.data() && userSnap.data().firebaseUid;
+  return typeof fuid === 'string' && fuid.length > 0 ? fuid : null;
+}
+
+/**
  * Process an owner-left signal for `roomId`.
  *
  * @param {object} args
@@ -94,17 +122,36 @@ async function handleOwnerLeftSignal({ db, presenceChecker, roomId, writerUid, n
   }
 
   // Writer-attestation check: the client that armed the RTDB onDisconnect
-  // signs the entry value with their own uid (enforced by the rule
-  // `newData.val() === auth.uid`). Here we additionally verify the writer
-  // is the room's owner — closes the "attacker writes ownerLeft for victim's
-  // room" forgery. Omitted writerUid is accepted for direct (non-listener)
-  // callers that don't have an attesting writer.
-  if (
-    writerUid !== undefined &&
-    writerUid !== null &&
-    String(writerUid) !== String(preRoom.ownerId)
-  ) {
-    return { action: OWNER_LEFT_ACTION.NOOP, reason: 'writer-not-owner' };
+  // signs the entry value with their own Firebase Auth uid (enforced by the
+  // rule `newData.val() === auth.uid` on `ownerLeft/{roomId}`). Here we
+  // additionally verify the writer matches the room's owner — closes the
+  // "attacker writes ownerLeft for victim's room" forgery vector.
+  //
+  // The comparison is against `room.ownerFirebaseUid`, the room owner's
+  // Firebase Auth uid denormalised at create-time. Two identity namespaces
+  // exist for every user: the Firestore `uniqueId` (room.ownerId, e.g.
+  // "10000005") and the Firebase Auth uid (firebaseUid, e.g. "abc123XYZ").
+  // The RTDB rule forces writerUid into the Firebase-Auth-uid namespace, so
+  // comparing it against ownerId (uniqueId namespace) would always fail.
+  // Denormalising ownerFirebaseUid lets the comparison happen in a single
+  // namespace without a per-signal cross-namespace lookup.
+  //
+  // Legacy rooms created before this field existed fall back to the users-
+  // collection lookup (matches the cached firebaseUid→uniqueId resolver in
+  // `middleware/auth.js`, just in the reverse direction). The fallback can
+  // be removed in a follow-up once all live rooms have closed and been
+  // recreated with the field.
+  //
+  // Omitted writerUid is accepted for direct (non-listener) callers that
+  // don't have an attesting writer.
+  if (writerUid !== undefined && writerUid !== null) {
+    const attestedOwnerFirebaseUid = await resolveOwnerFirebaseUid(preRoom, db);
+    if (
+      attestedOwnerFirebaseUid === null ||
+      String(writerUid) !== String(attestedOwnerFirebaseUid)
+    ) {
+      return { action: OWNER_LEFT_ACTION.NOOP, reason: 'writer-not-owner' };
+    }
   }
 
   // TOCTOU re-check: the signal may be stale by the time we process it (owner

--- a/express-api/tests/firestore-rules/room-rules.test.js
+++ b/express-api/tests/firestore-rules/room-rules.test.js
@@ -154,6 +154,18 @@ describe('rooms/{roomId} unaffected verbs — read / create / delete unchanged',
     expect(ROOM_BLOCK).toContain('request.resource.data.ownerId');
   });
 
+  test('create binds ownerFirebaseUid (when present) to request.auth.uid (cron-elim PR A0)', () => {
+    // The owner-left RTDB listener attests signals against
+    // `room.ownerFirebaseUid`. The Firestore rule binds the field — when
+    // the new-version client writes it — to `request.auth.uid`, making it
+    // unspoofable. The `.get(field, request.auth.uid)` default lets legacy
+    // app versions still create rooms during the Play/App Store rollout
+    // window (orchestrator's user-doc fallback covers their signals). A
+    // follow-up PR after rollout tightens this to a strict empty default.
+    expect(ROOM_BLOCK).toContain("request.resource.data.get('ownerFirebaseUid', request.auth.uid)");
+    expect(ROOM_BLOCK).toContain('== request.auth.uid');
+  });
+
   test('delete remains owner-only', () => {
     // closeRoom now writes state=CLOSED rather than deleting, but the rule
     // stays in place for legitimate owner-deletes (rare).

--- a/express-api/tests/utils/owner-left-orchestrator.test.js
+++ b/express-api/tests/utils/owner-left-orchestrator.test.js
@@ -21,6 +21,13 @@ const {
 const baseActiveRoom = {
   state: 'ACTIVE',
   ownerId: 'owner-1',
+  // Denormalised Firebase Auth uid of the room owner, written at create-time
+  // and bound unspoofable via the Firestore rule on rooms/{roomId} create
+  // (`request.resource.data.ownerFirebaseUid == request.auth.uid`). The
+  // writer-attestation check in the orchestrator compares the RTDB-signal
+  // writerUid (which the RTDB rule forces to equal `auth.uid`) against this
+  // field — same identity namespace on both sides.
+  ownerFirebaseUid: 'owner-fuid-1',
   ownerLeftAt: null,
   participantIds: ['owner-1', 'user-2'],
   seats: {
@@ -42,17 +49,33 @@ const activeWithSeatedUser = {
  * orchestrator: `db.doc(path)` returns a stable ref; `db.runTransaction(cb)`
  * supplies a transaction object with `t.get(ref)` and `t.update(ref, patch)`.
  *
+ * Path routing: `rooms/{...}` returns the room ref (driven by `initialRoom`),
+ * `users/{...}` returns the user ref (driven by `ownerUserDoc`, default null
+ * → exists:false). Any other path also routes to the room ref for backward
+ * compatibility with tests written before user-doc lookups existed; this
+ * matches what the original `jest.fn(() => roomRef)` did.
+ *
  * The factory exposes the captured mocks so tests can assert against them.
  */
-function makeMockDb({ initialRoom }) {
-  const roomRef = { __ref: true };
+function makeMockDb({ initialRoom, ownerUserDoc = null }) {
+  const roomRef = { __ref: 'room' };
+  const userRef = { __ref: 'user' };
   let currentRoom = initialRoom; // may be null/undefined to simulate missing
-  const docFn = jest.fn(() => roomRef);
 
   const preGetMock = jest
     .fn()
     .mockImplementation(async () => ({ exists: !!currentRoom, data: () => currentRoom }));
   roomRef.get = preGetMock;
+
+  const userGetMock = jest
+    .fn()
+    .mockImplementation(async () => ({ exists: !!ownerUserDoc, data: () => ownerUserDoc }));
+  userRef.get = userGetMock;
+
+  const docFn = jest.fn((path) => {
+    if (typeof path === 'string' && path.startsWith('users/')) return userRef;
+    return roomRef;
+  });
 
   const txMock = {
     get: jest
@@ -67,7 +90,14 @@ function makeMockDb({ initialRoom }) {
 
   const runTransaction = jest.fn().mockImplementation(async (callback) => callback(txMock));
 
-  return { db: { doc: docFn, runTransaction }, roomRef, txMock, preGetMock };
+  return {
+    db: { doc: docFn, runTransaction },
+    roomRef,
+    userRef,
+    txMock,
+    preGetMock,
+    userGetMock,
+  };
 }
 
 describe('handleOwnerLeftSignal', () => {
@@ -631,92 +661,6 @@ describe('handleOwnerLeftSignal', () => {
     });
   });
 
-  describe('writer-uid spoof prevention', () => {
-    // Without this check, an attacker can write `ownerLeft/{victim-room} = attacker-uid`
-    // (allowed by the RTDB rule `newData.val() === auth.uid`); the listener fires;
-    // the server reads room.ownerId = victim; presenceChecker for victim returns
-    // false if victim has a brief network blip — and the room is illegitimately
-    // closed or transitioned to OWNER_AWAY. The writerUid arg is the value at
-    // the RTDB signal entry (snap.val()) — it MUST match the room owner.
-    test('returns NOOP when writerUid does not match preRoom.ownerId', async () => {
-      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: 'owner-1' } });
-      const result = await handleOwnerLeftSignal({
-        db,
-        presenceChecker,
-        roomId: 'room-1',
-        writerUid: 'attacker-uid',
-        nowMs,
-      });
-      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
-      expect(result.reason).toBe('writer-not-owner');
-      // Critical: presenceChecker was NOT called — attacker can't even probe
-      // the victim's presence state via this signal-spam.
-      expect(presenceChecker).not.toHaveBeenCalled();
-    });
-
-    test('proceeds when writerUid matches preRoom.ownerId', async () => {
-      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: 'owner-1' } });
-      presenceChecker.mockResolvedValue(false);
-      const result = await handleOwnerLeftSignal({
-        db,
-        presenceChecker,
-        roomId: 'room-1',
-        writerUid: 'owner-1',
-        nowMs,
-      });
-      expect(result.action).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
-      expect(presenceChecker).toHaveBeenCalledWith('room-1', 'owner-1');
-    });
-
-    test('writerUid omitted (undefined) is accepted — backward compat for direct callers', async () => {
-      // The orchestrator can be called from contexts other than the RTDB
-      // listener; when no writer attestation is available, the existing
-      // ownerStillPresent / state-machine guards still apply.
-      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: 'owner-1' } });
-      presenceChecker.mockResolvedValue(false);
-      const result = await handleOwnerLeftSignal({
-        db,
-        presenceChecker,
-        roomId: 'room-1',
-        nowMs,
-      });
-      expect(result.action).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
-    });
-
-    test('writerUid normalisation handles string vs numeric ownerId', async () => {
-      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: 42 } });
-      presenceChecker.mockResolvedValue(true);
-      const result = await handleOwnerLeftSignal({
-        db,
-        presenceChecker,
-        roomId: 'room-1',
-        writerUid: '42',
-        nowMs,
-      });
-      // Match by string-normalised compare — should NOT be writer-not-owner.
-      expect(result.reason).not.toBe('writer-not-owner');
-    });
-
-    // R3 I1: the listener forwards `null` as writerUid when snap.val() is
-    // null. The orchestrator's `writerUid !== null && writerUid !== undefined`
-    // guard treats both as "no attestation" — but null and undefined exit
-    // the check at DIFFERENT short-circuit conditions, so test both paths.
-    test('writerUid explicitly null is accepted — treated as no attestation', async () => {
-      const { db } = makeMockDb({ initialRoom: { ...baseActiveRoom, ownerId: 'owner-1' } });
-      presenceChecker.mockResolvedValue(false);
-      const result = await handleOwnerLeftSignal({
-        db,
-        presenceChecker,
-        roomId: 'room-1',
-        writerUid: null,
-        nowMs,
-      });
-      expect(result.reason).not.toBe('writer-not-owner');
-      expect(result.action).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
-      expect(presenceChecker).toHaveBeenCalledWith('room-1', 'owner-1');
-    });
-  });
-
   describe('transaction retry on contention (I3)', () => {
     // Firestore Admin SDK retries the transaction callback on contention.
     // ownerStillPresent is captured BEFORE the txn opens and re-used across
@@ -791,6 +735,299 @@ describe('handleOwnerLeftSignal', () => {
         expect(call[0]).toBe(roomRef);
         expect(call[1]).toEqual({ state: 'OWNER_AWAY', ownerLeftAt: nowMs });
       }
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════
+  // Writer-attestation — fast path (room has ownerFirebaseUid)
+  // ═══════════════════════════════════════════════════════════════
+  //
+  // When the room doc carries the denormalised `ownerFirebaseUid` (rooms
+  // created after the denormalisation PR), the orchestrator compares the
+  // RTDB-signal writerUid against that field directly — no per-signal
+  // user-doc lookup needed. The Firestore rule on rooms create binds
+  // ownerFirebaseUid to `request.auth.uid` so the field is unspoofable.
+
+  describe('writer-attestation — fast path (room.ownerFirebaseUid present)', () => {
+    test('proceeds when writerUid matches room.ownerFirebaseUid', async () => {
+      const { db, txMock } = makeMockDb({ initialRoom: baseActiveRoom });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: 'owner-fuid-1',
+        nowMs,
+      });
+
+      // Fast path: legit owner-arming signal closes the empty room.
+      expect(result.action).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+      expect(txMock.update).toHaveBeenCalledTimes(1);
+    });
+
+    test('rejects forgery when writerUid does not match room.ownerFirebaseUid', async () => {
+      const { db, txMock } = makeMockDb({ initialRoom: baseActiveRoom });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: 'attacker-fuid',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('writer-not-owner');
+      // No presence read, no transaction — short-circuits to defend against
+      // presence-probing via spoofed ownerLeft writes.
+      expect(presenceChecker).not.toHaveBeenCalled();
+      expect(txMock.update).not.toHaveBeenCalled();
+    });
+
+    test('rejects forgery via the namespace-mismatch case (writerUid = ownerId-as-uniqueId)', async () => {
+      // The pre-denormalisation bug shape: an attacker (or buggy client)
+      // writes the room's uniqueId namespace value as the signal payload.
+      // Even though it matches room.ownerId, it does NOT match the Firebase
+      // Auth uid, so the rule-layer write would have been rejected upstream
+      // — but we still defend in depth at the orchestrator layer.
+      const { db, txMock } = makeMockDb({ initialRoom: baseActiveRoom });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: 'owner-1', // ownerId-as-uniqueId, NOT the firebaseUid
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('writer-not-owner');
+      expect(txMock.update).not.toHaveBeenCalled();
+    });
+
+    test('still skips attestation when writerUid is undefined (direct caller)', async () => {
+      // Backward compat: callers that invoke handleOwnerLeftSignal directly
+      // (not through the RTDB listener) don't have an attesting writer.
+      // The check must short-circuit so legit direct callers still work.
+      const { db, txMock } = makeMockDb({ initialRoom: baseActiveRoom });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        // no writerUid
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+      expect(txMock.update).toHaveBeenCalledTimes(1);
+    });
+
+    test('still skips attestation when writerUid is null', async () => {
+      const { db, txMock } = makeMockDb({ initialRoom: baseActiveRoom });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: null,
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+      expect(txMock.update).toHaveBeenCalledTimes(1);
+    });
+
+    test('does NOT query users-doc when room.ownerFirebaseUid is present', async () => {
+      const { db, userGetMock } = makeMockDb({
+        initialRoom: baseActiveRoom,
+        ownerUserDoc: { firebaseUid: 'owner-fuid-1' },
+      });
+      presenceChecker.mockResolvedValue(false);
+
+      await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: 'owner-fuid-1',
+        nowMs,
+      });
+
+      // Fast path: the denormalised field on the room shortcuts the lookup.
+      expect(userGetMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════
+  // Writer-attestation — legacy fallback (room missing ownerFirebaseUid)
+  // ═══════════════════════════════════════════════════════════════
+  //
+  // Rooms created before the denormalisation landed have no
+  // `ownerFirebaseUid`. The orchestrator falls back to reading
+  // `users/{ownerId}.firebaseUid` for these. Once the cron-elim cluster's
+  // PR A4 deletes the staleRooms safety net AND enough time has passed
+  // that all live rooms have closed, the fallback can be deleted.
+
+  describe('writer-attestation — legacy fallback (room missing ownerFirebaseUid)', () => {
+    const legacyRoom = { ...baseActiveRoom };
+    delete legacyRoom.ownerFirebaseUid;
+
+    test('proceeds when writerUid matches the looked-up users.firebaseUid', async () => {
+      const { db, txMock, userGetMock } = makeMockDb({
+        initialRoom: legacyRoom,
+        ownerUserDoc: { firebaseUid: 'looked-up-fuid' },
+      });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: 'looked-up-fuid',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+      expect(txMock.update).toHaveBeenCalledTimes(1);
+      // Fallback path: the user doc IS queried.
+      expect(userGetMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('rejects forgery when writerUid does not match looked-up firebaseUid', async () => {
+      const { db, txMock } = makeMockDb({
+        initialRoom: legacyRoom,
+        ownerUserDoc: { firebaseUid: 'looked-up-fuid' },
+      });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: 'attacker-fuid',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('writer-not-owner');
+      expect(presenceChecker).not.toHaveBeenCalled();
+      expect(txMock.update).not.toHaveBeenCalled();
+    });
+
+    test('rejects when user doc is missing (cannot attest)', async () => {
+      // Defensive: legacy room with no ownerFirebaseUid AND owner's user doc
+      // doesn't exist (orphaned room). Treating this as "skip attestation"
+      // would re-open the forgery vector — reject as writer-not-owner.
+      const { db, txMock } = makeMockDb({
+        initialRoom: legacyRoom,
+        ownerUserDoc: null, // user doc missing
+      });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: 'any-fuid',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('writer-not-owner');
+      expect(presenceChecker).not.toHaveBeenCalled();
+      expect(txMock.update).not.toHaveBeenCalled();
+    });
+
+    test('rejects when user doc exists but firebaseUid field is missing', async () => {
+      // Corrupt user doc — has the doc shell but no firebaseUid (shouldn't
+      // happen but defend anyway). Same outcome as a missing doc.
+      const { db, txMock } = makeMockDb({
+        initialRoom: legacyRoom,
+        ownerUserDoc: { someOtherField: 'value' }, // no firebaseUid
+      });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: 'any-fuid',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('writer-not-owner');
+      expect(txMock.update).not.toHaveBeenCalled();
+    });
+
+    test('rejects when user doc firebaseUid is an empty string', async () => {
+      const { db, txMock } = makeMockDb({
+        initialRoom: legacyRoom,
+        ownerUserDoc: { firebaseUid: '' }, // empty string — not a valid uid
+      });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: '',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('writer-not-owner');
+      expect(txMock.update).not.toHaveBeenCalled();
+    });
+
+    test('rejects when ownerFirebaseUid is present but empty string (treats as missing)', async () => {
+      // Edge case: someone wrote `ownerFirebaseUid: ''` to the room. Empty
+      // string is not a valid uid — must fall through to the lookup path
+      // (which will also fail here because no user doc is provided).
+      const { db } = makeMockDb({
+        initialRoom: { ...baseActiveRoom, ownerFirebaseUid: '' },
+        ownerUserDoc: null,
+      });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        writerUid: 'any-fuid',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.NOOP);
+      expect(result.reason).toBe('writer-not-owner');
+    });
+
+    test('still skips attestation when writerUid is undefined (legacy room, direct caller)', async () => {
+      // Direct callers without an attesting writer are accepted regardless
+      // of legacy/fast-path state — same skip applies.
+      const { db, txMock, userGetMock } = makeMockDb({
+        initialRoom: legacyRoom,
+        ownerUserDoc: { firebaseUid: 'whatever' },
+      });
+      presenceChecker.mockResolvedValue(false);
+
+      const result = await handleOwnerLeftSignal({
+        db,
+        presenceChecker,
+        roomId: 'room-1',
+        nowMs,
+      });
+
+      expect(result.action).toBe(OWNER_LEFT_ACTION.CLOSE_IMMEDIATE);
+      expect(txMock.update).toHaveBeenCalledTimes(1);
+      // Fast bail before fallback: undefined writerUid means we never look
+      // up the user doc either.
+      expect(userGetMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/firestore.rules
+++ b/firestore.rules
@@ -198,12 +198,31 @@ service cloud.firestore {
       // be used here because it reads `resource.data` (only valid
       // for update/read) — create-time the new doc is at
       // `request.resource.data`.
+      //
+      // Cron-elim PR A0 — `ownerFirebaseUid` is bound to
+      // `request.auth.uid` (the Firebase Auth uid baked into the
+      // server-signed JWT). The owner-left RTDB listener attests
+      // ownerLeft signals against this field; binding it to the
+      // signed JWT uid here makes it unspoofable.
+      //
+      // The `.get(field, request.auth.uid)` default is deliberate —
+      // legacy app versions (pre-cron-elim) don't write the field
+      // and we cannot break their createRoom path until Play Store
+      // and App Store rollout completes. Field-missing → default
+      // matches itself → passes; field-present-and-matching →
+      // passes; field-present-and-forged → fails. Forgery is closed
+      // in both branches; the orchestrator's legacy-fallback path
+      // handles rooms that arrive without the field. Follow-up PR
+      // (after rollout) tightens this to a strict
+      // `get('ownerFirebaseUid', '') == request.auth.uid`.
       allow create: if request.auth != null
         && request.resource.data.get('cohort', '')
             == request.auth.token.get('cohort', 'minor')
         && (request.resource.data.get('cohort', '') == 'adult'
             || request.resource.data.get('cohort', '') == 'minor')
-        && string(callerUniqueId()) == request.resource.data.ownerId;
+        && string(callerUniqueId()) == request.resource.data.ownerId
+        && request.resource.data.get('ownerFirebaseUid', request.auth.uid)
+            == request.auth.uid;
 
       // POST-LOCKDOWN (PR #858 server-authz cutover, this PR): client-side
       // room-doc UPDATEs are denied. ALL room-doc mutations now route through

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/RoomRepository.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/repository/RoomRepository.kt
@@ -28,6 +28,7 @@ interface RoomRepository {
     suspend fun createRoom(
         name: String,
         ownerId: String,
+        ownerFirebaseUid: String,
         cohort: String,
     ): Resource<String>
 

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/home/HomeViewModel.kt
@@ -404,7 +404,16 @@ class HomeViewModel(
                 else -> COHORT_MINOR
             }
 
-        when (val result = roomRepository.createRoom(name, userId, cohort)) {
+        // Cron-elim PR A0 — pass the Firebase Auth uid alongside the
+        // Firestore uniqueId. firestore.rules binds `ownerFirebaseUid` to
+        // `request.auth.uid` (unspoofable), and the owner-left RTDB
+        // listener attests signals against this field. Empty fallback if
+        // the user is somehow authenticated-without-firebaseUid (shouldn't
+        // happen — currentFirebaseUid returns auth.currentUser.uid which is
+        // present iff the user is signed in — but defends against an
+        // impossible-but-defensible NPE).
+        val ownerFirebaseUid = authRepository.currentFirebaseUid ?: ""
+        when (val result = roomRepository.createRoom(name, userId, ownerFirebaseUid, cohort)) {
             is Resource.Success -> {
                 logI(TAG, "Room created: id=${result.data}")
                 _uiState.update { it.copy(isLoading = false, createdRoomId = result.data) }

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosRoomRepositoryImpl.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosRoomRepositoryImpl.kt
@@ -76,6 +76,7 @@ class IosRoomRepositoryImpl(
     override suspend fun createRoom(
         name: String,
         ownerId: String,
+        ownerFirebaseUid: String,
         cohort: String,
     ): Resource<String> =
         firebaseCall("Failed to create room") {
@@ -92,6 +93,13 @@ class IosRoomRepositoryImpl(
                     "id" to roomId,
                     "name" to name,
                     "ownerId" to ownerId,
+                    // Cron-elim PR A0 — denormalised Firebase Auth uid of
+                    // the room owner. Bound to request.auth.uid by the
+                    // firestore.rules rooms-create rule and read by the
+                    // owner-left RTDB listener to attest signals. Two
+                    // identity namespaces exist for every user; ownerId is
+                    // the Firestore uniqueId, this is the Firebase Auth uid.
+                    "ownerFirebaseUid" to ownerFirebaseUid,
                     "state" to "ACTIVE",
                     "createdAt" to timestamp,
                     "participantIds" to listOf(ownerId),


### PR DESCRIPTION
## Summary

- **Root-cause fix** for a bug in PR #997 that would have caused every production owner-left signal to be rejected as a forgery. The orchestrator was comparing `writerUid` (Firebase Auth uid, per the RTDB rule `newData.val() === auth.uid`) against `room.ownerId` (Firestore uniqueId) — two different identity namespaces that never match in production. Existing tests didn't catch it because every fixture used the same string for both values.
- **Denormalise** `ownerFirebaseUid` onto the room doc at create-time. `firestore.rules` binds it to `request.auth.uid` (unspoofable — the JWT is server-signed). Orchestrator compares `writerUid` against this field directly. Legacy rooms fall back to a `users/{ownerId}.firebaseUid` lookup during transition.
- **Lenient Firestore rule** during rollout: `get('ownerFirebaseUid', request.auth.uid) == request.auth.uid` — accepts missing (legacy app versions), accepts matching (new clients), rejects forged. A follow-up PR (queued as Task #7) tightens to strict empty-default once Play Store + App Store rollout completes.

## Why the denormalisation

Per operator decision 2026-06-04 — denormalised both IDs on rooms (Option 3 from the namespace-mismatch triage). Avoids per-signal server-side `firebaseUid → uniqueId` lookup on the hot path. Server-derivation via JWT happens at create-time once.

## Test coverage

- **+13 orchestrator tests** covering both fast and fallback paths, including the namespace-swap regression guard (the exact pre-fix bug shape). Pre-existing `writer-uid spoof prevention` describe block deleted because it pinned the broken behaviour as a contract.
- **+1 room-rules test** pinning the new bind clause.
- **+2 RoomRepositoryImpl tests** pinning the field is stamped and that `ownerId` and `ownerFirebaseUid` aren't conflated.
- **+2 HomeViewModel tests** pinning the firebaseUid (not uniqueId) is passed in the new position + null-defence.

## Follow-up PRs (cron-elim cluster)

- PR A1 — Android-side `armOwnerLeftSignal` / `cancelOwnerLeftSignal` wiring (passes the now-known-correct `currentFirebaseUid`).
- PR A2 — iOS real impl.
- PR A3 — Web (if applicable).
- PR A4 — Delete `staleRooms` cron once all platforms ship.
- PR A0.tighten — strict Firestore rule (post-rollout).

## Test plan

- [x] Express tests: 11,408 pass (was 11,400 before: 13 new -5 removed +0 net = 8 net).
- [x] Kotlin unit tests (`testDevDebugUnitTest` + `:shared:jvmTest`) pass.
- [x] ktlint relative — clean.
- [x] detekt — 0 code smells.
- [x] `:shared:compileKotlinIosArm64` — succeeds.
- [x] Pre-push Sonar — quality gate passed.
- [ ] CI green on all required checks.
- [ ] Code-reviewer agent zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)