### PR TITLE
feat(rooms): RTDB owner-left signal — Android wiring + iOS stub (cron-elim A1)

### DIFF
--- a/app/src/androidTest/java/com/shyden/shytalk/fake/FakePresenceService.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/fake/FakePresenceService.kt
@@ -22,4 +22,11 @@ class FakePresenceService : PresenceService {
     ): Boolean = false
 
     override val roomEvents: Flow<RoomEvent> = MutableSharedFlow()
+
+    override fun armOwnerLeftSignal(
+        roomId: String,
+        ownerFirebaseUid: String,
+    ) { /* no-op */ }
+
+    override fun cancelOwnerLeftSignal() { /* no-op */ }
 }

--- a/app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt
@@ -39,6 +39,13 @@ class RtdbPresenceService(
     private var currentRoomId: String? = null
     private var currentUserId: String? = null
 
+    // Cron-elim A1 — owner-left signal state. Separate from currentRoomId/
+    // currentUserId because non-owners also call setPresence but only owners
+    // arm the signal; the reconnect listener guards re-arm by checking
+    // currentOwnerRoomId.
+    private var currentOwnerRoomId: String? = null
+    private var currentOwnerFirebaseUid: String? = null
+
     private var presenceListener: ValueEventListener? = null
     private var eventsListener: ValueEventListener? = null
     private var connectedListener: ValueEventListener? = null
@@ -66,15 +73,25 @@ class RtdbPresenceService(
         presenceRef.setValue(true)
         presenceRef.onDisconnect().removeValue()
 
-        // Re-establish presence on RTDB reconnect (onDisconnect may have fired during a blip)
+        // Re-establish presence on RTDB reconnect (onDisconnect may have fired during a blip).
+        // Cron-elim A1 — also re-arms the owner-left signal when this client
+        // is the owner of this room. Owner-left signals fire only on the
+        // owner-leaves-room transition, but a transient disconnect-reconnect
+        // blip during owner-attendance must not leave the signal disarmed.
         val connectedRef = db.getReference(".info/connected")
         connectedListener =
             object : ValueEventListener {
                 override fun onDataChange(snapshot: DataSnapshot) {
                     val connected = snapshot.getValue(Boolean::class.java) ?: false
-                    if (connected && currentRoomId == roomId && currentUserId == userId) {
-                        presenceRef.setValue(true)
-                        presenceRef.onDisconnect().removeValue()
+                    if (!connected || currentRoomId != roomId || currentUserId != userId) return
+                    presenceRef.setValue(true)
+                    presenceRef.onDisconnect().removeValue()
+                    val ownerFuid = currentOwnerFirebaseUid
+                    if (currentOwnerRoomId == roomId && ownerFuid != null) {
+                        val ownerLeftRef = db.getReference("ownerLeft/$roomId")
+                        ownerLeftRef.onDisconnect().cancel()
+                        ownerLeftRef.setValue(ownerFuid)
+                        ownerLeftRef.onDisconnect().setValue(ownerFuid)
                     }
                 }
 
@@ -155,6 +172,12 @@ class RtdbPresenceService(
     }
 
     override fun removePresence() {
+        // Cron-elim A1 — always cancel the owner-left signal first so every
+        // removePresence callsite (5+ in ActiveRoomManager) gets owner-left
+        // cancel "for free" without per-callsite churn. Safe no-op when no
+        // signal is armed.
+        cancelOwnerLeftSignal()
+
         val roomId = currentRoomId ?: return
         val userId = currentUserId ?: return
 
@@ -196,6 +219,64 @@ class RtdbPresenceService(
             Log.w(TAG, "isUserPresent check failed: ${e.message}")
             false
         }
+
+    override fun armOwnerLeftSignal(
+        roomId: String,
+        ownerFirebaseUid: String,
+    ) {
+        // Replace-roomId idempotency: if a prior signal is armed for a
+        // different room, cancel it first. Otherwise the stale signal would
+        // fire when the connection drops, attempting to close a room the
+        // owner already cleanly left.
+        if (currentOwnerRoomId != null && currentOwnerRoomId != roomId) {
+            cancelOwnerLeftSignal()
+        }
+
+        // Sequence MUST be: onDisconnect().cancel() → setValue → onDisconnect().setValue
+        //
+        // The cancel-first defends against a stale onDisconnect registration
+        // from a prior arm on the same path (e.g. re-entering the same room
+        // after a forced re-arm). Skipping cancel-first leaves both
+        // registrations queued and BOTH fire on disconnect, producing
+        // duplicate signal entries — the server-side listener handles
+        // dedup but spamming RTDB is wasteful.
+        //
+        // The setValue (vs no immediate write) ensures the entry exists
+        // BEFORE the onDisconnect arms — otherwise the server-side
+        // child_added listener would only fire on the next disconnect, not
+        // on the arm. The arm SHOULD trigger a child_added (the server
+        // orchestrator's TOCTOU re-check resolves: owner is still present,
+        // NOOP), making the listener path exercise itself on every arm.
+        val ownerLeftRef = db.getReference("ownerLeft/$roomId")
+        ownerLeftRef.onDisconnect().cancel()
+        ownerLeftRef.setValue(ownerFirebaseUid)
+        ownerLeftRef.onDisconnect().setValue(ownerFirebaseUid)
+
+        currentOwnerRoomId = roomId
+        currentOwnerFirebaseUid = ownerFirebaseUid
+
+        Log.d(TAG, "armOwnerLeftSignal room=$roomId")
+    }
+
+    override fun cancelOwnerLeftSignal() {
+        val roomId = currentOwnerRoomId ?: return
+
+        // Symmetric cleanup: cancel the onDisconnect FIRST (so a race-y
+        // disconnect during this method doesn't fire the stale signal),
+        // then remove the entry. Reverse order would briefly leave the
+        // entry present with no onDisconnect, but a disconnect at THAT
+        // moment would leave the entry orphaned — the server listener
+        // would still process it, but on a normal cancel-path that's a
+        // spurious signal.
+        val ownerLeftRef = db.getReference("ownerLeft/$roomId")
+        ownerLeftRef.onDisconnect().cancel()
+        ownerLeftRef.removeValue()
+
+        currentOwnerRoomId = null
+        currentOwnerFirebaseUid = null
+
+        Log.d(TAG, "cancelOwnerLeftSignal room=$roomId")
+    }
 
     /**
      * Detect owner absence from the presence set and call the Worker API.

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -31,6 +31,7 @@ import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -5214,4 +5215,188 @@ class RoomViewModelTest {
             // uiState should remain without a kick-sourced error (no error propagation by design)
             assertFalse(viewModel.uiState.value.wasKicked)
         }
+
+    // region cron-elim A1 — owner-left signal wiring
+
+    @Test
+    fun `ownerReturn arms owner-left signal with currentFirebaseUid not currentUserId`() =
+        roomTest {
+            // Cron-elim A1 — the architect explicitly noted (cron-elim A0
+            // discovery, PR #1001) that two identity namespaces exist for
+            // every user. The RTDB ownerLeft rule forces auth.uid namespace
+            // (`newData.val() === auth.uid`), so the signal value MUST be
+            // currentFirebaseUid (Firebase Auth uid), NOT currentUserId
+            // (Firestore uniqueId). Pin the namespace-correct call here so
+            // a future refactor that swaps the two would trip this test.
+            val testFirebaseUid = "firebase-uid-12345"
+            every { authRepository.currentFirebaseUid } returns testFirebaseUid
+            coEvery { roomRepository.setOwnerReturned(any(), any()) } returns Resource.Success(Unit)
+
+            emitRoomAsOwner(
+                TestData.createTestRoom(
+                    ownerId = currentUserId,
+                    state = RoomState.OWNER_AWAY,
+                    ownerLeftAt = System.currentTimeMillis() - 1_000,
+                ),
+            )
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.ownerReturn()
+            advanceUntilIdle()
+
+            // 3rd arg is the firebaseUid; assert exact value (not just any())
+            // to defend against position-swap or null-fallback regressions.
+            verify { presenceService.armOwnerLeftSignal("room-1", testFirebaseUid) }
+            // Negative-pin sanity: the two identity values are distinct in
+            // tests so a swap is observable, not vacuous.
+            assertTrue(currentUserId != testFirebaseUid)
+        }
+
+    @Test
+    fun `ownerReturn does NOT arm owner-left signal when currentFirebaseUid is null`() =
+        roomTest {
+            // Defensive: an authenticated owner SHOULD always have a non-null
+            // firebaseUid (currentFirebaseUid returns auth.currentUser.uid),
+            // but defend in case of a transient auth-state hole. The
+            // maybeArmOwnerLeftSignal helper bails out instead of writing
+            // an empty-string entry (which the rule would reject anyway via
+            // the strict-when-present clause, but no point arming a guaranteed-
+            // reject signal — wastes an RTDB round trip).
+            every { authRepository.currentFirebaseUid } returns null
+            coEvery { roomRepository.setOwnerReturned(any(), any()) } returns Resource.Success(Unit)
+
+            emitRoomAsOwner(
+                TestData.createTestRoom(
+                    ownerId = currentUserId,
+                    state = RoomState.OWNER_AWAY,
+                    ownerLeftAt = System.currentTimeMillis() - 1_000,
+                ),
+            )
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.ownerReturn()
+            advanceUntilIdle()
+
+            verify(exactly = 0) { presenceService.armOwnerLeftSignal(any(), any()) }
+        }
+
+    @Test
+    fun `ownerReturn does NOT arm owner-left signal when currentFirebaseUid is empty string`() =
+        roomTest {
+            // Empty string is treated identically to null at the helper
+            // boundary — the rule-layer would technically accept it (lenient
+            // default fires when field equals "" which won't equal auth.uid)
+            // but more importantly the orchestrator's fast-path requires a
+            // non-empty string. Sending "" guarantees a wasted round trip
+            // followed by a rejected signal. Cleaner to short-circuit at the
+            // client.
+            every { authRepository.currentFirebaseUid } returns ""
+            coEvery { roomRepository.setOwnerReturned(any(), any()) } returns Resource.Success(Unit)
+
+            emitRoomAsOwner(
+                TestData.createTestRoom(
+                    ownerId = currentUserId,
+                    state = RoomState.OWNER_AWAY,
+                    ownerLeftAt = System.currentTimeMillis() - 1_000,
+                ),
+            )
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.ownerReturn()
+            advanceUntilIdle()
+
+            verify(exactly = 0) { presenceService.armOwnerLeftSignal(any(), any()) }
+        }
+
+    @Test
+    fun `ownerReturn re-establishes presence BEFORE arming owner-left signal`() =
+        roomTest {
+            // Ordering matters: setPresence registers the connected-listener
+            // that re-arms the owner-left signal on RTDB reconnect blips
+            // (see RtdbPresenceService line 71+). If arm fired before
+            // setPresence, the reconnect-re-arm path wouldn't be wired and a
+            // disconnect-during-arm window would lose the signal silently.
+            every { authRepository.currentFirebaseUid } returns "firebase-uid-12345"
+            coEvery { roomRepository.setOwnerReturned(any(), any()) } returns Resource.Success(Unit)
+
+            emitRoomAsOwner(
+                TestData.createTestRoom(
+                    ownerId = currentUserId,
+                    state = RoomState.OWNER_AWAY,
+                    ownerLeftAt = System.currentTimeMillis() - 1_000,
+                ),
+            )
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.ownerReturn()
+            advanceUntilIdle()
+
+            verifyOrder {
+                presenceService.setPresence("room-1", currentUserId)
+                presenceService.armOwnerLeftSignal("room-1", "firebase-uid-12345")
+            }
+        }
+
+    @Test
+    fun `non-owner does NOT arm owner-left signal (guard at maybeArmOwnerLeftSignal)`() =
+        roomTest {
+            // The maybeArmOwnerLeftSignal helper short-circuits when
+            // room.ownerId != userId. Without this guard, every participant
+            // would write to ownerLeft/{roomId} — the rule would reject
+            // the writes (it requires auth.uid match, and the orchestrator
+            // would reject as writer-not-owner), but spamming RTDB with
+            // guaranteed-reject writes is wasteful. Pin the client-side
+            // guard so a refactor that drops it surfaces here, not at
+            // production load.
+            every { authRepository.currentFirebaseUid } returns "firebase-uid-12345"
+            // Note: ownerReturn() early-returns when room.ownerId != userId
+            // (line 1453), so we can't use ownerReturn() to test the
+            // helper's non-owner guard. Instead, observe the participant-
+            // join path — emit a room where currentUser is a participant
+            // but NOT the owner.
+            emitRoomAsAttendee()
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            // setPresence fires for the attendee join. The maybeArmOwnerLeftSignal
+            // guard should bail out without arming.
+            verify { presenceService.setPresence(any(), any()) }
+            verify(exactly = 0) { presenceService.armOwnerLeftSignal(any(), any()) }
+        }
+
+    @Test
+    fun `disconnectFromRoom calls removePresence which auto-cancels owner-left signal`() =
+        roomTest {
+            // The auto-cancel cascade — cancelOwnerLeftSignal lives inside
+            // removePresence (RtdbPresenceService cron-elim A1 change) so
+            // every removePresence callsite (5+ in ActiveRoomManager) gets
+            // owner-left cancel for free without per-callsite churn.
+            // This test asserts the ViewModel-side wiring delegates to
+            // removePresence (and not an explicit cancelOwnerLeftSignal,
+            // which would be a double-cancel — harmless but uglier).
+            every { authRepository.currentFirebaseUid } returns "firebase-uid-12345"
+            emitRoomAsOwner()
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            // Trigger a disconnect path via room-closed (one of the
+            // disconnectFromRoom paths — handleRoomClosed at line 410).
+            roomFlow.value =
+                TestData.createTestRoom(
+                    ownerId = currentUserId,
+                    state = RoomState.CLOSED,
+                )
+            advanceUntilIdle()
+
+            verify { presenceService.removePresence() }
+            // We do NOT also call cancelOwnerLeftSignal directly — that
+            // would be a double-cancel. Pin the delegation contract.
+            verify(exactly = 0) { presenceService.cancelOwnerLeftSignal() }
+        }
+
+    // endregion
 }

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -5242,12 +5242,19 @@ class RoomViewModelTest {
             viewModel = createViewModel()
             advanceUntilIdle()
 
+            // handleFirstJoin auto-triggers ownerReturn when state is
+            // OWNER_AWAY — clear the mock call count so the verify below
+            // tests the EXPLICIT viewModel.ownerReturn() path in isolation.
+            // Without this, the verify would pass on the auto-fire alone
+            // and a broken explicit-call path would slip through.
+            io.mockk.clearMocks(presenceService, answers = false)
+
             viewModel.ownerReturn()
             advanceUntilIdle()
 
             // 3rd arg is the firebaseUid; assert exact value (not just any())
             // to defend against position-swap or null-fallback regressions.
-            verify { presenceService.armOwnerLeftSignal("room-1", testFirebaseUid) }
+            verify(exactly = 1) { presenceService.armOwnerLeftSignal("room-1", testFirebaseUid) }
             // Negative-pin sanity: the two identity values are distinct in
             // tests so a swap is observable, not vacuous.
             assertTrue(currentUserId != testFirebaseUid)
@@ -5275,6 +5282,11 @@ class RoomViewModelTest {
             )
             viewModel = createViewModel()
             advanceUntilIdle()
+
+            // Clear auto-triggered call counts before the explicit test.
+            // The null-firebaseUid guard MUST apply on the explicit path —
+            // not just on the auto-trigger path — so isolate the call.
+            io.mockk.clearMocks(presenceService, answers = false)
 
             viewModel.ownerReturn()
             advanceUntilIdle()
@@ -5305,6 +5317,10 @@ class RoomViewModelTest {
             viewModel = createViewModel()
             advanceUntilIdle()
 
+            // Clear before explicit ownerReturn — same reason as the null
+            // test: pin the explicit-call guard, not the auto-fire guard.
+            io.mockk.clearMocks(presenceService, answers = false)
+
             viewModel.ownerReturn()
             advanceUntilIdle()
 
@@ -5332,6 +5348,10 @@ class RoomViewModelTest {
             viewModel = createViewModel()
             advanceUntilIdle()
 
+            // Clear before explicit ownerReturn — the verifyOrder below
+            // tests the ordering of the EXPLICIT call's two operations.
+            io.mockk.clearMocks(presenceService, answers = false)
+
             viewModel.ownerReturn()
             advanceUntilIdle()
 
@@ -5339,6 +5359,43 @@ class RoomViewModelTest {
                 presenceService.setPresence("room-1", currentUserId)
                 presenceService.armOwnerLeftSignal("room-1", "firebase-uid-12345")
             }
+        }
+
+    @Test
+    fun `owner first-join arms owner-left signal via handleFirstJoin path`() =
+        roomTest {
+            // Cron-elim A1 — coverage for site 941 (joinRoom → handleFirstJoin).
+            // This is the primary production flow for an owner: room created,
+            // owner becomes participant, RoomViewModel observes the room and
+            // calls handleFirstJoin → joinRoom → setPresence + arm. Without
+            // this test, the only arm-covered path was ownerReturn — a
+            // refactor that broke the first-join arm would ship undetected.
+            val testFirebaseUid = "firebase-uid-12345"
+            every { authRepository.currentFirebaseUid } returns testFirebaseUid
+
+            // Default emitRoomAsOwner: ACTIVE state, owner in participantIds.
+            // Natural flow triggers handleFirstJoin (not ownerReturn).
+            emitRoomAsOwner()
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            verify { presenceService.armOwnerLeftSignal("room-1", testFirebaseUid) }
+        }
+
+    @Test
+    fun `owner first-join does NOT arm with empty firebaseUid (defensive helper guard)`() =
+        roomTest {
+            // Defensive coverage: the maybeArmOwnerLeftSignal helper guard
+            // must apply at the joinRoom site (941), not just at ownerReturn.
+            // If the guard were inline-only at one site, a future inlining
+            // refactor that copied an unguarded version into the other sites
+            // would slip through.
+            every { authRepository.currentFirebaseUid } returns ""
+            emitRoomAsOwner()
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            verify(exactly = 0) { presenceService.armOwnerLeftSignal(any(), any()) }
         }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/data/remote/PresenceService.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/data/remote/PresenceService.kt
@@ -20,4 +20,36 @@ interface PresenceService {
 
     /** Room events observed via Firebase RTDB listeners. */
     val roomEvents: Flow<RoomEvent>
+
+    /**
+     * Arm the RTDB owner-left signal for [roomId]. The owner client writes its
+     * Firebase Auth uid to `ownerLeft/{roomId}` and registers an onDisconnect
+     * to re-write the same value when the connection drops. The server-side
+     * owner-left listener consumes the signal and decides whether to close
+     * or transition the room (see express-api/src/utils/owner-left-*.js).
+     *
+     * **[ownerFirebaseUid] must be the Firebase Auth uid (`auth.currentUser.uid`),
+     * NOT the Firestore uniqueId.** The RTDB security rule on `ownerLeft/{roomId}`
+     * enforces `newData.val() === auth.uid`, and the server-side orchestrator
+     * compares the signal value against `room.ownerFirebaseUid` (denormalised
+     * via PR #1001 / cron-elim A0). Passing the uniqueId here would cause the
+     * rule-layer write to fail silently and the feature to never trigger.
+     *
+     * Idempotent on replace: calling with a new [roomId] cancels any prior arm
+     * before installing the new one. Safe to call from the room-entry path on
+     * every setPresence — non-owners' calls are gated by the caller via an
+     * `if (room.ownerId == userId)` check.
+     */
+    fun armOwnerLeftSignal(
+        roomId: String,
+        ownerFirebaseUid: String,
+    )
+
+    /**
+     * Cancel any armed RTDB owner-left signal. Called from
+     * [removePresence] automatically (so all room-exit paths get cancel for
+     * free), and explicitly from the disconnect-from-room flow. No-op if no
+     * signal is currently armed.
+     */
+    fun cancelOwnerLeftSignal()
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/feature/room/RoomViewModel.kt
@@ -428,6 +428,9 @@ class RoomViewModel(
     }
 
     private fun disconnectFromRoom() {
+        // presenceService.removePresence() auto-cancels any armed owner-left
+        // signal (cron-elim A1) so non-owners and owners alike get cleanup
+        // for free; no explicit cancelOwnerLeftSignal call needed here.
         voiceService.leaveChannel()
         presenceService.removePresence()
         roomLifecycleManager.untrackRoom()
@@ -435,6 +438,24 @@ class RoomViewModel(
         viewModelScope.launch {
             userRepository.updateProfile(userId, mapOf("currentRoomId" to null))
         }
+    }
+
+    /**
+     * Arm the RTDB owner-left signal when this client is the room owner.
+     * Cron-elim A1 — paired with [PresenceService.setPresence] on every
+     * room-entry path. The signal MUST carry the Firebase Auth uid (NOT
+     * the Firestore uniqueId — see PR #1001 / cron-elim A0 for the
+     * namespace separation lesson). No-op for non-owners and for the
+     * impossible-but-defensible null-firebaseUid case.
+     */
+    private fun maybeArmOwnerLeftSignal(
+        room: ChatRoom,
+        userId: String,
+    ) {
+        if (room.ownerId != userId) return
+        val firebaseUid = authRepository.currentFirebaseUid.orEmpty()
+        if (firebaseUid.isEmpty()) return
+        presenceService.armOwnerLeftSignal(roomId, firebaseUid)
     }
 
     /** Returns true if user was kicked/removed and collection should stop. */
@@ -478,6 +499,7 @@ class RoomViewModel(
                     }
                     roomRepository.joinRoom(roomId, userId)
                     presenceService.setPresence(roomId, userId)
+                    maybeArmOwnerLeftSignal(room, userId)
                 }
                 return false
             }
@@ -914,7 +936,10 @@ class RoomViewModel(
                 }
             }
             // RTDB presence (independent)
-            launch { presenceService.setPresence(roomId, userId) }
+            launch {
+                presenceService.setPresence(roomId, userId)
+                if (room != null) maybeArmOwnerLeftSignal(room, userId)
+            }
             // User profile update (different document)
             launch { userRepository.updateProfile(userId, mapOf("currentRoomId" to roomId)) }
             // Voice join — biggest bottleneck, runs in parallel with writes
@@ -1464,6 +1489,9 @@ class RoomViewModel(
                 // fired while WiFi was off, removing the owner's presence entry.
                 // Without this, other phones keep detecting the owner as absent.
                 presenceService.setPresence(roomId, userId)
+                // Cron-elim A1 — re-arm owner-left after owner-returned. The
+                // function-entry guard at the top already confirmed ownership.
+                maybeArmOwnerLeftSignal(room, userId)
 
                 // Re-establish room tracking if lost during disconnect
                 if (!roomLifecycleManager.isInRoom(roomId)) {

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosRtdbServices.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosRtdbServices.kt
@@ -1,6 +1,7 @@
 package com.shyden.shytalk.data.remote
 
 import com.shyden.shytalk.core.util.currentTimeMillis
+import com.shyden.shytalk.core.util.logD
 import com.shyden.shytalk.core.util.logW
 import com.shyden.shytalk.data.repository.TypingRepository
 import dev.gitlive.firebase.database.FirebaseDatabase
@@ -149,6 +150,31 @@ class IosPresenceServiceImpl(
         } catch (e: Exception) {
             false
         }
+
+    // ── Owner-left signal (NO-OP STUB — real iOS impl in PR A2) ──
+    //
+    // The Android RtdbPresenceService implements arm/cancel against the
+    // RTDB `ownerLeft/{roomId}` path with an onDisconnect trigger; the
+    // server-side listener (express-api/src/utils/owner-left-*.js) consumes
+    // these signals and decides whether to close or transition the room.
+    // Until PR A2 lands the real iOS impl, owner-left signal arming on iOS
+    // is a no-op — the legacy lazy-reap path (PR #996) still handles iOS-
+    // owned rooms via on-access reaping with the 5-min grace window.
+
+    override fun armOwnerLeftSignal(
+        roomId: String,
+        ownerFirebaseUid: String,
+    ) {
+        // TODO(PR A2): real iOS impl via database.reference("ownerLeft/$roomId")
+        //   .setValue(ownerFirebaseUid) + .onDisconnect().setValue(ownerFirebaseUid)
+        logD(TAG, "armOwnerLeftSignal STUB (iOS A2 pending) roomId=$roomId")
+    }
+
+    override fun cancelOwnerLeftSignal() {
+        // TODO(PR A2): real iOS impl via database.reference("ownerLeft/$currentOwnerRoomId")
+        //   .onDisconnect().cancel() + .removeValue()
+        logD(TAG, "cancelOwnerLeftSignal STUB (iOS A2 pending)")
+    }
 }
 
 // ── ConversationWebSocketService (RTDB) ─────────────────────────

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosRtdbServices.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosRtdbServices.kt
@@ -180,6 +180,15 @@ class IosPresenceServiceImpl(
     override fun cancelOwnerLeftSignal() {
         // TODO(PR A2): real iOS impl via database.reference("ownerLeft/$currentOwnerRoomId")
         //   .onDisconnect().cancel() + .removeValue()
+        //
+        // IMPORTANT — A2 implementor: this method is called UNCONDITIONALLY
+        // from removePresence (line 113) BEFORE the currentRoomId null
+        // check. The implementation MUST guard internally on
+        // currentOwnerRoomId (mirror Android RtdbPresenceService.cancelOwnerLeftSignal
+        // line 261: `val roomId = currentOwnerRoomId ?: return`). Without
+        // the internal guard, calling cancelOwnerLeftSignal when no signal
+        // is armed will attempt to write to ownerLeft/null and corrupt
+        // the path. Safe today because this is a no-op log; trap for A2.
         logD(TAG, "cancelOwnerLeftSignal STUB (iOS A2 pending)")
     }
 }

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosRtdbServices.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosRtdbServices.kt
@@ -104,6 +104,13 @@ class IosPresenceServiceImpl(
     }
 
     override fun removePresence() {
+        // Cron-elim A1 — pin the auto-cancel contract NOW so PR A2 only has
+        // to implement the function body. cancelOwnerLeftSignal is a no-op
+        // stub today; once A2 makes it real, this call site already wires
+        // the contract that "every removePresence cleans up owner-left."
+        // Mirrors the Android RtdbPresenceService.removePresence pattern.
+        cancelOwnerLeftSignal()
+
         val roomId = currentRoomId ?: return
         val userId = currentUserId ?: return
         scope.launch {


### PR DESCRIPTION
## Summary

- **Adds `armOwnerLeftSignal` + `cancelOwnerLeftSignal` to PresenceService.** Real Android impl writes the Firebase Auth uid to `ownerLeft/{roomId}` with an `onDisconnect()` arm; the server-side listener (PR #997) consumes the signal and decides whether to close or transition the room. iOS gets an explicit no-op stub — real iOS impl is PR A2 (queued).
- **API names the namespace explicitly:** the parameter is `ownerFirebaseUid` (NOT `ownerUid`) to bake the cron-elim A0 lesson (PR #1001) into the contract. ShyTalk has two identity namespaces per user (Firestore uniqueId vs Firebase Auth uid); the RTDB rule on `ownerLeft/{roomId}` forces `auth.uid` namespace, so the caller MUST pass `currentFirebaseUid`.
- **Auto-cancel via `removePresence`:** `cancelOwnerLeftSignal` is called at the top of `RtdbPresenceService.removePresence` so all 5 ActiveRoomManager `removePresence` callsites get owner-left cleanup for free — zero per-callsite churn. `disconnectFromRoom` in RoomViewModel delegates the same way.
- **Cancel-first arm sequence + replace-roomId idempotency:** defends against stale `onDisconnect` registrations and against arming a new room while still armed for a different one.
- **Reconnect re-arm:** extended the existing `.info/connected` listener to also re-arm `ownerLeft` on RTDB reconnect blips, so a transient disconnect during owner-attendance doesn't silently disarm the signal.

## Why the helper

`maybeArmOwnerLeftSignal` in RoomViewModel centralizes (a) the owner check `room.ownerId == userId`, (b) the firebaseUid null/empty guard, and (c) the actual arm call. Three setPresence callsites (auto-rejoin, first-join, ownerReturn) call the helper, so a future bug fix only touches one place — and the L3 test only needs to verify the helper's contract.

## Tests (6 new in RoomViewModelTest)

| Test | Pins |
|---|---|
| `ownerReturn arms owner-left signal with currentFirebaseUid not currentUserId` | Namespace-swap regression guard (the exact A0 bug shape, prevented at the client) |
| `ownerReturn does NOT arm when currentFirebaseUid is null` | Defensive short-circuit; avoids guaranteed-reject RTDB writes |
| `ownerReturn does NOT arm when currentFirebaseUid is empty string` | Same as null path |
| `ownerReturn re-establishes presence BEFORE arming owner-left signal` | Order pin — the reconnect-re-arm path depends on setPresence's listener |
| `non-owner does NOT arm owner-left signal` | Helper guard at maybeArmOwnerLeftSignal |
| `disconnectFromRoom calls removePresence which auto-cancels owner-left signal` | Delegation pin — no double-cancel |

## Follow-up PRs (cron-elim cluster)

- **PR A2 — iOS real impl** (Task #4): replace iOS no-op stub with GitLive Firebase RTDB impl; also fix pre-existing `IosRtdbServices.kt:146 isUserPresent` stub per `feedback-fix-pre-existing-and-new-same`.
- **PR A3 — Web** (Task #5): investigate whether web clients can enter rooms; if yes, mirror.
- **PR A4 — Delete staleRooms cron** (Task #6): destructive — requires operator sign-off. Once all platforms verify in prod.
- **PR A0.tighten** (Task #7): strict Firestore rule after Play/App Store rollout.

## Test plan

- [x] `ktlint --relative` — clean
- [x] `:app:testDevDebugUnitTest` — RoomViewModelTest passes including 6 new tests
- [x] `:shared:jvmTest` — passes
- [x] `detekt` — 0 code smells
- [x] `:shared:compileKotlinIosArm64` — succeeds (iOS stub compiles)
- [x] Pre-push SonarCloud quality gate — passed
- [ ] CI green on all required checks
- [ ] Code-reviewer agent zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)