### PR TITLE
test(rooms): isolate explicit ownerReturn call from auto-trigger (A1 followup)

### DIFF
--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -2495,6 +2495,24 @@ class RoomViewModelTest {
             advanceUntilIdle()
             every { roomLifecycleManager.isInRoom("room-1") } returns false
 
+            // handleFirstJoin auto-triggers ownerReturn when state=OWNER_AWAY,
+            // so without clearMocks the verifies below would pass on the
+            // auto-fire alone — a broken explicit-call path would slip
+            // through. Clear the call counts (preserving stub answers) so
+            // the verify pins the EXPLICIT viewModel.ownerReturn() path.
+            io.mockk.clearMocks(
+                presenceService,
+                roomRepository,
+                roomLifecycleManager,
+                answers = false,
+            )
+            // Restore the suspendable setOwnerReturned answer that
+            // clearMocks dropped (answers = false preserves only the
+            // every{} stubs, not coEvery{} ones in pre-test setup).
+            coEvery { roomRepository.setOwnerReturned(any(), any()) } returns Resource.Success(Unit)
+            // isInRoom was set above; the explicit-call path reads it again.
+            every { roomLifecycleManager.isInRoom("room-1") } returns false
+
             viewModel.ownerReturn()
             advanceUntilIdle()
 
@@ -2516,6 +2534,14 @@ class RoomViewModelTest {
             viewModel = createViewModel()
             advanceUntilIdle()
 
+            // Same isolation pattern as the prior test — the OWNER_AWAY
+            // state auto-triggers ownerReturn during the createViewModel
+            // flow observation, so the verifies below would vacuously
+            // pass without clearing the call counts.
+            io.mockk.clearMocks(presenceService, roomRepository, answers = false)
+            coEvery { roomRepository.setOwnerReturned(any(), any()) } returns Resource.Success(Unit)
+            every { roomLifecycleManager.isInRoom("room-1") } returns true
+
             viewModel.ownerReturn()
             advanceUntilIdle()
 
@@ -2536,6 +2562,12 @@ class RoomViewModelTest {
             emitRoomAsOwner(room)
             advanceUntilIdle()
             joinedFlow.value = false
+
+            // Clear voiceService call count before the explicit ownerReturn
+            // — the auto-trigger from handleFirstJoin would also have
+            // attempted voice rejoin during setup.
+            io.mockk.clearMocks(voiceService, roomRepository, answers = false)
+            coEvery { roomRepository.setOwnerReturned(any(), any()) } returns Resource.Success(Unit)
 
             viewModel.ownerReturn()
             advanceUntilIdle()
@@ -2559,6 +2591,13 @@ class RoomViewModelTest {
             // Grant audio permission so ownerReturn will enable mic
             viewModel.onAudioPermissionResult(true)
             advanceUntilIdle()
+
+            // Clear voiceService call count before the explicit ownerReturn
+            // — the auto-trigger from handleFirstJoin would have called
+            // setMicrophoneEnabled during setup since joinedFlow was true
+            // when the audio-permission grant fired.
+            io.mockk.clearMocks(voiceService, roomRepository, answers = false)
+            coEvery { roomRepository.setOwnerReturned(any(), any()) } returns Resource.Success(Unit)
 
             viewModel.ownerReturn()
             advanceUntilIdle()

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -25,6 +25,7 @@ import com.shyden.shytalk.data.repository.StorageRepository
 import com.shyden.shytalk.data.repository.UserRepository
 import com.shyden.shytalk.testutil.MainDispatcherRule
 import com.shyden.shytalk.testutil.TestData
+import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifyOrder
@@ -2498,20 +2499,17 @@ class RoomViewModelTest {
             // handleFirstJoin auto-triggers ownerReturn when state=OWNER_AWAY,
             // so without clearMocks the verifies below would pass on the
             // auto-fire alone — a broken explicit-call path would slip
-            // through. Clear the call counts (preserving stub answers) so
-            // the verify pins the EXPLICIT viewModel.ownerReturn() path.
-            io.mockk.clearMocks(
+            // through. Reset call counts (answers=false preserves all
+            // every{}/coEvery{} stubs uniformly) so the verifies pin the
+            // EXPLICIT viewModel.ownerReturn() path. The roomRepository
+            // is relaxed so setOwnerReturned returns a default value
+            // post-clear without an explicit re-stub.
+            clearMocks(
                 presenceService,
                 roomRepository,
                 roomLifecycleManager,
                 answers = false,
             )
-            // Restore the suspendable setOwnerReturned answer that
-            // clearMocks dropped (answers = false preserves only the
-            // every{} stubs, not coEvery{} ones in pre-test setup).
-            coEvery { roomRepository.setOwnerReturned(any(), any()) } returns Resource.Success(Unit)
-            // isInRoom was set above; the explicit-call path reads it again.
-            every { roomLifecycleManager.isInRoom("room-1") } returns false
 
             viewModel.ownerReturn()
             advanceUntilIdle()
@@ -2537,10 +2535,8 @@ class RoomViewModelTest {
             // Same isolation pattern as the prior test — the OWNER_AWAY
             // state auto-triggers ownerReturn during the createViewModel
             // flow observation, so the verifies below would vacuously
-            // pass without clearing the call counts.
-            io.mockk.clearMocks(presenceService, roomRepository, answers = false)
-            coEvery { roomRepository.setOwnerReturned(any(), any()) } returns Resource.Success(Unit)
-            every { roomLifecycleManager.isInRoom("room-1") } returns true
+            // pass without clearing the call counts. Stubs are preserved.
+            clearMocks(presenceService, roomRepository, answers = false)
 
             viewModel.ownerReturn()
             advanceUntilIdle()
@@ -2565,9 +2561,9 @@ class RoomViewModelTest {
 
             // Clear voiceService call count before the explicit ownerReturn
             // — the auto-trigger from handleFirstJoin would also have
-            // attempted voice rejoin during setup.
-            io.mockk.clearMocks(voiceService, roomRepository, answers = false)
-            coEvery { roomRepository.setOwnerReturned(any(), any()) } returns Resource.Success(Unit)
+            // attempted voice rejoin during setup. Stubs preserved by
+            // answers=false; relaxed mocks handle their return values.
+            clearMocks(voiceService, roomRepository, answers = false)
 
             viewModel.ownerReturn()
             advanceUntilIdle()
@@ -2595,9 +2591,8 @@ class RoomViewModelTest {
             // Clear voiceService call count before the explicit ownerReturn
             // — the auto-trigger from handleFirstJoin would have called
             // setMicrophoneEnabled during setup since joinedFlow was true
-            // when the audio-permission grant fired.
-            io.mockk.clearMocks(voiceService, roomRepository, answers = false)
-            coEvery { roomRepository.setOwnerReturned(any(), any()) } returns Resource.Success(Unit)
+            // when the audio-permission grant fired. Stubs preserved.
+            clearMocks(voiceService, roomRepository, answers = false)
 
             viewModel.ownerReturn()
             advanceUntilIdle()
@@ -3127,7 +3122,7 @@ class RoomViewModelTest {
             advanceUntilIdle()
 
             // Reset voice mock call count from setup
-            io.mockk.clearMocks(voiceService, answers = false)
+            clearMocks(voiceService, answers = false)
             every { voiceService.speakingUsers } returns speakingFlow
             every { voiceService.isJoined } returns joinedFlow
             every { voiceService.error } returns voiceErrorFlow

--- a/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/feature/room/RoomViewModelTest.kt
@@ -3121,11 +3121,11 @@ class RoomViewModelTest {
             emitRoomAsOwner(TestData.createTestRoom(ownerId = currentUserId, seats = seats))
             advanceUntilIdle()
 
-            // Reset voice mock call count from setup
+            // Reset voice mock call count from setup. answers=false
+            // preserves all stubs (incl. the speakingUsers / isJoined /
+            // error flow stubs set in @Before at lines 90-92), so no
+            // re-stubs needed.
             clearMocks(voiceService, answers = false)
-            every { voiceService.speakingUsers } returns speakingFlow
-            every { voiceService.isJoined } returns joinedFlow
-            every { voiceService.error } returns voiceErrorFlow
 
             viewModel.toggleSelfMute(0)
             advanceUntilIdle()


### PR DESCRIPTION
## Summary

Follow-up to PR #1002 (cron-elim A1). Round-2 reviewer surfaced that 4 pre-existing `ownerReturn` tests at lines 2487-2568 have the same vacuous-test pattern as A1's region — `handleFirstJoin` auto-triggers `ownerReturn()` when state == OWNER_AWAY, so the explicit `viewModel.ownerReturn()` call's behavior wasn't actually under test.

Per `feedback-fix-pre-existing-and-new-same` (HARD GLOBAL): pre-existing bugs surfaced in review must be fixed in a follow-up PR **this session**.

## Tests fixed

- `ownerReturn - re-establishes presence when not in room`
- `ownerReturn - always re-establishes presence even when already in room`
- `ownerReturn - rejoins voice when not joined`
- `ownerReturn - enables mic when already joined`

## Fix pattern (mirrors PR #1002's A1 region)

```kotlin
io.mockk.clearMocks(<services-with-verifies>, answers = false)
// re-stub any coEvery{} answers that clearMocks dropped
coEvery { roomRepository.setOwnerReturned(any(), any()) } returns Resource.Success(Unit)
viewModel.ownerReturn()  // explicit call now isolated from auto-trigger
```

`clearMocks(..., answers = false)` preserves `every{}` stubs (so flows keep emitting, relaxed defaults still work) while resetting call counts. The subsequent `verify` is satisfied only by the explicit call's behavior, not the auto-trigger's.

## Test plan

- [x] `:app:testDevDebugUnitTest` — all 4 tests still pass with restructured isolation
- [x] `:shared:compileKotlinIosArm64` — passes
- [x] `detekt` — clean
- [x] `ktlint --relative` — clean
- [x] Pre-push SonarCloud quality gate — passed
- [ ] CI green on all required checks
- [ ] Code-reviewer agent zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)