### PR TITLE
fix(rooms): Android isUserPresent — drop dead Boolean check that broke cross-platform presence

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt
@@ -213,8 +213,23 @@ class RtdbPresenceService(
         userId: String,
     ): Boolean =
         try {
+            // Cron-elim A2 followup — was previously
+            //   snapshot.exists() && snapshot.getValue(Boolean::class.java) == true
+            // The Boolean arm broke cross-platform presence checks: this client
+            // writes Boolean `true` via setValue(true) on line 66, but the iOS
+            // client writes a Long via setValue(currentTimeMillis()) — so an
+            // Android-checking-iOS-user invocation got
+            //   true && (null == true) = false
+            // because getValue(Boolean) returns null for a Long-valued node.
+            // Net effect: ActiveRoomManager.kt:493's grace-period TOCTOU
+            // re-check was a no-op when an Android client checked an iOS
+            // user's presence — brief mobile-network blips that should be
+            // filtered by the re-check still triggered spurious setOwnerAway
+            // and removeDisconnectedUser actions for iOS users in mixed-
+            // platform rooms. snapshot.exists() alone is type-agnostic and
+            // matches the iOS impl shape introduced in cron-elim A2.
             val snapshot = db.getReference("rooms/$roomId/presence/$userId").get().await()
-            snapshot.exists() && snapshot.getValue(Boolean::class.java) == true
+            snapshot.exists()
         } catch (e: Exception) {
             Log.w(TAG, "isUserPresent check failed: ${e.message}")
             false

--- a/app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt
@@ -216,7 +216,7 @@ class RtdbPresenceService(
             // Cron-elim A2 followup — was previously
             //   snapshot.exists() && snapshot.getValue(Boolean::class.java) == true
             // The Boolean arm broke cross-platform presence checks: this client
-            // writes Boolean `true` via setValue(true) on line 66, but the iOS
+            // writes Boolean `true` via setValue(true) on line 73, but the iOS
             // client writes a Long via setValue(currentTimeMillis()) — so an
             // Android-checking-iOS-user invocation got
             //   true && (null == true) = false


### PR DESCRIPTION
## Summary

Surfaced by PR #1004 (cron-elim A2) round-3 review and verified in round-4 analysis. The Android `RtdbPresenceService.isUserPresent` had a cross-platform correctness bug — `getValue(Boolean::class.java) == true` returns false for iOS-written presence nodes (Long timestamp), making the grace-period TOCTOU re-check in `ActiveRoomManager.kt:493` a no-op for iOS users in mixed-platform rooms.

Per `feedback-fix-pre-existing-and-new-same`, this ships this session as the prescribed follow-up PR.

## The bug

Pre-fix:

```kotlin
snapshot.exists() && snapshot.getValue(Boolean::class.java) == true
```

Android writes Boolean `true` (`setValue(true)`, line 66). iOS writes a Long (`setValue(currentTimeMillis())`, IosPresenceServiceImpl line 96). For Android-checking-iOS-user:

- `snapshot.exists()` = true
- `getValue(Boolean::class.java)` = null (Long cannot coerce to Boolean)
- expression = `true && (null == true)` = `true && false` = **false**

Android isUserPresent returned false for every iOS-written presence node, even when present.

## Production impact

`ActiveRoomManager.kt:493` uses `isUserPresent` as a grace-period TOCTOU re-check before triggering disconnection actions. For Android-checking-iOS-user the re-check was a no-op, so brief WiFi blips on iOS-side that should have been filtered out actually triggered spurious setOwnerAway / removeDisconnectedUser actions for iOS users.

## Fix

```kotlin
snapshot.exists()
```

Type-agnostic, handles either data shape. Matches the iOS impl shape introduced in cron-elim A2.

## Follow-up still queued

The deeper anti-pattern (Android and iOS writing different data types at the same RTDB key) is not fixed here — that requires coordinated client deploys. Worth a future PR to harmonize via expect/actual or a shared constant.

## Test plan

- [x] testDevDebugUnitTest passes
- [x] compileKotlinIosArm64 passes
- [x] detekt clean
- [x] ktlint clean
- [x] Pre-push SonarCloud quality gate passed
- [ ] CI green
- [ ] Reviewer ZERO findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)