### PR TITLE
test(rooms): regression-guard tests for isUserPresent cross-platform fix (A2 followup3)

### DIFF
--- a/app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt
@@ -213,8 +213,23 @@ class RtdbPresenceService(
         userId: String,
     ): Boolean =
         try {
+            // Cron-elim A2 followup — was previously
+            //   snapshot.exists() && snapshot.getValue(Boolean::class.java) == true
+            // The Boolean arm broke cross-platform presence checks: this client
+            // writes Boolean `true` via setValue(true) on line 66, but the iOS
+            // client writes a Long via setValue(currentTimeMillis()) — so an
+            // Android-checking-iOS-user invocation got
+            //   true && (null == true) = false
+            // because getValue(Boolean) returns null for a Long-valued node.
+            // Net effect: ActiveRoomManager.kt:493's grace-period TOCTOU
+            // re-check was a no-op when an Android client checked an iOS
+            // user's presence — brief mobile-network blips that should be
+            // filtered by the re-check still triggered spurious setOwnerAway
+            // and removeDisconnectedUser actions for iOS users in mixed-
+            // platform rooms. snapshot.exists() alone is type-agnostic and
+            // matches the iOS impl shape introduced in cron-elim A2.
             val snapshot = db.getReference("rooms/$roomId/presence/$userId").get().await()
-            snapshot.exists() && snapshot.getValue(Boolean::class.java) == true
+            snapshot.exists()
         } catch (e: Exception) {
             Log.w(TAG, "isUserPresent check failed: ${e.message}")
             false

--- a/app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt
@@ -216,7 +216,7 @@ class RtdbPresenceService(
             // Cron-elim A2 followup — was previously
             //   snapshot.exists() && snapshot.getValue(Boolean::class.java) == true
             // The Boolean arm broke cross-platform presence checks: this client
-            // writes Boolean `true` via setValue(true) on line 66, but the iOS
+            // writes Boolean `true` via setValue(true) on line 73, but the iOS
             // client writes a Long via setValue(currentTimeMillis()) — so an
             // Android-checking-iOS-user invocation got
             //   true && (null == true) = false

--- a/app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt
+++ b/app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt
@@ -213,23 +213,8 @@ class RtdbPresenceService(
         userId: String,
     ): Boolean =
         try {
-            // Cron-elim A2 followup — was previously
-            //   snapshot.exists() && snapshot.getValue(Boolean::class.java) == true
-            // The Boolean arm broke cross-platform presence checks: this client
-            // writes Boolean `true` via setValue(true) on line 73, but the iOS
-            // client writes a Long via setValue(currentTimeMillis()) — so an
-            // Android-checking-iOS-user invocation got
-            //   true && (null == true) = false
-            // because getValue(Boolean) returns null for a Long-valued node.
-            // Net effect: ActiveRoomManager.kt:493's grace-period TOCTOU
-            // re-check was a no-op when an Android client checked an iOS
-            // user's presence — brief mobile-network blips that should be
-            // filtered by the re-check still triggered spurious setOwnerAway
-            // and removeDisconnectedUser actions for iOS users in mixed-
-            // platform rooms. snapshot.exists() alone is type-agnostic and
-            // matches the iOS impl shape introduced in cron-elim A2.
             val snapshot = db.getReference("rooms/$roomId/presence/$userId").get().await()
-            snapshot.exists()
+            snapshotIndicatesPresent(snapshot)
         } catch (e: Exception) {
             Log.w(TAG, "isUserPresent check failed: ${e.message}")
             false
@@ -324,3 +309,17 @@ class RtdbPresenceService(
         }
     }
 }
+
+/**
+ * Translates an RTDB DataSnapshot into a "user is present" Boolean.
+ *
+ * Pre-cron-elim-A2-followup2 (PR #1005), this was inline as
+ *   snapshot.exists() && snapshot.getValue(Boolean::class.java) == true
+ * which broke for iOS-written presence nodes (Long timestamp instead of
+ * Boolean true) — see PR #1005's commit message for the production
+ * impact. Extracted as an internal top-level helper for direct unit-
+ * test coverage of the cross-platform regression — see
+ * `PresenceServiceTest.kt`. The helper is type-agnostic by design;
+ * snapshot.exists is true iff the path has any non-null value.
+ */
+internal fun snapshotIndicatesPresent(snapshot: DataSnapshot): Boolean = snapshot.exists()

--- a/app/src/test/java/com/shyden/shytalk/data/remote/PresenceServiceTest.kt
+++ b/app/src/test/java/com/shyden/shytalk/data/remote/PresenceServiceTest.kt
@@ -1,8 +1,12 @@
 package com.shyden.shytalk.data.remote
 
+import com.google.firebase.database.DataSnapshot
+import io.mockk.every
 import io.mockk.mockk
 import okhttp3.OkHttpClient
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -13,6 +17,9 @@ import org.junit.Test
  * Firebase SDK calls that require the Firebase emulator for integration testing.
  * These unit tests verify the service can be created and basic API contracts hold.
  * Full integration testing is done via E2E tests (connectedDebugAndroidTest).
+ *
+ * The snapshotIndicatesPresent helper IS unit-tested below — its DataSnapshot
+ * arg is a plain interface that mockk can fully simulate, no emulator needed.
  */
 class PresenceServiceTest {
     private lateinit var httpClient: OkHttpClient
@@ -54,4 +61,59 @@ class PresenceServiceTest {
         presenceService.removePresence()
         presenceService.removePresence()
     }
+
+    // region snapshotIndicatesPresent — cron-elim A2 followup3 regression guards
+
+    @Test
+    fun `snapshotIndicatesPresent returns true for Boolean-valued node (Android-written presence)`() {
+        // Android RtdbPresenceService.setPresence writes Boolean true at line 73:
+        //   presenceRef.setValue(true)
+        // This test pins that a Boolean-valued node is correctly recognised
+        // as present — the Android-to-Android happy path.
+        val snapshot = mockk<DataSnapshot>(relaxed = true)
+        every { snapshot.exists() } returns true
+        every { snapshot.getValue(Boolean::class.java) } returns true
+        assertTrue(snapshotIndicatesPresent(snapshot))
+    }
+
+    @Test
+    fun `snapshotIndicatesPresent returns true for Long-valued node (iOS-written presence) — cross-platform regression guard`() {
+        // Cross-platform regression guard for the bug fixed in PR #1005:
+        // iOS IosPresenceServiceImpl.setPresence writes a Long via
+        //   ref.setValue(currentTimeMillis())
+        // The pre-fix expression was
+        //   snapshot.exists() && snapshot.getValue(Boolean::class.java) == true
+        // which evaluated to false for a Long-valued node (getValue(Boolean)
+        // returns null on a Long, null == true is false). The fix uses
+        // snapshot.exists() alone — type-agnostic. This test would have
+        // failed BEFORE the fix and now passes; a future refactor that
+        // re-introduces the Boolean type check would fail this test.
+        val snapshot = mockk<DataSnapshot>(relaxed = true)
+        every { snapshot.exists() } returns true
+        every { snapshot.getValue(Boolean::class.java) } returns null
+        assertTrue(snapshotIndicatesPresent(snapshot))
+    }
+
+    @Test
+    fun `snapshotIndicatesPresent returns false when node does not exist`() {
+        // The "user is absent" path — RTDB removed the presence entry
+        // (either via removePresence or via onDisconnect after a true
+        // disconnect). snapshot.exists() = false → return false.
+        val snapshot = mockk<DataSnapshot>(relaxed = true)
+        every { snapshot.exists() } returns false
+        assertFalse(snapshotIndicatesPresent(snapshot))
+    }
+
+    @Test
+    fun `snapshotIndicatesPresent returns false for non-existent node even when Boolean would coerce to true`() {
+        // Belt-and-braces: even if a non-existent node somehow returned
+        // Boolean true on getValue (shouldn't happen but defend), exists()
+        // being false is the gate. The helper is exists-only by design.
+        val snapshot = mockk<DataSnapshot>(relaxed = true)
+        every { snapshot.exists() } returns false
+        every { snapshot.getValue(Boolean::class.java) } returns true
+        assertFalse(snapshotIndicatesPresent(snapshot))
+    }
+
+    // endregion
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #1005 (cron-elim A2 followup2). PR #1005's reviewer flagged that no unit test covered `RtdbPresenceService.isUserPresent` — the pre-fix cross-platform bug would not have been caught by the existing test suite. Per CLAUDE.md (*"When fixing a bug, always write tests for it"*) the gap needed filling in a same-session follow-up PR per `feedback-fix-pre-existing-and-new-same`.

**This PR is stacked on PR #1005** — base is the A2-followup2 branch, so the diff against `main` includes #1005's fix until #1005 merges (at which point this PR auto-rebases against the new main).

## Changes

- Extract the snapshot interpretation from `isUserPresent` into a top-level `internal fun snapshotIndicatesPresent(snapshot: DataSnapshot): Boolean`. The Firebase async call stays in `isUserPresent`; the testable logic is the helper.
- Update `isUserPresent` to delegate to the helper.
- Add 4 unit tests in `PresenceServiceTest.kt`.

## The load-bearing test

```kotlin
@Test
fun `snapshotIndicatesPresent returns true for Long-valued node (iOS-written presence) — cross-platform regression guard`() {
    val snapshot = mockk<DataSnapshot>(relaxed = true)
    every { snapshot.exists() } returns true
    every { snapshot.getValue(Boolean::class.java) } returns null
    assertTrue(snapshotIndicatesPresent(snapshot))
}
```

This is the regression guard for the bug fixed in PR #1005. Before the fix, `getValue(Boolean) == true` evaluated to `(null == true)` = `false` on a Long-valued node. After the fix, `snapshot.exists()` returns true regardless of value type. A future refactor that re-introduces a Boolean type-check would fail this test.

## Test plan

- [x] `:app:testDevDebugUnitTest --tests PresenceServiceTest` — 9 tests pass (5 existing + 4 new)
- [x] `:shared:compileKotlinIosArm64` passes
- [x] `detekt` clean
- [x] `ktlint` clean
- [x] Pre-push SonarCloud quality gate passed
- [ ] CI green
- [ ] Reviewer ZERO findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)