### PR TITLE
feat(rooms): iOS RTDB reconnect re-arm for presence + owner-left signal (cron-elim A2 followup)

### DIFF
--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosRtdbServices.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosRtdbServices.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.retry
 import kotlinx.coroutines.launch
 
 private const val TAG = "RtdbServices"
@@ -81,7 +82,20 @@ class IosPresenceServiceImpl(
     private val database: FirebaseDatabase,
 ) : PresenceService {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    // @Volatile (via @kotlin.concurrent.Volatile per CLAUDE.md's KMP iOS
+    // compatibility rules) on state fields read by the reconnect-listener
+    // coroutine on Dispatchers.Default and written by caller-thread
+    // setPresence/removePresence/armOwnerLeftSignal/cancelOwnerLeftSignal.
+    // Without these, plain-var visibility across threads is not guaranteed
+    // on Kotlin/Native. Android's analogous service uses Dispatchers.Main.
+    // immediate so all access is single-threaded; iOS uses Default for
+    // the Firebase write-path, which makes cross-thread reads of these
+    // fields possible.
+    @kotlin.concurrent.Volatile
     private var currentRoomId: String? = null
+
+    @kotlin.concurrent.Volatile
     private var currentUserId: String? = null
 
     // Cron-elim A2 — owner-left signal state. Separate from currentRoomId
@@ -89,7 +103,10 @@ class IosPresenceServiceImpl(
     // owners arm the signal; cancelOwnerLeftSignal guards internally on
     // currentOwnerRoomId so the unconditional call from removePresence is
     // safe when no signal is armed.
+    @kotlin.concurrent.Volatile
     private var currentOwnerRoomId: String? = null
+
+    @kotlin.concurrent.Volatile
     private var currentOwnerFirebaseUid: String? = null
 
     // Cron-elim A2 followup — connected-listener Job for the
@@ -133,10 +150,20 @@ class IosPresenceServiceImpl(
         // removing the presence entry AND the owner-left signal entry.
         // Re-establish both (gated by currentRoomId/UserId match so a
         // stale listener for a now-replaced room is a no-op).
+        //
+        // .retry { e -> e !is CancellationException } re-subscribes the
+        // Flow on any non-cancellation error (RTDB connection reset,
+        // transient Firebase IPC failure, etc), giving the listener the
+        // same resilience that Android's persistent addValueEventListener
+        // gets for free. Cancellation propagates normally so
+        // connectedJob.cancel() still terminates the coroutine.
         connectedJob =
             scope.launch {
-                try {
-                    database.reference(".info/connected").valueEvents.collect { snapshot ->
+                database
+                    .reference(".info/connected")
+                    .valueEvents
+                    .retry { e -> e !is CancellationException }
+                    .collect { snapshot ->
                         val connected = snapshot.value<Boolean?>() ?: false
                         if (!connected ||
                             currentRoomId != roomId ||
@@ -167,11 +194,6 @@ class IosPresenceServiceImpl(
                             logW(TAG, "reconnect re-arm inner failed: ${e.message}")
                         }
                     }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    logW(TAG, "connectedListener failed: ${e.message}")
-                }
             }
     }
 

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosRtdbServices.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosRtdbServices.kt
@@ -8,12 +8,14 @@ import dev.gitlive.firebase.database.FirebaseDatabase
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -90,6 +92,11 @@ class IosPresenceServiceImpl(
     private var currentOwnerRoomId: String? = null
     private var currentOwnerFirebaseUid: String? = null
 
+    // Cron-elim A2 followup — connected-listener Job for the
+    // .info/connected reconnect re-arm path. Cancelled in removePresence
+    // and replaced when setPresence is called for a different room.
+    private var connectedJob: Job? = null
+
     private val _roomEvents = MutableSharedFlow<RoomEvent>(extraBufferCapacity = 10)
 
     override val roomEvents: Flow<RoomEvent> = _roomEvents.asSharedFlow()
@@ -98,20 +105,13 @@ class IosPresenceServiceImpl(
         roomId: String,
         userId: String,
     ) {
-        // Cron-elim A2 gap: unlike Android RtdbPresenceService.setPresence
-        // (lines 81-102) which registers a .info/connected listener that
-        // re-arms BOTH presence AND the owner-left signal on RTDB
-        // reconnect blips, iOS has no such listener. Transient mobile-
-        // network drops (WiFi↔cellular handoffs, brief underground
-        // transit) on iOS-owned rooms will: fire the onDisconnect signal
-        // → server orchestrator processes → TOCTOU re-check sees owner
-        // re-present (owner just reconnected) → NOOP → signal cleared.
-        // The TOCTOU re-check mitigates correctness; the cost is one
-        // round-trip of spurious server work per reconnect blip. Adding
-        // the .info/connected listener requires also extending iOS
-        // basic-presence reconnect handling and is queued as a
-        // standalone follow-up (Task #9) per the architect blueprint
-        // scoping A2 to arm/cancel + isUserPresent.
+        // Cancel any prior connected-listener (re-entry for a different
+        // room). Setting currentRoomId/UserId BEFORE the listener
+        // launches means a stale fire from the old listener (between
+        // cancel-call and actual cancellation) would see mismatched
+        // state and skip — matches the Android safety pattern.
+        connectedJob?.cancel()
+
         currentRoomId = roomId
         currentUserId = userId
         scope.launch {
@@ -125,6 +125,54 @@ class IosPresenceServiceImpl(
                 logW(TAG, "setPresence failed: ${e.message}")
             }
         }
+
+        // Cron-elim A2 followup3 — RTDB reconnect re-arm listener.
+        // Mirrors the Android RtdbPresenceService.setPresence
+        // .info/connected pattern. On RTDB reconnect after a transient
+        // network blip the onDisconnect may have already fired,
+        // removing the presence entry AND the owner-left signal entry.
+        // Re-establish both (gated by currentRoomId/UserId match so a
+        // stale listener for a now-replaced room is a no-op).
+        connectedJob =
+            scope.launch {
+                try {
+                    database.reference(".info/connected").valueEvents.collect { snapshot ->
+                        val connected = snapshot.value<Boolean?>() ?: false
+                        if (!connected ||
+                            currentRoomId != roomId ||
+                            currentUserId != userId
+                        ) {
+                            return@collect
+                        }
+                        try {
+                            val presenceRef =
+                                database.reference("rooms/$roomId/presence/$userId")
+                            presenceRef.setValue(currentTimeMillis())
+                            presenceRef.onDisconnect().removeValue()
+                            val ownerFuid = currentOwnerFirebaseUid
+                            if (currentOwnerRoomId == roomId && ownerFuid != null) {
+                                val ownerLeftRef =
+                                    database.reference("ownerLeft/$roomId")
+                                ownerLeftRef.onDisconnect().cancel()
+                                ownerLeftRef.setValue(ownerFuid)
+                                ownerLeftRef.onDisconnect().setValue(ownerFuid)
+                            }
+                            logD(TAG, "reconnect re-armed room=$roomId")
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            // Individual re-arm failure shouldn't kill the
+                            // listener — next reconnect tick gets another
+                            // try. Log + continue collecting.
+                            logW(TAG, "reconnect re-arm inner failed: ${e.message}")
+                        }
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    logW(TAG, "connectedListener failed: ${e.message}")
+                }
+            }
     }
 
     override fun removePresence() {
@@ -134,6 +182,12 @@ class IosPresenceServiceImpl(
         // when no signal is armed (non-owners, post-cancel re-call, etc).
         // Mirrors the Android RtdbPresenceService.removePresence pattern.
         cancelOwnerLeftSignal()
+
+        // Cron-elim A2 followup3 — cancel the .info/connected listener
+        // so a reconnect after removePresence doesn't re-establish
+        // presence for a room the user has already left.
+        connectedJob?.cancel()
+        connectedJob = null
 
         val roomId = currentRoomId ?: return
         val userId = currentUserId ?: return


### PR DESCRIPTION
## Summary

Closes Task #9 — adds the `.info/connected` listener to iOS that PR #1004 (A2) explicitly scoped out. iOS now matches Android's reconnect-re-arm behavior: on RTDB reconnect after a transient network blip (WiFi↔cellular handoff, brief underground transit), both presence AND any armed owner-left signal are re-established.

## The gap being closed

Pre-this-PR iOS behavior on a transient disconnect:
1. `onDisconnect` fires → presence entry removed, owner-left signal entry written (for owner)
2. Reconnect a few seconds later → presence stays missing until next explicit `setPresence` call
3. Server-side owner-left orchestrator processes the signal → TOCTOU re-check sees owner re-present → NOOP → signal cleared

Net result: one wasted server round-trip per blip on iOS-owned rooms. Correctness was maintained by the server-side TOCTOU re-check (`feedback-sonar-cdn-403-rerun-not-code` doc explained this trade-off when shipping A2), but the spurious-fire cost adds up on mobile networks.

## Implementation

- **New state field** `connectedJob: Job?` tracks the listener coroutine so `removePresence` can cancel it cleanly. `setPresence` cancels any prior `connectedJob` before launching a new one (re-entry safety on room switch).

- **The listener** collects `.info/connected`'s `valueEvents` Flow. When the value becomes `true` (connected), the listener:
  1. Re-establishes presence (`setValue(currentTimeMillis())` + `onDisconnect().removeValue()`), gated by `currentRoomId/UserId` match so a stale listener for a now-replaced room no-ops.
  2. Re-arms the owner-left signal IF this client is the room owner (`currentOwnerRoomId == roomId && currentOwnerFirebaseUid != null`), using the same `cancel-first / setValue / onDisconnect-setValue` sequence as the original `armOwnerLeftSignal`.

- **Inner try/catch** around each re-arm attempt means a single Firebase exception doesn't kill the listener — next reconnect tick gets another try. Outer try/catch handles listener-level failures.

- **`removePresence`** cancels `connectedJob` and clears the reference, so a reconnect after the user has left the room doesn't spuriously re-establish presence.

## Test plan

- [x] `:shared:compileKotlinIosArm64` succeeds
- [x] `detekt` clean
- [x] `ktlint --relative` clean
- [x] Pre-push SonarCloud quality gate passed
- [ ] CI green on all required checks
- [ ] **Manual device test on iPhone** with mobile-network handoff (operator-side; cannot device-test from this context)
- [ ] Code-reviewer agent zero findings

## Cron-elim cluster — fully complete after this lands

- ✅ #1001 — A0 (server denormalisation + orchestrator fix)
- ✅ #1002 — A1 (Android wiring + iOS stub)
- ✅ #1003 — A1 followup (vacuous test fix)
- ✅ #1004 — A2 (iOS real impl + isUserPresent stub fix)
- ✅ #1006 — A2 followup3 (regression-guard tests)
- ✅ #1007 — A4 (cron deletion)
- 🚀 **#1008 (this PR) — A2 followup (iOS reconnect re-arm)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)