### PR TITLE
chore(deps): Kotlin 2.4.0 stable + detekt 2.0.0-alpha.3 (G001, G053)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ cucumberAndroid = "7.18.1"
 securityCrypto = "1.1.0"
 biometric = "1.4.0-alpha07"
 ktlint = "14.2.0"
-detekt = "1.23.8"
+detekt = "2.0.0-alpha.3"
 gitliveFirebase = "2.4.0"
 
 [libraries]
@@ -141,4 +141,4 @@ compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "composeMu
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 play-publisher = { id = "com.github.triplet.play", version = "4.0.0" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+detekt = { id = "dev.detekt", version.ref = "detekt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "9.2.1"
-kotlin = "2.4.0-RC2" # Beta required: K/N 2.3.x has AutoboxingTransformer crash blocking iOS linking. Upgrade to stable when 2.4.0 releases.
+kotlin = "2.4.0"
 composeMultiplatform = "1.10.3"
 composeBom = "2026.05.01"
 coreKtx = "1.18.0"


### PR DESCRIPTION
## Summary

**Scope expanded** from initial single-line Kotlin bump to include the detekt 2.0 migration required for Kotlin 2.4.0 compatibility. PR-A1 of the zero-gap roadmap.

- **G001:** Kotlin 2.4.0-RC2 → 2.4.0 stable. The original RC pin was workaround for K/N 2.3.x's AutoboxingTransformer crash. Stable on Maven Central confirms unblock.
- **G053 (introduced in this PR cluster):** detekt 1.23.8 → 2.0.0-alpha.3 via the new `dev.detekt` namespace. detekt 1.23.8's metadata ceiling is Kotlin 2.1.0; Kotlin 2.4.0 emits metadata 2.4.0 (cite: detekt#8865). The 2.0.x series migrated from `io.gitlab.arturbosch.detekt` to `dev.detekt` — both Gradle Plugin Portal and Maven Central host `dev.detekt:2.0.0-alpha.3`.

## Verification (the proper evidence channel)

The round-1 reviewer correctly flagged that my initial `--info` grep was the wrong evidence channel for detekt#8865 — the bug manifests as false-positive findings in `build/reports/detekt/detekt.xml`, not as stderr warnings. After migrating to `dev.detekt:2.0.0-alpha.3`:

```
./gradlew detekt → BUILD SUCCESSFUL
0 findings in build/reports/detekt/detekt.xml
Analyzed: 333 .kt files, 430 classes, 1627 functions, 3556 properties
Complexity: 6,373 mcc, 7,773 cognitive
```

## Compatibility table (corrected)

| Tool | Effective version | Compatible w/ Kotlin 2.4.0? |
|---|---|---|
| AGP | 9.2.1 | ✅ (requires ≥ 9.1.0) |
| Compose Multiplatform | 1.10.3 | ✅ (CMP 1.10.x supports Kotlin 2.1.0+) |
| Gradle | 9.5.1 | ✅ |
| detekt (Gradle plugin + bundled compiler) | 2.0.0-alpha.3 via `dev.detekt` | ⚠️ officially built for K 2.3.21; K 2.4.0 empirically verified via 0-findings local run with `allWarningsAsErrors = true` — formal table entry expected in a subsequent alpha (tracked as G053-followup) |
| ktlint CLI (CI gate, what `lint.yml` invokes) | 1.8.0 | ✅ (passes locally + CI) |
| ktlint Gradle plugin (internal binary) | 1.5.0 | ⚠️ See "Pre-existing G054" below |

## Pre-existing G054 — ktlint version drift (not introduced by this PR)

`./gradlew ktlintCheck` fails with 15+ "Unused import" findings, but verified PRE-EXISTING on main (`git checkout origin/main -- gradle/libs.versions.toml && ./gradlew ktlintCheck` shows the same failures). Root cause: CI gate uses ktlint CLI 1.8.0 via `ktlint --relative` (passes); Gradle plugin uses ktlint 1.5.0 internally (older `no-unused-imports` rule). CLAUDE.md's pre-push routine doesn't include `./gradlew ktlintCheck`, so the Gradle path has been silently failing.

Per [[feedback-fix-pre-existing-and-new-same]] this will be fixed in the immediate follow-up PR (PR-A1.5 / G054) in the same session.

## Test plan

- [x] `ktlint --relative` (CLI 1.8.0) — zero findings
- [x] `:app:compileDevDebugKotlin` — SUCCESS
- [x] `:shared:jvmTest` — SUCCESS
- [x] `:shared:testAndroidHostTest` — SUCCESS (28 tests)
- [x] `detekt` (dev.detekt:2.0.0-alpha.3) — SUCCESS, 0 findings in XML report
- [x] `:shared:compileKotlinIosArm64` — SUCCESS (the originally-blocked K/N target)
- [x] `:app:testDevDebugUnitTest` — SUCCESS
- [x] `allWarningsAsErrors = true` — clean
- [ ] CI gauntlet (verifies on push)

## Round-1 reviewer Important findings (acknowledged, queued)

- biometric 1.4.0-alpha07 pre-release pin → G002, separate PR
- konan cache cold-miss on first CI run → intentional design (libs.versions.toml hash invalidation), awareness only

🤖 Generated with [Claude Code](https://claude.com/claude-code)