### PR TITLE
test(push): BDD coverage for push permission denial UX (PR-B2)

### DIFF
--- a/app/src/androidTest/assets/features/push_permission.feature
+++ b/app/src/androidTest/assets/features/push_permission.feature
@@ -1,0 +1,48 @@
+Feature: Push permission denial UX
+  As a ShyTalk user whose OS notifications are blocked
+  I want a visible, persistent reminder with a one-tap path to Settings
+  So that I can re-enable notifications without hunting through the OS
+
+  Background:
+    Given I am authenticated as "test-user-1"
+    And I am on the main screen
+
+  Scenario: Banner visible when push permission is DENIED
+    Given the push permission state is "DENIED"
+    Then I should see the element with tag "pushDeniedBanner"
+
+  Scenario: Banner hidden when push permission is AUTHORIZED
+    Given the push permission state is "AUTHORIZED"
+    Then I should not see the element with tag "pushDeniedBanner"
+
+  Scenario: Banner hidden when push permission is NOT_DETERMINED
+    Given the push permission state is "NOT_DETERMINED"
+    Then I should not see the element with tag "pushDeniedBanner"
+
+  Scenario: Banner hidden when push permission is PROVISIONAL
+    Given the push permission state is "PROVISIONAL"
+    Then I should not see the element with tag "pushDeniedBanner"
+
+  Scenario: Tapping the banner invokes the system settings deeplink
+    Given the push permission state is "DENIED"
+    When I tap the element with tag "pushDeniedBanner"
+    Then the system settings deeplink should be invoked
+
+  Scenario: Banner disappears when user grants permission via Settings (late grant)
+    Given the push permission state is "DENIED"
+    And I should see the element with tag "pushDeniedBanner"
+    When the push permission state changes to "AUTHORIZED"
+    Then I should not see the element with tag "pushDeniedBanner"
+
+  Scenario: Banner appears when user revokes permission via Settings (late revoke)
+    Given the push permission state is "AUTHORIZED"
+    And I should not see the element with tag "pushDeniedBanner"
+    When the push permission state changes to "DENIED"
+    Then I should see the element with tag "pushDeniedBanner"
+
+  Scenario: Banner is non-dismissible — tapping it does NOT hide it
+    Given the push permission state is "DENIED"
+    And I should see the element with tag "pushDeniedBanner"
+    When I tap the element with tag "pushDeniedBanner"
+    Then I should see the element with tag "pushDeniedBanner"
+    And the system settings deeplink should be invoked

--- a/app/src/androidTest/java/com/shyden/shytalk/steps/PushPermissionSteps.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/steps/PushPermissionSteps.kt
@@ -1,0 +1,83 @@
+package com.shyden.shytalk.steps
+
+import com.shyden.shytalk.core.push.PushPermissionBridge
+import com.shyden.shytalk.core.push.PushPermissionState
+import com.shyden.shytalk.core.push.PushPermissionStore
+import com.shyden.shytalk.util.ComposeTestRuleHolder
+import io.cucumber.java.Before
+import io.cucumber.java.en.Given
+import io.cucumber.java.en.Then
+import io.cucumber.java.en.When
+import org.junit.Assert.assertTrue
+import java.util.concurrent.atomic.AtomicInteger
+
+class PushPermissionSteps {
+    private val rule get() = ComposeTestRuleHolder.rule
+
+    // Bridge call-count is the single state we care about across steps in a
+    // scenario. Reset in @Before so each scenario starts with a clean slate
+    // even though PushPermissionStore is a process-singleton.
+    private val deeplinkCalls = AtomicInteger(0)
+
+    private val countingBridge =
+        object : PushPermissionBridge {
+            override fun openSystemSettings() {
+                deeplinkCalls.incrementAndGet()
+            }
+        }
+
+    @Before
+    fun resetPushPermissionStore() {
+        // PushPermissionStore.resetForTesting() is `internal` (commonTest-only).
+        // Re-seed the public surface instead: revert to the cold-start state and
+        // overwrite any bridge a prior scenario registered. last-writer-wins
+        // semantics on registerBridge() is documented in the store class.
+        PushPermissionStore.updateState(PushPermissionState.NOT_DETERMINED)
+        PushPermissionStore.registerBridge(countingBridge)
+        deeplinkCalls.set(0)
+    }
+
+    @Given("the push permission state is {string}")
+    fun givenPushPermissionState(stateName: String) {
+        PushPermissionStore.updateState(parseState(stateName))
+        propagateStateChange()
+    }
+
+    @When("the push permission state changes to {string}")
+    fun whenPushPermissionStateChangesTo(stateName: String) {
+        PushPermissionStore.updateState(parseState(stateName))
+        propagateStateChange()
+    }
+
+    /**
+     * NavGraphTestHelper disables Compose's auto-advance clock so ViewModel-scoped
+     * coroutines don't run unless the test explicitly advances time. HomeViewModel
+     * collects PushPermissionStore.state inside `viewModelScope.launch`, so updates
+     * are invisible to the Compose tree until the clock ticks. Advancing 500ms
+     * mirrors the bootstrap advance in NavGraphTestHelper.launchNavGraph — long
+     * enough for the collector and one downstream recomposition, short enough
+     * that scenarios stay fast.
+     */
+    private fun propagateStateChange() {
+        rule.mainClock.advanceTimeBy(500)
+        rule.waitForIdle()
+    }
+
+    @Then("the system settings deeplink should be invoked")
+    fun thenDeeplinkInvoked() {
+        assertTrue(
+            "Expected PushPermissionBridge.openSystemSettings to be called at least once, " +
+                "got ${deeplinkCalls.get()}",
+            deeplinkCalls.get() >= 1,
+        )
+    }
+
+    private fun parseState(stateName: String): PushPermissionState =
+        when (stateName.uppercase()) {
+            "NOT_DETERMINED" -> PushPermissionState.NOT_DETERMINED
+            "AUTHORIZED" -> PushPermissionState.AUTHORIZED
+            "DENIED" -> PushPermissionState.DENIED
+            "PROVISIONAL" -> PushPermissionState.PROVISIONAL
+            else -> error("Unknown push permission state: $stateName")
+        }
+}

--- a/app/src/androidTest/java/com/shyden/shytalk/steps/PushPermissionSteps.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/steps/PushPermissionSteps.kt
@@ -29,23 +29,29 @@ class PushPermissionSteps {
     @Before
     fun resetPushPermissionStore() {
         // PushPermissionStore.resetForTesting() is `internal` (commonTest-only).
-        // Re-seed the public surface instead: revert to the cold-start state and
-        // overwrite any bridge a prior scenario registered. last-writer-wins
-        // semantics on registerBridge() is documented in the store class.
+        // Re-seed the public surface instead: revert to the cold-start state.
+        // Bridge registration is deferred to the state-setting steps so that
+        // last-writer-wins ordering is guaranteed even if a future test setup
+        // boots MainActivity (which itself calls registerBridge in onCreate at
+        // app/src/main/java/com/shyden/shytalk/MainActivity.kt:141). The
+        // current launchNavGraph path (setContent { NavGraph(...) }) does NOT
+        // run MainActivity, so this is defence-in-depth rather than a fix for
+        // an observable bug — but the cost is one line per Given/When step.
         PushPermissionStore.updateState(PushPermissionState.NOT_DETERMINED)
-        PushPermissionStore.registerBridge(countingBridge)
         deeplinkCalls.set(0)
     }
 
     @Given("the push permission state is {string}")
     fun givenPushPermissionState(stateName: String) {
         PushPermissionStore.updateState(parseState(stateName))
+        PushPermissionStore.registerBridge(countingBridge)
         propagateStateChange()
     }
 
     @When("the push permission state changes to {string}")
     fun whenPushPermissionStateChangesTo(stateName: String) {
         PushPermissionStore.updateState(parseState(stateName))
+        PushPermissionStore.registerBridge(countingBridge)
         propagateStateChange()
     }
 


### PR DESCRIPTION
## Summary
- New androidTest .feature file `push_permission.feature` — 8 scenarios covering visibility per state, deeplink-on-tap, late-grant/revoke transitions, non-dismissibility
- New `PushPermissionSteps.kt` with 3 step phrases + an AtomicInteger-counting `PushPermissionBridge` stub
- Closes gap **PR-B2** from the 33-PR zero-gap remediation roadmap (BDD coverage for the push-perm UX shipped in #1009 + #1010)

## Why this matters
The push-perm denial banner shipped in #1009 (iOS+shared) and #1010 (Android) had unit coverage (PushPermissionStoreTest, AndroidPushPermissionTest) but ZERO BDD/journey-walk coverage. Per `every-commit-tested-via-user-journeys`, runtime UX needs scenario-level tests — this fills that gap.

## Non-obvious decision
HomeViewModel collects `PushPermissionStore.state` inside `viewModelScope.launch { ... }` on Dispatchers.Main. The Compose test runner has `mainClock.autoAdvance = false` so that coroutine never runs unless time is advanced. Step impl explicitly calls `rule.mainClock.advanceTimeBy(500)` after each `updateState()` to ensure the collector fires and the banner actually updates — without this, late-grant/revoke scenarios would silently green without the banner having changed.

## Verification
- [x] ktlint clean
- [x] `./gradlew :app:compileDevDebugAndroidTestKotlin` clean
- [x] `./gradlew detekt` clean
- [x] SonarCloud quality gate passed (pre-push)
- [ ] `connectedDevDebugAndroidTest` — requires emulator + local stack; deferred to CI / follow-up journey-matrix run
- [ ] Real-device journey walk — deferred (test-only PR; the feature it covers is already shipped)

## Test plan
- [ ] CI checks pass
- [ ] code-reviewer agent finds zero blockers
- [ ] Manual: once any emulator is available, run `./gradlew connectedDevDebugAndroidTest` and confirm all 8 scenarios in `push_permission.feature` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)