### PR TITLE
chore(actions): SHA-pin remaining 8 third-party action refs + guard (PR-G1)

### DIFF
--- a/.github/actions/start-firebase-emulators/action.yml
+++ b/.github/actions/start-firebase-emulators/action.yml
@@ -9,7 +9,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cache Firebase Emulators
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.cache/firebase/emulators
         key: firebase-emulators-${{ runner.os }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Workflow concurrency groups are scoped or intentionally global
         run: bash scripts/check-workflow-concurrency-scoping.sh
 
+      - name: Third-party GitHub Actions are SHA-pinned (supply-chain)
+        run: bash scripts/check-action-shas.sh
+
       - name: HTML data-i18n keys all have JS translation definitions
         run: bash scripts/check-orphan-i18n-keys.sh
 

--- a/.github/workflows/manual-qa-matrix.yml
+++ b/.github/workflows/manual-qa-matrix.yml
@@ -68,10 +68,10 @@ jobs:
         # qa-runner workflow family beats partial SHA-pinning that
         # locks down only checkout while setup-node/cache/upload-artifact
         # stay on floating tags (per reviewer C3).
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
           cache: npm
@@ -92,7 +92,7 @@ jobs:
         working-directory: express-api
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
@@ -177,7 +177,7 @@ jobs:
         # diagnosis. The report itself records per-cell pass/fail/skip/
         # timeout so the operator can see exactly which cells broke.
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: qa-matrix-report-${{ inputs.target }}-${{ github.run_id }}
           path: express-api/qa-matrix-report.*

--- a/.github/workflows/qa-runner-driver-checks.yml
+++ b/.github/workflows/qa-runner-driver-checks.yml
@@ -50,12 +50,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
           cache: npm
@@ -77,7 +77,7 @@ jobs:
         working-directory: express-api
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}

--- a/scripts/check-action-shas.sh
+++ b/scripts/check-action-shas.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Reject any workflow / composite action that references a third-party
+# GitHub Action by mutable tag (e.g. @v6) rather than a 40-char commit
+# SHA. Background: a tag can be re-pointed by the action owner at any
+# time, so a tagged dependency is a supply-chain attack surface — the
+# code that runs in CI today may not be the code that ran yesterday.
+# SHA-pinning makes the dependency immutable and auditable.
+#
+# Local action references (./.github/actions/...) are exempt because
+# they version with the repo. The convention is to append `# vX.Y.Z`
+# after the SHA so a human reader can see the intent at a glance.
+#
+# Add new exemptions by extending ALLOW_RE below.
+
+set -euo pipefail
+
+# Match `uses: <owner>/<repo>[/path]@<ref>` lines. We accept either
+# (a) a local action (./...) or (b) a 40-char lowercase hex SHA.
+# Everything else is rejected.
+ALLOW_RE='uses:[[:space:]]+(\./|[A-Za-z0-9._/-]+@[0-9a-f]{40}([[:space:]]|$))'
+
+# Scan all workflow YAML and composite action YAML. Match both YAML
+# forms — the standalone `uses:` step and the inline list form
+# `- uses: ...` — by allowing an optional `- ` before `uses:`.
+hits=$(
+  grep -rEn --include='*.yml' --include='*.yaml' '^[[:space:]]*(-[[:space:]]+)?uses:' \
+    .github/workflows .github/actions 2>/dev/null \
+    | grep -vE "$ALLOW_RE" || true
+)
+
+if [ -n "$hits" ]; then
+  echo "::error::Third-party action references must be pinned to a 40-char commit SHA, not a tag."
+  echo "$hits"
+  echo ""
+  echo "Fix each line above by replacing the tag with the corresponding"
+  echo "commit SHA from the action's repo. Example:"
+  echo "  uses: actions/checkout@v6"
+  echo "  → uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6"
+  echo ""
+  echo "Get the SHA via:"
+  echo "  gh api repos/<owner>/<repo>/git/refs/tags/<tag> --jq '.object.sha'"
+  exit 1
+fi
+
+echo "✓ All third-party action references are SHA-pinned."

--- a/scripts/check-action-shas.sh
+++ b/scripts/check-action-shas.sh
@@ -10,21 +10,30 @@
 # they version with the repo. The convention is to append `# vX.Y.Z`
 # after the SHA so a human reader can see the intent at a glance.
 #
-# Add new exemptions by extending ALLOW_RE below.
+# Per-action exemptions: ALLOW_RE is a GLOBAL allow pattern, not a
+# per-action list. To allow a non-SHA ref for a specific trusted
+# action, add a second narrowing `grep -vE` pass below — do NOT
+# broaden ALLOW_RE itself, which would silently weaken the guard
+# across every action ref in the repo.
 
 set -euo pipefail
 
 # Match `uses: <owner>/<repo>[/path]@<ref>` lines. We accept either
-# (a) a local action (./...) or (b) a 40-char lowercase hex SHA.
-# Everything else is rejected.
-ALLOW_RE='uses:[[:space:]]+(\./|[A-Za-z0-9._/-]+@[0-9a-f]{40}([[:space:]]|$))'
+# (a) a local action (./...) or (b) a 40-char lowercase hex SHA
+# followed by any non-hex character (so `@SHA # v6` and `@SHA#v6`
+# both pass, while `@SHAabc...` — a hypothetical 41+ hex extension
+# of a future SHA-256-style attack vector — is still rejected).
+ALLOW_RE='uses:[[:space:]]+(\./|[A-Za-z0-9._/-]+@[0-9a-f]{40}([^0-9a-f]|$))'
 
-# Scan all workflow YAML and composite action YAML. Match both YAML
-# forms — the standalone `uses:` step and the inline list form
-# `- uses: ...` — by allowing an optional `- ` before `uses:`.
+# Scan workflow YAML, composite action YAML, and CodeQL config YAML.
+# CodeQL `uses:` semantics differ (they reference query packs, not
+# action repos), but the audit-surface argument is the same — any
+# tag-pointed reference is mutable. Match both YAML forms — the
+# standalone `uses:` step and the inline list form `- uses: ...` —
+# by allowing an optional `- ` before `uses:`.
 hits=$(
   grep -rEn --include='*.yml' --include='*.yaml' '^[[:space:]]*(-[[:space:]]+)?uses:' \
-    .github/workflows .github/actions 2>/dev/null \
+    .github/workflows .github/actions .github/codeql 2>/dev/null \
     | grep -vE "$ALLOW_RE" || true
 )
 


### PR DESCRIPTION
## Summary
- Pins last 8 third-party action refs to 40-char commit SHAs across `.github/workflows/` + `.github/actions/`
- Adds `scripts/check-action-shas.sh` — reusable guard that fails CI on any non-SHA-pinned third-party action ref (both `uses:` and `- uses:` YAML forms)
- Wires guard into `lint.yml` alongside existing `check-no-paid-runners` + `check-workflow-concurrency-scoping`
- Closes gap **PR-G1** from the 33-PR zero-gap remediation roadmap

## SHA-pinning detail
| File | Before | After |
|---|---|---|
| `manual-qa-matrix.yml` ×4 | `actions/{checkout@v6,setup-node@v6,cache@v5,upload-artifact@v7}` | each pinned to the SHA already used elsewhere in the repo |
| `qa-runner-driver-checks.yml` ×3 | `actions/{checkout@v6,setup-node@v6,cache@v5}` | same as above |
| `start-firebase-emulators/action.yml` ×1 | `actions/cache@v4` | `actions/cache@0057852b # v4` (own SHA, kept on v4 — deliberately not bundling a version bump with the supply-chain pin) |

## Why this matters
Tag-pointed action refs are a supply-chain attack surface — the action owner can re-point a tag to malicious code at any time. SHA-pinning makes the dependency immutable and auditable. PR #370's lesson (paid-runner blocking) showed CI guards prevent recurrence; this PR adds the same protection for tag-pinning.

## Guard script behaviour
- Rejects `uses: foo/bar@v1` (mutable tag) → exit 1 with remediation hint + `gh api` lookup command
- Accepts `uses: foo/bar@<40-hex>` (immutable SHA)
- Accepts `uses: ./.github/actions/...` (local actions version with the repo)
- Handles both YAML forms — standalone `uses:` and inline list `- uses: ...`

## Verification
- [x] `bash scripts/check-action-shas.sh` passes on current state
- [x] Negative test — injected `- uses: actions/checkout@v6` → script catches it, exits 1 with correct error message + file:line citation
- [x] Negative test — comment lines containing `uses:` are correctly ignored (regex anchored)
- [x] `actionlint` clean (warnings present are pre-existing SC2086 hits suppressed by CI's `-shellcheck='-e SC2086'` flag, not introduced by this PR)
- [x] Pre-push hook passed (`actionlint` + SonarCloud "no code changes" skip)

## Test plan
- [ ] CI checks pass — incl. the new SHA-pin guard step
- [ ] code-reviewer agent finds zero blockers
- [ ] Manual: tag-pin a temp action ref to confirm CI fails red on the new step

🤖 Generated with [Claude Code](https://claude.com/claude-code)