### PR TITLE
ci(sonar): remove `|| true` from Express jest coverage step (G036)

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -58,9 +58,15 @@ jobs:
         # callbacks (data-export-builder.js uses `import('archiver')` since
         # archiver v8 is ESM-only). Mirrors the `test` script in
         # express-api/package.json + test-backend.yml + .husky/pre-push.
+        #
+        # No `|| true` fallback — the step previously swallowed Jest
+        # failures and Sonar then uploaded partial coverage as if all
+        # tests passed. Per feedback-warnings-are-failures, a failing
+        # test must fail the gate. If this surfaces a real regression
+        # the right fix is to repair the test, not restore the bypass.
         run: |
           cd express-api && npm ci
-          node --experimental-vm-modules node_modules/.bin/jest --coverage --coverageReporters=lcov || true
+          node --experimental-vm-modules node_modules/.bin/jest --coverage --coverageReporters=lcov
 
       - name: Download build outputs
         if: inputs.app_changed


### PR DESCRIPTION
## Summary
Removes the `|| true` fallback on the Express jest coverage step in `.github/workflows/sonarcloud.yml:63`. Was swallowing every Jest failure during Sonar's pre-coverage gather, so Sonar uploaded partial or missing `lcov` as if every test passed.

## Why this matters
Per `feedback-warnings-are-failures` (HARD), silent-green is itself a failure mode. The whole purpose of running tests in the coverage step is to surface failures — masking them with `|| true` defeats the gate.

Roadmap entry: **G036** (Polish) in `.project/test-plans/exhaustive/2026-06-05-zero-gap-roadmap.md`.

## What this does NOT do
- Doesn't touch the parallel `|| true` on line 96 (`./gradlew :shared:jvmTest ... || true` in the build-artifact-fallback path) — that's a different defensibility argument (best-effort fallback when artifacts are missing), out of scope for G036's literal entry. Worth its own roadmap item / follow-up if undesirable.
- Doesn't change the Sonar analysis step. Only the upstream test-execution step.

## Test plan
- [x] `actionlint` clean (pre-existing SC2086 in unrelated line is suppressed by CI's `-e SC2086` flag)
- [x] `scripts/check-action-shas.sh` clean
- [x] Pre-push hook passed (SonarCloud pre-push correctly SKIPPED — workflow-only change matches `^(app/|shared/|express-api/src/|express-api/tests/|public/)` filter to false)
- [ ] First merged PR after this that touches Express must demonstrate the gate fires red on a deliberate test failure (manual smoke from operator if desired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)