### PR TITLE
ci(allure): document why gh-pages restore is continue-on-error (G037)

### DIFF
--- a/.github/workflows/allure-report.yml
+++ b/.github/workflows/allure-report.yml
@@ -114,6 +114,12 @@ jobs:
         with:
           ref: gh-pages
           path: gh-pages
+        # Intentional: on the first run for a new suite the gh-pages
+        # branch doesn't exist yet, and a missing ref would fail the
+        # whole job. The next step's `cp ... 2>/dev/null || echo "No
+        # previous history (first run)"` already handles the missing
+        # dir gracefully, so trend tracking just degrades to "no
+        # history" for the first run, then self-heals on run 2+.
         continue-on-error: true
 
       - name: Copy history for trend tracking


### PR DESCRIPTION
## Summary
Adds a 5-line comment to `.github/workflows/allure-report.yml:117` explaining why the gh-pages-restore step is `continue-on-error: true`. Comment-only — no executable diff.

## Why this matters
G037 (Polish) in the zero-gap roadmap flagged this as "Intent unclear; confirm intentional or remove if not". Investigation shows it's load-bearing for first-run behaviour: a brand-new suite has no gh-pages branch yet, and a hard checkout failure would abort the entire report job before any results publish.

The matching graceful-degrade for the filesystem side already exists at line 123 (`cp ... 2>/dev/null || echo "No previous history (first run)"`). The comment now ties the two together.

## What this does NOT do
- Doesn't change runtime behaviour. Same `continue-on-error: true`, just documented.
- Doesn't touch any other `continue-on-error` in the repo. Each is its own roadmap question.

## Test plan
- [x] `actionlint` clean (pre-existing SC2129 unrelated style hint is suppressed by CI's actionlint config)
- [x] `scripts/check-action-shas.sh` clean
- [x] Workflow-only — SonarCloud pre-push correctly skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)