### PR TITLE
test(dev-sanity): convert API-down skip to CI-aware failure (G050)

### DIFF
--- a/tests/web/dev-sanity.spec.ts
+++ b/tests/web/dev-sanity.spec.ts
@@ -61,15 +61,29 @@ test.describe('Dev Sanity Checks', () => {
   });
 
   test('API health endpoint responds', async ({ page }) => {
-    // Skip if API isn't running (pre-push hook runs without full local stack)
     const probe = await page.request.get(`${API_BASE}/api/health`).catch(() => null);
-    test.skip(!probe, 'API not running — skipping API tests');
+    // CI starts the API in playwright-tests.yml (lines ~205-207 wait
+    // for /api/health to respond). A missing probe in CI means an
+    // unexpected outage — surface as a failure, not a silent skip
+    // (that was the G050 gap). Local pre-push may run without the
+    // full stack, so preserve the skip there.
+    if (!probe) {
+      if (process.env.CI) {
+        throw new Error(`API at ${API_BASE} did not respond — expected running in CI`);
+      }
+      test.skip(true, 'API not running — skipping (local pre-push without stack)');
+    }
     expect(probe!.ok()).toBe(true);
   });
 
   test('API firebase-config responds', async ({ page }) => {
     const probe = await page.request.get(`${API_BASE}/api/firebase-config`).catch(() => null);
-    test.skip(!probe, 'API not running — skipping API tests');
+    if (!probe) {
+      if (process.env.CI) {
+        throw new Error(`API at ${API_BASE} did not respond — expected running in CI`);
+      }
+      test.skip(true, 'API not running — skipping (local pre-push without stack)');
+    }
     expect(probe!.ok()).toBe(true);
     const data = await probe!.json();
     expect(data).toHaveProperty('apiKey');


### PR DESCRIPTION
## Summary
Replaces the unconditional `test.skip(!probe, 'API not running')` at `tests/web/dev-sanity.spec.ts:66,72` with a CI-aware branch: throw in CI, skip locally. Two scenarios touched (API health + API firebase-config).

## Why this matters
In CI the API is started by `playwright-tests.yml` (lines ~205-207 wait for `/api/health`). A missing probe in CI means an unexpected outage — surfacing it as a silent skip masked real bugs. Locally the pre-push hook may run without the full stack, so the skip is preserved there to keep dev workflow smooth.

Per `feedback-warnings-are-failures` (HARD), silent test-passing in CI is itself a failure mode.

Roadmap entry: **G050** (Polish) in `.project/test-plans/exhaustive/2026-06-05-zero-gap-roadmap.md`.

## Decision points
- **Used `process.env.CI` as the signal.** GitHub Actions sets it to `'true'`, and most CI systems do. Local pre-push doesn't. Standard Playwright pattern.
- **Inlined the fix at both call sites** instead of extracting a helper. Two callers → helper would be premature abstraction.
- **Did NOT touch other skips** in this file. Each is its own decision; G050 named these two specifically.

## Test plan
- [x] Static check: `process.env.CI` truthy → throw; falsy → skip with reason — confirmed by reading the branching logic
- [x] Pre-push hook clean (workflow-only — `tests/` is NOT in SonarCloud pre-push pattern, so it correctly skipped)
- [ ] Once merged, CI Playwright run on the next PR will exercise the throw path (if API genuinely down — won't be) and the assertion path

🤖 Generated with [Claude Code](https://claude.com/claude-code)