### PR TITLE
test(admin-core-modules): rationalize bare test.skip() into CI-aware path (G024)

### DIFF
--- a/tests/web/admin-core-modules.spec.ts
+++ b/tests/web/admin-core-modules.spec.ts
@@ -130,8 +130,17 @@ test.describe('Admin Core Modules Integration', () => {
       const ADMIN_EMAIL = process.env.ADMIN_EMAIL;
       const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
       if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
-        test.skip();
-        return;
+        // CI sets both env vars in playwright-tests.yml (lines ~254-255).
+        // Missing creds in CI means an unexpected workflow regression —
+        // surface as a failure, not a silent skip (that was the G024 gap).
+        // Local pre-push may omit them when running without the full
+        // stack, so the skip is preserved there with a clear reason.
+        if (process.env.CI) {
+          throw new Error(
+            'ADMIN_EMAIL/ADMIN_PASSWORD not set — CI must provide both (see playwright-tests.yml)',
+          );
+        }
+        test.skip(true, 'ADMIN_EMAIL/ADMIN_PASSWORD not set — skipping (local without stack)');
       }
       await page.getByRole('textbox', { name: 'Email' }).fill(ADMIN_EMAIL);
       await page.getByRole('textbox', { name: 'Password' }).fill(ADMIN_PASSWORD);


### PR DESCRIPTION
## Summary
Same anti-pattern as G050 (PR #1020) in a different file. The bare `test.skip()` at `tests/web/admin-core-modules.spec.ts:133` had no reason string AND was unconditional in the missing-env branch, so a CI regression that dropped ADMIN_EMAIL/ADMIN_PASSWORD would silently skip the test instead of failing.

Three improvements bundled in one fix:
1. Added explicit reason to the skip
2. Added CI-aware throw (CI sets both vars in `playwright-tests.yml:254-255`; missing them is a real bug)
3. Dropped the dead `return` after `test.skip()` — Playwright in-test skip throws a SkipError, so the next line is unreachable

## Why this matters
Per `feedback-warnings-are-failures` (HARD), a silent skip in CI is a failure mode. `playwright-tests.yml` lines 254-255 explicitly inject `ADMIN_EMAIL=claude-test@shytalk.dev` and `ADMIN_PASSWORD=localdev123` — they MUST be present in CI. Locally the pre-push hook may omit them when running without the full stack, so the skip is preserved there.

Roadmap entry: **G024** (Important) in `.project/test-plans/exhaustive/2026-06-05-zero-gap-roadmap.md`.

## Decision points
- Used `process.env.CI` for the gate — same signal as G050, GitHub Actions sets it unconditionally
- Inlined the fix (single call site, no helper needed)
- Did NOT touch other `test.skip` patterns in the file — this is the only one

## Test plan
- [x] Static check on TypeScript control flow (throw vs skip branches reachable correctly)
- [x] Pre-push hook clean (`tests/` not in SonarCloud pre-push pattern)
- [ ] CI Playwright run will exercise the throw path if creds are genuinely absent (won't be — playwright-tests.yml supplies them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)