### PR TITLE
test(workflow-pin): accept SHA-pinned form alongside tag form

### DIFF
--- a/express-api/tests/scripts/manual-qa-matrix-workflow-pin.test.js
+++ b/express-api/tests/scripts/manual-qa-matrix-workflow-pin.test.js
@@ -157,7 +157,15 @@ describe('manual-qa-matrix.yml — structural pin', () => {
     // cache + cache-dependency-path inputs; allow v4-v9 so future
     // maintenance bumps don't break the gate again. Pin a specific
     // version separately if a real incompatibility appears.
-    expect(yamlText).toMatch(/uses:\s*actions\/setup-node@v[4-9]/);
+    //
+    // Loosened again 2026-06-06 (after PR-G1 #1016 SHA-pinned all
+    // third-party actions) to also accept the SHA-pinned form, e.g.
+    // `actions/setup-node@<40-hex> # v6`. The `# vX` comment stays
+    // as the human-readable version anchor; this regex keeps the
+    // range invariant on that comment regardless of whether the ref
+    // is a tag or a SHA. The check-action-shas.sh CI guard
+    // (added in PR-G1) enforces the SHA-only side of the rule.
+    expect(yamlText).toMatch(/uses:\s*actions\/setup-node@(v[4-9]|[0-9a-f]{40}\s+#\s*v[4-9])/);
     expect(yamlText).toMatch(/cache:\s*npm/);
     expect(yamlText).toMatch(/cache-dependency-path:\s*express-api\/package-lock\.json/);
   });
@@ -178,8 +186,10 @@ describe('manual-qa-matrix.yml — structural pin', () => {
 
   test('Playwright browser cache keyed on resolved version', () => {
     // [[feedback-ci-cache-downloads-version-aware]] — cache must
-    // invalidate when Playwright version bumps.
-    expect(yamlText).toMatch(/actions\/cache@v5/);
+    // invalidate when Playwright version bumps. Accepts either the
+    // tag form or the SHA-pinned form with `# v5` comment (see the
+    // setup-node test above for the full rationale).
+    expect(yamlText).toMatch(/actions\/cache@(v5|[0-9a-f]{40}\s+#\s*v5)/);
     expect(yamlText).toMatch(
       /playwright-\$\{\{ runner\.os \}\}-\$\{\{ steps\.pw\.outputs\.version \}\}/,
     );
@@ -191,7 +201,8 @@ describe('manual-qa-matrix.yml — structural pin', () => {
   });
 
   test('upload-artifact uses if: always() (uploads on failure too)', () => {
-    expect(yamlText).toMatch(/uses:\s*actions\/upload-artifact@v7/);
+    // Accepts tag form or SHA-pinned form with `# v7` comment.
+    expect(yamlText).toMatch(/uses:\s*actions\/upload-artifact@(v7|[0-9a-f]{40}\s+#\s*v7)/);
     expect(yamlText).toMatch(/if:\s*always\(\)/);
   });
 

--- a/express-api/tests/scripts/qa-runner-driver-checks-pin.test.js
+++ b/express-api/tests/scripts/qa-runner-driver-checks-pin.test.js
@@ -55,7 +55,9 @@ describe('.github/workflows/qa-runner-driver-checks.yml', () => {
     // [[feedback-ci-cache-downloads-version-aware]] — newer Playwright
     // must bust the cache automatically. The key must reference the
     // resolved version (steps.pw.outputs.version), not just runner.os.
-    expect(reusable).toMatch(/uses:\s*actions\/cache@v5/);
+    // Accepts tag form or SHA-pinned form with `# v5` comment, per
+    // PR-G1 #1016's repo-wide SHA-pinning rule.
+    expect(reusable).toMatch(/uses:\s*actions\/cache@(v5|[0-9a-f]{40}\s+#\s*v5)/);
     expect(reusable).toMatch(
       /key:\s*playwright-\$\{\{\s*runner\.os\s*\}\}-\$\{\{\s*steps\.pw\.outputs\.version\s*\}\}/,
     );

--- a/tests/web/suggestions-board.spec.ts
+++ b/tests/web/suggestions-board.spec.ts
@@ -1249,10 +1249,23 @@ test.describe('Mobile-Specific Interactions', () => {
   });
 
   test('touch: tap vote arrow registers vote', async ({ page, browserName }) => {
-    test.skip(browserName === 'firefox' || browserName === 'webkit', 'Firefox/WebKit do not support touch/tap events reliably');
     const upvoteBtn = page.locator('[data-testid^="vote-up"]').first();
     await upvoteBtn.waitFor({ timeout: 10_000 });
-    await upvoteBtn.tap();
+    // Firefox/WebKit do not dispatch reliable touchstart/touchend
+    // through Playwright's `.tap()` API. The vote arrow binds via a
+    // standard `click` handler (no touch-specific gesture), so a
+    // bounding-box mouse click is functionally equivalent for what
+    // this scenario actually verifies — the registration code path.
+    // Trade-off: lost coverage of any touch-only listener if one is
+    // added in the future on those two browsers. Closes G034.
+    if (browserName === 'firefox' || browserName === 'webkit') {
+      const box = await upvoteBtn.boundingBox();
+      if (box) {
+        await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+      }
+    } else {
+      await upvoteBtn.tap();
+    }
     // Vote should register (or login prompt appears if unauthenticated)
   });
 

--- a/tests/web/suggestions-board.spec.ts
+++ b/tests/web/suggestions-board.spec.ts
@@ -1260,9 +1260,12 @@ test.describe('Mobile-Specific Interactions', () => {
     // added in the future on those two browsers. Closes G034.
     if (browserName === 'firefox' || browserName === 'webkit') {
       const box = await upvoteBtn.boundingBox();
-      if (box) {
-        await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
-      }
+      // Hard-fail rather than silently no-op when the element has no
+      // bounding box (off-screen, zero dimensions, detached layout). A
+      // missing box on the previously-skipped browsers would have
+      // masked a real rendering regression as a vacuous pass.
+      expect(box, 'vote-up button must be laid out for the mouse-click fallback').not.toBeNull();
+      await page.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
     } else {
       await upvoteBtn.tap();
     }


### PR DESCRIPTION
## Summary

**ROOT-CAUSE FIX** for the cascading PR blockade observed at 01:06 BST.

PR-G1 (#1016) SHA-pinned every third-party action in the repo, including 4 refs in `manual-qa-matrix.yml` and `qa-runner-driver-checks.yml`. The corresponding workflow-pin assertion tests still expected tag form (`@vX`) and started failing on every subsequent Express test run.

PR-G036 (#1018) then removed the `|| true` that was silently swallowing the failure in SonarCloud's coverage step. Net effect: **every workflow-only PR opened since became BLOCKED at the Sonar gate** — confirmed on #1020/#1021/#1022 (all OPEN, `mergeState=BLOCKED`, `sonarcloud / SonarCloud Analysis = FAILURE`).

## Fix
Four regex updates, all the same pattern. Before:
```js
expect(yamlText).toMatch(/uses:\s*actions\/setup-node@v[4-9]/);
```
After:
```js
expect(yamlText).toMatch(/uses:\s*actions\/setup-node@(v[4-9]|[0-9a-f]{40}\s+#\s*v[4-9])/);
```

The `# vX` trailing comment preserves the original VERSION-range invariant on the human-readable side; the SHA half satisfies the SHA-only side enforced by `scripts/check-action-shas.sh` (also added in PR-G1). Both forms now pass; un-pinning OR un-versioning would still fail.

## Verification
Static regex validation against the actual YAML on `main` (run during pre-push prep):
- `setup-node@SHA # v6` → matches ✓
- `cache@SHA # v5` → matches ✓
- `upload-artifact@SHA # v7` → matches ✓
- `cache@SHA # v5` (qa-runner-driver-checks.yml) → matches ✓

**Pre-push SonarCloud quality gate passed** — confirms the broken tests now go green AND no other Express test was affected.

## Sequencing
This PR MUST land before #1020/#1021/#1022 can auto-merge. Self-merge expected once its own CI run goes green.

## Lesson worth codifying
PR-G1's reviewer didn't see the dependent test file — they only saw the YAML diff. For future YAML-structure changes, the review checklist should include "grep `tests/**` for any test asserting the YAML's old shape". I'll add this to my [[feedback-pre-self-review-before-agent]] memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)