### PR TITLE
test(suggestions-board): boundingBox-assert at remaining two sites

### DIFF
--- a/tests/web/suggestions-board.spec.ts
+++ b/tests/web/suggestions-board.spec.ts
@@ -1278,12 +1278,15 @@ test.describe('Mobile-Specific Interactions', () => {
 
     // Long press should not open browser context menu
     const box = await card.boundingBox();
-    if (box) {
-      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-      await page.mouse.down();
-      await page.waitForTimeout(1000);
-      await page.mouse.up();
-    }
+    // Hard-fail rather than silently no-op the entire mouse sequence.
+    // Without the box, the test would vacuously pass the "no context
+    // menu visible" assertion (no press happened, so of course no menu).
+    // Same silent-no-op pattern PR-G034 fixed for the vote-arrow site.
+    expect(box, 'suggestion card must be laid out for long-press to test anything').not.toBeNull();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.waitForTimeout(1000);
+    await page.mouse.up();
     // No context menu should be visible
     const contextMenu = page.locator('[data-testid="context-menu"]');
     expect(await contextMenu.count()).toBe(0);
@@ -1325,11 +1328,14 @@ test.describe('Mobile-Specific Interactions', () => {
       await descInput.focus();
       await page.waitForTimeout(500);
       const box = await descInput.boundingBox();
-      if (box) {
-        // Element should be within the viewport
-        expect(box.y).toBeGreaterThanOrEqual(0);
-        expect(box.y + box.height).toBeLessThanOrEqual(812);
-      }
+      // Outer count() > 0 guard already gates on the element existing.
+      // The inner null-box guard previously silently no-op'd if the
+      // focused element was still in a transient unlaid-out state,
+      // hiding any real viewport-clipping bug. Hard-fail instead.
+      expect(box, 'desc input must be laid out after focus + 500ms wait').not.toBeNull();
+      // Element should be within the viewport
+      expect(box!.y).toBeGreaterThanOrEqual(0);
+      expect(box!.y + box!.height).toBeLessThanOrEqual(812);
     }
   });
 


### PR DESCRIPTION
## Summary
Follow-up to PR-G034 (#1022). The round-1 reviewer of #1022 noted that `tests/web/suggestions-board.spec.ts` had three sites using the `if (box) { ... }` silent-no-op pattern. PR-G034 fixed the first; this PR fixes the remaining two.

| Site | Test | Risk if no-op |
|---|---|---|
| L1280-1290 | `touch: long press on suggestion card does not trigger context menu` | Entire mouse-down/up inside `if (box)` — without box, no press happens but the "no context menu" assertion vacuously passes |
| L1327-1340 | `soft keyboard: description field does not get hidden behind keyboard` | Inner `if (box)` masks cases where focus + 500ms wait still leaves the input unlaid-out, hiding real viewport-clipping bugs |

Both fixes follow the same pattern PR-G034 established for the vote-arrow tap site: `expect(box).not.toBeNull()` with a descriptive message, then `box!` non-null assertions after.

## Why this matters
Per `feedback-warnings-are-failures` (HARD), a vacuously-passing test is a failure mode of its own. The round-1 reviewer flagged this as out-of-scope for PR-G034 but worth a follow-up (which I queued as task #26).

## Test plan
- [x] Static reasoning: in both cases, the outer guards (e.g. `count() > 0`) are preserved; only the inner null-box silent-no-op is converted to a hard assert
- [x] Pre-push hook clean (`tests/` not in SonarCloud pre-push pattern)
- [ ] CI Playwright run will exercise the assert path on real renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)