### PR TITLE
test(admin-suggestions): drop isMobile context + Firefox skip (G035)

### DIFF
--- a/tests/web/admin-suggestions.spec.ts
+++ b/tests/web/admin-suggestions.spec.ts
@@ -1345,9 +1345,12 @@ test.describe('Admin Identity Graph Visualization (11.65)', () => {
     await expect(c).toBeVisible();
   });
 
-  test('graph scrollable on mobile', async ({ browser, browserName }) => {
-    test.skip(browserName === 'firefox', 'Firefox does not support isMobile context option');
-    const ctx = await browser.newContext({ viewport: { width: 375, height: 812 }, isMobile: true });
+  test('graph scrollable on mobile', async ({ browser }) => {
+    // G035: dropped isMobile flag + Firefox skip — the assertion is
+    // about layout at a mobile viewport size, not touch events.
+    // CSS media queries respond to viewport size regardless of
+    // isMobile. Coverage extended to Firefox + WebKit.
+    const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
     const page = await ctx.newPage();
     await setupApiMocks(page);
     await adminLogin(page); await navigateToTab(page, 'Users');
@@ -1398,9 +1401,9 @@ test.describe('Admin Panel Responsive Design (11.86)', () => {
     await ctx.close();
   });
 
-  test('identity graph scrollable on mobile', async ({ browser, browserName, testData }) => {
-    test.skip(browserName === 'firefox', 'Firefox does not support isMobile context option');
-    const ctx = await browser.newContext({ viewport: { width: 375, height: 812 }, isMobile: true });
+  test('identity graph scrollable on mobile', async ({ browser, testData }) => {
+    // G035: see "graph scrollable on mobile" above for rationale.
+    const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
     const page = await ctx.newPage();
     await setupApiMocks(page);
     await adminLogin(page); await navigateToIdentityGraph(page, String(testData.user.uniqueId));
@@ -1410,9 +1413,9 @@ test.describe('Admin Panel Responsive Design (11.86)', () => {
     await ctx.close();
   });
 
-  test('audit log table horizontally scrollable on mobile', async ({ browser, browserName }) => {
-    test.skip(browserName === 'firefox', 'Firefox does not support isMobile context option');
-    const ctx = await browser.newContext({ viewport: { width: 375, height: 812 }, isMobile: true });
+  test('audit log table horizontally scrollable on mobile', async ({ browser }) => {
+    // G035: see "graph scrollable on mobile" above for rationale.
+    const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
     const page = await ctx.newPage();
     await setupApiMocks(page);
     await adminLogin(page); await navigateToAuditLog(page);
@@ -1422,9 +1425,9 @@ test.describe('Admin Panel Responsive Design (11.86)', () => {
     await ctx.close();
   });
 
-  test('moderation action buttons accessible on mobile', async ({ browser, browserName }) => {
-    test.skip(browserName === 'firefox', 'Firefox does not support isMobile context option');
-    const ctx = await browser.newContext({ viewport: { width: 375, height: 812 }, isMobile: true });
+  test('moderation action buttons accessible on mobile', async ({ browser }) => {
+    // G035: see "graph scrollable on mobile" above for rationale.
+    const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
     const page = await ctx.newPage();
     await setupApiMocks(page);
     await adminLogin(page); await navigateToSuggestions(page);


### PR DESCRIPTION
## Summary
Removes the Firefox skip from 4 responsive-design scenarios in `tests/web/admin-suggestions.spec.ts`. They were permanently skipped because Firefox doesn't support the `isMobile` context option. But the assertions are all LAYOUT-based (boundingBox sizing, container visibility, overflow scroll detection) — they don't actually need touch events or mobile UA. Dropping `isMobile: true` from the context while keeping the mobile viewport size preserves all assertions while unblocking Firefox + WebKit coverage.

## Sites
- L1349: `graph scrollable on mobile`
- L1402: `identity graph scrollable on mobile`
- L1414: `audit log table horizontally scrollable on mobile`
- L1426: `moderation action buttons accessible on mobile`

## Decision points
- **Used viewport size only** — CSS media queries respond to viewport size regardless of `isMobile` flag, so the responsive design assertions keep firing.
- **DPR trade-off** — drops from 2 (isMobile retina) to 1 (default). Assertions are in CSS pixels which are DPR-independent, so no scenario regresses.
- **If touch ever needed** — future tests should add `hasTouch: true` explicitly, not the whole `isMobile` bundle.

Roadmap entry: **G035** (Polish) in `.project/test-plans/exhaustive/2026-06-05-zero-gap-roadmap.md`.

## Test plan
- [x] Verified by grep: 0 remaining `isMobile: true` or `browserName === 'firefox'` in the file
- [x] Pre-push hook clean (`tests/` not in SonarCloud pre-push pattern)
- [ ] CI Playwright run on Firefox + WebKit will execute the previously-skipped paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)