### PR TITLE
chore: file EPIC-0002 — roadmap migration + lazy translation platform (SHY-0062/0072/0073)

### DIFF
--- a/.project/stories/EPIC-0002-public-roadmap-migration-translation.md
+++ b/.project/stories/EPIC-0002-public-roadmap-migration-translation.md
@@ -1,0 +1,41 @@
+---
+id: EPIC-0002
+status: In Progress
+owner: claude
+created: 2026-06-10
+priority: P1
+title: Public roadmap story-migration + lazy translation platform
+child_shys: [SHY-0062, SHY-0072, SHY-0073]
+---
+
+# EPIC-0002: Public roadmap story-migration + lazy translation platform
+
+## Vision
+
+shytalk.com/roadmap becomes fully story-driven: every entry a tracked SHY, auto-synced on merge (SHY-0038 pipeline), rendered with story badges and GitHub links (SHY-0061 + SHY-0073) — while staying **fully translated in all 20 locales, always** (operator hard rule, 2026-06-10). Translation moves to a platform-level lazy service: translate on first view per locale, server-cache, fail silently to English (admin-logged), Claude backfills misses via PRs — the operator-chosen standard for all future public translation, strictly $0.
+
+## Scope
+
+- **SHY-0062** — meta/tracking story for the ~95-entry migration (8 phase batches; batch SHYs filed at pickup, listed in SHY-0062's tracking table, added to `child_shys` as filed).
+- **SHY-0072** — lazy translation service (Express): unofficial-Google provider → server cache → English fail-silent + admin log + miss queue.
+- **SHY-0073** — renderer: items consume the translation service when locale ≠ en; items link to their GitHub story gated by a once-per-session translated confirm dialog for non-English visitors.
+- Future children: SHY-0074+ per-phase migration batches; pickup-review lifecycle formalisation rides separately (process, not this EPIC).
+
+## Child SHYs
+
+| SHY | Role | Status |
+|---|---|---|
+| SHY-0062 | Migration meta/tracker | In Progress |
+| SHY-0072 | Lazy translation service | Draft |
+| SHY-0073 | Renderer: lazy i18n + gated story links | Draft |
+
+## DoD at Epic Level
+
+- [ ] All 95 legacy `features[]` entries exist as `public: true` SHY files; `phases[].features` arrays retired from the renderer's read path.
+- [ ] Non-English visitors see translated names/descriptions for every entry (lazy service live, cache warm for visited locales, miss queue near-empty).
+- [ ] Every roadmap item links to its GitHub story; non-English visitors get the gated confirm exactly once per session.
+- [ ] No regression in the 20-locale page chrome; console-errors sweep green; $0 posture intact (no paid API anywhere).
+
+## Notes
+
+- 2026-06-10 ~10:10 BST — EPIC opened after three operator clarification rounds settled the design: stories English-only; webpage always translated; lazy-translate architecture with unofficial-Google + Claude-backfill chosen after the $0 reality check (official API is paid post-trial). Decisions codified in memory `feedback-public-translations-lazy-architecture`.

--- a/.project/stories/SHY-0062-migrate-legacy-roadmap-features.md
+++ b/.project/stories/SHY-0062-migrate-legacy-roadmap-features.md
@@ -1,0 +1,111 @@
+---
+id: SHY-0062
+status: In Progress
+owner: claude
+created: 2026-06-10
+priority: P1
+effort: XL
+type: chore
+roadmap_ids: []
+pr:
+epic: EPIC-0002
+---
+
+# SHY-0062: Migrate ~95 legacy roadmap features into tracked stories (meta/tracker)
+
+## User Story
+
+As the ShyTalk operator, I want every hand-written `phases[].features[]` entry on the public roadmap converted into a tracked, fully-refined SHY story, so the public page and the backlog are one system with no dual-source drift.
+
+## Why
+
+Reserved since 2026-06-07; operator greenlit FULL migration 2026-06-10 ("Yes, start it today"). The renderer reads `items[]` (SHY-0061, v0.97.9); the always-translated guarantee is carried by SHY-0072/0073. This meta-story coordinates the 8 phase batches and pins the conversion conventions so every batch is mechanical and reviewable.
+
+## Acceptance Criteria
+
+### Happy path (tracking-only — implementation lives in the batch SHYs)
+- [ ] Batch table below reaches 8/8 shipped; all 95 features exist as `public: true` SHYs with `phase` set; EPIC-0002 `child_shys` updated per batch.
+- [ ] **Conversion conventions (binding on every batch):**
+  - status mapping: `done` → `status: Done` + `released_in: pre-rule` (historic-shipped sentinel, SHY-0064-notes precedent) + `pr:` left empty with a Notes line "migrated historic feature; shipped pre-framework"; `in-progress` → `In Progress`; `planned` → `Draft`.
+  - every migrated SHY is FULLY REFINED at authoring (operator re-affirmed 2026-06-10) — descriptions seed the User Story/Why; AC across all 8 dimensions derived from the feature's meaning; the pickup-fitness-review gate (every-story rule) is the staleness net.
+  - English-only content (web translations are SHY-0072/0073's runtime concern — NO i18n payloads in story files; the legacy `i18n` data is left in place in roadmap-data.json's features[] until the phase's features[] entries are retired, then dropped with the batch that retires them).
+  - one batch = one PR = one batch-SHY; the batch PR contains: the batch-SHY file + that phase's feature-SHY files + removal of the migrated entries from the phase's `features[]` (sync regenerates `items[]` on merge; SHY-0073's renderer translates them lazily).
+  - ID allocation: batch SHYs and feature SHYs consume sequential IDs at filing time (no pre-reservation — gaps invite collisions; the table records actuals as they land).
+- [ ] Ordering: batches ship AFTER SHY-0072 + SHY-0073 are live (otherwise non-English visitors see untranslated migrated entries — violates the always-translated rule). Smallest phase first (Revenue & Status, 3) as the pilot to validate conventions cheaply, then by size.
+
+### Error paths
+- [ ] A migrated entry that proves unmappable to a sensible story (pure marketing copy, duplicates an existing SHY) → recorded in the batch-SHY Notes with disposition (merged-into-SHY-NNNN / dropped-with-operator-ack) — never silently skipped.
+
+### Edge cases
+- [ ] Features duplicating EXISTING tracked SHYs (e.g. "Age-gating per feature" = SHY-0060) → the existing SHY absorbs (gets `public: true` + phase if missing); no duplicate file.
+- [ ] `done` features that match already-shipped tracked work → cross-referenced in Notes rather than duplicated.
+
+### Performance
+- [ ] N/A — content migration; sync-perf is SHY-0040/0071 territory.
+
+### Security
+- [ ] Migrated public content review: no entry may leak internal infra detail beyond what the public page already showed (batch reviewer checklist item).
+
+### UX
+- [ ] Public page entry count never dips mid-migration (each batch PR removes features[] entries and adds items[] sources atomically in one merge).
+
+### i18n
+- [ ] Covered by SHY-0072/0073 (runtime); batches MUST NOT ship before those are live (ordering AC above).
+
+### Observability
+- [ ] Batch table below is the audit trail; per-batch Notes record counts + dispositions.
+
+## Batch tracker
+
+| # | Phase | Features | Batch SHY | Status |
+|---|---|---|---|---|
+| 1 | Revenue & Status (pilot) | 3 | TBD at filing | Pending |
+| 2 | Support & Feedback | 6 | TBD | Pending |
+| 3 | Entertainment | 8 | TBD | Pending |
+| 4 | Social & Discovery | 8 | TBD | Pending |
+| 5 | Quality of Life | 11 | TBD | Pending |
+| 6 | Platform & iOS | 17 | TBD | Pending |
+| 7 | Safety & Compliance | 20 | TBD | Pending |
+| 8 | Website & Presence | 22 | TBD | Pending |
+
+## BDD Scenarios
+
+**Scenario: a batch lands atomically**
+- **Given** SHY-0072 + SHY-0073 are live and batch 1's PR merges
+- **When** the sync regenerates roadmap-data.json
+- **Then** Revenue & Status shows its 3 entries as story-derived items (badged, linked, lazily translated) and its features[] array is empty
+- **And** the page's total visible entry count is unchanged
+
+**Scenario: duplicate-of-existing absorbs**
+- **Given** a feature matching an existing tracked SHY
+- **When** its batch is authored
+- **Then** the existing SHY gains public/phase fields and the batch Notes record the absorption — no new file
+
+## Test Plan
+
+Tracking-only: each batch SHY carries its own Test Plan (validator scan green; sync-regen assertions; entry-count parity check per the UX AC — a Playwright fixture test comparing pre/post counts ships with batch 1 and runs for every batch).
+
+## Out of Scope
+
+- The translation service + renderer work (SHY-0072/0073).
+- Retiring the `features[]` SCHEMA (only emptied per phase; schema removal is a follow-up once 8/8).
+- Backfilling `pr:` for historic done features (none exists; sentinel convention covers it).
+
+## Dependencies
+
+- SHY-0072 → SHY-0073 (hard ordering, then batches).
+- Operator decisions all captured 2026-06-10 (memory: feedback-public-translations-lazy-architecture; ask-freely posture remains in force for batch-time questions).
+
+## Risks & Mitigations
+
+- **Risk:** 95 fully-refined specs drift before pickup. **Mitigation:** the new every-story pickup-fitness-review rule exists precisely for this (operator chose full refinement with that net).
+- **Risk:** batch PRs balloon (20+ stories each for late phases). **Mitigation:** conventions validated on the 3-entry pilot; late phases may sub-split if review quality demands (operator informed first — ask-freely).
+
+## Definition of Done
+
+- [ ] 8/8 batches shipped + table complete; all conventions held; EPIC-0002 DoD items relating to migration satisfied; entry-count parity held at every step.
+- [ ] `status: Done` deferred to the release cut after batch 8; SHY-INDEX synced throughout.
+
+## Notes (running log)
+
+- 2026-06-10 ~10:25 BST — Meta-story authored after the operator's three-round design session (full migration greenlit; full refinement re-affirmed with the new pickup-review net; translations = web-layer lazy service; stories English-only; gated GitHub links). Filed alongside EPIC-0002 + SHY-0072 + SHY-0073.

--- a/.project/stories/SHY-0072-lazy-translation-service.md
+++ b/.project/stories/SHY-0072-lazy-translation-service.md
@@ -1,0 +1,119 @@
+---
+id: SHY-0072
+status: Draft
+owner: claude
+created: 2026-06-10
+priority: P1
+effort: M
+type: feature
+roadmap_ids: []
+pr:
+epic: EPIC-0002
+---
+
+# SHY-0072: Lazy translation service — translate-on-first-view with server cache
+
+## User Story
+
+As a non-English visitor to shytalk.com's public pages, I want dynamic content (starting with roadmap story names/descriptions) translated into my language on demand, so that the public surface stays fully native-quality in all 20 locales without anyone pre-translating content nobody views — and without ever showing me an error when translation isn't available.
+
+## Why
+
+Operator decision 2026-06-10 (memory `feedback-public-translations-lazy-architecture`): public pages are ALWAYS fully translated; GitHub stories are English-only; therefore the web layer needs a translation mechanism for story-derived content. Chosen architecture (over build-time pre-translation and paid APIs): translate on FIRST view per (text, locale), cache server-side, serve cache thereafter; on any failure serve English silently with admin-visible logging; misses queue for Claude build-time backfill. Declared "the right way for translating everything in the future." Strictly $0: unofficial Google endpoint (ToS-grey, accepted with eyes open after the pricing reality check) + free backfill.
+
+## Acceptance Criteria
+
+### Happy path
+- [ ] `POST /api/translate` accepts `{ texts: string[], target: <locale> }` (target ∈ the 20 supported locales; `en` rejected as a no-op with 400 — callers must not burn a request translating English to English).
+- [ ] Cache hit path: previously translated (text, target) pairs return from the server-side cache with NO provider call (asserted via provider-mock call counts).
+- [ ] Cache miss path: the unofficial Google endpoint (`translate.googleapis.com/translate_a/single` `client=gtx`) is called once per unique (text, target); the result is cached (durable across process restarts — disk-backed JSON/SQLite on the Express box, NOT Firestore: free-tier quota is a real constraint and this cache is hot) and returned.
+- [ ] Batch requests dedupe internally (same text twice in one request = one provider call) and partial-fill from cache (mixed hit/miss batches only fetch the misses).
+- [ ] Response shape `{ translations: { [text]: translated }, missed: string[] }` — `missed` lists texts served as English fallback this call.
+
+### Error paths
+- [ ] Provider failure (non-200, timeout ≤3s, malformed body, rate-limit): the affected texts return AS ENGLISH in `translations` and appear in `missed`; HTTP status stays 200 (fail-silent contract — the PAGE must never break); the failure is logged at WARN with provider status (admin-visible per existing log conventions) and the (text, target) is appended to the miss-queue file.
+- [ ] Miss-queue file (`express-api/data/translation-miss-queue.jsonl` or equivalent documented path) is append-only JSONL `{text, target, ts, reason}`, deduplicated on append (same text+target not re-queued), and survives restarts. Claude drains it via routine PRs that commit translations directly into the cache seed (the "fallback to claude" — build-time, $0).
+- [ ] Unsupported `target` (not in the 20) → 400 with a generic body; never forwarded to the provider.
+- [ ] Oversized input (text >2,000 chars or >50 texts/request) → 400 (the public roadmap needs name+description sizes; bounds prevent the endpoint becoming a free-translation proxy for abuse).
+
+### Edge cases
+- [ ] Texts containing HTML-meaningful characters round-trip unescaped through the service (escaping is the RENDERER's job at insertion; the service stores/returns raw text — documented in the route header).
+- [ ] Identical text requested for two locales concurrently: both fetch independently; cache keys are (sha256(text), target).
+- [ ] Provider returns the input unchanged (Google sometimes echoes for unknown words): cached as-is — an echo is a valid translation, not a miss.
+- [ ] Cache file corruption (truncated write/invalid JSON at boot): service starts with an empty cache + ERROR log, never crashes (fail-open to re-translation, fail-silent to users).
+
+### Performance
+- [ ] Cache hits answer in <10ms server-side (memory-mapped/loaded-at-boot index); misses bounded by the 3s provider timeout.
+- [ ] Cache writes are atomic (write-temp + rename) so a crash mid-write can't corrupt the store.
+
+### Security
+- [ ] No secrets involved (unofficial endpoint is keyless); the endpoint is PUBLIC but rate-limited per IP (reuse the repo's existing Express rate-limit middleware pattern) so it can't be farmed as a free translation proxy beyond the size bounds.
+- [ ] Inputs are never shell-interpolated/eval'd; provider URL is built via URLSearchParams (no string-concat injection).
+- [ ] Dev-console visibility AC lives in SHY-0073 (client side); the server contributes a `X-Translation-Missed: <n>` response header the client can read cheaply.
+
+### UX
+- [ ] N/A server-side — the fail-silent contract IS the UX guarantee (English, never errors).
+
+### i18n
+- [ ] All 20 locale codes accepted exactly as the site's language selector emits them (single source: reuse the canonical locale list from the repo, not a hand-typed copy — pinned by a test importing/grepping the same list the web uses).
+
+### Observability
+- [ ] WARN log per provider failure with `{event: 'translate_provider_fail', target, status, queued}`; INFO summary per process-hour is NOT required (avoid log spam — per-failure only).
+- [ ] Miss-queue length surfaces in the existing `/api/system/health` payload (one integer — admins see backlog at a glance).
+
+## BDD Scenarios
+
+**Scenario: first view translates and caches**
+- **Given** an empty cache and a working provider mock
+- **When** `POST /api/translate {texts:["Age-gating per feature"], target:"de"}` runs twice
+- **Then** the provider mock is called exactly once
+- **And** both responses carry the German translation with empty `missed`
+
+**Scenario: provider dies — visitors never know**
+- **Given** the provider mock returns 503
+- **When** a translation is requested for `fr`
+- **Then** the HTTP response is 200 with the English text and `missed` listing it
+- **And** a WARN `translate_provider_fail` log fires and the miss-queue gains one deduplicated line
+
+**Scenario: mixed batch partial-fills from cache**
+- **Given** text A cached for `ja` and text B uncached
+- **When** both are requested for `ja`
+- **Then** the provider is called only for B and the response contains both translations
+
+**Scenario: queue dedupe survives repeats**
+- **Given** the provider is down
+- **When** the same text+target misses three times
+- **Then** the miss-queue contains exactly one entry for it
+
+## Test Plan
+
+**Red first** (`express-api/tests/routes/translate.test.js`, supertest + provider mock via dependency-injected fetch/undici — mirror the route-test harness conventions; plus unit tests for the cache module `express-api/tests/utils/translation-cache.test.js`): every AC above has a named case — cache hit/miss/partial, dedupe, fail-silent 200 + WARN spy + queue append + queue dedupe, 400s (en/unsupported/oversize/too-many), atomic-write (simulate crash via temp-file inspection), corrupt-cache boot recovery, rate-limit pin, locale-list single-source pin, health-payload integer.
+**Green:** `express-api/src/routes/translate.js` + `express-api/src/utils/translation-cache.js` + provider client `translation-provider.js` (3s timeout, gtx endpoint) + health hook + miss-queue util.
+**Verify-by-running:** local stack curl per BDD; one REAL unofficial-endpoint smoke locally (single word, documented in Notes — proves the gtx contract at implementation time; CI uses mocks only).
+
+## Out of Scope
+
+- Client-side consumption, the dev-console error surface, and the gated GitHub links (SHY-0073).
+- Translating anything beyond raw text strings (no HTML/markdown-aware segmentation yet).
+- Admin UI for the queue (the health integer + JSONL file suffice; UI is a future story if backlog grows).
+- Provider alternatives (LibreTranslate self-host etc.) — revisit only if the gtx endpoint dies (the cache + English-fallback + backfill make that a degradation, not an outage).
+
+## Dependencies
+
+- None hard. SHY-0073 depends on THIS. The Express rate-limit middleware pattern already exists in-repo (locate at pickup-review).
+- Pickup-review gate (per the new every-story rule) must verify: the gtx endpoint's CURRENT response shape (it drifts), the canonical locale-list location, and the existing rate-limiter to reuse.
+
+## Risks & Mitigations
+
+- **Risk:** gtx endpoint breaks/blocks server IPs. **Mitigation:** by design — cache keeps served locales alive, English fail-silent for new content, queue + Claude backfill closes gaps; revisit provider only then.
+- **Risk:** cache grows unbounded. **Mitigation:** scope is name+desc strings (~95×20 ≈ 2K entries now); add an entry-count WARN at 50K (future story if ever hit).
+- **Risk:** abuse as a free proxy. **Mitigation:** size/count bounds + per-IP rate limit + only the 20 site locales.
+
+## Definition of Done
+
+- [ ] All AC checked; red→green; full express suite green; shellcheck N/A (JS only); reviewer ZERO before push; auto-merged.
+- [ ] Real-endpoint smoke evidence in Notes; `status: Done` deferred to release cut; SHY-INDEX + EPIC-0002 synced.
+
+## Notes (running log)
+
+- 2026-06-10 ~10:15 BST — Authored fully-refined from the operator's three-round design (ask-freely session): lazy-on-first-view, server cache, fail-silent English + admin log + miss queue + Claude build-time backfill; unofficial Google endpoint accepted after the $0 pricing reality check. Architecture memory: feedback-public-translations-lazy-architecture.

--- a/.project/stories/SHY-0073-renderer-lazy-i18n-and-gated-story-links.md
+++ b/.project/stories/SHY-0073-renderer-lazy-i18n-and-gated-story-links.md
@@ -1,0 +1,117 @@
+---
+id: SHY-0073
+status: Draft
+owner: claude
+created: 2026-06-10
+priority: P1
+effort: M
+type: feature
+roadmap_ids: []
+pr:
+epic: EPIC-0002
+public: true
+phase: Website & Presence
+---
+
+# SHY-0073: Roadmap renderer — lazy item translations + gated GitHub story links
+
+## User Story
+
+As a non-English visitor to shytalk.com/roadmap, I want story-derived entries shown in my language (fetched lazily, cached server-side) and a clear once-per-session heads-up before I follow a link to an English-only story on GitHub, so the page stays fully native while the underlying specs remain English.
+
+## Why
+
+Companion to SHY-0072 (the service) — this is the consumption half plus the operator-specified link gating: "roadmap page needs to still be fully translated always… only the github stories are english only… have a pop-up informing the user it will be in English only and confirm before they visit the page." Items gained badges in SHY-0061 but no links; migrated items (SHY-0062 batches) will be English-sourced, so without this story non-English visitors would see English names — violating the always-translated rule.
+
+## Acceptance Criteria
+
+### Happy path
+- [ ] When `currentLang !== 'en'`, after render the page collects every item-derived visible string (item names + descriptions from `items[]`/`currentlyWorkingOn`) and calls `POST /api/translate` ONCE (batched); returned translations are applied in place (text-node swap — same `escapeHtml` discipline as initial render).
+- [ ] Legacy `features[]` entries keep their existing embedded `i18n` payloads (untouched path); only story-derived items use the service. As migration batches land, the service path naturally takes over.
+- [ ] Each item row's shyId badge becomes an anchor to the story file on GitHub (`https://github.com/Shyden-Ltd/ShyTalk/blob/main/.project/stories/<slug>.md`; the sync emits the slug — extend `sync-shy-to-roadmap-data.mjs` to include `slug` per item, additive field).
+- [ ] For `currentLang === 'en'`: links navigate directly; NO translate call is made at all (zero overhead for the majority locale).
+- [ ] For non-English: first story-link click in a session shows a translated confirm dialog ("This story is available in English only — continue?" — dialog strings added to the renderer's LABELS map ×21, per-locale-block coverage test extended); confirm → navigates (new tab) and sets `sessionStorage` so later clicks pass straight through; cancel → stays, no navigation.
+
+### Error paths
+- [ ] Translate call fails/times out (service down, network): page KEEPS the English strings it already rendered — no spinner, no layout shift, no user-visible error; a single `console.error('[translate] …')` fires (the operator's dev-console surface) and the page reads `X-Translation-Missed` / `missed` to log WHICH strings fell back.
+- [ ] Partial response (`missed` non-empty): translated strings apply, missed ones stay English — per-string granularity, never all-or-nothing.
+- [ ] `sessionStorage` unavailable (privacy mode): dialog falls back to once-per-page-load (never blocks navigation permanently).
+
+### Edge cases
+- [ ] Items rendered in BOTH the In Progress lift and a phase body translate consistently (one batched call covers both; same text = same translation by construction).
+- [ ] RTL locales (ar): translated strings render correctly in the existing RTL layout (Playwright assertion in `ar`).
+- [ ] An item whose name the service echoes back unchanged displays without a re-render loop (apply-once semantics).
+- [ ] Dialog is keyboard-accessible (focus-trapped, Esc cancels) and announced via `role="dialog"` + translated `aria-label` — matches the page's existing a11y conventions.
+
+### Performance
+- [ ] Exactly ONE translate request per page view per non-English locale (batched); cache-warm responses apply within one frame budget (no observable flash for repeat visitors); cold first-view may visibly swap (accepted — lazy-by-design).
+
+### Security
+- [ ] Translated strings are inserted via text nodes/`textContent` (or `escapeHtml`-piped) — service output is treated as untrusted (defence-in-depth; the provider is third-party).
+- [ ] GitHub links carry `rel="noopener noreferrer"` + `target="_blank"`.
+
+### UX
+- [ ] Dialog copy is plain and friendly; confirm/cancel buttons translated; no dark patterns (cancel is equally prominent).
+
+### i18n
+- [ ] New LABELS keys (`storyEnglishOnlyTitle`, `storyEnglishOnlyBody`, `continueBtn`, `cancelBtn` — exact names at implementation) present in ALL 21 locale blocks, enforced by extending the per-locale-block structural test (same mechanism as `storyBadge`).
+
+### Observability
+- [ ] `console.error` on translate failure (dev-console surface per operator); `console.info` with missed-count when `missed` non-empty. Console-errors-all-pages sweep updated expectation: the sweep must still pass with the service MOCKED HEALTHY (a failing service in that sweep is a finding, not noise).
+
+## BDD Scenarios
+
+**Scenario: German visitor sees German items**
+- **Given** the translate service (mocked) returns German for the fixture item names
+- **When** the roadmap renders with locale `de`
+- **Then** one batched POST occurs and item rows display the German names
+- **And** legacy feature rows still show their embedded German payloads
+
+**Scenario: service down — page intact in English**
+- **Given** the translate route is mocked to 503
+- **When** the page renders with locale `fr`
+- **Then** items display English, layout unbroken, exactly one console.error fires, and the test's error-collection (filtered per the network-noise convention) records the translate failure as the ONLY console error
+
+**Scenario: gated link, once per session**
+- **Given** locale `ar` and a rendered item link
+- **When** the visitor clicks it
+- **Then** a translated RTL confirm dialog appears; cancel keeps them on the page
+- **And** after confirming once, a second item click navigates with no dialog
+
+**Scenario: English visitors pay zero cost**
+- **Given** locale `en`
+- **When** the page renders and a story link is clicked
+- **Then** no translate request is made and navigation is direct
+
+## Test Plan
+
+**Red first:** extend `tests/web/roadmap-shy-items.spec.ts` patterns into `tests/web/roadmap-i18n-lazy.spec.ts` (page.route mocks for BOTH roadmap-data.json AND /api/translate; scenarios above incl. ar/RTL + dialog a11y + sessionStorage privacy-mode via context override) + extend `express-api/tests/scripts/web-i18n-coverage.test.js` for the new LABELS keys ×21 + a sync-script test pinning the additive `slug` field (`sync-shy-to-roadmap-data` test file — locate at pickup-review).
+**Green:** roadmap-app.js (batched fetch + apply + dialog + links), LABELS ×21, sync-script slug emission, dialog CSS (neutral tokens).
+**Verify-by-running:** local stack with the REAL service (SHY-0072) — walk de + ar journeys per every-commit-tested; console sweep green.
+
+## Out of Scope
+
+- Translating page chrome (already translated via LABELS) or legacy features[] (embedded i18n stays).
+- The service itself (SHY-0072 — hard dependency).
+- Story-detail pages on shytalk.com (links go to GitHub by design).
+
+## Dependencies
+
+- **SHY-0072 merged** (the endpoint this consumes) — hard blocker.
+- SHY-0061 (badges, merged v0.97.9) — extends its row markup.
+- Pickup-review must verify: SHY-0061's final DOM shape, the sync test file location, dialog-precedent in the codebase (language-selector modal patterns to reuse).
+
+## Risks & Mitigations
+
+- **Risk:** visible English→translated swap on cold views. **Mitigation:** accepted by design (lazy); cache makes it once per locale ever.
+- **Risk:** dialog annoys multilingual users. **Mitigation:** once per session + sessionStorage; copy is one short sentence.
+- **Risk:** console sweep starts flaking from translate noise. **Mitigation:** sweep runs with healthy-mocked service; real-failure noise is filtered by the established network-noise convention.
+
+## Definition of Done
+
+- [ ] All AC checked; red→green; Playwright + i18n + sync tests green; console sweep green; reviewer ZERO; auto-merged; local de+ar journey walk evidence in Notes.
+- [ ] `status: Done` deferred to release cut; SHY-INDEX + EPIC-0002 synced.
+
+## Notes (running log)
+
+- 2026-06-10 ~10:20 BST — Authored fully-refined per the operator's corrected design (page always translated; stories English-only; gated links). Dialog + link scope confirmed by operator ("Yes — link + gated confirm").

--- a/.project/stories/SHY-INDEX.md
+++ b/.project/stories/SHY-INDEX.md
@@ -12,6 +12,9 @@ Live backlog of every piece of work captured under the Agile way of working ([[f
 | --------------------------------------------------------------- | --- | ------ | -------- | ------------------------------------------------------------------------------------------------ | -------------- | ---------------- | --- |
 | [SHY-0060](SHY-0060-age-gating-per-feature.md)                  | P0  | XL     | feature  | Age-gating per feature: tiered per-feature age thresholds replacing single 13+ signup gate       | 🚧 In Progress | —                | —   |
 | [SHY-0071](SHY-0071-sync-wall-clock-batching.md)                | P1  | M      | refactor | Sync wall-clock: batch gh lookups (one upfront list → map) + scan-mode validation (36.2s→≤6s)      | 📝 Draft       | —                | —   |
+| [SHY-0062](SHY-0062-migrate-legacy-roadmap-features.md)         | P1  | XL     | chore    | Migrate ~95 legacy roadmap features into tracked stories (meta/tracker; EPIC-0002)                | 🚧 In Progress | —                | —   |
+| [SHY-0072](SHY-0072-lazy-translation-service.md)                | P1  | M      | feature  | Lazy translation service: translate-on-first-view + server cache + fail-silent + miss queue       | 📝 Draft       | —                | —   |
+| [SHY-0073](SHY-0073-renderer-lazy-i18n-and-gated-story-links.md) | P1 | M      | feature  | Renderer: lazy item translations + gated GitHub story links (once-per-session confirm)            | 📝 Draft       | —                | —   |
 | [SHY-0070](SHY-0070-system-routes-observability.md)             | P2  | S      | feature  | System-routes observability: structured sweep logging + {swept,errors} plumbing                   | 📝 Draft       | —                | —   |
 | [SHY-0024](SHY-0024-resolve-navgraph-coexistence.md)            | P0  | L      | refactor | Migrate Android to SharedNavGraph + delete NavGraph.kt                                           | 📝 Draft       | G028             | —   |
 | [SHY-0029](SHY-0029-tighten-ownerfirebaseuid-rule.md)           | P0  | S      | bug      | Tighten ownerFirebaseUid rule (strict equality, no legacy fallback)                              | 📝 Draft       | G026             | —   |
@@ -100,7 +103,7 @@ These IDs are reserved by the SHY-0032 + SHY-0033 multi-PR plan (operator 2026-0
 | ~~SHY-0071~~ | ~~Sync wall-clock batching~~ — **FILED 2026-06-10** (see Active table)                                                                                                                                                | —                                                        |
 | ~~SHY-0040~~ | ~~Optimise sync-stories-to-issues.sh per-file overhead~~ — **FILED 2026-06-10** (see Active table)                                                                                                                    | —                                                        |
 | ~~SHY-0061~~ | ~~Public roadmap renderer reads SHY-derived `phases[].items[]`~~ — **FILED 2026-06-09** (see Active table)                                                                                                           | —                                                        |
-| SHY-0062     | Staged migration of ~95 legacy `phases[].features[]` entries into fully-refined SHYs with `public: true`. Batched by phase (~8 follow-up SHYs at ~12 features each); preserves user-visible content during transition | After SHY-0061 merges (renderer reads `items[]`)         |
+| ~~SHY-0062~~ | ~~Staged migration of ~95 legacy features~~ — **FILED 2026-06-10** (see Active table; EPIC-0002)                                                                                                              | —                                                        |
 
 ---
 
@@ -109,6 +112,7 @@ These IDs are reserved by the SHY-0032 + SHY-0033 multi-PR plan (operator 2026-0
 | EPIC      | Title                                                      | Status      | Child SHYs                                      |
 | --------- | ---------------------------------------------------------- | ----------- | ----------------------------------------------- |
 | EPIC-0001 | ShyTalk SHY framework (stories, validator, GH sync, EPICs) | In Progress | SHY-0001, SHY-0002, SHY-0003, SHY-0037 (4 SHYs) |
+| EPIC-0002 | Public roadmap story-migration + lazy translation platform | In Progress | SHY-0062, SHY-0072, SHY-0073 (+batches as filed) |
 
 EPICs are validated by `scripts/check-epic-frontmatter.sh` (separate from the SHY validator). The `epic:` field on SHY frontmatter is optional — most SHYs need not belong to an EPIC. See `CLAUDE.md` § "Agile Way of Working" → "### EPICs" for the full spec.
 


### PR DESCRIPTION
Stories-only PR filing the operator-designed program (full decision trail in each file's Notes + the EPIC):

- **EPIC-0002** — public roadmap story-migration + lazy translation platform
- **SHY-0062** — migration meta/tracker: conventions (status mapping, pre-rule sentinel, absorption of duplicates, atomic entry-count parity) + 8-batch table, smallest-first pilot
- **SHY-0072** — lazy translation service: translate-on-first-view, server cache, fail-silent English + admin log + miss queue + Claude backfill (strictly $0)
- **SHY-0073** — renderer: batched lazy item translations + gated GitHub story links (once-per-session translated confirm), public-facing story

Ordering: SHY-0072 → SHY-0073 → batches. Both scan validators green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)