### PR TITLE
chore: flip v0.97.10 SHYs to Done (7 stories) + WIP hygiene

### DIFF
--- a/.project/stories/SHY-0060-age-gating-per-feature.md
+++ b/.project/stories/SHY-0060-age-gating-per-feature.md
@@ -1,6 +1,6 @@
 ---
 id: SHY-0060
-status: In Progress
+status: Draft
 owner: claude
 created: 2026-06-08
 priority: P0

--- a/.project/stories/SHY-0062-migrate-legacy-roadmap-features.md
+++ b/.project/stories/SHY-0062-migrate-legacy-roadmap-features.md
@@ -1,6 +1,6 @@
 ---
 id: SHY-0062
-status: In Progress
+status: Draft
 owner: claude
 created: 2026-06-10
 priority: P1

--- a/.project/stories/SHY-0072-lazy-translation-service.md
+++ b/.project/stories/SHY-0072-lazy-translation-service.md
@@ -1,14 +1,15 @@
 ---
 id: SHY-0072
-status: In Progress
+status: Done
 owner: claude
 created: 2026-06-10
 priority: P1
 effort: M
 type: feature
 roadmap_ids: []
-pr:
+pr: https://github.com/Shyden-Ltd/ShyTalk/pull/1132
 epic: EPIC-0002
+released_in: v0.97.10
 ---
 
 # SHY-0072: Lazy translation service — translate-on-first-view with server cache

--- a/.project/stories/SHY-0073-renderer-lazy-i18n-and-gated-story-links.md
+++ b/.project/stories/SHY-0073-renderer-lazy-i18n-and-gated-story-links.md
@@ -1,16 +1,17 @@
 ---
 id: SHY-0073
-status: In Progress
+status: Done
 owner: claude
 created: 2026-06-10
 priority: P1
 effort: M
 type: feature
 roadmap_ids: []
-pr:
+pr: https://github.com/Shyden-Ltd/ShyTalk/pull/1133
 epic: EPIC-0002
 public: true
 phase: Website & Presence
+released_in: v0.97.10
 ---
 
 # SHY-0073: Roadmap renderer — lazy item translations + gated GitHub story links

--- a/.project/stories/SHY-0074-mirror-fidelity-board-body-labels.md
+++ b/.project/stories/SHY-0074-mirror-fidelity-board-body-labels.md
@@ -1,15 +1,16 @@
 ---
 id: SHY-0074
-status: In Progress
+status: Done
 owner: claude
 created: 2026-06-10
 priority: P1
 effort: XL
 type: bug
 roadmap_ids: []
-pr:
+pr: https://github.com/Shyden-Ltd/ShyTalk/pull/1134
 epic: EPIC-0001
 public: false
+released_in: v0.97.10
 ---
 
 # SHY-0074: Mirror architecture v2 — bugs-only Issues, draft cards for stories, faithful board columns

--- a/.project/stories/SHY-0078-mirror-idempotent-create-guard.md
+++ b/.project/stories/SHY-0078-mirror-idempotent-create-guard.md
@@ -1,6 +1,6 @@
 ---
 id: SHY-0078
-status: Draft
+status: Done
 owner: claude
 created: 2026-06-10
 priority: P1
@@ -9,6 +9,8 @@ type: bug
 roadmap_ids: []
 epic: EPIC-0001
 public: false
+pr: https://github.com/Shyden-Ltd/ShyTalk/pull/1243
+released_in: v0.97.10
 ---
 
 # SHY-0078: Mirror create-path idempotency guard against Projects v2 read-after-write lag

--- a/.project/stories/SHY-0079-draft-dedup-sidecar.md
+++ b/.project/stories/SHY-0079-draft-dedup-sidecar.md
@@ -1,6 +1,6 @@
 ---
 id: SHY-0079
-status: In Progress
+status: Done
 owner: claude
 created: 2026-06-11
 priority: P1
@@ -9,6 +9,8 @@ type: bug
 roadmap_ids: []
 epic: EPIC-0001
 public: false
+pr: https://github.com/Shyden-Ltd/ShyTalk/pull/1272
+released_in: v0.97.10
 ---
 
 # SHY-0079: Draft-dedup sidecar — a consistent board-items.json oracle overlaying the laggy Projects v2 query

--- a/.project/stories/SHY-0080-argmax-safe-map-merge.md
+++ b/.project/stories/SHY-0080-argmax-safe-map-merge.md
@@ -1,6 +1,6 @@
 ---
 id: SHY-0080
-status: In Progress
+status: Done
 owner: claude
 created: 2026-06-11
 priority: P0
@@ -9,6 +9,8 @@ type: bug
 roadmap_ids: []
 epic: EPIC-0001
 public: false
+pr: https://github.com/Shyden-Ltd/ShyTalk/pull/1274
+released_in: v0.97.10
 ---
 
 # SHY-0080: ARG_MAX-safe items-map merges — the real board-duplication root cause

--- a/.project/stories/SHY-0081-mirror-v3-uniform-board-drafts.md
+++ b/.project/stories/SHY-0081-mirror-v3-uniform-board-drafts.md
@@ -1,6 +1,6 @@
 ---
 id: SHY-0081
-status: In Progress
+status: Done
 owner: claude
 created: 2026-06-11
 priority: P1
@@ -9,6 +9,8 @@ type: refactor
 roadmap_ids: []
 epic: EPIC-0001
 public: false
+pr: https://github.com/Shyden-Ltd/ShyTalk/pull/1305
+released_in: v0.97.10
 ---
 
 # SHY-0081: Mirror v3 — every story is a board work-item card; the Issues page is reserved for bug reports


### PR DESCRIPTION
Release **v0.97.10** closeout (matches prior `chore: flip vX.Y.Z SHYs to Done` PRs #1113/#1127).

## To Done + `released_in: v0.97.10`
First contained in v0.97.10 (merged after v0.97.9 was tagged):
- SHY-0072 (#1132) — lazy translation service
- SHY-0073 (#1133) — renderer lazy i18n + gated story links
- SHY-0074 (#1134) — mirror architecture v2
- SHY-0078 (#1243) — mirror idempotent create-guard
- SHY-0079 (#1272) — draft-dedup sidecar
- SHY-0080 (#1274) — ARG_MAX-safe map merge
- SHY-0081 (#1305) — mirror v3 (uniform board drafts)

## Board hygiene (WIP=1)
- SHY-0060, SHY-0062 → Draft (not actively built).

Frontmatter-only; `check-story-frontmatter.sh --scan` passes. No `Closes #N` — board status is mirrored from frontmatter (v3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)