### PR TITLE
SHY-0084: Consolidate prod-deploy approval gates + fix Android & iOS boot smoke tests

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -164,6 +164,15 @@ jobs:
   # ── Build Android (shared by deploy + smoke test) ──────────
   build-android:
     name: Build Android
+    # SHY-0084 note: intentionally NOT gated on `approve-prod`. This job only
+    # BUILDS + signs artifacts (it does not deploy) — publication to Play Store
+    # is gated on the deploy-android-prod job, which DOES need approve-prod. The
+    # signing key is used by trusted CI either way; the gate controls SHIPPING,
+    # not signing. Building during the approval wait (rather than after) keeps
+    # the post-approval deploy fast — important for queued/overnight releases
+    # where the artifact is ready by the time the operator clicks approve.
+    # Behaviour unchanged from the pre-SHY-0084 design (the old per-platform
+    # gates were on the deploy jobs, never on this build).
     needs: [validate-release]
     if: inputs.android
     runs-on: ubuntu-latest
@@ -208,16 +217,34 @@ jobs:
           retention-days: 3
 
   # ── Deploy jobs ────────────────────────────────────────────
+  approve-prod:
+    name: Approve Prod Release
+    # SHY-0084: the SINGLE manual approval gate for the entire prod deploy.
+    # Replaces the four per-platform `environment: prod-*` gates (one release
+    # used to need four approval clicks). Every deploy job below `needs:` this
+    # job AND checks `needs.approve-prod.result == 'success'` in its `if:`, so
+    # ONE approval of the protected `production` environment unlocks backend +
+    # web + android + ios — and a DENIED approval (this job fails) blocks all
+    # four, even though they use `always()` for selective-platform logic.
+    # `production` is the pre-existing protected environment (required reviewer:
+    # the repo owner); no per-platform environment is auto-created un-gated.
+    needs: [validate-release]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: production
+    steps:
+      - name: Record approval
+        env:
+          DEPLOY_SHA: ${{ needs.validate-release.outputs.commit-sha || github.sha }}
+        run: echo "Production release approved for $DEPLOY_SHA"
+
   deploy-backend-prod:
     name: Deploy Backend to Prod
-    needs: [validate-release]
+    # SHY-0084: gated by the single `approve-prod` job above (no own
+    # environment). `needs: approve-prod` (no `always()` here) means a denied
+    # approval auto-skips this first deploy.
+    needs: [validate-release, approve-prod]
     if: inputs.backend
-    # Repo-owner approval gate (configured via GitHub Environments).
-    # The `prod-backend` environment must exist with the repo owner
-    # listed as a required reviewer — see PR description for one-time
-    # setup. Without the environment + reviewers, the job would run
-    # un-gated (environments default to empty reviewers when auto-created).
-    environment: prod-backend
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -308,7 +335,8 @@ jobs:
     # (incident 2026-05-03 run 25276782190 where web shipped with a
     # broken backend deploy and testers got a working-looking site
     # whose every API call errored). Prod stakes are higher than dev.
-    needs: [validate-release, deploy-backend-prod]
+    # SHY-0084: + approve-prod (the single gate); no own environment.
+    needs: [validate-release, approve-prod, deploy-backend-prod]
     # Allow `success` OR `skipped` — `skipped` covers the legitimate
     # `inputs.backend=false` web-only redeploy. Block only on `failure`
     # / `cancelled` so a crashed backend can't ship a working-looking
@@ -317,11 +345,13 @@ jobs:
     # rationale (run 25280868804 — implicit "needs success" gate skips
     # dependent jobs whenever upstream is `skipped`, even when explicit
     # `if:` checks for `result == 'skipped'`).
+    # The explicit `approve-prod.result == 'success'` keeps the gate
+    # enforced under always() (a denied approval blocks this deploy).
     if: |
       always() &&
       inputs.web &&
+      needs.approve-prod.result == 'success' &&
       (needs.deploy-backend-prod.result == 'success' || needs.deploy-backend-prod.result == 'skipped')
-    environment: prod-web
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -350,14 +380,17 @@ jobs:
     # Gate Android on backend success — see deploy-web-prod for the
     # rationale. Pushing a broken-backend build to Play Store would
     # be visible to every prod user on next app open.
-    needs: [validate-release, build-android, deploy-backend-prod]
+    # SHY-0084: + approve-prod (the single gate); no own environment.
+    needs: [validate-release, approve-prod, build-android, deploy-backend-prod]
     # See deploy-web-prod for `success || skipped` rationale.
     # See deploy-web-prod / deploy-dev.yml for `always()` + allowlist rationale.
+    # The explicit `approve-prod.result == 'success'` keeps the gate enforced
+    # under always() (a denied approval blocks this deploy).
     if: |
       always() &&
       inputs.android &&
+      needs.approve-prod.result == 'success' &&
       (needs.deploy-backend-prod.result == 'success' || needs.deploy-backend-prod.result == 'skipped')
-    environment: prod-android
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -396,14 +429,17 @@ jobs:
     # Gate iOS on backend success — see deploy-web-prod for the
     # rationale. Apple App Store review pulls and exercises the binary
     # against the live backend; a broken-backend build risks rejection.
-    needs: [validate-release, deploy-backend-prod]
+    # SHY-0084: + approve-prod (the single gate); no own environment.
+    needs: [validate-release, approve-prod, deploy-backend-prod]
     # See deploy-web-prod for `success || skipped` rationale.
     # See deploy-web-prod / deploy-dev.yml for `always()` + allowlist rationale.
+    # The explicit `approve-prod.result == 'success'` keeps the gate enforced
+    # under always() (a denied approval blocks this deploy).
     if: |
       always() &&
       inputs.ios &&
+      needs.approve-prod.result == 'success' &&
       (needs.deploy-backend-prod.result == 'success' || needs.deploy-backend-prod.result == 'skipped')
-    environment: prod-ios
     # Migrated 2026-05-20 from self-hosted Mac (shytalk-mac) to GitHub-hosted
     # macos-latest per the no-self-hosted-runners policy. See deploy-dev.yml
     # for full rationale.
@@ -723,6 +759,13 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
+      # SHY-0084: check out the repo so the committed bash smoke verifier
+      # (scripts/ci/android-smoke-verify.sh) exists on disk — this job
+      # previously only downloaded the APK artifact, with no working tree.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ needs.validate-release.outputs.commit-sha }}
+
       - name: Download debug APK
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -745,47 +788,14 @@ jobs:
           force-avd-creation: true
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
-          script: |
-            set -euo pipefail
-            echo "=== Installing APK ==="
-            shopt -s nullglob
-            apks=(debug-apk/*.apk)
-            shopt -u nullglob
-            if [ "${#apks[@]}" -ne 1 ]; then
-              echo "::error::Expected exactly one debug APK, found ${#apks[@]}"
-              exit 1
-            fi
-            adb install -r "${apks[0]}"
-            echo "=== Launching app ==="
-            am_output=$(adb shell am start -W -n com.shyden.shytalk/com.shyden.shytalk.MainActivity 2>&1)
-            echo "$am_output"
-            # Match only real failures. The benign messages
-            # "Activity not started, its current task has been brought to the front"
-            # and "Activity not started, intent has been delivered to currently running top-most instance"
-            # are normal `am start` output when re-launching. Match the
-            # "unable to" variant or explicit Error type/Java exception lines.
-            if echo "$am_output" | grep -qE '^Error|FATAL|Activity not started, unable to|java\.lang\.|Exception type'; then
-              echo "::error::am start reported an error — app failed to launch"
-              exit 1
-            fi
-            sleep 3
-            echo "=== Verifying app is foreground activity ==="
-            focused=$(adb shell dumpsys window windows 2>&1 | grep -E 'mCurrentFocus' || true)
-            echo "$focused"
-            if ! echo "$focused" | grep -q 'com.shyden.shytalk'; then
-              echo "::error::ShyTalk is not the foreground activity. Got: $focused"
-              exit 1
-            fi
-            sleep 5
-            echo "=== Checking for fatal crashes in logcat ==="
-            adb logcat -d -s AndroidRuntime > /tmp/runtime.log 2>&1
-            CRASHES=$(grep -c "FATAL EXCEPTION" /tmp/runtime.log || echo 0)
-            if [ "${CRASHES:-0}" -gt 0 ]; then
-              echo "::error::Found $CRASHES fatal crash(es)"
-              tail -30 /tmp/runtime.log
-              exit 1
-            fi
-            echo "No fatal crashes — Android APK installs and launches successfully"
+          # SHY-0084: the verification runs as a committed bash file. The action
+          # executes `script` via /usr/bin/sh (dash), where the previous inline
+          # `set -o pipefail` / `shopt` / arrays aborted on line 1 ("Illegal
+          # option -o pipefail") before installing anything — the emulator
+          # booted but the smoke never ran (prod run 27286731472, 2026-06-10).
+          # `bash <file>` guarantees a bash interpreter; the logic is unit-tested
+          # in tests/scripts/android-smoke-verify.test.js.
+          script: bash "$GITHUB_WORKSPACE/scripts/ci/android-smoke-verify.sh"
 
   smoke-test-ios:
     name: Smoke Test (iOS Boot)
@@ -796,7 +806,13 @@ jobs:
     # Migrated 2026-05-20 to GitHub-hosted macos-latest per the
     # no-self-hosted-runners policy. See deploy-dev.yml for rationale.
     runs-on: macos-latest
-    timeout-minutes: 20
+    # SHY-0084: raised 20 → 45. At 20 min the K/N framework link
+    # (--max-workers=1) + pod install + xcodebuild build consumed the whole
+    # budget on a cold ~/.konan cache and the job was CANCELLED before the
+    # "Boot simulator and verify" step ever ran (prod run 27286731472:
+    # started 17:21:26, cancelled 17:41:49 mid-build). 45 min leaves headroom
+    # for the boot+launch verification even on the cold-cache worst case.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:

--- a/.project/stories/SHY-0084-prod-deploy-gate-and-smoke-fixes.md
+++ b/.project/stories/SHY-0084-prod-deploy-gate-and-smoke-fixes.md
@@ -1,0 +1,169 @@
+---
+id: SHY-0084
+status: In Review
+owner: claude
+created: 2026-06-12
+priority: P0
+effort: M
+type: bug
+roadmap_ids: []
+pr:
+public: false
+mvp: true
+---
+
+# SHY-0084: Consolidate prod-deploy approval gates + fix Android & iOS boot smoke tests
+
+## User Story
+
+As the ShyTalk operator cutting a production release,
+I want a SINGLE manual approval gate for the whole prod deploy, an Android boot smoke test that passes reliably, and an iOS boot smoke test that actually runs,
+So that releasing to all three platforms is one decision (not four), and a green deploy genuinely proves the apps install + launch on both mobile platforms.
+
+## Why
+
+`.github/workflows/deploy-prod.yml` has three operator-flagged defects (all verified against the latest prod run **27286731472**, 2026-06-10, which FAILED):
+
+1. **Four separate approval gates.** Each platform deploy job carries its own GitHub `environment:` (each with manual-approval protection): `deploy-backend-prod`→`prod-backend` (line 220), `deploy-web-prod`→`prod-web` (324), `deploy-android-prod`→`prod-android` (360), `deploy-ios-prod`→`prod-ios` (406). One release = FOUR approval clicks across four environments. The operator wants ONE gate.
+2. **Android boot smoke FAILS.** `smoke-test-android` died in ~4 min, but NOT on the emulator/action download — the log shows the emulator BOOTED ("Emulator booted.") and then the verification `script:` died on its very first line:
+
+   ```
+   /usr/bin/sh -c set -euo pipefail
+   /usr/bin/sh: 1: set: Illegal option -o pipefail
+   ##[error]The process '/usr/bin/sh' failed with exit code 2
+   ```
+
+   **Root cause:** `reactivecircus/android-emulator-runner` executes its `script:` input via `/usr/bin/sh` (dash on Ubuntu runners), but the inline block opened with `set -euo pipefail` plus `shopt -s nullglob` and bash arrays (`apks=(...)`, `${#apks[@]}`) — all bash-only constructs. Under dash, line 1 aborts immediately, so the smoke never installs the APK. (The pinned SHA `e89f39f1…` is **correct** — it is the *commit* the annotated `v2.37.0` tag dereferences to; `0a638108…` is the tag-OBJECT sha, which must NOT be pinned. `e2e-tests.yml` already documents "executes `script` via /usr/bin/sh" and wraps its command in `bash -c`, so e2e is the CORRECT reference pattern, not a shared victim — no SHA change anywhere.)
+3. **iOS boot smoke NEVER RUNS.** `smoke-test-ios` (line 790) has `timeout-minutes: 20`, but the job spends the entire budget on setup → `:shared:linkDebugFrameworkIosSimulatorArm64` → `pod install` → `Build iOS app for simulator`, which was CANCELLED at exactly 20 min (started 17:21:26, cancelled 17:41:49). The actual "Boot simulator and verify app launches" step was **skipped**. So the iOS boot test has effectively never executed — the slow KMP/xcodebuild eats the whole timeout before the boot verification.
+
+Net effect: prod releases are blocked by a flaky/mis-pinned Android smoke, and the iOS smoke gives zero real coverage. Both are launch-blocking for the tri-platform MVP go-live (`mvp: true`).
+
+## Acceptance Criteria
+
+### Happy path
+
+- [ ] **One gate:** `deploy-prod.yml` uses a SINGLE protected GitHub environment (e.g. `prod`) such that exactly ONE manual approval unlocks all four platform deploys (backend/web/android/ios). Achieved either by (a) pointing all four deploy jobs at one `environment: prod`, or (b) a dedicated `approve-prod` gate job (`environment: prod`) that the four deploys `needs:`. The chosen approach is documented in a workflow comment.
+- [ ] **Android boot smoke passes:** `smoke-test-android` runs to completion and verifies the prod debug APK installs, launches `com.shyden.shytalk/.MainActivity`, is the foreground activity, and logs no `FATAL EXCEPTION` — on a green app build.
+- [ ] **iOS boot smoke ACTUALLY runs:** `smoke-test-ios`'s "Boot simulator and verify app launches" step EXECUTES (conclusion `success`, not `skipped`/`cancelled`) and verifies the prod app builds, the simulator boots, the app launches, and no crash report is produced.
+- [ ] A fully-successful deploy (all 4 deploys + all 4 smokes) ends with `alert-desync` NOT firing.
+
+### Error paths
+
+- [ ] **Real regressions still fail the smoke:** a genuine Android launch failure (e.g. `am start` error / app not foreground / `FATAL EXCEPTION`) still fails `smoke-test-android` (exit 1). A genuine iOS launch failure / crash report still fails `smoke-test-ios`. The fixes must NOT mask real failures to go green (no relaxed assertions, no `|| true`).
+- [ ] **The fix does not mask shell errors:** the extracted verifier runs under `bash` (its shebang) so `set -euo pipefail` is honoured — a non-zero adb/grep in the chain still fails the smoke. The script is NOT made to swallow errors to go green.
+- [ ] The single approval gate still HARD-requires approval — a deploy cannot proceed to any platform without the one approval. A DENIED approval (the `approve-prod` job fails) blocks all four deploys even though they use `always()` (each `if:` adds `needs.approve-prod.result == 'success'`).
+
+### Edge cases
+
+- [ ] **Cold iOS cache:** the raised iOS timeout (and/or a pre-built shared framework) leaves enough headroom for the boot step to run even on a COLD `~/.konan` cache (the slowest case), not just a warm-cache run.
+- [ ] **Android emulator boot stays reliable:** `smoke-test-android` keeps its `ubuntu-22.04` pin (the empirically-stable image for this action — see `android-e2e-emulator-boot-headroom.test.js`); the fix does not touch the emulator/action config, only the verification shell.
+- [ ] **No spurious SHA change:** the emulator-runner SHA (`e89f39f1…`) is left UNCHANGED in both `deploy-prod.yml` and `e2e-tests.yml` (it is the correct v2.37.0 commit). `android-e2e-emulator-boot-headroom.test.js`'s SHA + `ubuntu-22.04` pins stay green (regression-guarded).
+
+### Performance
+
+- [ ] iOS smoke completes WITH the boot step inside the (raised) `timeout-minutes`. If the framework is pre-built in a shared job (or cached), document the new budget. The consolidated gate must not unnecessarily serialise the four deploys (they may still run in parallel after the single approval).
+
+### Security
+
+- [ ] The single `prod` environment RETAINS the required-reviewers protection of the prior four (the consolidation reduces clicks, NOT the approval requirement). No secret is moved to a less-protected scope. The `no-self-hosted-runners` + `no-paid-runners` policies still hold (Android stays `ubuntu-22.04`, iOS stays `macos-latest`).
+
+### UX
+
+*(consumer = the operator approving a prod release)*
+
+- [ ] The deployer sees ONE "Review pending deployment" prompt for prod, not four. Approving it once releases all platforms.
+- [ ] The four smoke jobs report clear per-platform pass/fail; a failed smoke is visibly attributed to its platform (the existing `alert-desync` summary is preserved/updated).
+
+### i18n
+
+- N/A — CI/CD workflow change; no user-facing strings.
+
+### Observability
+
+- [ ] `alert-desync` (line 923) continues to surface per-platform deploy + smoke outcomes; its `needs`/`if` are updated to match the consolidated gate + the now-running iOS smoke (so a skipped-vs-failed iOS smoke is no longer ambiguous).
+- [ ] The iOS smoke's actual boot result is visible in the run (a real conclusion, not a perpetual `cancelled`).
+
+## BDD Scenarios
+
+**Scenario: one approval unlocks the whole prod deploy**
+- **Given** a prod deploy is dispatched
+- **When** the operator approves the single `prod` environment gate once
+- **Then** all four platform deploy jobs (backend/web/android/ios) proceed without any further approval prompt
+
+**Scenario: Android boot smoke verifies a green app**
+- **Given** the prod debug APK is built and the app is healthy
+- **When** `smoke-test-android` runs
+- **Then** the APK installs, the app launches and is the foreground activity, no FATAL EXCEPTION is logged, and the job concludes `success`
+
+**Scenario: iOS boot smoke actually executes the boot step**
+- **Given** the prod iOS app builds for the simulator within the timeout
+- **When** `smoke-test-ios` runs
+- **Then** the "Boot simulator and verify app launches" step has conclusion `success` (NOT skipped/cancelled) and verifies launch + no crash report
+
+**Scenario: a real Android crash still fails the smoke**
+- **Given** the app throws a FATAL EXCEPTION on launch
+- **When** `smoke-test-android` runs
+- **Then** the job fails (exit 1) and `alert-desync` fires for Android
+
+**Scenario: the Android verifier runs under bash (the dash regression is gone)**
+- **Given** `reactivecircus/android-emulator-runner` executes its `script:` via `/usr/bin/sh` (dash)
+- **When** the smoke `script:` invokes `bash "$GITHUB_WORKSPACE/scripts/ci/android-smoke-verify.sh"`
+- **Then** `set -o pipefail` / `shopt` / arrays in the verifier run under a bash interpreter and the APK install + launch verification proceeds (no "Illegal option -o pipefail")
+
+**Scenario: a missing/duplicate APK artifact fails the smoke loudly**
+- **Given** the `debug-apk` dir holds zero or more than one `*.apk`
+- **When** the verifier runs
+- **Then** it exits 1 with `::error::Expected exactly one debug APK … found N` (no silent pass)
+
+## Test Plan
+
+Workflow/CI change — validated by static lint + a real prod-deploy run + any SHA-pin assertion tests.
+
+**RED / discovery (done in this ticket's investigation):**
+- Confirmed the 4 `environment: prod-*` gates (deploy-prod.yml 220/324/360/406) + that the `production` environment ALREADY exists with the repo owner as required reviewer (so no operator setup needed for the consolidation).
+- Confirmed run 27286731472: Smoke Test (Android Boot) = failure — emulator BOOTED then `script:` died with `/usr/bin/sh: 1: set: Illegal option -o pipefail` (dash, not bash); Smoke Test (iOS Boot) = cancelled (build steps consumed the 20-min timeout; "Boot simulator and verify" skipped).
+- Confirmed the SHA `e89f39f1…` is CORRECT (the commit `v2.37.0` dereferences to; `0a638108…` is the annotated-tag object — NOT a pin target). So NO re-pin.
+
+**RED (failing-first tests):**
+- `express-api/tests/scripts/android-smoke-verify.test.js`: drives `scripts/ci/android-smoke-verify.sh` against a stubbed `adb` — value matrix: healthy→0; benign "already running" re-launch→0; 0 APKs→1; 2 APKs→1; `am start` error→1; not-foreground→1; FATAL EXCEPTION→1; clean logcat→0. (Fails at RED: script absent → exit 127.)
+- `express-api/tests/scripts/deploy-prod-single-gate-and-smoke.test.js`: asserts exactly ONE `environment:` (== `production`); none of the 4 legacy envs remain; `approve-prod` job on `production`; `deploy-backend-prod` needs `approve-prod` + has no own environment; Android smoke calls the bash verifier + has no `set -euo pipefail`/`shopt` + checks out the repo + stays `ubuntu-22.04`; iOS `timeout-minutes` ≥ 40 with the boot step intact.
+
+**GREEN (implementation):**
+- NEW `scripts/ci/android-smoke-verify.sh` (bash; install→launch→foreground→crash checks; env-knobbed for testability) + `bash "$GITHUB_WORKSPACE/scripts/ci/android-smoke-verify.sh"` as the action `script:`; add a checkout step to `smoke-test-android` so the file is on disk.
+- `deploy-prod.yml`: ONE `approve-prod` job (`environment: production`) that `deploy-backend-prod` needs; remove the 4 `environment: prod-*`; every deploy adds `approve-prod` to `needs:` + `needs.approve-prod.result == 'success'` to its `if:` (enforces the gate under `always()`).
+- `smoke-test-ios`: `timeout-minutes: 20 → 45` (headroom for the cold-cache build so "Boot simulator and verify" runs).
+
+**Validation:**
+- `npx jest` both new files green; `shellcheck scripts/ci/android-smoke-verify.sh` clean; `actionlint .github/workflows/deploy-prod.yml`; `check-action-shas.sh`; `android-e2e-emulator-boot-headroom.test.js` stays green (SHA + `ubuntu-22.04` regression guard); full `cd express-api && npm test`.
+- A real prod-deploy dispatch (operator-gated) showing: ONE approval, all 4 deploys, Android smoke `success`, iOS smoke boot step `success`. Evidence (run id + per-job conclusions) pasted into `## Notes`.
+
+## Out of Scope
+
+- Changing WHAT the smokes assert beyond making them run reliably (deeper E2E coverage is the journey-test corpus, not the boot smoke).
+- The dev deploy workflow (`deploy-dev.yml`) — unless it shares the same mis-pinned emulator-runner SHA, in which case re-pin only (no gate change; dev has no manual gates).
+- Migrating runners or the emulator API level beyond what's needed to make the Android smoke reliable.
+
+## Dependencies
+
+- GitHub `environments`: reuses the pre-existing **`production`** environment (required reviewer = repo owner, verified via `gh api repos/.../environments`). No operator setup needed — the four `prod-*` envs are simply abandoned.
+- No SHA change → no `check-action-shas.sh` impact; the existing emulator-runner pin stays.
+
+## Risks & Mitigations
+
+- **Misdiagnosis trap (annotated-tag SHA).** The original draft blamed a "wrong SHA" — but `git/refs/tags/v2.37.0` returns the annotated-tag OBJECT sha (`0a638108…`), not the commit; the pinned `e89f39f1…` is the correct dereferenced commit. Pinning the tag-object sha would have INTRODUCED a real digest-mismatch. *Mitigation:* verified via deref (`git/tags/<tagsha>`); the fix touches the shell, not the pin — caught by the pickup-fitness review before implementation.
+- **Collapsing to one environment weakens approval if misconfigured.** *Mitigation:* reuses the already-protected `production` env; each deploy's `if:` adds `needs.approve-prod.result == 'success'` so a denied approval blocks all four despite `always()`; the assertion test pins exactly-one-environment == `production`.
+- **Raising the iOS timeout just delays a still-too-slow build.** *Mitigation:* measure the cold-cache build time; if it can't fit a sane timeout, pre-build the framework in a shared job (the deploy-ios job already builds it — reuse its artifact/cache).
+- **Can't fully prove via CI alone** — a real prod-deploy run is the proof ([[feedback-workflow-verify-by-running]]); operator-gated.
+
+## Definition of Done
+
+- `deploy-prod.yml` consolidated to one approval gate; Android smoke re-pinned/reliable; iOS smoke boot step runs within timeout — all per the AC.
+- `actionlint` + `check-action-shas.sh` green; any SHA-assertion test updated; `code-reviewer` ZERO findings.
+- A real operator-gated prod-deploy run shows ONE approval + Android smoke `success` + iOS smoke boot step `success`; evidence in `## Notes`.
+- Merged + released (`released_in: vX.Y.Z`). SHY-INDEX row added.
+
+## Notes (running log)
+
+- 2026-06-12 ~01:32 BST — **IMPLEMENTED + ROOT-CAUSE CORRECTED (In Review).** Pickup-fitness review (re-validated the ticket vs current code BEFORE implementing) overturned defect 2's diagnosis: the Android smoke does NOT fail on a SHA/digest-mismatch. The pinned `e89f39f1…` IS the correct v2.37.0 commit — `git/refs/tags/v2.37.0` returns the annotated-tag OBJECT sha `0a638108…` (`type: tag`), and dereferencing it (`git/tags/<tagsha>`) gives the commit `e89f39f1…`. Pinning the draft's "correct" `0a638108…` would have INTRODUCED a real digest-mismatch. The REAL failure (run 27286731472 log): emulator booted, then the `script:` died with `/usr/bin/sh: 1: set: Illegal option -o pipefail` — the action runs `script` via dash, and the inline block used bash-only `set -o pipefail` + `shopt` + arrays. **Fixes shipped:** (1) NEW `scripts/ci/android-smoke-verify.sh` (bash; shellcheck-clean) invoked via `bash "$GITHUB_WORKSPACE/…"`, + a checkout step in `smoke-test-android` (it had none — only the APK artifact); (2) ONE `approve-prod` job on the pre-existing `production` env (repo-owner reviewer) gates all four deploys via `needs:` + an explicit `needs.approve-prod.result == 'success'` in each `if:` — removed the 4 `environment: prod-*`; (3) iOS smoke `timeout-minutes: 20 → 45`. **Tests:** `android-smoke-verify.test.js` (10, stubbed adb value-matrix) + `deploy-prod-single-gate-and-smoke.test.js` (13) — both RED-first then GREEN; `android-e2e-emulator-boot-headroom.test.js` still green (SHA + `ubuntu-22.04` unchanged); actionlint + check-action-shas clean; full express-api **12,178 pass**. No SHA changed anywhere. Live prod-deploy verification (one approval + Android/iOS smoke success) pending the operator-gated run (queued for morning approval per operator).
+  - **code-reviewer (agent ae4cd74d) cycle 1:** 2 Critical + 2 Important + 2 Minor. Resolved: **C2** (only `deploy-backend-prod` was test-pinned for the gate) → added 9 tests asserting `deploy-web/android/ios-prod` each carry `needs: approve-prod` + `needs.approve-prod.result == 'success'` under `always()` + no own environment. **I1** (no failing-`adb install` test) → added `installRc:'1'` case. **I2** (`^Error` misses lowercase adb-transport `error:`) → pattern → `^[Ee]rror` + a "device offline" test. **M1** (dead `${crashes:-0}` reassignment) → removed — and NOTE the reviewer's literal `|| echo 0` fix was itself BUGGY (grep prints "0" AND exits 1 on no-match → `|| echo 0` yields "0\n0" → arithmetic error; caught by the clean-logcat test), so I kept the correct `|| true` form. **C1** (`build-android` builds/signs prod artifacts pre-approval) → **documented won't-fix:** it is PRE-EXISTING (unchanged from the old design — the old gates were on the deploy jobs, never the build), it does NOT deploy (publication is gated on deploy-android-prod which needs approve-prod), sign≠publish, and gating it would force a ~25-min post-approval rebuild that hurts the queued-overnight deploy — a workflow comment records the deliberate choice. M2/I3 = design notes covered by the C2 tests. Re-verify: shellcheck + actionlint clean; 34 SHY-0084 tests green; full suite 12,178. **Operator: flag C1 if you'd prefer the Android build gated too (security-vs-speed trade-off).**
+- 2026-06-12 ~00:25 BST — Filed at operator request ("the deploy workflow does 4 separate manual approval gates — consolidate to one; the android smoke tests fail — look into it; the iOS smoke tests don't happen at all — fix that"). Investigation done against prod run **27286731472** (2026-06-10, FAILED): 4 gates = `prod-backend/web/android/ios`; Android smoke fails on the emulator-runner step (pinned SHA `e89f39f1…` ≠ real v2.37.0 `0a638108…` → `digest-mismatch`, ~4-min death); iOS smoke `cancelled` — the "Build iOS app for simulator" step hit the 20-min timeout so "Boot simulator and verify" was skipped (the boot test never runs). `mvp: true` — prod-deploy reliability gates the tri-platform go-live. Implementation deferred until SHY-0082 (Mirror v4) lands (one active branch); P0 in the queue thereafter.

--- a/.project/stories/SHY-INDEX.md
+++ b/.project/stories/SHY-INDEX.md
@@ -10,6 +10,7 @@ Live backlog of every piece of work captured under the Agile way of working ([[f
 
 | ID                                                              | Pri | Effort | Type     | Title                                                                                            | Status         | Roadmap IDs      | PR  |
 | --------------------------------------------------------------- | --- | ------ | -------- | ------------------------------------------------------------------------------------------------ | -------------- | ---------------- | --- |
+| [SHY-0084](SHY-0084-prod-deploy-gate-and-smoke-fixes.md)        | P0  | M      | bug      | Consolidate prod-deploy approval gates + fix Android & iOS boot smoke tests                      | 👀 In Review   | —                | —   |
 | [SHY-0060](SHY-0060-age-gating-per-feature.md)                  | P0  | XL     | feature  | Age-gating per feature: tiered per-feature age thresholds replacing single 13+ signup gate       | 📝 Draft       | —                | —   |
 | [SHY-0071](SHY-0071-sync-wall-clock-batching.md)                | P1  | M      | refactor | Sync wall-clock: batch gh lookups (one upfront list → map) + scan-mode validation (36.2s→≤6s)      | 📝 Draft       | —                | —   |
 | [SHY-0062](SHY-0062-migrate-legacy-roadmap-features.md)         | P1  | XL     | chore    | Migrate ~95 legacy roadmap features into tracked stories (meta/tracker; EPIC-0002)                | 📝 Draft       | —                | —   |

--- a/express-api/tests/scripts/android-smoke-verify.test.js
+++ b/express-api/tests/scripts/android-smoke-verify.test.js
@@ -1,0 +1,173 @@
+/**
+ * scripts/ci/android-smoke-verify.sh — Android boot smoke verification.
+ *
+ * SHY-0084. Extracted from deploy-prod.yml's inline `script:` because
+ * reactivecircus/android-emulator-runner executes `script` via /usr/bin/sh
+ * (dash on Ubuntu runners), where the original block's bash-only constructs —
+ * `set -o pipefail`, `shopt -s nullglob`, and arrays — abort immediately with
+ *   /usr/bin/sh: 1: set: Illegal option -o pipefail
+ *   ##[error]The process '/usr/bin/sh' failed with exit code 2
+ * (observed on prod run 27286731472, 2026-06-10: the emulator BOOTED, then the
+ * verification script died on its first line). A committed bash file runs under
+ * bash regardless of the action's default shell, AND is unit-testable here with
+ * a stubbed `adb` on PATH — exercising every create/launch/foreground/crash
+ * branch at the value level, not just "it runs".
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const SCRIPT = path.join(REPO_ROOT, 'scripts/ci/android-smoke-verify.sh');
+
+// dumpsys mCurrentFocus lines — one WITH the app id (foreground), one without.
+const FOCUS_OK = 'mCurrentFocus=Window{a1b2 u0 com.shyden.shytalk/com.shyden.shytalk.MainActivity}';
+const FOCUS_OTHER = 'mCurrentFocus=Window{c3d4 u0 com.android.launcher3/.Launcher}';
+
+// A normal successful `am start -W` block.
+const AM_OK = 'Starting: Intent {...}\nStatus: ok\nActivity: com.shyden.shytalk/.MainActivity';
+// Benign re-launch output — NOT a failure (the app was already running).
+const AM_BENIGN_RELAUNCH =
+  'Status: ok\nWarning: Activity not started, its current task has been brought to the front';
+
+function writeAdbStub(binDir) {
+  const adb = path.join(binDir, 'adb');
+  fs.writeFileSync(
+    adb,
+    [
+      '#!/usr/bin/env bash',
+      '# Stub adb: branches on the subcommand, emits scenario output from env.',
+      'if [ "$1" = "install" ]; then echo "Success"; exit "${STUB_INSTALL_RC:-0}"; fi',
+      'if [ "$1" = "shell" ] && [ "$2" = "am" ]; then printf "%s\\n" "${STUB_AM_OUTPUT}"; exit 0; fi',
+      'if [ "$1" = "shell" ] && [ "$2" = "dumpsys" ]; then printf "%s\\n" "${STUB_FOCUS}"; exit 0; fi',
+      'if [ "$1" = "logcat" ]; then printf "%s\\n" "${STUB_LOGCAT}"; exit 0; fi',
+      'exit 0',
+      '',
+    ].join('\n'),
+  );
+  fs.chmodSync(adb, 0o755);
+}
+
+function run({
+  apks = ['app-prod-debug.apk'],
+  am = AM_OK,
+  focus = FOCUS_OK,
+  logcat = '',
+  installRc = '0',
+} = {}) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'android-smoke-'));
+  const binDir = path.join(tmp, 'bin');
+  const apkDir = path.join(tmp, 'debug-apk');
+  fs.mkdirSync(binDir);
+  fs.mkdirSync(apkDir);
+  writeAdbStub(binDir);
+  for (const a of apks) fs.writeFileSync(path.join(apkDir, a), 'dummy-apk');
+
+  // Absolute interpreter path (not PATH-resolved) + $ADB pointed at an absolute
+  // stub below = no command is resolved through a writable PATH, so this needs
+  // no `sonarjs/no-os-command-from-path` suppression (cf. the file-level disable
+  // the older shell-harness tests use).
+  const res = spawnSync('/bin/bash', [SCRIPT], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      // Point the script's `$ADB` at the stub by ABSOLUTE path — no PATH
+      // manipulation (sonarjs/no-os-command-from-path), mirroring `$GH` in
+      // the sync-script tests.
+      ADB: path.join(binDir, 'adb'),
+      APK_DIR: apkDir,
+      LOGCAT_FILE: path.join(tmp, 'runtime.log'),
+      STUB_AM_OUTPUT: am,
+      STUB_FOCUS: focus,
+      STUB_LOGCAT: logcat,
+      STUB_INSTALL_RC: installRc,
+      // Collapse the post-launch settle sleeps so the suite stays fast + isolated.
+      SMOKE_LAUNCH_WAIT: '0',
+      SMOKE_FOREGROUND_WAIT: '0',
+    },
+  });
+  fs.rmSync(tmp, { recursive: true, force: true });
+  return res;
+}
+
+describe('SHY-0084: android-smoke-verify.sh', () => {
+  test('the script exists and is executable bash', () => {
+    expect(fs.existsSync(SCRIPT)).toBe(true);
+    expect(fs.readFileSync(SCRIPT, 'utf8')).toMatch(/^#!.*\bbash\b/);
+  });
+
+  test('it is POSIX-shell-INDEPENDENT: must NOT be the dash-breaking construct it replaces', () => {
+    // The whole point of the extraction: it runs under bash, so it MAY use
+    // bash features — but the action invokes it via `bash <file>`, never via
+    // the dash `script:` path. Guard the regression: the file must declare a
+    // bash shebang (asserted above) so a future "merge back inline" doesn't
+    // resurrect the `set -o pipefail` under /usr/bin/sh failure.
+    const body = fs.readFileSync(SCRIPT, 'utf8');
+    expect(body).toMatch(/#!\/usr\/bin\/env bash/);
+  });
+
+  test('healthy app: one APK installs, launches, is foreground, no crash → exit 0', () => {
+    const res = run();
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('installs and launches successfully');
+  });
+
+  test('benign "already running" re-launch is NOT treated as a failure → exit 0', () => {
+    const res = run({ am: AM_BENIGN_RELAUNCH });
+    expect(res.status).toBe(0);
+  });
+
+  test('zero APKs in the artifact dir → exit 1 with a clear count', () => {
+    const res = run({ apks: [] });
+    expect(res.status).toBe(1);
+    expect(res.stdout + res.stderr).toMatch(/Expected exactly one debug APK.*found 0/);
+  });
+
+  test('more than one APK → exit 1 with the actual count', () => {
+    const res = run({ apks: ['a-debug.apk', 'b-debug.apk'] });
+    expect(res.status).toBe(1);
+    expect(res.stdout + res.stderr).toMatch(/Expected exactly one debug APK.*found 2/);
+  });
+
+  test('am start reports an error → exit 1', () => {
+    const res = run({ am: 'Error type 3\nError: Activity class {…} does not exist.' });
+    expect(res.status).toBe(1);
+    expect(res.stdout).toContain('am start reported an error');
+  });
+
+  test('a lowercase adb transport error ("error: device offline") → exit 1', () => {
+    // adb's transport layer emits lowercase `error:` (vs am's `Error type N`);
+    // captured via 2>&1, it must still fail the smoke, not slip to a later step.
+    const res = run({ am: 'error: device offline' });
+    expect(res.status).toBe(1);
+    expect(res.stdout).toContain('am start reported an error');
+  });
+
+  test('a non-zero `adb install` exit fails the smoke (pipefail honoured under bash)', () => {
+    const res = run({ installRc: '1' });
+    expect(res.status).not.toBe(0);
+  });
+
+  test('app is not the foreground activity → exit 1', () => {
+    const res = run({ focus: FOCUS_OTHER });
+    expect(res.status).toBe(1);
+    expect(res.stdout).toContain('not the foreground activity');
+  });
+
+  test('a FATAL EXCEPTION in logcat → exit 1', () => {
+    const res = run({
+      logcat:
+        '06-10 15:53:59.000  1234  1234 E AndroidRuntime: FATAL EXCEPTION: main\n' +
+        '06-10 15:53:59.000  1234  1234 E AndroidRuntime: java.lang.NullPointerException',
+    });
+    expect(res.status).toBe(1);
+    expect(res.stdout).toContain('fatal crash');
+  });
+
+  test('a clean logcat (no FATAL EXCEPTION) → exit 0', () => {
+    const res = run({ logcat: '06-10 15:54:00.000  1234 I AndroidRuntime: NOTE: app started' });
+    expect(res.status).toBe(0);
+  });
+});

--- a/express-api/tests/scripts/deploy-prod-single-gate-and-smoke.test.js
+++ b/express-api/tests/scripts/deploy-prod-single-gate-and-smoke.test.js
@@ -1,0 +1,170 @@
+/**
+ * deploy-prod.yml — single approval gate + runnable mobile smoke tests (SHY-0084).
+ *
+ * Three operator-flagged defects, all verified against prod run 27286731472
+ * (2026-06-10, FAILED):
+ *
+ *  1. FOUR separate `environment:` approval gates (prod-backend/web/android/ios)
+ *     → ONE release needed four approval clicks. Consolidated to a single
+ *     `approve-prod` job on the existing `production` environment that
+ *     `deploy-backend-prod` needs; since every other deploy transitively needs
+ *     deploy-backend-prod, one approval cascades to all four platforms.
+ *
+ *  2. Android boot smoke FAILED in ~4 min: the emulator booted, then the inline
+ *     verification `script:` died on `set -euo pipefail` because the action runs
+ *     `script` via /usr/bin/sh (dash). Fixed by extracting the logic to a
+ *     committed bash file invoked with `bash`.
+ *
+ *  3. iOS boot smoke was CANCELLED at the 20-min job timeout while still
+ *     building — "Boot simulator and verify" never ran. Fixed by raising the
+ *     timeout so the boot step is reached.
+ *
+ * These pins fail loudly if a future "CI cleanup" reverts any of the three.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const DEPLOY_PROD_YML = path.join(REPO_ROOT, '.github/workflows/deploy-prod.yml');
+
+// Extract a top-level job block: from its `  <job>:` header to the next
+// 2-space-indented non-whitespace line (next job) or EOF.
+function extractJobBlock(yamlText, jobHeader) {
+  const headerIdx = yamlText.indexOf(jobHeader);
+  if (headerIdx < 0) return null;
+  const after = yamlText.substring(headerIdx).split('\n');
+  let endIdx = after.length;
+  for (let i = 1; i < after.length; i++) {
+    if (/^ {2}\S/.test(after[i])) {
+      endIdx = i;
+      break;
+    }
+  }
+  return after.slice(0, endIdx).join('\n');
+}
+
+describe('SHY-0084: deploy-prod.yml single approval gate', () => {
+  let yaml;
+  beforeAll(() => {
+    yaml = fs.readFileSync(DEPLOY_PROD_YML, 'utf8');
+  });
+
+  test('exactly ONE environment: gate exists in the whole workflow', () => {
+    const matches = yaml.match(/^[ \t]+environment:[ \t]*\S/gm) || [];
+    expect(matches.length).toBe(1);
+  });
+
+  test('the single gate targets the existing protected `production` environment', () => {
+    const match = yaml.match(/^[ \t]+environment:[ \t]*(\S+)/m);
+    expect(match).not.toBeNull();
+    expect(match[1]).toBe('production');
+  });
+
+  test('none of the four legacy per-platform environments remain', () => {
+    for (const env of ['prod-backend', 'prod-web', 'prod-android', 'prod-ios']) {
+      expect(yaml).not.toMatch(new RegExp(`environment:[ \\t]*${env}\\b`));
+    }
+  });
+
+  test('an approve-prod gate job exists on the production environment', () => {
+    const block = extractJobBlock(yaml, '  approve-prod:');
+    expect(block).not.toBeNull();
+    expect(block).toMatch(/^[ \t]+environment:[ \t]*production\b/m);
+  });
+
+  test('deploy-backend-prod needs approve-prod (the chokepoint that gates all platforms)', () => {
+    const block = extractJobBlock(yaml, '  deploy-backend-prod:');
+    expect(block).not.toBeNull();
+    const needs = block.match(/^[ \t]+needs:[ \t]*\[([^\]]*)\]/m);
+    expect(needs).not.toBeNull();
+    expect(needs[1]).toMatch(/\bapprove-prod\b/);
+  });
+
+  test('deploy-backend-prod no longer carries its own environment gate', () => {
+    const block = extractJobBlock(yaml, '  deploy-backend-prod:');
+    expect(block).not.toBeNull();
+    expect(block).not.toMatch(/^[ \t]+environment:/m);
+  });
+
+  // The security invariant: because the three downstream deploys use
+  // `always()` for selective-platform logic, the ONLY thing that blocks them
+  // on a DENIED approval is the explicit `needs.approve-prod.result ==
+  // 'success'` clause. Pin it on EACH (a future cleanup dropping it from any
+  // one would silently let that platform deploy without approval).
+  for (const job of ['deploy-web-prod', 'deploy-android-prod', 'deploy-ios-prod']) {
+    test(`${job} needs approve-prod`, () => {
+      const block = extractJobBlock(yaml, `  ${job}:`);
+      expect(block).not.toBeNull();
+      const needs = block.match(/^[ \t]+needs:[ \t]*\[([^\]]*)\]/m);
+      expect(needs).not.toBeNull();
+      expect(needs[1]).toMatch(/\bapprove-prod\b/);
+    });
+
+    test(`${job} if: enforces approve-prod success (gate holds under always())`, () => {
+      const block = extractJobBlock(yaml, `  ${job}:`);
+      expect(block).not.toBeNull();
+      expect(block).toMatch(/always\(\)/);
+      expect(block).toMatch(/needs\.approve-prod\.result\s*==\s*['"]success['"]/);
+    });
+
+    test(`${job} no longer carries its own per-platform environment gate`, () => {
+      const block = extractJobBlock(yaml, `  ${job}:`);
+      expect(block).not.toBeNull();
+      expect(block).not.toMatch(/^[ \t]+environment:/m);
+    });
+  }
+});
+
+describe('SHY-0084: deploy-prod.yml Android boot smoke runs under bash', () => {
+  let yaml;
+  let androidBlock;
+  beforeAll(() => {
+    yaml = fs.readFileSync(DEPLOY_PROD_YML, 'utf8');
+    androidBlock = extractJobBlock(yaml, '  smoke-test-android:');
+  });
+
+  test('the Android smoke calls the committed bash verifier', () => {
+    expect(androidBlock).not.toBeNull();
+    expect(androidBlock).toContain('scripts/ci/android-smoke-verify.sh');
+  });
+
+  test('the dash-incompatible inline constructs are GONE from the smoke job', () => {
+    // `set -o pipefail` / `shopt` under /usr/bin/sh were the actual failure.
+    expect(androidBlock).not.toMatch(/set -euo pipefail/);
+    expect(androidBlock).not.toMatch(/shopt /);
+  });
+
+  test('the verifier is invoked with bash (not the action default dash)', () => {
+    expect(androidBlock).toMatch(/bash[ \t]+["']?\$\{?GITHUB_WORKSPACE/);
+  });
+
+  test('the smoke job checks out the repo so the verifier file is present', () => {
+    // The job previously only downloaded the APK artifact — with no checkout
+    // the committed script would not exist on disk.
+    expect(androidBlock).toMatch(/uses:[ \t]*actions\/checkout@/);
+  });
+
+  test('still pinned to ubuntu-22.04 (emulator-boot-stability pin is preserved)', () => {
+    expect(androidBlock).toMatch(/^[ \t]+runs-on:[ \t]*ubuntu-22\.04\b/m);
+  });
+});
+
+describe('SHY-0084: deploy-prod.yml iOS boot smoke reaches the boot step', () => {
+  let iosBlock;
+  beforeAll(() => {
+    const yaml = fs.readFileSync(DEPLOY_PROD_YML, 'utf8');
+    iosBlock = extractJobBlock(yaml, '  smoke-test-ios:');
+  });
+
+  test('iOS smoke timeout is raised to at least 40 min (was 20, which the build consumed)', () => {
+    expect(iosBlock).not.toBeNull();
+    const match = iosBlock.match(/^[ \t]+timeout-minutes:[ \t]*(\d+)/m);
+    expect(match).not.toBeNull();
+    expect(parseInt(match[1], 10)).toBeGreaterThanOrEqual(40);
+  });
+
+  test('the "Boot simulator and verify" step still exists (we widen the budget, not drop it)', () => {
+    expect(iosBlock).toMatch(/Boot simulator and verify app launches/);
+  });
+});

--- a/scripts/ci/android-smoke-verify.sh
+++ b/scripts/ci/android-smoke-verify.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Android boot smoke verification (SHY-0084).
+#
+# Installs the prod debug APK on an already-booted emulator, launches
+# MainActivity, asserts the app is the foreground activity, and checks logcat
+# for fatal crashes. Exits non-zero (failing the prod-deploy smoke) on any
+# genuine problem; never masks a real failure.
+#
+# WHY THIS IS A COMMITTED FILE, NOT AN INLINE `script:`:
+# reactivecircus/android-emulator-runner runs its `script` input via
+# /usr/bin/sh (dash on Ubuntu runners). The previous inline block opened with
+# `set -euo pipefail` plus `shopt -s nullglob` and bash arrays — all bash-only.
+# Under dash the very first line aborted with
+#   /usr/bin/sh: 1: set: Illegal option -o pipefail
+# so the smoke FAILED before installing anything (prod run 27286731472,
+# 2026-06-10: "Emulator booted." then immediate exit code 2). Invoking this
+# file with `bash` guarantees a bash interpreter, and keeping the logic in a
+# file makes it unit-testable (tests/scripts/android-smoke-verify.test.js
+# drives it against a stubbed adb).
+#
+# Env knobs (all defaulted; the workflow uses the defaults, the tests override):
+#   APK_DIR               dir holding exactly one *.apk        (default debug-apk)
+#   APP_ID                package id                            (default com.shyden.shytalk)
+#   MAIN_ACTIVITY         launch activity                      (default $APP_ID.MainActivity)
+#   LOGCAT_FILE           where the AndroidRuntime dump lands   (default /tmp/runtime.log)
+#   SMOKE_LAUNCH_WAIT     seconds to settle after am start      (default 3)
+#   SMOKE_FOREGROUND_WAIT seconds to settle before logcat check (default 5)
+set -euo pipefail
+
+# Anchor to the workspace so the lookup does not depend on the action's cwd
+# (the download-artifact step writes the APK to $GITHUB_WORKSPACE/debug-apk).
+# `ADB` is configurable (not PATH-resolved) so the unit test points it at a
+# stub binary by absolute path — mirrors the sync script's `$GH` pattern and
+# avoids manipulating PATH with a writable dir (sonarjs/no-os-command-from-path).
+ADB="${ADB:-adb}"
+APK_DIR="${APK_DIR:-${GITHUB_WORKSPACE:-.}/debug-apk}"
+APP_ID="${APP_ID:-com.shyden.shytalk}"
+MAIN_ACTIVITY="${MAIN_ACTIVITY:-${APP_ID}.MainActivity}"
+LOGCAT_FILE="${LOGCAT_FILE:-/tmp/runtime.log}"
+SMOKE_LAUNCH_WAIT="${SMOKE_LAUNCH_WAIT:-3}"
+SMOKE_FOREGROUND_WAIT="${SMOKE_FOREGROUND_WAIT:-5}"
+
+echo "=== Installing APK ==="
+# Collect *.apk without relying on `shopt -s nullglob`: a non-matching glob
+# stays literal, so guard each candidate with an existence test.
+apk=""
+count=0
+for f in "${APK_DIR}"/*.apk; do
+  [ -e "$f" ] || continue
+  apk="$f"
+  count=$((count + 1))
+done
+if [ "$count" -ne 1 ]; then
+  echo "::error::Expected exactly one debug APK in ${APK_DIR}, found ${count}"
+  exit 1
+fi
+"$ADB" install -r "$apk"
+
+echo "=== Launching app ==="
+am_output="$("$ADB" shell am start -W -n "${APP_ID}/${MAIN_ACTIVITY}" 2>&1)"
+echo "$am_output"
+# Match only REAL failures. The benign messages
+#   "Activity not started, its current task has been brought to the front"
+#   "Activity not started, intent has been delivered to currently running top-most instance"
+# are normal `am start` output when re-launching. Match the "unable to"
+# variant or explicit Error type / Java exception lines.
+# `^[Ee]rror` also catches adb-transport failures ("error: device offline",
+# "error: no devices/emulators found") surfaced via 2>&1, not just `am`'s
+# "Error type N".
+if printf '%s\n' "$am_output" | grep -qE '^[Ee]rror|FATAL|Activity not started, unable to|java\.lang\.|Exception type'; then
+  echo "::error::am start reported an error — app failed to launch"
+  exit 1
+fi
+sleep "$SMOKE_LAUNCH_WAIT"
+
+echo "=== Verifying app is foreground activity ==="
+focused="$("$ADB" shell dumpsys window windows 2>&1 | grep -E 'mCurrentFocus' || true)"
+echo "$focused"
+if ! printf '%s\n' "$focused" | grep -q "$APP_ID"; then
+  echo "::error::ShyTalk is not the foreground activity. Got: $focused"
+  exit 1
+fi
+sleep "$SMOKE_FOREGROUND_WAIT"
+
+echo "=== Checking for fatal crashes in logcat ==="
+"$ADB" logcat -d -s AndroidRuntime >"$LOGCAT_FILE" 2>&1
+# grep -c prints the count (0 on no match) and exits 1 when 0 — `|| true`
+# keeps that "0" under `set -e`; the `${crashes:-0}` guards the impossible
+# empty case. (A `|| echo 0` would double the "0" on no-match and break the
+# arithmetic test, so keep the `|| true` form.)
+crashes="$(grep -c 'FATAL EXCEPTION' "$LOGCAT_FILE" || true)"
+if [ "${crashes:-0}" -gt 0 ]; then
+  echo "::error::Found ${crashes} fatal crash(es)"
+  tail -30 "$LOGCAT_FILE"
+  exit 1
+fi
+echo "No fatal crashes — Android APK installs and launches successfully"


### PR DESCRIPTION
Implements SHY-0084 — see `.project/stories/SHY-0084-prod-deploy-gate-and-smoke-fixes.md` for full spec, AC, BDD scenarios, and DoD.

**P0 — prod deploy is currently broken (run 27286731472 FAILED); `mvp: true` (gates tri-platform go-live).**

Three operator-flagged defects in `deploy-prod.yml`:

1. **4 approval gates → 1.** A new `approve-prod` job on the pre-existing protected `production` environment (repo-owner reviewer). Every deploy `needs: approve-prod` + adds `needs.approve-prod.result == 'success'` to its `if:` (so a DENIED approval blocks all four despite `always()`). The four `environment: prod-*` gates are removed → **one approval unlocks backend/web/android/ios**.
2. **Android boot smoke FAILED.** The emulator booted, then the inline `script:` died on `set -o pipefail` — the action runs `script` via `/usr/bin/sh` (dash). Extracted to a committed **bash** verifier `scripts/ci/android-smoke-verify.sh` (invoked with `bash`), + a checkout step so the file is present. The SHA is **unchanged** (`e89f39f1…` is the correct v2.37.0 commit; `0a638108…` is the annotated-tag object — pinning it would have *introduced* a digest-mismatch).
3. **iOS boot smoke NEVER RAN.** The 20-min job timeout was consumed by the K/N link + xcodebuild build → the job was cancelled before "Boot simulator and verify". Timeout raised **20 → 45**.

**Tests:** `android-smoke-verify.test.js` (12, stubbed-adb value matrix) + `deploy-prod-single-gate-and-smoke.test.js` (22, gate/smoke YAML invariants). Full suite **12,189 pass**; shellcheck + actionlint + check-action-shas clean. code-reviewer cycle-1 findings resolved (gate-guard tests for all 3 deploys, install-fail + lowercase-adb-error cases, dead-code removal). One pre-existing item (ungated `build-android`) documented as a reasoned won't-fix — flagged in the ticket for your call.

Live prod-deploy verification (one approval + Android/iOS smoke success) is queued for your morning approval.