### PR TITLE
chore(mvp): flag the MVP launch set (active stories; exclude Revenue/Entertainment)

### DIFF
--- a/.project/stories/SHY-0003-convert-roadmap-to-stories.md
+++ b/.project/stories/SHY-0003-convert-roadmap-to-stories.md
@@ -9,6 +9,7 @@ type: chore
 roadmap_ids: [G054]
 epic: EPIC-0001
 pr:
+mvp: true
 ---
 
 # SHY-0003: Convert zero-gap roadmap to user stories + cross-label

--- a/.project/stories/SHY-0005-biometric-alpha-to-stable.md
+++ b/.project/stories/SHY-0005-biometric-alpha-to-stable.md
@@ -8,6 +8,7 @@ effort: XS
 type: infra
 roadmap_ids: [G002]
 pr:
+mvp: true
 ---
 
 # SHY-0005: Biometric alpha → stable (downgrade or rationale comment)

--- a/.project/stories/SHY-0006-add-push-permission-vm-tests.md
+++ b/.project/stories/SHY-0006-add-push-permission-vm-tests.md
@@ -8,6 +8,7 @@ effort: S
 type: bug
 roadmap_ids: [G005, G013, G029]
 pr:
+mvp: true
 ---
 
 # SHY-0006: PushPermissionDeniedBanner + HomeScreen + HomeViewModel push tests

--- a/.project/stories/SHY-0007-add-gacha-and-age-verification-features.md
+++ b/.project/stories/SHY-0007-add-gacha-and-age-verification-features.md
@@ -8,6 +8,7 @@ effort: S
 type: feature
 roadmap_ids: [G007, G008]
 pr:
+mvp: true
 ---
 
 # SHY-0007: gacha.feature + age_verification.feature (BDD coverage)

--- a/.project/stories/SHY-0009-add-lock-pin-security-nav-coverage.md
+++ b/.project/stories/SHY-0009-add-lock-pin-security-nav-coverage.md
@@ -8,6 +8,7 @@ effort: S
 type: feature
 roadmap_ids: [G010]
 pr:
+mvp: true
 ---
 
 # SHY-0009: Lock/PinSetup/SecuritySettings navigation coverage

--- a/.project/stories/SHY-0010-add-home-gacha-vm-tests.md
+++ b/.project/stories/SHY-0010-add-home-gacha-vm-tests.md
@@ -8,6 +8,7 @@ effort: M
 type: bug
 roadmap_ids: [G003-D1]
 pr:
+mvp: true
 ---
 
 # SHY-0010: HomeViewModel + GachaViewModel tests

--- a/.project/stories/SHY-0012-add-remaining-vm-tests.md
+++ b/.project/stories/SHY-0012-add-remaining-vm-tests.md
@@ -8,6 +8,7 @@ effort: L
 type: bug
 roadmap_ids: [G003-D3]
 pr:
+mvp: true
 ---
 
 # SHY-0012: 10 remaining ViewModel test files (Messaging + Profile + Settings + Daily + Splash)

--- a/.project/stories/SHY-0013-add-core-infra-tests.md
+++ b/.project/stories/SHY-0013-add-core-infra-tests.md
@@ -8,6 +8,7 @@ effort: M
 type: infra
 roadmap_ids: [G004, G020]
 pr:
+mvp: true
 ---
 
 # SHY-0013: RoomLifecycleManager + AnimationQueue + ModerationFilter tests

--- a/.project/stories/SHY-0014-add-room-service-controller-tests.md
+++ b/.project/stories/SHY-0014-add-room-service-controller-tests.md
@@ -8,6 +8,7 @@ effort: M
 type: bug
 roadmap_ids: [G016]
 pr:
+mvp: true
 ---
 
 # SHY-0014: Android/Ios RoomServiceController tests + FakeRoomLifecycleManager extraction

--- a/.project/stories/SHY-0015-add-secure-storage-contract-tests.md
+++ b/.project/stories/SHY-0015-add-secure-storage-contract-tests.md
@@ -8,6 +8,7 @@ effort: S
 type: bug
 roadmap_ids: [G019]
 pr:
+mvp: true
 ---
 
 # SHY-0015: SecureStorage + CryptoKeyPair contract tests

--- a/.project/stories/SHY-0016-add-sticker-storage-tests.md
+++ b/.project/stories/SHY-0016-add-sticker-storage-tests.md
@@ -8,6 +8,7 @@ effort: S
 type: bug
 roadmap_ids: [G038]
 pr:
+mvp: true
 ---
 
 # SHY-0016: StickerStorage platform tests (file I/O lifecycle)

--- a/.project/stories/SHY-0017-add-ios-room-repo-tests.md
+++ b/.project/stories/SHY-0017-add-ios-room-repo-tests.md
@@ -8,6 +8,7 @@ effort: M
 type: bug
 roadmap_ids: [G014]
 pr:
+mvp: true
 ---
 
 # SHY-0017: IosRoomRepositoryImpl tests (P2 client migration coverage)

--- a/.project/stories/SHY-0018-add-ios-message-bridge-tests.md
+++ b/.project/stories/SHY-0018-add-ios-message-bridge-tests.md
@@ -8,6 +8,7 @@ effort: M
 type: bug
 roadmap_ids: [G015, G030]
 pr:
+mvp: true
 ---
 
 # SHY-0018: IosMessage + IosSeatRequest + IosEconomyGift + IosSmallRepositories + IosPushBridge tests

--- a/.project/stories/SHY-0019-fix-qa-runner-smoke-true.md
+++ b/.project/stories/SHY-0019-fix-qa-runner-smoke-true.md
@@ -8,6 +8,7 @@ effort: S
 type: infra
 roadmap_ids: [G012]
 pr:
+mvp: true
 ---
 
 # SHY-0019: qa-runner --smoke `|| true` → targeted exit-code handling

--- a/.project/stories/SHY-0020-add-release-to-qa-matrix-workflow-call.md
+++ b/.project/stories/SHY-0020-add-release-to-qa-matrix-workflow-call.md
@@ -8,6 +8,7 @@ effort: S
 type: infra
 roadmap_ids: [G022, G049]
 pr:
+mvp: true
 ---
 
 # SHY-0020: release.yml → manual-qa-matrix.yml workflow_call (event-driven E2 matrix)

--- a/.project/stories/SHY-0022-seed-admin-keyboard-data-fixtures.md
+++ b/.project/stories/SHY-0022-seed-admin-keyboard-data-fixtures.md
@@ -8,6 +8,7 @@ effort: M
 type: bug
 roadmap_ids: [G023]
 pr:
+mvp: true
 ---
 
 # SHY-0022: admin-keyboard data-dependent skip remediation

--- a/.project/stories/SHY-0023-seed-admin-backups-cross-tab-fixtures.md
+++ b/.project/stories/SHY-0023-seed-admin-backups-cross-tab-fixtures.md
@@ -8,6 +8,7 @@ effort: S
 type: bug
 roadmap_ids: [G033]
 pr:
+mvp: true
 ---
 
 # SHY-0023: admin-backups + admin-cross-tab data fixture gaps

--- a/.project/stories/SHY-0024-resolve-navgraph-coexistence.md
+++ b/.project/stories/SHY-0024-resolve-navgraph-coexistence.md
@@ -8,6 +8,7 @@ effort: L
 type: refactor
 roadmap_ids: [G028]
 pr:
+mvp: true
 ---
 
 # SHY-0024: Migrate Android to SharedNavGraph + delete NavGraph.kt

--- a/.project/stories/SHY-0025-upgrade-locale-parity-key-set.md
+++ b/.project/stories/SHY-0025-upgrade-locale-parity-key-set.md
@@ -8,6 +8,7 @@ effort: XS
 type: bug
 roadmap_ids: [G042, G052]
 pr:
+mvp: true
 ---
 
 # SHY-0025: Locale parity test upgrade (key-set comparison) + PR #1010 string verification

--- a/.project/stories/SHY-0026-add-mobile-driver-helper-scripts.md
+++ b/.project/stories/SHY-0026-add-mobile-driver-helper-scripts.md
@@ -8,6 +8,7 @@ effort: S
 type: infra
 roadmap_ids: [G043, G044]
 pr:
+mvp: true
 ---
 
 # SHY-0026: Mobile driver helper scripts (Android flags check + iOS WDA build)

--- a/.project/stories/SHY-0027-dependabot-sweep-codeql-kotlin.md
+++ b/.project/stories/SHY-0027-dependabot-sweep-codeql-kotlin.md
@@ -8,6 +8,7 @@ effort: XS
 type: chore
 roadmap_ids: [G045, G047]
 pr:
+mvp: true
 ---
 
 # SHY-0027: Dependabot open-PR sweep + CodeQL Kotlin enable

--- a/.project/stories/SHY-0028-gradle-deprecation-sweep.md
+++ b/.project/stories/SHY-0028-gradle-deprecation-sweep.md
@@ -8,6 +8,7 @@ effort: S
 type: chore
 roadmap_ids: [G046]
 pr:
+mvp: true
 ---
 
 # SHY-0028: Gradle deprecation sweep (--warning-mode all)

--- a/.project/stories/SHY-0029-tighten-ownerfirebaseuid-rule.md
+++ b/.project/stories/SHY-0029-tighten-ownerfirebaseuid-rule.md
@@ -8,6 +8,7 @@ effort: S
 type: bug
 roadmap_ids: [G026]
 pr:
+mvp: true
 ---
 
 # SHY-0029: Tighten ownerFirebaseUid rule (strict equality, no legacy fallback)

--- a/.project/stories/SHY-0030-refresh-ios-parity-navigation-feature.md
+++ b/.project/stories/SHY-0030-refresh-ios-parity-navigation-feature.md
@@ -8,6 +8,7 @@ effort: XS
 type: feature
 roadmap_ids: [G039]
 pr:
+mvp: true
 ---
 
 # SHY-0030: ios_parity_navigation.feature freshness check + update

--- a/.project/stories/SHY-0031-serialise-gh-pages-deploys.md
+++ b/.project/stories/SHY-0031-serialise-gh-pages-deploys.md
@@ -8,6 +8,7 @@ effort: S
 type: infra
 roadmap_ids: [G055]
 pr:
+mvp: true
 ---
 
 # SHY-0031: Serialise gh-pages cross-workflow deploys (split-job + shared concurrency group)

--- a/.project/stories/SHY-0041-upgrade-kotlin-stable.md
+++ b/.project/stories/SHY-0041-upgrade-kotlin-stable.md
@@ -8,6 +8,7 @@ effort: XS
 type: chore
 roadmap_ids: [G001]
 pr:
+mvp: true
 ---
 
 # SHY-0041: Upgrade Kotlin from 2.4.0-RC2 to 2.4.0 stable

--- a/.project/stories/SHY-0042-viewmodel-coverage-tracker.md
+++ b/.project/stories/SHY-0042-viewmodel-coverage-tracker.md
@@ -8,6 +8,7 @@ effort: XS
 type: docs
 roadmap_ids: [G003]
 pr:
+mvp: true
 ---
 
 # SHY-0042: G003 ViewModel-coverage tracker (meta — links the 3 implementation SHYs)

--- a/.project/stories/SHY-0043-add-push-permission-feature.md
+++ b/.project/stories/SHY-0043-add-push-permission-feature.md
@@ -8,6 +8,7 @@ effort: S
 type: feature
 roadmap_ids: [G006]
 pr:
+mvp: true
 ---
 
 # SHY-0043: Add `push_permission.feature` BDD coverage for PR #1010's denial flow

--- a/.project/stories/SHY-0044-fix-admin-claim-throw.md
+++ b/.project/stories/SHY-0044-fix-admin-claim-throw.md
@@ -8,6 +8,7 @@ effort: XS
 type: bug
 roadmap_ids: [G025]
 pr:
+mvp: true
 ---
 
 # SHY-0044: Fix `firestore.rules:140` admin-claim throws-on-absent — use `isAdmin()` helper

--- a/.project/stories/SHY-0045-sha-pin-floating-action-tags.md
+++ b/.project/stories/SHY-0045-sha-pin-floating-action-tags.md
@@ -8,6 +8,7 @@ effort: XS
 type: infra
 roadmap_ids: [G011]
 pr:
+mvp: true
 ---
 
 # SHY-0045: SHA-pin floating Action tags in manual-qa-matrix.yml + qa-runner-driver-checks.yml

--- a/.project/stories/SHY-0046-verify-gift-wall-feature-e2e.md
+++ b/.project/stories/SHY-0046-verify-gift-wall-feature-e2e.md
@@ -8,6 +8,7 @@ effort: XS
 type: chore
 roadmap_ids: [G018]
 pr:
+mvp: true
 ---
 
 # SHY-0046: Verify `gift_wall.feature` covers loading/populated/empty states + GiftWallScreen test tags

--- a/.project/stories/SHY-0047-fix-admin-core-modules-skip.md
+++ b/.project/stories/SHY-0047-fix-admin-core-modules-skip.md
@@ -8,6 +8,7 @@ effort: XS
 type: bug
 roadmap_ids: [G024]
 pr:
+mvp: true
 ---
 
 # SHY-0047: Fix bare `test.skip()` at `admin-core-modules.spec.ts:133` — identify intent + implement or remove

--- a/.project/stories/SHY-0048-track-detekt-2-stable.md
+++ b/.project/stories/SHY-0048-track-detekt-2-stable.md
@@ -8,6 +8,7 @@ effort: S
 type: chore
 roadmap_ids: [G053]
 pr:
+mvp: true
 ---
 
 # SHY-0048: Track detekt 2.0 stable release on Gradle Plugin Portal + migrate config

--- a/.project/stories/SHY-0049-add-kotlin-prerelease-ci-gate.md
+++ b/.project/stories/SHY-0049-add-kotlin-prerelease-ci-gate.md
@@ -8,6 +8,7 @@ effort: XS
 type: infra
 roadmap_ids: [G031]
 pr:
+mvp: true
 ---
 
 # SHY-0049: Add `check-kotlin-prerelease.sh` CI gate (fires when Kotlin stable lands)

--- a/.project/stories/SHY-0050-add-biometric-alpha-rationale-comment.md
+++ b/.project/stories/SHY-0050-add-biometric-alpha-rationale-comment.md
@@ -8,6 +8,7 @@ effort: XS
 type: docs
 roadmap_ids: [G032]
 pr:
+mvp: true
 ---
 
 # SHY-0050: Add rationale comment to `biometric = "1.4.0-alpha07"` in libs.versions.toml

--- a/.project/stories/SHY-0051-fix-touch-drag-skip-mouse-event.md
+++ b/.project/stories/SHY-0051-fix-touch-drag-skip-mouse-event.md
@@ -8,6 +8,7 @@ effort: XS
 type: bug
 roadmap_ids: [G034]
 pr:
+mvp: true
 ---
 
 # SHY-0051: Convert Firefox/WebKit touch-skip in suggestions-board.spec.ts to mouse-event drag

--- a/.project/stories/SHY-0052-fix-mobile-isMobile-skip-viewport.md
+++ b/.project/stories/SHY-0052-fix-mobile-isMobile-skip-viewport.md
@@ -8,6 +8,7 @@ effort: S
 type: bug
 roadmap_ids: [G035]
 pr:
+mvp: true
 ---
 
 # SHY-0052: Rewrite admin-suggestions.spec.ts mobile-context skips using viewport sizing

--- a/.project/stories/SHY-0053-fix-sonarcloud-yml-true-swallow.md
+++ b/.project/stories/SHY-0053-fix-sonarcloud-yml-true-swallow.md
@@ -8,6 +8,7 @@ effort: XS
 type: bug
 roadmap_ids: [G036]
 pr:
+mvp: true
 ---
 
 # SHY-0053: Remove `|| true` from sonarcloud.yml coverage step (was silently swallowing Jest failures)

--- a/.project/stories/SHY-0054-audit-allure-report-continue-on-error.md
+++ b/.project/stories/SHY-0054-audit-allure-report-continue-on-error.md
@@ -8,6 +8,7 @@ effort: XS
 type: chore
 roadmap_ids: [G037]
 pr:
+mvp: true
 ---
 
 # SHY-0054: Audit `.github/workflows/allure-report.yml:117`'s `continue-on-error: true`

--- a/.project/stories/SHY-0055-update-claude-md-feature-count.md
+++ b/.project/stories/SHY-0055-update-claude-md-feature-count.md
@@ -8,6 +8,7 @@ effort: XS
 type: docs
 roadmap_ids: [G040]
 pr:
+mvp: true
 ---
 
 # SHY-0055: Update CLAUDE.md stale feature-file count (33 → 47)

--- a/.project/stories/SHY-0056-document-app-lock-nav-pattern.md
+++ b/.project/stories/SHY-0056-document-app-lock-nav-pattern.md
@@ -8,6 +8,7 @@ effort: XS
 type: docs
 roadmap_ids: [G041]
 pr:
+mvp: true
 ---
 
 # SHY-0056: Document App Lock navigation intercept pattern in CLAUDE.md

--- a/.project/stories/SHY-0057-split-admin-keyboard-mobile-skip.md
+++ b/.project/stories/SHY-0057-split-admin-keyboard-mobile-skip.md
@@ -8,6 +8,7 @@ effort: XS
 type: bug
 roadmap_ids: [G048]
 pr:
+mvp: true
 ---
 
 # SHY-0057: Split admin-keyboard.spec.ts:61 mobile-viewport skip — keyboard-only vs general

--- a/.project/stories/SHY-0058-fix-dev-sanity-api-skip.md
+++ b/.project/stories/SHY-0058-fix-dev-sanity-api-skip.md
@@ -8,6 +8,7 @@ effort: XS
 type: bug
 roadmap_ids: [G050]
 pr:
+mvp: true
 ---
 
 # SHY-0058: Convert dev-sanity.spec.ts:66-72 API-not-running skip to assertion error

--- a/.project/stories/SHY-0059-fix-admin-users-moderation-skip.md
+++ b/.project/stories/SHY-0059-fix-admin-users-moderation-skip.md
@@ -8,6 +8,7 @@ effort: XS
 type: bug
 roadmap_ids: [G051]
 pr:
+mvp: true
 ---
 
 # SHY-0059: Audit admin-users-moderation.spec.ts:149 conditional skip + seed required data

--- a/.project/stories/SHY-0060-age-gating-per-feature.md
+++ b/.project/stories/SHY-0060-age-gating-per-feature.md
@@ -10,6 +10,7 @@ roadmap_ids: []
 phase: Safety & Compliance
 public: true
 pr:
+mvp: true
 ---
 
 # SHY-0060: Age-gating per feature — replace single 13+ signup gate with tiered per-feature age thresholds

--- a/.project/stories/SHY-0062-migrate-legacy-roadmap-features.md
+++ b/.project/stories/SHY-0062-migrate-legacy-roadmap-features.md
@@ -9,6 +9,7 @@ type: chore
 roadmap_ids: []
 pr:
 epic: EPIC-0002
+mvp: true
 ---
 
 # SHY-0062: Migrate ~95 legacy roadmap features into tracked stories (meta/tracker)

--- a/.project/stories/SHY-0070-system-routes-observability.md
+++ b/.project/stories/SHY-0070-system-routes-observability.md
@@ -8,6 +8,7 @@ effort: S
 type: feature
 roadmap_ids: []
 pr:
+mvp: true
 ---
 
 # SHY-0070: System-routes observability — structured sweep logging + count plumbing

--- a/.project/stories/SHY-0071-sync-wall-clock-batching.md
+++ b/.project/stories/SHY-0071-sync-wall-clock-batching.md
@@ -8,6 +8,7 @@ effort: M
 type: refactor
 roadmap_ids: []
 pr:
+mvp: true
 ---
 
 # SHY-0071: Sync wall-clock — batch per-file gh lookups + scan-mode validation

--- a/.project/stories/SHY-0085-board-sync-loud-degraded-read.md
+++ b/.project/stories/SHY-0085-board-sync-loud-degraded-read.md
@@ -10,6 +10,7 @@ roadmap_ids: []
 pr:
 epic: EPIC-0001
 public: false
+mvp: true
 ---
 
 # SHY-0085: Make a fully-degraded board items-map read LOUD (sidecar-only sync)


### PR DESCRIPTION
Applies the `mvp: true` flag (SHY-0083 field) across the **active** backlog per the inclusive launch boundary you chose (quality/CI/test-coverage work IS in; only **Revenue/Entertainment** scope is excluded).

**Result:** 50 active stories now `mvp: true` (49 newly flagged + SHY-0084). Validator `--scan` exit 0.

**Excluded (pure economy/Revenue) — please confirm:**
- **SHY-0011** — Wallet + Gifting + TransactionHistory VM tests
- **SHY-0008** — economy BDD coverage (subscription + gifting + backpack)

**Borderline flagged IN (bundle MVP-critical work — flag if you'd rather split/exclude):**
- **SHY-0010** — Home (core) + Gacha (entertainment) VM tests
- **SHY-0007** — gacha (entertainment) + age_verification (Safety) features
- **SHY-0018** — iOS parity tests incl. IosEconomyGift among core bridges
- **SHY-0046** — gift_wall coverage-verify

**Scope:** active/open stories only (the remaining launch work). Done (already-shipped) stories were not flagged — say if you want them flagged too for roadmap-display completeness.

No board/sync impact (`mvp:` is frontmatter, outside the body-hash + not a board field). No auto-merge — your call on the exclusions first.