### PR TITLE
fix(deploy-prod): Android smoke checks out the verifier from the workflow ref (SHY-0084 follow-up)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -762,9 +762,13 @@ jobs:
       # SHY-0084: check out the repo so the committed bash smoke verifier
       # (scripts/ci/android-smoke-verify.sh) exists on disk — this job
       # previously only downloaded the APK artifact, with no working tree.
+      # Do NOT pin `ref:` to the DEPLOYED ref: the verifier is workflow TOOLING
+      # and must come from the workflow's own version (the default checkout ref
+      # = the dispatched branch, main). Pinning the deploy ref broke the smoke
+      # when deploying a tag cut BEFORE this script existed (run 27388236740:
+      # deploying v0.97.12 → "No such file", exit 127). The deployed APP under
+      # test is the downloaded APK artifact, not this checked-out tree.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          ref: ${{ needs.validate-release.outputs.commit-sha }}
 
       - name: Download debug APK
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/express-api/tests/scripts/deploy-prod-single-gate-and-smoke.test.js
+++ b/express-api/tests/scripts/deploy-prod-single-gate-and-smoke.test.js
@@ -145,6 +145,19 @@ describe('SHY-0084: deploy-prod.yml Android boot smoke runs under bash', () => {
     expect(androidBlock).toMatch(/uses:[ \t]*actions\/checkout@/);
   });
 
+  test('the smoke checkout does NOT pin the DEPLOYED ref (verifier is workflow tooling)', () => {
+    // Regression guard (run 27388236740): pinning the smoke checkout to the
+    // deploy ref (needs.validate-release.outputs.commit-sha) made the bash
+    // verifier "No such file" when deploying a tag cut before the script
+    // existed. The verifier must come from the workflow's own (default) ref;
+    // the deployed APP under test is the downloaded APK artifact.
+    const checkoutIdx = androidBlock.indexOf('actions/checkout@');
+    expect(checkoutIdx).toBeGreaterThanOrEqual(0);
+    // The 4 lines following the checkout must not re-introduce the deploy-ref pin.
+    const after = androidBlock.slice(checkoutIdx).split('\n').slice(0, 4).join('\n');
+    expect(after).not.toMatch(/ref:\s*\$\{\{\s*needs\.validate-release\.outputs\.commit-sha/);
+  });
+
   test('still pinned to ubuntu-22.04 (emulator-boot-stability pin is preserved)', () => {
     expect(androidBlock).toMatch(/^[ \t]+runs-on:[ \t]*ubuntu-22\.04\b/m);
   });


### PR DESCRIPTION
**SHY-0084 follow-up — caught by live verification (prod run 27388236740).**

The Android boot smoke pinned its `checkout` to the DEPLOYED ref (`needs.validate-release.outputs.commit-sha`), but `scripts/ci/android-smoke-verify.sh` is workflow TOOLING that only exists from the SHY-0084 commit onward. Deploying v0.97.12 (a tag cut before the script) made the smoke fail `No such file` (exit 127) — even though the emulator booted and the `bash …` invocation was correct (the dash→bash fix itself works).

**Fix:** drop the `ref:` pin so the smoke checkout uses the workflow's own ref (the dispatched branch, main) where the verifier lives. The deployed APP under test is the downloaded APK artifact, not the checked-out tree.

**Test:** `deploy-prod-single-gate-and-smoke.test.js` now asserts the smoke checkout does NOT re-pin the deploy ref (regression guard). Full suite 12,194 green; actionlint clean. Self-reviewed (low-risk workflow tooling fix).

Once merged, v0.97.13 will be cut (bundles SHY-0084 + this fix + SHY-0085 + MVP classification); deploying it verifies the Android+iOS smokes end-to-end → SHY-0084 → Done.