### PR TITLE
SHY-0087: Run iOS boot smoke in parallel with the App Store deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -803,10 +803,25 @@ jobs:
 
   smoke-test-ios:
     name: Smoke Test (iOS Boot)
-    needs: [validate-release, deploy-ios-prod]
-    if: |
-      always() &&
-      needs.deploy-ios-prod.result == 'success'
+    # SHY-0087: run the iOS boot smoke IN PARALLEL with deploy-ios-prod instead
+    # of serially after it — ~25 min off the post-approval critical path. The
+    # smoke shares NO data with the deploy: it checks out the same source commit
+    # (needs.validate-release.outputs.commit-sha) and rebuilds the simulator app
+    # from scratch, so depending on deploy-ios-prod was only a "skip if the
+    # deploy died" gate, never a data handoff. We gate on approve-prod instead:
+    # the smoke still waits for the single approval (so no expensive macos-latest
+    # runner is burned pre-approval or on a denied release) but now overlaps the
+    # deploy rather than queuing behind it. Trade-off (accepted per the SHY-0086
+    # escalation): a wasted runner on the RARE post-approval deploy FAILURE, in
+    # exchange for ~25 min saved on every successful release — and the smoke
+    # still yields a valid boot signal (it builds from source, not the deployed
+    # IPA). inputs.ios is now checked EXPLICITLY: it is the only thing that skips
+    # the smoke on a non-iOS release (approve-prod runs regardless of platform,
+    # so the old deploy-result gate can no longer stand in for the iOS-deselect
+    # check). No always() — we WANT the default auto-skip when approve-prod is
+    # denied/cancelled.
+    needs: [validate-release, approve-prod]
+    if: inputs.ios && needs.approve-prod.result == 'success'
     # Migrated 2026-05-20 to GitHub-hosted macos-latest per the
     # no-self-hosted-runners policy. See deploy-dev.yml for rationale.
     runs-on: macos-latest

--- a/.project/stories/SHY-0087-parallelize-ios-smoke-with-deploy.md
+++ b/.project/stories/SHY-0087-parallelize-ios-smoke-with-deploy.md
@@ -1,6 +1,6 @@
 ---
 id: SHY-0087
-status: Draft
+status: In Review
 owner: claude
 created: 2026-06-12
 priority: P1
@@ -30,7 +30,7 @@ So that the post-approval iOS critical path drops from ~82 min to ~57 min with n
 
 ### Happy path
 
-- [ ] `smoke-test-ios`'s `needs:` no longer includes `deploy-ios-prod` — it becomes `needs: [validate-release]` so GitHub schedules it as soon as `validate-release` completes (concurrently with `deploy-ios-prod`).
+- [ ] `smoke-test-ios`'s `needs:` no longer includes `deploy-ios-prod` — it becomes `needs: [validate-release, approve-prod]` so GitHub schedules it concurrently with `deploy-ios-prod` once the single approval gate clears. (Refined from the original `needs: [validate-release]`: gating on `approve-prod` rather than bare `validate-release` keeps the smoke from burning an expensive `macos-latest` runner pre-approval / on a denied release — see Notes.)
 - [ ] On a release where `inputs.ios` is true and both jobs succeed, the run graph shows `smoke-test-ios` and `deploy-ios-prod` with **overlapping** `started_at`/`completed_at` windows (verified via `gh api .../jobs`), and the run's total post-approval wall-clock is ≈ `max(deploy-ios, smoke-ios)`, not their sum.
 - [ ] The iOS smoke still gates on `inputs.ios` (it must not run when iOS is deselected for the release).
 
@@ -114,4 +114,17 @@ So that the post-approval iOS critical path drops from ~82 min to ~57 min with n
 
 ## Notes (running log)
 
+- 2026-06-12 ~19:42 BST — **code-reviewer cycle 1: 0 Critical, 2 Important, 2 Minor → all dispositioned; suite now 31/31 GREEN, eslint clean.**
+  - ✅ **Fixed (Important):** added a negative assertion that the smoke `if` does NOT contain `always()`. The auto-skip-on-deny/cancel guarantee depends on its absence — a "make it consistent with the deploy-*-prod jobs" refactor adding `always()` would silently let the smoke (and a 10×-billed `macos-latest` runner) run on a DENIED release. Now pinned.
+  - ✅ **Fixed (Minor):** the Happy-path AC bullet still read `needs: [validate-release]`; updated to `[validate-release, approve-prod]` to match the implemented + Notes-documented refinement.
+  - ⛔ **Not a finding (verified against the file, [[feedback-reviewer-regex-anchoring-false-alarms]]):** reviewer claimed the `alert-desync` needs-regex test omitted a `not.toBeNull()` guard — it already has one. No change.
+  - ⛔ **No action (verified harmless):** concurrent `~/.konan` cache save is first-writer-wins + both steps `continue-on-error: true`; pre-existing, not worsened by the now-parallel jobs.
+- 2026-06-12 ~19:30 BST — **IMPLEMENTED (Draft → In Progress). TDD RED→GREEN; self-review clean.**
+  - **Pickup-fitness re-validated against live `deploy-prod.yml`:** confirmed `smoke-test-ios needs: [validate-release, deploy-ios-prod]` (the serial chain) + `alert-desync` still depends on both the iOS deploy and the iOS smoke. Story still accurate against current code.
+  - **TDD:** added a `SHY-0087:` describe block to `express-api/tests/scripts/deploy-prod-single-gate-and-smoke.test.js` (+81 lines, 7 assertions) — 4 failed RED against the serial YAML (needs-not-deploy, needs-has-approve, if-approve-success, if-inputs.ios), then GREEN after the workflow edit (**30/30 pass**). actionlint exit 0; prettier OK; `check-no-paid-runners` / `check-workflow-concurrency-scoping` / `check-action-shas` all OK.
+  - **REFINEMENT — gate on `approve-prod`, not bare `validate-release`.** The story's prose Test Plan said `needs: [validate-release]`, but that would start the smoke **pre-approval** — burning a 10×-billed `macos-latest` runner on *every* dispatch (incl. denied/abandoned releases) during a potentially multi-hour approval wait, and it contradicts this story's own BDD ("When validate-release completes **and the approval gate is cleared**, Then both start"). Implemented the BDD-consistent form: `needs: [validate-release, approve-prod]` + `if: inputs.ios && needs.approve-prod.result == 'success'` (no `always()` — we WANT the default auto-skip when approval is denied/cancelled). This still satisfies every Test-Plan assertion: (a) `needs` no longer contains `deploy-ios-prod`; (b) `needs` contains `validate-release`; (c) `if` references `inputs.ios`; (d) `alert-desync.needs` unchanged (both retained).
+  - **Why `inputs.ios` became explicit:** the old `deploy-ios-prod.result == 'success'` gate did double duty — "skip if deploy died" AND "skip if iOS deselected" (deselected → deploy skipped → not success). With the deploy dependency gone, `inputs.ios` is now the sole iOS-deselect guard (approve-prod runs regardless of platform), so it had to be added to the `if`.
+  - **Concurrency edge verified (not assumed):** smoke + deploy now write the shared `~/.konan` key concurrently on a cold cache; both save steps are `continue-on-error: true` (deploy L653, smoke L936) so a 409 collision is tolerated by both — neither job fails. Saves are last-writer-wins, content-valid (compiler/klib layer is target-agnostic).
+  - **Architect skipped** (low-risk infra, [[feedback-rate-limit-slowdown-strategies]]); the spec-inconsistency that an architect would have caught (literal `needs` vs BDD) was found + resolved during pickup-fitness above.
+  - **Live-verification AC still OPEN:** the overlap proof (`gh api .../jobs` showing overlapping windows + post-approval iOS path < 60 min) can only be captured on the next REAL prod release. Status holds at In Review after merge until that release confirms it (infra DoD = verify-on-real-deploy), then → Done with `released_in`.
 - 2026-06-12 — Filed by SHY-0086 (prod-deploy profiling spike). Origin: the iOS smoke runs serially after the iOS deploy despite sharing no data with it; parallelising saves ~25 min off the post-approval critical path. Highest-ROI / lowest-risk of the three SHY-0086 follow-ups — do first.

--- a/express-api/tests/scripts/deploy-prod-single-gate-and-smoke.test.js
+++ b/express-api/tests/scripts/deploy-prod-single-gate-and-smoke.test.js
@@ -181,3 +181,100 @@ describe('SHY-0084: deploy-prod.yml iOS boot smoke reaches the boot step', () =>
     expect(iosBlock).toMatch(/Boot simulator and verify app launches/);
   });
 });
+
+describe('SHY-0087: iOS smoke runs in PARALLEL with the iOS App Store deploy', () => {
+  let iosSmokeBlock;
+  let iosSmokeNeeds;
+  let iosSmokeIf;
+  let alertDesyncBlock;
+  beforeAll(() => {
+    const yaml = fs.readFileSync(DEPLOY_PROD_YML, 'utf8');
+    iosSmokeBlock = extractJobBlock(yaml, '  smoke-test-ios:');
+    // Parse the needs array + the JOB-LEVEL if (the FIRST `if:` in the block —
+    // step-level `if:`s come later). Extracting the if VALUE (not scanning the
+    // whole block) is deliberate: the job's explanatory comment legitimately
+    // mentions `inputs.ios` / the old deploy gate in prose, and asserting
+    // against the comment would false-pass. We pin the actual expression.
+    const needsMatch = iosSmokeBlock && iosSmokeBlock.match(/^[ \t]+needs:[ \t]*\[([^\]]*)\]/m);
+    iosSmokeNeeds = needsMatch ? needsMatch[1] : null;
+    // `(\S.*)` not `(.+)`: anchoring the capture to a non-space first char keeps
+    // `[ \t]*` and the capture as disjoint classes (no overlapping quantifiers →
+    // no super-linear backtracking; sonarjs/slow-regex). The first char of an
+    // `if:` value is always non-space.
+    const ifMatch = iosSmokeBlock && iosSmokeBlock.match(/^[ \t]+if:[ \t]*(\S.*)$/m);
+    iosSmokeIf = ifMatch ? ifMatch[1] : null;
+    alertDesyncBlock = extractJobBlock(yaml, '  alert-desync:');
+  });
+
+  // AC (happy path): the serial chain that forced the ~25-min smoke to run
+  // AFTER the 56-min deploy is gone — smoke no longer depends on the deploy, so
+  // GitHub can schedule the two concurrently. This is THE change that buys the
+  // ~25 min off the post-approval critical path.
+  test('smoke-test-ios.needs no longer depends on deploy-ios-prod', () => {
+    expect(iosSmokeNeeds).not.toBeNull();
+    expect(iosSmokeNeeds).not.toMatch(/\bdeploy-ios-prod\b/);
+  });
+
+  // AC: it still needs validate-release (it checks out
+  // needs.validate-release.outputs.commit-sha to build the same source).
+  test('smoke-test-ios.needs still includes validate-release', () => {
+    expect(iosSmokeNeeds).not.toBeNull();
+    expect(iosSmokeNeeds).toMatch(/\bvalidate-release\b/);
+  });
+
+  // SHY-0087 refinement (BDD: "When ... the approval gate is cleared, Then both
+  // start"): gate the smoke on approve-prod — NOT the deploy — so it (1) overlaps
+  // the deploy post-approval and (2) does NOT burn an expensive (10x-billed)
+  // macos-latest runner pre-approval or on a DENIED release. A plain
+  // `needs: [validate-release]` would start the smoke before approval.
+  test('smoke-test-ios.needs gates on approve-prod (no pre-approval / no-denial runner burn)', () => {
+    expect(iosSmokeNeeds).not.toBeNull();
+    expect(iosSmokeNeeds).toMatch(/\bapprove-prod\b/);
+  });
+
+  test('smoke-test-ios job-level if enforces approve-prod success', () => {
+    expect(iosSmokeIf).not.toBeNull();
+    expect(iosSmokeIf).toMatch(/needs\.approve-prod\.result\s*==\s*['"]success['"]/);
+  });
+
+  // The auto-skip-on-deny/cancel guarantee depends on the ABSENCE of always():
+  // GitHub auto-skips a job whose needed gate (approve-prod) was denied/cancelled
+  // ONLY when the if has no always(). A well-meaning "make it consistent with the
+  // deploy-*-prod jobs" refactor that adds always() would silently let the smoke
+  // run — burning a 10x-billed macos-latest runner — on a DENIED release. Pin the
+  // absence so that regression fails loudly here. (The deploy jobs DO use
+  // always() because they have a success||skipped need; the smoke does not.)
+  test('smoke-test-ios job-level if does NOT use always() (auto-skip on deny/cancel is the guard)', () => {
+    expect(iosSmokeIf).not.toBeNull();
+    expect(iosSmokeIf).not.toMatch(/always\(\)/);
+  });
+
+  // AC (edge case): an iOS-DESELECTED release must not run an orphan smoke. The
+  // old `deploy-ios-prod.result == 'success'` gate gave this for free
+  // (deselected → deploy skipped → not success → smoke skipped); with the deploy
+  // dependency gone, inputs.ios must be checked EXPLICITLY in the if.
+  test('smoke-test-ios job-level if still gates on inputs.ios (no orphan smoke when iOS deselected)', () => {
+    expect(iosSmokeIf).not.toBeNull();
+    expect(iosSmokeIf).toMatch(/inputs\.ios/);
+  });
+
+  // AC (error path) + regression: the data-less "skip if the deploy died" clause
+  // is fully removed from the if. A deploy FAILURE must NOT suppress the smoke —
+  // both report independently. If this clause crept back, the smoke would
+  // re-serialize behind the deploy and the ~25 min would be lost again.
+  test('smoke-test-ios job-level if no longer references the deploy result (truly decoupled)', () => {
+    expect(iosSmokeIf).not.toBeNull();
+    expect(iosSmokeIf).not.toMatch(/needs\.deploy-ios-prod\.result/);
+  });
+
+  // AC: the desync alarm must still cover BOTH the iOS deploy and the iOS smoke
+  // — decoupling the smoke from the deploy must NOT drop either from the
+  // failure-aggregation job.
+  test('alert-desync still needs both deploy-ios-prod and smoke-test-ios', () => {
+    expect(alertDesyncBlock).not.toBeNull();
+    const needs = alertDesyncBlock.match(/^[ \t]+needs:[ \t]*\[([^\]]*)\]/m);
+    expect(needs).not.toBeNull();
+    expect(needs[1]).toMatch(/\bdeploy-ios-prod\b/);
+    expect(needs[1]).toMatch(/\bsmoke-test-ios\b/);
+  });
+});


### PR DESCRIPTION
Implements SHY-0087 — see .project/stories/SHY-0087-parallelize-ios-smoke-with-deploy.md for full spec, AC, BDD scenarios, and DoD.

## Problem (from the SHY-0086 profiling spike)
The post-approval iOS critical path was ~82 min: `deploy-backend (1m) → deploy-ios-prod (56m) → smoke-test-ios (~25-30m)`. The iOS boot smoke ran **serially after** the App Store deploy even though it shares **no data** with it — it checks out the same source commit and rebuilds the simulator app from scratch. The `needs: deploy-ios-prod` was only a "skip if the deploy died" gate, not a data handoff.

## Change
`smoke-test-ios`: `needs: [validate-release, deploy-ios-prod]` → `needs: [validate-release, approve-prod]`, and the job-level `if:` from `always() && needs.deploy-ios-prod.result == 'success'` → `inputs.ios && needs.approve-prod.result == 'success'`.

The smoke now runs **in parallel** with the iOS deploy → iOS path collapses to ~`max(57, 30) ≈ 57 min`, **~25 min saved per release**, zero new build cost.

**Why gate on `approve-prod`, not bare `validate-release`** (refinement of the story's prose, consistent with its BDD): a bare `validate-release` gate would start the smoke **pre-approval**, burning a 10×-billed `macos-latest` runner on every dispatch — including denied/abandoned releases — during a potentially multi-hour approval wait. Gating on `approve-prod` overlaps the deploy while still respecting the single approval gate. No `always()`, so the smoke correctly **auto-skips on a denied/cancelled approval**.

**Why `inputs.ios` is now explicit:** the old `deploy-ios-prod.result == 'success'` clause did double duty (skip-if-deploy-died **and** skip-if-iOS-deselected). With the deploy dependency gone, `inputs.ios` is the sole iOS-deselect guard.

## Tests (TDD)
8 assertions added to `express-api/tests/scripts/deploy-prod-single-gate-and-smoke.test.js` (a new `SHY-0087:` describe) — 4 RED against the serial YAML → **31/31 GREEN**. Covers: deploy dependency removed, validate-release+approve-prod retained, `if` gates approve-prod success + `inputs.ios`, `if` no longer references the deploy result, **`if` has no `always()`** (the deny/cancel auto-skip guard), and `alert-desync` still depends on both the iOS deploy and the iOS smoke.

The `if`-value is extracted via `/^[ \t]+if:[ \t]*(\S.*)$/m` (non-backtracking; isolates the expression so the job's prose comment can't false-pass).

## Verification
- actionlint exit 0; prettier clean; `check-no-paid-runners` / `check-workflow-concurrency-scoping` / `check-action-shas` all pass; SonarCloud quality gate passed (pre-push).
- Concurrency edge verified: the now-parallel deploy + smoke write the shared `~/.konan` key, but both saves are `continue-on-error: true` (first-writer-wins, content-valid).
- code-reviewer: 0 Critical; 1 Important + 1 Minor fixed; 1 claimed finding verified false-positive.

## Out of scope / follow-ups
- The iOS **build** cost (29m `xcodebuild archive`, 22m K/N link) = SHY-0088 / SHY-0089.
- **Live-verification AC** (overlap via `gh api .../jobs`, post-approval iOS path < 60 min) can only be proven on the next real prod release → recorded as an open Notes item; story stays In Review until then (infra verify-on-real-deploy DoD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)