### PR TITLE
SHY-0092: correct misleading STUB/SCAFFOLD driver docstrings + non-canonical notes [DRAFT — device gauntlet pending]

### DIFF
--- a/.project/stories/SHY-0092-driver-docstring-honesty.md
+++ b/.project/stories/SHY-0092-driver-docstring-honesty.md
@@ -1,6 +1,6 @@
 ---
 id: SHY-0092
-status: Draft
+status: In Progress
 owner: claude
 created: 2026-06-13
 priority: P2

--- a/express-api/scripts/drivers/android-adb-driver.js
+++ b/express-api/scripts/drivers/android-adb-driver.js
@@ -7,11 +7,12 @@
  * Android driver backed by `adb` (shell + uiautomator).
  *
  * Exposes the ctx.uiDriver methods that manual-qa-runner.js matchers
- * call for Android scenarios. The current implementation is a SCAFFOLD:
- * every method name from the matcher contract is wired to a stub that
- * returns false + logs a clear "not implemented" message. As scenarios
- * are exercised end-to-end, methods get real implementations one at a
- * time (input tap, uiautomator dump, am start, intent broadcast).
+ * call for Android scenarios. This is a REAL, fully-implemented adb /
+ * UIAutomator driver (~2.5k lines): every method name from the matcher
+ * contract is first registered with a fail-loud fallback (returns false
+ * + logs a clear "not implemented yet" message for any not-yet-mapped
+ * name), then the real implementations below override the mapped names
+ * (input tap, uiautomator dump, am start, intent broadcast).
  *
  * Wiring contract:
  *   - `createAndroidDriver({ serial })` selects which adb device to drive.
@@ -28,9 +29,8 @@
  *   - `adb shell am start -n pkg/.Activity`  — launches activity
  *   - `adb shell am broadcast -a ...`        — broadcasts intent
  *
- * The driver doesn't currently know which Activity each "screen"
- * corresponds to — that mapping needs to come from the app's
- * navigation registry. For now, methods log "not implemented" and the
+ * Where a "screen"→Activity mapping isn't yet wired, that method falls
+ * through to the fail-loud fallback (logs + returns false) and the
  * runner surfaces a finding listing the matcher and the missing call.
  */
 const { execSync } = require('child_process');
@@ -59,8 +59,9 @@ function selectSerial(preferredSerial) {
 /**
  * Method-name list the runner expects on ctx.uiDriver for Android
  * scenarios. Extracted by grepping `androidXxx:` patterns in
- * manual-qa-runner.js. Each name maps to a stub returning false +
- * log; real implementations replace stubs incrementally.
+ * manual-qa-runner.js. Each name is registered with the fail-loud
+ * fallback, then overridden below by its real implementation where one
+ * exists.
  */
 const ANDROID_METHOD_NAMES = [
   // Wake 86-106 vocabulary (matcher contract):

--- a/express-api/scripts/drivers/ios-devicectl-driver.js
+++ b/express-api/scripts/drivers/ios-devicectl-driver.js
@@ -4,17 +4,17 @@
 /**
  * iOS driver backed by `xcrun devicectl` — physical iPhone target.
  *
- * Replaces `ios-simctl-driver.js` (simulator-only) per the policy
- * shift: journey tests run on a real device over wireless, not on a
- * simulator (see feedback-ios-also-journey-tested.md). The simctl
- * driver is preserved in-tree for reference but the runner now
- * imports from this file.
+ * NON-CANONICAL ALTERNATIVE (EPIC-0003, 2026-06-13): the canonical
+ * real-iPhone native path is `ios-appium-driver.js` (Appium + WebDriver-
+ * Agent). This devicectl driver is kept in-tree as a non-canonical
+ * alternative; its UI inspection is INTENTIONALLY left unbuilt and it is
+ * NOT on the Pre-Merge gauntlet path — so it is not a No-Stubs violation
+ * to "complete". Do not build it out; use the Appium driver instead.
  *
- * SCAFFOLD STATE: this is the Phase 5 root PR. The factory + method
- * name registry + stub methods are in place; real UI inspection
- * (devicectl + WDA / XCTest harness) lands in subsequent PRs that
- * convert each stub into a foundation presence-check method, mirror-
- * ing the Android cluster's pattern.
+ * State: the factory + method-name registry + device selection are real;
+ * UI inspection (`iosUiDump()` returns '' → every `iosShows*` returns
+ * false) is the part deliberately not implemented here. `ios-simctl-
+ * driver.js` is the simulator-only sibling (also non-canonical).
  *
  * Wiring contract:
  *   - `createIosDriver({ udid })` picks the first connected physical
@@ -31,9 +31,9 @@
  *   - `device process launch <bundleId>`— launch app
  *   - `device info details`             — device metadata
  *   - For UI inspection on physical devices, devicectl alone is
- *     insufficient; this scaffold uses WebDriverAgent / XCTest as a
- *     future integration. Until that lands, `iosUiDump()` returns ''
- *     and every presence-check method returns false in real journeys.
+ *     insufficient; the canonical path (ios-appium-driver.js) uses
+ *     WebDriverAgent for this. Here, `iosUiDump()` returns '' and every
+ *     presence-check returns false — intentionally unbuilt (see above).
  *
  * Foundation parity with android-adb-driver.js:
  *   - `iosUiDump()` is the rough equivalent of `androidUiDump()` —

--- a/express-api/scripts/drivers/ios-simctl-driver.js
+++ b/express-api/scripts/drivers/ios-simctl-driver.js
@@ -4,13 +4,19 @@
    Xcode command-line dispatcher; resolving via PATH is the standard
    macOS pattern. Operator-installed; not user input. */
 /**
- * iOS driver backed by `xcrun simctl`.
+ * iOS driver backed by `xcrun simctl` (simulator).
  *
- * Exposes the ctx.uiDriver methods that manual-qa-runner.js matchers
- * call for iOS scenarios. Real implementations of UI taps + reads
- * require an instrumentation framework (XCUITest, Appium, or
- * idb-companion); the scaffold here provides `openurl`, `launch`,
- * `screenshot`, `status_bar` and stubs for the rest.
+ * NON-CANONICAL ALTERNATIVE (EPIC-0003, 2026-06-13): the canonical
+ * real-iPhone native path is `ios-appium-driver.js` (Appium + WebDriver-
+ * Agent on a REAL device). This simctl driver targets the simulator and
+ * is kept as a non-canonical alternative; the No-Stubs / Pre-Merge
+ * gauntlet requires a real device, so simctl is NOT on the gauntlet path
+ * and its unimplemented methods are not a violation to "complete".
+ *
+ * Exposes the ctx.uiDriver methods the runner's matchers call. It
+ * provides real `openurl`, `launch`, `screenshot`, `status_bar`; UI tap/
+ * read methods need an instrumentation framework (XCUITest/Appium/idb-
+ * companion) and fall through to the fail-loud fallback here.
  *
  * Wiring contract:
  *   - `createIosDriver({ udid })` picks a booted simulator; defaults

--- a/express-api/scripts/drivers/web-playwright-driver.js
+++ b/express-api/scripts/drivers/web-playwright-driver.js
@@ -19,10 +19,13 @@
  *     (e.g., `webShowsRoomClosedSummary`, `webShowsCountBadge`)
  *   - First arg is typically the actor's persona name (string)
  *
- * Initial implementation: STUB FOR EVERY METHOD that returns false +
- * logs "not implemented yet" so the runner produces a finding instead
- * of crashing on undefined. As scenarios are exercised, methods get
- * real implementations one at a time.
+ * Implementation pattern — stub-registration + real overrides: every
+ * name in WEB_METHOD_NAMES is first wired to a fail-loud fallback
+ * (returns false + logs "not implemented yet" so the runner surfaces a
+ * finding instead of crashing on undefined for any not-yet-mapped
+ * name), then the real Playwright implementations below OVERRIDE the
+ * names that are implemented. Many methods are real today; the fallback
+ * remains only for names a scenario reaches before they get a body.
  */
 const path = require('path');
 
@@ -49,14 +52,15 @@ function loadPlaywright() {
 
 /**
  * Method-name list the runner expects (extracted by scanning matchers
- * for `ctx.webDriver?.<methodName>` references). Each is stubbed below.
- * The list is the source of truth for "what scenarios will be able to
+ * for `ctx.webDriver?.<methodName>` references). Each is registered with
+ * the fail-loud fallback, then OVERRIDDEN below where a real Playwright
+ * body exists. The list is the source of truth for "what scenarios can
  * exercise"; additions/removals here must mirror runner matcher edits.
  */
 const WEB_METHOD_NAMES = [
-  // Wake 86-106 vocabulary — extracted by grep over runner. Currently
-  // all return false (not implemented). As scenarios surface needs,
-  // each method gets a real Playwright body.
+  // Wake 86-106 vocabulary — extracted by grep over runner. Each name
+  // gets the fail-loud fallback at registration; the real Playwright
+  // bodies below override the implemented names.
   'webAdminShowsAppealText',
   'webAdminShowsDashboardCounters',
   'webAdminShowsNewReportInQueue',

--- a/express-api/tests/scripts/drivers/driver-docstring-honesty.test.js
+++ b/express-api/tests/scripts/drivers/driver-docstring-honesty.test.js
@@ -1,0 +1,93 @@
+/**
+ * SHY-0092 — driver docstring-honesty guard.
+ *
+ * Two driver headers historically claimed "STUB FOR EVERY METHOD" /
+ * "the current implementation is a SCAFFOLD" over code that is in fact
+ * fully implemented — the inverse No-Stubs hazard (a comment lying that
+ * real code is a placeholder, which misleads a pickup session into
+ * "rebuilding" working drivers). Two others (devicectl/simctl) are
+ * genuinely NON-CANONICAL alternatives — the canonical real-iPhone
+ * native path is ios-appium-driver.js per EPIC-0003 (2026-06-13) — and
+ * their headers must say so, so nobody "completes" them under No-Stubs.
+ *
+ * Each driver's check pairs a header-text assertion (the literal
+ * artifact being corrected) with a behavioural anchor (the driver loads
+ * and still registers its real method surface), so the guard cannot be
+ * satisfied by gutting either the file or its header.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const SRC = path.resolve(__dirname, '../../../scripts/drivers');
+
+/** Leading block comment + registry intro (first 90 lines is ample). */
+function headerOf(file) {
+  return fs.readFileSync(path.join(SRC, file), 'utf8').split('\n').slice(0, 90).join('\n');
+}
+function load(file) {
+  return require(path.join(SRC, file));
+}
+
+describe('SHY-0092 driver docstring honesty', () => {
+  describe('web-playwright-driver.js — real overrides, not a blanket stub', () => {
+    const header = headerOf('web-playwright-driver.js');
+    it('header does not falsely claim a blanket "STUB FOR EVERY METHOD"', () => {
+      expect(header).not.toMatch(/STUB FOR EVERY METHOD/i);
+    });
+    it('header does not falsely claim methods "all return false (not implemented)"', () => {
+      expect(header).not.toMatch(/all return false \(not implemented\)/i);
+    });
+    it('header describes the real stub-registration + override pattern', () => {
+      expect(header).toMatch(/override/i);
+    });
+    it('behavioural anchor: still registers its real method surface', () => {
+      const drv = load('web-playwright-driver.js');
+      expect(typeof drv.listMethods).toBe('function');
+      expect(drv.listMethods().length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('android-adb-driver.js — real ADB/UIAutomator driver, not a scaffold', () => {
+    const header = headerOf('android-adb-driver.js');
+    it('header does not falsely claim "the current implementation is a SCAFFOLD"', () => {
+      expect(header).not.toMatch(/is a SCAFFOLD/i);
+    });
+    it('header does not falsely claim "real implementations replace stubs incrementally"', () => {
+      expect(header).not.toMatch(/real implementations replace stubs incrementally/i);
+    });
+    it('header states it is a real / fully-implemented driver', () => {
+      expect(header).toMatch(/real|fully[- ]implemented/i);
+    });
+    it('behavioural anchor: still registers its real method surface', () => {
+      const drv = load('android-adb-driver.js');
+      expect(typeof drv.listMethods).toBe('function');
+      expect(drv.listMethods().length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('ios-devicectl-driver.js — documented non-canonical alternative', () => {
+    const header = headerOf('ios-devicectl-driver.js');
+    it('header marks it NON-CANONICAL', () => {
+      expect(header).toMatch(/non-canonical/i);
+    });
+    it('header names ios-appium-driver as the canonical real-iPhone native path', () => {
+      expect(header).toMatch(/ios-appium-driver/);
+    });
+    it('behavioural anchor: still loads + registers its method surface', () => {
+      expect(load('ios-devicectl-driver.js').listMethods().length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('ios-simctl-driver.js — documented non-canonical alternative', () => {
+    const header = headerOf('ios-simctl-driver.js');
+    it('header marks it NON-CANONICAL', () => {
+      expect(header).toMatch(/non-canonical/i);
+    });
+    it('header names ios-appium-driver as the canonical real-iPhone native path', () => {
+      expect(header).toMatch(/ios-appium-driver/);
+    });
+    it('behavioural anchor: still loads + registers its method surface', () => {
+      expect(load('ios-simctl-driver.js').listMethods().length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
**EPIC-0003 child (build item D).** Draft — code-complete + Node-gate-green, but **NOT for merge yet**: the real-device gauntlet can't run autonomously (see "Blocker" below).

## What
The inverse No-Stubs hazard — comments lying that real code is a placeholder:
- `web-playwright-driver.js` header claimed *"STUB FOR EVERY METHOD that returns false"* / *"all return false (not implemented)"* over a driver with extensive real Playwright overrides → rewritten to describe the real **stub-registration + override** pattern.
- `android-adb-driver.js` header claimed *"the current implementation is a SCAFFOLD"* over **2560 lines** of real adb/UIAutomator code → rewritten as a real, fully-implemented driver with a fail-loud fallback.
- `ios-devicectl-driver.js` + `ios-simctl-driver.js`: added **NON-CANONICAL ALTERNATIVE** notes (canonical real-iPhone native path is `ios-appium-driver.js` per EPIC-0003; their UI inspection is intentionally unbuilt — not a No-Stubs violation to "complete").
- New `driver-docstring-honesty.test.js` guard: per driver, asserts the falsifying phrase is absent (or the non-canonical marker present) **AND** a behavioural anchor (driver loads + registers its real method surface), so it can't be gamed by gutting the file/header.

## Testing — device-independent gate GREEN
- Full Jest: **12222 / 12222** pass (incl. new guard, RED→GREEN).
- `eslint --max-warnings=0`: clean. Pre-push SonarCloud quality gate: passed.
- `--check-drivers --target local`: surface unchanged (**5 ok / 7 skip**), all 4 drivers still load + register.

## ⚠️ Blocker — real-device gauntlet not autonomously runnable
Per `CLAUDE.md` § Pre-Merge Testing Protocol, this `.js` change requires the Phase-1 device gauntlet (real Android + real iPhone + all browsers). `--check-drivers` shows only **5/12 cells run**; the other 7 need **operator-side setup that can't be scripted**: on-device `chrome://flags` (android-mobile cells) + Xcode WDA signing & an awake iPhone (iOS cells; iPhone currently "unavailable"). **Reviewer + device gauntlet + merge are deferred until the devices are ready.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)