### PR TITLE
SHY-0133: Local pre-merge gate refuses added-Draft spec PRs — align with the SHY-0131 CI exemption

### DIFF
--- a/.project/stories/SHY-0133-pre-merge-check-exempt-added-drafts.md
+++ b/.project/stories/SHY-0133-pre-merge-check-exempt-added-drafts.md
@@ -1,6 +1,6 @@
 ---
 id: SHY-0133
-status: Draft
+status: In Review
 owner: claude
 created: 2026-06-20
 priority: P2
@@ -133,3 +133,6 @@ All existing tests (In Review OK, no-marker refuse, code-after-marker refuse, Do
 ## Notes (running log)
 
 - 2026-06-20 — **Filed (operator chose "fix the merge-gate" 2026-06-20).** Surfaced while judgment-merging the SHY-0132 spec PR #1486: `pre-merge-check.sh` REFUSED its added Draft while the CI `PR Gate` passed it — SHY-0131 updated the CI gate (`check-pr-story-status.js:87` `code === 'A' && status === 'Draft'`) but not the local sibling. This story closes that oversight: mirror the add-only, Draft-only exemption into `pre-merge-check.sh` and split the `REFUSES on a Draft story` test into added-Draft-EXEMPT + modified-to-Draft-REFUSE. Add-only + Draft-only keeps every other guard (modified-Draft, non-Draft adds, Done/Cancelled, unreviewed code) intact.
+- 2026-06-20 — **Implemented + reviewed (filed + built in one PR, SHY-0131 pattern).** RED: split the `REFUSES on a Draft story` test → added-Draft EXEMPT + modified-to-Draft REFUSE; GREEN: `pre-merge-check.sh` `--name-status` + add-only/Draft-only exemption. 17/17 Jest green (incl. mixed-PR, renamed-Draft R≠A, FILINGS=2 multi-filing); shellcheck/eslint/prettier/no-stubs clean. `code-reviewer`: pass 1 = 2 Important + 3 Minor (honest filing-only checklist, FILINGS=2 test, printf, DRY helper) → all fixed; pass 2 (re-review of the fix) = ZERO findings. Status → In Review.
+
+Reviewed-up-to: 30d86b3a641

--- a/.project/stories/SHY-0133-pre-merge-check-exempt-added-drafts.md
+++ b/.project/stories/SHY-0133-pre-merge-check-exempt-added-drafts.md
@@ -1,0 +1,135 @@
+---
+id: SHY-0133
+status: Draft
+owner: claude
+created: 2026-06-20
+priority: P2
+effort: S
+type: bug
+roadmap_ids: []
+public: false
+mvp: false
+---
+
+# SHY-0133: Local pre-merge gate refuses added-Draft spec PRs — align with the SHY-0131 CI exemption
+
+## User Story
+
+As a **maintainer running the mandatory local pre-merge gate before a judgment-merge**,
+I want **`scripts/pre-merge-check.sh` to exempt a newly-ADDED Draft story file (a spec filing), exactly as the CI Pre-Merge Gate already does**,
+So that **a Draft spec-filing PR can pass the local gate and be merged the documented way, instead of the local and CI gates contradicting each other**.
+
+## Why
+
+SHY-0131 made the **CI** Pre-Merge Gate (`scripts/check-pr-story-status.js`) exempt a newly-ADDED story `.md` at status `Draft` — filing a brand-new backlog story is legitimately Draft, and blocking it would make it impossible to land a new story. But SHY-0131 only touched the CI script; it did **not** update the sibling **local** gate `scripts/pre-merge-check.sh`, which still requires `In Review` for **every** changed story (`--diff-filter=ACMR` + a blanket status check at L44/L52), with no added-Draft carve-out.
+
+So the two gates now **disagree**: for a Draft spec-filing PR, the CI `PR Gate` check is GREEN (exempted) while `bash scripts/pre-merge-check.sh <PR#>` REFUSES (`status is "Draft" — must be "In Review"`). Because running `pre-merge-check.sh` to an `OK` is a HARD pre-merge rule (SHY-0127), this contradiction blocks merging **every** Draft spec-filing PR via the documented path — surfaced concretely while trying to merge the SHY-0132 spec (PR #1486). The local gate must mirror the CI gate's `code === 'A' && status === 'Draft'` filing exemption.
+
+The exemption is **add-only** and **Draft-only**, preserving every existing guard: a story **modified** to Draft (a regression), an added story at any non-Draft status, and the local gate's intentional extra strictness on `Done`/`Cancelled` (only `In Review` passes locally — the script header documents this) all still REFUSE.
+
+## Acceptance Criteria
+
+### Happy path
+- [ ] A PR whose only story change is a newly-**ADDED** `.project/stories/SHY-XXXX-*.md` at status `Draft` passes `pre-merge-check.sh` and emits `PRE-MERGE-CHECK: OK` (no `In Review` / `Reviewed-up-to` requirement for that filing).
+- [ ] The behaviour matches `check-pr-story-status.js` (SHY-0131) for the added-Draft case — the two gates agree.
+
+### Error paths
+- [ ] A story **MODIFIED** to `Draft` (code `M`, i.e. an existing story regressed/edited to Draft) still REFUSES (the exemption is add-only).
+- [ ] An **added** story at `In Progress` (or any non-Draft, non-allowed status) still REFUSES with the existing "must be In Review" message.
+- [ ] `Done` / `Cancelled` stories still REFUSE locally (the local gate stays stricter than CI by design — unchanged).
+
+### Edge cases
+- [ ] A PR with NO story `.md` change still REFUSES with "nothing to gate" (unchanged).
+- [ ] A mixed PR (one added-Draft filing + one modified `In Review` implementation story) gates the In-Review story normally (status + `Reviewed-up-to` + Gate-3 unreviewed-commit check) while exempting the filing — the exemption is per-story, not whole-PR.
+- [ ] A **renamed** story (`R<score>\t<old>\t<new>`) is parsed correctly (the new path is the gated file; rename ≠ add, so it is NOT filing-exempt).
+- [ ] An added-Draft filing with NO `Reviewed-up-to` marker still passes (a freshly-filed Draft has no reviewed commit — the exemption skips that requirement too).
+
+### Performance
+- N/A — a read-only shell gate over a small `git diff`; no measurable change.
+
+### Security
+- [ ] The exemption does NOT weaken the gate: it only lets through what the authoritative CI gate already lets through (added-Draft). All code-bearing / non-Draft / modified-Draft paths still refuse, so no unreviewed implementation can slip through the local gate via this change.
+
+### UX
+- [ ] The printed pre-merge checklist is honest for a filing PR — the status line reads as satisfied by "In Review **or** a newly-added Draft filing", not a false "status = In Review".
+- [ ] A clear stderr line announces each filing exemption (e.g. `filing exemption: <file> newly-added Draft`) so the operator sees WHY it passed.
+
+### i18n
+- N/A — developer tooling; no user-facing strings.
+
+### Observability
+- [ ] The exemption emits a visible `filing exemption: …` line to stderr per exempted story, so a passing filing PR is auditable (not a silent skip).
+
+## BDD Scenarios
+
+**Scenario: a newly-added Draft spec filing passes the local gate**
+- **Given** a branch whose only story change adds `.project/stories/SHY-0999-x.md` at `status: Draft`
+- **When** `bash scripts/pre-merge-check.sh <PR#> --skip-ci-check` runs
+- **Then** it exits 0 and prints `PRE-MERGE-CHECK: OK`
+- **And** stderr notes the filing exemption for that file
+
+**Scenario: a story modified to Draft is still refused (add-only)**
+- **Given** a story that exists on `main` as `In Review`, modified to `status: Draft` on the branch
+- **When** the gate runs
+- **Then** it REFUSES (non-zero, no OK token) with the "must be In Review" message
+
+**Scenario: an added non-Draft story is still gated**
+- **Given** a branch adding a story at `status: In Progress`
+- **When** the gate runs
+- **Then** it REFUSES (the exemption is Draft-only)
+
+**Scenario: mixed PR gates the implementation story, exempts the filing**
+- **Given** a branch that adds a Draft filing AND modifies an implementation story to `In Review` with a valid `Reviewed-up-to`, with an unreviewed code commit after the marker
+- **When** the gate runs
+- **Then** it REFUSES on the In-Review story's unreviewed commit (the filing exemption does not suppress Gate-3 for the other story)
+
+**Scenario: Done/Cancelled still refused locally (unchanged)**
+- **Given** a branch adding a story at `status: Done` (or `Cancelled`)
+- **When** the gate runs
+- **Then** it REFUSES (local gate stays stricter than CI on terminal statuses)
+
+## Test Plan
+
+**RED (failing-first):** in `express-api/tests/scripts/pre-merge-check.test.js` (drives the REAL `pre-merge-check.sh` against a REAL throwaway git repo — no mocks), replace the single `REFUSES on a Draft story` test with:
+- `EXEMPTS a newly-ADDED Draft story (filing — SHY-0131 parity)` — `init()` + add a Draft story + commit; expect exit 0 + `PRE-MERGE-CHECK: OK`. **Fails before the fix** (the script still refuses added Draft).
+- `REFUSES a story MODIFIED to Draft (add-only exemption)` — put the story on `main` as `In Review`, modify it to Draft on the branch; expect refuse + `/In Review/`.
+- `EXEMPTS the filing but still gates a co-changed In-Review story` (mixed PR) — expect refuse on the In-Review story's unreviewed commit.
+
+All existing tests (In Review OK, no-marker refuse, code-after-marker refuse, Done/Cancelled refuse, nothing-to-gate, bogus-SHA refuse, multi-story marker) must stay green.
+
+**GREEN:** `scripts/pre-merge-check.sh` —
+- L44 `git diff --name-only` → `--name-status` (still `--diff-filter=ACMR`); parse each line into `code` (first field, first char) + `file` (last tab-field — the new path on a rename); filter to `STORY_RE` on `file`.
+- In the per-story loop: `if [ "$code" = "A" ] && [ "$status" = "Draft" ]` → emit a `filing exemption:` stderr line and `continue` (skip the In-Review + `Reviewed-up-to` requirements). Otherwise run the existing In-Review + marker logic unchanged.
+- Preserve the "nothing to gate" guard (a `FOUND_STORY` flag) and the Done/Cancelled-refuse behaviour. Make the printed checklist status line honest for filings.
+- bash 3.2-compatible (parameter expansion + `grep`, no `mapfile`/awk intervals).
+
+**Frameworks:** Express/Jest (`pre-merge-check.test.js`) + eslint + prettier (the test file) + shellcheck/actionlint (pre-push hook covers the `.sh`). No app/device surface — `*.md` + script + test only.
+
+## Out of Scope
+
+- The CI gate `check-pr-story-status.js` — already correct (SHY-0131); not touched.
+- The Gate-2 CI leg of `pre-merge-check.sh` (`gh pr checks`) and any change to its name-by-name verification — separate concern.
+- Loosening the local gate's intentional Done/Cancelled strictness — preserved exactly.
+- Any change to the merge lifecycle, the board sync, or the story validator.
+
+## Dependencies
+
+- SHY-0131 (`check-pr-story-status.js` added-Draft exemption) — the canonical behaviour this story mirrors into the local gate.
+- SHY-0127 (`pre-merge-check.sh` Gates 2+3) — the script being amended; its existing test harness `pre-merge-check.test.js`.
+
+## Risks & Mitigations
+
+- **Risk:** parsing `--name-status` wrong (codes like `R100`, multi-tab rename lines) → a story is mis-classified. **Mitigation:** take `code` = first char of the first tab-field and `file` = the LAST tab-field (correct for `A`/`M`/`R<old>\t<new>`); a dedicated rename test pins it.
+- **Risk:** the exemption accidentally lets unreviewed CODE through on a filing PR. **Mitigation:** the exemption is per-story and Draft+add-only; a co-changed implementation story is still fully gated (mixed-PR test); a pure filing PR is `.md`-only by construction (no code to review). Mirrors exactly what CI already permits.
+- **Risk:** breaking an existing guard. **Mitigation:** all pre-existing `pre-merge-check.test.js` cases stay green (regression guard); only the one Draft test is replaced.
+
+## Definition of Done
+
+- RED tests written failing-first then green; all pre-existing `pre-merge-check.test.js` cases stay green; the local gate now agrees with the CI gate on added-Draft.
+- `code-reviewer` 100% clean before push; eslint/prettier clean; shellcheck (pre-push) clean; CI required checks (Detect Changes, Analyze JavaScript, PR Gate) green.
+- Verified end-to-end: `pre-merge-check.sh` emits `PRE-MERGE-CHECK: OK` on PR #1486 (the SHY-0132 Draft spec) after this lands.
+- Released in a `vX.Y.Z` cut with `released_in:` set.
+
+## Notes (running log)
+
+- 2026-06-20 — **Filed (operator chose "fix the merge-gate" 2026-06-20).** Surfaced while judgment-merging the SHY-0132 spec PR #1486: `pre-merge-check.sh` REFUSED its added Draft while the CI `PR Gate` passed it — SHY-0131 updated the CI gate (`check-pr-story-status.js:87` `code === 'A' && status === 'Draft'`) but not the local sibling. This story closes that oversight: mirror the add-only, Draft-only exemption into `pre-merge-check.sh` and split the `REFUSES on a Draft story` test into added-Draft-EXEMPT + modified-to-Draft-REFUSE. Add-only + Draft-only keeps every other guard (modified-Draft, non-Draft adds, Done/Cancelled, unreviewed code) intact.

--- a/express-api/tests/scripts/pre-merge-check.test.js
+++ b/express-api/tests/scripts/pre-merge-check.test.js
@@ -11,7 +11,7 @@
  * re-review (Gate 3) logic for real without needing a live PR; the CI leg
  * (Gate 2) is `gh pr checks` and is covered by live use, not unit-faked.
  */
-const { execFileSync } = require('node:child_process');
+const { execFileSync, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -63,16 +63,16 @@ function cleanRepo() {
 
 function run(dir, { skipCi = true } = {}) {
   const args = skipCi ? ['42', '--skip-ci-check'] : ['99999999'];
-  try {
-    const stdout = execFileSync('bash', [SCRIPT, ...args], {
-      cwd: dir,
-      encoding: 'utf8',
-      env: { ...process.env, BASE_REF: 'main' },
-    });
-    return { code: 0, stdout, stderr: '' };
-  } catch (e) {
-    return { code: e.status, stdout: String(e.stdout), stderr: String(e.stderr) };
-  }
+  // spawnSync captures BOTH stdout and stderr regardless of exit code — the
+  // success path emits a `filing exemption:` line on stderr (SHY-0133) that
+  // execFileSync (which only returns stdout, and surfaces stderr solely via the
+  // thrown error on non-zero exit) could not observe.
+  const r = spawnSync('bash', [SCRIPT, ...args], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: { ...process.env, BASE_REF: 'main' },
+  });
+  return { code: r.status, stdout: String(r.stdout), stderr: String(r.stderr) };
 }
 
 describe('SHY-0127 Gates 2+3 — pre-merge-check.sh', () => {
@@ -170,12 +170,80 @@ describe('SHY-0127 Gates 2+3 — pre-merge-check.sh', () => {
     expect(stderr).toMatch(/In Review/);
   });
 
-  test('REFUSES on a Draft story', () => {
+  // SHY-0133 — a newly-ADDED Draft story is a legitimate spec filing and is
+  // EXEMPT (mirrors the SHY-0131 CI-gate exemption in check-pr-story-status.js).
+  test('EXEMPTS a newly-ADDED Draft story (filing — SHY-0131 parity)', () => {
     const dir = init();
-    writeStory(dir, 'Draft', null);
-    commit(dir, 'draft story');
+    writeStory(dir, 'Draft', null); // brand-new story file, added on the branch
+    commit(dir, 'file new draft story');
+    const { code, stdout, stderr } = run(dir);
+    expect(code).toBe(0);
+    expect(stdout).toContain('PRE-MERGE-CHECK: OK');
+    expect(stderr).toMatch(/filing exemption/i);
+  });
+
+  // SHY-0133 — the exemption is ADD-ONLY: a story that already exists and is
+  // MODIFIED to Draft (a regression) is still refused.
+  test('REFUSES a story MODIFIED to Draft (add-only exemption)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shy0133-mod-'));
+    git(dir, ['init', '-q', '-b', 'main']);
+    git(dir, ['config', 'user.email', 't@t.co']);
+    git(dir, ['config', 'user.name', 'T']);
+    fs.mkdirSync(path.join(dir, '.project/stories'), { recursive: true });
+    writeStory(dir, 'In Review', 'deadbeef'); // exists on main as In Review
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'base with story on main']);
+    git(dir, ['checkout', '-q', '-b', 'feature']);
+    writeStory(dir, 'Draft', null); // MODIFIED to Draft on the branch (code M)
+    commit(dir, 'regress story to draft');
     const { code, stderr } = run(dir);
     expect(code).not.toBe(0);
+    expect(stderr).toMatch(/In Review/);
+  });
+
+  // SHY-0133 — the exemption is PER-STORY: a co-changed In-Review implementation
+  // story is still fully gated (Gate 3) even when a Draft filing rides along.
+  test('EXEMPTS the filing but still gates a co-changed In-Review story', () => {
+    const dir = init();
+    const base = git(dir, ['rev-parse', 'HEAD']);
+    // Implementation story (In Review) + code, reviewed up to `base` (loose) so
+    // the later code commit is unreviewed; plus a brand-new Draft filing.
+    fs.writeFileSync(path.join(dir, 'code.js'), 'x\n');
+    fs.writeFileSync(
+      path.join(dir, '.project/stories/SHY-0998-impl.md'),
+      `---\nid: SHY-0998\nstatus: In Review\n---\n\n## Notes\nReviewed-up-to: ${base}\n`,
+    );
+    writeStory(dir, 'Draft', null); // SHY-0999-x.md added as a Draft filing
+    commit(dir, 'impl story + code + draft filing');
+    const { code, stdout, stderr } = run(dir);
+    expect(code).not.toBe(0);
+    expect(stdout).not.toContain('PRE-MERGE-CHECK: OK');
+    // Must refuse for the IN-REVIEW story's unreviewed code — proving the filing
+    // exemption did NOT short-circuit Gate-3 (before the fix it would refuse on
+    // the Draft status instead).
+    expect(stderr).toMatch(/unreviewed/i);
+  });
+
+  // SHY-0133 — a RENAMED Draft story has change-code R (not A), so it is NOT
+  // filing-exempt; it is gated like any other change. A `git mv` of unchanged
+  // content yields a deterministic R100 in --name-status.
+  test('a RENAMED Draft story is gated, not filing-exempt (rename != add)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shy0133-ren-'));
+    git(dir, ['init', '-q', '-b', 'main']);
+    git(dir, ['config', 'user.email', 't@t.co']);
+    git(dir, ['config', 'user.name', 'T']);
+    fs.mkdirSync(path.join(dir, '.project/stories'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, '.project/stories/SHY-0997-old.md'),
+      `---\nid: SHY-0997\nstatus: Draft\n---\n\n# SHY-0997\n\n## Notes\n`,
+    );
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'base draft story on main']);
+    git(dir, ['checkout', '-q', '-b', 'feature']);
+    git(dir, ['mv', '.project/stories/SHY-0997-old.md', '.project/stories/SHY-0997-new.md']); // unchanged content → R100
+    commit(dir, 'rename story file');
+    const { code, stderr } = run(dir);
+    expect(code).not.toBe(0); // R + Draft is NOT the add-only exemption
     expect(stderr).toMatch(/In Review/);
   });
 

--- a/express-api/tests/scripts/pre-merge-check.test.js
+++ b/express-api/tests/scripts/pre-merge-check.test.js
@@ -49,6 +49,21 @@ function commit(dir, msg) {
   return git(dir, ['rev-parse', 'HEAD']);
 }
 
+/** A repo with `setup(dir)` committed on `main`, then checked out to `feature` —
+ * for tests that need a story to already EXIST on main (modified/renamed cases). */
+function mainThenFeature(setup) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shy0133-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 't@t.co']);
+  git(dir, ['config', 'user.name', 'T']);
+  fs.mkdirSync(path.join(dir, '.project/stories'), { recursive: true });
+  setup(dir);
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-qm', 'base on main']);
+  git(dir, ['checkout', '-q', '-b', 'feature']);
+  return dir;
+}
+
 /** A fully-clean, reviewed branch: code reviewed up to commit B, then a
  * story-only marker-bump commit C on top. */
 function cleanRepo() {
@@ -180,20 +195,33 @@ describe('SHY-0127 Gates 2+3 — pre-merge-check.sh', () => {
     expect(code).toBe(0);
     expect(stdout).toContain('PRE-MERGE-CHECK: OK');
     expect(stderr).toMatch(/filing exemption/i);
+    // UX AC — the checklist is honest for a filing-only PR: the status line names
+    // the exemption, and the re-review line does NOT show an empty marker.
+    expect(stdout).toContain('+ 1 newly-added Draft filing(s) exempt');
+    expect(stdout).toContain('filing only — no implementation story to re-review');
+    expect(stdout).not.toContain('Reviewed-up-to: )');
+  });
+
+  // SHY-0133 — multiple Draft filings in one PR (e.g. an EPIC's child stories):
+  // the FILINGS counter pluralises and every filing is exempt.
+  test('EXEMPTS multiple newly-added Draft filings (FILINGS=2)', () => {
+    const dir = init();
+    writeStory(dir, 'Draft', null); // SHY-0999-x.md
+    fs.writeFileSync(
+      path.join(dir, '.project/stories/SHY-0998-y.md'),
+      `---\nid: SHY-0998\nstatus: Draft\n---\n\n# SHY-0998\n\n## Notes\n`,
+    );
+    commit(dir, 'file two draft stories');
+    const { code, stdout } = run(dir);
+    expect(code).toBe(0);
+    expect(stdout).toContain('PRE-MERGE-CHECK: OK');
+    expect(stdout).toContain('+ 2 newly-added Draft filing(s) exempt');
   });
 
   // SHY-0133 — the exemption is ADD-ONLY: a story that already exists and is
   // MODIFIED to Draft (a regression) is still refused.
   test('REFUSES a story MODIFIED to Draft (add-only exemption)', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shy0133-mod-'));
-    git(dir, ['init', '-q', '-b', 'main']);
-    git(dir, ['config', 'user.email', 't@t.co']);
-    git(dir, ['config', 'user.name', 'T']);
-    fs.mkdirSync(path.join(dir, '.project/stories'), { recursive: true });
-    writeStory(dir, 'In Review', 'deadbeef'); // exists on main as In Review
-    git(dir, ['add', '-A']);
-    git(dir, ['commit', '-qm', 'base with story on main']);
-    git(dir, ['checkout', '-q', '-b', 'feature']);
+    const dir = mainThenFeature((d) => writeStory(d, 'In Review', 'deadbeef'));
     writeStory(dir, 'Draft', null); // MODIFIED to Draft on the branch (code M)
     commit(dir, 'regress story to draft');
     const { code, stderr } = run(dir);
@@ -228,18 +256,12 @@ describe('SHY-0127 Gates 2+3 — pre-merge-check.sh', () => {
   // filing-exempt; it is gated like any other change. A `git mv` of unchanged
   // content yields a deterministic R100 in --name-status.
   test('a RENAMED Draft story is gated, not filing-exempt (rename != add)', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shy0133-ren-'));
-    git(dir, ['init', '-q', '-b', 'main']);
-    git(dir, ['config', 'user.email', 't@t.co']);
-    git(dir, ['config', 'user.name', 'T']);
-    fs.mkdirSync(path.join(dir, '.project/stories'), { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, '.project/stories/SHY-0997-old.md'),
-      `---\nid: SHY-0997\nstatus: Draft\n---\n\n# SHY-0997\n\n## Notes\n`,
+    const dir = mainThenFeature((d) =>
+      fs.writeFileSync(
+        path.join(d, '.project/stories/SHY-0997-old.md'),
+        `---\nid: SHY-0997\nstatus: Draft\n---\n\n# SHY-0997\n\n## Notes\n`,
+      ),
     );
-    git(dir, ['add', '-A']);
-    git(dir, ['commit', '-qm', 'base draft story on main']);
-    git(dir, ['checkout', '-q', '-b', 'feature']);
     git(dir, ['mv', '.project/stories/SHY-0997-old.md', '.project/stories/SHY-0997-new.md']); // unchanged content → R100
     commit(dir, 'rename story file');
     const { code, stderr } = run(dir);

--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -63,7 +63,7 @@ while IFS= read -r line; do
   FOUND_STORY=true
   status=$(grep -m1 '^status:' "$story" | sed 's/^status:[[:space:]]*//' | tr -d '\r')
   if [ "$code" = "A" ] && [ "$status" = "Draft" ]; then
-    echo "  filing exemption: $story newly-added Draft (SHY-0131 parity)" >&2
+    printf '  filing exemption: %s newly-added Draft (SHY-0131 parity)\n' "$story" >&2
     FILINGS=$((FILINGS + 1))
     continue
   fi
@@ -102,6 +102,13 @@ fi
 CI_LINE="verified"
 [ "$SKIP_CI" = "true" ] && CI_LINE="SKIPPED (--skip-ci-check)"
 REVIEWED_DISPLAY=$(echo "$MARKERS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+# Honest display when there are no implementation stories (a filing-only PR has
+# no markers → nothing to re-review).
+if [ -n "$REVIEWED_DISPLAY" ]; then
+  REVIEW_NOTE="Reviewed-up-to: $REVIEWED_DISPLAY"
+else
+  REVIEW_NOTE="filing only — no implementation story to re-review"
+fi
 
 STATUS_LINE="each changed story In Review"
 [ "$FILINGS" -gt 0 ] && STATUS_LINE="$STATUS_LINE (+ $FILINGS newly-added Draft filing(s) exempt — SHY-0131 parity)"
@@ -109,7 +116,7 @@ STATUS_LINE="each changed story In Review"
 cat <<EOF
 ── Pre-merge gate (SHY-0127) ──
   [x] $STATUS_LINE
-  [x] no unreviewed commits since last review (Reviewed-up-to: $REVIEWED_DISPLAY)
+  [x] no unreviewed commits since last review ($REVIEW_NOTE)
   [x] CI checks green: $CI_LINE
   Confirm the human-judgment items before merging:
   [ ] Definition of Done met

--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -41,14 +41,32 @@ fail() {
 
 [ -n "$PR" ] || fail "usage: pre-merge-check.sh <PR#> [--skip-ci-check]"
 
-STORIES=$(git diff --name-only --diff-filter=ACMR "${BASE_REF}...HEAD" | grep -E "$STORY_RE" || true)
-[ -n "$STORIES" ] || fail "no SHY story .md changed on this branch (BASE_REF=$BASE_REF) — nothing to gate"
+# name-status (not name-only): each line is "<code>\t<path>" — or for a rename,
+# "<code>\t<old>\t<new>". The change code (A/M/R…) lets us apply the SHY-0131
+# added-Draft filing exemption (a brand-new Draft story is a legitimate filing).
+STATUS_LINES=$(git diff --name-status --diff-filter=ACMR "${BASE_REF}...HEAD")
 
-# Validate each changed story: status In Review + a REAL Reviewed-up-to commit.
+# Validate each changed story: status In Review + a REAL Reviewed-up-to commit —
+# EXCEPT a newly-ADDED Draft (a spec filing), which is exempt to match the CI gate
+# (scripts/check-pr-story-status.js, SHY-0131). The exemption is add-only AND
+# Draft-only: a story MODIFIED to Draft, a non-Draft add, or a Done/Cancelled
+# story all still refuse (the local gate stays stricter than CI on terminals).
 MARKERS=""
-while IFS= read -r story; do
-  [ -z "$story" ] && continue
+FOUND_STORY=false
+FILINGS=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  code=${line%%$'\t'*} # first tab-field (e.g. A, M, R100)
+  code=${code:0:1}     # leading char (A/M/D/R/C)
+  story=${line##*$'\t'} # last tab-field = the path (new path on a rename)
+  printf '%s\n' "$story" | grep -qE "$STORY_RE" || continue
+  FOUND_STORY=true
   status=$(grep -m1 '^status:' "$story" | sed 's/^status:[[:space:]]*//' | tr -d '\r')
+  if [ "$code" = "A" ] && [ "$status" = "Draft" ]; then
+    echo "  filing exemption: $story newly-added Draft (SHY-0131 parity)" >&2
+    FILINGS=$((FILINGS + 1))
+    continue
+  fi
   [ "$status" = "In Review" ] || fail "$story status is \"$status\" — must be \"In Review\" before merge"
   rs=$(grep -m1 '^Reviewed-up-to:' "$story" | sed 's/^Reviewed-up-to:[[:space:]]*//' | tr -d '\r')
   [ -n "$rs" ] || fail "$story has no 'Reviewed-up-to: <sha>' marker in its Notes — record the reviewed commit then re-run"
@@ -57,7 +75,8 @@ while IFS= read -r story; do
   git cat-file -e "${rs}^{commit}" 2>/dev/null ||
     fail "$story Reviewed-up-to: '$rs' is not a valid commit in this repo — record the actual reviewed SHA"
   MARKERS="${MARKERS}${rs}"$'\n'
-done <<< "$STORIES"
+done <<< "$STATUS_LINES"
+[ "$FOUND_STORY" = true ] || fail "no SHY story .md changed on this branch (BASE_REF=$BASE_REF) — nothing to gate"
 
 # Gate 3: for EVERY story's marker, a commit after it that touches anything other
 # than a story .md is unreviewed code. Checking every marker keeps multi-story PRs
@@ -84,9 +103,12 @@ CI_LINE="verified"
 [ "$SKIP_CI" = "true" ] && CI_LINE="SKIPPED (--skip-ci-check)"
 REVIEWED_DISPLAY=$(echo "$MARKERS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')
 
+STATUS_LINE="each changed story In Review"
+[ "$FILINGS" -gt 0 ] && STATUS_LINE="$STATUS_LINE (+ $FILINGS newly-added Draft filing(s) exempt — SHY-0131 parity)"
+
 cat <<EOF
 ── Pre-merge gate (SHY-0127) ──
-  [x] story status = In Review
+  [x] $STATUS_LINE
   [x] no unreviewed commits since last review (Reviewed-up-to: $REVIEWED_DISPLAY)
   [x] CI checks green: $CI_LINE
   Confirm the human-judgment items before merging:


### PR DESCRIPTION
Implements SHY-0133 — see .project/stories/SHY-0133-pre-merge-check-exempt-added-drafts.md for full spec, AC, BDD scenarios, and DoD.

## Problem
The **local** pre-merge gate `scripts/pre-merge-check.sh` (SHY-0127) required `In Review` for **every** changed story, refusing a newly-ADDED Draft story (a legitimate spec filing). The **CI** gate `scripts/check-pr-story-status.js` (SHY-0131) already exempts exactly that. The two gates disagreed, blocking every Draft spec-filing PR from passing the documented local gate — surfaced trying to merge the SHY-0132 spec (PR #1486), which the local gate REFUSED while CI passed it.

## Fix (mirror SHY-0131 into the bash gate)
- `pre-merge-check.sh`: `--name-only` → `--name-status`; parse the change code + path; exempt `code == A && status == Draft` (**add-only, Draft-only**) with a visible `filing exemption:` stderr line + an honest checklist. **Modified-to-Draft, non-Draft adds, renamed Draft (R≠A), and Done/Cancelled all still REFUSE** — the local gate keeps its intentional extra strictness on terminal statuses. bash 3.2-safe (`$'\t'` parameter expansion).
- `pre-merge-check.test.js`: split `REFUSES on a Draft story` into added-Draft EXEMPT + modified-to-Draft REFUSE; added mixed-PR (filing rides along, In-Review story still Gate-3-gated), renamed-Draft (R≠A), and FILINGS=2 multi-filing cases; switched `run()` to `spawnSync` to observe the success-path stderr. **17/17** real-bash-against-real-git-repo tests.

## Verification
- 17/17 Jest (real script, real throwaway git repos — no mocks); shellcheck + eslint + prettier + no-stubs clean; pre-push Sonar passed.
- `code-reviewer`: 2 Important + 3 Minor → all fixed; re-review of the fix = **zero findings**.
- **End-to-end self-test:** the fixed `pre-merge-check.sh` emits `PRE-MERGE-CHECK: OK` on this very branch (an In-Review impl PR), and (per the test suite) on an added-Draft filing PR like #1486.

Filed + implemented in one PR (SHY-0131 pattern); story is `In Review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)