### PR TITLE
SHY-0136: Consolidate dev persona-password to one secret (DEV_QA_PERSONAS_PASSWORD)

### DIFF
--- a/.github/workflows/seed-dev-personas.yml
+++ b/.github/workflows/seed-dev-personas.yml
@@ -33,8 +33,8 @@ on:
       FIREBASE_SERVICE_ACCOUNT_DEV:
         description: 'Firebase service account JSON for the dev project'
         required: true
-      PERSONAS_PASSWORD_DEV:
-        description: 'Shared seeded-persona password'
+      DEV_QA_PERSONAS_PASSWORD:
+        description: 'Shared seeded-persona password (single source of truth — the same secret the Android/iOS app builds, pr-checks, deploy-dev and the journey matrix all read)'
         required: true
 
   workflow_dispatch:
@@ -108,10 +108,10 @@ jobs:
         with:
           # For workflow_call, secrets are forwarded by the caller via
           # `secrets:` block; for workflow_dispatch, they resolve from
-          # the repo-level GitHub Actions secrets (PERSONAS_PASSWORD_DEV,
+          # the repo-level GitHub Actions secrets (DEV_QA_PERSONAS_PASSWORD,
           # FIREBASE_SERVICE_ACCOUNT_DEV). Both paths land in the same
           # `secrets.X` references at this scope.
           service-account-json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DEV }}
           firebase-project: ${{ steps.target-values.outputs.firebase-project }}
-          personas-password: ${{ secrets.PERSONAS_PASSWORD_DEV }}
+          personas-password: ${{ secrets.DEV_QA_PERSONAS_PASSWORD }}
           database-url: ${{ steps.target-values.outputs.database-url }}

--- a/.project/stories/SHY-0136-consolidate-persona-password-secret.md
+++ b/.project/stories/SHY-0136-consolidate-persona-password-secret.md
@@ -1,0 +1,110 @@
+---
+id: SHY-0136
+status: In Review
+owner: claude
+created: 2026-06-20
+priority: P2
+effort: XS
+type: infra
+roadmap_ids: []
+pr: https://github.com/Shyden-Ltd/ShyTalk/pull/PENDING
+public: false
+mvp: false
+---
+
+# SHY-0136: Consolidate the dev persona-password secret to a single source of truth
+
+## User Story
+
+As a **maintainer deploying dev builds for device testing**,
+I want **the seeded test-persona password and the password the app build bakes in to come from ONE GitHub secret**,
+So that **persona sign-in on dev can never silently break from two redundant secrets drifting out of sync**.
+
+## Why
+
+There were **two** GitHub Actions secrets holding the same logical value — the dev test-persona password:
+
+- **`DEV_QA_PERSONAS_PASSWORD`** (created 2026-05-21) — the canonical one, read by the **Android app build** (`MainActivity.kt` → `BuildConfig.DEV_QA_PERSONAS_PASSWORD`), the **iOS app build** (`$(DEV_QA_PERSONAS_PASSWORD)` xcconfig), **pr-checks**, **deploy-dev** (APK build) and the **manual-qa journey matrix**.
+- **`PERSONAS_PASSWORD_DEV`** (created 2026-05-29, when the standalone `seed-dev-personas` workflow was added) — read by **exactly one place**: the seed workflow, to set the personas' password.
+
+Nothing enforced the two equal. They drifted, so the personas got seeded with one value while every client signed in with the other → Firebase `INVALID_CREDENTIALS` → the app's generic *"Persona sign-in failed"* (the `DevSignInHelper` swallows the specific error). This blocked the SHY-0130 dev device-test session on 2026-06-20.
+
+The redundant secret created a **manual synchronisation obligation with no enforcement** — the textbook duplicated-config failure. This story removes it: the seed workflow now reads the canonical `DEV_QA_PERSONAS_PASSWORD`, so there is **one** persona-password secret used everywhere.
+
+## Acceptance Criteria
+
+### Happy path
+- [ ] `seed-dev-personas.yml` reads `secrets.DEV_QA_PERSONAS_PASSWORD` (not `PERSONAS_PASSWORD_DEV`) for both invocation paths (`workflow_call` from deploy-dev + direct `workflow_dispatch`).
+- [ ] A repo-wide grep for `PERSONAS_PASSWORD_DEV` returns **zero** references (workflow + comments + tests) — the secret name is fully retired in code.
+- [ ] After deploy, the freshly-built APK (bakes `DEV_QA_PERSONAS_PASSWORD`) and the freshly-seeded personas (now seeded from the same secret) share one value → persona sign-in succeeds on a real device.
+
+### Error paths
+- [ ] The `workflow_call` `secrets:` block still declares the persona-password secret `required: true`, so a future caller that forgets `secrets: inherit` fails at workflow_call validation, not silently at runtime.
+
+### Edge cases
+- [ ] The direct `workflow_dispatch` path still resolves the secret from repo-level Actions secrets (it now resolves `DEV_QA_PERSONAS_PASSWORD`, which exists repo-wide).
+
+### Performance
+- N/A — CI config rename; no runtime path changed.
+
+### Security
+- [ ] No secret VALUE is committed or logged; only the secret NAME reference in YAML changes. Retiring the redundant `PERSONAS_PASSWORD_DEV` reduces the secret surface (one fewer credential to rotate/leak).
+- [ ] The change does not alter what the seed script does or which project it targets (still dev-only, `assertSafeProject()` unchanged).
+
+### UX
+- N/A — no user-facing surface.
+
+### i18n
+- N/A — no user-facing strings.
+
+### Observability
+- [ ] The pin test `deploy-dev-seed-personas.test.js` asserts the canonical secret name, so a future re-introduction of a divergent name fails CI loudly.
+
+## BDD Scenarios
+
+**Scenario: seed workflow reads the canonical secret**
+- **Given** the consolidated `seed-dev-personas.yml`
+- **When** the `deploy-dev` workflow calls it with `secrets: inherit`
+- **Then** the seed action receives `personas-password` from `secrets.DEV_QA_PERSONAS_PASSWORD`
+- **And** the personas are seeded with the same value the app build bakes in
+
+**Scenario: the redundant secret name is gone (regression guard)**
+- **Given** the repo after this change
+- **When** `deploy-dev-seed-personas.test.js` runs
+- **Then** it asserts `DEV_QA_PERSONAS_PASSWORD:` is declared `required: true` in the workflow
+- **And** a re-introduction of `PERSONAS_PASSWORD_DEV` would fail the suite
+
+## Test Plan
+
+**Red:** flip `express-api/tests/scripts/deploy-dev-seed-personas.test.js` to expect `DEV_QA_PERSONAS_PASSWORD:` → run `node --experimental-vm-modules node_modules/.bin/jest tests/scripts/deploy-dev-seed-personas.test.js` → FAILS against the unchanged workflow (proves the guard).
+
+**Green:** rename the 3 references in `seed-dev-personas.yml` (`workflow_call.secrets` declaration + the comment + `personas-password:` usage) → rerun the suite → **20/20 pass** + actionlint clean + repo grep for `PERSONAS_PASSWORD_DEV` returns none.
+
+**Live:** deploy-dev (Android) from the consolidated workflow re-seeds + rebuilds from the one secret; persona sign-in verified on a real Android device (the SHY-0130 device session this unblocks).
+
+## Out of Scope
+
+- The SHY-0130 conversations id-type fix and its device test (this only fixes the sign-in infra that blocked it).
+- Rotating / setting the secret VALUE (an operational step done out-of-band; this PR only changes which secret NAME the seeder reads).
+- The `local` flavor persona password (hardcoded `localdev123` for the emulator — a separate, intentional constant).
+
+## Dependencies
+
+- The repo-level GitHub secret `DEV_QA_PERSONAS_PASSWORD` must hold the intended dev persona password (it does; set fresh 2026-06-20).
+- After merge, the now-unused `PERSONAS_PASSWORD_DEV` repo secret should be **deleted** in GitHub settings (operational follow-up; no code depends on it).
+
+## Risks & Mitigations
+
+- **Risk:** a future caller of the reusable workflow passes secrets explicitly by the old name. **Mitigation:** the only caller (`deploy-dev.yml`) uses `secrets: inherit`; the pin test asserts the declared name.
+- **Risk:** the secret value is wrong/empty post-rename. **Mitigation:** the deploy's seed + the app build now read the SAME secret, so they cannot disagree; an empty value would fail BOTH symmetrically (loud), not silently mismatch.
+
+## Definition of Done
+
+- `seed-dev-personas.yml` + the pin test reference only `DEV_QA_PERSONAS_PASSWORD`; repo grep for the old name is empty.
+- Pin test green via the canonical runner; actionlint clean; CI required checks green by name.
+- `code-reviewer` clean; merged; `PERSONAS_PASSWORD_DEV` repo secret deleted.
+- Released in a `vX.Y.Z` cut with `released_in:` set.
+
+## Notes (running log)
+
+- 2026-06-20 — Filed live while unblocking the SHY-0130 dev device-test (persona sign-in failed on a real Android device). Root cause traced to the two-secret drift (`DEV_QA_PERSONAS_PASSWORD` 2026-05-21 vs `PERSONAS_PASSWORD_DEV` 2026-05-29). Fix is TDD'd (red→green on the pin test, 20/20) + actionlint clean + repo grep clean. Architect step skipped (XS config rename, low-risk; per rate-limit-slowdown guidance). Deployed to dev via `gh workflow run deploy-dev.yml --ref chore/SHY-0136-... -f ref=story/SHY-0130-...` so the re-seed + APK rebuild both read the single secret before the PR merges. After merge: delete the redundant `PERSONAS_PASSWORD_DEV` GitHub secret.

--- a/express-api/tests/scripts/deploy-dev-seed-personas.test.js
+++ b/express-api/tests/scripts/deploy-dev-seed-personas.test.js
@@ -90,7 +90,7 @@ describe('deploy-dev.yml — seed-dev-personas job (reusable workflow caller)', 
     expect(jobBlock).toMatch(/if:.*inputs\.seed-personas\s*!=\s*false/);
   });
 
-  test('seed-dev-personas job inherits secrets (so the reusable workflow can read FIREBASE_SERVICE_ACCOUNT_DEV / PERSONAS_PASSWORD_DEV)', () => {
+  test('seed-dev-personas job inherits secrets (so the reusable workflow can read FIREBASE_SERVICE_ACCOUNT_DEV / DEV_QA_PERSONAS_PASSWORD)', () => {
     // `secrets: inherit` is the only path by which the reusable workflow
     // sees the calling repo's secrets. Without it, the workflow_call
     // would fail at the secrets validation in seed-dev-personas.yml.
@@ -119,14 +119,14 @@ describe('seed-dev-personas.yml — reusable workflow + direct dispatch', () => 
     // an explicit per-secret mapping. Names match the repo's GitHub
     // Actions secrets settings.
     expect(SEED_WORKFLOW).toContain('FIREBASE_SERVICE_ACCOUNT_DEV:');
-    expect(SEED_WORKFLOW).toContain('PERSONAS_PASSWORD_DEV:');
+    expect(SEED_WORKFLOW).toContain('DEV_QA_PERSONAS_PASSWORD:');
     // Both must be required so a future caller that forgets to forward
     // them fails at workflow_call validation rather than at runtime.
     const callIdx = SEED_WORKFLOW.indexOf('workflow_call:');
     const dispatchIdx = SEED_WORKFLOW.indexOf('workflow_dispatch:');
     const callBlock = SEED_WORKFLOW.slice(callIdx, dispatchIdx);
     expect(callBlock).toMatch(/FIREBASE_SERVICE_ACCOUNT_DEV:[\s\S]{1,200}required: true/);
-    expect(callBlock).toMatch(/PERSONAS_PASSWORD_DEV:[\s\S]{1,200}required: true/);
+    expect(callBlock).toMatch(/DEV_QA_PERSONAS_PASSWORD:[\s\S]{1,200}required: true/);
   });
 
   test('declares a `target` input on both triggers with `dev` as the only allowed value', () => {


### PR DESCRIPTION
Implements SHY-0136 — see `.project/stories/SHY-0136-consolidate-persona-password-secret.md` for full spec, AC, BDD scenarios, and DoD.

## What
The `seed-dev-personas` workflow read `PERSONAS_PASSWORD_DEV` while the **app builds (Android + iOS), pr-checks, deploy-dev and the journey matrix** all read `DEV_QA_PERSONAS_PASSWORD`. Two secrets for one logical value, with nothing enforcing they match — they drifted, so personas were seeded with one password while the app signed in with the other → Firebase invalid-credentials → the app's generic *"Persona sign-in failed."* This blocked the SHY-0130 dev device-test on 2026-06-20.

## Change
Point the seeder at the canonical `DEV_QA_PERSONAS_PASSWORD` (both `workflow_call` and direct `workflow_dispatch` paths). `PERSONAS_PASSWORD_DEV` is now fully unused — a repo-wide grep returns zero references.

- `seed-dev-personas.yml`: 3 references renamed (the `workflow_call.secrets` declaration, a comment, the `personas-password:` usage).
- `deploy-dev-seed-personas.test.js`: the pin test flipped to assert the canonical name (TDD red→green; this test is what stops the drift recurring).

## Verification
- Pin test red→green via the canonical runner — **20/20 pass**.
- actionlint clean; repo grep for `PERSONAS_PASSWORD_DEV` returns none.
- End-to-end: dev deployed from this branch's workflow re-seeds + rebuilds from the single secret; persona sign-in verified on a real Android device (the SHY-0130 session this unblocks).

## After merge
Delete the now-unused `PERSONAS_PASSWORD_DEV` repo secret → one persona-password secret, permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
