### PR TITLE
docs: codify non-technical BDD standard (CLAUDE.md § BDD)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,11 @@ A dimension may carry `N/A — <one-line rationale>` if it genuinely doesn't app
 **Scenario: <short description>**
 - **Given** <preconditions>
 - **When** <action>
-- **Then** <observable outcome — exact exit code, stderr substring, etc>
+- **Then** <observable outcome — what the user sees/experiences>
 - **And** <additional observable>
 ```
+
+**Scenarios are NON-TECHNICAL (HARD RULE).** Every `Given`/`When`/`Then`/`And` must be readable by a **non-technical** stakeholder and describe observable **user behaviour** — what the user does and sees. **No** code identifiers, function/route/screen constant names (`Screen.Main`, `getIdToken(...)`, `startDestination`), collection names, or HTTP status codes in scenarios — those belong in `## Acceptance Criteria` + `## Test Plan` (which keep the engineering precision). Write "the app opens straight to the room list — no login screen, no loading screen", NOT "`startDestination = Screen.Main` and neither SignIn nor the splash is shown". Translate every mechanism to its user-visible effect ("confirmed they're allowed to see this group's content", not "cohort claim refreshed"). Code-hygiene checks (grep-clean, no orphaned strings, a `404`) are not user behaviour → assert them in AC/Test Plan, never as a BDD scenario. (Operator standard, 2026-07-01.)
 
 ### Stories born fully refined (NO skeletons) — HARD RULE
 


### PR DESCRIPTION
Codifies the **non-technical BDD** standard in `CLAUDE.md § BDD scenario format`: every `Given`/`When`/`Then`/`And` must be readable by a non-technical stakeholder and describe observable **user behaviour** — no code identifiers, function/route/screen constant names, collection names, or HTTP status codes (those live in `## Acceptance Criteria` + `## Test Plan`, which keep the engineering precision). Code-hygiene checks (grep-clean, a `404`) are asserted in AC/Test Plan, never as a BDD scenario.

Operator standard set 2026-07-01 while reviewing the EPIC-0004/0005 stories (whose BDD was written to comply). Companion to the backlog-filing PR #1525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QmS4gQ79QgvbHsy9JrwU7
