### PR TITLE
SHY-0185: Stop the iOS SIGABRT when the user-flags Firestore listener errors

### DIFF
--- a/.project/stories/SHY-0185-ios-userflags-listener-crash.md
+++ b/.project/stories/SHY-0185-ios-userflags-listener-crash.md
@@ -44,7 +44,7 @@ Root-caused 2026-07-13 from 20 on-device crash reports (`idevicecrashreport`, al
 - [ ] On a listener error the fallback is the SAFE state (`isSuspended=false`, `hasActiveWarning=false`) — a read error must NOT lock a user out or fabricate a warning; it fails OPEN for the user's own non-privileged flags, matching Android's existing swallow-the-error behaviour.
 
 ### UX
-- [ ] N/A — no user-visible string or layout change; the observable difference is "no crash". A subsequent recomposition re-subscribes the listener, so live updates resume.
+- [ ] N/A — no user-visible string or layout change; the observable difference is "no crash". **Accepted residual:** because the recovery completes the Flow (no retry — a persistent rules denial would hot-loop), live flag monitoring stays down until the collector re-subscribes on the **next sign-in**, not on recomposition (the `LaunchedEffect(uid)` only relaunches when `uid` changes). This is strictly better than the crash and matches the fail-safe intent; restoring continuous observation is EPIC-0006's route-via-API work. Server-side suspension/ban enforcement is unaffected (independent of this listener).
 
 ### i18n
 - [ ] N/A — no user-facing copy.

--- a/.project/stories/SHY-0185-ios-userflags-listener-crash.md
+++ b/.project/stories/SHY-0185-ios-userflags-listener-crash.md
@@ -1,0 +1,107 @@
+---
+id: SHY-0185
+status: In Progress
+owner: claude
+created: 2026-07-13
+priority: P0
+type: bug
+effort: S
+roadmap_ids: []
+mvp: true
+---
+
+# SHY-0185: iOS app crashes (SIGABRT) when the user-flags Firestore listener errors after sign-in
+
+## User Story
+
+**As** a ShyTalk user on iOS,
+**I want** the app to stay running when a background real-time listener hits a transient error,
+**So that** a Firestore rules denial or a momentary network drop degrades gracefully instead of crashing me out of the app right after I sign in.
+
+## Why
+
+Root-caused 2026-07-13 from 20 on-device crash reports (`idevicecrashreport`, all `EXC_CRASH SIGABRT`). The crashing coroutine's `lastExceptionBacktrace` is a `dev.gitlive.firebase.firestore.FirebaseFirestoreException` thrown by a `NativeDocumentReference$snapshots` listener. Traced to `IosUserRepositoryImpl.observeUserFlags()` — a direct gitlive Firestore `users/{uid}.snapshots` **Flow with no error handling** — collected by `SharedNavGraph.kt:116` `LaunchedEffect(uid){ …collect{} }` right after sign-in. When the listener errors (dev rules `PERMISSION_DENIED` / transient network), gitlive surfaces it as a **Flow exception**; nothing catches it, so it propagates to Kotlin/Native's final-resort handler → `SIGABRT` → the app drops to SpringBoard. This is the "app crashes after legal acceptance" that blocked the SHY-0151 device proof all session.
+
+**Android does not crash** here: its `addSnapshotListener` callback does `if (error != null …) return`, swallowing the listener error. This story gives the iOS `.snapshots` Flow the same safety. (The deeper fix — never touch Firestore from the client, route via the API — is [[feedback-no-direct-backend-all-via-api]] / EPIC-0006; this is the acute crash mitigation.)
+
+## Acceptance Criteria
+
+### Happy path
+- [ ] A healthy `observeUserFlags` Flow still emits every real `UserFlags` snapshot unchanged (no behavioural regression when there is no error).
+
+### Error paths
+- [ ] When the underlying listener Flow throws (e.g. a `FirebaseFirestoreException` from a rules denial or network drop), the app does NOT crash; the observing collector receives a safe default `UserFlags()` (not-suspended, no-warning) instead of an unhandled exception.
+- [ ] Emissions received before the error still reach the collector; only the error is replaced by the fallback.
+
+### Edge cases
+- [ ] A Flow that errors on its very first term (before any value) recovers to the single fallback value.
+- [ ] The recovery helper is generic over the emitted type so it can protect other listener Flows without duplication.
+
+### Performance
+- [ ] The fix is a single terminal `catch` operator — no added allocation per emission, no polling, no retry loop (a retry on a persistent `PERMISSION_DENIED` would hot-loop).
+
+### Security
+- [ ] On a listener error the fallback is the SAFE state (`isSuspended=false`, `hasActiveWarning=false`) — a read error must NOT lock a user out or fabricate a warning; it fails OPEN for the user's own non-privileged flags, matching Android's existing swallow-the-error behaviour.
+
+### UX
+- [ ] N/A — no user-visible string or layout change; the observable difference is "no crash". A subsequent recomposition re-subscribes the listener, so live updates resume.
+
+### i18n
+- [ ] N/A — no user-facing copy.
+
+### Observability
+- [ ] N/A for this mitigation — the fallback is silent (parity with Android's silent swallow). The direct-Firestore access itself is tracked under EPIC-0006; adding structured logging belongs with that route-via-API work, not this crash stop-gap.
+
+## BDD Scenarios
+
+**Scenario: a listener error no longer crashes the app**
+- **Given** the iOS app has signed in and is observing the current user's flags
+- **When** the Firestore user-flags listener emits an error (rules denial or network drop)
+- **Then** the app keeps running (no `SIGABRT`)
+- **And** the flags collector receives a default `UserFlags()` (not-suspended, no-warning)
+
+**Scenario: healthy updates are unaffected**
+- **Given** the user-flags listener is delivering normal snapshots
+- **When** a snapshot arrives with `isSuspended=true`
+- **Then** the collector receives `UserFlags(isSuspended=true, …)` exactly as before (the recovery operator is transparent to non-error emissions)
+
+**Scenario: values before an error are preserved**
+- **Given** a listener Flow that emits one valid value then errors
+- **When** it is observed through the recovery operator
+- **Then** the collector receives the valid value followed by the fallback, in order
+
+## Test Plan
+
+**Red (fails before the fix):**
+- `shared/src/commonTest/.../core/util/FlowRecoveryTest.kt` — `a flow that errors recovers to the fallback instead of throwing` (a `flow { emit(1); throw … }` collected via the new `recoverListenerErrors(99)` must yield `[1, 99]`, not throw). Fails to compile/pass until the helper exists.
+
+**Green:**
+- New `shared/src/commonMain/.../core/util/FlowRecovery.kt` — `fun <T> Flow<T>.recoverListenerErrors(fallback: T): Flow<T> = catch { emit(fallback) }`.
+- `FlowRecoveryTest.kt` — (1) error → `[emitted…, fallback]`; (2) healthy flow → unchanged; (3) error-on-first-term → `[fallback]`.
+- `IosUserRepositoryImpl.observeUserFlags` gains a terminal `.recoverListenerErrors(UserFlags())`.
+- `:shared:jvmTest` green; `:shared:compileKotlinIosArm64` green.
+
+**Device (the real proof — deferred to the SHY-0151 device gauntlet, iPhone-gated):** on a real iPhone, sign in as a persona whose user-flags read errors (or induce a transient rules denial) and confirm the app stays up + the SHY-0151 bind→lock→ban proof can now complete past sign-in.
+
+## Out of Scope
+
+- Routing `observeUserFlags` (and the other iOS `.snapshots` listeners) through the Express API — the systematic direct-backend-access fix is **EPIC-0006** ([[feedback-no-direct-backend-all-via-api]]).
+- Retrying/re-subscribing the listener after an error to keep observing (Android relies on the SDK's internal retry; a KMP re-subscribe belongs with the API migration, not this stop-gap).
+- The other unguarded iOS `.snapshots` Flows (`observeUsers`, economy/room/PM repos) — same latent risk, but this story fixes the CONFIRMED crash path; the helper is reusable for them under EPIC-0006.
+
+## Dependencies
+
+- None. Pure additive helper + a one-line change to one iOS impl.
+
+## Risks & Mitigations
+
+- **Recovery masks a real persistent error (user's flags never load).** → Acceptable for the safe non-privileged flags: Android already swallows the same error, and a recomposition re-subscribes. The proper observability lands with EPIC-0006.
+- **`catch` swallowing a programming error (e.g. a bug in `.map`) rather than only listener errors.** → The `.map` here is trivial (null-safe casts with defaults) and cannot throw on valid data; the only realistic upstream throw is the listener error. The helper is placed terminally so it also covers the map, which is the desired safety.
+
+## Definition of Done
+
+- `recoverListenerErrors` helper + `FlowRecoveryTest` (3 cases) green; `IosUserRepositoryImpl.observeUserFlags` uses it; `:shared:jvmTest` + `:shared:compileKotlinIosArm64` green; ktlint + detekt clean; `code-reviewer` 100% clean; merged to develop; the SHY-0151 device proof re-run confirms the app no longer crashes after sign-in (device-gauntlet phase); released.
+
+## Notes (running log)
+
+- 2026-07-13 ~20:20 WIB — Filed from the SHY-0151 device-proof crash investigation (operator authorised the mitigation). Evidence: 20 `iosApp-2026-07-13-*.ips` crash reports (scratchpad/crash2), all SIGABRT via `FirebaseFirestoreException` from `NativeDocumentReference$snapshots` → `IosUserRepositoryImpl.observeUserFlags` (no catch) → `SharedNavGraph.kt:116` collect. Android impl (`app/src/main/.../UserRepositoryImpl.kt:189`) already swallows the error arg. Root fix = EPIC-0006 (route via API). Related history: [[project-shy0139-ios-crash-fix]].

--- a/.project/stories/SHY-0185-ios-userflags-listener-crash.md
+++ b/.project/stories/SHY-0185-ios-userflags-listener-crash.md
@@ -1,6 +1,6 @@
 ---
 id: SHY-0185
-status: In Progress
+status: In Review
 owner: claude
 created: 2026-07-13
 priority: P0
@@ -104,4 +104,8 @@ Root-caused 2026-07-13 from 20 on-device crash reports (`idevicecrashreport`, al
 
 ## Notes (running log)
 
+Reviewed-up-to: 952d965a204
+
+- 2026-07-13 ~21:11 WIB — **ON-DEVICE VERIFIED (real iPhone).** Rebuilt the Debug-Dev app WITH the fix, reinstalled fresh, drove sign-in (alert→legal→sign-in screen). Crash count via `idevicecrashreport` stayed at the **baseline 20 — ZERO new crashes**; the newest .ips is still the pre-fix 16:56 one. The app stayed alive (`processId 1365`, queryable ShyTalk dump) through legal acceptance onto the sign-in screen — exactly where the unfixed app SIGABRT'd to SpringBoard 20 times earlier today. Crash fix confirmed. (The run's bind-x "picker never opened" is the SEPARATE pre-existing iOS-27 sign-in-landing snapshot-hang / coord-tap flakiness — not a crash, tracked with the SHY-0151 device proof.)
+- 2026-07-13 ~20:30 WIB — **code-reviewer R1 clean after fixes** (commit `952d965a204`): Exception-only boundary (fatal Error rethrows), cancellation + Error + UserFlags-safe-default tests (FlowRecoveryTest 6), logging at the iOS call site, KDoc + story-UX-AC corrections. Reviewer confirmed no exploitable fail-open (server-side suspension/ban enforcement is independent of this client listener). jvmTest + compileKotlinIosArm64 green; ktlint+detekt clean.
 - 2026-07-13 ~20:20 WIB — Filed from the SHY-0151 device-proof crash investigation (operator authorised the mitigation). Evidence: 20 `iosApp-2026-07-13-*.ips` crash reports (scratchpad/crash2), all SIGABRT via `FirebaseFirestoreException` from `NativeDocumentReference$snapshots` → `IosUserRepositoryImpl.observeUserFlags` (no catch) → `SharedNavGraph.kt:116` collect. Android impl (`app/src/main/.../UserRepositoryImpl.kt:189`) already swallows the error arg. Root fix = EPIC-0006 (route via API). Related history: [[project-shy0139-ios-crash-fix]].

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/FlowRecovery.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/FlowRecovery.kt
@@ -1,0 +1,26 @@
+package com.shyden.shytalk.core.util
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+
+/**
+ * Recovers a real-time-listener [Flow] that ERRORS to a safe [fallback] instead
+ * of letting the exception crash the app (SHY-0185).
+ *
+ * gitlive Firestore's `.snapshots` Flow surfaces an underlying listener error
+ * (a rules `PERMISSION_DENIED` or a transient network drop) as a
+ * `FirebaseFirestoreException` emitted INTO the Flow. On iOS an uncaught Flow
+ * exception reaches Kotlin/Native's final-resort handler and aborts the process
+ * (`SIGABRT`) — the confirmed cause of the post-sign-in crash. Android's
+ * `addSnapshotListener` callback already swallows the error argument; this gives
+ * the iOS Flows the same safety.
+ *
+ * Terminal `catch` so it also covers any downstream `map`. Values emitted before
+ * the error are preserved; only the error is replaced by [fallback]. Deliberately
+ * does NOT retry — a persistent error (e.g. a real rules denial) would hot-loop.
+ *
+ * The proper fix is to stop touching Firestore from the client and route via the
+ * Express API ([[feedback-no-direct-backend-all-via-api]] / EPIC-0006); this is
+ * the acute crash mitigation.
+ */
+fun <T> Flow<T>.recoverListenerErrors(fallback: T): Flow<T> = catch { emit(fallback) }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/FlowRecovery.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/util/FlowRecovery.kt
@@ -15,12 +15,25 @@ import kotlinx.coroutines.flow.catch
  * `addSnapshotListener` callback already swallows the error argument; this gives
  * the iOS Flows the same safety.
  *
- * Terminal `catch` so it also covers any downstream `map`. Values emitted before
- * the error are preserved; only the error is replaced by [fallback]. Deliberately
- * does NOT retry — a persistent error (e.g. a real rules denial) would hot-loop.
+ * Place it LAST in the chain: upstream operators (e.g. `map`) run before it, so
+ * their errors are recovered too; anything added AFTER it is not protected.
+ * Values emitted before the error are preserved; only the error is replaced by
+ * [fallback]. Deliberately does NOT retry — a persistent error (e.g. a real rules
+ * denial) would hot-loop; the listener therefore stays down until the collector
+ * re-subscribes (next sign-in), which is the accepted residual until EPIC-0006.
+ *
+ * Recovers only an [Exception]. A fatal [Error] (OutOfMemoryError, StackOverflow)
+ * is rethrown so a genuinely unrecoverable condition isn't masked as a safe
+ * default — matching the boundary in [firebaseCall]. `kotlinx` `catch` already
+ * rethrows [kotlinx.coroutines.CancellationException] before this lambda runs, so
+ * coroutine cancellation is never swallowed.
  *
  * The proper fix is to stop touching Firestore from the client and route via the
  * Express API ([[feedback-no-direct-backend-all-via-api]] / EPIC-0006); this is
  * the acute crash mitigation.
  */
-fun <T> Flow<T>.recoverListenerErrors(fallback: T): Flow<T> = catch { emit(fallback) }
+fun <T> Flow<T>.recoverListenerErrors(fallback: T): Flow<T> =
+    catch { e ->
+        if (e !is Exception) throw e
+        emit(fallback)
+    }

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/FlowRecoveryTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/FlowRecoveryTest.kt
@@ -1,0 +1,46 @@
+package com.shyden.shytalk.core.util
+
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * SHY-0185 — a realtime-listener Flow that errors (gitlive Firestore `.snapshots`
+ * emitting a FirebaseFirestoreException on a rules-denial / network drop) must
+ * NOT crash the app; [recoverListenerErrors] recovers it to a safe fallback.
+ * Verifies the recovery operator directly (the iOS impl that consumes it is
+ * device-gauntlet-verified — see the story Test Plan).
+ */
+class FlowRecoveryTest {
+    @Test
+    fun `a flow that errors recovers to the fallback instead of throwing`() =
+        runTest {
+            val out =
+                flow<Int> {
+                    emit(1)
+                    throw RuntimeException("simulated listener error")
+                }.recoverListenerErrors(99).toList()
+            // The value emitted before the error survives; the error is REPLACED by the fallback.
+            assertEquals(listOf(1, 99), out)
+        }
+
+    @Test
+    fun `a healthy flow passes through untouched`() =
+        runTest {
+            val out = flowOf(1, 2, 3).recoverListenerErrors(99).toList()
+            assertEquals(listOf(1, 2, 3), out)
+        }
+
+    @Test
+    fun `a flow that errors on the very first term recovers to the single fallback`() =
+        runTest {
+            val out =
+                flow<Int> {
+                    throw RuntimeException("error before any emission")
+                }.recoverListenerErrors(42).toList()
+            assertEquals(listOf(42), out)
+        }
+}

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/FlowRecoveryTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/util/FlowRecoveryTest.kt
@@ -1,11 +1,19 @@
 package com.shyden.shytalk.core.util
 
+import com.shyden.shytalk.data.repository.UserFlags
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 /**
  * SHY-0185 — a realtime-listener Flow that errors (gitlive Firestore `.snapshots`
@@ -42,5 +50,56 @@ class FlowRecoveryTest {
                     throw RuntimeException("error before any emission")
                 }.recoverListenerErrors(42).toList()
             assertEquals(listOf(42), out)
+        }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `cancellation propagates uncaught and does NOT receive the fallback (structured concurrency)`() =
+        runTest {
+            // Swallowing CancellationException would break coroutine cancellation
+            // propagation — a scope canceller would never get its cancel signal.
+            // Guards against a future refactor to a bare catch(e: Exception){emit}.
+            val collected = mutableListOf<Int>()
+            val job =
+                launch {
+                    flow {
+                        emit(1)
+                        awaitCancellation()
+                    }.recoverListenerErrors(99).collect { collected.add(it) }
+                }
+            advanceUntilIdle()
+            job.cancel()
+            job.join()
+            assertTrue(job.isCancelled)
+            assertEquals(listOf(1), collected) // the fallback (99) must NOT be appended
+        }
+
+    @Test
+    fun `a fatal Error propagates uncaught rather than being masked as the fallback`() =
+        runTest {
+            // Parity with firebaseCall's boundary: OOM / StackOverflow are genuinely
+            // unrecoverable and must crash the coroutine, not become a safe default.
+            assertFailsWith<OutOfMemoryError> {
+                flow<Int> {
+                    throw OutOfMemoryError("simulated fatal")
+                }.recoverListenerErrors(99).toList()
+            }
+        }
+
+    @Test
+    fun `the UserFlags fallback is the SAFE default state (Security AC)`() =
+        runTest {
+            // The observeUserFlags fix recovers to UserFlags(); a read error must
+            // NOT lock a user out or fabricate a warning. Pin that contract here.
+            val out =
+                flow<UserFlags> {
+                    throw RuntimeException("listener error")
+                }.recoverListenerErrors(UserFlags()).toList()
+            assertEquals(1, out.size)
+            val flags = out.single()
+            assertEquals(false, flags.isSuspended)
+            assertEquals(null, flags.suspensionEndDate)
+            assertEquals(false, flags.hasActiveWarning)
+            assertEquals(null, flags.warningReason)
         }
 }

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosUserRepositoryImpl.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosUserRepositoryImpl.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
@@ -192,8 +193,14 @@ class IosUserRepositoryImpl(
             // SHY-0185: a `.snapshots` listener error (rules denial / network
             // drop) surfaces as a FirebaseFirestoreException emitted into the
             // Flow; uncaught on iOS it SIGABRTs the app right after sign-in.
-            // Recover to a safe default (parity with Android's swallow).
-            .recoverListenerErrors(UserFlags())
+            // Log it (default debug-logging rule; parity with this file's other
+            // swallow sites) then recover to a safe default. The logging `catch`
+            // rethrows so the terminal recovery still fires; `kotlinx` catch
+            // never invokes either lambda for CancellationException.
+            .catch { e ->
+                logW(TAG, "observeUserFlags listener error for $userId — falling back to safe defaults", e)
+                throw e
+            }.recoverListenerErrors(UserFlags())
 
     override fun observeUsers(userIds: Set<String>): Flow<User> {
         if (userIds.isEmpty()) return emptyFlow()

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosUserRepositoryImpl.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/repository/IosUserRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.core.util.currentTimeMillis
 import com.shyden.shytalk.core.util.firebaseCall
 import com.shyden.shytalk.core.util.logW
+import com.shyden.shytalk.core.util.recoverListenerErrors
 import com.shyden.shytalk.data.firestore.dataMap
 import com.shyden.shytalk.data.remote.IosApiClient
 import dev.gitlive.firebase.firestore.Direction
@@ -188,6 +189,11 @@ class IosUserRepositoryImpl(
                     warningReason = data["warningReason"] as? String,
                 )
             }
+            // SHY-0185: a `.snapshots` listener error (rules denial / network
+            // drop) surfaces as a FirebaseFirestoreException emitted into the
+            // Flow; uncaught on iOS it SIGABRTs the app right after sign-in.
+            // Recover to a safe default (parity with Android's swallow).
+            .recoverListenerErrors(UserFlags())
 
     override fun observeUsers(userIds: Set<String>): Flow<User> {
         if (userIds.isEmpty()) return emptyFlow()


### PR DESCRIPTION
Implements SHY-0185 — see .project/stories/SHY-0185-ios-userflags-listener-crash.md for full spec, AC, BDD, and DoD.

## The crash (root-caused from 20 on-device reports)
Every report is `EXC_CRASH SIGABRT` from an unhandled Kotlin coroutine exception; the `lastExceptionBacktrace` is a `dev.gitlive.firebase.firestore.FirebaseFirestoreException` from a `NativeDocumentReference$snapshots` listener. `IosUserRepositoryImpl.observeUserFlags()` opens a direct gitlive Firestore `users/{uid}.snapshots` Flow with no error handling, collected by `SharedNavGraph.kt:116` in a `LaunchedEffect` right after sign-in. When the listener errors (dev rules `PERMISSION_DENIED` / transient network), the Flow exception is uncaught → the app aborts to SpringBoard. **This is the crash that blocked the SHY-0151 device proof all along.** Android's `addSnapshotListener` callback already swallows the same error.

## Fix
- New commonMain `Flow<T>.recoverListenerErrors(fallback)` = `catch { if (e !is Exception) throw e; emit(fallback) }` — recovers a listener error to a safe fallback, rethrows fatal `Error`s, never swallows `CancellationException`.
- `observeUserFlags` recovers to a safe default `UserFlags()` (not-suspended/no-warning — a read error must not lock out or fabricate a warning; parity with Android) + logs the error at the call site.
- Acute mitigation; the systematic fix (never touch Firestore from the client — route via the API) is **EPIC-0006**.

## Verification
- `FlowRecoveryTest` 6 green (passthrough, error→fallback, error-first, **cancellation-not-swallowed**, **fatal-Error-propagates**, **UserFlags-safe-default**); `:shared:jvmTest` + `:shared:compileKotlinIosArm64` green; ktlint+detekt clean.
- **code-reviewer R1 clean** (Exception-boundary, logging, tests all applied; no exploitable fail-open — server-side enforcement is independent).
- **On-device (real iPhone):** rebuilt with the fix, drove sign-in — crash count stayed at baseline **20, zero new crashes**; the app stayed alive through legal→sign-in where the unfixed app SIGABRT'd 20× earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T53wXPsQ5XQfM2s9w7c18n