### PR TITLE
SHY-0239: Gauntlet v2 — PIN-ready start gate + event-driven self-notify

### DIFF
--- a/.project/stories/SHY-0239-gauntlet-v2-pause-ping-self-notify.md
+++ b/.project/stories/SHY-0239-gauntlet-v2-pause-ping-self-notify.md
@@ -1,0 +1,175 @@
+---
+id: SHY-0239
+status: In Progress
+owner: claude
+created: 2026-07-25
+priority: P1
+effort: M
+type: infra
+roadmap_ids: []
+epic: EPIC-0009
+---
+
+# SHY-0239: Gauntlet v2 — PIN-ready start gate + event-driven self-notify (console + phone) + fail-fast first-failure ping
+
+## User Story
+
+As **the engineer running the release gauntlet detached**,
+I want **the run to pause and ping me to confirm the devices are PIN-ready before it dispatches anything, then announce itself — live on the console and to my phone — the moment it completes, fails, or hits the first failure**,
+So that **I can prep + unlock the devices, watch the first minute to confirm liveness, then walk away and be pulled back exactly when the run needs me or is done — instead of babysitting a silent multi-hour run or discovering a stall hours later**.
+
+## Why
+
+The grounding investigation (2026-07-25, recorded in `## Notes`) mapped the real primitives and settled two load-bearing facts:
+
+1. **Nothing self-announces today.** Completion is signalled *only* by the `DONE`/`FAIL` filesystem sentinels a human or wrapper must poll (`gauntlet-v2.sh:268/276`). There is no push, desktop, audible, or console self-announce anywhere in the orchestration layer — the placeholder comment at `gauntlet-v2.sh:30` literally reserves it for this story.
+2. **The detached device matrix cannot pause mid-run for a human.** The runner is built fully unattended — zero `readline`/`stdin`/prompt primitives across `manual-qa-runner.js` + every driver — and the real PIN problem is solved today by *preparation*, not mid-run pausing: `30-android.sh:70` warns a secure lock *"cannot be dismissed here — disable it for runs"*, and `50-matrix.sh:94` requires the iPhone already unlocked + trusted. Auto-detecting an OS PIN overlay inside the detached matrix would need a driver rewrite — exactly the kind of large, low-payoff change EPIC-0009's Pragmatic decision excludes.
+
+So the achievable, high-value shape of "pause/ping + self-notify" is:
+
+- **A PIN-ready START gate** — the correct place to handle PIN, since the real fix is up-front device prep. Before any device is touched, the run pauses, pings (console + phone), and awaits an explicit confirm — the *"explicit checkpoint fallback where the OS overlay can't be detected"* the epic already anticipates. Bounded, so a walked-away operator can't hang the gate forever (the same liveness discipline SHY-0238 put on matrix-wait).
+- **Event-driven self-notify** — the run emits a machine-readable event at each moment that matters (start, pin-wait, pin-ready, first-failure, complete, failed, aborted) to an append-only `events.log` **and** a loud source-prefixed `[notify]` console line (+ terminal bell). The console half is pure bash. The **phone** half is assistant-mediated by the operator's chosen channel (Claude Code app push): the script emits the events; the orchestrating assistant bridges them to the phone via `PushNotification`, driven by the already-sanctioned "detached run + scheduled check" pattern — **one status read per checkpoint, never a polling loop**.
+- **A single-shot `--status` reader** — resolves the current run to one line (`complete`/`failed`/`pin-wait`/`running`/`died`) from the sentinels + a `pid` liveness check, so the assistant's per-checkpoint wake is a single cheap read rather than ad-hoc `ls`-ing of sentinels.
+
+This delivers the operator's verbatim intent — *"pause + ping for PIN before start; ping on complete/fail; no token-burning polling"* — without the infeasible mid-run auto-pause.
+
+## Acceptance Criteria
+
+### Happy path
+- [ ] When the matrix is dispatched, a **PIN-ready start gate** runs *before* matrix-dispatch (and before android-prep): it writes a `PIN_WAIT` marker (with the readiness reason), emits a `pin-wait` notify (console + event), and blocks until confirmed.
+- [ ] On a TTY the gate confirms via an interactive `read` (operator presses Enter); with no TTY (detached) it confirms when a `PIN_READY` token file appears under `RUN_DIR` (touched by the operator or the orchestrating assistant).
+- [ ] On confirm, the gate removes `PIN_WAIT`, emits a `pin-ready` notify, and the run proceeds to dispatch.
+- [ ] The run emits a `complete` notify (console + event + bell) and writes `DONE` when every step passed; a `failed` notify + `FAIL` when any step failed (SHY-0236 sentinel contract preserved — exactly one of `DONE`/`FAIL`).
+- [ ] `gauntlet-v2.sh --status [run_dir]` prints the run's current state on one line — a single word (`complete`/`failed`/`running`/`died`/`unknown`), or `pin-wait<TAB><reason>` for the gate-blocked case so the bridge can surface *what* is needed — and exits 0, defaulting to the `latest-v2` run when no dir is given.
+
+### Error paths
+- [ ] If the gate is not confirmed within `PIN_GATE_TIMEOUT` (default 1800s; env-overridable), it removes `PIN_WAIT`, emits an `aborted` notify, and fails the run (non-zero, `FAIL` written) — a gate that never returns is worse than a FAIL.
+- [ ] A fatal step (ERR trap) emits a `failed` event before the existing red banner + `FAIL` (SHY-0236 fail-fast contract intact); the notify path in the trap is pure-append and cannot re-enter the trap.
+- [ ] An interrupt (SIGINT/SIGTERM) emits an `aborted` event, reaps the overlapped suites (SHY-0238 `on_signal`), and exits `128+signal`.
+
+### Edge cases
+- [ ] `--no-pin-gate` (or a frameworks-only `--no-matrix` run) skips the gate entirely — no `PIN_WAIT` written, run proceeds straight to work.
+- [ ] **Fail-fast, once:** the *first* recorded step failure emits a single `suite-fail` notify (the phone ping); subsequent failures are console `WARN`s only — no per-failure phone spam. The run still completes best-effort (SHY-0236), the tally still lists every failure.
+- [ ] `--status` precedence is honoured: `DONE` ⇒ `complete` even if a stale `PIN_WAIT`/`FAIL` co-exists; `FAIL` ⇒ `failed`; else `PIN_WAIT` ⇒ `pin-wait`; else pid-alive ⇒ `running`, pid-dead-without-sentinel ⇒ `died`.
+- [ ] `notify`/`emit_event`/`pin_ready_gate`/`cmd_status` are defined in the library-mode section (above the `GAUNTLET_V2_LIB` early-return) so they are exercisable by the behavioural tests without running the orchestration.
+
+### Performance
+- [ ] The gate adds zero measurable overhead to a `--no-pin-gate`/`--no-matrix` run (single guard check, immediate return).
+- [ ] `emit_event` is an O(1) append; `--status` is a single-shot read (no loop, no `sleep`) — consistent with "no token-burning polling".
+
+### Security
+- [ ] N/A — local dev/QA orchestration tooling. `events.log` records only run-lifecycle event kinds + non-secret detail strings (phase names, suite names, counts); no credentials, tokens, or persona data are written. No network trust boundary, no runtime surface.
+
+### UX
+- [ ] Every self-notify is a single loud, colour-distinct `[notify] <event> <detail>` console line (+ terminal bell) so it stands out from the interleaved `[matrix]`/suite streams a watching operator sees.
+- [ ] The gate prints a clear, actionable prompt naming exactly what "PIN-ready" means (unlock both devices, disable the Android secure lock, unlock + trust the iPhone) and how to confirm/abort.
+
+### i18n
+- [ ] N/A — developer-facing CLI tooling; no user-facing strings, no locale files touched.
+
+### Observability
+- [ ] `RUN_DIR/events.log` is an append-only, timestamped, tab-separated audit trail (`<iso-ts>\t<event>\t<phase>\t<detail>`) capturing every lifecycle event, readable post-hoc + parseable by the `--status`/assistant bridge.
+- [ ] The `PIN_WAIT` marker's presence + contents are the machine-readable "operator action needed" signal; its removal is the machine-readable "gate released" signal.
+
+## BDD Scenarios
+
+**Scenario: The run pauses + pings before touching any device**
+- **Given** a v2 run with the matrix enabled and the PIN gate not disabled
+- **When** the orchestrator finishes bringing the stack up
+- **Then** before matrix-dispatch it writes a `PIN_WAIT` marker under `RUN_DIR` and emits a `pin-wait` notify to the console + `events.log`
+- **And** it does not dispatch the matrix until the gate is confirmed
+
+**Scenario: Detached confirm via the PIN_READY token**
+- **Given** a gate blocking with no controlling TTY
+- **When** a `PIN_READY` file appears under `RUN_DIR`
+- **Then** the gate removes `PIN_WAIT`, emits a `pin-ready` notify, and the run proceeds
+
+**Scenario: The gate refuses to hang forever**
+- **Given** a gate blocking with a short `PIN_GATE_TIMEOUT` and no confirm
+- **When** the timeout elapses
+- **Then** the gate emits an `aborted` notify, removes `PIN_WAIT`, and the run exits non-zero with `FAIL` written
+
+**Scenario: First failure pings once, run continues**
+- **Given** a v2 run in which two suites fail
+- **When** the failures are recorded
+- **Then** exactly one `suite-fail` event is emitted (the first), the run still completes best-effort, and the final tally lists both failures
+
+**Scenario: Completion announces itself**
+- **Given** a v2 run where every step passes
+- **When** the run reaches the tally
+- **Then** it emits a `complete` notify (console + event + bell) and writes exactly `DONE`
+
+**Scenario: Status reader resolves the run to one line**
+- **Given** a run dir containing a `DONE` sentinel
+- **When** `gauntlet-v2.sh --status <dir>` is invoked
+- **Then** it prints `complete` and exits 0
+- **And** with only a live `pid` and no sentinel it prints `running`; with a dead `pid` and no sentinel it prints `died`
+
+## Test Plan
+
+**Classification: test-tooling-only.** Confined to `express-api/scripts/gauntlet/gauntlet-v2.sh` + new test files under `express-api/tests/scripts/` — a local dev/QA orchestration harness with no app/backend/website runtime surface. Per the Pre-Merge Protocol tooling exemption (CI-config/tooling), the device/browser gauntlet does not gate this change; the proof is the tooling running correctly + the structural/behavioural pins. The **phone-push leg is proven at the first real v2 run** (the release gate), where the orchestrating assistant bridges the emitted events to `PushNotification` — it cannot be unit-asserted because `PushNotification` is an assistant tool, not a script call.
+
+**Structural pins** (`express-api/tests/scripts/gauntlet-v2-notify-structure.test.js`, new — regex/source over the orchestrator):
+- the `pin-ready-gate` phase appears **before** `matrix-dispatch` and before the first `start_overlapped`;
+- the gate is guarded by both the PIN-gate flag and the matrix flag (skippable), writes `PIN_WAIT`, and is **bounded** (a `read -t`/timeout path, not an unbounded block) with both a `[ -t 0 ]` TTY branch and a non-TTY `PIN_READY`-file wait;
+- `notify`/`emit_event` write to `events.log` **and** a `[notify]` console line;
+- the first-failure sites (`wait_overlapped`, `run_logged`, matrix-wait FAIL branch) route through the once-only fail-fast notify;
+- terminal notify is wired into the tally (`complete`/`failed`), `on_signal` (`aborted`), and `on_fail` (`failed` event);
+- a `--status` subcommand exists, short-circuits **before** the orchestration, and encodes the `DONE>FAIL>PIN_WAIT>running/died` precedence;
+- the helpers live above the `GAUNTLET_V2_LIB` early-return; `--no-pin-gate` is parsed.
+
+**Behavioural pins** (`express-api/tests/scripts/gauntlet-v2-notify.test.js`, new — real `spawnSync` in lib mode, the SHY-0236/0238 discipline against real throwaway files/processes):
+- `notify` real-appends a parseable `\t`-separated event line to `events.log` and prints `[notify]` to the console;
+- `pin_ready_gate` non-TTY happy path: backgrounded, it writes `PIN_WAIT`; after a real `touch PIN_READY` it returns, removes `PIN_WAIT`, and logs `pin-ready`;
+- `pin_ready_gate` timeout path: with `PIN_GATE_TIMEOUT=1` and no confirm, it emits `aborted`, removes `PIN_WAIT`, and exits non-zero (run in a subshell so it doesn't kill the harness);
+- `pin_ready_gate` skip: with the gate flag off it returns 0 immediately and writes no `PIN_WAIT`;
+- fail-fast guard: recording two failures yields exactly one `suite-fail` line in `events.log`;
+- `--status` real entrypoint: a temp run dir with `DONE`⇒`complete`, `FAIL`-only⇒`failed`, `PIN_WAIT`-only⇒`pin-wait`, live-pid+no-sentinel⇒`running`, dead-pid+no-sentinel⇒`died`.
+
+**Guards:** `bash -n` on the orchestrator; `eslint --max-warnings=0` + `prettier` on the new JS tests; `shellcheck` clean; `scripts/check-no-new-stubs.js` clean (no doubles — the fixtures are real files/processes the harness drives); `code-reviewer` 100% clean on the diff.
+
+## Out of Scope
+
+- **Mid-run auto-pause** of the detached device matrix for a PIN overlay — needs an unattended-runner/driver rewrite (Pragmatic v2 explicitly OUT); the START gate + pre-disabled secure lock is the sanctioned handling.
+- **The `PushNotification` call itself** — an assistant runtime action, not script code; proven at the first real v2 run. The script's testable contract is *emitting the consumable events*.
+- **ntfy / script-direct-to-phone channels** — the operator chose the Claude Code app push (assistant-mediated); a script-native push channel is a possible future swap, not this story.
+- **Adding a self-detach (`--detach`) to the orchestrator** — the assistant nohup-wraps the foreground script at launch (the sanctioned detach idiom); no new flag needed here.
+- Pre-flight smoke + cross-platform real-time coverage (SHY-0240); the overlap core (SHY-0238, done).
+
+## Dependencies
+
+- **SHY-0238** (merged to develop) — this extends the v2 orchestrator: the gate slots before its matrix-dispatch phase, the notify hooks attach to its `on_fail`/`on_signal`/tally, and the helpers live alongside its `start_overlapped`/`run_logged` in the lib-mode section.
+- **SHY-0236** (merged) — the `DONE`/`FAIL` sentinel + best-effort-with-tally contract the notify + `--status` build on.
+
+## Risks & Mitigations
+
+- **Risk:** the gate hangs forever if the operator never confirms. **Mitigation:** a bounded `PIN_GATE_TIMEOUT` with an `aborted`+`FAIL` exit — the same liveness discipline SHY-0238 applied to matrix-wait; a behavioural pin drives the real timeout.
+- **Risk:** `notify` inside the ERR/signal trap re-triggers the trap or loops. **Mitigation:** the trap uses the pure-append `emit_event` (a guarded `printf >> … 2>/dev/null || true`), no command that can fail-and-re-enter; structural pin asserts the trap wiring.
+- **Risk:** every failure pings the phone (notification spam). **Mitigation:** a once-only `NOTIFIED_FIRST_FAIL` guard — only the first failure emits `suite-fail`; a behavioural pin asserts exactly one event after two failures.
+- **Risk:** the phone leg is invisible in tests, so a regression could ship silently. **Mitigation:** the script's job is reduced to *emitting a consumable event* (fully tested via `events.log`); the assistant bridge + the first real run's live `PushNotification` are the end-to-end proof, recorded at the release gate.
+- **Risk (documented limitation):** because the channel is assistant-mediated, the phone ping only fires when the assistant orchestrates the run; a standalone terminal run gets console-only. **Mitigation:** operator-accepted trade-off (channel chosen 2026-07-25); an ntfy swap remains a clean future option if standalone phone push is ever wanted.
+
+## Definition of Done
+
+- `gauntlet-v2.sh` gains a bounded PIN-ready start gate (TTY + non-TTY confirm), event-driven `notify`/`emit_event` wired into start/gate/first-failure/complete/failed/aborted, and a single-shot `--status` reader — all in the lib-testable section.
+- Structural + behavioural pins green (real-execution, SHY-0236/0238 discipline); `bash -n` + `shellcheck` + eslint `--max-warnings=0` + prettier + no-new-stubs clean; `code-reviewer` 100% clean; merged to develop.
+- The phone-push leg is exercised end-to-end at the first real v2 run (release gate) and the outcome recorded in `## Notes`.
+
+## Notes
+
+**2026-07-25 — grounding investigation (Explore).** Mapped the primitives before designing (evidence, not guesswork): **Q1** no notification/pause primitive exists anywhere — completion is only the `DONE`/`FAIL` sentinel; `gauntlet-v2.sh:30` reserves self-notify for this story. **Q2** integration surface: `phase()` at `:165`, `on_fail` ERR at `:155-158`, `on_signal` INT/TERM at `:103-107`, tally/sentinel at `:266-279`, CLI parse at `:128-146`; the orchestrator runs foreground and dispatches the *detached* matrix via `50-matrix.sh launch` (`:191`). **Q3** the runner is fully unattended (zero `readline`/`stdin`/prompt in `manual-qa-runner.js` + drivers); the PIN problem is solved by pre-disabling the secure lock (`30-android.sh:70`) + pre-unlocking the iPhone (`50-matrix.sh:94`), so mid-run auto-pause is infeasible without a driver rewrite (out of Pragmatic scope). **Q4** the run dir exposes `log`/`pid`/`DONE`/`FAIL`/`matrix-latest`; there is no machine-readable event stream — so this story introduces `events.log` + `PIN_WAIT`/`PIN_READY` markers as the consumable signals.
+
+**2026-07-25 — channel decision (operator).** Phone channel = **Claude Code app push** (my `PushNotification`), chosen over ntfy/Brevo/console-only. Architectural consequence: the phone leg is **assistant-mediated** — the bash script emits events; the orchestrating assistant bridges them to the phone via the sanctioned "detached run + one scheduled `--status` check per checkpoint" pattern (no polling loop). Active-suppression means the push stays quiet while the operator is in-session and reaches the phone once they walk away — exactly the intended "watch the first minute then leave" behaviour; presence-file tricks are not used ([[project-phone-push-active-suppression-and-presence-file]]). Design honours [[feedback-detached-suites-scheduled-checks]] + [[feedback-scheduled-wakeups-over-monitors]].
+
+**2026-07-25 — implemented.** `express-api/scripts/gauntlet/gauntlet-v2.sh`: added (all in the lib-testable section) `emit_event` (guarded pure-append tab-separated `events.log`), `notify` (event + loud `[notify]` console line + bell), `notify_first_fail` (once-only guard), `pin_ready_gate` (guarded + bounded; TTY `read -t` / non-TTY `PIN_READY`-file wait; writes/clears `PIN_WAIT`), and `cmd_status` (DONE>FAIL>PIN_WAIT>running/died). `phase()` relocated above the lib-return so the gate can set its phase in lib mode. Wiring: gate called after `services` before any device touch; `notify_first_fail` at the three failure sites; `emit_event failed/aborted` in `on_fail`/`on_signal`; `notify complete/failed` in the tally; `notify start` + `echo $$ > pid` at startup; `--status [dir]` short-circuit before the flag loop; `--no-pin-gate` flag; `-h` made range-robust (`sed …/^set -uo/…` — also fixes a pre-existing leak of two code lines into the help). Tests (SHY-0236/0238 real-execution discipline): `gauntlet-v2-notify-structure.test.js` (12 structural pins) + `gauntlet-v2-notify.test.js` (10 behavioural — real `spawnSync`/files: event trail, non-TTY gate release, bounded-timeout abort, skip, once-only fail-fast, and the `--status` precedence incl. live/dead pid liveness). **51 gauntlet-v2 tests green** (SHY-0238's 29 + these 22); the fail-fast guard is mutation-proven (disabling it → 2 events, test goes red). `bash -n` + shellcheck + eslint + prettier + no-new-stubs clean.
+
+**2026-07-25 — pre-self-review catch (before the reviewer).** The gate-timeout path first used `die` (= `printf; exit 1`), but an explicit `exit` does NOT fire the `ERR` trap — so it would exit non-zero WITHOUT `on_fail` writing the `FAIL` sentinel, violating the "FAIL written" AC + the SHY-0236 contract and making `cmd_status` report `died` instead of `failed`. Fixed to `return 1` from the function, so the bare `pin_ready_gate` call fails under `set -e` → `ERR` → `on_fail` writes `FAIL` uniformly (the single sentinel-owner). Added a structural pin that `on_fail` still writes `FAIL` (the dependency the gate's `return 1` relies on).
+
+**2026-07-25 — Code-review R1** (`code-reviewer`, reviewer-before-push gate on the local commit): 2 Critical + 5 Important + minors, ALL applied (fix round self-certified per [[feedback-agent-token-frugality]]).
+- **C1 — the non-TTY timeout branch STILL called `die`.** My pre-review `replace_all` matched only the 6-space TTY branch; the 8-space non-TTY branch — the PRIMARY detached path — was missed, so the most-used path failed WITHOUT writing `FAIL` (`cmd_status` → `died`, not `failed`). Fixed: BOTH timeout branches now `touch "$RUN_DIR/FAIL"; return 1` (explicit sentinel = belt; `ERR`→`on_fail` = suspenders; matches gauntlet.sh's proven mid-run idiom).
+- **C2 — the `return 1 → ERR → FAIL` mechanism was unverified + untestable in lib mode.** Verified empirically (a bare `return 1` from inside a nested while/if in a function DOES fire an outer `trap ERR` under `set -e` without `errtrace`). Making `FAIL` explicit (C1) also made it provable in lib mode; added a behavioural pin asserting `FAIL` on timeout — **mutation-proven** (drop the `touch` → test goes red, confirming lib-mode can't lean on the ERR trap).
+- **I3/I4 — `--status` default (`latest-v2`) + the `MATRIX=0` skip had no behavioural coverage.** Added real tests for both.
+- **I5 — a non-integer `PIN_GATE_TIMEOUT` hung the non-TTY loop forever** (the `[ -ge ]` errs every iteration inside an `-e`-exempt `if`, never aborting). Fixed: clamp non-numeric to the default with a loud `warn`; behavioural pin (`PIN_GATE_TIMEOUT=abc` → warns + releases, no hang).
+- **I6/I7 — `on_signal`'s new `aborted` event + `emit_event`'s unwritable-`RUN_DIR` guard had no behavioural proof.** Added real tests (drive `on_signal 130` in lib mode → `aborted` in `events.log`; `notify` against a `/nonexistent` `RUN_DIR` → survives, RC 0, console line still printed).
+- **Minors (all applied):** event-order pin (pin-wait before pin-ready), missing-detail-arg tolerance, `-h` no-code-leak pin, `--status` AC wording (pin-wait carries a tab-reason), README `PIN_GATE_TIMEOUT` knob row.
+- Gates: **58 gauntlet-v2 tests green** (SHY-0238's 29 + these 29 = 12 structural + 17 behavioural); FAIL-on-timeout + the fail-fast guard both mutation-proven; `bash -n` + shellcheck + eslint `--max-warnings=0` + prettier + no-new-stubs clean.

--- a/.project/stories/SHY-0239-gauntlet-v2-pause-ping-self-notify.md
+++ b/.project/stories/SHY-0239-gauntlet-v2-pause-ping-self-notify.md
@@ -1,6 +1,6 @@
 ---
 id: SHY-0239
-status: In Progress
+status: In Review
 owner: claude
 created: 2026-07-25
 priority: P1
@@ -173,3 +173,5 @@ This delivers the operator's verbatim intent — *"pause + ping for PIN before s
 - **I6/I7 — `on_signal`'s new `aborted` event + `emit_event`'s unwritable-`RUN_DIR` guard had no behavioural proof.** Added real tests (drive `on_signal 130` in lib mode → `aborted` in `events.log`; `notify` against a `/nonexistent` `RUN_DIR` → survives, RC 0, console line still printed).
 - **Minors (all applied):** event-order pin (pin-wait before pin-ready), missing-detail-arg tolerance, `-h` no-code-leak pin, `--status` AC wording (pin-wait carries a tab-reason), README `PIN_GATE_TIMEOUT` knob row.
 - Gates: **58 gauntlet-v2 tests green** (SHY-0238's 29 + these 29 = 12 structural + 17 behavioural); FAIL-on-timeout + the fail-fast guard both mutation-proven; `bash -n` + shellcheck + eslint `--max-warnings=0` + prettier + no-new-stubs clean.
+
+Reviewed-up-to: 125cd34dafae29cfaec2ddba42a899024b4cad3e

--- a/express-api/scripts/gauntlet/README.md
+++ b/express-api/scripts/gauntlet/README.md
@@ -117,7 +117,8 @@ stack is down, seeding fails, or no physical iPhone is visible to
 
 ## Environment knobs
 
-| Variable       | Default                            | Meaning                                 |
-| -------------- | ---------------------------------- | --------------------------------------- |
-| `SHYTALK_REPO` | auto-detected from script location | repo checkout the scripts operate on    |
-| `GAUNTLET_TMP` | `/tmp/shytalk-gauntlet`            | where run artifacts/logs/sentinels live |
+| Variable           | Default                            | Meaning                                                                                                                   |
+| ------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `SHYTALK_REPO`     | auto-detected from script location | repo checkout the scripts operate on                                                                                      |
+| `GAUNTLET_TMP`     | `/tmp/shytalk-gauntlet`            | where run artifacts/logs/sentinels live                                                                                   |
+| `PIN_GATE_TIMEOUT` | `1800`                             | seconds `gauntlet-v2.sh`'s PIN-ready gate waits for confirm before failing the run (non-integer → clamped to the default) |

--- a/express-api/scripts/gauntlet/gauntlet-v2.sh
+++ b/express-api/scripts/gauntlet/gauntlet-v2.sh
@@ -25,10 +25,17 @@
 #   --reset-app     pm clear the app (signed-out) during device prep
 #   --fresh         full teardown before bring-up
 #   --no-matrix     don't dispatch the matrix (frameworks only)
+#   --no-pin-gate   skip the PIN-ready start gate (devices already prepared)
 #   --target <t>    matrix target: local (default) | dev
+#   --status [dir]  print the current run state (complete/failed/pin-wait/
+#                   running/died) for the latest run (or <dir>) and exit
 #
-# Self-notify on complete/fail + PIN pause/ping arrive in SHY-0239; the pre-flight
-# smoke + cross-platform coverage in SHY-0240. This story is the overlap core.
+# Before dispatch a PIN-ready gate pauses + pings (console + phone) until the
+# operator confirms the devices are unlocked + secure-lock-disabled (SHY-0239);
+# the run then self-notifies (console + phone) on the first failure, on
+# completion, and on any abort. The phone leg is assistant-mediated: the script
+# emits events, the orchestrating assistant bridges them to PushNotification.
+# The pre-flight smoke + cross-platform coverage arrive in SHY-0240.
 set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
@@ -75,6 +82,7 @@ wait_overlapped() {
     else
       warn "${OVERLAP_NAMES[$i]} FAILED — $RUN_DIR/${OVERLAP_NAMES[$i]}.log"
       FAILED_STEPS+=("${OVERLAP_NAMES[$i]}")
+      notify_first_fail "${OVERLAP_NAMES[$i]}"
     fi
   done
   OVERLAP_PIDS=()
@@ -101,6 +109,7 @@ reap_overlapped() {
 # would kill the suites yet march on into the hours-long matrix-wait. Reap, then
 # actually terminate with the conventional 128+signal code.
 on_signal() { # <exit-code>
+  emit_event aborted "interrupted (signal ${1:-})"
   reap_overlapped
   trap - EXIT INT TERM
   exit "${1:-143}"
@@ -117,7 +126,96 @@ run_logged() { # <name> <cmd...>
   else
     warn "$name FAILED — $logf"
     FAILED_STEPS+=("$name")
+    notify_first_fail "$name"
   fi
+}
+
+# ── SHY-0239: phase banner + self-notify + PIN-ready gate + status reader ────
+# phase() lives here (above the lib-mode return) so pin_ready_gate can set the
+# run phase when the behavioural tests drive it in lib mode.
+phase() { PHASE="$1"; log "━━━ PHASE: $1 ━━━"; }
+
+# Append-only, timestamped, tab-separated event trail under RUN_DIR. Pure append
+# (guarded) so it is safe to call from the ERR/signal traps without re-entering.
+emit_event() { # <event> <detail>
+  { printf '%s\t%s\t%s\t%s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$1" "${PHASE:-}" "${2:-}" \
+      >> "$RUN_DIR/events.log"; } 2>/dev/null || true
+}
+
+# Loud, colour-distinct console line (+ terminal bell) AND an event — the self-
+# notify. The console half is pure bash; the phone half is the orchestrating
+# assistant bridging events.log to PushNotification (operator's channel choice).
+notify() { # <event> <detail>
+  emit_event "$1" "${2:-}"
+  printf '\033[1;35m[notify] %s\033[0m %s\a\n' "$1" "${2:-}"
+}
+
+# Fail-fast: the FIRST recorded step failure pings once (phone-worthy); later
+# failures stay console WARNs only — no per-failure notification spam.
+NOTIFIED_FIRST_FAIL=0
+notify_first_fail() { # <failed-step-name>
+  [ "$NOTIFIED_FIRST_FAIL" = "1" ] && return 0
+  NOTIFIED_FIRST_FAIL=1
+  notify suite-fail "first failure: $1 (run continues best-effort; see final tally)"
+}
+
+# PIN-ready START gate: pause + ping + await explicit confirm BEFORE any device
+# is touched. The real PIN fix is up-front prep (secure lock disabled, iPhone
+# unlocked + trusted), so this is the checkpoint — not a mid-run pause (the
+# detached runner is unattended by design). Bounded by PIN_GATE_TIMEOUT: a gate
+# that never returns is worse than a FAIL (the SHY-0238 matrix-wait liveness).
+#   TTY     → interactive `read -t` (operator presses Enter).
+#   non-TTY → wait for a PIN_READY token file (operator/assistant touches it).
+pin_ready_gate() {
+  [ "${PIN_GATE:-1}" = "1" ] || return 0
+  [ "${MATRIX:-1}" = "1" ] || return 0
+  phase "pin-ready-gate"
+  local reason="Unlock BOTH devices, DISABLE the Android secure lock, unlock + trust the iPhone, then confirm."
+  printf '%s\n' "$reason" > "$RUN_DIR/PIN_WAIT"
+  notify pin-wait "$reason"
+  local timeout="${PIN_GATE_TIMEOUT:-1800}"
+  # Fail-safe the bound: a non-integer timeout makes `read -t` / the numeric
+  # compare error every iteration and the gate would hang FOREVER — the very
+  # thing the bound exists to prevent. Clamp bad input to the default, loudly.
+  case "$timeout" in ''|*[!0-9]*) warn "PIN_GATE_TIMEOUT='$timeout' is not a non-negative integer — using 1800"; timeout=1800 ;; esac
+  if [ -t 0 ]; then
+    if read -t "$timeout" -r -p "▶ Press Enter when the devices are PIN-ready (Ctrl-C to abort)… " _; then
+      touch "$RUN_DIR/PIN_READY"
+    else
+      # not confirmed: fail the run. Write FAIL explicitly (belt) so the sentinel
+      # is guaranteed even in lib mode (no ERR trap); the bare call ALSO fires
+      # ERR→on_fail (suspenders). Matches gauntlet.sh's proven mid-run idiom.
+      rm -f "$RUN_DIR/PIN_WAIT"
+      notify aborted "PIN-ready gate timed out after ${timeout}s with no confirm"
+      touch "$RUN_DIR/FAIL"; return 1
+    fi
+  else
+    local waited=0
+    while [ ! -e "$RUN_DIR/PIN_READY" ]; do
+      if [ "$waited" -ge "$timeout" ]; then
+        rm -f "$RUN_DIR/PIN_WAIT"
+        notify aborted "PIN-ready gate timed out after ${timeout}s with no confirm"
+        touch "$RUN_DIR/FAIL"; return 1
+      fi
+      sleep 1
+      waited=$((waited + 1))
+    done
+  fi
+  rm -f "$RUN_DIR/PIN_WAIT"
+  notify pin-ready "devices confirmed PIN-ready — dispatching"
+}
+
+# Single-shot run-state reader for the assistant's per-checkpoint wake (no loop,
+# no polling). Precedence: DONE > FAIL > PIN_WAIT > live-pid running > died.
+cmd_status() { # [run_dir]
+  local dir="${1:-}"
+  [ -n "$dir" ] || dir="$(readlink "$GAUNTLET_TMP/latest-v2" 2>/dev/null || true)"
+  if [ -z "$dir" ] || [ ! -d "$dir" ]; then echo "unknown"; return 0; fi
+  if [ -e "$dir/DONE" ]; then echo "complete"; return 0; fi
+  if [ -e "$dir/FAIL" ]; then echo "failed"; return 0; fi
+  if [ -e "$dir/PIN_WAIT" ]; then printf 'pin-wait\t%s\n' "$(cat "$dir/PIN_WAIT" 2>/dev/null | head -1)"; return 0; fi
+  local pid; pid="$(cat "$dir/pid" 2>/dev/null || true)"
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then echo "running"; else echo "died"; fi
 }
 
 # Library mode: sourced by the behavioural tests to exercise the helpers above
@@ -125,9 +223,13 @@ run_logged() { # <name> <cmd...>
 # any orchestration side effect.
 [ -n "${GAUNTLET_V2_LIB:-}" ] && return 0 2>/dev/null
 
+# --status [dir]: single-shot state read for the assistant's per-checkpoint wake
+# (resolve + print + exit before any orchestration side effect).
+[ "${1:-}" = "--status" ] && { cmd_status "${2:-}"; exit 0; }
+
 # ── flags ──────────────────────────────────────────────────────────────────
 FRAMEWORKS=0 ANDROID_BDD=0 IOS=0 INSTALL_APK=0 RESET_APP=0 FRESH=0 MATRIX=1
-TARGET="local"
+PIN_GATE=1 TARGET="local"
 while [ $# -gt 0 ]; do
   case "$1" in
     --frameworks) FRAMEWORKS=1 ;;
@@ -137,8 +239,9 @@ while [ $# -gt 0 ]; do
     --reset-app) RESET_APP=1 ;;
     --fresh) FRESH=1 ;;
     --no-matrix) MATRIX=0 ;;
+    --no-pin-gate) PIN_GATE=0 ;;
     --target) shift; TARGET="${1:?--target needs a value}" ;;
-    -h|--help) sed -n '2,33p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help) sed -n '2,/^set -uo/p' "$0" | sed '$d; s/^# \{0,1\}//'; exit 0 ;;
     *) die "unknown flag: $1 (see --help)" ;;
   esac
   shift
@@ -148,12 +251,14 @@ case "$TARGET" in local|dev) ;; *) die "--target must be local or dev" ;; esac
 RUN_ID="$(date +%Y%m%d-%H%M%S)-v2"
 RUN_DIR="$GAUNTLET_TMP/$RUN_ID"
 mkdir -p "$RUN_DIR"
+echo $$ > "$RUN_DIR/pid"   # the orchestrator's own pid — cmd_status liveness check
 ln -sfn "$RUN_DIR" "$GAUNTLET_TMP/latest-v2"
 caffeinate -i -w $$ &   # keep the Mac awake while this run lives
 
 TAIL_PID=""
 on_fail() {
   touch "$RUN_DIR/FAIL"
+  emit_event failed "fatal at phase ${PHASE:-startup}"
   printf '\033[1;31mGAUNTLET v2 FAILED at phase: %s — log dir: %s\033[0m\n' "${PHASE:-startup}" "$RUN_DIR" >&2
 }
 trap on_fail ERR
@@ -162,8 +267,8 @@ trap 'on_signal 130' INT    # reap + exit (130 = 128+SIGINT) — an interrupt mu
 trap 'on_signal 143' TERM   # reap + exit (143 = 128+SIGTERM)
 set -e   # arm AFTER the traps (SHY-0236: a die before the trap writes no sentinel)
 
-phase() { PHASE="$1"; log "━━━ PHASE: $1 ━━━"; }
 FAILED_STEPS=()
+notify start "gauntlet v2 run $RUN_ID (target=$TARGET)"
 
 MATRIX_DIR="" MATRIX_LOG="" MATRIX_PID=""
 
@@ -171,6 +276,11 @@ MATRIX_DIR="" MATRIX_LOG="" MATRIX_PID=""
 phase "prereqs"; bash "$HERE/00-prereqs.sh"
 phase "services"
 if [ "$FRESH" = "1" ]; then bash "$HERE/10-services.sh" --fresh; else bash "$HERE/10-services.sh"; fi
+
+# PIN-ready gate: pause + ping until the operator confirms the devices are
+# unlocked + secure-lock-disabled, BEFORE any device is touched (SHY-0239).
+# No-op under --no-pin-gate or --no-matrix.
+pin_ready_gate
 
 # Optional APK (re)build / app reset must happen BEFORE dispatch — 50-matrix's
 # own device prep (30-android.sh with no args) does not install/reset. Its
@@ -234,6 +344,7 @@ if [ "$MATRIX" = "1" ] && [ -n "$MATRIX_DIR" ]; then
   if [ -e "$MATRIX_DIR/FAIL" ]; then
     warn "device journey matrix FAILED — results: bash $HERE/50-matrix.sh results"
     FAILED_STEPS+=("journey-matrix")
+    notify_first_fail "journey-matrix"
   else
     ok "device journey matrix passed"
   fi
@@ -267,6 +378,7 @@ fi
 if [ "${#FAILED_STEPS[@]}" -gt 0 ]; then
   touch "$RUN_DIR/FAIL"
   trap - ERR
+  notify failed "${#FAILED_STEPS[@]} step(s) failed: ${FAILED_STEPS[*]}"
   printf '\033[1;31mGAUNTLET v2 completed WITH %d FAILED STEP(S): %s\033[0m\n' \
     "${#FAILED_STEPS[@]}" "${FAILED_STEPS[*]}" >&2
   log "artifacts in $RUN_DIR"
@@ -275,5 +387,6 @@ fi
 
 touch "$RUN_DIR/DONE"
 trap - ERR
+notify complete "all green — artifacts in $RUN_DIR"
 phase "done"
 log "gauntlet v2 complete — artifacts in $RUN_DIR"

--- a/express-api/tests/scripts/gauntlet-v2-notify-structure.test.js
+++ b/express-api/tests/scripts/gauntlet-v2-notify-structure.test.js
@@ -1,0 +1,183 @@
+'use strict';
+
+// SHY-0239 — structural invariants for the Gauntlet v2 self-notify + PIN-ready
+// gate + status reader added to express-api/scripts/gauntlet/gauntlet-v2.sh.
+//
+// As with SHY-0238, the full orchestrator can't be unit-run (Docker, emulators,
+// devices, hours-long suites), but its load-bearing control-flow IS greppable:
+// the gate lands BEFORE any device dispatch, is guarded + bounded, the notify
+// hooks attach to the right lifecycle points, and the helpers stay in the
+// library-mode section so the behavioural file can drive them for real. The
+// behavioural pins live in gauntlet-v2-notify.test.js.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/gauntlet/gauntlet-v2.sh');
+const src = fs.readFileSync(SCRIPT, 'utf8');
+const lines = src.split('\n');
+
+const at = (re) => lines.findIndex((l) => re.test(l));
+// Extract a shell function body ("name() { … \n}") for site-scoped assertions.
+const bodyOf = (name) => {
+  const m = src.match(new RegExp(`${name}\\(\\)\\s*\\{[\\s\\S]*?\\n\\}`));
+  return m ? m[0] : null;
+};
+
+describe('gauntlet-v2.sh — helpers stay library-testable (SHY-0239)', () => {
+  const libIdx = at(/GAUNTLET_V2_LIB.*&&\s*return 0/);
+
+  test('the new helpers are defined ABOVE the lib-mode early-return', () => {
+    // The behavioural tests source the script in lib mode and call these — so
+    // each MUST be defined before the GAUNTLET_V2_LIB return, like the SHY-0238
+    // overlap helpers.
+    for (const fn of [
+      'emit_event',
+      'notify',
+      'notify_first_fail',
+      'pin_ready_gate',
+      'cmd_status',
+    ]) {
+      const defIdx = at(new RegExp(`^${fn}\\(\\)`));
+      expect(defIdx).toBeGreaterThan(-1);
+      expect(defIdx).toBeLessThan(libIdx);
+    }
+  });
+
+  test('phase() is defined above the lib-return so the gate can set its phase in lib mode', () => {
+    const phaseIdx = at(/^phase\(\)\s*\{/);
+    expect(phaseIdx).toBeGreaterThan(-1);
+    expect(phaseIdx).toBeLessThan(libIdx);
+  });
+});
+
+describe('gauntlet-v2.sh — the PIN-ready START gate (SHY-0239)', () => {
+  test('the gate is invoked BEFORE android-prep, matrix-dispatch, and the first overlap', () => {
+    // The gate must pause before ANY device is touched. Pin the CALL site
+    // (bare `pin_ready_gate` at column 0), not the function definition.
+    const callIdx = at(/^pin_ready_gate$/);
+    const servicesIdx = at(/phase "services"/);
+    const dispatchIdx = at(/50-matrix\.sh" launch/);
+    const overlapIdx = at(/start_overlapped /);
+    expect(callIdx).toBeGreaterThan(-1);
+    expect(callIdx).toBeGreaterThan(servicesIdx); // after the stack is up
+    expect(callIdx).toBeLessThan(dispatchIdx); // before the devices run
+    expect(callIdx).toBeLessThan(overlapIdx);
+  });
+
+  test('the gate is guarded (skippable) and writes the PIN_WAIT marker', () => {
+    const body = bodyOf('pin_ready_gate');
+    expect(body).not.toBeNull();
+    expect(body).toMatch(/PIN_GATE/); // --no-pin-gate escape
+    expect(body).toMatch(/MATRIX/); // no devices ⇒ no gate
+    expect(body).toMatch(/> "\$RUN_DIR\/PIN_WAIT"/); // writes the marker
+    expect(body).toMatch(/rm -f "\$RUN_DIR\/PIN_WAIT"/); // clears it on release
+    expect(body).toMatch(/notify pin-wait/);
+    expect(body).toMatch(/notify pin-ready/);
+  });
+
+  test('the gate is BOUNDED (no infinite hang) with both a TTY and a non-TTY path', () => {
+    // A release gate that never returns is worse than a FAIL — the SHY-0238
+    // matrix-wait liveness discipline. TTY ⇒ `read -t <timeout>`; non-TTY ⇒
+    // wait for the PIN_READY token, also bounded.
+    const body = bodyOf('pin_ready_gate');
+    expect(body).toMatch(/PIN_GATE_TIMEOUT/);
+    expect(body).toMatch(/\[ -t 0 \]/); // TTY branch
+    expect(body).toMatch(/read -t "\$timeout"/); // bounded interactive read
+    expect(body).toMatch(/PIN_READY/); // non-TTY confirm token
+    expect(body).toMatch(/notify aborted/); // timeout ⇒ aborted
+    // On timeout it writes FAIL EXPLICITLY (belt) + `return 1` (suspenders:
+    // ERR→on_fail). NOT die/exit, which would skip the sentinel and leave
+    // cmd_status reporting "died". BOTH timeout branches must do this.
+    expect(body).toMatch(/touch "\$RUN_DIR\/FAIL"; return 1/);
+    expect(body).not.toMatch(/\bdie\b/); // die/exit would bypass the sentinel
+    // a non-integer PIN_GATE_TIMEOUT is clamped (not left to hang forever)
+    expect(body).toMatch(/not a non-negative integer/);
+  });
+});
+
+describe('gauntlet-v2.sh — event-driven self-notify (SHY-0239)', () => {
+  test('emit_event appends to events.log; notify also prints a [notify] console line', () => {
+    const emit = bodyOf('emit_event');
+    expect(emit).not.toBeNull();
+    expect(emit).toMatch(/>> "\$RUN_DIR\/events\.log"/);
+    // pure-append + guarded so it is safe to call from the ERR/signal traps
+    expect(emit).toMatch(/2>\/dev\/null \|\| true/);
+
+    const notify = bodyOf('notify');
+    expect(notify).not.toBeNull();
+    expect(notify).toMatch(/emit_event/);
+    expect(notify).toMatch(/\[notify\]/);
+  });
+
+  test('fail-fast: every failure-recording site routes through the once-only notify', () => {
+    // The FIRST failure pings; later ones are console WARNs only.
+    const guard = bodyOf('notify_first_fail');
+    expect(guard).not.toBeNull();
+    expect(guard).toMatch(/NOTIFIED_FIRST_FAIL/);
+    expect(guard).toMatch(/notify suite-fail/);
+
+    for (const fn of ['wait_overlapped', 'run_logged']) {
+      expect(bodyOf(fn)).toMatch(/notify_first_fail/);
+    }
+    // the matrix-wait FAIL branch too
+    const waitBlock = src.match(/phase "matrix-wait"[\s\S]*?\n {2}done/);
+    expect(waitBlock).not.toBeNull();
+    // the journey-matrix failure is recorded just after the block; assert the
+    // notify sits with the FAILED_STEPS+=("journey-matrix") record.
+    const matrixFail = src.match(/FAILED_STEPS\+=\("journey-matrix"\)[\s\S]{0,120}/);
+    expect(matrixFail[0]).toMatch(/notify_first_fail/);
+  });
+
+  test('terminal notify is wired into the tally, the signal trap, and the ERR trap', () => {
+    // complete / failed on the tally
+    const failBranch = src.match(/if \[ "\$\{#FAILED_STEPS\[@\]\}" -gt 0 \]; then[\s\S]*?\nfi/);
+    expect(failBranch[0]).toMatch(/notify failed/);
+    expect(src).toMatch(/notify complete/);
+    // aborted from on_signal (pure emit_event — safe inside a trap)
+    expect(bodyOf('on_signal')).toMatch(/emit_event aborted/);
+    // failed event from the ERR trap (pure emit_event) — and it writes the FAIL
+    // sentinel the gate's `return 1` relies on (remove it and the gate-timeout
+    // path would silently stop failing the run).
+    expect(bodyOf('on_fail')).toMatch(/emit_event failed/);
+    expect(bodyOf('on_fail')).toMatch(/touch "\$RUN_DIR\/FAIL"/);
+  });
+
+  test('a run start marker + a pid file are written for the status reader', () => {
+    expect(src).toMatch(/echo \$\$ > "\$RUN_DIR\/pid"/);
+    expect(src).toMatch(/notify start/);
+  });
+});
+
+describe('gauntlet-v2.sh — the --status reader (SHY-0239)', () => {
+  test('--status short-circuits BEFORE the orchestration (never brings a stack up)', () => {
+    const statusIdx = at(/--status".*cmd_status|cmd_status "\$\{2/);
+    const runIdIdx = at(/^RUN_ID=/);
+    expect(statusIdx).toBeGreaterThan(-1);
+    expect(statusIdx).toBeLessThan(runIdIdx); // resolves + exits before any side effect
+  });
+
+  test('cmd_status encodes the DONE > FAIL > PIN_WAIT > running/died precedence', () => {
+    const body = bodyOf('cmd_status');
+    expect(body).not.toBeNull();
+    // ordering of the branches is the precedence — assert DONE precedes FAIL
+    // precedes PIN_WAIT precedes the pid-liveness split.
+    const iDone = body.indexOf('DONE');
+    const iFail = body.indexOf('FAIL');
+    const iPin = body.indexOf('PIN_WAIT');
+    const iPid = body.indexOf('kill -0');
+    expect(iDone).toBeGreaterThan(-1);
+    expect(iDone).toBeLessThan(iFail);
+    expect(iFail).toBeLessThan(iPin);
+    expect(iPin).toBeLessThan(iPid);
+    expect(body).toMatch(/complete/);
+    expect(body).toMatch(/failed/);
+    expect(body).toMatch(/pin-wait/);
+    expect(body).toMatch(/running/);
+    expect(body).toMatch(/died/);
+  });
+
+  test('--no-pin-gate is a parsed flag', () => {
+    expect(src).toMatch(/--no-pin-gate\)/);
+  });
+});

--- a/express-api/tests/scripts/gauntlet-v2-notify.test.js
+++ b/express-api/tests/scripts/gauntlet-v2-notify.test.js
@@ -1,0 +1,286 @@
+'use strict';
+
+// SHY-0239 — BEHAVIOURAL (real-execution) coverage for the Gauntlet v2 self-
+// notify + PIN-ready gate + status reader (gauntlet-v2.sh).
+//
+// gauntlet-v2.sh's library mode (GAUNTLET_V2_LIB=1) lets us source it and drive
+// notify / pin_ready_gate / notify_first_fail for real against throwaway files
+// and processes — no Docker, emulators, or devices. The --status reader is
+// exercised through the REAL entrypoint (`bash gauntlet-v2.sh --status <dir>`).
+// Mirrors SHY-0236/0238: the stubs are genuine shell processes + files the
+// harness runs, never mocked collaborators. Structural pins: the companion file.
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/gauntlet/gauntlet-v2.sh');
+
+// Run a bash body with the v2 helpers sourced (lib mode) + a fresh RUN_DIR.
+function runLib(body, extraEnv = '', timeout = 20000) {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shy0239-'));
+  const script = `
+    set -uo pipefail
+    export GAUNTLET_V2_LIB=1
+    RUN_DIR="${runDir}"
+    FAILED_STEPS=()
+    ${extraEnv}
+    source "${SCRIPT}" 2>/dev/null
+    ${body}
+  `;
+  const result = spawnSync('/bin/bash', ['-c', script], { encoding: 'utf8', timeout });
+  return { result, runDir };
+}
+
+// Run the REAL entrypoint (not lib mode).
+const runStatus = (dir) =>
+  spawnSync('/bin/bash', [SCRIPT, '--status', dir], { encoding: 'utf8', timeout: 10000 });
+
+describe('notify / emit_event — real event trail (SHY-0239)', () => {
+  test('notify appends a parseable tab-separated event AND prints [notify]', () => {
+    const { result, runDir } = runLib(`
+      PHASE="demo"
+      notify pin-wait "devices please"
+    `);
+    // console
+    expect(result.stdout).toMatch(/\[notify\] pin-wait/);
+    // file: <iso-ts> \t <event> \t <phase> \t <detail>
+    const events = fs.readFileSync(path.join(runDir, 'events.log'), 'utf8').trim();
+    const cols = events.split('\t');
+    expect(cols[1]).toBe('pin-wait');
+    expect(cols[2]).toBe('demo');
+    expect(cols[3]).toBe('devices please');
+  });
+
+  test('notify tolerates a missing detail arg without crashing', () => {
+    const { result, runDir } = runLib(`
+      notify start
+      echo "RC=$?"
+    `);
+    expect(result.stdout).toMatch(/RC=0/);
+    expect(result.stdout).toMatch(/\[notify\] start/);
+    expect(fs.readFileSync(path.join(runDir, 'events.log'), 'utf8')).toMatch(/\tstart\t/);
+  });
+
+  test('emit_event/notify survive an unwritable RUN_DIR (guarded — safe in traps)', () => {
+    // emit_event fires from on_fail/on_signal when things are already going wrong;
+    // a bad RUN_DIR must NOT crash the trap. Point it at a non-writable path.
+    const { result } = runLib(`
+      RUN_DIR=/nonexistent/shy0239/nope
+      notify complete "done anyway"
+      echo "RC=$?"
+    `);
+    expect(result.stdout).toMatch(/RC=0/); // guarded append swallowed the failure
+    expect(result.stdout).toMatch(/\[notify\] complete/); // console line still printed
+  });
+});
+
+describe('on_signal — an interrupt emits an aborted event (SHY-0239)', () => {
+  test('on_signal writes an aborted event before reaping + exiting 128+sig', () => {
+    // on_signal is reachable in lib mode (defined above the GAUNTLET_V2_LIB
+    // return). The SHY-0238 test proved reap+exit; this proves the new event.
+    const { result, runDir } = runLib(`
+      ( on_signal 130 ); echo "RC=$?"
+    `);
+    expect(result.stdout).toMatch(/RC=130/); // 128 + SIGINT
+    expect(fs.readFileSync(path.join(runDir, 'events.log'), 'utf8')).toMatch(/\taborted\t/);
+  });
+});
+
+describe('pin_ready_gate — real pause/confirm (SHY-0239)', () => {
+  test('non-TTY: blocks with PIN_WAIT, releases when PIN_READY appears', () => {
+    // spawnSync gives no controlling TTY ⇒ the non-TTY (token-file) path.
+    const { result, runDir } = runLib(
+      `
+      ( pin_ready_gate ) &
+      gate=$!
+      for _ in $(seq 1 100); do [ -e "$RUN_DIR/PIN_WAIT" ] && break; sleep 0.05; done
+      [ -e "$RUN_DIR/PIN_WAIT" ] && echo "WAIT=PRESENT" || echo "WAIT=MISSING"
+      touch "$RUN_DIR/PIN_READY"
+      wait "$gate"; echo "GATE_RC=$?"
+      [ -e "$RUN_DIR/PIN_WAIT" ] && echo "WAIT=STILL" || echo "WAIT=CLEARED"
+    `,
+      'PIN_GATE=1 MATRIX=1 PIN_GATE_TIMEOUT=30',
+    );
+    expect(result.stdout).toMatch(/WAIT=PRESENT/); // really blocked on the marker
+    expect(result.stdout).toMatch(/GATE_RC=0/); // released cleanly
+    expect(result.stdout).toMatch(/WAIT=CLEARED/); // marker removed on release
+    const events = fs.readFileSync(path.join(runDir, 'events.log'), 'utf8');
+    expect(events).toMatch(/\tpin-wait\t/);
+    expect(events).toMatch(/\tpin-ready\t/);
+    // …and in that ORDER — wait announced before the release (not just both present)
+    expect(events.indexOf('\tpin-wait\t')).toBeLessThan(events.indexOf('\tpin-ready\t'));
+  });
+
+  test('non-TTY: the gate refuses to hang forever (bounded timeout ⇒ aborted + FAIL + non-zero)', () => {
+    // PIN_GATE_TIMEOUT=1, no confirm ⇒ the gate must clear PIN_WAIT, write FAIL,
+    // and return non-zero. Subshell so the failure doesn't kill the harness shell.
+    const { result, runDir } = runLib(
+      `
+      ( pin_ready_gate ); echo "GATE_RC=$?"
+      [ -e "$RUN_DIR/PIN_WAIT" ] && echo "WAIT=STILL" || echo "WAIT=CLEARED"
+      [ -e "$RUN_DIR/FAIL" ] && echo "FAIL=WRITTEN" || echo "FAIL=MISSING"
+    `,
+      'PIN_GATE=1 MATRIX=1 PIN_GATE_TIMEOUT=1',
+    );
+    expect(result.stdout).toMatch(/GATE_RC=[1-9]/); // non-zero
+    expect(result.stdout).toMatch(/WAIT=CLEARED/);
+    // the sentinel is written EXPLICITLY (proven even in lib mode with no ERR trap)
+    expect(result.stdout).toMatch(/FAIL=WRITTEN/);
+    const events = fs.readFileSync(path.join(runDir, 'events.log'), 'utf8');
+    expect(events).toMatch(/\taborted\t/);
+  });
+
+  test('a non-integer PIN_GATE_TIMEOUT is clamped, not left to hang', () => {
+    // Garbage timeout ⇒ warn + clamp to 1800 (would otherwise loop forever on the
+    // failing numeric compare). Prove no-hang by releasing via PIN_READY at once.
+    const { result } = runLib(
+      `
+      ( pin_ready_gate ) &
+      gate=$!
+      for _ in $(seq 1 100); do [ -e "$RUN_DIR/PIN_WAIT" ] && break; sleep 0.05; done
+      touch "$RUN_DIR/PIN_READY"
+      wait "$gate"; echo "GATE_RC=$?"
+    `,
+      'PIN_GATE=1 MATRIX=1 PIN_GATE_TIMEOUT=abc',
+    );
+    expect(result.stdout).toMatch(/GATE_RC=0/); // released — did not hang or abort
+    expect(result.stderr).toMatch(/not a non-negative integer/); // clamp warned loudly
+  });
+
+  test('skippable: --no-pin-gate (PIN_GATE=0) returns immediately, writes no PIN_WAIT', () => {
+    const { result, runDir } = runLib(
+      `
+      pin_ready_gate; echo "GATE_RC=$?"
+      [ -e "$RUN_DIR/PIN_WAIT" ] && echo "WAIT=PRESENT" || echo "WAIT=NONE"
+    `,
+      'PIN_GATE=0 MATRIX=1 PIN_GATE_TIMEOUT=30',
+    );
+    expect(result.stdout).toMatch(/GATE_RC=0/);
+    expect(result.stdout).toMatch(/WAIT=NONE/);
+    expect(fs.existsSync(path.join(runDir, 'events.log'))).toBe(false);
+  });
+
+  test('skippable: a no-matrix run (MATRIX=0) also skips the gate (2nd AC condition)', () => {
+    const { result } = runLib(
+      `
+      pin_ready_gate; echo "GATE_RC=$?"
+      [ -e "$RUN_DIR/PIN_WAIT" ] && echo "WAIT=PRESENT" || echo "WAIT=NONE"
+    `,
+      'PIN_GATE=1 MATRIX=0 PIN_GATE_TIMEOUT=30',
+    );
+    expect(result.stdout).toMatch(/GATE_RC=0/);
+    expect(result.stdout).toMatch(/WAIT=NONE/);
+  });
+});
+
+describe('fail-fast — the first failure pings once (SHY-0239)', () => {
+  test('two failures ⇒ exactly one suite-fail event', () => {
+    const { runDir } = runLib(`
+      notify_first_fail alpha
+      notify_first_fail beta
+    `);
+    const events = fs.readFileSync(path.join(runDir, 'events.log'), 'utf8').trim().split('\n');
+    const fails = events.filter((l) => l.split('\t')[1] === 'suite-fail');
+    expect(fails).toHaveLength(1);
+    expect(fails[0]).toMatch(/alpha/); // the FIRST one
+    expect(fails[0]).not.toMatch(/beta/);
+  });
+});
+
+describe('--status — single-shot run-state reader (SHY-0239)', () => {
+  const freshDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'shy0239-st-'));
+
+  test('DONE ⇒ complete (and wins over a co-existing FAIL/PIN_WAIT)', () => {
+    const dir = freshDir();
+    fs.writeFileSync(path.join(dir, 'FAIL'), '');
+    fs.writeFileSync(path.join(dir, 'PIN_WAIT'), 'x');
+    fs.writeFileSync(path.join(dir, 'DONE'), '');
+    expect(runStatus(dir).stdout.trim()).toBe('complete');
+  });
+
+  test('FAIL only ⇒ failed', () => {
+    const dir = freshDir();
+    fs.writeFileSync(path.join(dir, 'FAIL'), '');
+    expect(runStatus(dir).stdout.trim()).toBe('failed');
+  });
+
+  test('PIN_WAIT only ⇒ pin-wait (with the reason)', () => {
+    const dir = freshDir();
+    fs.writeFileSync(path.join(dir, 'PIN_WAIT'), 'unlock the devices\n');
+    const r = runStatus(dir);
+    expect(r.stdout).toMatch(/^pin-wait\t/);
+    expect(r.stdout).toMatch(/unlock the devices/);
+  });
+
+  test('live pid + no sentinel ⇒ running; dead pid + no sentinel ⇒ died', () => {
+    // Arrange the pid file + call the real entrypoint in ONE bash script so the
+    // liveness read happens while the process is genuinely alive / already dead.
+    const dir = freshDir();
+    const running = spawnSync(
+      '/bin/bash',
+      [
+        '-c',
+        `
+      sleep 5 & p=$!
+      echo "$p" > "${dir}/pid"
+      bash "${SCRIPT}" --status "${dir}"
+      kill "$p" 2>/dev/null || true
+    `,
+      ],
+      { encoding: 'utf8', timeout: 10000 },
+    );
+    expect(running.stdout.trim()).toBe('running');
+
+    const dir2 = freshDir();
+    const died = spawnSync(
+      '/bin/bash',
+      [
+        '-c',
+        `
+      bash -c 'exit 0' & p=$!; wait "$p"   # p is now reaped/dead
+      echo "$p" > "${dir2}/pid"
+      bash "${SCRIPT}" --status "${dir2}"
+    `,
+      ],
+      { encoding: 'utf8', timeout: 10000 },
+    );
+    expect(died.stdout.trim()).toBe('died');
+  });
+
+  test('a run dir with nothing ⇒ died (pid file absent) and a missing dir ⇒ unknown', () => {
+    const dir = freshDir(); // exists but empty, no pid
+    expect(runStatus(dir).stdout.trim()).toBe('died');
+    expect(runStatus('/nonexistent/shy0239/nope').stdout.trim()).toBe('unknown');
+  });
+
+  test('--status with NO dir resolves the latest-v2 run (AC default)', () => {
+    // Point GAUNTLET_TMP at a scratch root with a latest-v2 symlink, then call
+    // --status with no arg → it must resolve + report that run.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'shy0239-gt-'));
+    const run = path.join(tmp, '20260101-000000-v2');
+    fs.mkdirSync(run);
+    fs.writeFileSync(path.join(run, 'DONE'), '');
+    fs.symlinkSync(run, path.join(tmp, 'latest-v2'));
+    const r = spawnSync('/bin/bash', [SCRIPT, '--status'], {
+      encoding: 'utf8',
+      timeout: 10000,
+      env: { ...process.env, GAUNTLET_TMP: tmp },
+    });
+    expect(r.stdout.trim()).toBe('complete');
+  });
+});
+
+describe('gauntlet-v2.sh --help — no code leaks into the usage (SHY-0239)', () => {
+  test('-h prints the comment header only, never raw shell', () => {
+    const r = spawnSync('/bin/bash', [SCRIPT, '-h'], { encoding: 'utf8', timeout: 10000 });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/--frameworks/); // real usage content
+    expect(r.stdout).toMatch(/--status/); // the new flag is documented
+    // the range-robust `sed …/^set -uo/…` must stop before the code — a naive
+    // fixed line range previously leaked `set -uo pipefail` + `HERE=` into help.
+    expect(r.stdout).not.toMatch(/set -uo pipefail/);
+    expect(r.stdout).not.toMatch(/HERE=/);
+  });
+});


### PR DESCRIPTION
Implements SHY-0239 — see `.project/stories/SHY-0239-gauntlet-v2-pause-ping-self-notify.md` for full spec, AC, BDD scenarios, and DoD.

## What
Extends the Gauntlet v2 orchestrator (`express-api/scripts/gauntlet/gauntlet-v2.sh`) so the release run stops needing a babysitter:

- **PIN-ready START gate** — before any device is touched, pause + ping and await an explicit confirm (bounded by `PIN_GATE_TIMEOUT`, default 1800s; TTY `read -t` / non-TTY `PIN_READY`-file). The real PIN fix is up-front device prep, so this is the checkpoint — not a mid-run pause (the detached runner is unattended by design).
- **Event-driven self-notify** — an append-only `events.log` + a loud `[notify]` console line (+ bell) at start, pin-wait, pin-ready, the **first** failure (once — no spam), completion, and abort. The console half is pure bash; the **phone** half is assistant-mediated (the script emits events; the orchestrating assistant bridges them to `PushNotification` — the operator's chosen channel — via the sanctioned "detached + one scheduled `--status` check per checkpoint" pattern, no polling loop).
- **`--status [dir]` reader** — single-shot `complete`/`failed`/`pin-wait`/`running`/`died`/`unknown` for the per-checkpoint wake.

## Correctness notes
- Both gate-timeout branches write `FAIL` **explicitly** + `return 1` (belt: provable in lib mode; suspenders: `ERR`→`on_fail`). A `die`/`exit` would bypass the ERR trap and skip the sentinel — a bug the review caught in the non-TTY (primary detached) path.
- A non-integer `PIN_GATE_TIMEOUT` is clamped to the default (would otherwise hang the numeric-compare loop forever — defeating the whole "bounded" purpose).

## Tests / gates
Tooling-only (`scripts/gauntlet/**` + `tests/scripts/**`) — Pre-Merge Protocol tooling exemption; no product runtime surface.
- **58 gauntlet-v2 tests green** (SHY-0238's 29 + 29 new = 12 structural + 17 behavioural, real `spawnSync`/files — no doubles).
- FAIL-on-timeout + fail-fast guard **mutation-proven**.
- `bash -n` + shellcheck + eslint `--max-warnings=0` + prettier + no-new-stubs clean.
- `code-reviewer` R1 (2 Critical + 5 Important + minors) all applied + self-certified (see story Notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)