### PR TITLE
SHY-0243: Make the Linux-CI liveness and git-identity probes honest

### DIFF
--- a/.project/stories/SHY-0243-honest-linux-ci-test-harness.md
+++ b/.project/stories/SHY-0243-honest-linux-ci-test-harness.md
@@ -1,6 +1,6 @@
 ---
 id: SHY-0243
-status: In Progress
+status: In Review
 owner: claude
 created: 2026-07-25
 priority: P0
@@ -168,5 +168,9 @@ Proven before any code was written (Linux container, real `gauntlet-v2.sh`): `re
   The detached-HEAD condition was reproduced non-destructively by mounting a file containing a raw sha over `/repo/.git/HEAD` (`git rev-parse --abbrev-ref HEAD` → `HEAD`), leaving the host working tree untouched.
 
 - **2026-07-25 ~13:35 WIB — class sweep.** Grepped the corpus for both defect shapes. `50-matrix-cmd-stop.test.js` matches on `pgrep -P` (parent PID, exact) or probes via `spawnSync` **from Node**, whose argv never carries the tag; `gauntlet-cold-boot-structure.test.js` only pins the script's source text; `prepush-sonar-main-only-gate.test.js` already documents the literal-`HEAD` case; `android-git-identity-pin.test.js` is a structural pin. The self-match trap requires the probe to run *inside* the `bash -c` whose body holds the tag — no other site does. Class confined to the one file.
+
+- **2026-07-25 ~13:45 WIB — status → In Review.** Implementation complete, both suites green on macOS and Linux, lint clean. CI's Pre-Merge Gate (SHY-0127 Gate 1, `scripts/check-pr-story-status.js`) correctly refused the PR while this story sat at `In Progress` — the newly-added exemption covers `Draft` only. Flipped as the protocol prescribes.
+
+  **Review provenance (honest record):** the `code-reviewer` agent was NOT dispatched — this session carries an explicit "do not call the Agent tool unless requested" constraint. Two self-review passes ran instead and both produced findings that were fixed before push (weak negative assertion; tag-prefix collision hazard). `Reviewed-up-to:` is deliberately NOT claimed. An agent review is owed before merge if the operator wants Gate 3 satisfied in the usual way.
 
 - **2026-07-25 ~13:40 WIB — self-review finding (fixed before push).** The first draft of the hostile-branch case asserted `not.toContain('a<b')`, a substring that never existed in the raw refname `feat/a"b<c&d` — a trivially-passing negative. Replaced with the three pairs that genuinely appear in the raw value (`a"b`, `b<c`, `c&d`); mutation-proven above.

--- a/.project/stories/SHY-0243-honest-linux-ci-test-harness.md
+++ b/.project/stories/SHY-0243-honest-linux-ci-test-harness.md
@@ -1,0 +1,172 @@
+---
+id: SHY-0243
+status: In Progress
+owner: claude
+created: 2026-07-25
+priority: P0
+effort: S
+type: bug
+roadmap_ids: []
+epic: EPIC-0009
+---
+
+# SHY-0243: Two test harnesses lie on Linux CI — make the liveness probe and the git-identity probe environment-honest
+
+## User Story
+
+As **the engineer relying on the develop CI gate to tell the truth about a change**,
+I want **the `gauntlet-v2` reap tests and the `serve-web` git-meta test to assert the product's contract rather than the assumptions of the machine they happen to run on**,
+So that **every PR into develop is gated on a signal that is real — instead of being blocked by four failures that say nothing about the code under review**.
+
+## Why
+
+SHY-0242 armed the develop ruleset, so **every** develop PR now runs `test-backend` + `sonarcloud`. The first PRs through the new gate (#1668, #1669) went red on four tests that have nothing to do with their diffs. Both harnesses pass on macOS and fail on every Linux runner, for two independent reasons — and in both cases the *product* code is correct:
+
+1. **`gauntlet-v2-overlap.test.js` (3 tests).** The fixture interpolates a unique tag into the `bash -c` script text, then probes liveness with `pgrep -f <tag>`. On Linux the script text **is** the parent's `/proc/<pid>/cmdline`, so `pgrep -f` matches the parent bash itself. `PRE=ALIVE` is therefore a tautology (true even if the fixture never started) and `POST=DEAD` is unreachable. macOS does not expose the `-c` body to `pgrep -f`, which is why it went green locally and has never been green on Linux.
+2. **`serve-web-meta-injection.test.js` (1 test).** The test recomputes `git rev-parse --abbrev-ref HEAD` and asserts the result appears as a `<meta>` `content`. GitHub Actions checks out a **detached HEAD**, so that command returns the literal `"HEAD"` — which `local/build-meta.js:70-71` *deliberately* degrades to `null` ("branch unknown, not a branch name") so no `shytalk-git-branch` tag is emitted. The test asserts the exact thing the product is documented to never do.
+
+Both are the same underlying defect: **the test encoded the caller's environment instead of sweeping the contract's class** ([[feedback-parameterized-probe-fixtures]]). Both hid a real coverage hole — a harness that cannot fail is not coverage ([[feedback-verify-the-harness-not-just-the-result]]).
+
+Proven before any code was written (Linux container, real `gauntlet-v2.sh`): `reap_overlapped` and `on_signal` genuinely kill the suite tree, the tail tree and exit `130` on Linux — `POST=DEAD` on all three, with a negative control confirming the probe is not self-satisfying. The product is not broken; only the proof was.
+
+## Acceptance Criteria
+
+### Happy path
+
+- [ ] `gauntlet-v2-overlap.test.js` passes on Linux **and** macOS, with the liveness tag passed through the environment so it never appears in any ancestor's command line.
+- [ ] `serve-web-meta-injection.test.js` passes on Linux **and** macOS regardless of whether the ambient checkout is attached or detached.
+- [ ] `test-backend` and `sonarcloud` are green on a develop PR that contains only this change.
+
+### Error paths
+
+- [ ] If `reap_overlapped` is neutered (body replaced with `:`), the reap tests **FAIL** on Linux — proving the assertion is load-bearing, not self-satisfying.
+- [ ] If `on_signal`'s `reap_overlapped` call is removed, the signal test **FAILS** on Linux.
+- [ ] If `build-meta.js` stops degrading detached `"HEAD"` to `null`, the new detached-HEAD test **FAILS**.
+
+### Edge cases
+
+- [ ] A negative control asserts a never-started tag reads MISSING, so a future self-match regression is caught by the harness itself rather than by a confusing red elsewhere.
+- [ ] The git-identity test owns its git state: it drives a **scratch repository** it created, covering the attached-branch case and the detached-HEAD case explicitly, instead of inheriting whatever branch the runner happens to be on.
+- [ ] A branch name containing shell/HTML-hostile characters still round-trips through `sanitizeLabel`/`escapeAttr` into a well-formed attribute.
+
+### Performance
+
+- [ ] No added sleeps: liveness is polled on the existing bounded `seq 1 60` × 0.05s loops. Total added wall-clock across both suites stays under ~5s.
+
+### Security
+
+- [ ] No secret, token or absolute developer path is written into a probe tag, a log line, or an injected `<meta>` value.
+- [ ] The scratch repository is created under `os.tmpdir()` and removed in a `finally`, so no test artefact is left inside the working tree.
+
+### UX
+
+- N/A — test-harness only; no user-facing surface changes.
+
+### i18n
+
+- N/A — test-harness only; no user-facing strings.
+
+### Observability
+
+- [ ] Each probe prints an explicit `PRE=` / `POST=` verdict line so a future CI failure names which side of the reap broke, rather than only showing a regex miss.
+
+## BDD Scenarios
+
+**Scenario: the liveness probe does not count its own parent as the fixture**
+- **Given** a fixture that starts a tagged long-running stub through `start_overlapped`
+- **When** the harness probes liveness on a Linux runner where the parent's `cmdline` would contain the tag if it were inlined
+- **Then** the probe reports `PRE=ALIVE` only because the stub is genuinely running
+- **And** a never-started tag reports MISSING in the same run
+
+**Scenario: reaping an overlapped suite really kills the tree**
+- **Given** a tagged stub running under an overlapped suite
+- **When** `reap_overlapped` runs
+- **Then** the tag is gone from the process table within the bounded poll window
+- **And** the same assertion FAILS if `reap_overlapped`'s body is emptied
+
+**Scenario: a signal aborts the run and reaps**
+- **Given** a tagged stub running under an overlapped suite
+- **When** `on_signal 130` runs in a subshell
+- **Then** the subshell exits `130`
+- **And** the tagged stub is gone from the process table
+
+**Scenario: the served page names the branch when the repo is on one**
+- **Given** a scratch repository checked out on a real branch
+- **When** an html page is served from it
+- **Then** the response carries a `shytalk-git-branch` meta whose content is that branch
+- **And** the `shytalk-git-sha` meta matches that repository's short sha
+
+**Scenario: the served page omits the branch when the repo is detached**
+- **Given** a scratch repository checked out at a detached commit
+- **When** an html page is served from it
+- **Then** the response carries **no** `shytalk-git-branch` meta at all
+- **And** it still carries the sha and dirty metas, so the watermark degrades to "?" rather than lying
+
+## Test Plan
+
+**Classification: CI-config-only is NOT claimed.** This touches `express-api/tests/**` only — no app, backend or website runtime surface — but it is verified by real execution on the real target platform, not by inspection.
+
+### Red (must fail first)
+
+- `express-api/tests/scripts/gauntlet-v2-overlap.test.js` — the three reap/signal tests, executed on Linux, currently produce `POST=ALIVE` / `TAIL=ALIVE` / `SUITE=ALIVE`. Reproduced in a Linux container against the real `gauntlet-v2.sh` before any edit.
+- `express-api/tests/scripts/serve-web-meta-injection.test.js` — a new detached-HEAD case fails before the fix because the existing assertion demands `content="HEAD"`.
+
+### Green
+
+- Both suites pass under `npm test -- tests/scripts/gauntlet-v2-overlap.test.js tests/scripts/serve-web-meta-injection.test.js` on macOS.
+- Both suites pass on Linux — proven by the container probe pre-fix (RED) and post-fix (GREEN), and finally by `test-backend` + `sonarcloud` green on the PR.
+
+### Mutation proof
+
+- Empty `reap_overlapped`'s body → reap tests fail on Linux.
+- Drop the `rawBranch === "HEAD" ? null : rawBranch` degradation in `local/build-meta.js` → the detached-HEAD test fails.
+
+## Out of Scope
+
+- The `firebase-bom 34.15.0` deprecation breakage (`onNewToken`, `Task<String>.token`) that fails `Build & Test` on #1669 — a real Android API migration, tracked separately.
+- Any change to `gauntlet-v2.sh` or `local/build-meta.js` production behaviour. Both were proven correct; this story changes tests only.
+- Re-running the device gauntlet: no runtime surface is touched.
+
+## Dependencies
+
+- SHY-0242 (develop CI hard-gate) — the reason these latent failures are now blocking.
+- Docker Desktop, for the Linux reproduction of a Linux-only defect.
+
+## Risks & Mitigations
+
+- **Risk:** "fixing" the tests could quietly weaken them into always-green. **Mitigation:** every changed assertion carries an explicit mutation proof (neuter the product function, watch the test go red) plus an in-run negative control.
+- **Risk:** the scratch-repo git fixture could inherit ambient `user.email`/`gpgsign` config and fail to commit. **Mitigation:** the fixture sets its own identity and disables signing locally.
+- **Risk:** a future harness could reintroduce the self-match. **Mitigation:** the negative control lives in the test run itself, so the regression surfaces as a named failure.
+
+## Definition of Done
+
+- [ ] Both suites green on macOS and on Linux CI.
+- [ ] `test-backend`, `sonarcloud`, `Detect Changes`, `Analyze JavaScript`, `PR Gate` green by name on the PR.
+- [ ] Mutation proofs recorded verbatim in `## Notes`, showing the MUTANT and the resulting failure.
+- [ ] `code-reviewer` 100% clean on the local commit before push.
+- [ ] Status flipped to `In Review` before merge.
+
+## Notes (running log)
+
+- **2026-07-25 ~13:00 WIB** — Diagnosed from PR #1668/#1669 CI. Linux container probe against the real `gauntlet-v2.sh` returned `P1_POST=DEAD`, `P2_POST=DEAD`, `P3_RC=130`, `P3_POST=DEAD`, negative control `P4=MISSING` — product code correct, harness at fault. `pgrep -f` self-match confirmed on `ubuntu:24.04` (`PARENT_MATCHED=YES`) and refuted on macOS (`PARENT_MATCHED=NO`).
+
+- **2026-07-25 ~13:30 WIB — RED reproduced, GREEN proven, mutations verified.** Jest cannot run on Linux against this repo's macOS-installed `node_modules` (jest-resolve is backed by `unrs-resolver`; only `@unrs/resolver-binding-darwin-arm64` is present, so `Resolver.findNodeModule` returns `null` for files that exist). The real test files were therefore executed **unmodified** on `node:24` under a minimal jest-globals shim; CI runs its own `npm ci` and is unaffected.
+
+  | Run | Result |
+  |---|---|
+  | Original `gauntlet-v2-overlap.test.js`, Linux | **8 passed, 3 failed** — `POST=ALIVE`, `TAIL=ALIVE`, `SUITE=ALIVE` (byte-identical to the CI failure) |
+  | Fixed, Linux | **11 passed, 0 failed** |
+  | Fixed + `reap_overlapped` neutered to `:` | **8 passed, 3 failed** — assertions are load-bearing |
+  | Original `serve-web-meta-injection.test.js`, Linux, detached HEAD | **3 passed, 1 failed** — `expected: content="HEAD"` (the CI message) |
+  | Fixed, Linux, detached HEAD | **7 passed, 0 failed** |
+  | Fixed + detached-HEAD degradation removed from `build-meta.js` | **6 passed, 1 failed** — the detached case catches it |
+  | Fixed + `sanitizeLabel`/`escapeAttr` both neutered | **6 passed, 1 failed** — the hostile-branch case catches the breakout |
+  | Both suites together, Linux, detached HEAD | **18 passed, 0 failed** |
+
+  MUTANTS verbatim: `reap_overlapped() {\n  : # MUTANT (SHY-0243): reap disabled\n}` · `const branch = rawBranch; // MUTANT (SHY-0243): detached-HEAD degradation removed` · `return String(value); // MUTANT (SHY-0243): sanitiser disabled` + `// MUTANT (SHY-0243): escaping disabled`.
+
+  The detached-HEAD condition was reproduced non-destructively by mounting a file containing a raw sha over `/repo/.git/HEAD` (`git rev-parse --abbrev-ref HEAD` → `HEAD`), leaving the host working tree untouched.
+
+- **2026-07-25 ~13:35 WIB — class sweep.** Grepped the corpus for both defect shapes. `50-matrix-cmd-stop.test.js` matches on `pgrep -P` (parent PID, exact) or probes via `spawnSync` **from Node**, whose argv never carries the tag; `gauntlet-cold-boot-structure.test.js` only pins the script's source text; `prepush-sonar-main-only-gate.test.js` already documents the literal-`HEAD` case; `android-git-identity-pin.test.js` is a structural pin. The self-match trap requires the probe to run *inside* the `bash -c` whose body holds the tag — no other site does. Class confined to the one file.
+
+- **2026-07-25 ~13:40 WIB — self-review finding (fixed before push).** The first draft of the hostile-branch case asserted `not.toContain('a<b')`, a substring that never existed in the raw refname `feat/a"b<c&d` — a trivially-passing negative. Replaced with the three pairs that genuinely appear in the raw value (`a"b`, `b<c`, `c&d`); mutation-proven above.

--- a/express-api/tests/scripts/gauntlet-v2-overlap.test.js
+++ b/express-api/tests/scripts/gauntlet-v2-overlap.test.js
@@ -19,7 +19,9 @@ const { spawnSync } = require('node:child_process');
 const SCRIPT = path.resolve(__dirname, '../../scripts/gauntlet/gauntlet-v2.sh');
 
 // Run a bash body with the v2 helpers sourced (lib mode) + a fresh RUN_DIR.
-function runLib(body, timeout = 20000) {
+// `env` entries are merged into the child's environment — see probeEnv below
+// for why any process tag MUST arrive that way and never inside `body`.
+function runLib(body, { timeout = 20000, env = {} } = {}) {
   const runDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shy0238-'));
   const script = `
     set -uo pipefail
@@ -29,8 +31,33 @@ function runLib(body, timeout = 20000) {
     source "${SCRIPT}" 2>/dev/null
     ${body}
   `;
-  const result = spawnSync('/bin/bash', ['-c', script], { encoding: 'utf8', timeout });
+  const result = spawnSync('/bin/bash', ['-c', script], {
+    encoding: 'utf8',
+    timeout,
+    env: { ...process.env, ...env },
+  });
   return { result, runDir };
+}
+
+// SHY-0243 — process tags reach the script through the ENVIRONMENT, never
+// interpolated into `body`. On Linux the `bash -c` script text IS the parent's
+// /proc/<pid>/cmdline, so an inlined tag makes `pgrep -f <tag>` match the
+// parent bash itself: PRE=ALIVE becomes a tautology and POST=DEAD becomes
+// unreachable. macOS does not expose the `-c` body to `pgrep -f`, which is why
+// the inlined form passed locally and had never once been green on CI.
+//
+// SHY_NEG_TAG is a negative control that is never started. Every liveness
+// assertion pairs with `NEG=MISSING`, so if the probe ever starts self-matching
+// again the tests fail by name instead of quietly going green.
+// The counter is zero-padded so no tag can ever be a PREFIX of another
+// (`-1` would match `-10` under pgrep's substring semantics).
+let tagSeq = 0;
+function probeEnv() {
+  const n = String(++tagSeq).padStart(3, '0');
+  return {
+    SHY_LIVE_TAG: `shy0243-live-${process.pid}-${n}`,
+    SHY_NEG_TAG: `shy0243-neg-${process.pid}-${n}`,
+  };
 }
 
 describe('start_overlapped / wait_overlapped — real execution (SHY-0238)', () => {
@@ -81,16 +108,20 @@ describe('reap_overlapped — real teardown (SHY-0238)', () => {
     // Start a long stub, wait until pgrep can see it, reap, then assert it is
     // gone via `pgrep` — NOT kill(pid,0): a killed child would zombie and
     // kill(pid,0) would falsely report it alive (reference-node-spawn-zombie-...).
-    const tag = `shy0238-reap-${process.pid}`;
-    const { result } = runLib(`
-      start_overlapped longrun bash -c 'exec -a ${tag} sleep 30'
-      for _ in $(seq 1 60); do pgrep -f ${tag} >/dev/null 2>&1 && break; sleep 0.05; done
-      pgrep -f ${tag} >/dev/null 2>&1 && echo "PRE=ALIVE" || echo "PRE=MISSING"
+    const { result } = runLib(
+      `
+      start_overlapped longrun bash -c 'exec -a "$SHY_LIVE_TAG" sleep 30'
+      for _ in $(seq 1 60); do pgrep -f "$SHY_LIVE_TAG" >/dev/null 2>&1 && break; sleep 0.05; done
+      pgrep -f "$SHY_LIVE_TAG" >/dev/null 2>&1 && echo "PRE=ALIVE" || echo "PRE=MISSING"
+      pgrep -f "$SHY_NEG_TAG" >/dev/null 2>&1 && echo "NEG=ALIVE" || echo "NEG=MISSING"
       reap_overlapped
-      for _ in $(seq 1 60); do pgrep -f ${tag} >/dev/null 2>&1 || break; sleep 0.05; done
-      pgrep -f ${tag} >/dev/null 2>&1 && echo "POST=ALIVE" || echo "POST=DEAD"
-      pkill -f ${tag} 2>/dev/null || true
-    `);
+      for _ in $(seq 1 60); do pgrep -f "$SHY_LIVE_TAG" >/dev/null 2>&1 || break; sleep 0.05; done
+      pgrep -f "$SHY_LIVE_TAG" >/dev/null 2>&1 && echo "POST=ALIVE" || echo "POST=DEAD"
+      pkill -f "$SHY_LIVE_TAG" 2>/dev/null || true
+    `,
+      { env: probeEnv() },
+    );
+    expect(result.stdout).toMatch(/NEG=MISSING/); // probe is not self-matching
     expect(result.stdout).toMatch(/PRE=ALIVE/); // fixture really started
     expect(result.stdout).toMatch(/POST=DEAD/); // reap actually killed the tree
   });
@@ -99,17 +130,21 @@ describe('reap_overlapped — real teardown (SHY-0238)', () => {
     // The real tail is `( tail -F | awk ) &`, so TAIL_PID is the subshell — a
     // bare `kill $TAIL_PID` orphans the inner `tail -F` (runs forever). The
     // fixture mirrors that shape (long stub is a GRANDCHILD of TAIL_PID).
-    const tag = `shy0238-tail-${process.pid}`;
-    const { result } = runLib(`
-      ( bash -c 'exec -a ${tag} sleep 30' | cat ) &
+    const { result } = runLib(
+      `
+      ( bash -c 'exec -a "$SHY_LIVE_TAG" sleep 30' | cat ) &
       TAIL_PID=$!
-      for _ in $(seq 1 60); do pgrep -f ${tag} >/dev/null 2>&1 && break; sleep 0.05; done
-      pgrep -f ${tag} >/dev/null 2>&1 && echo "PRE=ALIVE" || echo "PRE=MISSING"
+      for _ in $(seq 1 60); do pgrep -f "$SHY_LIVE_TAG" >/dev/null 2>&1 && break; sleep 0.05; done
+      pgrep -f "$SHY_LIVE_TAG" >/dev/null 2>&1 && echo "PRE=ALIVE" || echo "PRE=MISSING"
+      pgrep -f "$SHY_NEG_TAG" >/dev/null 2>&1 && echo "NEG=ALIVE" || echo "NEG=MISSING"
       reap_overlapped
-      for _ in $(seq 1 60); do pgrep -f ${tag} >/dev/null 2>&1 || break; sleep 0.05; done
-      pgrep -f ${tag} >/dev/null 2>&1 && echo "TAIL=ALIVE" || echo "TAIL=DEAD"
-      pkill -f ${tag} 2>/dev/null || true
-    `);
+      for _ in $(seq 1 60); do pgrep -f "$SHY_LIVE_TAG" >/dev/null 2>&1 || break; sleep 0.05; done
+      pgrep -f "$SHY_LIVE_TAG" >/dev/null 2>&1 && echo "TAIL=ALIVE" || echo "TAIL=DEAD"
+      pkill -f "$SHY_LIVE_TAG" 2>/dev/null || true
+    `,
+      { env: probeEnv() },
+    );
+    expect(result.stdout).toMatch(/NEG=MISSING/);
     expect(result.stdout).toMatch(/PRE=ALIVE/);
     expect(result.stdout).toMatch(/TAIL=DEAD/);
   });
@@ -119,15 +154,21 @@ describe('on_signal — a signal actually ABORTS the run (SHY-0238)', () => {
   test('reaps the overlapped suites AND exits with the given code', () => {
     // A bare INT/TERM trap that only reaps would RESUME the run; on_signal must
     // exit. Run it in a subshell so its exit doesn't kill the test harness.
-    const tag = `shy0238-sig-${process.pid}`;
-    const { result } = runLib(`
-      start_overlapped longrun bash -c 'exec -a ${tag} sleep 30'
-      for _ in $(seq 1 60); do pgrep -f ${tag} >/dev/null 2>&1 && break; sleep 0.05; done
+    const { result } = runLib(
+      `
+      start_overlapped longrun bash -c 'exec -a "$SHY_LIVE_TAG" sleep 30'
+      for _ in $(seq 1 60); do pgrep -f "$SHY_LIVE_TAG" >/dev/null 2>&1 && break; sleep 0.05; done
+      pgrep -f "$SHY_LIVE_TAG" >/dev/null 2>&1 && echo "PRE=ALIVE" || echo "PRE=MISSING"
+      pgrep -f "$SHY_NEG_TAG" >/dev/null 2>&1 && echo "NEG=ALIVE" || echo "NEG=MISSING"
       ( on_signal 130 ); echo "RC=$?"
-      for _ in $(seq 1 60); do pgrep -f ${tag} >/dev/null 2>&1 || break; sleep 0.05; done
-      pgrep -f ${tag} >/dev/null 2>&1 && echo "SUITE=ALIVE" || echo "SUITE=DEAD"
-      pkill -f ${tag} 2>/dev/null || true
-    `);
+      for _ in $(seq 1 60); do pgrep -f "$SHY_LIVE_TAG" >/dev/null 2>&1 || break; sleep 0.05; done
+      pgrep -f "$SHY_LIVE_TAG" >/dev/null 2>&1 && echo "SUITE=ALIVE" || echo "SUITE=DEAD"
+      pkill -f "$SHY_LIVE_TAG" 2>/dev/null || true
+    `,
+      { env: probeEnv() },
+    );
+    expect(result.stdout).toMatch(/NEG=MISSING/); // probe is not self-matching
+    expect(result.stdout).toMatch(/PRE=ALIVE/); // fixture really started
     expect(result.stdout).toMatch(/RC=130/); // exited with 128+SIGINT
     expect(result.stdout).toMatch(/SUITE=DEAD/); // and reaped
   });

--- a/express-api/tests/scripts/serve-web-meta-injection.test.js
+++ b/express-api/tests/scripts/serve-web-meta-injection.test.js
@@ -62,6 +62,37 @@ function startServer(cwd, root) {
   });
 }
 
+/**
+ * Builds a throwaway repository with a single commit, so the git-identity
+ * assertions OWN their git state instead of inheriting the runner's checkout —
+ * the convention jest-git-env-isolation.js (SHY-0097) already sets for every
+ * other git-using test here: "git-using tests build their own repositories".
+ *
+ * SHY-0243: CI checks out a DETACHED HEAD, so a test that re-reads the ambient
+ * branch is asserting a property of the runner, not of the product. Owning the
+ * repo lets both sides of the contract — on a branch, and detached — be pinned.
+ */
+function makeScratchRepo(branch) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'serve-web-git-'));
+  const git = (...args) =>
+    execFileSync(GIT, args, {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  git('init', '-q');
+  // `git init --initial-branch` needs git 2.28+; symbolic-ref works everywhere
+  // and does not depend on the runner's init.defaultBranch.
+  git('symbolic-ref', 'HEAD', `refs/heads/${branch}`);
+  git('config', 'user.email', 'fixture@shytalk.invalid');
+  git('config', 'user.name', 'SHY-0243 fixture');
+  git('config', 'commit.gpgsign', 'false'); // ambient signing config must not apply
+  fs.writeFileSync(path.join(dir, 'seed.txt'), 'seed\n');
+  git('add', 'seed.txt');
+  git('commit', '-q', '-m', 'seed');
+  return { dir, git, sha: git('rev-parse', '--short', 'HEAD') };
+}
+
 function makeWebRoot(base) {
   fs.mkdirSync(path.join(base, 'web'), { recursive: true });
   fs.writeFileSync(
@@ -80,8 +111,11 @@ describe('serve-web git-meta injection (SHY-0205)', () => {
   });
 
   test('html responses carry the live git identity of the serving repo', async () => {
-    // Serve from a scratch web root INSIDE the real repo — the git values
-    // must match what git reports for the repo right now.
+    // Serve from a scratch web root INSIDE the real repo — the sha must match
+    // what git reports for THIS repo right now. Deliberately asserts nothing
+    // about the branch: CI serves from a detached HEAD, so branch presence is a
+    // property of the checkout, not of the product (pinned by the scratch-repo
+    // cases below instead).
     const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'serve-web-test-'));
     try {
       makeWebRoot(scratch);
@@ -89,21 +123,81 @@ describe('serve-web git-meta injection (SHY-0205)', () => {
       proc = started.proc;
       const res = await get(started.port, '/');
       expect(res.status).toBe(200);
-      const branch = execFileSync(GIT, ['rev-parse', '--abbrev-ref', 'HEAD'], {
-        cwd: REPO_ROOT,
-        encoding: 'utf8',
-      }).trim();
       const sha = execFileSync(GIT, ['rev-parse', '--short', 'HEAD'], {
         cwd: REPO_ROOT,
         encoding: 'utf8',
       }).trim();
       expect(res.body).toContain(`name="shytalk-git-sha" content="${sha}"`);
-      expect(res.body).toContain(`content="${branch}"`);
       expect(res.body.indexOf('shytalk-git-sha')).toBeLessThan(res.body.indexOf('</head>'));
       // Content-Length must match the INJECTED body, not the disk file.
       expect(parseInt(res.headers['content-length'], 10)).toBe(Buffer.byteLength(res.body));
     } finally {
       fs.rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  test('on a branch, the page names that branch alongside sha and clean state', async () => {
+    const repo = makeScratchRepo('probe-branch');
+    const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'serve-web-test-'));
+    try {
+      makeWebRoot(scratch); // web root lives OUTSIDE the repo, so dirty is deterministic
+      const started = await startServer(repo.dir, path.join(scratch, 'web'));
+      proc = started.proc;
+      const res = await get(started.port, '/');
+      expect(res.status).toBe(200);
+      expect(res.body).toContain('name="shytalk-git-branch" content="probe-branch"');
+      expect(res.body).toContain(`name="shytalk-git-sha" content="${repo.sha}"`);
+      expect(res.body).toContain('name="shytalk-git-dirty" content="0"');
+    } finally {
+      fs.rmSync(scratch, { recursive: true, force: true });
+      fs.rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a detached HEAD omits the branch meta rather than publishing "HEAD"', async () => {
+    // Exactly the state actions/checkout leaves a CI runner in. build-meta.js
+    // degrades the literal "HEAD" to null ("branch unknown"), so the watermark
+    // renders "?" instead of naming a branch that does not exist.
+    const repo = makeScratchRepo('probe-branch');
+    const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'serve-web-test-'));
+    try {
+      makeWebRoot(scratch);
+      repo.git('checkout', '-q', '--detach');
+      expect(repo.git('rev-parse', '--abbrev-ref', 'HEAD')).toBe('HEAD'); // fixture is really detached
+      const started = await startServer(repo.dir, path.join(scratch, 'web'));
+      proc = started.proc;
+      const res = await get(started.port, '/');
+      expect(res.status).toBe(200);
+      expect(res.body).not.toContain('shytalk-git-branch');
+      // ...but the identity it DOES know is still published.
+      expect(res.body).toContain(`name="shytalk-git-sha" content="${repo.sha}"`);
+      expect(res.body).toContain('name="shytalk-git-dirty" content="0"');
+    } finally {
+      fs.rmSync(scratch, { recursive: true, force: true });
+      fs.rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  test('an attribute-hostile branch name is sanitised, never breaking out of the tag', async () => {
+    // `"`, `<` and `&` are all legal in a git refname but would corrupt the
+    // markup if they reached the attribute. sanitizeLabel collapses them first,
+    // so the value degrades visibly instead of the page breaking silently.
+    const repo = makeScratchRepo('feat/a"b<c&d');
+    const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'serve-web-test-'));
+    try {
+      makeWebRoot(scratch);
+      const started = await startServer(repo.dir, path.join(scratch, 'web'));
+      proc = started.proc;
+      const res = await get(started.port, '/');
+      expect(res.status).toBe(200);
+      expect(res.body).toContain('name="shytalk-git-branch" content="feat/a-b-c-d"');
+      // Each hostile pair as it appears in the RAW refname — none may survive.
+      expect(res.body).not.toContain('a"b');
+      expect(res.body).not.toContain('b<c');
+      expect(res.body).not.toContain('c&d');
+    } finally {
+      fs.rmSync(scratch, { recursive: true, force: true });
+      fs.rmSync(repo.dir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
Implements SHY-0243 — see `.project/stories/SHY-0243-honest-linux-ci-test-harness.md` for full spec, AC, BDD scenarios, and DoD.

## Why this is blocking

SHY-0242 armed the develop ruleset, so every develop PR now runs `test-backend` + `sonarcloud`. The first PRs through the new gate (#1668, #1669) went red on **four tests that have nothing to do with their diffs**. Both harnesses pass on macOS and can never pass on a Linux runner. **In both cases the product code is correct — only the proof was wrong.**

| Root cause | Effect |
|---|---|
| `gauntlet-v2-overlap.test.js` interpolated its process tag into the `bash -c` script text — which on Linux **is** the parent's `/proc/<pid>/cmdline` — so `pgrep -f <tag>` matched the parent bash itself | `PRE=ALIVE` was a **tautology**, `POST=DEAD` unreachable. 3 tests, never once green on Linux |
| `serve-web-meta-injection.test.js` re-read `git rev-parse --abbrev-ref HEAD` and asserted the result appeared as a meta value. `actions/checkout` leaves a **detached HEAD**, where that returns the literal `"HEAD"` — exactly what `local/build-meta.js` deliberately degrades to `null` | The test asserted the one thing the product is documented never to do. 1 test |

## What changed (tests only — no runtime surface)

- Process tags now reach the fixture **through the environment**, never inside the script body. Every liveness assertion is paired with a never-started **negative-control** tag, so a future self-match fails by name instead of quietly going green. The counter is zero-padded so no tag can be a prefix of another.
- The git-identity test now **owns its git state** via a scratch repository — the convention `jest-git-env-isolation.js` (SHY-0097) already set: *"git-using tests build their own repositories"*. Both sides of the contract are pinned: named on a branch, **omitted** when detached. Plus a new case proving an attribute-hostile refname (`feat/a"b<c&d`) cannot break out of the tag.

## Verification

Jest cannot run on Linux against a macOS-installed `node_modules` (jest-resolve is backed by `unrs-resolver`; only the darwin-arm64 binding is present). The **real test files were executed unmodified** on `node:24` under a minimal jest-globals shim. CI runs its own `npm ci` and is unaffected.

| Run | Result |
|---|---|
| Original overlap suite, Linux | **8 passed, 3 failed** — `POST=ALIVE`/`TAIL=ALIVE`/`SUITE=ALIVE`, byte-identical to CI |
| Fixed, Linux | **11 passed, 0 failed** |
| Fixed + `reap_overlapped` neutered to `:` | **8 passed, 3 failed** — assertions are load-bearing |
| Original serve-web suite, Linux, detached HEAD | **3 passed, 1 failed** — `expected: content="HEAD"`, the CI message |
| Fixed, Linux, detached HEAD | **7 passed, 0 failed** |
| Fixed + detached-HEAD degradation removed from `build-meta.js` | **6 passed, 1 failed** |
| Fixed + `sanitizeLabel`/`escapeAttr` both neutered | **6 passed, 1 failed** |
| **Both suites, Linux, detached HEAD** | **18 passed, 0 failed** |

Also 18/18 on macOS under canonical `npm test`; `tests/scripts/` 141/143 suites green locally (the 2 failures are the emulator-dependent suites, local stack down). prettier + eslint `--max-warnings=0` clean.

Independently proven before any edit: on Linux the real `gauntlet-v2.sh` reaps correctly — suite tree dead, tail tree dead, `on_signal` exits `130` — with a negative control confirming the probe was honest.

## Class sweep

`50-matrix-cmd-stop.test.js` matches on `pgrep -P` (parent PID, exact) or probes via `spawnSync` from Node, whose argv never carries the tag; `gauntlet-cold-boot-structure.test.js` only pins source text; `prepush-sonar-main-only-gate.test.js` already documents the literal-`HEAD` case. The trap needs the probe to run *inside* the `bash -c` holding the tag — no other site does.

## Scope

Out of scope: the `firebase-bom 34.15.0` deprecations (`onNewToken`, `Task<String>.token`) failing `Build & Test` on #1669 — a real Android API migration, tracked separately. No app/backend/website runtime surface is touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCdx7Mufv1nyqoaY3Aq4v5