### PR TITLE
SHY-0269: Stop dev persona seeding from failing silently

### DIFF
--- a/.github/actions/seed-test-personas/action.yml
+++ b/.github/actions/seed-test-personas/action.yml
@@ -72,4 +72,16 @@ runs:
         # dev Express host. In CI the secrets are exported as env vars
         # directly (PERSONAS_PASSWORD, GOOGLE_APPLICATION_CREDENTIALS,
         # FIREBASE_PROJECT_ID all set above), so dotenv adds nothing.
-        node scripts/provision-test-personas.js
+        # SHY-0269: exit 0 is NOT evidence the seeding happened. The
+        # script's last line on a complete run is `PROVISION_ALL_OK
+        # count=N`; assert it, so a future early-return path (or a script
+        # that no-ops because the persona list came back empty) reports
+        # failure instead of a green job over an unseeded project.
+        # `set -o pipefail` is already in effect, so a non-zero exit from
+        # node still fails despite the pipe.
+        node scripts/provision-test-personas.js | tee /tmp/seed-personas.log
+        if ! grep -q 'PROVISION_ALL_OK' /tmp/seed-personas.log; then
+          echo "::error title=Dev persona seeding did not complete::provision-test-personas.js exited 0 but never printed PROVISION_ALL_OK — no personas were provisioned. Seeded personas (P-02..P-19) are stale."
+          exit 1
+        fi
+        echo "Seeded: $(grep -o 'PROVISION_ALL_OK count=[0-9]*' /tmp/seed-personas.log)"

--- a/.github/known-secrets.yml
+++ b/.github/known-secrets.yml
@@ -1,0 +1,69 @@
+# Authoritative inventory of GitHub Actions secrets configured on this
+# repository.
+#
+# WHY THIS FILE EXISTS (SHY-0269): dev persona seeding was dead for ~18 days
+# because `seed-dev-personas.yml` still referenced `PERSONAS_PASSWORD_DEV`
+# after SHY-0136 renamed the secret to `DEV_QA_PERSONAS_PASSWORD`. Every
+# other workflow moved; that one did not. Nothing could catch it — a
+# workflow cannot enumerate the repo's secrets at runtime, and the pin test
+# that "guarded" the name asserted the WRONG name, so it locked the defect
+# in rather than catching it.
+#
+# This file is the ground truth the CI files are checked against.
+# `express-api/tests/scripts/workflow-secrets-inventory.test.js` fails if any
+# `secrets.X` reference under `.github/workflows/**` or `.github/actions/**`
+# is not listed here.
+#
+# WHEN YOU ADD, RENAME OR DELETE A SECRET in
+# Settings → Secrets and variables → Actions, update this list in the SAME
+# PR as the workflow change. A rename that only touches one workflow will
+# now fail CI instead of silently disabling a job.
+#
+# NOTE ON LIMITS: this proves the repo agrees with ITSELF about secret
+# names. It cannot prove a listed secret is still present in GitHub — that
+# is what the preflight step in `seed-dev-personas.yml` is for, which fails
+# loudly, in the run log, naming the missing secret.
+#
+# `secrets.GITHUB_TOKEN` is supplied by Actions itself and is not listed.
+
+secrets:
+  - APP_STORE_CONNECT_ISSUER_ID
+  - APP_STORE_CONNECT_KEY
+  - APP_STORE_CONNECT_KEY_ID
+  - CLOUDFLARE_API_TOKEN
+  - DEV_BASIC_AUTH_PASSWORD
+  - DEV_FIREBASE_API_KEY
+  - DEV_QA_PERSONAS_PASSWORD
+  - FIREBASE_SERVICE_ACCOUNT_DEV
+  - FIREBASE_SERVICE_ACCOUNT_PROD
+  - GH_PAT_PROJECT
+  - GOOGLE_SERVICES_DEV_BASE64
+  - GOOGLE_SERVICES_PROD_BASE64
+  - IOS_CERTIFICATE_BASE64
+  - IOS_CERTIFICATE_PASSWORD
+  - IOS_PROVISION_PROFILE_BASE64
+  - KEYSTORE_BASE64
+  - KEYSTORE_PASSWORD
+  - LIVEKIT_URL
+  - LONDON_SSH_KEY
+  - PLAY_SERVICE_ACCOUNT_JSON
+  - PROD_FIREBASE_API_KEY
+  - RELEASE_APP_ID
+  - RELEASE_APP_PRIVATE_KEY
+  - RELEASE_TOKEN
+  - SINGAPORE_SSH_KEY
+  - SMOKE_TARGET_UNIQUE_ID
+  - SMOKE_TEST_EMAIL
+  - SMOKE_TEST_PASSWORD
+  - SONAR_TOKEN
+  - SYSTEM_SHARED_SECRET
+
+# Referenced by a workflow but deliberately NOT configured. Each of these
+# carries an explicit `|| <configured secret>` fallback at the reference
+# site, so its absence is a designed default rather than drift.
+optional:
+  # deploy-dev.yml smoke tests: `secrets.SMOKE_FIREBASE_API_KEY ||
+  # secrets.DEV_FIREBASE_API_KEY`. Exists so a dedicated smoke-account key
+  # can be swapped in without editing the workflow; unset means the dev key
+  # is used. The job's own preflight names it if BOTH end up empty.
+  - SMOKE_FIREBASE_API_KEY

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -187,6 +187,51 @@ jobs:
     uses: ./.github/workflows/seed-dev-personas.yml
     secrets: inherit
 
+  # SHY-0269 — the seed outcome must be readable WITHOUT expanding a job.
+  # Five of the last eight dev deploys ran with a failing seed job and one
+  # ran with a SKIPPED one while the run reported green; in every case the
+  # only trace was a check-run annotation. This job always() runs and puts
+  # the verdict at the top of the run page, naming the consequence (stale
+  # personas) rather than just a status word.
+  seed-personas-report:
+    name: Seed Personas Report
+    needs: seed-dev-personas
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Summarise seed outcome
+        env:
+          SEED_RESULT: ${{ needs.seed-dev-personas.result }}
+          SEED_REQUESTED: ${{ inputs.seed-personas }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Dev test personas (P-02..P-19)"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          case "$SEED_RESULT" in
+            success)
+              echo "✅ Re-seeded — persona state on dev is fresh for this build." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            skipped)
+              echo "⏭️ **Skipped** — personas were NOT refreshed, so dev still holds whatever state the last run left behind. Requested via input: \`$SEED_REQUESTED\`; the job also skips when the backend deploy did not succeed." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            failure | cancelled)
+              {
+                echo "❌ **Seeding $SEED_RESULT — personas on dev are STALE.**"
+                echo ""
+                echo "Journey tests and manual QA that rely on P-02..P-19 may fail for reasons that have nothing to do with the build under test."
+                echo ""
+                echo "Open the \`Seed Dev Personas\` job. If it has no steps at all, the failure happened during secrets evaluation — check the secret names against \`.github/known-secrets.yml\`."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "::error title=Dev personas are stale::Seed job result: $SEED_RESULT. See the run summary."
+              ;;
+            *)
+              echo "❔ Unrecognised seed result: \`$SEED_RESULT\`" >> "$GITHUB_STEP_SUMMARY"
+              ;;
+          esac
+
   deploy-web-dev:
     name: Deploy Web to Dev
     # Web depends on the dev API to function (firebase-config, /api/health,

--- a/.github/workflows/seed-dev-personas.yml
+++ b/.github/workflows/seed-dev-personas.yml
@@ -25,17 +25,25 @@ on:
         default: dev
         required: false
     secrets:
-      # Declared with the EXACT repo-level secret names so `secrets: inherit`
-      # from the caller (deploy-dev.yml) forwards by name, AND actionlint
-      # static-checks the references inside this workflow against the same
-      # declared names. Using camelCase aliases here instead would force a
-      # named-mapping in every caller; the inherit path is simpler.
+      # Declared with the EXACT repo-level secret names (see
+      # .github/known-secrets.yml) so `secrets: inherit` from the caller
+      # forwards by name, AND actionlint static-checks the `secrets.X`
+      # references inside this workflow against the same declared names.
+      #
+      # DELIBERATELY `required: false` (SHY-0269). A required workflow_call
+      # secret is validated BEFORE the job starts: GitHub fails the call
+      # with zero steps and zero logs, and the reason ("Secret X is
+      # required, but not provided while calling") only ever appears as a
+      # check-run annotation. That is how this job stayed broken across
+      # five dev deploys without anyone noticing. Optional here + an
+      # explicit preflight step below means a missing secret fails IN THE
+      # RUN LOG, naming the secret.
       FIREBASE_SERVICE_ACCOUNT_DEV:
         description: 'Firebase service account JSON for the dev project'
-        required: true
-      PERSONAS_PASSWORD_DEV:
-        description: 'Shared seeded-persona password'
-        required: true
+        required: false
+      DEV_QA_PERSONAS_PASSWORD:
+        description: 'Shared seeded-persona password (canonical name since SHY-0136)'
+        required: false
 
   workflow_dispatch:
     inputs:
@@ -67,6 +75,24 @@ jobs:
     # Auth quota throttling without letting a stuck run idle forever.
     timeout-minutes: 10
     steps:
+      # SHY-0269 — runs BEFORE checkout so a misconfigured repo fails in
+      # two seconds with an actionable message rather than an empty job.
+      - name: Verify required secrets are present
+        env:
+          SA_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DEV }}
+          PERSONAS_PASSWORD: ${{ secrets.DEV_QA_PERSONAS_PASSWORD }}
+        run: |
+          set -euo pipefail
+          missing=""
+          [ -n "${SA_JSON:-}" ] || missing="$missing FIREBASE_SERVICE_ACCOUNT_DEV"
+          [ -n "${PERSONAS_PASSWORD:-}" ] || missing="$missing DEV_QA_PERSONAS_PASSWORD"
+          if [ -n "$missing" ]; then
+            echo "::error title=Dev persona seeding cannot run::Missing repository secret(s):$missing. Set them in Settings > Secrets and variables > Actions, and make sure the name matches .github/known-secrets.yml. Seeded personas (P-02..P-19) are NOT refreshed until this is fixed."
+            echo "Missing repository secret(s):$missing" >&2
+            exit 1
+          fi
+          echo "Both required secrets are present."
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: ./.github/actions/setup-node
@@ -108,10 +134,10 @@ jobs:
         with:
           # For workflow_call, secrets are forwarded by the caller via
           # `secrets:` block; for workflow_dispatch, they resolve from
-          # the repo-level GitHub Actions secrets (PERSONAS_PASSWORD_DEV,
-          # FIREBASE_SERVICE_ACCOUNT_DEV). Both paths land in the same
-          # `secrets.X` references at this scope.
+          # the repo-level GitHub Actions secrets (DEV_QA_PERSONAS_PASSWORD,
+          # FIREBASE_SERVICE_ACCOUNT_DEV — see .github/known-secrets.yml).
+          # Both paths land in the same `secrets.X` references at this scope.
           service-account-json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DEV }}
           firebase-project: ${{ steps.target-values.outputs.firebase-project }}
-          personas-password: ${{ secrets.PERSONAS_PASSWORD_DEV }}
+          personas-password: ${{ secrets.DEV_QA_PERSONAS_PASSWORD }}
           database-url: ${{ steps.target-values.outputs.database-url }}

--- a/.project/stories/SHY-0269-seed-personas-silent-failure.md
+++ b/.project/stories/SHY-0269-seed-personas-silent-failure.md
@@ -1,6 +1,6 @@
 ---
 id: SHY-0269
-status: In Progress
+status: In Review
 owner: claude
 created: 2026-08-03
 priority: P0
@@ -175,6 +175,9 @@ time since 2026-07-16.
 - **2026-08-03 08:0x BST** — Root cause read from the check-run annotation, not
   inferred. `git log -S` showed `PERSONAS_PASSWORD_DEV` unchanged in this
   workflow since 2026-05-29, so the repo secret was renamed under it.
+- **2026-08-03 12:4x BST** — Flipped to In Review. CI-config-only (no app, backend or
+  website runtime surface), so the device/browser gauntlet is not applicable; the fix is
+  additionally live-proven by a real dispatch that reached `PROVISION_ALL_OK count=17`.
 - The inventory check immediately found one further reference not backed by a
   configured secret — `SMOKE_FIREBASE_API_KEY` — which turned out to be a
   deliberate `|| DEV_FIREBASE_API_KEY` override with its own preflight. Modelled

--- a/.project/stories/SHY-0269-seed-personas-silent-failure.md
+++ b/.project/stories/SHY-0269-seed-personas-silent-failure.md
@@ -1,0 +1,181 @@
+---
+id: SHY-0269
+status: In Progress
+owner: claude
+created: 2026-08-03
+priority: P0
+effort: S
+type: bug
+roadmap_ids: []
+pr:
+mvp: true
+---
+
+# SHY-0269: Dev persona seeding died silently and stayed dead for 18 days
+
+## User Story
+
+As the operator relying on dev for manual QA and journey runs,
+I want a deployment step that stops working to say so where I will see it,
+So that I never test against stale data believing it is fresh.
+
+## Why
+
+Spotted while checking an unrelated dev deploy on 2026-08-03: the `Seed Dev
+Personas` job had failed. It had also failed on the previous deploy, and on three
+before that — five of the last eight, plus one run where it was silently
+**skipped** while the deploy reported green. The last successful seed was
+2026-07-16. Dev personas P-02..P-19 had not been refreshed for ~18 days.
+
+Three separate defects, and the least interesting one is the trigger:
+
+1. **The trigger.** `seed-dev-personas.yml` declares and reads
+   `PERSONAS_PASSWORD_DEV`. SHY-0136 renamed that secret to
+   `DEV_QA_PERSONAS_PASSWORD`; four other workflows moved with it, this one did
+   not.
+2. **The silence — the real defect.** The secret was declared `required: true`
+   on `workflow_call`, so GitHub failed the call during *secrets evaluation*,
+   before the job had any steps. The result is a failed job with **zero steps
+   and zero logs**: `gh run view --log-failed` returns nothing. The reason
+   ("Secret PERSONAS_PASSWORD_DEV is required, but not provided while calling")
+   existed only as a check-run annotation, which nothing surfaces.
+3. **Nothing was watching.** The seed result sat among seven jobs on a run that
+   still deployed the backend, web, APK and TestFlight build. Nothing summarised
+   it, and a *skipped* seed produced a fully green run.
+
+And the test that should have caught (1) instead **pinned it**: it asserted the
+workflow contained the literal `PERSONAS_PASSWORD_DEV:` and its comment claimed
+"names match the repo's GitHub Actions secrets settings". A string compared to a
+string has no ground truth.
+
+## Acceptance Criteria
+
+### Happy path
+- [ ] A dev deploy refreshes the seeded personas and says so in the run summary
+
+### Error paths
+- [ ] A missing secret fails in a step, in the run log, naming the secret
+- [ ] A seed that cannot run makes the consequence explicit: personas are stale
+- [ ] A skipped seed is reported as skipped, not left to look like success
+
+### Edge cases
+- [ ] A provisioning script that exits 0 without completing is treated as failure
+- [ ] A secret that is deliberately absent because it has a fallback is not
+      reported as drift
+
+### Performance
+- [ ] N/A — the preflight is a shell test on two variables and the report job is
+      a single `echo`; both are seconds against a multi-minute deploy.
+
+### Security
+- [ ] Neither the preflight nor the summary ever prints a secret VALUE — only
+      names of secrets that are missing
+- [ ] The service-account credential is still wiped by the existing `trap`
+
+### UX
+- [ ] The operator learns that dev data is stale from the run page, without
+      opening a job or reading annotations
+
+### i18n
+- [ ] N/A — CI operator output, English-only by design.
+
+### Observability
+- [ ] Every referenced secret name is checked against a committed inventory, so
+      a rename cannot silently disable a job again
+
+## BDD Scenarios
+
+**Scenario: A missing secret explains itself in the log**
+- **Given** a secret the seeding needs is not configured
+- **When** a dev deploy runs the seeding step
+- **Then** the run fails naming the missing secret and says personas are stale
+
+**Scenario: A skipped seeding is reported, not hidden**
+- **Given** a dev deploy where the seeding does not run
+- **When** the deploy finishes
+- **Then** the summary states personas were not refreshed
+
+**Scenario: Provisioning that does not complete is a failure**
+- **Given** the provisioning finishes without confirming it seeded anyone
+- **When** the seeding step checks the result
+- **Then** the step fails rather than reporting success
+
+**Scenario: A renamed secret cannot silently disable a job**
+- **Given** a workflow referring to a secret name that is not in the inventory
+- **When** the test suite runs
+- **Then** it fails naming the workflow and the unknown secret
+
+## Test Plan
+
+**Red first** — 8 failures before the fix, in
+`express-api/tests/scripts/`:
+
+- `workflow-secrets-inventory.test.js` (new) — every `secrets.X` under
+  `.github/workflows/**` and `.github/actions/**` must appear in
+  `.github/known-secrets.yml`. Comments are stripped first so prose about a
+  secret is not counted as a reference, and a vacuous-pass guard asserts the
+  extractor actually finds references. An `optional:` section models names that
+  are intentionally absent behind a documented `|| fallback`, and each entry
+  must state that fallback.
+- `deploy-dev-seed-personas.test.js` — corrected the mis-pinned secret name;
+  added: `workflow_call` secrets must NOT be `required: true` (so failures land
+  in logs), a preflight step must name every missing secret via `::error`, the
+  deploy must report the seed outcome to `$GITHUB_STEP_SUMMARY` from an
+  `if: always()` job distinguishing success/failure/skipped, and the seed action
+  must assert the provisioning completion marker.
+
+**Green** — 29/29 pass; `actionlint` clean on both workflows; `eslint
+--max-warnings=0` clean; prettier clean.
+
+**Live proof** — the reusable workflow is dispatched against this branch and
+must reach `PROVISION_ALL_OK`, which also refreshes dev personas for the first
+time since 2026-07-16.
+
+## Out of Scope
+
+- Verifying the inventory against GitHub's actual secret list at runtime — a
+  workflow cannot enumerate secrets. The inventory proves the repo agrees with
+  itself; the preflight catches a secret that is listed but absent.
+- Auditing every other CI job for the same silent-failure shape. The inventory
+  check already swept every workflow for the secret-name half; the
+  `required: true` + no-summary shape elsewhere is a follow-up.
+
+## Dependencies
+
+- None. Secret `DEV_QA_PERSONAS_PASSWORD` already exists on the repository.
+
+## Risks & Mitigations
+
+- **Risk:** `required: false` weakens the contract — a caller could forget to
+  forward the secret. **Mitigation:** the preflight fails the job on the very
+  first step with a louder, more actionable message than the platform's, and it
+  covers the `workflow_dispatch` path too, which `required:` never did.
+- **Risk:** the inventory drifts from GitHub's real secret list.
+  **Mitigation:** it is a committed file with a stated update rule, and the
+  preflight independently catches a listed-but-absent secret at runtime.
+- **Risk:** the `| tee` in the seed action masks the script's exit code.
+  **Mitigation:** the step already runs under `set -euo pipefail`; a pin test
+  asserts the invocation and the absence of a dotenv preload.
+
+## Definition of Done
+
+- [ ] 29/29 tests green; actionlint, eslint, prettier clean
+- [ ] `seed-dev-personas.yml` dispatched against this branch and reaching
+      `PROVISION_ALL_OK` — dev personas actually refreshed
+- [ ] A deliberately-broken dispatch shows the failure in the run LOG, not only
+      in an annotation
+- [ ] Merged to develop; `released_in:` set at the next release cut
+
+## Notes (running log)
+
+- **2026-08-03 07:5x BST** — Found while verifying an unrelated dev deploy.
+  Quantified before diagnosing: last 8 deploy-dev runs showed seed
+  failure/failure/skipped/failure/failure/success/failure/failure, last success
+  2026-07-16.
+- **2026-08-03 08:0x BST** — Root cause read from the check-run annotation, not
+  inferred. `git log -S` showed `PERSONAS_PASSWORD_DEV` unchanged in this
+  workflow since 2026-05-29, so the repo secret was renamed under it.
+- The inventory check immediately found one further reference not backed by a
+  configured secret — `SMOKE_FIREBASE_API_KEY` — which turned out to be a
+  deliberate `|| DEV_FIREBASE_API_KEY` override with its own preflight. Modelled
+  as `optional:` rather than silenced.

--- a/express-api/tests/scripts/deploy-dev-seed-personas.test.js
+++ b/express-api/tests/scripts/deploy-dev-seed-personas.test.js
@@ -112,21 +112,41 @@ describe('seed-dev-personas.yml — reusable workflow + direct dispatch', () => 
     expect(SEED_WORKFLOW).toMatch(/^ {2}workflow_dispatch:$/m);
   });
 
-  test('workflow_call declares the secrets it needs (caller forwards via `secrets: inherit`)', () => {
-    // Declared with the EXACT repo-level secret names so actionlint can
-    // type-check the `secrets.X` references inside the workflow AND so
-    // `secrets: inherit` from the caller forwards by name without needing
-    // an explicit per-secret mapping. Names match the repo's GitHub
-    // Actions secrets settings.
+  test('workflow_call declares the CANONICAL repo secret names', () => {
+    // SHY-0269: this test previously asserted `PERSONAS_PASSWORD_DEV:` and
+    // its comment claimed the names matched the repo's Actions settings.
+    // They did not — SHY-0136 renamed the secret to
+    // DEV_QA_PERSONAS_PASSWORD and this workflow was left behind, so the
+    // pin locked in the defect instead of catching it. The inventory
+    // cross-check in workflow-secrets-inventory.test.js is the real guard;
+    // this is the named pin for the one that actually broke.
     expect(SEED_WORKFLOW).toContain('FIREBASE_SERVICE_ACCOUNT_DEV:');
-    expect(SEED_WORKFLOW).toContain('PERSONAS_PASSWORD_DEV:');
-    // Both must be required so a future caller that forgets to forward
-    // them fails at workflow_call validation rather than at runtime.
+    expect(SEED_WORKFLOW).toContain('DEV_QA_PERSONAS_PASSWORD:');
+    expect(SEED_WORKFLOW).not.toContain('PERSONAS_PASSWORD_DEV');
+  });
+
+  test('workflow_call secrets are NOT `required: true` — so a missing one fails IN A STEP, with logs', () => {
+    // A `required: true` workflow_call secret is validated BEFORE the job
+    // starts. GitHub then fails the call with zero steps and zero logs;
+    // the reason exists only as a check-run annotation. That is precisely
+    // how dev persona seeding stayed broken for ~18 days across 5 deploys.
+    // Declaring them optional lets the job start and fail in an explicit
+    // preflight step, where the reason lands in the run log.
     const callIdx = SEED_WORKFLOW.indexOf('workflow_call:');
     const dispatchIdx = SEED_WORKFLOW.indexOf('workflow_dispatch:');
     const callBlock = SEED_WORKFLOW.slice(callIdx, dispatchIdx);
-    expect(callBlock).toMatch(/FIREBASE_SERVICE_ACCOUNT_DEV:[\s\S]{1,200}required: true/);
-    expect(callBlock).toMatch(/PERSONAS_PASSWORD_DEV:[\s\S]{1,200}required: true/);
+    expect(callBlock).not.toMatch(/required: true/);
+  });
+
+  test('a preflight step names every missing secret via ::error:: before doing any work', () => {
+    expect(SEED_WORKFLOW).toMatch(/Verify required secrets/i);
+    expect(SEED_WORKFLOW).toContain('::error');
+    // The message must name the secrets, or the log is as useless as the
+    // annotation was.
+    const preflightIdx = SEED_WORKFLOW.search(/Verify required secrets/i);
+    const preflight = SEED_WORKFLOW.slice(preflightIdx, preflightIdx + 1600);
+    expect(preflight).toContain('DEV_QA_PERSONAS_PASSWORD');
+    expect(preflight).toContain('FIREBASE_SERVICE_ACCOUNT_DEV');
   });
 
   test('declares a `target` input on both triggers with `dev` as the only allowed value', () => {
@@ -310,6 +330,42 @@ describe('seed-test-personas composite action — interface (unchanged by refact
     expect(installIdx).toBeGreaterThan(cdIdx);
     expect(nodeIdx).toBeGreaterThan(installIdx);
     expect(lines[installIdx]).toContain('--omit=dev');
-    expect(lines[nodeIdx]).toMatch(/^\s*node\s+scripts\/provision-test-personas\.js\s*$/);
+    // Anchored on the INVOCATION, not the whole line: SHY-0269 appends
+    // `| tee /tmp/seed-personas.log` so the run can be checked for the
+    // script's PROVISION_ALL_OK completion marker. The contract this test
+    // owns is ordering (cd → npm ci → node) and the absence of a dotenv
+    // preload — pinning the trailing `$` also pinned "no output capture",
+    // which was never the point.
+    expect(lines[nodeIdx]).toMatch(/^\s*node\s+scripts\/provision-test-personas\.js(\s|$)/);
+    expect(lines[nodeIdx]).not.toContain('dotenv');
+  });
+});
+
+// ── SHY-0269: the outcome must be visible without opening a job ────────
+
+describe('seed outcome reporting (SHY-0269 — silent failure is the real defect)', () => {
+  test('deploy-dev.yml reports the seed outcome to the run summary even when it fails or is skipped', () => {
+    // Five of the last eight dev deploys had a failing seed job; one had a
+    // SKIPPED seed job while the run went green. Both are invisible unless
+    // someone expands the job list, so the outcome is written to
+    // $GITHUB_STEP_SUMMARY by a job that always() runs.
+    expect(DEPLOY_DEV).toMatch(/seed-personas-report|Seed Personas Report/);
+    const idx = DEPLOY_DEV.search(/seed-personas-report:/);
+    expect(idx).toBeGreaterThan(-1);
+    const job = DEPLOY_DEV.slice(idx, idx + 2200);
+    expect(job).toMatch(/if:\s*always\(\)/);
+    expect(job).toContain('GITHUB_STEP_SUMMARY');
+    // It must distinguish all three outcomes — a report that only knows
+    // "success" reproduces the silence for the skipped case.
+    expect(job).toMatch(/skipped/i);
+    expect(job).toMatch(/failure/i);
+    expect(job).toMatch(/success/i);
+  });
+
+  test('the seed action proves the provision actually ran (exit 0 is not evidence)', () => {
+    // provision-test-personas.js prints `PROVISION_ALL_OK count=N` as its
+    // final line. Asserting on it means a script that silently no-ops, or
+    // exits early on a path that forgets to fail, cannot report success.
+    expect(SEED_ACTION).toContain('PROVISION_ALL_OK');
   });
 });

--- a/express-api/tests/scripts/workflow-secrets-inventory.test.js
+++ b/express-api/tests/scripts/workflow-secrets-inventory.test.js
@@ -1,0 +1,161 @@
+/**
+ * SHY-0269 — every `secrets.X` referenced by CI must be a secret that
+ * actually exists.
+ *
+ * Dev persona seeding was dead for ~18 days and nobody knew. The reusable
+ * workflow `seed-dev-personas.yml` declared `PERSONAS_PASSWORD_DEV` as a
+ * REQUIRED `workflow_call` secret; the repo secret had been renamed to
+ * `DEV_QA_PERSONAS_PASSWORD` (SHY-0136) and every other workflow moved with
+ * it. GitHub failed the call during secrets EVALUATION — before any step
+ * exists — so the job produced zero steps and zero logs, and the reason
+ * ("Secret PERSONAS_PASSWORD_DEV is required, but not provided while
+ * calling") lived only in a check-run annotation nobody reads.
+ *
+ * The existing pin test could not catch it: it asserted the workflow
+ * contained the literal string `PERSONAS_PASSWORD_DEV:`, which is exactly
+ * the wrong name. A string-to-string pin has no ground truth — it pinned
+ * the bug.
+ *
+ * `.github/known-secrets.yml` is that ground truth: the authoritative list
+ * of secret names configured on the repository. Renaming a secret now has
+ * to touch the inventory, and this test fails for any workflow left behind.
+ *
+ * Known limitation: the inventory is human-maintained (the Actions API
+ * cannot be read from inside a workflow run). It cannot prove a listed
+ * secret still exists — it proves the repo AGREES WITH ITSELF about the
+ * name, which is the drift that actually bit.
+ */
+
+const { readFileSync, readdirSync, statSync } = require('fs');
+const { join } = require('path');
+
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const GITHUB_DIR = join(REPO_ROOT, '.github');
+const INVENTORY_PATH = join(GITHUB_DIR, 'known-secrets.yml');
+
+/** Recursively collect every .yml/.yaml under .github/workflows + .github/actions. */
+function collectCiFiles() {
+  const roots = [join(GITHUB_DIR, 'workflows'), join(GITHUB_DIR, 'actions')];
+  const out = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (/\.ya?ml$/.test(entry)) out.push(full);
+    }
+  };
+  roots.forEach(walk);
+  return out;
+}
+
+/**
+ * Strip a YAML line comment without a backtracking regex. A `#` only opens
+ * a comment at the start of a line or after whitespace, so `a#b` (a value)
+ * survives while `a  # note` does not.
+ */
+function stripYamlComment(line) {
+  const idx = line.indexOf('#');
+  if (idx === -1) return line;
+  if (idx === 0) return '';
+  return /\s/.test(line[idx - 1]) ? line.slice(0, idx) : line;
+}
+
+/**
+ * Secret names referenced as `secrets.NAME` in the OPERATIONAL body of a CI
+ * file. YAML comments are stripped first: prose like "resolve from the repo
+ * secrets (secrets.X)" is documentation, not a reference, and counting it
+ * makes the guard cry wolf on its own explanatory comments.
+ */
+function referencedSecrets(text) {
+  const names = new Set();
+  const re = /secrets\.([A-Z0-9_]+)/g;
+  for (const rawLine of text.split('\n')) {
+    const line = stripYamlComment(rawLine);
+    let m;
+    while ((m = re.exec(line)) !== null) names.add(m[1]);
+  }
+  return names;
+}
+
+/**
+ * @param {'secrets'|'optional'} section
+ * `secrets:` — names configured on the repository.
+ * `optional:` — names a workflow may reference that are deliberately NOT
+ *   configured, because the reference carries a documented `|| fallback`.
+ *   Listing them separately keeps the strict check strict: an unlisted name
+ *   is still a failure, but an intentional override is not misreported as
+ *   drift.
+ */
+function inventoryNames(section = 'secrets') {
+  const raw = readFileSync(INVENTORY_PATH, 'utf8');
+  const start = raw.indexOf(`\n${section}:`);
+  if (start === -1) return [];
+  const rest = raw.slice(start + section.length + 2);
+  const end = rest.search(/\n[a-z_]+:/);
+  return (end === -1 ? rest : rest.slice(0, end))
+    .split('\n')
+    .map((line) => stripYamlComment(line).trim())
+    .filter((line) => line.startsWith('- '))
+    .map((line) => line.slice(2).trim())
+    .filter(Boolean);
+}
+
+describe('.github/known-secrets.yml — CI secret inventory', () => {
+  test('the inventory file exists and lists at least the three known repo secrets', () => {
+    const names = inventoryNames();
+    expect(names).toEqual(expect.arrayContaining(['DEV_QA_PERSONAS_PASSWORD']));
+    expect(names.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('the inventory has no duplicate entries', () => {
+    const names = inventoryNames();
+    expect(names).toHaveLength(new Set(names).size);
+  });
+
+  test('every secrets.X referenced by any workflow or action is in the inventory', () => {
+    const inventory = new Set([...inventoryNames('secrets'), ...inventoryNames('optional')]);
+    const offenders = [];
+
+    for (const file of collectCiFiles()) {
+      const text = readFileSync(file, 'utf8');
+      for (const name of referencedSecrets(text)) {
+        // `secrets.GITHUB_TOKEN` is provided by Actions itself, and
+        // `secrets.inherit` is syntax, not a secret name.
+        if (name === 'GITHUB_TOKEN' || name === 'ACTIONS_RUNNER_DEBUG') continue;
+        if (!inventory.has(name)) {
+          offenders.push(`${file.replace(`${REPO_ROOT}/`, '')} → secrets.${name}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  test('every optional entry documents the fallback that makes its absence safe', () => {
+    // An `optional:` entry without a stated fallback is just an unchecked
+    // secret wearing a badge. The comment on its line has to say what
+    // happens when it is absent.
+    const raw = readFileSync(INVENTORY_PATH, 'utf8');
+    for (const name of inventoryNames('optional')) {
+      const line = raw.split('\n').find((l) => l.trim().startsWith(`- ${name}`)) || '';
+      const context = raw.slice(
+        Math.max(0, raw.indexOf(line) - 400),
+        raw.indexOf(line) + line.length,
+      );
+      expect(context).toMatch(/fallback|falls back|\|\|/i);
+    }
+  });
+
+  test('the extractor actually finds references (guard against a vacuous pass)', () => {
+    const files = collectCiFiles();
+    expect(files.length).toBeGreaterThan(5);
+    const total = files.reduce((n, f) => n + referencedSecrets(readFileSync(f, 'utf8')).size, 0);
+    expect(total).toBeGreaterThan(5);
+  });
+});


### PR DESCRIPTION
Implements SHY-0269 — see .project/stories/SHY-0269-seed-personas-silent-failure.md for full spec, AC, BDD scenarios, and DoD.

Dev persona seeding had been dead since 2026-07-16 — five of the last eight dev deploys failed it, one skipped it while the run went green, and nobody knew. Personas P-02..P-19 were ~18 days stale underneath manual QA and journey runs.

The trigger was a rename (SHY-0136 moved the secret to `DEV_QA_PERSONAS_PASSWORD`; four workflows followed, `seed-dev-personas.yml` did not). The reason it survived 18 days is the interesting part: a `required: true` secret on a `workflow_call` is validated BEFORE the job starts, so GitHub failed it with **zero steps and zero logs** — the reason existed only in a check-run annotation nothing surfaces.

Fixes:
- canonical secret name
- secrets optional at the call boundary + a preflight step that names every missing one via `::error` **in the run log**, covering the `workflow_dispatch` path too (which `required:` never did)
- an `always()` job writing the verdict to `$GITHUB_STEP_SUMMARY`, distinguishing success / failure / **skipped** and stating the consequence ("personas on dev are STALE")
- `exit 0` no longer counts as evidence — the action asserts the provisioning script's `PROVISION_ALL_OK` marker

The pin test that should have caught the rename had asserted the WRONG name, with a comment claiming it matched the repo's settings — it pinned the bug. Replaced with ground truth: `.github/known-secrets.yml` plus a test that fails when any workflow references a name that isn't there. It found a second unbacked reference immediately (`SMOKE_FIREBASE_API_KEY`), which turned out to be a deliberate `|| DEV_FIREBASE_API_KEY` override — now modelled as `optional:` with its fallback documented rather than silenced.

**Proven live, not just tested.** Dispatched against this branch: seed job `success (steps=9)` — previously `failure (steps=0)` — with `Both required secrets are present.` and `PROVISION_ALL_OK count=17` in the log. Dev personas are fresh for the first time since 2026-07-16.

29/29 tests, actionlint + eslint + prettier clean.

CI-config-only: no app, backend or website runtime surface is touched, so the device/browser gauntlet would exercise nothing related to the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHiDwcJoD3BDp3vMiQPgrK