### PR TITLE
SHY-0270: Voice rooms close themselves seconds after opening

### DIFF
--- a/.project/stories/SHY-0270-rtdb-presence-identity.md
+++ b/.project/stories/SHY-0270-rtdb-presence-identity.md
@@ -1,0 +1,152 @@
+---
+id: SHY-0270
+status: In Review
+owner: claude
+created: 2026-08-03
+priority: P0
+effort: S
+type: bug
+roadmap_ids: []
+pr:
+mvp: true
+---
+
+# SHY-0270: Voice rooms close themselves seconds after opening on dev
+
+## User Story
+
+As someone opening a voice room,
+I want the room to stay open once I have created it,
+So that people can actually join me instead of arriving to find it already closed.
+
+## Why
+
+Found while walking the SHY-0268 device gauntlet on dev. Every room created from a real
+device closed itself about two and a half seconds later — consistently: 2408ms, 2420ms,
+2408ms across attempts. A timer, not a race.
+
+The cause is an identity mismatch between the client and the realtime-database rule.
+
+The client writes presence at `rooms/{roomId}/presence/{uniqueId}` — `RtdbPresenceService`
+is handed the app's numeric uniqueId. The rule required `auth.uid == $userId`, which is the
+*Firebase* uid. Those two are different values for the same person (50000030 vs
+`t7BBRjbHXXPIvPAhzwhMKpRqRnt2`), so the comparison could never be true and every presence
+write was denied:
+
+```
+setValue at /rooms/{roomId}/presence/50000030 failed: Permission denied
+onDisconnect().setValue at /rooms/{roomId}/presence/50000030 failed: Permission denied
+```
+
+With no presence ever recorded, the room read as empty, and the client's own
+"owner alone → close" path closed it.
+
+The uniqueId is the correct key, not a client bug: `ActiveRoomManager` computes
+`absentUsers = participantIds - presentUserIds - currentUserId`, and `participantIds` are
+uniqueIds. Keying presence by Firebase uid would make every participant permanently absent.
+
+Rules cannot query Firestore, but they do not need to — `uniqueId` is already a custom claim
+on the token (`{"uniqueId":50000030,"cohort":"adult"}`), so the rule can authorise the write
+without weakening it.
+
+This never showed up locally: the emulator was not enforcing these rules, so the room stayed
+open on local and died on dev. Local-green, dev-red.
+
+## Acceptance Criteria
+
+### Happy path
+- [ ] A room created on dev stays open, with the creator recorded as present
+
+### Error paths
+- [ ] A user still cannot write presence under someone else's id
+- [ ] Typing indicators, which use the same identity, are authorised the same way
+
+### Edge cases
+- [ ] The uniqueId claim is a NUMBER and the path key is a STRING — the comparison must
+      survive that, not silently never match
+
+### Performance
+- [ ] N/A — a rule expression change; no additional reads or round trips.
+
+### Security
+- [ ] Self-ownership is preserved: authenticated, and only for your own id
+- [ ] No path becomes world-writable; the root deny is untouched
+- [ ] The claim is server-issued, so it cannot be spoofed by the client
+
+### UX
+- [ ] Rooms no longer close underneath the person who just opened them
+
+### i18n
+- [ ] N/A — no user-facing strings.
+
+### Observability
+- [ ] The permission-denied warnings disappear from device logs
+
+## BDD Scenarios
+
+**Scenario: A newly created room stays open**
+- **Given** a member has just created a voice room
+- **When** they wait in it
+- **Then** the room is still open and they are shown as present
+
+**Scenario: Presence cannot be forged for someone else**
+- **Given** a signed-in member
+- **When** they try to mark a different member as present
+- **Then** the write is refused
+
+## Test Plan
+
+**Red first** — `express-api/tests/rtdb-rules/presence-rules.test.js` (new): 3 of 6 assertions
+failed against the old rule. It pins that presence is authorised by the uniqueId claim rather
+than the Firebase uid, that self-ownership and authentication survive, that the numeric claim
+is string-compared, and that typing uses the same identity.
+
+`owner-left-rules.test.js` had pinned the literal `auth.uid == $userId` as the thing not to
+regress — pinning the defect. Corrected to assert the security PROPERTY (authenticated +
+self-owned) and to leave the identity contract to the new file.
+
+**Green** — 14/14 rules tests pass.
+
+**Device proof (real OnePlus over USB, dev backend):**
+- before: `state=CLOSED`, closed 2.4s after creation, 4+ permission-denied warnings per room
+- after: `state=ACTIVE` at 17.4s, `participantIds=["50000030"]`, RTDB presence
+  `{"50000030": true}`, **zero** denials
+- the SHY-0268 journey then completed on dev: gacha → age wall → "Verify now" → verification
+  screen, app alive, zero exceptions
+
+## Out of Scope
+
+- The `/ownerLeft/{roomId}` denial seen in the same logs. Its rule signs with `auth.uid` and
+  the client passes the Firebase uid, so it is a different question; it needs its own
+  investigation rather than being swept in here.
+- Making the local emulator enforce these rules. That is the reason this was invisible
+  locally and deserves its own story — a local run that cannot fail on rules is a local run
+  that cannot catch this class of bug.
+
+## Dependencies
+
+- None. The `uniqueId` custom claim already exists on issued tokens.
+
+## Risks & Mitigations
+
+- **Risk:** the claim is missing on an older token, so presence silently fails again.
+  **Mitigation:** claims are set at sign-in and refreshed on cohort change; the failure mode
+  is identical to today's (denied write), not worse, and the device walk confirms real tokens
+  carry it.
+- **Risk:** string/number coercion is fragile. **Mitigation:** pinned by its own test, and the
+  device proof shows the write landing.
+
+## Definition of Done
+
+- [ ] 14/14 rules tests green
+- [ ] Rules deployed to dev and a room verified to stay open on a real device
+- [ ] iOS device walk of the same room-open path
+- [ ] Merged to develop; `released_in:` at the next release cut
+
+## Notes (running log)
+
+- **2026-08-03 15:4x BST** — Found during the SHY-0268 gauntlet. Quantified before diagnosing:
+  three creations, closing at 2408/2420/2408ms. Ruled out the stale-room reaper (needs
+  `OWNER_AWAY` plus a 5-minute grace) and a coincidental `delay(2600)` in RoomScreen (that is
+  the gacha win animation). Root cause read from device logs, not inferred.
+- **2026-08-03 16:0x BST** — Rules deployed to dev; before/after measured on the same device.

--- a/.project/stories/SHY-0270-rtdb-presence-identity.md
+++ b/.project/stories/SHY-0270-rtdb-presence-identity.md
@@ -42,15 +42,26 @@ With no presence ever recorded, the room read as empty. On dev that ends in the 
 closed within seconds; the fix removes the denials and the room stays open (measured
 before/after on the same device, below).
 
-**What is proven vs what is inferred.** Proven: the denials were real, the fix removes them,
-and the room then stays open. Inferred: the exact closing path. The same denials occur
-LOCALLY — 85 local rooms, zero presence nodes — yet local rooms stay open indefinitely
-(a local room from this session was still ACTIVE hours later). So denied presence is
-necessary but not sufficient, and something dev-only completes the chain. The device log
-shows the likely completer: `setValue at /ownerLeft/{roomId} failed: Permission denied`
-alongside `connectionMonitor: state=DISCONNECTED`, i.e. the arm/cancel of the owner-left
-signal is also broken, and the server-side owner-left handler acts on it. That path is
-tracked separately rather than asserted here.
+**The closing path, established end to end in the source.** Entering a room arms an
+owner-left signal, and `RtdbPresenceService.armOwnerLeftSignal` deliberately writes
+`ownerLeft/{roomId}` IMMEDIATELY — its own comment explains why: the entry must exist before
+the `onDisconnect` arms, so the arm itself fires the server's `child_added` listener, which
+is expected to re-check and NOOP because the owner is obviously present.
+
+That re-check is the hinge. `owner-left-orchestrator.js:169` calls
+`presenceChecker(roomId, preRoom.ownerId)` — keyed by uniqueId, exactly where the client
+writes presence — and `owner-left-handler.js:48` returns NOOP only `if (ownerStillPresent)`.
+With presence denied there is nothing to find, so `ownerStillPresent` is false, and the
+handler's documented branch for "ACTIVE and no non-owner seated" is to **close the room
+immediately**. Hence ~2.4s: the round trip of arm → listener → re-check → transaction.
+
+The fix closes the loop: presence writes land, the re-check finds the owner, the handler
+NOOPs, and the room stays open — which is precisely what the before/after measurement shows.
+
+Local escapes this because the signal path never completes there — 85 local rooms carry zero
+presence nodes and no room ever closed, so the listener is not acting on local rooms at all.
+Why the path does not complete locally is genuinely open, and is the reason a local run gave
+false confidence.
 
 The uniqueId is the correct key, not a client bug: `ActiveRoomManager` computes
 `absentUsers = participantIds - presentUserIds - currentUserId`, and `participantIds` are
@@ -168,6 +179,11 @@ self-owned) and to leave the identity contract to the new file.
   `OWNER_AWAY` plus a 5-minute grace) and a coincidental `delay(2600)` in RoomScreen (that is
   the gacha win animation). Root cause read from device logs, not inferred.
 - **2026-08-03 16:0x BST** — Rules deployed to dev; before/after measured on the same device.
+- **2026-08-03 22:4x BST** — Traced the closing path to source and upgraded it from inferred
+  to established: arm writes `ownerLeft` immediately (by design), the server re-checks
+  presence by uniqueId (`owner-left-orchestrator.js:169`), and NOOPs only if present
+  (`owner-left-handler.js:48`); with presence denied it takes the "ACTIVE, no non-owner
+  seated → close immediately" branch. The 2.4s is that round trip.
 - **2026-08-03 22:3x BST** — Re-examined the causal claim rather than leaving it tidy. The
   first write-up said the emulator "was not enforcing these rules"; that is NOT established.
   The emulator loads them and enforces them for authenticated clients (proved by allowing an

--- a/.project/stories/SHY-0270-rtdb-presence-identity.md
+++ b/.project/stories/SHY-0270-rtdb-presence-identity.md
@@ -38,8 +38,19 @@ setValue at /rooms/{roomId}/presence/50000030 failed: Permission denied
 onDisconnect().setValue at /rooms/{roomId}/presence/50000030 failed: Permission denied
 ```
 
-With no presence ever recorded, the room read as empty, and the client's own
-"owner alone → close" path closed it.
+With no presence ever recorded, the room read as empty. On dev that ends in the room being
+closed within seconds; the fix removes the denials and the room stays open (measured
+before/after on the same device, below).
+
+**What is proven vs what is inferred.** Proven: the denials were real, the fix removes them,
+and the room then stays open. Inferred: the exact closing path. The same denials occur
+LOCALLY — 85 local rooms, zero presence nodes — yet local rooms stay open indefinitely
+(a local room from this session was still ACTIVE hours later). So denied presence is
+necessary but not sufficient, and something dev-only completes the chain. The device log
+shows the likely completer: `setValue at /ownerLeft/{roomId} failed: Permission denied`
+alongside `connectionMonitor: state=DISCONNECTED`, i.e. the arm/cancel of the owner-left
+signal is also broken, and the server-side owner-left handler acts on it. That path is
+tracked separately rather than asserted here.
 
 The uniqueId is the correct key, not a client bug: `ActiveRoomManager` computes
 `absentUsers = participantIds - presentUserIds - currentUserId`, and `participantIds` are
@@ -49,8 +60,14 @@ Rules cannot query Firestore, but they do not need to — `uniqueId` is already 
 on the token (`{"uniqueId":50000030,"cohort":"adult"}`), so the rule can authorise the write
 without weakening it.
 
-This never showed up locally: the emulator was not enforcing these rules, so the room stayed
-open on local and died on dev. Local-green, dev-red.
+It did not show up locally, and the reason is worth recording precisely because the obvious
+explanation is wrong. The emulator DOES load these rules ("Rules updated" on start) and DOES
+enforce them for an authenticated client — verified directly: with the fixed rule, writing
+your own presence is ALLOWED and writing someone else's is DENIED. Two things hide it
+locally: the emulator's REST API answers as admin, so a casual probe always succeeds; and
+rules bind to the `<projectId>-default-rtdb` namespace, so anything pointed at a different
+namespace sees no rules at all. Local rooms nonetheless stay open despite identical denials
+— see the proven/inferred note above.
 
 ## Acceptance Criteria
 
@@ -119,9 +136,10 @@ self-owned) and to leave the identity contract to the new file.
 - The `/ownerLeft/{roomId}` denial seen in the same logs. Its rule signs with `auth.uid` and
   the client passes the Firebase uid, so it is a different question; it needs its own
   investigation rather than being swept in here.
-- Making the local emulator enforce these rules. That is the reason this was invisible
-  locally and deserves its own story — a local run that cannot fail on rules is a local run
-  that cannot catch this class of bug.
+- Why local rooms survive the SAME denials while dev rooms do not. That difference is real
+  and unexplained, and it is the reason a local run gave false confidence. It needs its own
+  investigation — most likely the owner-left arm/cancel path above, which only completes when
+  the client actually reaches the realtime database.
 
 ## Dependencies
 
@@ -150,3 +168,10 @@ self-owned) and to leave the identity contract to the new file.
   `OWNER_AWAY` plus a 5-minute grace) and a coincidental `delay(2600)` in RoomScreen (that is
   the gacha win animation). Root cause read from device logs, not inferred.
 - **2026-08-03 16:0x BST** — Rules deployed to dev; before/after measured on the same device.
+- **2026-08-03 22:3x BST** — Re-examined the causal claim rather than leaving it tidy. The
+  first write-up said the emulator "was not enforcing these rules"; that is NOT established.
+  The emulator loads them and enforces them for authenticated clients (proved by allowing an
+  own-id write and denying an other-id write against the running emulator). The local silence
+  is explained by the admin REST bypass plus namespace binding. Separately, local rooms stay
+  open under the SAME denials, so presence-denial alone does not close a room — wording
+  tightened to separate what is proven from what is inferred.

--- a/database.rules.json
+++ b/database.rules.json
@@ -5,7 +5,7 @@
         "presence": {
           ".read": "auth != null",
           "$userId": {
-            ".write": "auth != null && auth.uid == $userId",
+            ".write": "auth != null && auth.token.uniqueId + '' === $userId",
             ".validate": "newData.isBoolean()"
           }
         },
@@ -22,7 +22,7 @@
         "typing": {
           ".read": "auth != null",
           "$userId": {
-            ".write": "auth != null && auth.uid == $userId",
+            ".write": "auth != null && auth.token.uniqueId + '' === $userId",
             ".validate": "newData.isBoolean()"
           }
         },

--- a/express-api/tests/rtdb-rules/owner-left-rules.test.js
+++ b/express-api/tests/rtdb-rules/owner-left-rules.test.js
@@ -93,7 +93,14 @@ describe('database.rules.json — ownerLeft rule', () => {
   test('rule does not accidentally widen reads/writes on adjacent paths', () => {
     // Pin the existing structure so this PR did not regress the presence
     // or events rules on rooms/{roomId}.
-    expect(RULES.rules.rooms.$roomId.presence.$userId['.write']).toContain('auth.uid == $userId');
+    // Presence must stay authenticated + self-owned. The IDENTITY it checks
+    // is owned by presence-rules.test.js: SHY-0270 moved it from `auth.uid`
+    // (the Firebase uid) to the `uniqueId` claim, because the client keys
+    // presence by uniqueId and the old comparison could never be true.
+    // Pinning the literal old expression here pinned that defect.
+    const presenceWrite = RULES.rules.rooms.$roomId.presence.$userId['.write'];
+    expect(presenceWrite).toContain('auth != null');
+    expect(presenceWrite).toContain('$userId');
     expect(RULES.rules.rooms.$roomId.events.lastEvent['.write']).toBe(false);
     expect(RULES.rules['.read']).toBe(false);
     expect(RULES.rules['.write']).toBe(false);

--- a/express-api/tests/rtdb-rules/presence-contract.test.js
+++ b/express-api/tests/rtdb-rules/presence-contract.test.js
@@ -1,0 +1,74 @@
+/**
+ * SHY-0270 — the presence path is a THREE-PARTY contract, and it silently broke.
+ *
+ * Three artefacts have to agree, and nothing checked that they did:
+ *
+ *   1. the CLIENT writes    rooms/{roomId}/presence/{uniqueId}
+ *      (RtdbPresenceService.setPresence, handed currentUserId)
+ *   2. the SERVER reads     rooms/{roomId}/presence/{userId}
+ *      (event-listeners.js presenceChecker, called with room.ownerId — a uniqueId)
+ *   3. the RULE authorises  rooms/$roomId/presence/$userId
+ *
+ * Parties 1 and 2 agreed on the uniqueId. Party 3 compared against `auth.uid`,
+ * the FIREBASE uid. Every write was denied, the server's owner-left re-check
+ * found no owner present, and it closed the room — which is the documented
+ * "ACTIVE and no non-owner seated" branch, not a timeout.
+ *
+ * Each artefact was individually defensible; only the RELATIONSHIP was wrong,
+ * so no per-file test could see it. This one checks the relationship.
+ *
+ * Deliberately source-level: it must fail at commit time, not at 2.4 seconds
+ * into a room on a real phone.
+ */
+
+const { readFileSync } = require('fs');
+const { join } = require('path');
+
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const read = (rel) => readFileSync(join(REPO_ROOT, rel), 'utf8');
+
+const RULES = JSON.parse(read('database.rules.json')).rules;
+const CLIENT = read('app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt');
+const LISTENERS = read('express-api/src/utils/event-listeners.js');
+const ORCHESTRATOR = read('express-api/src/utils/owner-left-orchestrator.js');
+
+describe('presence path: client write, server read, and rule all agree', () => {
+  test('the client writes presence under rooms/{roomId}/presence/{userId}', () => {
+    expect(CLIENT).toMatch(/rooms\/\$roomId\/presence\/\$userId/);
+  });
+
+  test('the server reads presence from the same path shape', () => {
+    expect(LISTENERS).toMatch(/rooms\/\$\{roomId\}\/presence\/\$\{userId\}/);
+  });
+
+  test('the server checks presence for the room OWNER, whose id is a uniqueId', () => {
+    // `room.ownerId` is the numeric uniqueId (the same value the client is
+    // handed as currentUserId). If this ever became a Firebase uid, the rule
+    // and the client would both have to move with it.
+    expect(ORCHESTRATOR).toMatch(/presenceChecker\(\s*roomId\s*,\s*\w+\.ownerId\s*\)/);
+  });
+
+  test('the rule authorises the identity the client actually writes', () => {
+    const write = RULES.rooms.$roomId.presence.$userId['.write'];
+    // The client key is a uniqueId, so the rule must compare against the
+    // uniqueId claim. Comparing against auth.uid can never be true — that was
+    // the defect, and it denied every presence write.
+    expect(write).toContain('auth.token.uniqueId');
+    expect(write).not.toMatch(/auth\.uid\s*==\s*\$userId/);
+  });
+
+  test('a denied presence write would close the room — so this contract is load-bearing', () => {
+    // Pins WHY the mismatch was so destructive, so a future reader does not
+    // treat presence as cosmetic: the owner-left handler NOOPs only when the
+    // owner is found present, and otherwise closes an ACTIVE room outright.
+    const handler = read('express-api/src/utils/owner-left-handler.js');
+    expect(handler).toMatch(/if\s*\(ownerStillPresent\)\s*return\s+OWNER_LEFT_ACTION\.NOOP/);
+    expect(handler).toMatch(/CLOSE/);
+  });
+
+  test('the guard reads real files (vacuous-pass guard)', () => {
+    expect(CLIENT.length).toBeGreaterThan(500);
+    expect(LISTENERS.length).toBeGreaterThan(500);
+    expect(ORCHESTRATOR.length).toBeGreaterThan(500);
+  });
+});

--- a/express-api/tests/rtdb-rules/presence-rules.test.js
+++ b/express-api/tests/rtdb-rules/presence-rules.test.js
@@ -1,0 +1,82 @@
+/**
+ * SHY-0270 — the RTDB presence rule must be written against the identity the
+ * CLIENT actually uses.
+ *
+ * Observed on a real device against dev:
+ *
+ *   setValue at /rooms/{roomId}/presence/50000030 failed: Permission denied
+ *
+ * The client writes `rooms/{roomId}/presence/{uniqueId}` — see
+ * `RtdbPresenceService.setPresence`, which is handed
+ * `_uiState.value.currentUserId`, the app's numeric uniqueId. The rule
+ * required `auth.uid == $userId`, i.e. the FIREBASE uid. Those two never
+ * match, so every presence write was denied, the room looked empty to the
+ * connection monitor, and the client closed the room ~2.4s after creation.
+ *
+ * The uniqueId is the correct key, not a client bug: `ActiveRoomManager`
+ * computes `absentUsers = participantIds - presentUserIds - currentUserId`,
+ * and `participantIds` are uniqueIds. Keying presence by Firebase uid would
+ * make every participant permanently "absent".
+ *
+ * Rules cannot query Firestore, but they do not need to: `uniqueId` is a
+ * custom claim on the token (verified on dev:
+ * `{"uniqueId":50000030,"cohort":"adult"}`), so the rule can authorise the
+ * write without weakening it — a user may still only write their OWN
+ * presence.
+ *
+ * Structural grep, matching the convention in `owner-left-rules.test.js`:
+ * parse the rules file, assert the shape, no emulator.
+ */
+
+const { readFileSync } = require('fs');
+const { join } = require('path');
+
+const RULES_PATH = join(__dirname, '..', '..', '..', 'database.rules.json');
+const rules = JSON.parse(readFileSync(RULES_PATH, 'utf8')).rules;
+
+/** The `$userId` node under a room's presence map. */
+const presenceUser = rules?.rooms?.$roomId?.presence?.$userId;
+/** The `$userId` node under a conversation's typing map — same identity shape. */
+const typingUser = rules?.conversations?.$convId?.typing?.$userId;
+
+describe('RTDB presence rule authorises the identity the client writes', () => {
+  test('the presence node exists where the client writes it', () => {
+    // Guards against a vacuous pass if the rules are restructured.
+    expect(presenceUser).toBeDefined();
+    expect(typeof presenceUser['.write']).toBe('string');
+  });
+
+  test('presence is authorised by the uniqueId claim, not the Firebase uid', () => {
+    const write = presenceUser['.write'];
+    expect(write).toContain('auth.token.uniqueId');
+    // `auth.uid == $userId` is the defect: the client keys presence by
+    // uniqueId, so that comparison can never be true.
+    expect(write).not.toMatch(/auth\.uid\s*==\s*\$userId/);
+  });
+
+  test('presence still requires authentication and self-ownership', () => {
+    const write = presenceUser['.write'];
+    expect(write).toContain('auth != null');
+    // Self-ownership: the key being written must be the caller's own id.
+    expect(write).toContain('$userId');
+  });
+
+  test('the uniqueId claim is compared as a string', () => {
+    // The claim is a NUMBER (50000030) and RTDB path keys are STRINGS, so a
+    // bare `===` would silently never match — the same class of failure this
+    // story exists to fix.
+    expect(presenceUser['.write']).toMatch(/auth\.token\.uniqueId\s*\+\s*''/);
+  });
+
+  test('typing presence uses the same identity as room presence', () => {
+    // conversations/{id}/typing/{userId} is written by the same client-side
+    // identity. Leaving it on auth.uid would reproduce this bug in DMs.
+    expect(typingUser).toBeDefined();
+    expect(typingUser['.write']).toContain('auth.token.uniqueId');
+    expect(typingUser['.write']).not.toMatch(/auth\.uid\s*==\s*\$userId/);
+  });
+
+  test('presence values are still validated as booleans', () => {
+    expect(presenceUser['.validate']).toContain('isBoolean');
+  });
+});


### PR DESCRIPTION
Implements SHY-0270 — see .project/stories/SHY-0270-rtdb-presence-identity.md for full spec, AC, BDD scenarios, and DoD.

Found while walking the SHY-0268 device gauntlet on dev: every room created from a real device closed itself ~2.4s later — 2408ms, 2420ms, 2408ms across attempts. A timer, not a race.

## The defect

The client writes presence at `rooms/{roomId}/presence/{uniqueId}`, but the rule required `auth.uid == $userId` — the **Firebase** uid. For the same person those are different values (`50000030` vs `t7BBRjbHXXPIvPAhzwhMKpRqRnt2`), so the comparison could never be true and every presence write was denied:

```
setValue at /rooms/{roomId}/presence/50000030 failed: Permission denied
```

`uniqueId` is the **correct** key, not a client bug: `ActiveRoomManager` computes `absentUsers = participantIds - presentUserIds - currentUserId`, and `participantIds` are uniqueIds — keying presence by Firebase uid would make every participant permanently absent. Rules cannot query Firestore but do not need to: `uniqueId` is already a custom claim, so the rule authorises the write without weakening self-ownership. Typing indicators share the identity and are fixed with it.

## Proven vs inferred

I re-examined my own first write-up and two claims in it did not hold up. They are corrected here rather than left standing.

**Proven:** the denials were real; the fix removes them; the room then stays open. Measured before and after on the same device.

| | before | after |
|---|---|---|
| room state | CLOSED @ 2.4s | **ACTIVE @ 17.4s** |
| participants | `[]` | `["50000030"]` |
| RTDB presence | none | `{"50000030": true}` |
| permission denials | 4+ per room | **0** |

**Corrected #1 — "the local emulator was not enforcing these rules."** Wrong. It loads them (`Rules updated` at startup) and enforces them for an authenticated client; verified directly against the running emulator with the fixed rule — writing your OWN presence is allowed, writing someone else's is denied. Two things had hidden that: the emulator's REST API answers as **admin**, so a casual probe always succeeds, and rules bind to the `<projectId>-default-rtdb` **namespace**, so a probe pointed elsewhere sees no rules at all. My first probe fell into both traps.

**Corrected #2 — "no presence → room reads empty → client closes it."** Under-determined. The same denials happen locally (85 local rooms, zero presence nodes) yet local rooms stay open indefinitely — one from this session was still ACTIVE hours later. So denied presence is necessary but **not sufficient**, and something dev-only completes the chain. The device log names the likely completer: `setValue at /ownerLeft/{roomId} failed: Permission denied` alongside `connectionMonitor: state=DISCONNECTED`. That path is carried as an open question, not asserted.

The rule change stands on its own regardless: a rule comparing against the Firebase uid can never authorise a write keyed by uniqueId.

## Diagnosis was narrowed, not guessed

The stale-room reaper was ruled out (needs `OWNER_AWAY` plus a five-minute grace; this fired in 2.4s), and a `delay(2600)` in `RoomScreen` that matched the timing suspiciously well turned out to be the gacha win animation.

`owner-left-rules.test.js` had pinned the literal `auth.uid == $userId` as the thing not to regress — pinning the defect. Corrected to assert the security *property*.

With rooms alive, the SHY-0268 journey then completed on dev end to end: gacha → age wall → "Verify now" → verification screen, app alive, zero exceptions.

14/14 rules tests pass. Rules already deployed to dev for this verification.

## Out of scope

- Why local rooms survive the same denials while dev rooms do not — real, unexplained, and the reason a local run gave false confidence.
- The `/ownerLeft/{roomId}` denial itself.

**iOS device walk still owed** — currently blocked: taps never reach the Compose surface on iOS (Appium finds elements and accepts gestures, but accessibility-id, predicate and raw coordinate injection all have no effect, including on a link with an unmistakable navigation effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHiDwcJoD3BDp3vMiQPgrK