### PR TITLE
SHY-0271: Test what translations say — and fix 8 String.format crashes it uncovered

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -87,6 +87,14 @@ jobs:
               # and iOS pipelines, defeating the speedup.
               shared/src/iosMain/*) IOS_APP=true; APP=true ;;
               shared/src/androidMain/*) ANDROID_APP=true; APP=true ;;
+              # The locale corpus is guarded by Jest tests that live in
+              # express-api (locale-string-content, compose-resources-locale-
+              # parity), so BACKEND must be set for those to run at all —
+              # the same reasoning as the qa-runner drivers arm above.
+              # Without it a locale-only PR skipped `test-backend` entirely
+              # and the content guard ran only incidentally, inside the
+              # sonarcloud job's unfiltered suite (SHY-0271).
+              shared/src/commonMain/composeResources/*) ANDROID_APP=true; IOS_APP=true; APP=true; BACKEND=true ;;
               # commonMain et al affects every platform consumer of
               # the shared module. Setting both flags is the safe
               # conservative behaviour.

--- a/.project/stories/SHY-0270-rtdb-presence-identity.md
+++ b/.project/stories/SHY-0270-rtdb-presence-identity.md
@@ -1,0 +1,152 @@
+---
+id: SHY-0270
+status: In Review
+owner: claude
+created: 2026-08-03
+priority: P0
+effort: S
+type: bug
+roadmap_ids: []
+pr:
+mvp: true
+---
+
+# SHY-0270: Voice rooms close themselves seconds after opening on dev
+
+## User Story
+
+As someone opening a voice room,
+I want the room to stay open once I have created it,
+So that people can actually join me instead of arriving to find it already closed.
+
+## Why
+
+Found while walking the SHY-0268 device gauntlet on dev. Every room created from a real
+device closed itself about two and a half seconds later — consistently: 2408ms, 2420ms,
+2408ms across attempts. A timer, not a race.
+
+The cause is an identity mismatch between the client and the realtime-database rule.
+
+The client writes presence at `rooms/{roomId}/presence/{uniqueId}` — `RtdbPresenceService`
+is handed the app's numeric uniqueId. The rule required `auth.uid == $userId`, which is the
+*Firebase* uid. Those two are different values for the same person (50000030 vs
+`t7BBRjbHXXPIvPAhzwhMKpRqRnt2`), so the comparison could never be true and every presence
+write was denied:
+
+```
+setValue at /rooms/{roomId}/presence/50000030 failed: Permission denied
+onDisconnect().setValue at /rooms/{roomId}/presence/50000030 failed: Permission denied
+```
+
+With no presence ever recorded, the room read as empty, and the client's own
+"owner alone → close" path closed it.
+
+The uniqueId is the correct key, not a client bug: `ActiveRoomManager` computes
+`absentUsers = participantIds - presentUserIds - currentUserId`, and `participantIds` are
+uniqueIds. Keying presence by Firebase uid would make every participant permanently absent.
+
+Rules cannot query Firestore, but they do not need to — `uniqueId` is already a custom claim
+on the token (`{"uniqueId":50000030,"cohort":"adult"}`), so the rule can authorise the write
+without weakening it.
+
+This never showed up locally: the emulator was not enforcing these rules, so the room stayed
+open on local and died on dev. Local-green, dev-red.
+
+## Acceptance Criteria
+
+### Happy path
+- [ ] A room created on dev stays open, with the creator recorded as present
+
+### Error paths
+- [ ] A user still cannot write presence under someone else's id
+- [ ] Typing indicators, which use the same identity, are authorised the same way
+
+### Edge cases
+- [ ] The uniqueId claim is a NUMBER and the path key is a STRING — the comparison must
+      survive that, not silently never match
+
+### Performance
+- [ ] N/A — a rule expression change; no additional reads or round trips.
+
+### Security
+- [ ] Self-ownership is preserved: authenticated, and only for your own id
+- [ ] No path becomes world-writable; the root deny is untouched
+- [ ] The claim is server-issued, so it cannot be spoofed by the client
+
+### UX
+- [ ] Rooms no longer close underneath the person who just opened them
+
+### i18n
+- [ ] N/A — no user-facing strings.
+
+### Observability
+- [ ] The permission-denied warnings disappear from device logs
+
+## BDD Scenarios
+
+**Scenario: A newly created room stays open**
+- **Given** a member has just created a voice room
+- **When** they wait in it
+- **Then** the room is still open and they are shown as present
+
+**Scenario: Presence cannot be forged for someone else**
+- **Given** a signed-in member
+- **When** they try to mark a different member as present
+- **Then** the write is refused
+
+## Test Plan
+
+**Red first** — `express-api/tests/rtdb-rules/presence-rules.test.js` (new): 3 of 6 assertions
+failed against the old rule. It pins that presence is authorised by the uniqueId claim rather
+than the Firebase uid, that self-ownership and authentication survive, that the numeric claim
+is string-compared, and that typing uses the same identity.
+
+`owner-left-rules.test.js` had pinned the literal `auth.uid == $userId` as the thing not to
+regress — pinning the defect. Corrected to assert the security PROPERTY (authenticated +
+self-owned) and to leave the identity contract to the new file.
+
+**Green** — 14/14 rules tests pass.
+
+**Device proof (real OnePlus over USB, dev backend):**
+- before: `state=CLOSED`, closed 2.4s after creation, 4+ permission-denied warnings per room
+- after: `state=ACTIVE` at 17.4s, `participantIds=["50000030"]`, RTDB presence
+  `{"50000030": true}`, **zero** denials
+- the SHY-0268 journey then completed on dev: gacha → age wall → "Verify now" → verification
+  screen, app alive, zero exceptions
+
+## Out of Scope
+
+- The `/ownerLeft/{roomId}` denial seen in the same logs. Its rule signs with `auth.uid` and
+  the client passes the Firebase uid, so it is a different question; it needs its own
+  investigation rather than being swept in here.
+- Making the local emulator enforce these rules. That is the reason this was invisible
+  locally and deserves its own story — a local run that cannot fail on rules is a local run
+  that cannot catch this class of bug.
+
+## Dependencies
+
+- None. The `uniqueId` custom claim already exists on issued tokens.
+
+## Risks & Mitigations
+
+- **Risk:** the claim is missing on an older token, so presence silently fails again.
+  **Mitigation:** claims are set at sign-in and refreshed on cohort change; the failure mode
+  is identical to today's (denied write), not worse, and the device walk confirms real tokens
+  carry it.
+- **Risk:** string/number coercion is fragile. **Mitigation:** pinned by its own test, and the
+  device proof shows the write landing.
+
+## Definition of Done
+
+- [ ] 14/14 rules tests green
+- [ ] Rules deployed to dev and a room verified to stay open on a real device
+- [ ] iOS device walk of the same room-open path
+- [ ] Merged to develop; `released_in:` at the next release cut
+
+## Notes (running log)
+
+- **2026-08-03 15:4x BST** — Found during the SHY-0268 gauntlet. Quantified before diagnosing:
+  three creations, closing at 2408/2420/2408ms. Ruled out the stale-room reaper (needs
+  `OWNER_AWAY` plus a 5-minute grace) and a coincidental `delay(2600)` in RoomScreen (that is
+  the gacha win animation). Root cause read from device logs, not inferred.
+- **2026-08-03 16:0x BST** — Rules deployed to dev; before/after measured on the same device.

--- a/.project/stories/SHY-0270-rtdb-presence-identity.md
+++ b/.project/stories/SHY-0270-rtdb-presence-identity.md
@@ -42,15 +42,26 @@ With no presence ever recorded, the room read as empty. On dev that ends in the 
 closed within seconds; the fix removes the denials and the room stays open (measured
 before/after on the same device, below).
 
-**What is proven vs what is inferred.** Proven: the denials were real, the fix removes them,
-and the room then stays open. Inferred: the exact closing path. The same denials occur
-LOCALLY — 85 local rooms, zero presence nodes — yet local rooms stay open indefinitely
-(a local room from this session was still ACTIVE hours later). So denied presence is
-necessary but not sufficient, and something dev-only completes the chain. The device log
-shows the likely completer: `setValue at /ownerLeft/{roomId} failed: Permission denied`
-alongside `connectionMonitor: state=DISCONNECTED`, i.e. the arm/cancel of the owner-left
-signal is also broken, and the server-side owner-left handler acts on it. That path is
-tracked separately rather than asserted here.
+**The closing path, established end to end in the source.** Entering a room arms an
+owner-left signal, and `RtdbPresenceService.armOwnerLeftSignal` deliberately writes
+`ownerLeft/{roomId}` IMMEDIATELY — its own comment explains why: the entry must exist before
+the `onDisconnect` arms, so the arm itself fires the server's `child_added` listener, which
+is expected to re-check and NOOP because the owner is obviously present.
+
+That re-check is the hinge. `owner-left-orchestrator.js:169` calls
+`presenceChecker(roomId, preRoom.ownerId)` — keyed by uniqueId, exactly where the client
+writes presence — and `owner-left-handler.js:48` returns NOOP only `if (ownerStillPresent)`.
+With presence denied there is nothing to find, so `ownerStillPresent` is false, and the
+handler's documented branch for "ACTIVE and no non-owner seated" is to **close the room
+immediately**. Hence ~2.4s: the round trip of arm → listener → re-check → transaction.
+
+The fix closes the loop: presence writes land, the re-check finds the owner, the handler
+NOOPs, and the room stays open — which is precisely what the before/after measurement shows.
+
+Local escapes this because the signal path never completes there — 85 local rooms carry zero
+presence nodes and no room ever closed, so the listener is not acting on local rooms at all.
+Why the path does not complete locally is genuinely open, and is the reason a local run gave
+false confidence.
 
 The uniqueId is the correct key, not a client bug: `ActiveRoomManager` computes
 `absentUsers = participantIds - presentUserIds - currentUserId`, and `participantIds` are
@@ -168,6 +179,11 @@ self-owned) and to leave the identity contract to the new file.
   `OWNER_AWAY` plus a 5-minute grace) and a coincidental `delay(2600)` in RoomScreen (that is
   the gacha win animation). Root cause read from device logs, not inferred.
 - **2026-08-03 16:0x BST** — Rules deployed to dev; before/after measured on the same device.
+- **2026-08-03 22:4x BST** — Traced the closing path to source and upgraded it from inferred
+  to established: arm writes `ownerLeft` immediately (by design), the server re-checks
+  presence by uniqueId (`owner-left-orchestrator.js:169`), and NOOPs only if present
+  (`owner-left-handler.js:48`); with presence denied it takes the "ACTIVE, no non-owner
+  seated → close immediately" branch. The 2.4s is that round trip.
 - **2026-08-03 22:3x BST** — Re-examined the causal claim rather than leaving it tidy. The
   first write-up said the emulator "was not enforcing these rules"; that is NOT established.
   The emulator loads them and enforces them for authenticated clients (proved by allowing an

--- a/.project/stories/SHY-0270-rtdb-presence-identity.md
+++ b/.project/stories/SHY-0270-rtdb-presence-identity.md
@@ -38,8 +38,19 @@ setValue at /rooms/{roomId}/presence/50000030 failed: Permission denied
 onDisconnect().setValue at /rooms/{roomId}/presence/50000030 failed: Permission denied
 ```
 
-With no presence ever recorded, the room read as empty, and the client's own
-"owner alone → close" path closed it.
+With no presence ever recorded, the room read as empty. On dev that ends in the room being
+closed within seconds; the fix removes the denials and the room stays open (measured
+before/after on the same device, below).
+
+**What is proven vs what is inferred.** Proven: the denials were real, the fix removes them,
+and the room then stays open. Inferred: the exact closing path. The same denials occur
+LOCALLY — 85 local rooms, zero presence nodes — yet local rooms stay open indefinitely
+(a local room from this session was still ACTIVE hours later). So denied presence is
+necessary but not sufficient, and something dev-only completes the chain. The device log
+shows the likely completer: `setValue at /ownerLeft/{roomId} failed: Permission denied`
+alongside `connectionMonitor: state=DISCONNECTED`, i.e. the arm/cancel of the owner-left
+signal is also broken, and the server-side owner-left handler acts on it. That path is
+tracked separately rather than asserted here.
 
 The uniqueId is the correct key, not a client bug: `ActiveRoomManager` computes
 `absentUsers = participantIds - presentUserIds - currentUserId`, and `participantIds` are
@@ -49,8 +60,14 @@ Rules cannot query Firestore, but they do not need to — `uniqueId` is already 
 on the token (`{"uniqueId":50000030,"cohort":"adult"}`), so the rule can authorise the write
 without weakening it.
 
-This never showed up locally: the emulator was not enforcing these rules, so the room stayed
-open on local and died on dev. Local-green, dev-red.
+It did not show up locally, and the reason is worth recording precisely because the obvious
+explanation is wrong. The emulator DOES load these rules ("Rules updated" on start) and DOES
+enforce them for an authenticated client — verified directly: with the fixed rule, writing
+your own presence is ALLOWED and writing someone else's is DENIED. Two things hide it
+locally: the emulator's REST API answers as admin, so a casual probe always succeeds; and
+rules bind to the `<projectId>-default-rtdb` namespace, so anything pointed at a different
+namespace sees no rules at all. Local rooms nonetheless stay open despite identical denials
+— see the proven/inferred note above.
 
 ## Acceptance Criteria
 
@@ -119,9 +136,10 @@ self-owned) and to leave the identity contract to the new file.
 - The `/ownerLeft/{roomId}` denial seen in the same logs. Its rule signs with `auth.uid` and
   the client passes the Firebase uid, so it is a different question; it needs its own
   investigation rather than being swept in here.
-- Making the local emulator enforce these rules. That is the reason this was invisible
-  locally and deserves its own story — a local run that cannot fail on rules is a local run
-  that cannot catch this class of bug.
+- Why local rooms survive the SAME denials while dev rooms do not. That difference is real
+  and unexplained, and it is the reason a local run gave false confidence. It needs its own
+  investigation — most likely the owner-left arm/cancel path above, which only completes when
+  the client actually reaches the realtime database.
 
 ## Dependencies
 
@@ -150,3 +168,10 @@ self-owned) and to leave the identity contract to the new file.
   `OWNER_AWAY` plus a 5-minute grace) and a coincidental `delay(2600)` in RoomScreen (that is
   the gacha win animation). Root cause read from device logs, not inferred.
 - **2026-08-03 16:0x BST** — Rules deployed to dev; before/after measured on the same device.
+- **2026-08-03 22:3x BST** — Re-examined the causal claim rather than leaving it tidy. The
+  first write-up said the emulator "was not enforcing these rules"; that is NOT established.
+  The emulator loads them and enforces them for authenticated clients (proved by allowing an
+  own-id write and denying an other-id write against the running emulator). The local silence
+  is explained by the admin REST bypass plus namespace binding. Separately, local rooms stay
+  open under the SAME denials, so presence-denial alone does not close a room — wording
+  tightened to separate what is proven from what is inferred.

--- a/.project/stories/SHY-0271-locale-content-is-untested.md
+++ b/.project/stories/SHY-0271-locale-content-is-untested.md
@@ -3,8 +3,8 @@ id: SHY-0271
 status: In Progress
 owner: claude
 created: 2026-08-04
-priority: P1
-effort: S
+priority: P0
+effort: M
 type: bug
 roadmap_ids: []
 pr:
@@ -15,9 +15,9 @@ mvp: true
 
 ## User Story
 
-As someone verifying their age,
-I want the buttons to be written in plain, correct English,
-So that I trust the screen enough to hand it a photo of my ID.
+As someone using the app in my own language,
+I want the words on screen to be written properly and to include the numbers they promise,
+So that the app reads like it was made for me rather than machine-translated at me.
 
 ## Why
 
@@ -35,7 +35,7 @@ self-contradictory about this — 11 apostrophes written plainly alongside 17 es
 nothing noticed, because nothing was reading the values at all.
 
 **Why every existing check passed it.** This is the part worth recording, because the defect
-was visible and the suite was large:
+was visible and the suite is large:
 
 - **Locale parity counts KEYS, not values.** All 21 files carry 838 keys; the check compares
   those key sets. A key whose value is garbage is a perfectly good key.
@@ -47,15 +47,48 @@ was visible and the suite was large:
 - **The journey corpus asserts screens, not sentences.** Steps are declarative ("they are shown
   the verification screen"), which is correct BDD but says nothing about the copy.
 
-So the string was rendered, clicked, screenshotted and shipped without one assertion ever
-reading it. The gap is not that a check was wrong — it is that **content was not a test surface**.
+So the string was rendered, clicked and shipped without one assertion ever reading it. The gap
+is not that a check was wrong — **content was not a test surface at all**.
 
-Scope of the rot: **221 strings across 18 of the 21 locales** (`values` 15, `values-fr` 93,
-`values-it` 47, `values-tr` 41, `values-uk` 12, and one each in thirteen others).
+**The generator was still writing the defect, and a green test demanded it.** Fixing the 221
+strings would have been useless on its own: `scripts/translate-strings.js` converted every
+apostrophe to `\'` on every write, so the next translation run would have restored all of them.
+Worse, `translate-strings.test.js` asserted `toContain("it\\'s")` — the suite was *green on the
+operator's defect*, pinning the bug as the contract. Both `escapeXml` and `unescapeXml` were
+exported "for testing" and neither had a single direct test.
 
-The equivalent web catalogs (`public/js/*-translations.js`, `public/portal`, `public/admin`)
-were checked and are clean — in JavaScript `\'` is a *parser* escape and is consumed before the
-string exists, so the defect is specific to the Compose XML surface.
+**What Compose actually unescapes was settled by measurement, not argument.** `Res.allStringResources`
+exposes every key at runtime, so a device test resolves all 838 through the real pipeline and
+asserts on what a user would read. Result: **`\uXXXX` IS unescaped; `\'` is NOT.** That matters,
+because the corpus held 57 `…` — had they rendered literally, `Loading…` was on the
+first screen of every session. They do not. The corpus was normalised anyway, so the rule can be
+a flat "no backslash except `\n`" with no allowlist to maintain.
+
+**Pulling that thread found worse than backslashes.** Once translations were compared for
+content rather than key names, six strings turned out to have had their *format specifier*
+translated:
+
+| locale | key | shipped | should be |
+|---|---|---|---|
+| ar | `user_id` | `المعرف: %1$د` | `%1$d` |
+| ar | `seat_number` | `المقعد %1$د` | `%1$d` |
+| id | `day_streak` | `%1$hari berturut-turut` | `%1$d hari …` |
+| ko | `day_streak` | `%1$일 연속` | `%1$d일 연속` |
+| ru | `active_days_ago` | `Активен %1$дд назад` | `%1$dд` |
+| ru | `active_minutes_ago` | `Активен %1$дм назад` | `%1$dм` |
+
+The machine translator read the `d` in `%1$d` as the first letter of a word and localised it.
+On Android `stringResource(res, arg)` routes to `String.format`, and `%1$د` is an unknown
+conversion — **`UnknownFormatConversionException`, a crash**, in Arabic, Korean, Russian and
+Indonesian. Two more (`de` and `fr` `success_redeemed_beans_bonus`) had the `%%` escape broken
+apart into `% %` and `% `, the same crash by a different route. English, Spanish and Italian had
+it right, which is why nobody looked.
+
+Scope: **221 escaped apostrophes/quotes** (18 locales), **58 further escape artefacts** (21
+locales, incl. zh's `\“…\”`), **8 broken format strings** (6 locales).
+
+The web catalogs (`public/js/*-translations.js`, `public/portal`, `public/admin`) were checked
+and are clean — in JavaScript `\'` is a *parser* escape, consumed before the string exists.
 
 ## Acceptance Criteria
 
@@ -64,13 +97,15 @@ string exists, so the defect is specific to the Compose XML surface.
 
 ### Error paths
 - [ ] A re-introduced `\'` fails a test rather than reaching a screen
+- [ ] The generator can no longer write an escaped apostrophe
 
 ### Edge cases
 - [ ] `\n` is preserved — it is a real line break, not an escaping artefact
-- [ ] Spanish/Portuguese `TODO` ("all") is not mistaken for a developer marker
+- [ ] `%%` is preserved where a literal percent is intended
+- [ ] Spanish `all_caps` / `collect_all` (`TODO` = "all") are not mistaken for developer markers
 
 ### Performance
-- [ ] N/A — a string-content fix plus two file-reading tests; no runtime cost.
+- [ ] N/A — string content plus file-reading tests; no runtime cost.
 
 ### Security
 - [ ] N/A — no authorisation, identity, or data path is touched.
@@ -79,17 +114,24 @@ string exists, so the defect is specific to the Compose XML surface.
 - [ ] No user-facing string renders a stray backslash in any of the 21 locales
 
 ### i18n
-- [ ] All 21 locales are checked, not just English
-- [ ] Key parity is unchanged at 838 keys per locale
+- [ ] Every translation takes the same format arguments as the English it replaces
+- [ ] No locale can crash `String.format` with a translated or unescaped specifier
+- [ ] Key parity unchanged at 838 keys per locale
 
 ### Observability
-- [ ] The failure names the offending locale, key, and value, so the fix is obvious
+- [ ] Each failure names the offending locale, key and value, so the fix is obvious
 
 ## BDD Scenarios
 
 **Scenario: The ID buttons are written in plain English**
-- **Given** someone is choosing which ID to submit
+- **Given** someone is verifying their age
+- **When** they reach the step that asks which ID they will use
 - **Then** the options read "Passport", "Driver's license" and "National ID card"
+
+**Scenario: A translation keeps the number it promises**
+- **Given** a profile shown in Arabic
+- **When** the member views their ID
+- **Then** the number appears, and the screen does not crash
 
 **Scenario: Corrupt copy is caught before it ships**
 - **Given** a translation containing a stray escape character
@@ -104,29 +146,49 @@ verbatim into `values/strings.xml` and the instrumented suite run on a real OneP
 ```
 methodButtonsRenderTheirLabels_notJustTheirTags            FAILED
   AssertionError: Failed to assert the following: (Text + EditableText = [Driver's license])
-noRenderedTextOnThisScreenCarriesAnEscapeSequence          FAILED
+noRenderedTextOnAnyStepCarriesAnEscapeSequence            FAILED
 ```
 
-Restoring the fix turns both green (`BUILD SUCCESSFUL`). The mutant was the operator's string
-character-for-character, so this is a demonstrated catch, not a claimed one.
+Restoring the fix turns both green. The mutant was the operator's string character-for-character.
 
-**New — `express-api/tests/scripts/locale-string-content.test.js`** reads all 21 locale files as
-text and asserts no escaped apostrophe or quote, no empty value, no leaked markup, and no
-developer marker — with a vacuous-pass guard (≥20 files, >15,000 strings) so it cannot silently
-stop reading, and a self-mutation guard proving the escape predicate fires.
+**New — `express-api/tests/scripts/locale-string-content.test.js`** (9 tests) reads all 21 locale
+files and asserts: no backslash except `\n`; no empty value; no leaked markup; no developer
+marker; **placeholder parity against English per key**; and **no unescaped `%` in a format
+string**. Guards on the guard: per-file parse-completeness (the parser's yield must equal the
+raw `<string` count, so a reformat cannot silently blank a file), an allowlist-rot check, and two
+mutation guards that call the *same* predicate the real checks use rather than an inline copy.
 
-**New — two tests in `AgeVerificationSubmitScreenTest`**: one asserting the three labels by text
-via `assertTextEquals`, one sweeping every text node on the screen for a backslash so future
-strings are covered without being named.
+**New — `app/src/androidTest/.../resources/StringResourceContentTest.kt`** resolves all 838 keys
+through `Res.allStringResources` + `getString` on a real device — the actual Compose pipeline,
+not a proxy for it. This is what established that `\uXXXX` is unescaped and `\'` is not.
 
-**Green** — 6/6 locale-content tests; instrumented suite green on device; key parity unchanged
-at 838 per locale; `\n` count in English unchanged at 9.
+**New — three tests in `AgeVerificationSubmitScreenTest`**: the three labels by text; a sweep of
+`Text` + `EditableText` + `ContentDescription` across **all** steps of the flow; and a guard that
+the walk actually advances, so the sweep cannot quietly shrink to one step.
+
+**New — `express-api/tests/scripts/pr-checks-locale-guard-gating.test.js`** pins that a
+locale-only PR runs these guards at all. It did not: `shared/*` set only the app flags, so
+`test-backend` was skipped and the content guard ran incidentally inside sonarcloud's unfiltered
+suite. `pr-checks.yml` now has a `composeResources` arm setting `BACKEND`, ordered before
+`shared/*` because `case` is first-match.
+
+**Root cause — `scripts/translate-strings.js`**: `escapeXml` no longer escapes apostrophes, the
+test that demanded `it\'s` is inverted (and now also asserts `not.toContain("\\'")`), and both
+`escapeXml` and `unescapeXml` gained direct tests including a round-trip and a
+"never emits a backslash" property.
+
+**Green** — 99/99 across the four locale-related suites; 9/9 instrumented on device; 3/3 whole-
+corpus runtime tests on device; key parity unchanged at 838; 412 `\n` preserved; the no-new-stubs
+ratchet clean.
 
 ## Out of Scope
 
-- Translation *quality* (whether the French is good French). This story is about mechanical
-  corruption of the copy, which is objectively checkable.
-- The web catalogs, which were checked and found clean.
+- Translation *quality* (whether the French reads well). This story is about mechanical
+  corruption, which is objectively checkable.
+- The web catalogs, checked and found clean.
+- The pre-existing anonymous `AgeVerificationRepository` double in `AgeVerificationSubmitScreenTest`.
+  It predates this story, the no-new-stubs ratchet does not flag it, and replacing it means giving
+  a Compose UI test a real upload backend — a separate piece of work, noted here so it is not lost.
 
 ## Dependencies
 
@@ -135,23 +197,33 @@ at 838 per locale; `\n` count in English unchanged at 9.
 ## Risks & Mitigations
 
 - **Risk:** the value-scoped rewrite mangles `\n` or an attribute.
-  **Mitigation:** the replacement is scoped to text between `<string>` tags and targets only
-  `\'`/`\"`; `\n` count and key parity were both measured before and after and are unchanged.
-- **Risk:** the marker check false-positives on a real word.
-  **Mitigation:** it already did — Spanish `RECOGER TODO` ("collect all"). `TODO` is excluded for
-  es/pt with the reason written at the exclusion.
+  **Mitigation:** the diff was verified mechanically — 221 removed / 221 added, every pair
+  differing *only* by removed backslashes; `\n` count and key parity measured before and after.
+- **Risk:** the strict "no backslash" rule rejects a legitimate future string.
+  **Mitigation:** it is the correct rule for this corpus — no user-facing copy in this app needs
+  a backslash — and a genuine need would be a deliberate, reviewed change to one named predicate.
+- **Risk:** the format-specifier fixes change meaning in languages I do not read.
+  **Mitigation:** each fix restores the *specifier only*, leaving translated words untouched, and
+  the surrounding text was already reviewed against the sibling locales that were correct.
 
 ## Definition of Done
 
-- [ ] 221 strings fixed across 18 locales
-- [ ] Content guard green and mutation-verified
-- [ ] Instrumented text assertions green on a real Android device
+- [ ] 221 escapes + 58 artefacts + 8 broken format strings fixed
+- [ ] Generator no longer writes the defect; its test no longer demands it
+- [ ] Guards green and mutation-verified; CI gating pinned
+- [ ] Instrumented + whole-corpus runtime tests green on a real Android device
+- [ ] iOS device walk of the same screen
 - [ ] Merged to develop; `released_in:` at the next release cut
 
 ## Notes (running log)
 
-- **2026-08-04 00:0x BST** — Operator reported `Driver\'s license` on the age-verification
-  screen and asked how it got past testing. It got past because content was never a test
-  surface: parity counts keys, UI assertions match tags, and nothing read the files as text.
-  Worth recording that I had printed that exact string in a device dump earlier in the session
-  and read past it — the guard now is mechanical rather than attentional.
+- **2026-08-04 00:0x BST** — Operator reported `Driver\'s license` and asked how it got past
+  testing. It got past because content was never a test surface: parity counts keys, UI
+  assertions match tags, and nothing read the files as text. Recording that I had printed that
+  exact string in a device dump earlier in the session and read past it — which is why the guard
+  is mechanical rather than attentional.
+- **2026-08-04 00:4x BST** — Review found the generator still writing the defect and a green test
+  demanding it. Fixed at source. Chased the class rather than the instance: added a whole-corpus
+  runtime test, which disproved the worry that 57 `\uXXXX` were live defects, and added
+  placeholder parity, which found 8 genuine `String.format` crashes across 6 locales that had
+  been shipping unnoticed.

--- a/.project/stories/SHY-0271-locale-content-is-untested.md
+++ b/.project/stories/SHY-0271-locale-content-is-untested.md
@@ -1,0 +1,157 @@
+---
+id: SHY-0271
+status: In Progress
+owner: claude
+created: 2026-08-04
+priority: P1
+effort: S
+type: bug
+roadmap_ids: []
+pr:
+mvp: true
+---
+
+# SHY-0271: Translations are never checked for what they actually say
+
+## User Story
+
+As someone verifying their age,
+I want the buttons to be written in plain, correct English,
+So that I trust the screen enough to hand it a photo of my ID.
+
+## Why
+
+The operator read this off the age-verification screen on a real device:
+
+```
+Driver\'s license
+```
+
+A literal backslash, on a compliance screen, in production copy. It had shipped.
+
+**The trap.** `\'` and `\"` are ANDROID XML escaping. Compose Multiplatform's `composeResources`
+does not unescape them, so they reach the screen verbatim. The English file was already
+self-contradictory about this — 11 apostrophes written plainly alongside 17 escaped — and
+nothing noticed, because nothing was reading the values at all.
+
+**Why every existing check passed it.** This is the part worth recording, because the defect
+was visible and the suite was large:
+
+- **Locale parity counts KEYS, not values.** All 21 files carry 838 keys; the check compares
+  those key sets. A key whose value is garbage is a perfectly good key.
+- **UI assertions match by `testTag`.** `AgeVerificationSubmitScreenTest` *clicks*
+  `TAG_AGE_VERIF_METHOD_DRIVERS` in two separate tests. The tag is on the `Button`; the corrupt
+  string is on a `Text` inside it. Both tests drove the broken button and passed.
+- **Nothing read the locale files as text.** No test in any framework opened `strings.xml` and
+  looked at what was between the tags.
+- **The journey corpus asserts screens, not sentences.** Steps are declarative ("they are shown
+  the verification screen"), which is correct BDD but says nothing about the copy.
+
+So the string was rendered, clicked, screenshotted and shipped without one assertion ever
+reading it. The gap is not that a check was wrong — it is that **content was not a test surface**.
+
+Scope of the rot: **221 strings across 18 of the 21 locales** (`values` 15, `values-fr` 93,
+`values-it` 47, `values-tr` 41, `values-uk` 12, and one each in thirteen others).
+
+The equivalent web catalogs (`public/js/*-translations.js`, `public/portal`, `public/admin`)
+were checked and are clean — in JavaScript `\'` is a *parser* escape and is consumed before the
+string exists, so the defect is specific to the Compose XML surface.
+
+## Acceptance Criteria
+
+### Happy path
+- [ ] The age-verification method buttons read `Passport`, `Driver's license`, `National ID card`
+
+### Error paths
+- [ ] A re-introduced `\'` fails a test rather than reaching a screen
+
+### Edge cases
+- [ ] `\n` is preserved — it is a real line break, not an escaping artefact
+- [ ] Spanish/Portuguese `TODO` ("all") is not mistaken for a developer marker
+
+### Performance
+- [ ] N/A — a string-content fix plus two file-reading tests; no runtime cost.
+
+### Security
+- [ ] N/A — no authorisation, identity, or data path is touched.
+
+### UX
+- [ ] No user-facing string renders a stray backslash in any of the 21 locales
+
+### i18n
+- [ ] All 21 locales are checked, not just English
+- [ ] Key parity is unchanged at 838 keys per locale
+
+### Observability
+- [ ] The failure names the offending locale, key, and value, so the fix is obvious
+
+## BDD Scenarios
+
+**Scenario: The ID buttons are written in plain English**
+- **Given** someone is choosing which ID to submit
+- **Then** the options read "Passport", "Driver's license" and "National ID card"
+
+**Scenario: Corrupt copy is caught before it ships**
+- **Given** a translation containing a stray escape character
+- **When** the test suite runs
+- **Then** it fails and names the locale and key
+
+## Test Plan
+
+**Red first — proven on a real device, not asserted.** The exact defect was re-introduced
+verbatim into `values/strings.xml` and the instrumented suite run on a real OnePlus (CPH2653):
+
+```
+methodButtonsRenderTheirLabels_notJustTheirTags            FAILED
+  AssertionError: Failed to assert the following: (Text + EditableText = [Driver's license])
+noRenderedTextOnThisScreenCarriesAnEscapeSequence          FAILED
+```
+
+Restoring the fix turns both green (`BUILD SUCCESSFUL`). The mutant was the operator's string
+character-for-character, so this is a demonstrated catch, not a claimed one.
+
+**New — `express-api/tests/scripts/locale-string-content.test.js`** reads all 21 locale files as
+text and asserts no escaped apostrophe or quote, no empty value, no leaked markup, and no
+developer marker — with a vacuous-pass guard (≥20 files, >15,000 strings) so it cannot silently
+stop reading, and a self-mutation guard proving the escape predicate fires.
+
+**New — two tests in `AgeVerificationSubmitScreenTest`**: one asserting the three labels by text
+via `assertTextEquals`, one sweeping every text node on the screen for a backslash so future
+strings are covered without being named.
+
+**Green** — 6/6 locale-content tests; instrumented suite green on device; key parity unchanged
+at 838 per locale; `\n` count in English unchanged at 9.
+
+## Out of Scope
+
+- Translation *quality* (whether the French is good French). This story is about mechanical
+  corruption of the copy, which is objectively checkable.
+- The web catalogs, which were checked and found clean.
+
+## Dependencies
+
+- None.
+
+## Risks & Mitigations
+
+- **Risk:** the value-scoped rewrite mangles `\n` or an attribute.
+  **Mitigation:** the replacement is scoped to text between `<string>` tags and targets only
+  `\'`/`\"`; `\n` count and key parity were both measured before and after and are unchanged.
+- **Risk:** the marker check false-positives on a real word.
+  **Mitigation:** it already did — Spanish `RECOGER TODO` ("collect all"). `TODO` is excluded for
+  es/pt with the reason written at the exclusion.
+
+## Definition of Done
+
+- [ ] 221 strings fixed across 18 locales
+- [ ] Content guard green and mutation-verified
+- [ ] Instrumented text assertions green on a real Android device
+- [ ] Merged to develop; `released_in:` at the next release cut
+
+## Notes (running log)
+
+- **2026-08-04 00:0x BST** — Operator reported `Driver\'s license` on the age-verification
+  screen and asked how it got past testing. It got past because content was never a test
+  surface: parity counts keys, UI assertions match tags, and nothing read the files as text.
+  Worth recording that I had printed that exact string in a device dump earlier in the session
+  and read past it — the guard now is mechanical rather than attentional.

--- a/.project/stories/SHY-0271-locale-content-is-untested.md
+++ b/.project/stories/SHY-0271-locale-content-is-untested.md
@@ -227,3 +227,16 @@ ratchet clean.
   runtime test, which disproved the worry that 57 `\uXXXX` were live defects, and added
   placeholder parity, which found 8 genuine `String.format` crashes across 6 locales that had
   been shipping unnoticed.
+- **2026-08-04 02:5x BST** — Second review round found the SAME defect in its entity form:
+  `unescapeXml` did not decode `&apos;`, while `escapeXml` re-escapes `&`, so the next
+  translation run would have written `&amp;apos;` — which DOES render literally — into all 20
+  locales. Six English strings carried `&apos;`. Fixed the decode (ordered before `&amp;`, which
+  stays last), normalised the six, and added a corpus rule that only `&amp;`/`&lt;`/`&gt;` may
+  appear. Settled the render question on the device rather than reasoning about it, the same way
+  `\uXXXX` was settled: **Compose DOES decode entities**, so `&apos;` was not itself visible —
+  but `&amp;apos;` would have been.
+  Also closed: the sweep now shares its walk with its own guard (the guard used to do a private
+  walk and stayed green if the sweep shrank), covers the Explanation step it previously skipped,
+  and the parity test now uses the shared parser instead of a second private regex.
+
+Reviewed-up-to: (this commit)

--- a/app/src/androidTest/java/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitScreenTest.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitScreenTest.kt
@@ -199,15 +199,56 @@ class AgeVerificationSubmitScreenTest {
     /** Set by [showPickMethodStep] so a test can drive the flow past PickImage. */
     private lateinit var pickMethodVm: AgeVerificationSubmitViewModel
 
-    /** Advances to the PickMethod step, where the three ID buttons live. */
-    private fun showPickMethodStep() {
+    /** Renders the screen on its FIRST step (Explanation). */
+    private fun renderScreen() {
         pickMethodVm = AgeVerificationSubmitViewModel(fakeRepo, isPreviewBuild = true)
         composeTestRule.setContent {
             MaterialTheme {
                 AgeVerificationSubmitScreen(onClose = {}, viewModel = pickMethodVm)
             }
         }
+    }
+
+    /** Advances to the PickMethod step, where the three ID buttons live. */
+    private fun showPickMethodStep() {
+        renderScreen()
         composeTestRule.onNodeWithTag(TAG_AGE_VERIF_CONTINUE).performClick()
+    }
+
+    /**
+     * Walks the flow and collects every user-readable string at each step.
+     *
+     * Deliberately shared by the sweep AND its guard (SHY-0271). An earlier
+     * version had the guard perform its own private walk, which meant deleting
+     * the sweep's steps left the guard green — a guard that does not guard the
+     * thing it is named after.
+     *
+     * Returns the strings seen and how many steps were actually visited.
+     */
+    private fun sweepEveryStep(): Pair<List<String>, Int> {
+        val seen = mutableListOf<String>()
+        var steps = 0
+
+        renderScreen() // Explanation — previously skipped entirely
+        seen += visibleStrings()
+        steps++
+
+        composeTestRule.onNodeWithTag(TAG_AGE_VERIF_CONTINUE).performClick()
+        composeTestRule.waitForIdle()
+        seen += visibleStrings() // PickMethod
+        steps++
+
+        composeTestRule.onNodeWithTag(TAG_AGE_VERIF_METHOD_PASSPORT).performClick()
+        composeTestRule.waitForIdle()
+        seen += visibleStrings() // PickImage
+        steps++
+
+        pickMethodVm.setImage(byteArrayOf(0x01), ContentType.Jpeg)
+        composeTestRule.waitForIdle()
+        seen += visibleStrings() // Confirm
+        steps++
+
+        return seen.distinct() to steps
     }
 
     @Test
@@ -262,40 +303,20 @@ class AgeVerificationSubmitScreenTest {
 
     @Test
     fun noRenderedTextOnAnyStepCarriesAnEscapeSequence() {
-        // The general form of the same defect. Walks EVERY step of the flow —
-        // an earlier version only rendered PickMethod and so covered about a
-        // third of the screen's copy while being named after the whole of it.
-        showPickMethodStep()
-        val offenders = mutableListOf<String>()
-        offenders += visibleStrings().filter(::carriesEscape)
-
-        composeTestRule.onNodeWithTag(TAG_AGE_VERIF_METHOD_PASSPORT).performClick()
-        composeTestRule.waitForIdle()
-        offenders += visibleStrings().filter(::carriesEscape) // PickImage
-
-        pickMethodVm.setImage(byteArrayOf(0x01), ContentType.Jpeg)
-        composeTestRule.waitForIdle()
-        offenders += visibleStrings().filter(::carriesEscape) // Confirm
-
-        pickMethodVm.back()
-        composeTestRule.waitForIdle()
-        offenders += visibleStrings().filter(::carriesEscape)
-
-        assertEquals(emptyList<String>(), offenders.distinct().sorted())
+        // The general form of the defect, across the whole flow rather than
+        // one screen of it.
+        val (seen, _) = sweepEveryStep()
+        assertEquals(emptyList<String>(), seen.filter(::carriesEscape).sorted())
     }
 
     @Test
-    fun theSweepCoversMoreThanASingleStep() {
-        // Guards the walk itself. If a future edit collapses the test back to
-        // one step, the copy it stops covering would vanish silently — the
-        // sweep would still pass, on less. Pins that the flow actually moves.
-        showPickMethodStep()
-        val atPickMethod = visibleStrings()
-        composeTestRule.onNodeWithTag(TAG_AGE_VERIF_METHOD_PASSPORT).performClick()
-        composeTestRule.waitForIdle()
-        val atPickImage = visibleStrings()
-        assertTrue("the flow did not advance — the sweep would cover one step", atPickImage != atPickMethod)
-        assertTrue("no strings were read at all", atPickMethod.isNotEmpty() && atPickImage.isNotEmpty())
+    fun theSweepReallyVisitsEveryStepItClaims() {
+        // Guards the SWEEP, by calling the same walk it calls. If a future edit
+        // collapses the walk to one step, the copy it stops covering would
+        // vanish silently and the sweep would still pass — on less.
+        val (seen, steps) = sweepEveryStep()
+        assertEquals("the walk did not visit every step", 4, steps)
+        assertTrue("no strings were read at all", seen.size > 5)
     }
 
     @Test

--- a/app/src/androidTest/java/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitScreenTest.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitScreenTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.AnnotatedString
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.shyden.shytalk.core.util.Resource
 import com.shyden.shytalk.data.repository.AgeVerificationRepository
@@ -19,6 +20,7 @@ import com.shyden.shytalk.data.repository.AgeVerificationRepository.ContentType
 import com.shyden.shytalk.data.repository.AgeVerificationRepository.IdMethod
 import com.shyden.shytalk.data.repository.AgeVerificationRepository.UploadHandle
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -194,14 +196,15 @@ class AgeVerificationSubmitScreenTest {
 
     // ─── Rendered CONTENT of the method buttons (SHY-0271) ─────────────
 
+    /** Set by [showPickMethodStep] so a test can drive the flow past PickImage. */
+    private lateinit var pickMethodVm: AgeVerificationSubmitViewModel
+
     /** Advances to the PickMethod step, where the three ID buttons live. */
     private fun showPickMethodStep() {
+        pickMethodVm = AgeVerificationSubmitViewModel(fakeRepo, isPreviewBuild = true)
         composeTestRule.setContent {
             MaterialTheme {
-                AgeVerificationSubmitScreen(
-                    onClose = {},
-                    viewModel = AgeVerificationSubmitViewModel(fakeRepo, isPreviewBuild = true),
-                )
+                AgeVerificationSubmitScreen(onClose = {}, viewModel = pickMethodVm)
             }
         }
         composeTestRule.onNodeWithTag(TAG_AGE_VERIF_CONTINUE).performClick()
@@ -229,27 +232,83 @@ class AgeVerificationSubmitScreenTest {
         }
     }
 
-    @Test
-    fun noRenderedTextOnThisScreenCarriesAnEscapeSequence() {
-        // The general form of the same defect: a stray backslash anywhere in
-        // the copy. Catches every future string on this screen, in whichever
-        // locale the device is running, without naming them one by one.
-        showPickMethodStep()
-        val offenders =
+    /**
+     * Every user-readable string currently composed, from all three semantics
+     * properties a user can perceive.
+     *
+     * `ContentDescription` matters as much as `Text` here: the back control at
+     * `AgeVerificationSubmitScreen` carries its label only as a description, so
+     * a sweep over `Text` alone would let a corrupt string reach every TalkBack
+     * user unchallenged. `EditableText` is what a field's own contents live in.
+     */
+    private fun visibleStrings(): List<String> =
+        listOf(
+            SemanticsProperties.Text,
+            SemanticsProperties.EditableText,
+            SemanticsProperties.ContentDescription,
+        ).flatMap { key ->
             composeTestRule
-                .onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Text), useUnmergedTree = true)
+                .onAllNodes(SemanticsMatcher.keyIsDefined(key), useUnmergedTree = true)
                 .fetchSemanticsNodes()
-                .flatMap { it.config.getOrNull(SemanticsProperties.Text).orEmpty() }
-                .map { it.text }
-                .filter { it.contains('\\') }
-        assertEquals(emptyList<String>(), offenders)
+                .flatMap { node ->
+                    when (val v = node.config.getOrNull(key)) {
+                        is AnnotatedString -> listOf(v.text)
+                        is List<*> -> v.map { it.toString() }
+                        null -> emptyList()
+                        else -> listOf(v.toString())
+                    }
+                }
+        }
+
+    @Test
+    fun noRenderedTextOnAnyStepCarriesAnEscapeSequence() {
+        // The general form of the same defect. Walks EVERY step of the flow —
+        // an earlier version only rendered PickMethod and so covered about a
+        // third of the screen's copy while being named after the whole of it.
+        showPickMethodStep()
+        val offenders = mutableListOf<String>()
+        offenders += visibleStrings().filter(::carriesEscape)
+
+        composeTestRule.onNodeWithTag(TAG_AGE_VERIF_METHOD_PASSPORT).performClick()
+        composeTestRule.waitForIdle()
+        offenders += visibleStrings().filter(::carriesEscape) // PickImage
+
+        pickMethodVm.setImage(byteArrayOf(0x01), ContentType.Jpeg)
+        composeTestRule.waitForIdle()
+        offenders += visibleStrings().filter(::carriesEscape) // Confirm
+
+        pickMethodVm.back()
+        composeTestRule.waitForIdle()
+        offenders += visibleStrings().filter(::carriesEscape)
+
+        assertEquals(emptyList<String>(), offenders.distinct().sorted())
+    }
+
+    @Test
+    fun theSweepCoversMoreThanASingleStep() {
+        // Guards the walk itself. If a future edit collapses the test back to
+        // one step, the copy it stops covering would vanish silently — the
+        // sweep would still pass, on less. Pins that the flow actually moves.
+        showPickMethodStep()
+        val atPickMethod = visibleStrings()
+        composeTestRule.onNodeWithTag(TAG_AGE_VERIF_METHOD_PASSPORT).performClick()
+        composeTestRule.waitForIdle()
+        val atPickImage = visibleStrings()
+        assertTrue("the flow did not advance — the sweep would cover one step", atPickImage != atPickMethod)
+        assertTrue("no strings were read at all", atPickMethod.isNotEmpty() && atPickImage.isNotEmpty())
     }
 
     @Test
     fun theEscapeSweepCanActuallyFail() {
-        // Mutation guard: a sweep that cannot detect its own target is exactly
-        // how this shipped. Proves the predicate fires on the real defect.
-        val corrupt = listOf("Passport", "Driver\\'s license")
-        assertEquals(listOf("Driver\\'s license"), corrupt.filter { it.contains('\\') })
+        // Mutation guard on the SHARED predicate used by the sweep above — not
+        // an inline copy of it. A guard with its own private copy stays green
+        // while the real rule is weakened, which proves only that Kotlin's
+        // `String.contains` works.
+        assertTrue(carriesEscape("Driver\\'s license"))
+        assertTrue(carriesEscape("an escaped \\\" quote"))
+        assertEquals(false, carriesEscape("Driver's license"))
     }
 }
+
+/** No user-facing copy in this app legitimately contains a backslash. */
+internal fun carriesEscape(s: String): Boolean = s.contains('\\')

--- a/app/src/androidTest/java/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitScreenTest.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/feature/ageverification/AgeVerificationSubmitScreenTest.kt
@@ -1,8 +1,12 @@
 package com.shyden.shytalk.feature.ageverification
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
@@ -14,6 +18,7 @@ import com.shyden.shytalk.data.repository.AgeVerificationRepository
 import com.shyden.shytalk.data.repository.AgeVerificationRepository.ContentType
 import com.shyden.shytalk.data.repository.AgeVerificationRepository.IdMethod
 import com.shyden.shytalk.data.repository.AgeVerificationRepository.UploadHandle
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -185,5 +190,66 @@ class AgeVerificationSubmitScreenTest {
         composeTestRule
             .onNodeWithTag(TAG_AGE_VERIF_TEST_ENV_WARNING)
             .assertIsDisplayed()
+    }
+
+    // ─── Rendered CONTENT of the method buttons (SHY-0271) ─────────────
+
+    /** Advances to the PickMethod step, where the three ID buttons live. */
+    private fun showPickMethodStep() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                AgeVerificationSubmitScreen(
+                    onClose = {},
+                    viewModel = AgeVerificationSubmitViewModel(fakeRepo, isPreviewBuild = true),
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag(TAG_AGE_VERIF_CONTINUE).performClick()
+    }
+
+    @Test
+    fun methodButtonsRenderTheirLabels_notJustTheirTags() {
+        // The operator read `Driver\'s license` — backslash and all — off this
+        // screen, and it had shipped. Every test above CLICKS these buttons by
+        // tag and none reads them, so a corrupt label passed the whole suite.
+        //
+        // `\'` is ANDROID XML escaping; Compose Multiplatform's
+        // `composeResources` does not unescape it, so it reaches the screen
+        // verbatim. Asserting the tag proves a button exists; only asserting
+        // the TEXT proves it says the right thing.
+        showPickMethodStep()
+        mapOf(
+            TAG_AGE_VERIF_METHOD_PASSPORT to "Passport",
+            TAG_AGE_VERIF_METHOD_DRIVERS to "Driver's license",
+            TAG_AGE_VERIF_METHOD_NATIONAL to "National ID card",
+        ).forEach { (tag, label) ->
+            // Compose merges a clickable's descendants, so the Button's node
+            // carries its child Text — the same node the click tests use.
+            composeTestRule.onNodeWithTag(tag).assertTextEquals(label)
+        }
+    }
+
+    @Test
+    fun noRenderedTextOnThisScreenCarriesAnEscapeSequence() {
+        // The general form of the same defect: a stray backslash anywhere in
+        // the copy. Catches every future string on this screen, in whichever
+        // locale the device is running, without naming them one by one.
+        showPickMethodStep()
+        val offenders =
+            composeTestRule
+                .onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Text), useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .flatMap { it.config.getOrNull(SemanticsProperties.Text).orEmpty() }
+                .map { it.text }
+                .filter { it.contains('\\') }
+        assertEquals(emptyList<String>(), offenders)
+    }
+
+    @Test
+    fun theEscapeSweepCanActuallyFail() {
+        // Mutation guard: a sweep that cannot detect its own target is exactly
+        // how this shipped. Proves the predicate fires on the real defect.
+        val corrupt = listOf("Passport", "Driver\\'s license")
+        assertEquals(listOf("Driver\\'s license"), corrupt.filter { it.contains('\\') })
     }
 }

--- a/app/src/androidTest/java/com/shyden/shytalk/resources/StringResourceContentTest.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/resources/StringResourceContentTest.kt
@@ -1,0 +1,79 @@
+package com.shyden.shytalk.resources
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.getString
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * SHY-0271 — every string resource, resolved through the REAL Compose
+ * pipeline, on a REAL device.
+ *
+ * The operator read `Driver\'s license` off the age-verification screen. The
+ * file-level guard in `express-api/tests/scripts/locale-string-content.test.js`
+ * catches that pattern in the source XML, but it can only ever be a PROXY for
+ * the question that actually matters: what does Compose Multiplatform DO with
+ * an escape sequence?
+ *
+ * `Res.allStringResources` answers it directly. This resolves all ~838 keys via
+ * `getString` — the same path `stringResource` uses — and asserts on the value a
+ * user would actually read. A test written against the files can be fooled by a
+ * new escape family nobody thought to grep for; this one cannot, because it
+ * inspects the output rather than the input.
+ *
+ * It also settles empirically whether `\uXXXX` survives to the screen, which
+ * decides the fate of `Loading…` on the starting screen.
+ */
+@OptIn(ExperimentalResourceApi::class)
+@RunWith(AndroidJUnit4::class)
+class StringResourceContentTest {
+    private fun resolveAll(): Map<String, String> =
+        runBlocking {
+            Res.allStringResources.mapValues { (_, res) -> getString(res) }
+        }
+
+    @Test
+    fun theWholeCorpusWasActuallyResolved() {
+        // Vacuous-pass guard. An empty or truncated map would make every
+        // assertion below pass while checking nothing — the exact shape of
+        // failure this story exists to eliminate.
+        val all = resolveAll()
+        assertEquals(
+            "resource count changed — update this number deliberately, do not weaken it",
+            838,
+            all.size,
+        )
+        assertTrue("every resource resolved to a non-null value", all.values.all { it.isNotEmpty() })
+    }
+
+    @Test
+    fun noStringResourceRendersABackslash() {
+        // Deliberately ANY backslash, not an enumerated list of escapes. A
+        // predicate that names the sequences it knows about can only catch
+        // yesterday's defect; `\'` was missed for exactly that reason, and
+        // `\"`, `…` and `\“` are all the same mistake wearing a different
+        // character. No user-facing copy in this app legitimately contains a
+        // backslash, so the strict rule is also the correct one.
+        val offenders =
+            resolveAll()
+                .filterValues { it.contains('\\') }
+                .map { (key, value) -> "$key = $value" }
+                .sorted()
+        assertEquals(emptyList<String>(), offenders)
+    }
+
+    @Test
+    fun noStringResourceIsBlankOrLeaksMarkup() {
+        val offenders =
+            resolveAll()
+                .filterValues { value ->
+                    value.isBlank() || Regex("</?(?:div|span|p|br|b|i|html|body)\\b", RegexOption.IGNORE_CASE).containsMatchIn(value)
+                }.map { (key, value) -> "$key = $value" }
+                .sorted()
+        assertEquals(emptyList<String>(), offenders)
+    }
+}

--- a/app/src/androidTest/java/com/shyden/shytalk/resources/StringResourceContentTest.kt
+++ b/app/src/androidTest/java/com/shyden/shytalk/resources/StringResourceContentTest.kt
@@ -8,6 +8,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.Locale
 
 /**
  * SHY-0271 — every string resource, resolved through the REAL Compose
@@ -36,6 +37,15 @@ class StringResourceContentTest {
             Res.allStringResources.mapValues { (_, res) -> getString(res) }
         }
 
+    /** Which locale this run actually verified — a green result is otherwise ambiguous. */
+    private val resolvedLocale: String get() = Locale.getDefault().toLanguageTag()
+
+    private companion object {
+        // Hoisted: constructing this inside a filter recompiles it once per string.
+        val MARKUP = Regex("</?(?:div|span|p|br|b|i|html|body)\\b", RegexOption.IGNORE_CASE)
+        val ENTITY = Regex("&[a-zA-Z#][a-zA-Z0-9]*;")
+    }
+
     @Test
     fun theWholeCorpusWasActuallyResolved() {
         // Vacuous-pass guard. An empty or truncated map would make every
@@ -63,17 +73,32 @@ class StringResourceContentTest {
                 .filterValues { it.contains('\\') }
                 .map { (key, value) -> "$key = $value" }
                 .sorted()
-        assertEquals(emptyList<String>(), offenders)
+        assertEquals("resolved locale: $resolvedLocale", emptyList<String>(), offenders)
     }
 
     @Test
     fun noStringResourceIsBlankOrLeaksMarkup() {
         val offenders =
             resolveAll()
-                .filterValues { value ->
-                    value.isBlank() || Regex("</?(?:div|span|p|br|b|i|html|body)\\b", RegexOption.IGNORE_CASE).containsMatchIn(value)
-                }.map { (key, value) -> "$key = $value" }
+                .filterValues { it.isBlank() || MARKUP.containsMatchIn(it) }
+                .map { (key, value) -> "$key = $value" }
                 .sorted()
-        assertEquals(emptyList<String>(), offenders)
+        assertEquals("resolved locale: $resolvedLocale", emptyList<String>(), offenders)
+    }
+
+    @Test
+    fun noStringResourceRendersAnUndecodedEntity() {
+        // Settles for entities what this file already settled for backslashes:
+        // does Compose decode `&amp;` and friends, or do they reach the screen?
+        // Four locales legitimately contain `&amp;` in their terms copy, so if
+        // CMP decodes entities this passes and proves it; if it does not, it
+        // has caught `Terms &amp; Conditions` shipping. Either answer is worth
+        // knowing, and neither can be settled by reading the files.
+        val offenders =
+            resolveAll()
+                .filterValues { ENTITY.containsMatchIn(it) }
+                .map { (key, value) -> "$key = $value" }
+                .sorted()
+        assertEquals("resolved locale: $resolvedLocale", emptyList<String>(), offenders)
     }
 }

--- a/database.rules.json
+++ b/database.rules.json
@@ -5,7 +5,7 @@
         "presence": {
           ".read": "auth != null",
           "$userId": {
-            ".write": "auth != null && auth.uid == $userId",
+            ".write": "auth != null && auth.token.uniqueId + '' === $userId",
             ".validate": "newData.isBoolean()"
           }
         },
@@ -22,7 +22,7 @@
         "typing": {
           ".read": "auth != null",
           "$userId": {
-            ".write": "auth != null && auth.uid == $userId",
+            ".write": "auth != null && auth.token.uniqueId + '' === $userId",
             ".validate": "newData.isBoolean()"
           }
         },

--- a/express-api/tests/_helpers/compose-locales.js
+++ b/express-api/tests/_helpers/compose-locales.js
@@ -1,0 +1,73 @@
+/**
+ * The Compose-resources locale corpus, declared once.
+ *
+ * SHY-0271: three files had each grown their own idea of "the locale set" —
+ * `scripts/translate-strings.js` hard-codes 20, `compose-resources-locale-parity`
+ * hard-codes 20, and the new content guard was DISCOVERING them from disk. The
+ * discovering one was the weak link: a renamed or deleted locale directory just
+ * disappears from a discovered set, so the suite goes quieter instead of redder.
+ *
+ * Declared, not discovered. Adding a locale is a deliberate edit here.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const RESOURCES_DIR = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'shared',
+  'src',
+  'commonMain',
+  'composeResources',
+);
+
+/** The 20 translated locales (the default `values` dir is separate). */
+const ALL_LOCALES = [
+  'ar',
+  'de',
+  'es',
+  'fr',
+  'hi',
+  'id',
+  'it',
+  'ja',
+  'km',
+  'ko',
+  'nl',
+  'pl',
+  'pt',
+  'ru',
+  'sv',
+  'th',
+  'tr',
+  'uk',
+  'vi',
+  'zh',
+];
+
+/** Every resource directory, default first: ['values', 'values-ar', ...]. */
+const ALL_LOCALE_DIRS = ['values', ...ALL_LOCALES.map((l) => `values-${l}`)];
+
+const localeFilePath = (dir) => path.join(RESOURCES_DIR, dir, 'strings.xml');
+
+/**
+ * Parse one locale file into `[{ name, value }]`.
+ *
+ * Also returns `rawCount` — the number of `<string` elements the file actually
+ * contains — so a caller can prove the parser saw all of them. A regex that
+ * silently stops matching after a reformat is the failure mode that lets a
+ * content guard pass while reading nothing.
+ */
+function readLocaleStrings(dir) {
+  const xml = fs.readFileSync(localeFilePath(dir), 'utf8');
+  const entries = [];
+  for (const m of xml.matchAll(/<string name="([^"]+)"[^>]*>([\s\S]*?)<\/string>/g)) {
+    entries.push({ name: m[1], value: m[2] });
+  }
+  return { entries, rawCount: (xml.match(/<string\b/g) || []).length };
+}
+
+module.exports = { RESOURCES_DIR, ALL_LOCALES, ALL_LOCALE_DIRS, localeFilePath, readLocaleStrings };

--- a/express-api/tests/rtdb-rules/owner-left-rules.test.js
+++ b/express-api/tests/rtdb-rules/owner-left-rules.test.js
@@ -93,7 +93,14 @@ describe('database.rules.json — ownerLeft rule', () => {
   test('rule does not accidentally widen reads/writes on adjacent paths', () => {
     // Pin the existing structure so this PR did not regress the presence
     // or events rules on rooms/{roomId}.
-    expect(RULES.rules.rooms.$roomId.presence.$userId['.write']).toContain('auth.uid == $userId');
+    // Presence must stay authenticated + self-owned. The IDENTITY it checks
+    // is owned by presence-rules.test.js: SHY-0270 moved it from `auth.uid`
+    // (the Firebase uid) to the `uniqueId` claim, because the client keys
+    // presence by uniqueId and the old comparison could never be true.
+    // Pinning the literal old expression here pinned that defect.
+    const presenceWrite = RULES.rules.rooms.$roomId.presence.$userId['.write'];
+    expect(presenceWrite).toContain('auth != null');
+    expect(presenceWrite).toContain('$userId');
     expect(RULES.rules.rooms.$roomId.events.lastEvent['.write']).toBe(false);
     expect(RULES.rules['.read']).toBe(false);
     expect(RULES.rules['.write']).toBe(false);

--- a/express-api/tests/rtdb-rules/presence-contract.test.js
+++ b/express-api/tests/rtdb-rules/presence-contract.test.js
@@ -1,0 +1,74 @@
+/**
+ * SHY-0270 — the presence path is a THREE-PARTY contract, and it silently broke.
+ *
+ * Three artefacts have to agree, and nothing checked that they did:
+ *
+ *   1. the CLIENT writes    rooms/{roomId}/presence/{uniqueId}
+ *      (RtdbPresenceService.setPresence, handed currentUserId)
+ *   2. the SERVER reads     rooms/{roomId}/presence/{userId}
+ *      (event-listeners.js presenceChecker, called with room.ownerId — a uniqueId)
+ *   3. the RULE authorises  rooms/$roomId/presence/$userId
+ *
+ * Parties 1 and 2 agreed on the uniqueId. Party 3 compared against `auth.uid`,
+ * the FIREBASE uid. Every write was denied, the server's owner-left re-check
+ * found no owner present, and it closed the room — which is the documented
+ * "ACTIVE and no non-owner seated" branch, not a timeout.
+ *
+ * Each artefact was individually defensible; only the RELATIONSHIP was wrong,
+ * so no per-file test could see it. This one checks the relationship.
+ *
+ * Deliberately source-level: it must fail at commit time, not at 2.4 seconds
+ * into a room on a real phone.
+ */
+
+const { readFileSync } = require('fs');
+const { join } = require('path');
+
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const read = (rel) => readFileSync(join(REPO_ROOT, rel), 'utf8');
+
+const RULES = JSON.parse(read('database.rules.json')).rules;
+const CLIENT = read('app/src/main/java/com/shyden/shytalk/data/remote/RtdbPresenceService.kt');
+const LISTENERS = read('express-api/src/utils/event-listeners.js');
+const ORCHESTRATOR = read('express-api/src/utils/owner-left-orchestrator.js');
+
+describe('presence path: client write, server read, and rule all agree', () => {
+  test('the client writes presence under rooms/{roomId}/presence/{userId}', () => {
+    expect(CLIENT).toMatch(/rooms\/\$roomId\/presence\/\$userId/);
+  });
+
+  test('the server reads presence from the same path shape', () => {
+    expect(LISTENERS).toMatch(/rooms\/\$\{roomId\}\/presence\/\$\{userId\}/);
+  });
+
+  test('the server checks presence for the room OWNER, whose id is a uniqueId', () => {
+    // `room.ownerId` is the numeric uniqueId (the same value the client is
+    // handed as currentUserId). If this ever became a Firebase uid, the rule
+    // and the client would both have to move with it.
+    expect(ORCHESTRATOR).toMatch(/presenceChecker\(\s*roomId\s*,\s*\w+\.ownerId\s*\)/);
+  });
+
+  test('the rule authorises the identity the client actually writes', () => {
+    const write = RULES.rooms.$roomId.presence.$userId['.write'];
+    // The client key is a uniqueId, so the rule must compare against the
+    // uniqueId claim. Comparing against auth.uid can never be true — that was
+    // the defect, and it denied every presence write.
+    expect(write).toContain('auth.token.uniqueId');
+    expect(write).not.toMatch(/auth\.uid\s*==\s*\$userId/);
+  });
+
+  test('a denied presence write would close the room — so this contract is load-bearing', () => {
+    // Pins WHY the mismatch was so destructive, so a future reader does not
+    // treat presence as cosmetic: the owner-left handler NOOPs only when the
+    // owner is found present, and otherwise closes an ACTIVE room outright.
+    const handler = read('express-api/src/utils/owner-left-handler.js');
+    expect(handler).toMatch(/if\s*\(ownerStillPresent\)\s*return\s+OWNER_LEFT_ACTION\.NOOP/);
+    expect(handler).toMatch(/CLOSE/);
+  });
+
+  test('the guard reads real files (vacuous-pass guard)', () => {
+    expect(CLIENT.length).toBeGreaterThan(500);
+    expect(LISTENERS.length).toBeGreaterThan(500);
+    expect(ORCHESTRATOR.length).toBeGreaterThan(500);
+  });
+});

--- a/express-api/tests/rtdb-rules/presence-rules.test.js
+++ b/express-api/tests/rtdb-rules/presence-rules.test.js
@@ -1,0 +1,82 @@
+/**
+ * SHY-0270 — the RTDB presence rule must be written against the identity the
+ * CLIENT actually uses.
+ *
+ * Observed on a real device against dev:
+ *
+ *   setValue at /rooms/{roomId}/presence/50000030 failed: Permission denied
+ *
+ * The client writes `rooms/{roomId}/presence/{uniqueId}` — see
+ * `RtdbPresenceService.setPresence`, which is handed
+ * `_uiState.value.currentUserId`, the app's numeric uniqueId. The rule
+ * required `auth.uid == $userId`, i.e. the FIREBASE uid. Those two never
+ * match, so every presence write was denied, the room looked empty to the
+ * connection monitor, and the client closed the room ~2.4s after creation.
+ *
+ * The uniqueId is the correct key, not a client bug: `ActiveRoomManager`
+ * computes `absentUsers = participantIds - presentUserIds - currentUserId`,
+ * and `participantIds` are uniqueIds. Keying presence by Firebase uid would
+ * make every participant permanently "absent".
+ *
+ * Rules cannot query Firestore, but they do not need to: `uniqueId` is a
+ * custom claim on the token (verified on dev:
+ * `{"uniqueId":50000030,"cohort":"adult"}`), so the rule can authorise the
+ * write without weakening it — a user may still only write their OWN
+ * presence.
+ *
+ * Structural grep, matching the convention in `owner-left-rules.test.js`:
+ * parse the rules file, assert the shape, no emulator.
+ */
+
+const { readFileSync } = require('fs');
+const { join } = require('path');
+
+const RULES_PATH = join(__dirname, '..', '..', '..', 'database.rules.json');
+const rules = JSON.parse(readFileSync(RULES_PATH, 'utf8')).rules;
+
+/** The `$userId` node under a room's presence map. */
+const presenceUser = rules?.rooms?.$roomId?.presence?.$userId;
+/** The `$userId` node under a conversation's typing map — same identity shape. */
+const typingUser = rules?.conversations?.$convId?.typing?.$userId;
+
+describe('RTDB presence rule authorises the identity the client writes', () => {
+  test('the presence node exists where the client writes it', () => {
+    // Guards against a vacuous pass if the rules are restructured.
+    expect(presenceUser).toBeDefined();
+    expect(typeof presenceUser['.write']).toBe('string');
+  });
+
+  test('presence is authorised by the uniqueId claim, not the Firebase uid', () => {
+    const write = presenceUser['.write'];
+    expect(write).toContain('auth.token.uniqueId');
+    // `auth.uid == $userId` is the defect: the client keys presence by
+    // uniqueId, so that comparison can never be true.
+    expect(write).not.toMatch(/auth\.uid\s*==\s*\$userId/);
+  });
+
+  test('presence still requires authentication and self-ownership', () => {
+    const write = presenceUser['.write'];
+    expect(write).toContain('auth != null');
+    // Self-ownership: the key being written must be the caller's own id.
+    expect(write).toContain('$userId');
+  });
+
+  test('the uniqueId claim is compared as a string', () => {
+    // The claim is a NUMBER (50000030) and RTDB path keys are STRINGS, so a
+    // bare `===` would silently never match — the same class of failure this
+    // story exists to fix.
+    expect(presenceUser['.write']).toMatch(/auth\.token\.uniqueId\s*\+\s*''/);
+  });
+
+  test('typing presence uses the same identity as room presence', () => {
+    // conversations/{id}/typing/{userId} is written by the same client-side
+    // identity. Leaving it on auth.uid would reproduce this bug in DMs.
+    expect(typingUser).toBeDefined();
+    expect(typingUser['.write']).toContain('auth.token.uniqueId');
+    expect(typingUser['.write']).not.toMatch(/auth\.uid\s*==\s*\$userId/);
+  });
+
+  test('presence values are still validated as booleans', () => {
+    expect(presenceUser['.validate']).toContain('isBoolean');
+  });
+});

--- a/express-api/tests/scripts/compose-resources-locale-parity.test.js
+++ b/express-api/tests/scripts/compose-resources-locale-parity.test.js
@@ -26,16 +26,14 @@ const path = require('node:path');
 // SHY-0271: the locale set is declared ONCE, in the shared helper. Three
 // files used to keep private copies; the divergence is how a discovered set
 // could quietly lose a locale.
-const { RESOURCES_DIR, ALL_LOCALES } = require('../_helpers/compose-locales');
+const { RESOURCES_DIR, ALL_LOCALES, readLocaleStrings } = require('../_helpers/compose-locales');
 
+// SHY-0271: one parser for one corpus. This file used to keep a second regex,
+// and two regexes over the same files can disagree — the parity one matched a
+// self-closing `<string name="x"/>` that the content guard did not, so a key
+// could be "present" to one check and invisible to the other.
 function readKeys(localeDir) {
-  const xmlPath = path.join(RESOURCES_DIR, localeDir, 'strings.xml');
-  const content = fs.readFileSync(xmlPath, 'utf-8');
-  const keys = new Set();
-  for (const match of content.matchAll(/<string name="([^"]+)"/g)) {
-    keys.add(match[1]);
-  }
-  return keys;
+  return new Set(readLocaleStrings(localeDir).entries.map((e) => e.name));
 }
 
 describe('Compose strings.xml locale parity', () => {

--- a/express-api/tests/scripts/compose-resources-locale-parity.test.js
+++ b/express-api/tests/scripts/compose-resources-locale-parity.test.js
@@ -23,39 +23,10 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-const RESOURCES_DIR = path.join(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'shared',
-  'src',
-  'commonMain',
-  'composeResources',
-);
-
-const ALL_LOCALES = [
-  'ar',
-  'de',
-  'es',
-  'fr',
-  'hi',
-  'id',
-  'it',
-  'ja',
-  'km',
-  'ko',
-  'nl',
-  'pl',
-  'pt',
-  'ru',
-  'sv',
-  'th',
-  'tr',
-  'uk',
-  'vi',
-  'zh',
-];
+// SHY-0271: the locale set is declared ONCE, in the shared helper. Three
+// files used to keep private copies; the divergence is how a discovered set
+// could quietly lose a locale.
+const { RESOURCES_DIR, ALL_LOCALES } = require('../_helpers/compose-locales');
 
 function readKeys(localeDir) {
   const xmlPath = path.join(RESOURCES_DIR, localeDir, 'strings.xml');

--- a/express-api/tests/scripts/locale-string-content.test.js
+++ b/express-api/tests/scripts/locale-string-content.test.js
@@ -1,0 +1,102 @@
+/**
+ * SHY-0271 — locale strings are CONTENT, and nothing was checking their content.
+ *
+ * The operator read `Driver\'s license` — with a literal backslash — off the
+ * age-verification screen. It had shipped. Every existing check passed it:
+ *
+ *   - key-parity across the 21 locales counts KEYS, never their values
+ *   - journey and instrumented assertions match by testTag, so a control with
+ *     a corrupt label is still "found"
+ *   - nothing at all reads the locale files as text
+ *
+ * The trap: `\'` and `\"` are ANDROID XML escaping. Compose Multiplatform's
+ * `composeResources` does NOT unescape them, so they render literally. The
+ * English file already carried 11 correctly-unescaped apostrophes ALONGSIDE 17
+ * escaped ones, so the corpus contradicted itself and no one noticed.
+ *
+ * `\n` is deliberately still allowed — it is a real line break and renders
+ * correctly. This checks the escapes that are known to leak to the screen.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..', '..', '..');
+const RES_DIR = path.join(REPO_ROOT, 'shared', 'src', 'commonMain', 'composeResources');
+
+function localeFiles() {
+  return fs
+    .readdirSync(RES_DIR)
+    .filter((d) => d === 'values' || d.startsWith('values-'))
+    .map((d) => ({ locale: d, file: path.join(RES_DIR, d, 'strings.xml') }))
+    .filter(({ file }) => fs.existsSync(file));
+}
+
+/** [{ locale, name, value }] for every <string> in every locale. */
+function allStrings() {
+  const out = [];
+  for (const { locale, file } of localeFiles()) {
+    const xml = fs.readFileSync(file, 'utf8');
+    for (const m of xml.matchAll(/<string name="([^"]+)"[^>]*>([\s\S]*?)<\/string>/g)) {
+      out.push({ locale, name: m[1], value: m[2] });
+    }
+  }
+  return out;
+}
+
+describe('locale strings render as written', () => {
+  const strings = allStrings();
+
+  test('the locale corpus was actually read (vacuous-pass guard)', () => {
+    expect(localeFiles().length).toBeGreaterThanOrEqual(20);
+    expect(strings.length).toBeGreaterThan(15000);
+  });
+
+  test('no string carries an Android-style escaped apostrophe or quote', () => {
+    // These reach the screen verbatim under Compose Multiplatform. The user
+    // sees the backslash.
+    const offenders = strings
+      .filter((s) => /\\['"]/.test(s.value))
+      .map((s) => `${s.locale}/${s.name}: ${s.value.slice(0, 60)}`);
+    expect(offenders).toEqual([]);
+  });
+
+  test('no string is empty or whitespace-only', () => {
+    const offenders = strings
+      .filter((s) => s.value.trim() === '')
+      .map((s) => `${s.locale}/${s.name}`);
+    expect(offenders).toEqual([]);
+  });
+
+  test('no string leaks a developer marker left in place of copy', () => {
+    // TODO is deliberately NOT checked in es/pt: "todo" is the ordinary word
+    // for "all" there, and `RECOGER TODO` ("collect all") is correct Spanish.
+    // Flagging it would be the classic locale false positive — the detector
+    // would be wrong, not the translation.
+    const TODO_IS_A_REAL_WORD = new Set(['values-es', 'values-pt']);
+    const offenders = strings
+      .filter((s) => {
+        if (/\b(FIXME|XXX|PLACEHOLDER)\b/.test(s.value)) return true;
+        if (TODO_IS_A_REAL_WORD.has(s.locale)) return false;
+        return /\bTODO\b/.test(s.value);
+      })
+      .map((s) => `${s.locale}/${s.name}: ${s.value.slice(0, 60)}`);
+    expect(offenders).toEqual([]);
+  });
+
+  test('no string contains a stray XML/HTML tag', () => {
+    // Compose renders these literally; they are almost always a paste error.
+    const offenders = strings
+      .filter((s) => /<\/?(?:div|span|p|br|b|i|html|body)\b/i.test(s.value))
+      .map((s) => `${s.locale}/${s.name}: ${s.value.slice(0, 60)}`);
+    expect(offenders).toEqual([]);
+  });
+
+  test('the escape detector actually fires (mutation guard)', () => {
+    // Proves the regex above can fail — a content check that cannot detect its
+    // own target is the reason this shipped in the first place.
+    const sample = [{ locale: 'values', name: 'probe', value: "Driver\\'s license" }];
+    const caught = sample.filter((s) => /\\['"]/.test(s.value));
+    expect(caught).toHaveLength(1);
+  });
+});

--- a/express-api/tests/scripts/locale-string-content.test.js
+++ b/express-api/tests/scripts/locale-string-content.test.js
@@ -156,6 +156,19 @@ describe('locale strings render as written', () => {
     expect(isBroken('+10% daily login coins')).toBe(false);
   });
 
+  test('no string leaks an XML entity other than the three XML requires', () => {
+    // `&apos;` is the entity form of the same defect the escapes were. It also
+    // round-trips WRONG through the translation pipeline: `unescapeXml` used
+    // not to decode it, so the raw `&apos;` reached the translator and came
+    // back through `escapeXml`, which escapes `&` — writing `&amp;apos;` into
+    // all 20 locales. Only `&amp;` `&lt;` `&gt;` are structurally required in
+    // XML element text; everything else should be the literal character.
+    const offenders = strings
+      .filter((s) => /&(?!amp;|lt;|gt;)[a-zA-Z#][a-zA-Z0-9]*;/.test(s.value))
+      .map(describeOffender);
+    expect(offenders).toEqual([]);
+  });
+
   test('the escape predicate actually fires, and spares a real line break', () => {
     // Mutation guard on the SHARED predicate — weakening the rule above
     // reddens this. A guard with its own inline copy of the regex proves
@@ -164,6 +177,12 @@ describe('locale strings render as written', () => {
     expect(carriesAndroidEscape('escaped \\" quote')).toBe(true);
     expect(carriesAndroidEscape('curly \\“ quote')).toBe(true);
     expect(carriesAndroidEscape('a real\\nline break')).toBe(false);
+    // Boundary cases that encode deliberate decisions, so a future
+    // "relaxation" of the rule has to break a test to happen.
+    expect(carriesAndroidEscape('a\\tb')).toBe(true); // no tabs — write the character
+    expect(carriesAndroidEscape('a\\\\b')).toBe(true); // escaped backslash
+    expect(carriesAndroidEscape('ends with\\')).toBe(true); // trailing
+    expect(carriesAndroidEscape('\\Name')).toBe(true); // uppercase N is not \n
     expect(carriesAndroidEscape("Driver's license")).toBe(false);
   });
 });

--- a/express-api/tests/scripts/locale-string-content.test.js
+++ b/express-api/tests/scripts/locale-string-content.test.js
@@ -7,96 +7,163 @@
  *   - key-parity across the 21 locales counts KEYS, never their values
  *   - journey and instrumented assertions match by testTag, so a control with
  *     a corrupt label is still "found"
- *   - nothing at all reads the locale files as text
+ *   - nothing at all read the locale files as text
  *
  * The trap: `\'` and `\"` are ANDROID XML escaping. Compose Multiplatform's
- * `composeResources` does NOT unescape them, so they render literally. The
- * English file already carried 11 correctly-unescaped apostrophes ALONGSIDE 17
- * escaped ones, so the corpus contradicted itself and no one noticed.
+ * `composeResources` does NOT unescape them, so they render literally.
  *
- * `\n` is deliberately still allowed — it is a real line break and renders
- * correctly. This checks the escapes that are known to leak to the screen.
+ * What Compose DOES unescape was settled empirically rather than argued, by
+ * resolving all 838 strings through the real pipeline on a real device
+ * (`StringResourceContentTest`): `\uXXXX` IS unescaped, `\'` is NOT. The corpus
+ * has since been normalised so the only backslash sequence remaining anywhere
+ * is `\n`, a genuine line break — which lets the rule below be a flat "no
+ * backslashes except `\n`" with no allowlist to rot.
+ *
+ * This file is the cross-locale half of the guard; the device test is the other
+ * half. Neither is sufficient alone: this one reads all 21 locales but only as
+ * text, and that one renders for real but only in the device's locale.
  */
 
-const fs = require('fs');
-const path = require('path');
+const {
+  ALL_LOCALE_DIRS,
+  localeFilePath,
+  readLocaleStrings,
+} = require('../_helpers/compose-locales');
 
-const REPO_ROOT = path.join(__dirname, '..', '..', '..');
-const RES_DIR = path.join(REPO_ROOT, 'shared', 'src', 'commonMain', 'composeResources');
+const fs = require('node:fs');
 
-function localeFiles() {
-  return fs
-    .readdirSync(RES_DIR)
-    .filter((d) => d === 'values' || d.startsWith('values-'))
-    .map((d) => ({ locale: d, file: path.join(RES_DIR, d, 'strings.xml') }))
-    .filter(({ file }) => fs.existsSync(file));
-}
+/**
+ * The single escape predicate. Referenced by the real check AND by the mutation
+ * guard, deliberately: a guard that re-declares the predicate inline only ever
+ * proves that `String.includes` works, and stays green while the real one is
+ * weakened.
+ */
+const carriesAndroidEscape = (value) => /\\(?!n)/.test(value);
+
+/** `TODO` is the ordinary Spanish word for "all" — these two are correct copy. */
+const TODO_IS_A_REAL_WORD = new Set(['values-es/all_caps', 'values-es/collect_all']);
 
 /** [{ locale, name, value }] for every <string> in every locale. */
 function allStrings() {
-  const out = [];
-  for (const { locale, file } of localeFiles()) {
-    const xml = fs.readFileSync(file, 'utf8');
-    for (const m of xml.matchAll(/<string name="([^"]+)"[^>]*>([\s\S]*?)<\/string>/g)) {
-      out.push({ locale, name: m[1], value: m[2] });
-    }
-  }
-  return out;
+  return ALL_LOCALE_DIRS.flatMap((locale) =>
+    readLocaleStrings(locale).entries.map(({ name, value }) => ({ locale, name, value })),
+  );
 }
+
+/** The format placeholders a string takes, e.g. ['%1$s', '%2$d'], sorted. */
+const placeholders = (value) => (value.match(/%\d+\$[a-z]/g) || []).sort();
 
 describe('locale strings render as written', () => {
   const strings = allStrings();
+  const describeOffender = (s) => `${s.locale}/${s.name}: ${s.value.slice(0, 60)}`;
 
-  test('the locale corpus was actually read (vacuous-pass guard)', () => {
-    expect(localeFiles().length).toBeGreaterThanOrEqual(20);
-    expect(strings.length).toBeGreaterThan(15000);
+  test('every declared locale file exists and was parsed COMPLETELY', () => {
+    // Not a threshold. A count-based floor ("at least 20 files, at least 15000
+    // strings") tolerates whole files going dark — three could vanish and the
+    // suite would stay green. Comparing the parser's yield against the raw
+    // element count, per file, fails on any formatting the regex cannot handle.
+    const report = ALL_LOCALE_DIRS.map((dir) => {
+      expect(fs.existsSync(localeFilePath(dir))).toBe(true);
+      const { entries, rawCount } = readLocaleStrings(dir);
+      return { dir, parsed: entries.length, raw: rawCount };
+    });
+    expect(report.filter((r) => r.parsed !== r.raw)).toEqual([]);
+    // Every locale carries the same key count; a change here is deliberate.
+    expect([...new Set(report.map((r) => r.parsed))]).toEqual([838]);
   });
 
-  test('no string carries an Android-style escaped apostrophe or quote', () => {
-    // These reach the screen verbatim under Compose Multiplatform. The user
-    // sees the backslash.
-    const offenders = strings
-      .filter((s) => /\\['"]/.test(s.value))
-      .map((s) => `${s.locale}/${s.name}: ${s.value.slice(0, 60)}`);
-    expect(offenders).toEqual([]);
+  test('no string carries an Android-style escape sequence', () => {
+    // Any backslash except `\n`. Enumerating the sequences we know about is
+    // exactly how `\'` survived — and then `\"`, and then zh's `\“`. The strict
+    // rule needs no maintenance and cannot be outflanked by a new character.
+    expect(strings.filter((s) => carriesAndroidEscape(s.value)).map(describeOffender)).toEqual([]);
   });
 
   test('no string is empty or whitespace-only', () => {
-    const offenders = strings
-      .filter((s) => s.value.trim() === '')
-      .map((s) => `${s.locale}/${s.name}`);
-    expect(offenders).toEqual([]);
+    expect(strings.filter((s) => s.value.trim() === '').map(describeOffender)).toEqual([]);
   });
 
   test('no string leaks a developer marker left in place of copy', () => {
-    // TODO is deliberately NOT checked in es/pt: "todo" is the ordinary word
-    // for "all" there, and `RECOGER TODO` ("collect all") is correct Spanish.
-    // Flagging it would be the classic locale false positive — the detector
-    // would be wrong, not the translation.
-    const TODO_IS_A_REAL_WORD = new Set(['values-es', 'values-pt']);
     const offenders = strings
       .filter((s) => {
         if (/\b(FIXME|XXX|PLACEHOLDER)\b/.test(s.value)) return true;
-        if (TODO_IS_A_REAL_WORD.has(s.locale)) return false;
+        if (TODO_IS_A_REAL_WORD.has(`${s.locale}/${s.name}`)) return false;
         return /\bTODO\b/.test(s.value);
       })
-      .map((s) => `${s.locale}/${s.name}: ${s.value.slice(0, 60)}`);
+      .map(describeOffender);
     expect(offenders).toEqual([]);
+  });
+
+  test('the TODO allowlist has no dead entries', () => {
+    // An allowlist that stops matching decays into a silent bypass. If one of
+    // these keys is retranslated away from "TODO", the entry must go too.
+    const stale = [...TODO_IS_A_REAL_WORD].filter(
+      (entry) =>
+        !strings.some((s) => `${s.locale}/${s.name}` === entry && /\bTODO\b/.test(s.value)),
+    );
+    expect(stale).toEqual([]);
   });
 
   test('no string contains a stray XML/HTML tag', () => {
     // Compose renders these literally; they are almost always a paste error.
     const offenders = strings
       .filter((s) => /<\/?(?:div|span|p|br|b|i|html|body)\b/i.test(s.value))
-      .map((s) => `${s.locale}/${s.name}: ${s.value.slice(0, 60)}`);
+      .map(describeOffender);
     expect(offenders).toEqual([]);
   });
 
-  test('the escape detector actually fires (mutation guard)', () => {
-    // Proves the regex above can fail — a content check that cannot detect its
-    // own target is the reason this shipped in the first place.
-    const sample = [{ locale: 'values', name: 'probe', value: "Driver\\'s license" }];
-    const caught = sample.filter((s) => /\\['"]/.test(s.value));
-    expect(caught).toHaveLength(1);
+  test('every translation takes the same placeholders as the English it replaces', () => {
+    // A translation that drops `%1$d` renders a sentence with the number
+    // missing — a count or a username that simply never appears. Key parity
+    // cannot see this: the key is present and the value is plausible prose.
+    const english = new Map(
+      strings.filter((s) => s.locale === 'values').map((s) => [s.name, s.value]),
+    );
+    const offenders = strings
+      .filter((s) => s.locale !== 'values')
+      .filter((s) => english.has(s.name))
+      .map((s) => ({ s, en: placeholders(english.get(s.name)), loc: placeholders(s.value) }))
+      .filter(({ en, loc }) => en.join(',') !== loc.join(','))
+      .map(({ s, en, loc }) => `${s.locale}/${s.name}: en=[${en}] ${s.locale}=[${loc}]`);
+    expect(offenders).toEqual([]);
+  });
+
+  test('a format string never contains an unescaped literal percent', () => {
+    // `String.format` reads every `%` as the start of a conversion, so a bare
+    // one in a string that also takes arguments throws
+    // UnknownFormatConversionException at render time — a crash, not a typo.
+    // Found live: German shipped `(10 % % Bonus!)` and French `(bonus de 10 % !)`
+    // where English correctly had `10%%`. A machine translator had inserted a
+    // space into the escape.
+    //
+    // Strings with NO arguments never reach `String.format`, so a bare `%` in
+    // prose ("10% bonus") is fine there and deliberately not flagged.
+    const offenders = strings
+      .filter((s) => /%\d+\$[a-z]/.test(s.value))
+      .filter((s) => s.value.replace(/%(?:\d+\$[a-z]|%)/g, '').includes('%'))
+      .map(describeOffender);
+    expect(offenders).toEqual([]);
+  });
+
+  test('the percent rule distinguishes a crash from ordinary prose', () => {
+    // Mutation guard for the check above: it must fire on the real German
+    // defect and stay quiet on both a correctly-escaped format string and a
+    // plain sentence that merely mentions a percentage.
+    const isBroken = (v) =>
+      /%\d+\$[a-z]/.test(v) && v.replace(/%(?:\d+\$[a-z]|%)/g, '').includes('%');
+    expect(isBroken('%1$s Bohnen (10 % % Bonus!)')).toBe(true);
+    expect(isBroken('Redeemed %1$s beans (10%% bonus!)')).toBe(false);
+    expect(isBroken('+10% daily login coins')).toBe(false);
+  });
+
+  test('the escape predicate actually fires, and spares a real line break', () => {
+    // Mutation guard on the SHARED predicate — weakening the rule above
+    // reddens this. A guard with its own inline copy of the regex proves
+    // nothing, which is the reason this defect shipped in the first place.
+    expect(carriesAndroidEscape("Driver\\'s license")).toBe(true);
+    expect(carriesAndroidEscape('escaped \\" quote')).toBe(true);
+    expect(carriesAndroidEscape('curly \\“ quote')).toBe(true);
+    expect(carriesAndroidEscape('a real\\nline break')).toBe(false);
+    expect(carriesAndroidEscape("Driver's license")).toBe(false);
   });
 });

--- a/express-api/tests/scripts/pr-checks-locale-guard-gating.test.js
+++ b/express-api/tests/scripts/pr-checks-locale-guard-gating.test.js
@@ -1,0 +1,66 @@
+/**
+ * pr-checks-locale-guard-gating.test.js — SHY-0271.
+ *
+ * Pins that a locale-only PR actually RUNS the guard that protects the locale
+ * corpus.
+ *
+ * The corpus lives in `shared/src/commonMain/composeResources/`, but the tests
+ * that check its CONTENT live in express-api. Before this pin, `shared/*` set
+ * only the app flags, so `test-backend` was skipped on a locale-only PR and the
+ * content guard ran solely by accident — inside the sonarcloud job, which
+ * happens to invoke the whole Jest suite unfiltered. Narrowing that one step to
+ * a test-path pattern would have silently disarmed the guard with nothing to
+ * notice.
+ *
+ * Static pin over the workflow YAML, matching the convention of
+ * `pr-checks-backend-forces-full.test.js` and `pr-checks-ios-gating.test.js`.
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const yml = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/pr-checks.yml'), 'utf8');
+const jestConfig = require('../../jest.config.js');
+
+const GUARDS = [
+  'tests/scripts/locale-string-content.test.js',
+  'tests/scripts/compose-resources-locale-parity.test.js',
+];
+
+describe('SHY-0271 — a locale-only PR runs the locale guards', () => {
+  test('composeResources has its own detect-changes arm', () => {
+    expect(yml).toContain('shared/src/commonMain/composeResources/*)');
+  });
+
+  test('that arm sets BACKEND, so the job running the guards is not skipped', () => {
+    const arm = yml.slice(yml.indexOf('shared/src/commonMain/composeResources/*)'));
+    expect(arm.slice(0, 160)).toMatch(/BACKEND=true/);
+  });
+
+  test('the arm precedes the generic shared/* arm (case is first-match)', () => {
+    // Ordering is load-bearing: shell `case` takes the first matching arm, so a
+    // composeResources arm placed after `shared/*` would never be reached.
+    const specific = yml.indexOf('shared/src/commonMain/composeResources/*)');
+    const generic = yml.indexOf('shared/*) ANDROID_APP=true');
+    expect(specific).toBeGreaterThan(-1);
+    expect(generic).toBeGreaterThan(-1);
+    expect(specific).toBeLessThan(generic);
+  });
+
+  test('test-backend gates on backend_changed, which the arm now sets', () => {
+    const job = yml.slice(yml.indexOf('  test-backend:'), yml.indexOf('  test-backend:') + 400);
+    expect(job).toMatch(/needs\.detect-changes\.outputs\.backend_changed == 'true'/);
+  });
+
+  test('the guard files exist and are not excluded from the Jest run', () => {
+    // A pin that points at a moved or renamed file is worse than no pin: it
+    // stays green while guarding nothing.
+    for (const rel of GUARDS) {
+      expect(fs.existsSync(path.join(__dirname, '../..', rel))).toBe(true);
+    }
+    const ignored = jestConfig.testPathIgnorePatterns || [];
+    for (const rel of GUARDS) {
+      expect(ignored.some((p) => new RegExp(p).test(rel))).toBe(false);
+    }
+  });
+});

--- a/express-api/tests/scripts/pr-checks-locale-guard-gating.test.js
+++ b/express-api/tests/scripts/pr-checks-locale-guard-gating.test.js
@@ -22,6 +22,9 @@ const REPO_ROOT = path.resolve(__dirname, '../../..');
 const yml = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/pr-checks.yml'), 'utf8');
 const jestConfig = require('../../jest.config.js');
 
+/** The detect-changes arm itself, at a line start so comments cannot match. */
+const ARM_RE = /^\s{2,}shared\/src\/commonMain\/composeResources\/\*\)/;
+
 const GUARDS = [
   'tests/scripts/locale-string-content.test.js',
   'tests/scripts/compose-resources-locale-parity.test.js',
@@ -33,15 +36,20 @@ describe('SHY-0271 — a locale-only PR runs the locale guards', () => {
   });
 
   test('that arm sets BACKEND, so the job running the guards is not skipped', () => {
-    const arm = yml.slice(yml.indexOf('shared/src/commonMain/composeResources/*)'));
-    expect(arm.slice(0, 160)).toMatch(/BACKEND=true/);
+    // Anchored on a line START, not a raw indexOf: a future COMMENT quoting the
+    // arm text would otherwise satisfy these assertions while the real arm was
+    // gone or misplaced — a pin that passes while guarding nothing.
+    const armLine = yml.split('\n').find((l) => ARM_RE.test(l));
+    expect(armLine).toBeDefined();
+    expect(armLine).toMatch(/BACKEND=true/);
   });
 
   test('the arm precedes the generic shared/* arm (case is first-match)', () => {
     // Ordering is load-bearing: shell `case` takes the first matching arm, so a
     // composeResources arm placed after `shared/*` would never be reached.
-    const specific = yml.indexOf('shared/src/commonMain/composeResources/*)');
-    const generic = yml.indexOf('shared/*) ANDROID_APP=true');
+    const lines = yml.split('\n');
+    const specific = lines.findIndex((l) => ARM_RE.test(l));
+    const generic = lines.findIndex((l) => /^\s{2,}shared\/\*\)/.test(l));
     expect(specific).toBeGreaterThan(-1);
     expect(generic).toBeGreaterThan(-1);
     expect(specific).toBeLessThan(generic);

--- a/express-api/tests/scripts/translate-strings.test.js
+++ b/express-api/tests/scripts/translate-strings.test.js
@@ -128,7 +128,7 @@ describe('upsertTranslation', () => {
     expect((result.match(/<string name="key">/g) || []).length).toBe(1);
   });
 
-  test('escapes XML-sensitive characters in translated value', () => {
+  test('escapes XML-sensitive characters but NOT the apostrophe', () => {
     const localePath = path.join(tmpDir, 'strings.xml');
     fs.writeFileSync(
       localePath,
@@ -140,7 +140,76 @@ describe('upsertTranslation', () => {
     const { upsertTranslation } = loadScript();
     upsertTranslation(localePath, 'key', `5 < 10 & it's true`, 'google');
     const result = fs.readFileSync(localePath, 'utf8');
-    expect(result).toContain("5 &lt; 10 &amp; it\\'s true");
+    // SHY-0271: this assertion used to demand `it\'s`, which made the suite
+    // GREEN on the exact defect the operator later read off the screen — the
+    // test pinned the bug as the contract. Compose Multiplatform does not
+    // unescape `\'`, so the backslash rendered.
+    expect(result).toContain("5 &lt; 10 &amp; it's true");
+    expect(result).not.toContain("\\'");
+  });
+});
+
+// ─── escapeXml / unescapeXml (SHY-0271) ───────────────────────────
+//
+// Both were exported "for testing" and neither had a single direct test. The
+// untested one wrote a visible backslash into 221 strings across 18 locales.
+
+describe('escapeXml', () => {
+  test('leaves an apostrophe alone', () => {
+    const { escapeXml } = loadScript();
+    expect(escapeXml("Driver's license")).toBe("Driver's license");
+  });
+
+  test('escapes the three characters XML actually requires', () => {
+    const { escapeXml } = loadScript();
+    expect(escapeXml('a & b < c > d')).toBe('a &amp; b &lt; c &gt; d');
+  });
+
+  test('leaves typographic quotes and ellipses alone', () => {
+    // The zh corpus carried `\u201c` / `\u201d`; escaping those is the same
+    // mistake wearing a different character.
+    const { escapeXml } = loadScript();
+    expect(escapeXml('\u201cquoted\u201d and\u2026')).toBe('\u201cquoted\u201d and\u2026');
+  });
+
+  test('handles the empty string', () => {
+    const { escapeXml } = loadScript();
+    expect(escapeXml('')).toBe('');
+  });
+
+  test('never emits a backslash, whatever it is given', () => {
+    // The general property. A future escape added to this function would have
+    // to break this test on its way to the screen.
+    const { escapeXml } = loadScript();
+    const samples = [
+      "it's",
+      'a & b',
+      '<tag>',
+      '\u201cq\u201d',
+      'plain',
+      "multiple ' apostrophes '",
+    ];
+    expect(samples.map(escapeXml).filter((v) => v.includes('\\'))).toEqual([]);
+  });
+});
+
+describe('unescapeXml', () => {
+  test('normalises a legacy escaped apostrophe on read', () => {
+    // Retained deliberately: the corpus was full of `\'` before SHY-0271, and
+    // reading one back must still yield a clean apostrophe.
+    const { unescapeXml } = loadScript();
+    expect(unescapeXml("Driver\\'s license")).toBe("Driver's license");
+  });
+
+  test('reverses the entity escapes', () => {
+    const { unescapeXml } = loadScript();
+    expect(unescapeXml('a &amp; b &lt; c &gt; d')).toBe('a & b < c > d');
+  });
+
+  test('round-trips with escapeXml', () => {
+    const { escapeXml, unescapeXml } = loadScript();
+    const samples = ["Driver's license", 'a & b < c > d', '\u201cquoted\u201d', 'plain text', ''];
+    samples.forEach((s) => expect(unescapeXml(escapeXml(s))).toBe(s));
   });
 });
 

--- a/express-api/tests/scripts/translate-strings.test.js
+++ b/express-api/tests/scripts/translate-strings.test.js
@@ -211,6 +211,23 @@ describe('unescapeXml', () => {
     const samples = ["Driver's license", 'a & b < c > d', '\u201cquoted\u201d', 'plain text', ''];
     samples.forEach((s) => expect(unescapeXml(escapeXml(s))).toBe(s));
   });
+
+  test('decodes the apostrophe and quote entities on read', () => {
+    // SHY-0271: the English corpus carried `&apos;`. Without this, that string
+    // reached the translator raw and `escapeXml` then turned its `&` into
+    // `&amp;`, writing `&amp;apos;` into all 20 locale files — the shipped
+    // escape defect, one layer up.
+    const { unescapeXml } = loadScript();
+    expect(unescapeXml('You&apos;re on the latest version.')).toBe("You're on the latest version.");
+    expect(unescapeXml('a &quot;quoted&quot; word')).toBe('a "quoted" word');
+  });
+
+  test('does NOT over-decode an already-escaped ampersand entity', () => {
+    // Ordering guard: `&amp;` must be decoded LAST, so `&amp;apos;` becomes the
+    // literal text `&apos;` rather than collapsing straight to an apostrophe.
+    const { unescapeXml } = loadScript();
+    expect(unescapeXml('&amp;apos;')).toBe('&apos;');
+  });
 });
 
 // ─── readEnglishStrings ───────────────────────────────────────────

--- a/scripts/translate-strings.js
+++ b/scripts/translate-strings.js
@@ -108,11 +108,12 @@ function unescapeXml(s) {
 }
 
 function escapeXml(s) {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/'/g, "\\'");
+  // NO apostrophe escaping (SHY-0271). `\'` is an ANDROID XML convention that
+  // Compose Multiplatform's `composeResources` does NOT unescape, so every
+  // apostrophe this function touched reached the screen with a visible
+  // backslash — `Driver\'s license` shipped that way. An apostrophe needs no
+  // escaping in XML element text; `&`, `<` and `>` genuinely do.
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 // ── Locale file mutation ──────────────────────────────────────────

--- a/scripts/translate-strings.js
+++ b/scripts/translate-strings.js
@@ -100,9 +100,17 @@ function readEnglishStrings(filePath) {
 }
 
 function unescapeXml(s) {
+  // `&apos;` / `&quot;` are decoded BEFORE `&amp;`, and `&amp;` stays LAST
+  // (SHY-0271). Without the first two, an English string carrying `&apos;`
+  // went to the translator verbatim and came back to `escapeXml`, which turns
+  // every `&` into `&amp;` — writing `&amp;apos;` into all 20 locale files.
+  // That is the shipped-escape defect one layer up. `&amp;` last prevents
+  // double-decoding `&amp;apos;` straight to an apostrophe.
   return s
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
     .replace(/&amp;/g, '&')
     .replace(/\\'/g, "'");
 }

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -695,7 +695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">التفاصيل: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">الرسالة: \"%1$s\"</string>
+    <string name="report_message_prefix">الرسالة: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">المراسل: %1$s | تم الإبلاغ: %2$s</string>
 

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -404,7 +404,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="user">مستخدم</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="user_id">المعرف: %1$د</string>
+    <string name="user_id">المعرف: %1$d</string>
     <!-- google-translated 2026-05-04 -->
     <string name="visitor_count">%1$d زائر (زائرين)</string>
     <!-- google-translated 2026-05-04 -->
@@ -430,7 +430,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="request_accepted">تم قبول طلبك!</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="seat_number">المقعد %1$د</string>
+    <string name="seat_number">المقعد %1$d</string>
     <!-- google-translated 2026-05-04 -->
     <string name="user_wants_to_sit">%1$s يريد الجلوس</string>
 
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">أدخل رقم التعريف الشخصي الخاص بك للمتابعة</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">التحقق\u2026</string>
+    <string name="pin_verifying">التحقق…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">رقم تعريف شخصي خاطئ. متبقي %1$d من المحاولات.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1600,7 +1600,7 @@
     <string name="biometric_start_failed">تعذر بدء التحقق البيومتري</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">تسجيل الدخول\u2026</string>
+    <string name="signing_in_loading">تسجيل الدخول…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">الآن</string>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -693,7 +693,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">Details: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">Nachricht: \"%1$s\"</string>
+    <string name="report_message_prefix">Nachricht: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">Reporter: %1$s | Gemeldet: %2$s</string>
 

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -1246,7 +1246,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="success_redeemed_beans">%1$s Bohnen eingelöst</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="success_redeemed_beans_bonus">%1$s Bohnen eingelöst (10 % % Bonus!)</string>
+    <string name="success_redeemed_beans_bonus">%1$s Bohnen eingelöst (10 %% Bonus!)</string>
     <!-- google-translated 2026-05-04 -->
     <string name="success_report_resolved">Bericht gelöst</string>
     <!-- google-translated 2026-05-04 -->
@@ -1469,7 +1469,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">Warnillustration</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">Laden\u2026</string>
+    <string name="starting_screen_loading">Laden…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">Sicherheit</string>
@@ -1572,7 +1572,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">Geben Sie Ihre PIN ein, um fortzufahren</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">Verifizierung\u2026</string>
+    <string name="pin_verifying">Verifizierung…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">Falsche PIN. Es verbleiben noch %1$d Versuche.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1598,7 +1598,7 @@
     <string name="biometric_start_failed">Die biometrische Überprüfung konnte nicht gestartet werden</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">Anmelden\u2026</string>
+    <string name="signing_in_loading">Anmelden…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">soeben</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -695,7 +695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">Detalles: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">Mensaje: \"%1$s\"</string>
+    <string name="report_message_prefix">Mensaje: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">Reportero: %1$s | Reportado: %2$s</string>
 

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -1471,7 +1471,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">Ilustración de advertencia</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">Cargando\u2026</string>
+    <string name="starting_screen_loading">Cargando…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">Seguridad</string>
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">Introduce tu PIN para continuar</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">Verificando\u2026</string>
+    <string name="pin_verifying">Verificando…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">PIN incorrecto. Quedan %1$d intentos.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1600,7 +1600,7 @@
     <string name="biometric_start_failed">No se pudo iniciar la verificación biométrica</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">Iniciar sesión\u2026</string>
+    <string name="signing_in_loading">Iniciar sesión…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">En este momento</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -1245,7 +1245,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="success_redeemed_beans">%1$s beans échangés</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="success_redeemed_beans_bonus">Beans %1$s échangés (bonus de 10 % !)</string>
+    <string name="success_redeemed_beans_bonus">Beans %1$s échangés (bonus de 10 %% !)</string>
     <!-- google-translated 2026-05-04 -->
     <string name="success_report_resolved">Rapport résolu</string>
     <!-- google-translated 2026-05-04 -->
@@ -1468,7 +1468,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">Illustration d'avertissement</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">Chargement\u2026</string>
+    <string name="starting_screen_loading">Chargement…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">Sécurité</string>
@@ -1571,7 +1571,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">Entrez votre code PIN pour continuer</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">Vérification\u2026</string>
+    <string name="pin_verifying">Vérification…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">Mauvais code PIN. %1$d tentatives restantes.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1597,7 +1597,7 @@
     <string name="biometric_start_failed">Impossible de démarrer la vérification biométrique</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">Connexion\u2026</string>
+    <string name="signing_in_loading">Connexion…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">tout à l' heure</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -24,9 +24,9 @@
     <!-- google-translated 2026-05-04 -->
     <string name="edit">Modifier</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="error_generic">Quelque chose s\'est mal passé</string>
+    <string name="error_generic">Quelque chose s'est mal passé</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="got_it">J\'ai compris</string>
+    <string name="got_it">J'ai compris</string>
     <!-- google-translated 2026-05-04 -->
     <string name="learn_more">Apprendre encore plus</string>
     <!-- google-translated 2026-05-04 -->
@@ -38,7 +38,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="next">Suivant</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="ok">D\'ACCORD</string>
+    <string name="ok">D'ACCORD</string>
     <!-- google-translated 2026-05-04 -->
     <string name="retry">Réessayer</string>
     <!-- google-translated 2026-05-04 -->
@@ -104,7 +104,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="translated_from">Traduit de %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="show_original">Afficher l\'original</string>
+    <string name="show_original">Afficher l'original</string>
     <!-- google-translated 2026-05-04 -->
     <string name="translation_limit_reached">Limite quotidienne atteinte. Passez à SuperShy pour des traductions illimitées.</string>
     <!-- google-translated 2026-05-04 -->
@@ -112,7 +112,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="auto_translate_description">Traduisez automatiquement les messages entrants dans votre langue</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="translations_remaining">%1$d traductions restantes aujourd\'hui</string>
+    <string name="translations_remaining">%1$d traductions restantes aujourd'hui</string>
 
     <!-- Settings -->
     <!-- google-translated 2026-05-04 -->
@@ -168,7 +168,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="connections">Relations</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="display_name">Nom d\'affichage</string>
+    <string name="display_name">Nom d'affichage</string>
     <!-- google-translated 2026-05-04 -->
     <string name="dob_privacy_note">Votre date de naissance est obligatoire mais vous pouvez masquer votre âge dans les paramètres de confidentialité.</string>
     <!-- google-translated 2026-05-04 -->
@@ -194,9 +194,9 @@
     <!-- google-translated 2026-05-04 -->
     <string name="gift_value_coins">Valeur : %1$d pièces</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="no_followers_yet">Pas encore d\'abonnés</string>
+    <string name="no_followers_yet">Pas encore d'abonnés</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="no_profile_visitors">Aucun visiteur de profil pour l\'instant</string>
+    <string name="no_profile_visitors">Aucun visiteur de profil pour l'instant</string>
     <!-- google-translated 2026-05-04 -->
     <string name="not_following_anyone">Je ne suis encore personne</string>
     <!-- google-translated 2026-05-04 -->
@@ -204,7 +204,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="profile">Profil</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="profile_setup_subtitle">Choisissez un nom d\'affichage et entrez votre date de naissance</string>
+    <string name="profile_setup_subtitle">Choisissez un nom d'affichage et entrez votre date de naissance</string>
     <!-- google-translated 2026-05-04 -->
     <string name="received_times">Reçu %1$d fois</string>
     <!-- google-translated 2026-05-04 -->
@@ -255,7 +255,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="ban">Interdire</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="block_user">Bloquer l\'utilisateur</string>
+    <string name="block_user">Bloquer l'utilisateur</string>
     <!-- google-translated 2026-05-04 -->
     <string name="block_user_confirm">Êtes-vous sûr de vouloir bloquer %1$s ?</string>
     <!-- google-translated 2026-05-04 -->
@@ -277,11 +277,11 @@
     <!-- google-translated 2026-05-04 -->
     <string name="hosts">Hôtes</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="invite_to_seat">Inviter à s\'asseoir</string>
+    <string name="invite_to_seat">Inviter à s'asseoir</string>
     <!-- google-translated 2026-05-04 -->
     <string name="kick">Coup</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="kick_user">Expulser l\'utilisateur</string>
+    <string name="kick_user">Expulser l'utilisateur</string>
     <!-- google-translated 2026-05-04 -->
     <string name="kick_user_confirm">Êtes-vous sûr de vouloir expulser %1$s de la pièce ? Ils ne pourront pas réintégrer.</string>
     <!-- google-translated 2026-05-04 -->
@@ -291,7 +291,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="lock_seating">Verrouillage des sièges</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="lock_seating_description">Seul le propriétaire peut inviter les utilisateurs à s\'asseoir</string>
+    <string name="lock_seating_description">Seul le propriétaire peut inviter les utilisateurs à s'asseoir</string>
     <!-- google-translated 2026-05-04 -->
     <string name="buy_coins">Acheter des pièces</string>
     <!-- google-translated 2026-05-04 -->
@@ -313,7 +313,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="prizes">Prix</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="skip_animation">PASSER L\'ANIMATION</string>
+    <string name="skip_animation">PASSER L'ANIMATION</string>
     <!-- google-translated 2026-05-04 -->
     <string name="spin">ROTATION</string>
     <!-- google-translated 2026-05-04 -->
@@ -353,7 +353,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="remove">Retirer</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="remove_as_host">Supprimer en tant qu\'hôte</string>
+    <string name="remove_as_host">Supprimer en tant qu'hôte</string>
     <!-- google-translated 2026-05-04 -->
     <string name="remove_from_room">Supprimer de la pièce</string>
     <!-- google-translated 2026-05-04 -->
@@ -369,7 +369,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="room_closed">Salle fermée</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="room_closing_no_super_shy">Le propriétaire de la salle n\'a pas Super Shy, donc cette salle fermera bientôt.</string>
+    <string name="room_closing_no_super_shy">Le propriétaire de la salle n'a pas Super Shy, donc cette salle fermera bientôt.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="room_closing_in">Fermeture de la salle dans %1$d :%2$s</string>
     <!-- google-translated 2026-05-04 -->
@@ -413,7 +413,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="you_have_super_shy_room">Vous êtes super timide ! Ouvrez votre propre salle pour un maximum de %1$d heures de durée prolongée.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="get_super_shy_rooms">Devenez Super Shy pour profiter de salles qui durent jusqu\'à %1$d heures !</string>
+    <string name="get_super_shy_rooms">Devenez Super Shy pour profiter de salles qui durent jusqu'à %1$d heures !</string>
 
     <!-- Room - Notifications -->
     <!-- google-translated 2026-05-04 -->
@@ -431,7 +431,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="seat_number">Siège %1$d</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="user_wants_to_sit">%1$s veut s\'asseoir</string>
+    <string name="user_wants_to_sit">%1$s veut s'asseoir</string>
 
     <!-- Room - Chat -->
     <!-- google-translated 2026-05-04 -->
@@ -447,7 +447,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="action_cannot_be_undone">CETTE ACTION NE PEUT ÊTRE ANNULÉE.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="confirm_send">Confirmer l\'envoi</string>
+    <string name="confirm_send">Confirmer l'envoi</string>
     <!-- google-translated 2026-05-04 -->
     <string name="from_backpack_items">Depuis le sac à dos : %1$d articles</string>
     <!-- google-translated 2026-05-04 -->
@@ -457,7 +457,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="send_all_includes">Cela inclut TOUS les %1$d articles parmi %2$d cadeaux différents.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="send_all_warning">Vous êtes sur le point d\'envoyer TOUT votre sac à dos à %1$s.</string>
+    <string name="send_all_warning">Vous êtes sur le point d'envoyer TOUT votre sac à dos à %1$s.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="send_everything_confirm">Je comprends, envoie tout</string>
     <!-- google-translated 2026-05-04 -->
@@ -482,7 +482,7 @@
     <string name="cant_message_user">Vous ne pouvez pas envoyer de message à cet utilisateur</string>
     <string name="group_frozen_banner">This group has been preserved but no new members can be added, as part of a recent change to how ShyTalk organises accounts.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pm_locked_other_user_notice">Vous ne pouvez pas envoyer de message à cette personne car nous pensons qu\'elle a moins de 18 ans.</string>
+    <string name="pm_locked_other_user_notice">Vous ne pouvez pas envoyer de message à cette personne car nous pensons qu'elle a moins de 18 ans.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="chat">Chat</string>
     <!-- google-translated 2026-05-04 -->
@@ -492,7 +492,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="compressing">Compression...</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="conversation_start_hint">Démarrer une conversation à partir du\nprofil ou de la carte utilisateur d\'une personne dans un salon</string>
+    <string name="conversation_start_hint">Démarrer une conversation à partir du\nprofil ou de la carte utilisateur d'une personne dans un salon</string>
     <!-- google-translated 2026-05-04 -->
     <string name="create_group">Créer un groupe</string>
     <!-- google-translated 2026-05-04 -->
@@ -500,19 +500,19 @@
     <!-- google-translated 2026-05-04 -->
     <string name="delete_conversation">Supprimer la conversation</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="delete_conversation_warning">Cela supprimera la conversation de votre liste. Les messages sont conservés et réapparaîtront si l\'autre personne vous envoie à nouveau un message.</string>
+    <string name="delete_conversation_warning">Cela supprimera la conversation de votre liste. Les messages sont conservés et réapparaîtront si l'autre personne vous envoie à nouveau un message.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="description_label">Description</string>
     <!-- google-translated 2026-05-04 -->
     <string name="description_optional">Description (facultatif)</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="edit_history">Modifier l\'historique</string>
+    <string name="edit_history">Modifier l'historique</string>
     <!-- google-translated 2026-05-04 -->
     <string name="editing_message">Modification du message</string>
     <!-- google-translated 2026-05-04 -->
     <string name="evidence">Preuve</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="evidence_required">Au moins une capture d\'écran ou un enregistrement est requis.</string>
+    <string name="evidence_required">Au moins une capture d'écran ou un enregistrement est requis.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="general">Général</string>
     <!-- google-translated 2026-05-04 -->
@@ -552,7 +552,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="mod_notifications">Notifications de modules</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="move_to_front">Se déplacer vers l\'avant</string>
+    <string name="move_to_front">Se déplacer vers l'avant</string>
     <!-- google-translated 2026-05-04 -->
     <string name="mute_notifications">Notifications muettes</string>
     <!-- google-translated 2026-05-04 -->
@@ -582,7 +582,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="no_pending_reports">Aucun rapport en attente</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="no_stickers_yet">Pas encore d\'autocollants</string>
+    <string name="no_stickers_yet">Pas encore d'autocollants</string>
     <!-- google-translated 2026-05-04 -->
     <string name="no_users_found">Aucun utilisateur trouvé</string>
     <!-- google-translated 2026-05-04 -->
@@ -618,7 +618,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="result_count">%1$d résultat(s)</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="review_report">Rapport d\'examen</string>
+    <string name="review_report">Rapport d'examen</string>
     <!-- google-translated 2026-05-04 -->
     <string name="role_admin">Administrateur</string>
     <!-- google-translated 2026-05-04 -->
@@ -638,7 +638,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="search_people">Rechercher des personnes...</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="select_action">Sélectionnez l\'action :</string>
+    <string name="select_action">Sélectionnez l'action :</string>
     <!-- google-translated 2026-05-04 -->
     <string name="selected_count">%1$d sélectionné</string>
     <!-- google-translated 2026-05-04 -->
@@ -694,7 +694,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">Détails : %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">Message : \"%1$s\"</string>
+    <string name="report_message_prefix">Message : "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">Journaliste : %1$s | Signalé : %2$s</string>
 
@@ -724,7 +724,7 @@
 
     <!-- Messaging - date separators -->
     <!-- google-translated 2026-05-04 -->
-    <string name="today">Aujourd\'hui</string>
+    <string name="today">Aujourd'hui</string>
     <!-- google-translated 2026-05-04 -->
     <string name="yesterday">Hier</string>
 
@@ -756,7 +756,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="milestone">Jalon</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="milestone_bonus">Bonus d\'étape !</string>
+    <string name="milestone_bonus">Bonus d'étape !</string>
     <!-- google-translated 2026-05-04 -->
     <string name="plus_coins">+%1$d pièces !</string>
     <!-- google-translated 2026-05-04 -->
@@ -802,7 +802,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="no_filtered_transactions">Aucune transaction %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="no_transactions_yet">Aucune transaction pour l\'instant</string>
+    <string name="no_transactions_yet">Aucune transaction pour l'instant</string>
     <!-- google-translated 2026-05-04 -->
     <string name="transaction_history">Historique des transactions</string>
     <!-- google-translated 2026-05-04 -->
@@ -812,13 +812,13 @@
 
     <!-- Super Shy -->
     <!-- google-translated 2026-05-04 -->
-    <string name="benefit_daily_bonus">+10 % de pièces de connexion quotidiennes (arrondies à l\'unité supérieure)</string>
+    <string name="benefit_daily_bonus">+10 % de pièces de connexion quotidiennes (arrondies à l'unité supérieure)</string>
     <!-- google-translated 2026-05-04 -->
     <string name="benefit_extended_room">Durée de la chambre prolongée (12 heures)</string>
     <!-- google-translated 2026-05-04 -->
     <string name="benefit_full_room">Salle complète de 8 places</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="benefit_gold_name">Nom d\'affichage en or partout</string>
+    <string name="benefit_gold_name">Nom d'affichage en or partout</string>
     <!-- google-translated 2026-05-04 -->
     <string name="benefit_profile_frame">Cadre profilé exclusif</string>
     <!-- google-translated 2026-05-04 -->
@@ -832,7 +832,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="claimed">Réclamé !</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="claimed_activate_backpack">Pour l\'activer, trouvez-le dans votre sac à dos lorsque vous êtes dans une salle de discussion.</string>
+    <string name="claimed_activate_backpack">Pour l'activer, trouvez-le dans votre sac à dos lorsque vous êtes dans une salle de discussion.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="claiming">Réclame…</string>
     <!-- google-translated 2026-05-04 -->
@@ -872,7 +872,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="cyber_bullying_policy">Politique sur la cyberintimidation</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="i_have_read_and_agree">J\'ai lu et j\'accepte le</string>
+    <string name="i_have_read_and_agree">J'ai lu et j'accepte le</string>
     <!-- google-translated 2026-05-04 -->
     <string name="privacy_policy">politique de confidentialité</string>
     <!-- google-translated 2026-05-04 -->
@@ -902,7 +902,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="active_hours_ago">Actif il y a %1$dh</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="active_just_now">Actif à l\'instant</string>
+    <string name="active_just_now">Actif à l'instant</string>
     <!-- google-translated 2026-05-04 -->
     <string name="active_long_ago">Actif il y a plus de 30 jours</string>
     <!-- google-translated 2026-05-04 -->
@@ -920,7 +920,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="appeal_submitted">Votre appel a été soumis et sera examiné. En cas de succès, votre suspension sera levée. Vous ne recevrez aucun autre retour sur votre appel et vous ne pourrez pas soumettre un autre appel.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="appeal_unsuccessful">Votre appel a été examiné et n\'a pas abouti. Vous ne pouvez pas soumettre un autre appel.</string>
+    <string name="appeal_unsuccessful">Votre appel a été examiné et n'a pas abouti. Vous ne pouvez pas soumettre un autre appel.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="ban_expires">Expire : %1$s</string>
     <!-- google-translated 2026-05-04 -->
@@ -956,9 +956,9 @@
     <!-- google-translated 2026-05-04 -->
     <string name="cache_cleared">Cache vidé</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="cache_cleared_description">Le cache de l\'application a été vidé.</string>
+    <string name="cache_cleared_description">Le cache de l'application a été vidé.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="cannot_enter_room">Impossible d\'entrer dans la pièce</string>
+    <string name="cannot_enter_room">Impossible d'entrer dans la pièce</string>
     <!-- google-translated 2026-05-04 -->
     <string name="chat_display">Affichage du chat</string>
     <!-- google-translated 2026-05-04 -->
@@ -986,7 +986,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="connection_trouble">ShyTalk a du mal à atteindre nos serveurs. Veuillez vérifier votre connexion Internet et réessayer.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="contact_support_help">Si vous avez besoin d\'aide, contactez shytalk.help@gmail.com</string>
+    <string name="contact_support_help">Si vous avez besoin d'aide, contactez shytalk.help@gmail.com</string>
     <!-- google-translated 2026-05-04 -->
     <string name="contact_support_hint">Si le problème persiste, contactez shytalk.help@gmail.com</string>
     <!-- google-translated 2026-05-04 -->
@@ -1016,13 +1016,13 @@
     <!-- google-translated 2026-05-04 -->
     <string name="description">Description</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="device_locked_description">Cet appareil est déjà associé à un autre compte.\nUn seul compte est autorisé par appareil.\n\nPour obtenir de l\'aide, contactez shytalk.help@gmail.com</string>
+    <string name="device_locked_description">Cet appareil est déjà associé à un autre compte.\nUn seul compte est autorisé par appareil.\n\nPour obtenir de l'aide, contactez shytalk.help@gmail.com</string>
     <!-- google-translated 2026-05-04 -->
     <string name="device_not_supported">Appareil non pris en charge</string>
     <!-- google-translated 2026-05-04 -->
     <string name="device_not_supported_description">ShyTalk ne peut pas fonctionner sur des appareils rootés ou émulés. Veuillez utiliser un appareil non modifié.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="display_over_other_apps">Afficher sur d\'autres applications</string>
+    <string name="display_over_other_apps">Afficher sur d'autres applications</string>
     <!-- google-translated 2026-05-04 -->
     <string name="display_over_other_apps_description">Autorisez ShyTalk à afficher une bulle flottante lorsque vous quittez une salle vocale, afin que vous puissiez y revenir rapidement.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1078,13 +1078,13 @@
     <!-- google-translated 2026-05-04 -->
     <string name="enter">Entrer</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="error_block_user">Échec du blocage de l\'utilisateur</string>
+    <string name="error_block_user">Échec du blocage de l'utilisateur</string>
     <!-- google-translated 2026-05-04 -->
     <string name="error_check_updates">Échec de la vérification des mises à jour</string>
     <!-- google-translated 2026-05-04 -->
     <string name="error_could_not_submit_report">Impossible de soumettre le rapport</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="error_follow_user">Impossible de suivre l\'utilisateur</string>
+    <string name="error_follow_user">Impossible de suivre l'utilisateur</string>
     <!-- google-translated 2026-05-04 -->
     <string name="error_load_user_data">Échec du chargement des données utilisateur</string>
     <string name="error_load_users">Failed to load users</string>
@@ -1103,17 +1103,17 @@
     <!-- google-translated 2026-05-04 -->
     <string name="error_resolve_report">Échec de la résolution du rapport</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="error_save_dob">Échec de l\'enregistrement de la date de naissance</string>
+    <string name="error_save_dob">Échec de l'enregistrement de la date de naissance</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="error_submit_appeal">Échec de la soumission de l\'appel</string>
+    <string name="error_submit_appeal">Échec de la soumission de l'appel</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="error_submit_report">Échec de l\'envoi du rapport</string>
+    <string name="error_submit_report">Échec de l'envoi du rapport</string>
     <!-- google-translated 2026-05-04 -->
     <string name="error_title">Erreur</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="error_unblock_user">Échec du déblocage de l\'utilisateur</string>
+    <string name="error_unblock_user">Échec du déblocage de l'utilisateur</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="error_unfollow_user">Échec de la désabonnement de l\'utilisateur</string>
+    <string name="error_unfollow_user">Échec de la désabonnement de l'utilisateur</string>
     <!-- google-translated 2026-05-04 -->
     <string name="error_update_privacy">Échec de la mise à jour des paramètres de confidentialité</string>
     <!-- google-translated 2026-05-04 -->
@@ -1123,7 +1123,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="everyone">Tout le monde</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="hide_age">Masquer l\'âge</string>
+    <string name="hide_age">Masquer l'âge</string>
     <!-- google-translated 2026-05-04 -->
     <string name="hide_age_description">Les autres ne verront pas votre âge sur votre profil.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1137,7 +1137,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="i_understand">Je comprends</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="i_understand_and_accept">Je comprends et j\'accepte</string>
+    <string name="i_understand_and_accept">Je comprends et j'accepte</string>
     <!-- google-translated 2026-05-04 -->
     <string name="kick_reason">Raison : %1$s</string>
     <!-- google-translated 2026-05-04 -->
@@ -1167,7 +1167,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="no_one">Personne</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="not_allowed_to_enter">Vous n\'êtes pas autorisé à entrer dans cette pièce.</string>
+    <string name="not_allowed_to_enter">Vous n'êtes pas autorisé à entrer dans cette pièce.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="not_now">Pas maintenant</string>
     <!-- google-translated 2026-05-04 -->
@@ -1175,7 +1175,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="notification_sound">Son de notification</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="notification_sound_description">Jouez un son lorsqu\'un nouveau message arrive.</string>
+    <string name="notification_sound_description">Jouez un son lorsqu'un nouveau message arrive.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="notifications_permission_description">Recevez des alertes lorsque vous êtes dans une salle en direct en arrière-plan.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1191,13 +1191,13 @@
     <!-- google-translated 2026-05-04 -->
     <string name="private_messages">Messages privés</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="profile_not_available">Ce profil n\'est pas disponible</string>
+    <string name="profile_not_available">Ce profil n'est pas disponible</string>
     <!-- google-translated 2026-05-04 -->
     <string name="profile_not_found">Profil introuvable</string>
     <!-- google-translated 2026-05-04 -->
     <string name="removed_from_room">Supprimé de la salle</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_thank_you">Merci pour votre rapport. Nous l\'examinerons sous peu.</string>
+    <string name="report_thank_you">Merci pour votre rapport. Nous l'examinerons sous peu.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_user_generic">Signaler un utilisateur</string>
     <!-- google-translated 2026-05-04 -->
@@ -1205,9 +1205,9 @@
     <!-- google-translated 2026-05-04 -->
     <string name="room_alerts">Alertes de salle</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="self_destruct_countdown">Compte à rebours d\'autodestruction</string>
+    <string name="self_destruct_countdown">Compte à rebours d'autodestruction</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="self_destruct_description">Diffusez une annonce vocale lorsque la minuterie d\'autodestruction de 5 minutes d\'une pièce démarre ou s\'arrête.</string>
+    <string name="self_destruct_description">Diffusez une annonce vocale lorsque la minuterie d'autodestruction de 5 minutes d'une pièce démarre ou s'arrête.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="show_date_separators">Afficher les séparateurs de dates</string>
     <!-- google-translated 2026-05-04 -->
@@ -1257,7 +1257,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="super_shy_lifetime">Super timide ✦ À vie</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="support_contact">Pour obtenir de l\'aide, contactez shytalk.help@gmail.com</string>
+    <string name="support_contact">Pour obtenir de l'aide, contactez shytalk.help@gmail.com</string>
     <!-- google-translated 2026-05-04 -->
     <string name="suspension_ends_at">Fin : %1$s</string>
     <!-- google-translated 2026-05-04 -->
@@ -1295,9 +1295,9 @@
     <!-- google-translated 2026-05-04 -->
     <string name="update_required">Mise à jour requise</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="update_required_description">Une nouvelle version de ShyTalk est disponible. Veuillez mettre à jour pour continuer à utiliser l\'application.</string>
+    <string name="update_required_description">Une nouvelle version de ShyTalk est disponible. Veuillez mettre à jour pour continuer à utiliser l'application.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="update_open_store_failed">Impossible d\'ouvrir automatiquement l\'App Store. Veuillez mettre à jour ShyTalk manuellement à partir de la boutique d\'applications de votre appareil.</string>
+    <string name="update_open_store_failed">Impossible d'ouvrir automatiquement l'App Store. Veuillez mettre à jour ShyTalk manuellement à partir de la boutique d'applications de votre appareil.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="view_community_standards">Afficher les normes de la communauté</string>
     <!-- google-translated 2026-05-04 -->
@@ -1308,7 +1308,7 @@
     <string name="wallet_with_balance">Portefeuille · %1$s</string>
     <!-- google-translated 2026-05-04 -->
     <string name="warning_consequence">Des violations continues peuvent entraîner la suspension de votre compte.</string>
-    <string name="warning_acknowledge_failed">Impossible de lever l\'avertissement. Vérifiez votre connexion et réessayez.</string>
+    <string name="warning_acknowledge_failed">Impossible de lever l'avertissement. Vérifiez votre connexion et réessayez.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="warning_reviewed">Votre compte a été examiné et un avertissement a été émis.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1316,7 +1316,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="who_can_message_description">Contrôlez qui peut vous envoyer des messages privés.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="who_can_message_me">Qui peut m\'envoyer un message</string>
+    <string name="who_can_message_me">Qui peut m'envoyer un message</string>
     <!-- google-translated 2026-05-04 -->
     <string name="you_were_banned">Vous avez été banni de cette pièce.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1334,7 +1334,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="messages_title">Messages</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="no_conversations_yet">Aucune conversation pour l\'instant</string>
+    <string name="no_conversations_yet">Aucune conversation pour l'instant</string>
     <!-- google-translated 2026-05-04 -->
     <string name="spin_again_with_cost">%1$s TOURNEZ ENCORE · 🪙%2$d</string>
     <!-- google-translated 2026-05-04 -->
@@ -1381,9 +1381,9 @@
     <!-- google-translated 2026-05-04 -->
     <string name="network_banned_title">Réseau interdit</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="device_banned_description">Cet appareil a été interdit d\'utiliser ShyTalk.</string>
+    <string name="device_banned_description">Cet appareil a été interdit d'utiliser ShyTalk.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="network_banned_description">Votre réseau a été interdit d\'utiliser ShyTalk. Essayez de vous connecter à partir d\'un autre réseau.</string>
+    <string name="network_banned_description">Votre réseau a été interdit d'utiliser ShyTalk. Essayez de vous connecter à partir d'un autre réseau.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="full_screen_photo">Photo plein écran</string>
     <!-- google-translated 2026-05-04 -->
@@ -1460,20 +1460,20 @@
     <string name="security">Sécurité</string>
     <!-- Starting Screens -->
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_pre_launch_title">ShyTalk n\'est pas encore disponible</string>
+    <string name="starting_screen_pre_launch_title">ShyTalk n'est pas encore disponible</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_pre_launch_message">ShyTalk n\'est pas encore sorti. Pour postuler pour tester l\'application, contactez Shyden. Les tests sont disponibles pour les utilisateurs iOS et Android.</string>
+    <string name="starting_screen_pre_launch_message">ShyTalk n'est pas encore sorti. Pour postuler pour tester l'application, contactez Shyden. Les tests sont disponibles pour les utilisateurs iOS et Android.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_dismiss">Continuer</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_police_duck_description">Illustration d\'avertissement</string>
+    <string name="starting_screen_police_duck_description">Illustration d'avertissement</string>
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_loading">Chargement\u2026</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">Sécurité</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="security_app_lock">Verrouillage d\'application</string>
+    <string name="security_app_lock">Verrouillage d'application</string>
     <!-- google-translated 2026-05-04 -->
     <string name="security_app_lock_desc">Exiger un code PIN ou des données biométriques pour déverrouiller</string>
     <!-- google-translated 2026-05-04 -->
@@ -1491,7 +1491,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="security_biometric_login">Connexion biométrique</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="security_biometric_desc">Utilisez l\'empreinte digitale ou le visage pour déverrouiller</string>
+    <string name="security_biometric_desc">Utilisez l'empreinte digitale ou le visage pour déverrouiller</string>
     <!-- google-translated 2026-05-04 -->
     <string name="security_biometric_unavailable">Non disponible sur cet appareil</string>
     <!-- google-translated 2026-05-04 -->
@@ -1528,7 +1528,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="email_disposable_blocked">Les adresses e-mail jetables ne sont pas autorisées</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="email_send_failed">Échec de l\'envoi du code</string>
+    <string name="email_send_failed">Échec de l'envoi du code</string>
     <!-- google-translated 2026-05-04 -->
     <string name="email_enter_code">Entrez le code à 6 chiffres</string>
     <!-- google-translated 2026-05-04 -->
@@ -1600,7 +1600,7 @@
     <string name="signing_in_loading">Connexion\u2026</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
-    <string name="time_just_now">tout à l\' heure</string>
+    <string name="time_just_now">tout à l' heure</string>
     <!-- google-translated 2026-05-04 -->
     <string name="time_minutes_ago">Il y a %1$d minutes</string>
     <!-- google-translated 2026-05-04 -->
@@ -1615,7 +1615,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="time_minutes">%1$d minutes</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="time_less_than_minute">Moins d\'une minute</string>
+    <string name="time_less_than_minute">Moins d'une minute</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_dots_state">%1$d sur %2$d chiffres saisis</string>
     <!-- google-translated 2026-05-04 -->
@@ -1625,7 +1625,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="replace_room_title">Fermer la pièce existante ?</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="replace_room_message">Vous disposez déjà d\'une salle active. L’ouverture d’une nouvelle salle fermera celle existante. Voulez-vous continuer ?</string>
+    <string name="replace_room_message">Vous disposez déjà d'une salle active. L’ouverture d’une nouvelle salle fermera celle existante. Voulez-vous continuer ?</string>
     <!-- google-translated 2026-05-04 -->
     <string name="replace_room_confirm">Fermer et créer un nouveau</string>
 
@@ -1665,23 +1665,23 @@
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_explanation_title">Comment ça marche</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="age_verif_step_explanation_body">Nous avons besoin d\'une photo d\'une pièce d\'identité émise par le gouvernement pour confirmer que vous avez au moins 18 ans. L\'image est cryptée pendant le transport, examinée par un modérateur humain et définitivement supprimée dès qu\'une décision est enregistrée, généralement dans les 24 heures. Seules la date de naissance et le résultat de la vérification sont conservés.</string>
+    <string name="age_verif_step_explanation_body">Nous avons besoin d'une photo d'une pièce d'identité émise par le gouvernement pour confirmer que vous avez au moins 18 ans. L'image est cryptée pendant le transport, examinée par un modérateur humain et définitivement supprimée dès qu'une décision est enregistrée, généralement dans les 24 heures. Seules la date de naissance et le résultat de la vérification sont conservés.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_explanation_continue">Je comprends — continuez</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_method_title">Quel document ?</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="age_verif_step_method_body">Choisissez le type de pièce d\'identité que vous soumettrez. La date de naissance sur le document doit correspondre à celle de votre compte.</string>
+    <string name="age_verif_step_method_body">Choisissez le type de pièce d'identité que vous soumettrez. La date de naissance sur le document doit correspondre à celle de votre compte.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_method_passport">Passeport</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_method_drivers_license">Le permis de conduire</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="age_verif_method_national_id">Carte d\'identité nationale</string>
+    <string name="age_verif_method_national_id">Carte d'identité nationale</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_image_title">Ajouter la photo</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="age_verif_step_image_body">Choisissez une photo claire de la pièce d\'identité. Assurez-vous que la date de naissance est entièrement lisible.</string>
+    <string name="age_verif_step_image_body">Choisissez une photo claire de la pièce d'identité. Assurez-vous que la date de naissance est entièrement lisible.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_image_pick">Choisir une photo</string>
     <!-- google-translated 2026-05-04 -->
@@ -1689,9 +1689,9 @@
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_confirm_title">Prêt à soumettre ?</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="age_verif_step_confirm_body">Une fois soumise, la photo est envoyée pour examen. Vous recevrez un message système lorsqu\'une décision sera enregistrée.</string>
+    <string name="age_verif_step_confirm_body">Une fois soumise, la photo est envoyée pour examen. Vous recevrez un message système lorsqu'une décision sera enregistrée.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="age_verif_field_method">Type d\'identification :</string>
+    <string name="age_verif_field_method">Type d'identification :</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_field_photo">Photo:</string>
     <!-- google-translated 2026-05-04 -->
@@ -1701,13 +1701,13 @@
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_submitted_title">Merci</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="age_verif_step_submitted_body">Votre soumission est dans la file d\'attente. Nous vous enverrons un message ici lorsqu’une décision sera enregistrée.</string>
+    <string name="age_verif_step_submitted_body">Votre soumission est dans la file d'attente. Nous vous enverrons un message ici lorsqu’une décision sera enregistrée.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_submitted_done">Fait</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_back">Dos</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="age_verif_submit_error_no_method">Veuillez choisir un type d\'identification avant de soumettre.</string>
+    <string name="age_verif_submit_error_no_method">Veuillez choisir un type d'identification avant de soumettre.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_submit_error_no_image">Veuillez ajouter une photo avant de soumettre.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1715,27 +1715,27 @@
     <!-- google-translated 2026-05-08 -->
     <string name="age_verif_test_env_label">Environnement de test</string>
     <!-- google-translated 2026-05-08 -->
-    <string name="age_verif_test_env_warning">Téléchargez n\'importe quelle image : il s\'agit d\'un environnement de test, les véritables identifiants ne sont pas requis et ne sont pas stockés à long terme.</string>
+    <string name="age_verif_test_env_warning">Téléchargez n'importe quelle image : il s'agit d'un environnement de test, les véritables identifiants ne sont pas requis et ne sont pas stockés à long terme.</string>
     <!-- google-translated 2026-05-09 -->
-    <string name="success_report_resolved_with_issues">Rapport résolu, mais certaines actions n\'ont pas abouti. Vérifiez le panneau Web d\'administration et réessayez si nécessaire.</string>
+    <string name="success_report_resolved_with_issues">Rapport résolu, mais certaines actions n'ont pas abouti. Vérifiez le panneau Web d'administration et réessayez si nécessaire.</string>
     <!-- google-translated 2026-05-15 -->
-    <string name="age_seg_relationship_removed_pm">Votre lien de suivi avec %1$s a été supprimé dans le cadre d\'un changement récent dans la façon dont ShyTalk organise les comptes.\n\nC\'est automatique ; cela ne reflète rien de ce que vous avez fait, et le lien d\'origine ne peut pas être restauré à partir d\'ici.\n\nSi vous ne reconnaissez pas le nom, cela signifie simplement qu\'une connexion passée a été corrigée.</string>
+    <string name="age_seg_relationship_removed_pm">Votre lien de suivi avec %1$s a été supprimé dans le cadre d'un changement récent dans la façon dont ShyTalk organise les comptes.\n\nC'est automatique ; cela ne reflète rien de ce que vous avez fait, et le lien d'origine ne peut pas être restauré à partir d'ici.\n\nSi vous ne reconnaissez pas le nom, cela signifie simplement qu'une connexion passée a été corrigée.</string>
     <!-- google-translated 2026-05-15 -->
-    <string name="age_seg_room_removed_pm">Vous avez été supprimé de %1$s dans le cadre d\'un changement récent dans la façon dont ShyTalk organise les comptes.\n\nCela est automatique et ne reflète rien de ce que vous avez fait. La chambre elle-même est bien ; nous ne pouvons tout simplement pas vous y garder avec le nouvel arrangement.\n\nVous pouvez toujours créer ou rejoindre d\'autres salles de votre manière habituelle.</string>
+    <string name="age_seg_room_removed_pm">Vous avez été supprimé de %1$s dans le cadre d'un changement récent dans la façon dont ShyTalk organise les comptes.\n\nCela est automatique et ne reflète rien de ce que vous avez fait. La chambre elle-même est bien ; nous ne pouvons tout simplement pas vous y garder avec le nouvel arrangement.\n\nVous pouvez toujours créer ou rejoindre d'autres salles de votre manière habituelle.</string>
     <!-- google-translated 2026-05-15 -->
     <string name="age_seg_unavailable">Indisponible</string>
     <!-- google-translated 2026-05-15 -->
-    <string name="age_seg_user_unavailable">Cet utilisateur n\'est pas disponible.</string>
+    <string name="age_seg_user_unavailable">Cet utilisateur n'est pas disponible.</string>
     <!-- google-translated 2026-05-15 -->
-    <string name="age_seg_room_unavailable">Cette salle n\'est pas disponible.</string>
+    <string name="age_seg_room_unavailable">Cette salle n'est pas disponible.</string>
     <!-- google-translated 2026-05-15 -->
-    <string name="age_seg_cross_cohort_blocked_toast">Cette action n\'est pas disponible pour votre compte.</string>
+    <string name="age_seg_cross_cohort_blocked_toast">Cette action n'est pas disponible pour votre compte.</string>
     <!-- google-translated 2026-05-15 -->
-    <string name="age_seg_thread_hidden_pm">Votre fil de discussion avec %1$s a été conservé mais ne peut pas continuer, dans le cadre d\'un changement récent dans la façon dont ShyTalk organise les comptes.\n\nC\'est automatique ; rien de ce que vous avez envoyé auparavant n’est perdu. Les nouveaux messages ne peuvent pas être échangés dans ce fil de discussion, mais vous pouvez toujours démarrer de nouvelles conversations avec des personnes de votre cercle habituel.</string>
+    <string name="age_seg_thread_hidden_pm">Votre fil de discussion avec %1$s a été conservé mais ne peut pas continuer, dans le cadre d'un changement récent dans la façon dont ShyTalk organise les comptes.\n\nC'est automatique ; rien de ce que vous avez envoyé auparavant n’est perdu. Les nouveaux messages ne peuvent pas être échangés dans ce fil de discussion, mais vous pouvez toujours démarrer de nouvelles conversations avec des personnes de votre cercle habituel.</string>
     <!-- google-translated 2026-05-15 -->
     <string name="age_seg_group_frozen_banner">Ce groupe ne peut pas accepter de nouveaux membres ou de nouveaux messages suite à un changement récent dans la manière dont ShyTalk organise les comptes.</string>
     <!-- google-translated 2026-05-15 -->
     <string name="age_seg_age_up_welcome_pm">Bienvenue — votre compte a rejoint le cercle ShyTalk plus large.\n\nVous commencerez à voir plus de personnes dans les découvertes et les listes à partir de maintenant. Les connexions précédentes qui ont été rétablies alors que votre compte se trouvait dans le cercle plus petit ne peuvent pas être restaurées automatiquement, mais vous pouvez rajouter toute personne que vous souhaitez suivre.</string>
     <!-- google-translated 2026-05-15 -->
-    <string name="age_seg_age_down_admin_pm">Les détails de votre compte ont été mis à jour par le personnel de ShyTalk. Par conséquent, les personnes et les salles visibles ont été réduites à un cercle plus petit.\n\nSi vous pensez qu\'il s\'agit d\'une erreur, contactez l\'assistance et nous l\'examinerons.</string>
+    <string name="age_seg_age_down_admin_pm">Les détails de votre compte ont été mis à jour par le personnel de ShyTalk. Par conséquent, les personnes et les salles visibles ont été réduites à un cercle plus petit.\n\nSi vous pensez qu'il s'agit d'une erreur, contactez l'assistance et nous l'examinerons.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -695,7 +695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">विवरण: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">संदेश: \"%1$s\"</string>
+    <string name="report_message_prefix">संदेश: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">रिपोर्टर: %1$s | रिपोर्ट: %2$s</string>
 

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -1471,7 +1471,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">चेतावनी चित्रण</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">लोड हो रहा है\u2026</string>
+    <string name="starting_screen_loading">लोड हो रहा है…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">सुरक्षा</string>
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">जारी रखने के लिए अपना पिन दर्ज करें</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">सत्यापन किया जा रहा है\u2026</string>
+    <string name="pin_verifying">सत्यापन किया जा रहा है…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">ग़लत पिन. %1$d प्रयास शेष हैं.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1600,7 +1600,7 @@
     <string name="biometric_start_failed">बायोमेट्रिक सत्यापन प्रारंभ नहीं हो सका</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">साइन इन हो रहा है\u2026</string>
+    <string name="signing_in_loading">साइन इन हो रहा है…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">बस अब</string>

--- a/shared/src/commonMain/composeResources/values-id/strings.xml
+++ b/shared/src/commonMain/composeResources/values-id/strings.xml
@@ -743,7 +743,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="day_sat">Duduk</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="day_streak">%1$hari berturut-turut</string>
+    <string name="day_streak">%1$d hari berturut-turut</string>
     <!-- google-translated 2026-05-04 -->
     <string name="day_sun">Matahari</string>
     <!-- google-translated 2026-05-04 -->
@@ -1471,7 +1471,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">Ilustrasi peringatan</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">Memuat\u2026</string>
+    <string name="starting_screen_loading">Memuat…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">Keamanan</string>
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">Masukkan PIN Anda untuk melanjutkan</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">Memverifikasi\u2026</string>
+    <string name="pin_verifying">Memverifikasi…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">PIN salah. %1$d percobaan tersisa.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1600,7 +1600,7 @@
     <string name="biometric_start_failed">Tidak dapat memulai verifikasi biometrik</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">Masuk\u2026</string>
+    <string name="signing_in_loading">Masuk…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">baru saja</string>

--- a/shared/src/commonMain/composeResources/values-id/strings.xml
+++ b/shared/src/commonMain/composeResources/values-id/strings.xml
@@ -695,7 +695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">Detail: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">Pesan: \"%1$s\"</string>
+    <string name="report_message_prefix">Pesan: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">Pelapor: %1$s | Dilaporkan: %2$s</string>
 

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -186,7 +186,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="following_count">Seguito (%1$d)</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="following_list_private">L\'elenco che segue di questo utente è privato</string>
+    <string name="following_list_private">L'elenco che segue di questo utente è privato</string>
     <!-- google-translated 2026-05-04 -->
     <string name="get_super_shy">Diventa super timido</string>
     <!-- google-translated 2026-05-04 -->
@@ -282,7 +282,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="kick">Calcio</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="kick_user">Caccia l\'utente</string>
+    <string name="kick_user">Caccia l'utente</string>
     <!-- google-translated 2026-05-04 -->
     <string name="kick_user_confirm">Sei sicuro di voler espellere %1$s dalla stanza? Non potranno ricongiungersi.</string>
     <!-- google-translated 2026-05-04 -->
@@ -384,7 +384,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="seat_swap_with">Posto %1$d (scambia con %2$s)</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="set_alias">Imposta l\'alias</string>
+    <string name="set_alias">Imposta l'alias</string>
     <!-- google-translated 2026-05-04 -->
     <string name="set_alias_description">Imposta un alias personale per %1$s. Solo tu lo vedrai.</string>
     <!-- google-translated 2026-05-04 -->
@@ -448,7 +448,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="action_cannot_be_undone">QUESTA AZIONE NON PUÒ ESSERE ANNULLATA.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="confirm_send">Conferma l\'invio</string>
+    <string name="confirm_send">Conferma l'invio</string>
     <!-- google-translated 2026-05-04 -->
     <string name="from_backpack_items">Dallo zaino: %1$d articoli</string>
     <!-- google-translated 2026-05-04 -->
@@ -501,7 +501,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="delete_conversation">Elimina conversazione</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="delete_conversation_warning">Ciò rimuoverà la conversazione dal tuo elenco. I messaggi vengono conservati e riappariranno se l\'altra persona ti invia nuovamente un messaggio.</string>
+    <string name="delete_conversation_warning">Ciò rimuoverà la conversazione dal tuo elenco. I messaggi vengono conservati e riappariranno se l'altra persona ti invia nuovamente un messaggio.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="description_label">Descrizione</string>
     <!-- google-translated 2026-05-04 -->
@@ -561,11 +561,11 @@
     <!-- google-translated 2026-05-04 -->
     <string name="muted">Disattivato</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="muted_for_hours_minutes">L\'audio è disattivato per %1$dh %2$dm</string>
+    <string name="muted_for_hours_minutes">L'audio è disattivato per %1$dh %2$dm</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="muted_for_minutes">L\'audio è disattivato per %1$dm</string>
+    <string name="muted_for_minutes">L'audio è disattivato per %1$dm</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="muted_indefinitely">L\'audio è disattivato</string>
+    <string name="muted_indefinitely">L'audio è disattivato</string>
     <!-- google-translated 2026-05-04 -->
     <string name="new_group">Nuovo gruppo</string>
     <!-- google-translated 2026-05-04 -->
@@ -695,7 +695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">Dettagli: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">Messaggio: \"%1$s\"</string>
+    <string name="report_message_prefix">Messaggio: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">Reporter: %1$s | Segnalato: %2$s</string>
 
@@ -719,7 +719,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="perm_who_can_delete_messages">Chi può eliminare i messaggi</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="perm_who_can_mute_members">Chi può disattivare l\'audio dei membri</string>
+    <string name="perm_who_can_mute_members">Chi può disattivare l'audio dei membri</string>
     <!-- google-translated 2026-05-04 -->
     <string name="perm_who_can_remove_members">Chi può rimuovere i membri</string>
 
@@ -845,7 +845,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="per_month">al mese</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="per_year">all\'anno</string>
+    <string name="per_year">all'anno</string>
     <!-- google-translated 2026-05-04 -->
     <string name="super_shy">Super timido</string>
     <!-- google-translated 2026-05-04 -->
@@ -895,7 +895,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="account_restricted">Conto limitato</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="account_suspended_description">L\'account di questo utente è stato sospeso.</string>
+    <string name="account_suspended_description">L'account di questo utente è stato sospeso.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="account_suspended_label">Conto sospeso</string>
     <!-- google-translated 2026-05-04 -->
@@ -945,7 +945,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="blocked_by_user">Sei stato bloccato da questo utente</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="blocked_by_user_in_room_description">Un utente in questa stanza ti ha bloccato. Potresti avere un\'esperienza limitata. Entra comunque?</string>
+    <string name="blocked_by_user_in_room_description">Un utente in questa stanza ti ha bloccato. Potresti avere un'esperienza limitata. Entra comunque?</string>
     <!-- google-translated 2026-05-04 -->
     <string name="blocked_user_in_room">Utente bloccato nella stanza</string>
     <!-- google-translated 2026-05-04 -->
@@ -957,7 +957,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="cache_cleared">Cache cancellata</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="cache_cleared_description">La cache dell\'app è stata cancellata.</string>
+    <string name="cache_cleared_description">La cache dell'app è stata cancellata.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="cannot_enter_room">Impossibile entrare nella stanza</string>
     <!-- google-translated 2026-05-04 -->
@@ -967,7 +967,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="checking_for_updates">Controllo aggiornamenti…</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="choose_another_room">Scegli un\'altra stanza</string>
+    <string name="choose_another_room">Scegli un'altra stanza</string>
     <!-- google-translated 2026-05-04 -->
     <string name="clear">Chiaro</string>
     <!-- google-translated 2026-05-04 -->
@@ -997,15 +997,15 @@
     <!-- google-translated 2026-05-04 -->
     <string name="delete_account">Elimina account</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="delete_account_description">Il tuo account e tutti i dati verranno eliminati definitivamente dopo il periodo di grazia. Puoi annullare l\'accesso effettuando l\'accesso prima di tale data.</string>
+    <string name="delete_account_description">Il tuo account e tutti i dati verranno eliminati definitivamente dopo il periodo di grazia. Puoi annullare l'accesso effettuando l'accesso prima di tale data.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="delete_account_scheduled">È prevista l\'eliminazione del tuo account il %1$s. Desideri annullare?</string>
+    <string name="delete_account_scheduled">È prevista l'eliminazione del tuo account il %1$s. Desideri annullare?</string>
     <!-- google-translated 2026-05-04 -->
     <string name="delete_account_cancel">Annulla eliminazione</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="delete_account_continue">Continuare con l\'eliminazione</string>
+    <string name="delete_account_continue">Continuare con l'eliminazione</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="delete_account_success">È stata programmata l\'eliminazione del tuo account.</string>
+    <string name="delete_account_success">È stata programmata l'eliminazione del tuo account.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="delete_account_pin_required">Verifica la tua identità per eliminare il tuo account</string>
     <!-- google-translated 2026-05-04 -->
@@ -1074,19 +1074,19 @@
     <!-- google-translated 2026-05-04 -->
     <string name="enable_dnd">Abilita Non disturbare</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="enable_dnd_description">Silenzia tutte le notifiche PM durante l\'orario pianificato.</string>
+    <string name="enable_dnd_description">Silenzia tutte le notifiche PM durante l'orario pianificato.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="end">FINE</string>
     <!-- google-translated 2026-05-04 -->
     <string name="enter">Entra</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="error_block_user">Impossibile bloccare l\'utente</string>
+    <string name="error_block_user">Impossibile bloccare l'utente</string>
     <!-- google-translated 2026-05-04 -->
     <string name="error_check_updates">Impossibile controllare gli aggiornamenti</string>
     <!-- google-translated 2026-05-04 -->
     <string name="error_could_not_submit_report">Impossibile inviare il rapporto</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="error_follow_user">Impossibile seguire l\'utente</string>
+    <string name="error_follow_user">Impossibile seguire l'utente</string>
     <!-- google-translated 2026-05-04 -->
     <string name="error_load_user_data">Impossibile caricare i dati utente</string>
     <!-- google-translated 2026-05-04 -->
@@ -1114,9 +1114,9 @@
     <!-- google-translated 2026-05-04 -->
     <string name="error_title">Errore</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="error_unblock_user">Impossibile sbloccare l\'utente</string>
+    <string name="error_unblock_user">Impossibile sbloccare l'utente</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="error_unfollow_user">Impossibile smettere di seguire l\'utente</string>
+    <string name="error_unfollow_user">Impossibile smettere di seguire l'utente</string>
     <!-- google-translated 2026-05-04 -->
     <string name="error_update_privacy">Impossibile aggiornare le impostazioni sulla privacy</string>
     <!-- google-translated 2026-05-04 -->
@@ -1208,7 +1208,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="room_alerts">Avvisi sulla stanza</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="self_destruct_countdown">Conto alla rovescia per l\'autodistruzione</string>
+    <string name="self_destruct_countdown">Conto alla rovescia per l'autodistruzione</string>
     <!-- google-translated 2026-05-04 -->
     <string name="self_destruct_description">Riproduci un annuncio vocale quando il timer di autodistruzione di 5 minuti di una stanza si avvia o si ferma.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1224,7 +1224,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="sign_in_with_google">Accedi con Google</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="sign_in_with_email">Accedi con l\'e-mail</string>
+    <string name="sign_in_with_email">Accedi con l'e-mail</string>
     <!-- google-translated 2026-05-04 -->
     <string name="email_hint">Indirizzo e-mail</string>
     <!-- google-translated 2026-05-04 -->
@@ -1286,7 +1286,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="up_to_date">Aggiornato</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="up_to_date_description">Sei sull\'ultima versione.</string>
+    <string name="up_to_date_description">Sei sull'ultima versione.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="update_available">Aggiornamento disponibile</string>
     <!-- google-translated 2026-05-04 -->
@@ -1298,9 +1298,9 @@
     <!-- google-translated 2026-05-04 -->
     <string name="update_required">Aggiornamento richiesto</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="update_required_description">È disponibile una nuova versione di ShyTalk. Aggiorna per continuare a utilizzare l\'app.</string>
+    <string name="update_required_description">È disponibile una nuova versione di ShyTalk. Aggiorna per continuare a utilizzare l'app.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="update_open_store_failed">Impossibile aprire automaticamente l\'app store. Aggiorna ShyTalk manualmente dall\'app store del tuo dispositivo.</string>
+    <string name="update_open_store_failed">Impossibile aprire automaticamente l'app store. Aggiorna ShyTalk manualmente dall'app store del tuo dispositivo.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="view_community_standards">Visualizza gli standard comunitari</string>
     <!-- google-translated 2026-05-04 -->
@@ -1311,7 +1311,7 @@
     <string name="wallet_with_balance">Portafoglio · %1$s</string>
     <!-- google-translated 2026-05-04 -->
     <string name="warning_consequence">Violazioni continue potrebbero comportare la sospensione del tuo account.</string>
-    <string name="warning_acknowledge_failed">Impossibile rimuovere l\'avviso. Controlla la connessione e riprova.</string>
+    <string name="warning_acknowledge_failed">Impossibile rimuovere l'avviso. Controlla la connessione e riprova.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="warning_reviewed">Il tuo account è stato esaminato ed è stato emesso un avviso.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1384,9 +1384,9 @@
     <!-- google-translated 2026-05-04 -->
     <string name="network_banned_title">Rete vietata</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="device_banned_description">A questo dispositivo è stato vietato l\'utilizzo di ShyTalk.</string>
+    <string name="device_banned_description">A questo dispositivo è stato vietato l'utilizzo di ShyTalk.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="network_banned_description">Alla tua rete è stato vietato l\'uso di ShyTalk. Prova a connetterti da una rete diversa.</string>
+    <string name="network_banned_description">Alla tua rete è stato vietato l'uso di ShyTalk. Prova a connetterti da una rete diversa.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="full_screen_photo">Foto a schermo intero</string>
     <!-- google-translated 2026-05-04 -->
@@ -1432,7 +1432,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="resend_link">Invia nuovamente</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="use_different_email">Utilizza un\'e-mail diversa</string>
+    <string name="use_different_email">Utilizza un'e-mail diversa</string>
     <!-- google-translated 2026-05-04 -->
     <string name="email_link_paste_hint">Apri il collegamento nella tua email, quindi torna indietro e tocca Incolla collegamento.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1465,7 +1465,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_pre_launch_title">ShyTalk non è ancora disponibile</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_pre_launch_message">ShyTalk non è stato ancora rilasciato. Per fare domanda per testare l\'applicazione, contattare Shyden. Il test è disponibile per gli utenti iOS e Android.</string>
+    <string name="starting_screen_pre_launch_message">ShyTalk non è stato ancora rilasciato. Per fare domanda per testare l'applicazione, contattare Shyden. Il test è disponibile per gli utenti iOS e Android.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_dismiss">Continuare</string>
     <!-- google-translated 2026-05-04 -->
@@ -1476,7 +1476,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">Sicurezza</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="security_app_lock">Blocco dell\'app</string>
+    <string name="security_app_lock">Blocco dell'app</string>
     <!-- google-translated 2026-05-04 -->
     <string name="security_app_lock_desc">Richiedi PIN o biometrico per sbloccare</string>
     <!-- google-translated 2026-05-04 -->
@@ -1494,7 +1494,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="security_biometric_login">Accesso biometrico</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="security_biometric_desc">Usa l\'impronta digitale o il volto per sbloccare</string>
+    <string name="security_biometric_desc">Usa l'impronta digitale o il volto per sbloccare</string>
     <!-- google-translated 2026-05-04 -->
     <string name="security_biometric_unavailable">Non disponibile su questo dispositivo</string>
     <!-- google-translated 2026-05-04 -->
@@ -1507,7 +1507,7 @@
     <!-- google-translated 2026-05-04 -->
     <!-- Email sign-in -->
     <!-- google-translated 2026-05-04 -->
-    <string name="email_sign_in_title">Accedi con l\'e-mail</string>
+    <string name="email_sign_in_title">Accedi con l'e-mail</string>
     <!-- google-translated 2026-05-04 -->
     <string name="email_enter_address">Inserisci il tuo indirizzo email</string>
     <!-- google-translated 2026-05-04 -->
@@ -1544,7 +1544,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_confirm_title">Conferma il tuo PIN</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_enable_biometric_title">Abilitare l\'accesso biometrico?</string>
+    <string name="pin_enable_biometric_title">Abilitare l'accesso biometrico?</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_enable_biometric_desc">Usa la tua impronta digitale o il tuo volto per sbloccare rapidamente ShyTalk.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1591,7 +1591,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="biometric_unlock_title">Sblocca ShyTalk</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="biometric_unlock_desc">Usa l\'impronta digitale o il viso per sbloccare</string>
+    <string name="biometric_unlock_desc">Usa l'impronta digitale o il viso per sbloccare</string>
     <!-- google-translated 2026-05-04 -->
     <string name="biometric_sign_failed">Firma non riuscita</string>
     <!-- google-translated 2026-05-04 -->
@@ -1629,7 +1629,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="replace_room_title">Chiudere la stanza esistente?</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="replace_room_message">Hai già una stanza attiva. L\'apertura di una nuova stanza chiuderà quella esistente. Vuoi continuare?</string>
+    <string name="replace_room_message">Hai già una stanza attiva. L'apertura di una nuova stanza chiuderà quella esistente. Vuoi continuare?</string>
     <!-- google-translated 2026-05-04 -->
     <string name="replace_room_confirm">Chiudi e creane uno nuovo</string>
 
@@ -1669,23 +1669,23 @@
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_explanation_title">Come funziona</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="age_verif_step_explanation_body">Abbiamo bisogno della foto di un documento d\'identità rilasciato dal governo per confermare che hai almeno 18 anni. L\'immagine viene crittografata durante il transito, esaminata da un moderatore umano ed eliminata definitivamente non appena viene registrata una decisione, di solito entro 24 ore. Vengono conservati solo la data di nascita e l\'esito della verifica.</string>
+    <string name="age_verif_step_explanation_body">Abbiamo bisogno della foto di un documento d'identità rilasciato dal governo per confermare che hai almeno 18 anni. L'immagine viene crittografata durante il transito, esaminata da un moderatore umano ed eliminata definitivamente non appena viene registrata una decisione, di solito entro 24 ore. Vengono conservati solo la data di nascita e l'esito della verifica.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_explanation_continue">Capisco: continua</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_method_title">Quale documento?</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="age_verif_step_method_body">Scegli il tipo di documento d\'identità che invierai. Il DOB sul documento deve corrispondere a quello sul tuo account.</string>
+    <string name="age_verif_step_method_body">Scegli il tipo di documento d'identità che invierai. Il DOB sul documento deve corrispondere a quello sul tuo account.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_method_passport">Passaporto</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_method_drivers_license">Patente di guida</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="age_verif_method_national_id">Carta d\'identità nazionale</string>
+    <string name="age_verif_method_national_id">Carta d'identità nazionale</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_image_title">Aggiungi la foto</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="age_verif_step_image_body">Scegli una foto nitida del documento d\'identità. Assicurati che la data di nascita sia completamente leggibile.</string>
+    <string name="age_verif_step_image_body">Scegli una foto nitida del documento d'identità. Assicurati che la data di nascita sia completamente leggibile.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_image_pick">Scegli la foto</string>
     <!-- google-translated 2026-05-04 -->
@@ -1695,7 +1695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_step_confirm_body">Una volta inviata, la foto viene inviata per la revisione. Riceverai un messaggio di sistema quando viene registrata una decisione.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="age_verif_field_method">Tipo di documento d\'identità:</string>
+    <string name="age_verif_field_method">Tipo di documento d'identità:</string>
     <!-- google-translated 2026-05-04 -->
     <string name="age_verif_field_photo">Foto:</string>
     <!-- google-translated 2026-05-04 -->
@@ -1739,7 +1739,7 @@
     <!-- google-translated 2026-05-15 -->
     <string name="age_seg_group_frozen_banner">Questo gruppo non può accettare nuovi membri o messaggi a seguito di una recente modifica al modo in cui ShyTalk organizza gli account.</string>
     <!-- google-translated 2026-05-15 -->
-    <string name="age_seg_age_up_welcome_pm">Benvenuto: il tuo account è stato spostato nel circolo più ampio di ShyTalk.\n\nD\'ora in poi inizierai a vedere più persone nella scoperta e negli elenchi. Le connessioni precedenti che sono state riordinate mentre il tuo account era nella cerchia più piccola non possono essere ripristinate automaticamente, ma puoi aggiungere nuovamente chiunque desideri seguire.</string>
+    <string name="age_seg_age_up_welcome_pm">Benvenuto: il tuo account è stato spostato nel circolo più ampio di ShyTalk.\n\nD'ora in poi inizierai a vedere più persone nella scoperta e negli elenchi. Le connessioni precedenti che sono state riordinate mentre il tuo account era nella cerchia più piccola non possono essere ripristinate automaticamente, ma puoi aggiungere nuovamente chiunque desideri seguire.</string>
     <!-- google-translated 2026-05-15 -->
-    <string name="age_seg_age_down_admin_pm">I dettagli del tuo account sono stati aggiornati dallo staff di ShyTalk. Di conseguenza, le persone e le stanze virtuali visibili per te sono state ristrette a una cerchia più piccola.\n\nSe ritieni che si tratti di un errore, contatta l\'assistenza e lo esamineremo.</string>
+    <string name="age_seg_age_down_admin_pm">I dettagli del tuo account sono stati aggiornati dallo staff di ShyTalk. Di conseguenza, le persone e le stanze virtuali visibili per te sono state ristrette a una cerchia più piccola.\n\nSe ritieni che si tratti di un errore, contatta l'assistenza e lo esamineremo.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">Inserisci il tuo PIN per continuare</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">Verifica\u2026</string>
+    <string name="pin_verifying">Verifica…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">PIN sbagliato. %1$d tentativi rimanenti.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1600,7 +1600,7 @@
     <string name="biometric_start_failed">Impossibile avviare la verifica biometrica</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">Accesso in corso\u2026</string>
+    <string name="signing_in_loading">Accesso in corso…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">proprio adesso</string>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -1471,7 +1471,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">警告イラスト</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">読み込み中\u2026</string>
+    <string name="starting_screen_loading">読み込み中…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">安全</string>
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">続行するにはPINを入力してください</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">確認中\u2026</string>
+    <string name="pin_verifying">確認中…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">PIN が間違っています。残りの試行回数は %1$d です。</string>
     <!-- google-translated 2026-05-04 -->
@@ -1600,7 +1600,7 @@
     <string name="biometric_start_failed">生体認証を開始できませんでした</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">サインイン\u2026</string>
+    <string name="signing_in_loading">サインイン…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">ちょうど今</string>

--- a/shared/src/commonMain/composeResources/values-km/strings.xml
+++ b/shared/src/commonMain/composeResources/values-km/strings.xml
@@ -709,7 +709,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">ព័ត៌មានលម្អិត៖ %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">សារ៖ \"%1$s\"</string>
+    <string name="report_message_prefix">សារ៖ "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">អ្នករាយការណ៍៖ %1$s | បានរាយការណ៍៖ %2$s</string>
 

--- a/shared/src/commonMain/composeResources/values-km/strings.xml
+++ b/shared/src/commonMain/composeResources/values-km/strings.xml
@@ -1560,7 +1560,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">រូបភាពព្រមាន</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">កំពុងផ្ទុក\u2026</string>
+    <string name="starting_screen_loading">កំពុងផ្ទុក…</string>
 
     <!-- Security Settings Screen -->
     <!-- google-translated 2026-05-04 -->
@@ -1668,7 +1668,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">បញ្ចូលកូដ PIN របស់អ្នកដើម្បីបន្ត</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">កំពុងផ្ទៀងផ្ទាត់\u2026</string>
+    <string name="pin_verifying">កំពុងផ្ទៀងផ្ទាត់…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">កូដ PIN ខុស។ នៅសល់ការព្យាយាម %1$d ដង។</string>
     <!-- google-translated 2026-05-04 -->
@@ -1694,7 +1694,7 @@
 
     <!-- Sign-in loading states -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">ចូល\u2026</string>
+    <string name="signing_in_loading">ចូល…</string>
 
     <!-- Date/Time (DateUtils) -->
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-ko/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ko/strings.xml
@@ -695,7 +695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">세부정보: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">메시지: \"%1$s\"</string>
+    <string name="report_message_prefix">메시지: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">기자: %1$s | 보고됨: %2$s</string>
 

--- a/shared/src/commonMain/composeResources/values-ko/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ko/strings.xml
@@ -743,7 +743,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="day_sat">앉았다</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="day_streak">%1$일 연속</string>
+    <string name="day_streak">%1$d일 연속</string>
     <!-- google-translated 2026-05-04 -->
     <string name="day_sun">해</string>
     <!-- google-translated 2026-05-04 -->
@@ -1471,7 +1471,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">경고 그림</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">로드 중\u2026</string>
+    <string name="starting_screen_loading">로드 중…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">보안</string>
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">계속하려면 PIN을 입력하세요.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">확인 중\u2026</string>
+    <string name="pin_verifying">확인 중…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">PIN이 잘못되었습니다. %1$d회 시도 남았습니다.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -695,7 +695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">Details: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">Bericht: \"%1$s\"</string>
+    <string name="report_message_prefix">Bericht: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">Verslaggever: %1$s | Gerapporteerd: %2$s</string>
 

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -1471,7 +1471,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">Waarschuwingsillustratie</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">Laden\u2026</string>
+    <string name="starting_screen_loading">Laden…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">Beveiliging</string>
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">Voer uw pincode in om door te gaan</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">Verifiëren\u2026</string>
+    <string name="pin_verifying">Verifiëren…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">Verkeerde pincode. %1$d pogingen resterend.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1600,7 +1600,7 @@
     <string name="biometric_start_failed">Kan biometrische verificatie niet starten</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">Aanmelden\u2026</string>
+    <string name="signing_in_loading">Aanmelden…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">zojuist</string>

--- a/shared/src/commonMain/composeResources/values-pl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pl/strings.xml
@@ -1471,7 +1471,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">Ilustracja ostrzegawcza</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">Ładuję\u2026</string>
+    <string name="starting_screen_loading">Ładuję…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">Bezpieczeństwo</string>
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">Wprowadź swój PIN, aby kontynuować</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">Weryfikuję\u2026</string>
+    <string name="pin_verifying">Weryfikuję…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">Zły PIN. Pozostało %1$d prób.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1600,7 +1600,7 @@
     <string name="biometric_start_failed">Nie można rozpocząć weryfikacji biometrycznej</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">Logowanie\u2026</string>
+    <string name="signing_in_loading">Logowanie…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">właśnie</string>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -1471,7 +1471,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">Ilustração de aviso</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">Carregando\u2026</string>
+    <string name="starting_screen_loading">Carregando…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">Segurança</string>
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">Digite seu PIN para continuar</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">Verificando\u2026</string>
+    <string name="pin_verifying">Verificando…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">PIN errado. %1$d tentativas restantes.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1600,7 +1600,7 @@
     <string name="biometric_start_failed">Não foi possível iniciar a verificação biométrica</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">Fazendo login\u2026</string>
+    <string name="signing_in_loading">Fazendo login…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">agora mesmo</string>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -695,7 +695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">Detalhes: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">Mensagem: \"%1$s\"</string>
+    <string name="report_message_prefix">Mensagem: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">Repórter: %1$s | Relatado: %2$s</string>
 

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -899,7 +899,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="account_suspended_label">Аккаунт заблокирован</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="active_days_ago">Активен %1$дд назад</string>
+    <string name="active_days_ago">Активен %1$dд назад</string>
     <!-- google-translated 2026-05-04 -->
     <string name="active_hours_ago">Активен %1$dh назад</string>
     <!-- google-translated 2026-05-04 -->
@@ -907,7 +907,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="active_long_ago">Активен более 30 дней назад</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="active_minutes_ago">Активен %1$дм назад</string>
+    <string name="active_minutes_ago">Активен %1$dм назад</string>
     <!-- google-translated 2026-05-04 -->
     <string name="allow">Позволять</string>
     <!-- google-translated 2026-05-04 -->
@@ -1471,7 +1471,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">Предупреждающая иллюстрация</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">Загрузка\u2026</string>
+    <string name="starting_screen_loading">Загрузка…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">Безопасность</string>
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">Введите свой PIN-код, чтобы продолжить</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">Проверка\u2026</string>
+    <string name="pin_verifying">Проверка…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">Неправильный ПИН-код. Осталось %1$d попыток.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1600,7 +1600,7 @@
     <string name="biometric_start_failed">Не удалось начать биометрическую проверку.</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">Вход\u2026</string>
+    <string name="signing_in_loading">Вход…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">прямо сейчас</string>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -695,7 +695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">Подробности: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">Сообщение: \"%1$s\"</string>
+    <string name="report_message_prefix">Сообщение: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">Репортер: %1$s | Сообщено: %2$s</string>
 

--- a/shared/src/commonMain/composeResources/values-sv/strings.xml
+++ b/shared/src/commonMain/composeResources/values-sv/strings.xml
@@ -1573,7 +1573,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">Ange din PIN-kod för att fortsätta</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">Verifierar\u2026</string>
+    <string name="pin_verifying">Verifierar…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">Fel PIN-kod. %1$d försök kvar.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1599,7 +1599,7 @@
     <string name="biometric_start_failed">Det gick inte att starta biometrisk verifiering</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">Loggar in\u2026</string>
+    <string name="signing_in_loading">Loggar in…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">just nu</string>

--- a/shared/src/commonMain/composeResources/values-sv/strings.xml
+++ b/shared/src/commonMain/composeResources/values-sv/strings.xml
@@ -695,7 +695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">Detaljer: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">Meddelande: \"%1$s\"</string>
+    <string name="report_message_prefix">Meddelande: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">Reporter: %1$s | Rapporterad: %2$s</string>
 

--- a/shared/src/commonMain/composeResources/values-th/strings.xml
+++ b/shared/src/commonMain/composeResources/values-th/strings.xml
@@ -693,7 +693,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">รายละเอียด: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">ข้อความ: \"%1$s\"</string>
+    <string name="report_message_prefix">ข้อความ: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">ผู้รายงาน: %1$s | รายงานแล้ว: %2$s</string>
 

--- a/shared/src/commonMain/composeResources/values-th/strings.xml
+++ b/shared/src/commonMain/composeResources/values-th/strings.xml
@@ -1469,7 +1469,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">ภาพประกอบคำเตือน</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">กำลังโหลด\u2026</string>
+    <string name="starting_screen_loading">กำลังโหลด…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">ความปลอดภัย</string>
@@ -1572,7 +1572,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">ป้อน PIN ของคุณเพื่อดำเนินการต่อ</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">กำลังยืนยัน\u2026</string>
+    <string name="pin_verifying">กำลังยืนยัน…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">PIN ผิด เหลือความพยายามอีก %1$d ครั้ง</string>
     <!-- google-translated 2026-05-04 -->
@@ -1598,7 +1598,7 @@
     <string name="biometric_start_failed">ไม่สามารถเริ่มการยืนยันไบโอเมตริกซ์ได้</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">กำลังลงชื่อเข้าใช้\u2026</string>
+    <string name="signing_in_loading">กำลังลงชื่อเข้าใช้…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">แค่ตอนนี้</string>

--- a/shared/src/commonMain/composeResources/values-tr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tr/strings.xml
@@ -106,7 +106,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="show_original">Orijinali göster</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="translation_limit_reached">Günlük sınıra ulaşıldı. Sınırsız çeviri için SuperShy\'ye yükseltin.</string>
+    <string name="translation_limit_reached">Günlük sınıra ulaşıldı. Sınırsız çeviri için SuperShy'ye yükseltin.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="auto_translate">Otomatik çeviri</string>
     <!-- google-translated 2026-05-04 -->
@@ -160,7 +160,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="speakers_count">%1$d/%2$d hoparlör</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="tap_plus_to_create">Bir tane oluşturmak için +\'ya dokunun</string>
+    <string name="tap_plus_to_create">Bir tane oluşturmak için +'ya dokunun</string>
     <!-- google-translated 2026-05-04 -->
     <string name="visitors_count">%1$d ziyaretçi</string>
 
@@ -258,7 +258,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="block_user">Kullanıcıyı Engelle</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="block_user_confirm">%1$s\'ı engellemek istediğinizden emin misiniz?</string>
+    <string name="block_user_confirm">%1$s'ı engellemek istediğinizden emin misiniz?</string>
     <!-- google-translated 2026-05-04 -->
     <string name="close_room">Odayı Kapat</string>
     <!-- google-translated 2026-05-04 -->
@@ -284,7 +284,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="kick_user">Kullanıcıyı At</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="kick_user_confirm">%1$s\'ı odadan atmak istediğinizden emin misiniz? Tekrar katılamayacaklar.</string>
+    <string name="kick_user_confirm">%1$s'ı odadan atmak istediğinizden emin misiniz? Tekrar katılamayacaklar.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="leave_room">Odadan Ayrıl</string>
     <!-- google-translated 2026-05-04 -->
@@ -370,7 +370,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="room_closed">Oda Kapalı</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="room_closing_no_super_shy">Oda sahibinin Super Shy\'si yok, dolayısıyla bu oda yakında kapanacak.</string>
+    <string name="room_closing_no_super_shy">Oda sahibinin Super Shy'si yok, dolayısıyla bu oda yakında kapanacak.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="room_closing_in">%1$d:%2$s içinde oda kapanıyor</string>
     <!-- google-translated 2026-05-04 -->
@@ -611,7 +611,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_review">Rapor İncelemesi</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_user">%1$s\'ı bildirin</string>
+    <string name="report_user">%1$s'ı bildirin</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_user_prompt">Bu kullanıcıyı neden rapor ediyorsunuz?</string>
     <!-- google-translated 2026-05-04 -->
@@ -685,7 +685,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_action_perm_suspension">Kalıcı Askıya Alma</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_action_pm_ban">Başbakan\'dan yasaklama</string>
+    <string name="report_action_pm_ban">Başbakan'dan yasaklama</string>
 
     <!-- Messaging - report details -->
     <!-- google-translated 2026-05-04 -->
@@ -695,7 +695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">Ayrıntılar: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">Mesaj: \"%1$s\"</string>
+    <string name="report_message_prefix">Mesaj: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">Muhabir: %1$s | Bildirildi: %2$s</string>
 
@@ -765,7 +765,7 @@
 
     <!-- Economy -->
     <!-- google-translated 2026-05-04 -->
-    <string name="bean_redeem_description">1 fasulye = 1 jeton. %10 bonus için 2.000\'den fazla para kullanın!</string>
+    <string name="bean_redeem_description">1 fasulye = 1 jeton. %10 bonus için 2.000'den fazla para kullanın!</string>
     <!-- google-translated 2026-05-04 -->
     <string name="bonus_coins">+%1$d bonus</string>
     <!-- google-translated 2026-05-04 -->
@@ -853,7 +853,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="tap_to_claim_backpack">Almak için dokunun; sırt çantanıza eklendi</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="testing_mode_super_shy">Test modu — gerçek para alınmaz. Süper Utangaç\'ı anında etkinleştirmek için bir plana dokunun.</string>
+    <string name="testing_mode_super_shy">Test modu — gerçek para alınmaz. Süper Utangaç'ı anında etkinleştirmek için bir plana dokunun.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="tier_label">Seviye: %1$s</string>
     <!-- google-translated 2026-05-04 -->
@@ -881,7 +881,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="terms_and_conditions">Şartlar ve Koşullar</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="welcome_to_shytalk">ShyTalk\'a hoş geldiniz</string>
+    <string name="welcome_to_shytalk">ShyTalk'a hoş geldiniz</string>
 
     <!-- Auth -->
     <!-- google-translated 2026-05-04 -->
@@ -993,7 +993,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="contact_us">Bize Ulaşın</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="shyden_ltd_brand">ShyTalk, 71-75 Shelton Street, Covent Garden, Londra, WC2H 9JQ, Birleşik Krallık adresinde bulunan Shyden Ltd\'nin (Şirket No. 17110487) bir markasıdır.</string>
+    <string name="shyden_ltd_brand">ShyTalk, 71-75 Shelton Street, Covent Garden, Londra, WC2H 9JQ, Birleşik Krallık adresinde bulunan Shyden Ltd'nin (Şirket No. 17110487) bir markasıdır.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="delete_account">Hesabı Sil</string>
     <!-- google-translated 2026-05-04 -->
@@ -1025,7 +1025,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="display_over_other_apps">Diğer uygulamaların üzerinde görüntüle</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="display_over_other_apps_description">Ses odasından çıktığınızda ShyTalk\'un yüzen bir baloncuk göstermesine izin verin, böylece hızlı bir şekilde geri dönebilirsiniz.</string>
+    <string name="display_over_other_apps_description">Ses odasından çıktığınızda ShyTalk'un yüzen bir baloncuk göstermesine izin verin, böylece hızlı bir şekilde geri dönebilirsiniz.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="dnd_end_time">DND Bitiş Zamanı</string>
     <!-- google-translated 2026-05-04 -->
@@ -1049,7 +1049,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="unlink">Bağlantıyı kaldır</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="unlink_provider_confirm">%1$s\'ın bağlantısı kaldırılsın mı?</string>
+    <string name="unlink_provider_confirm">%1$s'ın bağlantısı kaldırılsın mı?</string>
     <!-- google-translated 2026-05-04 -->
     <string name="unlink_provider_description">Bu hesabı daha sonra yeniden bağlayabilirsiniz ancak tekrar doğrulamanız gerekecektir.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1280,7 +1280,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="unable_to_connect">Bağlantı Kurulamıyor</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="unblock_confirm">%1$s\'ın engellemesi kaldırılsın mı?</string>
+    <string name="unblock_confirm">%1$s'ın engellemesi kaldırılsın mı?</string>
     <!-- google-translated 2026-05-04 -->
     <string name="unblock_description">Profilinizi tekrar görüntüleyebilecekler.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1292,15 +1292,15 @@
     <!-- google-translated 2026-05-04 -->
     <string name="update_available_description">%1$s sürümü mevcut.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="update_available_soft">ShyTalk\'un yeni bir sürümü (%1$s) mevcut.</string>
+    <string name="update_available_soft">ShyTalk'un yeni bir sürümü (%1$s) mevcut.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="update_now">Şimdi Güncelle</string>
     <!-- google-translated 2026-05-04 -->
     <string name="update_required">Güncelleme Gerekli</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="update_required_description">ShyTalk\'un yeni bir sürümü mevcut. Uygulamayı kullanmaya devam etmek için lütfen güncelleyin.</string>
+    <string name="update_required_description">ShyTalk'un yeni bir sürümü mevcut. Uygulamayı kullanmaya devam etmek için lütfen güncelleyin.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="update_open_store_failed">Uygulama mağazası otomatik olarak açılamıyor. Lütfen ShyTalk\'u cihazınızın uygulama mağazasından manuel olarak güncelleyin.</string>
+    <string name="update_open_store_failed">Uygulama mağazası otomatik olarak açılamıyor. Lütfen ShyTalk'u cihazınızın uygulama mağazasından manuel olarak güncelleyin.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="view_community_standards">Topluluk Standartlarını Görüntüle</string>
     <!-- google-translated 2026-05-04 -->
@@ -1331,7 +1331,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="send_gift_header">%1$dx %2$s gönder</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="send_gift_header_multiple">%1$dx %2$s\'yi %3$d kullanıcıya gönderin</string>
+    <string name="send_gift_header_multiple">%1$dx %2$s'yi %3$d kullanıcıya gönderin</string>
     <!-- google-translated 2026-05-04 -->
     <string name="owner_away_banner">Sahibi uzakta - Oda %1$s içinde kapanıyor</string>
     <!-- google-translated 2026-05-04 -->
@@ -1349,7 +1349,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="video_too_large">Video yüklenemeyecek kadar büyük. Lütfen daha kısa bir klip kullanın.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="file_too_large">Dosya çok büyük. Maksimum boyut 10 MB\'tır.</string>
+    <string name="file_too_large">Dosya çok büyük. Maksimum boyut 10 MB'tır.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="this_user">bu kullanıcı</string>
 
@@ -1367,9 +1367,9 @@
 
     <!-- Broadcast Banner -->
     <!-- google-translated 2026-05-04 -->
-    <string name="broadcast_gacha_win">%1$s, Lucky Spin\'den %2$s%3$s%4$s kazandı!</string>
+    <string name="broadcast_gacha_win">%1$s, Lucky Spin'den %2$s%3$s%4$s kazandı!</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="broadcast_gift_sent">%1$s, %2$s%3$s%4$s\'yi %5$s\'ye gönderdi!</string>
+    <string name="broadcast_gift_sent">%1$s, %2$s%3$s%4$s'yi %5$s'ye gönderdi!</string>
 
     <!-- google-translated 2026-05-04 -->
     <string name="play_effect">Çalma Efekti</string>
@@ -1384,9 +1384,9 @@
     <!-- google-translated 2026-05-04 -->
     <string name="network_banned_title">Ağ Yasaklandı</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="device_banned_description">Bu cihazın ShyTalk\'u kullanması yasaklandı.</string>
+    <string name="device_banned_description">Bu cihazın ShyTalk'u kullanması yasaklandı.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="network_banned_description">Ağınızın ShyTalk\'u kullanması yasaklandı. Farklı bir ağdan bağlanmayı deneyin.</string>
+    <string name="network_banned_description">Ağınızın ShyTalk'u kullanması yasaklandı. Farklı bir ağdan bağlanmayı deneyin.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="full_screen_photo">Tam ekran fotoğraf</string>
     <!-- google-translated 2026-05-04 -->
@@ -1419,12 +1419,12 @@
     <!-- google-translated 2026-05-04 -->
     <string name="english_language">İngilizce</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="google_sign_in_failed">Google\'da oturum açma başarısız oldu</string>
+    <string name="google_sign_in_failed">Google'da oturum açma başarısız oldu</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="apple_sign_in_failed">Apple\'da Oturum Açma başarısız oldu</string>
+    <string name="apple_sign_in_failed">Apple'da Oturum Açma başarısız oldu</string>
     <string name="sign_in_not_available_on_local">Yerel ortamda oturum açma kullanılamıyor</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="sign_in_with_apple">Apple\'la oturum açın</string>
+    <string name="sign_in_with_apple">Apple'la oturum açın</string>
     <!-- google-translated 2026-05-04 -->
     <string name="send_link">Bağlantıyı Gönder</string>
     <!-- google-translated 2026-05-04 -->
@@ -1434,21 +1434,21 @@
     <!-- google-translated 2026-05-04 -->
     <string name="use_different_email">Farklı bir e-posta kullanın</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="email_link_paste_hint">E-postanızdaki bağlantıyı açın, ardından geri gelip Bağlantıyı Yapıştır\'a dokunun.</string>
+    <string name="email_link_paste_hint">E-postanızdaki bağlantıyı açın, ardından geri gelip Bağlantıyı Yapıştır'a dokunun.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="error_invalid_email_link">Bu geçerli bir oturum açma bağlantısına benzemiyor. Lütfen e-postanızdaki bağlantının tamamını yapıştırın.</string>
 
     <!-- PIN & Security -->
     <!-- google-translated 2026-05-04 -->
-    <string name="enter_pin">PIN\'inizi girin</string>
+    <string name="enter_pin">PIN'inizi girin</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_mismatch">PIN\'ler eşleşmiyor. Tekrar deneyin.</string>
+    <string name="pin_mismatch">PIN'ler eşleşmiyor. Tekrar deneyin.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_locked">Çok fazla deneme. %1$d dakika sonra tekrar deneyin.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_locked_reauth">Hesap kilitlendi. PIN\'inizi sıfırlamak için lütfen tekrar oturum açın.</string>
+    <string name="pin_locked_reauth">Hesap kilitlendi. PIN'inizi sıfırlamak için lütfen tekrar oturum açın.</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="reset_pin">PIN\'i sıfırla</string>
+    <string name="reset_pin">PIN'i sıfırla</string>
     <!-- google-translated 2026-05-04 -->
     <string name="account_locked">Hesap Kilitlendi</string>
     <!-- google-translated 2026-05-04 -->
@@ -1498,7 +1498,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="security_biometric_unavailable">Bu cihazda kullanılamıyor</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="security_reset_pin">PIN\'i sıfırla</string>
+    <string name="security_reset_pin">PIN'i sıfırla</string>
     <!-- google-translated 2026-05-04 -->
     <string name="security_reset_pin_desc">Yeni bir PIN belirlemek için kimliğinizi doğrulayın</string>
     <string name="security_set_pin">PIN belirle</string>
@@ -1542,11 +1542,11 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_create_title">PIN oluştur</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_confirm_title">PIN\'inizi onaylayın</string>
+    <string name="pin_confirm_title">PIN'inizi onaylayın</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_enable_biometric_title">Biyometrik giriş etkinleştirilsin mi?</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_enable_biometric_desc">ShyTalk\'un kilidini hızlı bir şekilde açmak için parmak izinizi veya yüzünüzü kullanın.</string>
+    <string name="pin_enable_biometric_desc">ShyTalk'un kilidini hızlı bir şekilde açmak için parmak izinizi veya yüzünüzü kullanın.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_enable">Olanak vermek</string>
     <!-- google-translated 2026-05-04 -->
@@ -1572,7 +1572,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_title">Kimliğinizi doğrulayın</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verify_subtitle">Devam etmek için PIN\'inizi girin</string>
+    <string name="pin_verify_subtitle">Devam etmek için PIN'inizi girin</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verifying">Doğrulanıyor\u2026</string>
     <!-- google-translated 2026-05-04 -->
@@ -1589,7 +1589,7 @@
     <string name="pin_delete">Silmek</string>
     <!-- Biometric -->
     <!-- google-translated 2026-05-04 -->
-    <string name="biometric_unlock_title">ShyTalk\'un kilidini aç</string>
+    <string name="biometric_unlock_title">ShyTalk'un kilidini aç</string>
     <!-- google-translated 2026-05-04 -->
     <string name="biometric_unlock_desc">Kilidi açmak için parmak izinizi veya yüzünüzü kullanın</string>
     <!-- google-translated 2026-05-04 -->
@@ -1723,9 +1723,9 @@
     <!-- google-translated 2026-05-09 -->
     <string name="success_report_resolved_with_issues">Rapor çözümlendi ancak bazı işlemler tamamlanmadı. Yönetici web panelini kontrol edin ve gerektiğinde yeniden deneyin.</string>
     <!-- google-translated 2026-05-15 -->
-    <string name="age_seg_relationship_removed_pm">%1$s ile takip bağlantınız, ShyTalk\'un hesapları düzenleme biçiminde yakın zamanda yapılan bir değişikliğin parçası olarak kaldırıldı.\n\nBu otomatiktir; ikinizin de yaptığı hiçbir şeyi yansıtmıyor ve orijinal bağlantı buradan geri yüklenemez.\n\nAdını tanımıyorsanız bu yalnızca geçmişteki bir bağlantının düzeltildiği anlamına gelir.</string>
+    <string name="age_seg_relationship_removed_pm">%1$s ile takip bağlantınız, ShyTalk'un hesapları düzenleme biçiminde yakın zamanda yapılan bir değişikliğin parçası olarak kaldırıldı.\n\nBu otomatiktir; ikinizin de yaptığı hiçbir şeyi yansıtmıyor ve orijinal bağlantı buradan geri yüklenemez.\n\nAdını tanımıyorsanız bu yalnızca geçmişteki bir bağlantının düzeltildiği anlamına gelir.</string>
     <!-- google-translated 2026-05-15 -->
-    <string name="age_seg_room_removed_pm">ShyTalk\'un hesapları düzenleme biçiminde yakın zamanda yapılan bir değişikliğin parçası olarak %1$s\'den çıkarıldınız.\n\nBu otomatiktir ve yaptığınız hiçbir şeyi yansıtmaz. Oda gayet iyi; yeni düzenlemeye göre sizi burada tutamayız.\n\nHer zamanki gibi başka odalar oluşturabilir veya başka odalara katılabilirsiniz.</string>
+    <string name="age_seg_room_removed_pm">ShyTalk'un hesapları düzenleme biçiminde yakın zamanda yapılan bir değişikliğin parçası olarak %1$s'den çıkarıldınız.\n\nBu otomatiktir ve yaptığınız hiçbir şeyi yansıtmaz. Oda gayet iyi; yeni düzenlemeye göre sizi burada tutamayız.\n\nHer zamanki gibi başka odalar oluşturabilir veya başka odalara katılabilirsiniz.</string>
     <!-- google-translated 2026-05-15 -->
     <string name="age_seg_unavailable">Kullanılamıyor</string>
     <!-- google-translated 2026-05-15 -->
@@ -1735,9 +1735,9 @@
     <!-- google-translated 2026-05-15 -->
     <string name="age_seg_cross_cohort_blocked_toast">Bu işlem hesabınızda kullanılamıyor.</string>
     <!-- google-translated 2026-05-15 -->
-    <string name="age_seg_thread_hidden_pm">%1$s ile olan ileti diziniz korundu ancak ShyTalk\'un hesapları düzenleme biçiminde yakın zamanda yapılan bir değişikliğin parçası olarak devam edemiyor.\n\nBu otomatiktir; daha önce gönderdiğiniz hiçbir şey kaybolmaz. Bu mesaj dizisinde yeni mesaj alışverişi yapılamaz ancak yine de her zamanki çevrenizdeki kişilerle yeni sohbetler başlatabilirsiniz.</string>
+    <string name="age_seg_thread_hidden_pm">%1$s ile olan ileti diziniz korundu ancak ShyTalk'un hesapları düzenleme biçiminde yakın zamanda yapılan bir değişikliğin parçası olarak devam edemiyor.\n\nBu otomatiktir; daha önce gönderdiğiniz hiçbir şey kaybolmaz. Bu mesaj dizisinde yeni mesaj alışverişi yapılamaz ancak yine de her zamanki çevrenizdeki kişilerle yeni sohbetler başlatabilirsiniz.</string>
     <!-- google-translated 2026-05-15 -->
-    <string name="age_seg_group_frozen_banner">ShyTalk\'un hesapları düzenleme biçiminde yakın zamanda yapılan bir değişiklik nedeniyle bu grup yeni üyeleri veya mesajları kabul edemez.</string>
+    <string name="age_seg_group_frozen_banner">ShyTalk'un hesapları düzenleme biçiminde yakın zamanda yapılan bir değişiklik nedeniyle bu grup yeni üyeleri veya mesajları kabul edemez.</string>
     <!-- google-translated 2026-05-15 -->
     <string name="age_seg_age_up_welcome_pm">Hoş geldiniz — hesabınız daha geniş ShyTalk çevresine taşındı.\n\nBundan sonra keşiflerde ve listelerde daha fazla kişi görmeye başlayacaksınız. Hesabınız daha küçük bir çevredeyken düzenlenen önceki bağlantılar otomatik olarak geri yüklenemez, ancak takip etmek istediğiniz kişileri yeniden ekleyebilirsiniz.</string>
     <!-- google-translated 2026-05-15 -->

--- a/shared/src/commonMain/composeResources/values-tr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tr/strings.xml
@@ -1471,7 +1471,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">Uyarı illüstrasyonu</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">Yükleniyor\u2026</string>
+    <string name="starting_screen_loading">Yükleniyor…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">Güvenlik</string>
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">Devam etmek için PIN'inizi girin</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">Doğrulanıyor\u2026</string>
+    <string name="pin_verifying">Doğrulanıyor…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">Yanlış PIN. %1$d deneme kaldı.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1600,7 +1600,7 @@
     <string name="biometric_start_failed">Biyometrik doğrulama başlatılamadı</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">Oturum açılıyor\u2026</string>
+    <string name="signing_in_loading">Oturum açılıyor…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">Şu anda</string>

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -166,9 +166,9 @@
 
     <!-- Profile -->
     <!-- google-translated 2026-05-04 -->
-    <string name="connections">Зв\'язки</string>
+    <string name="connections">Зв'язки</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="display_name">Відображуване ім\'я</string>
+    <string name="display_name">Відображуване ім'я</string>
     <!-- google-translated 2026-05-04 -->
     <string name="dob_privacy_note">Потрібна ваша дата народження, але ви можете приховати свій вік у налаштуваннях конфіденційності.</string>
     <!-- google-translated 2026-05-04 -->
@@ -188,7 +188,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="following_list_private">Наступний список цього користувача є приватним</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="get_super_shy">Стань супер сором\'язливим</string>
+    <string name="get_super_shy">Стань супер сором'язливим</string>
     <!-- google-translated 2026-05-04 -->
     <string name="gift_wall">Подарункова стіна</string>
     <!-- google-translated 2026-05-04 -->
@@ -347,7 +347,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="owner">Власник</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="reason_optional">Причина (необов\'язково)</string>
+    <string name="reason_optional">Причина (необов'язково)</string>
     <!-- google-translated 2026-05-04 -->
     <string name="reject">Відхиляти</string>
     <!-- google-translated 2026-05-04 -->
@@ -473,7 +473,7 @@
 
     <!-- Messaging -->
     <!-- google-translated 2026-05-04 -->
-    <string name="additional_details_optional">Додаткові відомості (необов\'язково)</string>
+    <string name="additional_details_optional">Додаткові відомості (необов'язково)</string>
     <!-- google-translated 2026-05-04 -->
     <string name="all_admins_and_mods">Всі адміни та моди</string>
     <!-- google-translated 2026-05-04 -->
@@ -504,7 +504,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="description_label">опис</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="description_optional">Опис (необов\'язково)</string>
+    <string name="description_optional">Опис (необов'язково)</string>
     <!-- google-translated 2026-05-04 -->
     <string name="edit_history">Історія редагування</string>
     <!-- google-translated 2026-05-04 -->
@@ -694,7 +694,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">Подробиці: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">Повідомлення: \"%1$s\"</string>
+    <string name="report_message_prefix">Повідомлення: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">Репортер: %1$s | Повідомлено: %2$s</string>
 
@@ -848,7 +848,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="super_shy">Супер сором’язливий</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="super_shy_for_life">Ти супер сором\'язливий на все життя!</string>
+    <string name="super_shy_for_life">Ти супер сором'язливий на все життя!</string>
     <!-- google-translated 2026-05-04 -->
     <string name="tap_to_claim_backpack">Натисніть, щоб отримати — додано у ваш рюкзак</string>
     <!-- google-translated 2026-05-04 -->
@@ -990,7 +990,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="contact_support_hint">Якщо проблема не зникає, зверніться до shytalk.help@gmail.com</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="contact_us">Зв\'яжіться з нами</string>
+    <string name="contact_us">Зв'яжіться з нами</string>
     <!-- google-translated 2026-05-04 -->
     <string name="shyden_ltd_brand">ShyTalk є брендом компанії Shyden Ltd (номер компанії 17110487), 71-75 Shelton Street, Covent Garden, London, WC2H 9JQ, Сполучене Королівство.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1042,7 +1042,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="linked_accounts">Пов’язані облікові записи</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="linked">Пов\'язано</string>
+    <string name="linked">Пов'язано</string>
     <!-- google-translated 2026-05-04 -->
     <string name="unlinked">Від’єднано</string>
     <!-- google-translated 2026-05-04 -->
@@ -1255,7 +1255,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="success_super_shy_activated">Super Shy активовано! +30 днів</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="super_shy_days">Супер сором\'язливий ✦ %1$dd</string>
+    <string name="super_shy_days">Супер сором'язливий ✦ %1$dd</string>
     <!-- google-translated 2026-05-04 -->
     <string name="super_shy_lifetime">Супер сором’язливий ✦ на все життя</string>
     <!-- google-translated 2026-05-04 -->
@@ -1310,7 +1310,7 @@
     <string name="wallet_with_balance">Гаманець · %1$s</string>
     <!-- google-translated 2026-05-04 -->
     <string name="warning_consequence">Подальше порушення може призвести до призупинення дії вашого облікового запису.</string>
-    <string name="warning_acknowledge_failed">Не вдалося зняти попередження. Перевірте з\'єднання та повторіть спробу.</string>
+    <string name="warning_acknowledge_failed">Не вдалося зняти попередження. Перевірте з'єднання та повторіть спробу.</string>
     <!-- google-translated 2026-05-04 -->
     <string name="warning_reviewed">Ваш обліковий запис переглянуто та винесено попередження.</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -1470,7 +1470,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">Попередження ілюстрації</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">Завантаження\u2026</string>
+    <string name="starting_screen_loading">Завантаження…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">Безпека</string>
@@ -1573,7 +1573,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">Введіть PIN-код, щоб продовжити</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">Перевірка\u2026</string>
+    <string name="pin_verifying">Перевірка…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">Неправильний PIN-код. Залишилося спроб: %1$d.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1599,7 +1599,7 @@
     <string name="biometric_start_failed">Не вдалося розпочати біометричну перевірку</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">Вхід\u2026</string>
+    <string name="signing_in_loading">Вхід…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">тільки зараз</string>

--- a/shared/src/commonMain/composeResources/values-vi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-vi/strings.xml
@@ -695,7 +695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">Chi tiết: %1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">Tin nhắn: \"%1$s\"</string>
+    <string name="report_message_prefix">Tin nhắn: "%1$s"</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">Phóng viên: %1$s | Đã báo cáo: %2$s</string>
 

--- a/shared/src/commonMain/composeResources/values-vi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-vi/strings.xml
@@ -1471,7 +1471,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="starting_screen_police_duck_description">Minh họa cảnh báo</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="starting_screen_loading">Đang tải\u2026</string>
+    <string name="starting_screen_loading">Đang tải…</string>
     <!-- Security -->
     <!-- google-translated 2026-05-04 -->
     <string name="security_title">Bảo vệ</string>
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">Nhập mã PIN của bạn để tiếp tục</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">Đang xác minh\u2026</string>
+    <string name="pin_verifying">Đang xác minh…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">Mã PIN sai. Còn lại %1$d lần thử.</string>
     <!-- google-translated 2026-05-04 -->
@@ -1600,7 +1600,7 @@
     <string name="biometric_start_failed">Không thể bắt đầu xác minh sinh trắc học</string>
     <!-- Auth loading -->
     <!-- google-translated 2026-05-04 -->
-    <string name="signing_in_loading">Đang đăng nhập\u2026</string>
+    <string name="signing_in_loading">Đang đăng nhập…</string>
     <!-- Time -->
     <!-- google-translated 2026-05-04 -->
     <string name="time_just_now">ngay bây giờ</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -695,7 +695,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="report_details_prefix">详细信息：%1$s</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="report_message_prefix">消息：\“%1$s\”</string>
+    <string name="report_message_prefix">消息：“%1$s”</string>
     <!-- google-translated 2026-05-04 -->
     <string name="report_reporter_reported">记者：%1$s |报告：%2$s</string>
 
@@ -1574,7 +1574,7 @@
     <!-- google-translated 2026-05-04 -->
     <string name="pin_verify_subtitle">输入您的 PIN 码以继续</string>
     <!-- google-translated 2026-05-04 -->
-    <string name="pin_verifying">正在验证\u2026</string>
+    <string name="pin_verifying">正在验证…</string>
     <!-- google-translated 2026-05-04 -->
     <string name="pin_wrong_attempts">PIN 码错误。还剩 %1$d 次尝试。</string>
     <!-- google-translated 2026-05-04 -->

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -488,7 +488,7 @@
     <string name="check_for_updates">Check for Updates</string>
     <string name="clear_cache_with_size">Clear Cache (%1$s)</string>
     <string name="up_to_date">Up to Date</string>
-    <string name="up_to_date_description">You&apos;re on the latest version.</string>
+    <string name="up_to_date_description">You're on the latest version.</string>
     <string name="update_available">Update Available</string>
     <string name="update_available_description">Version %1$s is available.</string>
     <string name="update_available_soft">A new version (%1$s) of ShyTalk is available.</string>
@@ -531,11 +531,11 @@
 
     <!-- Settings - Privacy page -->
     <string name="hide_following_list">Hide Following List</string>
-    <string name="hide_following_description">Others won&apos;t see who you follow. Followers are always visible.</string>
+    <string name="hide_following_description">Others won't see who you follow. Followers are always visible.</string>
     <string name="hide_online_status">Hide Online Status</string>
-    <string name="hide_online_status_description">Others won&apos;t see when you&apos;re online.</string>
+    <string name="hide_online_status_description">Others won't see when you're online.</string>
     <string name="hide_age">Hide Age</string>
-    <string name="hide_age_description">Others won&apos;t see your age on your profile.</string>
+    <string name="hide_age_description">Others won't see your age on your profile.</string>
     <string name="who_can_message_me">Who can message me</string>
     <string name="who_can_message_description">Control who can send you private messages.</string>
     <string name="everyone">Everyone</string>
@@ -562,10 +562,10 @@
     <string name="end">End</string>
     <string name="room_alerts">Room Alerts</string>
     <string name="self_destruct_countdown">Self-Destruct Countdown</string>
-    <string name="self_destruct_description">Play a voice announcement when a room&apos;s 5-minute self-destruct timer starts or stops.</string>
+    <string name="self_destruct_description">Play a voice announcement when a room's 5-minute self-destruct timer starts or stops.</string>
 
     <!-- Settings - Permissions page -->
-    <string name="notifications_permission_description">Receive alerts when you&apos;re in a live room in the background.</string>
+    <string name="notifications_permission_description">Receive alerts when you're in a live room in the background.</string>
     <string name="overlay_permission_description">Show a floating bubble when you leave a voice room, so you can quickly return.</string>
     <string name="microphone">Microphone</string>
     <string name="microphone_description">Required for voice chat in rooms.</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -857,7 +857,7 @@
     <string name="starting_screen_pre_launch_message">ShyTalk has not been released yet. To apply to test the application, contact Shyden. Testing is available for iOS and Android users.</string>
     <string name="starting_screen_dismiss">Continue</string>
     <string name="starting_screen_police_duck_description">Warning illustration</string>
-    <string name="starting_screen_loading">Loading\u2026</string>
+    <string name="starting_screen_loading">Loading…</string>
 
     <!-- Security Settings Screen -->
     <string name="security_title">Security</string>
@@ -915,7 +915,7 @@
     <!-- PIN Verify / Lock Screen -->
     <string name="pin_verify_title">Verify your identity</string>
     <string name="pin_verify_subtitle">Enter your PIN to continue</string>
-    <string name="pin_verifying">Verifying\u2026</string>
+    <string name="pin_verifying">Verifying…</string>
     <string name="pin_wrong_attempts">Wrong PIN. %1$d attempts remaining.</string>
     <string name="pin_account_locked">Account locked</string>
     <string name="pin_verify_failed">Verification failed</string>
@@ -929,7 +929,7 @@
     <string name="biometric_start_failed">Could not start biometric verification</string>
 
     <!-- Sign-in loading states -->
-    <string name="signing_in_loading">Signing in\u2026</string>
+    <string name="signing_in_loading">Signing in…</string>
 
     <!-- Date/Time (DateUtils) -->
     <string name="time_just_now">just now</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -369,7 +369,7 @@
     <string name="report_reason_prefix">Reason: %1$s</string>
     <string name="report_type_prefix">Type: %1$s</string>
     <string name="report_details_prefix">Details: %1$s</string>
-    <string name="report_message_prefix">Message: \"%1$s\"</string>
+    <string name="report_message_prefix">Message: "%1$s"</string>
     <string name="report_reporter_reported">Reporter: %1$s | Reported: %2$s</string>
 
     <!-- Messaging - system message labels -->
@@ -608,7 +608,7 @@
     <string name="description">Description</string>
     <string name="report_user_generic">Report User</string>
     <string name="block_confirm">Block %1$s?</string>
-    <string name="block_description">They won\'t be able to view your profile.</string>
+    <string name="block_description">They won't be able to view your profile.</string>
 
     <!-- Room block warnings -->
     <string name="banned_from_room">Banned from Room</string>
@@ -683,11 +683,11 @@
     <string name="profile_not_available">This profile is not available</string>
     <string name="blocked_by_user">You have been blocked by this user</string>
     <string name="account_suspended_label">Account Suspended</string>
-    <string name="account_suspended_description">This user\'s account has been suspended.</string>
+    <string name="account_suspended_description">This user's account has been suspended.</string>
     <string name="closing">Closing...</string>
     <string name="connecting">Connecting...</string>
     <string name="voice_chat_unavailable">Voice chat is temporarily unavailable</string>
-    <string name="mic_permission_denied">Microphone permission denied. You won\'t be able to use voice chat.</string>
+    <string name="mic_permission_denied">Microphone permission denied. You won't be able to use voice chat.</string>
     <string name="replace_room_title">Close existing room?</string>
     <string name="replace_room_message">You already have an active room. Opening a new room will close your existing one. Do you want to continue?</string>
     <string name="replace_room_confirm">Close and create new</string>
@@ -697,7 +697,7 @@
     <string name="warning_reviewed">Your account has been reviewed and a warning has been issued.</string>
     <string name="warning_reviewed_for_reason">Your account has been reviewed for %1$s and a warning has been issued.</string>
     <string name="warning_consequence">Continued violations may result in suspension of your account.</string>
-    <string name="warning_acknowledge_failed">Couldn\'t clear your warning. Please check your connection and try again.</string>
+    <string name="warning_acknowledge_failed">Couldn't clear your warning. Please check your connection and try again.</string>
 
     <!-- Unsafe device -->
     <string name="device_not_supported">Device Not Supported</string>
@@ -843,7 +843,7 @@
 
     <!-- PIN & Security -->
     <string name="enter_pin">Enter your PIN</string>
-    <string name="pin_mismatch">PINs don\'t match. Try again.</string>
+    <string name="pin_mismatch">PINs don't match. Try again.</string>
     <string name="pin_locked">Too many attempts. Try again in %1$d minutes.</string>
     <string name="pin_locked_reauth">Account locked. Please sign in again to reset your PIN.</string>
     <string name="reset_pin">Reset PIN</string>
@@ -971,14 +971,14 @@
     <string name="age_verif_step_method_title">Which document?</string>
     <string name="age_verif_step_method_body">Pick the type of ID you will submit. The DOB on the document must match the one on your account.</string>
     <string name="age_verif_method_passport">Passport</string>
-    <string name="age_verif_method_drivers_license">Driver\'s license</string>
+    <string name="age_verif_method_drivers_license">Driver's license</string>
     <string name="age_verif_method_national_id">National ID card</string>
     <string name="age_verif_step_image_title">Add the photo</string>
     <string name="age_verif_step_image_body">Choose a clear photo of the ID. Make sure the date of birth is fully readable.</string>
     <string name="age_verif_step_image_pick">Choose photo</string>
     <string name="age_verif_step_image_replace">Replace photo</string>
     <string name="age_verif_step_confirm_title">Ready to submit?</string>
-    <string name="age_verif_step_confirm_body">Once submitted, the photo is sent for review. You\'ll get a system message when a decision is recorded.</string>
+    <string name="age_verif_step_confirm_body">Once submitted, the photo is sent for review. You'll get a system message when a decision is recorded.</string>
     <string name="age_verif_field_method">ID type:</string>
     <string name="age_verif_field_photo">Photo:</string>
     <string name="age_verif_photo_attached">attached</string>
@@ -994,10 +994,10 @@
     <string name="age_verif_test_env_warning">Upload any image — this is a test environment, real IDs are not required and not stored long-term.</string>
 
     <!-- UK OSA #17 PR 6: cohort-segregation relationship-removed system PM body. NOT REFERENCED by Kotlin/Swift code today — this entry is the canonical English source-of-truth for the copy that the Express migration script (express-api/scripts/migrate-segregation-relationships.js) currently hardcodes. PR 14 will add server-side locale awareness at PM-dispatch time and switch the migration to look this string up; the remaining 19 locale translations ship in PR 14 alongside that wiring. Copy is intentionally cohort-agnostic — "a recent change to how ShyTalk organises accounts" rather than "you are in different groups" — so the recipient cannot infer the counterparty's cohort. -->
-    <string name="age_seg_relationship_removed_pm">Your follow link with %1$s has been removed as part of a recent change to how ShyTalk organises accounts.\n\nThis is automatic; it doesn\'t reflect anything either of you did, and the original link can\'t be restored from here.\n\nIf you don\'t recognise the name, this just means a past connection has been tidied up.</string>
+    <string name="age_seg_relationship_removed_pm">Your follow link with %1$s has been removed as part of a recent change to how ShyTalk organises accounts.\n\nThis is automatic; it doesn't reflect anything either of you did, and the original link can't be restored from here.\n\nIf you don't recognise the name, this just means a past connection has been tidied up.</string>
 
     <!-- UK OSA #17 PR 7: cohort-segregation room-ejection system PM body. Sibling of age_seg_relationship_removed_pm — same English-only-in-this-PR contract; remaining 19 locales ship in PR 14 alongside server-side locale awareness. The %1$s placeholder is the (sanitised) room name. Copy reuses the load-bearing "a recent change to how ShyTalk organises accounts" phrase so the user-facing voice is consistent across PR 6 + PR 7 ejection paths. Cohort-agnostic by construction — see formatRoomEjectionPm test for the full denylist. -->
-    <string name="age_seg_room_removed_pm">You\'ve been removed from %1$s as part of a recent change to how ShyTalk organises accounts.\n\nThis is automatic and doesn\'t reflect anything you did. The room itself is fine; we just can\'t keep you in it under the new arrangement.\n\nYou can still create or join other rooms in your usual way.</string>
+    <string name="age_seg_room_removed_pm">You've been removed from %1$s as part of a recent change to how ShyTalk organises accounts.\n\nThis is automatic and doesn't reflect anything you did. The room itself is fine; we just can't keep you in it under the new arrangement.\n\nYou can still create or join other rooms in your usual way.</string>
 
     <!-- UK OSA #17 PR 12: cohort-segregation placeholder label used by Compose UI to render a generic "unavailable" tile when the cross-cohort filter (CrossCohortPolicy.PLACEHOLDER) drops an item from a list. English-only in this PR; remaining 19 locales ship in PR 14 with the locale-awareness sweep. Cohort-agnostic by construction — must never name "minor" / "adult" / age, since the placeholder is rendered to the OTHER cohort and would otherwise leak the dropped item's cohort. -->
     <string name="age_seg_unavailable">Unavailable</string>
@@ -1009,18 +1009,18 @@
     <string name="age_seg_room_unavailable">This room is unavailable.</string>
 
     <!-- UK OSA #17 PR 14: generic cross-cohort write-blocked toast surfaced for any same-cohort middleware rejection that doesn\'t have a more specific 404 cover (e.g., follow / gift / room join in flight when the viewer\'s cohort flips). Intentionally vague — does not reveal cohort boundary as the failure cause. -->
-    <string name="age_seg_cross_cohort_blocked_toast">This action isn\'t available for your account.</string>
+    <string name="age_seg_cross_cohort_blocked_toast">This action isn't available for your account.</string>
 
     <!-- UK OSA #17 PR 14: system PM dispatched when a cross-cohort 1:1 thread is hidden by the migration script (express-api/scripts/migrate-segregation-relationships.js line ~167). %1$s = sanitised counterparty display name. Same cohort-agnostic voice as age_seg_relationship_removed_pm — server-side locale lookup ships in a follow-up PR; this is the canonical English source-of-truth. -->
-    <string name="age_seg_thread_hidden_pm">Your thread with %1$s has been preserved but cannot continue, as part of a recent change to how ShyTalk organises accounts.\n\nThis is automatic; nothing you sent before is lost. New messages can\'t be exchanged in this thread, but you can still start fresh conversations with people in your usual circle.</string>
+    <string name="age_seg_thread_hidden_pm">Your thread with %1$s has been preserved but cannot continue, as part of a recent change to how ShyTalk organises accounts.\n\nThis is automatic; nothing you sent before is lost. New messages can't be exchanged in this thread, but you can still start fresh conversations with people in your usual circle.</string>
 
     <!-- UK OSA #17 PR 14: banner displayed inside a group conversation when the group has been frozen by the migration script for containing mixed-cohort members. Distinct from a PM — this is the in-conversation persistent banner shown to every remaining member. Brief, cohort-agnostic. -->
-    <string name="age_seg_group_frozen_banner">This group can\'t accept new members or messages following a recent change to how ShyTalk organises accounts.</string>
+    <string name="age_seg_group_frozen_banner">This group can't accept new members or messages following a recent change to how ShyTalk organises accounts.</string>
 
     <!-- UK OSA #17 PR 14: welcome system PM dispatched on the first sign-in after a user\'s minor→adult cohort flip (DOB-derived, lazy at sign-in via pm-lock-check.js). No reveal of WHY the cohort flipped — copy assumes the user knows their own birthday. -->
-    <string name="age_seg_age_up_welcome_pm">Welcome — your account has moved into the wider ShyTalk circle.\n\nYou\'ll start seeing more people in discovery and lists from now on. Previous connections that were tidied up while your account was in the smaller circle can\'t be restored automatically, but you can re-add anyone you\'d like to follow.</string>
+    <string name="age_seg_age_up_welcome_pm">Welcome — your account has moved into the wider ShyTalk circle.\n\nYou'll start seeing more people in discovery and lists from now on. Previous connections that were tidied up while your account was in the smaller circle can't be restored automatically, but you can re-add anyone you'd like to follow.</string>
 
     <!-- UK OSA #17 PR 14: system PM dispatched when an admin lowers a user\'s DOB through admin-age-verification.js and the resulting cohort flips downward (adult→minor). Distinct from age_up_welcome_pm — the user did not initiate this and may be surprised. Copy is plain-spoken about what changed (visibility scope) without naming "minor"; routes the user to support for disputes. -->
-    <string name="age_seg_age_down_admin_pm">Your account details have been updated by ShyTalk staff. As a result, the people and rooms visible to you have been narrowed to a smaller circle.\n\nIf you think this is a mistake, contact support and we\'ll review it.</string>
+    <string name="age_seg_age_down_admin_pm">Your account details have been updated by ShyTalk staff. As a result, the people and rooms visible to you have been narrowed to a smaller circle.\n\nIf you think this is a mistake, contact support and we'll review it.</string>
 
 </resources>


### PR DESCRIPTION
Implements SHY-0271 — see `.project/stories/SHY-0271-locale-content-is-untested.md` for full spec, AC, BDD scenarios, and DoD.

Stacked on #1689 (SHY-0270). Review the two commits on this branch only.

## What the operator saw

`Driver\'s license` — literal backslash — on the age-verification screen, on a real device, in production copy.

## Why nothing caught it

Content was never a test surface:

- **Locale parity counts KEYS.** All 21 files carry 838 keys and passed. A key whose value is garbage is a perfectly good key.
- **UI assertions match by `testTag`.** `AgeVerificationSubmitScreenTest` *clicks* `TAG_AGE_VERIF_METHOD_DRIVERS` in two tests. The tag is on the `Button`; the corrupt string is on a `Text` inside it. Both drove the broken button and passed.
- **Nothing read the locale files as text.**

`\'` is ANDROID XML escaping. Compose Multiplatform's `composeResources` does not unescape it. The English file was already self-contradictory — 11 plain apostrophes alongside 17 escaped.

## The generator was still writing it, and a test demanded it

Fixing the 221 strings alone would have been pointless. `scripts/translate-strings.js` escaped every apostrophe on every write, and `translate-strings.test.js` asserted `toContain("it\\'s")` — **the suite was green on the operator's exact defect**. Both `escapeXml` and `unescapeXml` were exported "for testing" with no direct tests. All fixed.

## Settled by measurement, not argument

A new device test resolves all 838 keys through `Res.allStringResources` + `getString` — the real Compose pipeline. Result: **`\uXXXX` IS unescaped; `\'` is NOT.** So the 57 `…` were never a live defect (`Loading…` renders fine). Normalised anyway, along with zh's `\“…\”`, so the rule is a flat "no backslash except `\n`" with no allowlist to rot.

## Comparing content found 8 crashes that were shipping

Six strings had their **format specifier translated** — the machine translator read the `d` of `%1$d` as the first letter of a word:

| locale | key | shipped | should be |
|---|---|---|---|
| ar | `user_id` | `%1$د` | `%1$d` |
| ar | `seat_number` | `%1$د` | `%1$d` |
| id | `day_streak` | `%1$hari` | `%1$d hari` |
| ko | `day_streak` | `%1$일` | `%1$d일` |
| ru | `active_days_ago` | `%1$дд` | `%1$dд` |
| ru | `active_minutes_ago` | `%1$дм` | `%1$dм` |

Two more (`de`, `fr` `success_redeemed_beans_bonus`) had `%%` broken into `% %` and `% `. On Android these reach `String.format`; every one throws `UnknownFormatConversionException`. English, Spanish and Italian were correct, which is why nobody looked.

## Verification

- Mutation-verified on a **real OnePlus**: the operator's string re-introduced character-for-character fails both new assertions; restoring it turns them green.
- **99/99** across the four locale suites · **9/9** instrumented · **3/3** whole-corpus runtime, all on device.
- The 221-line locale diff proven mechanically to be unescaping only: 221 removed / 221 added, zero lines differing by anything else. `\n` preserved (412); key parity unchanged (838).
- `check-no-new-stubs` ratchet clean.

## Guard hardening (from review)

Per-file parse-completeness replaces a count threshold that would have tolerated three whole files going dark; both mutation guards now call the *same* predicate the real checks use rather than an inline copy; the `TODO` bypass is scoped to the two genuine Spanish keys (`TODO` = "all") instead of two whole locales, with a rot check; the device sweep covers `Text` + `EditableText` + `ContentDescription` across every step of the flow.

New pin: a locale-only PR **skipped `test-backend` entirely** — the guard ran only incidentally inside sonarcloud's unfiltered suite. `pr-checks.yml` now has a `composeResources` arm setting `BACKEND`, ordered before `shared/*` because `case` is first-match, with `pr-checks-locale-guard-gating.test.js` pinning it.

## Known

`50-matrix-cmd-stop.test.js` fails in the full run on this branch. It passes in isolation; the fix (`3288cb4490a`, cross-suite interference) is on the SHY-0268 branch, which is not in this ancestry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHiDwcJoD3BDp3vMiQPgrK