### PR TITLE
SHY-0275: The iOS local build points a real iPhone at itself

### DIFF
--- a/.project/stories/SHY-0275-ios-local-cannot-reach-stack.md
+++ b/.project/stories/SHY-0275-ios-local-cannot-reach-stack.md
@@ -125,9 +125,12 @@ advertising an unreachable ICE candidate (server-side), and is Android-proven.
 
 ## Test Plan
 
-**RED first.** `iosApp/iosAppTests/AppEnvironmentTests` gains cases pinning that the resolved
-API / RTDB / LiveKit URLs carry the configured host rather than a literal `localhost`, and
-`LiveKitBridgeTests` gains the allow-list matrix below. Both fail against the current code.
+**RED first.** `iosApp/iosAppTests/AppEnvironmentTests.swift` gains cases pinning that the
+resolved API / RTDB / LiveKit URLs carry the configured host rather than a literal `localhost`,
+including a stub `Bundle` so the READ-the-plist-key path is exercised and not only the fallback.
+`iosApp/iosAppTests/AgeSegregationTests.swift` — the file that already owns the LiveKit
+allow-list boundary — gains the matrix below. `shared/src/commonTest/.../BuildVariantTest.kt`
+gains the `liveKitUrl` slot and `resolveVoiceServerUrl` cases. All fail against current code.
 
 **Allow-list matrix** — the security-sensitive part, so it is enumerated rather than sampled:
 accepted in DEBUG (`ws://10.0.0.5:7880`, `ws://172.16.0.1`, `ws://192.168.1.9`,

--- a/.project/stories/SHY-0275-ios-local-cannot-reach-stack.md
+++ b/.project/stories/SHY-0275-ios-local-cannot-reach-stack.md
@@ -1,0 +1,195 @@
+---
+id: SHY-0275
+status: In Progress
+owner: claude
+created: 2026-08-04
+priority: P1
+effort: M
+type: bug
+roadmap_ids: []
+pr:
+mvp: false
+---
+
+# SHY-0275: The iOS local build points a real iPhone at itself
+
+## User Story
+
+As someone testing ShyTalk on a real iPhone against the local stack,
+I want the app to actually reach the stack running on my Mac,
+So that I can walk iOS journeys locally instead of only ever testing iOS against dev.
+
+## Why
+
+The iOS `Debug-Local` build cannot reach the local stack from a physical iPhone. Not voice —
+**nothing**. Measured on device 2026-08-04 (iPhone Air, built with `LOCAL_HOST=192.168.1.9`
+passed to `xcodebuild`), the device console reads:
+
+```
+[ShyTalk] DEBUG build — using Firebase Emulators (project=demo-shytalk, db=localhost:9000)
+I/KoinHelper: Firebase emulators: Firestore=localhost:8080, Auth=localhost:9099, RTDB=localhost:9000
+D/PreviewWatermark: server health unknown -> false
+```
+
+An iPhone has no `adb reverse` equivalent, so `localhost` **is the phone**. Every backend call
+goes to a port on the handset itself. Sign-in cannot work, so the whole iOS-local leg of the
+journey gauntlet is unrunnable — and has been reported as "iOS-local unsupported" rather than
+as this bug.
+
+There are three independent causes, and all three must go for iOS-local to work:
+
+1. **`LOCAL_HOST` is dead configuration.** `iosApp/Configurations/Local.xcconfig` defines
+   `LOCAL_HOST`, `LOCAL_API_BASE_URL`, `LOCAL_LIVEKIT_URL` and `LOCAL_FIREBASE_RTDB_URL`, and
+   **nothing reads them** — a repo-wide search over `*.swift` / `*.plist` / `*.xcconfig` /
+   `*.pbxproj` returns only their own definitions and their own comments. The real values are
+   Swift literals: `AppEnvironment.swift` `localApiBaseUrl = "http://localhost:3000"`,
+   `iOSApp.swift` `options.databaseURL = "http://localhost:9000?ns=demo-shytalk"`, and
+   `KoinHelper.kt` `val host = "localhost"`. Passing `LOCAL_HOST=` to `xcodebuild` therefore
+   sets a build setting that reaches no code — which is worse than having no knob at all,
+   because the recipe *looks* followed.
+
+2. **iOS has no local LiveKit URL at all.** `express-api/src/routes/livekit.js` deliberately
+   omits `url` from the token response when `NODE_ENV === 'local'`, leaving the client to use
+   its own. Android has one (`BuildConfig.LIVEKIT_SERVER_URL`); iOS has no equivalent, so
+   `IosLiveKitVoiceService` takes `response.url ?: ""` and tries to connect to the empty
+   string. Symmetry gap, not a design decision.
+
+3. **The LiveKit URL allow-list cannot express "my Mac".** `LiveKitBridge.isAllowedURL()`
+   permits cleartext `ws://` only for `localhost` / `127.0.0.1`; everything else must be
+   `wss://` to the two Oracle hosts. A real iPhone must use the Mac's LAN address, so
+   `ws://192.168.1.9:7880` is rejected before any network call.
+
+Cause 3 is a **deliberate and correct** security boundary — cleartext signalling carries the
+join token — so it is relaxed only for private-LAN addresses and only in `DEBUG` builds. The
+shipped Release boundary is unchanged.
+
+Discovered while device-proving SHY-0273. Distinct root cause: SHY-0273 was LiveKit
+advertising an unreachable ICE candidate (server-side), and is Android-proven.
+
+## Acceptance Criteria
+
+### Happy path
+- [ ] A real iPhone on the same Wi-Fi as the Mac reaches the local API, Firestore, Auth and RTDB
+- [ ] A tester can sign in as a seeded persona on a real iPhone against the local stack
+- [ ] Voice connects in a room on a real iPhone against the local stack
+
+### Error paths
+- [ ] When no local host is configured, the app falls back to `localhost` and says so in the
+      startup log rather than failing silently
+- [ ] An empty or blank LiveKit URL is still refused, as today
+
+### Edge cases
+- [ ] A build made with no `LOCAL_HOST` override behaves exactly as it does today
+- [ ] `dev` and `release` builds are unaffected — they never read the local host
+
+### Performance
+- [ ] N/A — one string resolved once at app launch.
+
+### Security
+- [ ] Cleartext `ws://` to a private-LAN address is accepted ONLY in `DEBUG` builds; a Release
+      build's allow-list is byte-for-byte unchanged in behaviour
+- [ ] Only RFC1918 private ranges are accepted, decided by NUMERIC octet comparison, never by
+      string prefix
+- [ ] A public address over cleartext is still rejected, in every build
+
+### UX
+- [ ] The resolved host appears in the startup log so a wrong one is obvious immediately
+
+### i18n
+- [ ] N/A — developer tooling; no user-facing strings.
+
+### Observability
+- [ ] The startup log names the resolved host for API, emulators and LiveKit
+
+## BDD Scenarios
+
+**Scenario: A tester signs in on a real iPhone against the local stack**
+- **Given** the local stack is running and the iPhone is on the same network
+- **When** the tester signs in as a seeded persona
+- **Then** they reach the app's main screen
+
+**Scenario: Voice connects on a real iPhone**
+- **Given** a tester is signed in on a real iPhone against the local stack
+- **When** they join a voice room
+- **Then** the audio connects
+
+**Scenario: A misconfigured build says so instead of failing quietly**
+- **Given** a build made without a local host configured
+- **When** the app starts
+- **Then** the startup log names the host it fell back to
+
+**Scenario: A shipped build still refuses cleartext voice**
+- **Given** a release build of the app
+- **When** it is handed a cleartext voice address on a local network
+- **Then** it refuses the connection
+
+## Test Plan
+
+**RED first.** `iosApp/iosAppTests/AppEnvironmentTests` gains cases pinning that the resolved
+API / RTDB / LiveKit URLs carry the configured host rather than a literal `localhost`, and
+`LiveKitBridgeTests` gains the allow-list matrix below. Both fail against the current code.
+
+**Allow-list matrix** — the security-sensitive part, so it is enumerated rather than sampled:
+accepted in DEBUG (`ws://10.0.0.5:7880`, `ws://172.16.0.1`, `ws://192.168.1.9`,
+`ws://127.0.0.1`, `ws://localhost`); rejected in EVERY build (`ws://8.8.8.8`,
+`ws://172.32.0.1` — just outside the 172.16/12 block and the case a string-prefix check gets
+wrong, `ws://192.169.1.1`, `ws://evil.com`, `ws://10.0.0.5.evil.com`, empty, whitespace);
+`wss://` to the two Oracle hosts accepted everywhere. The `172.32` and `10.0.0.5.evil.com`
+cases exist specifically to kill a `hasPrefix` implementation.
+
+**Structural pins** — `express-api/tests/scripts/ios-local-host-wiring.test.js`: `Info.plist`
+carries the `$(LOCAL_HOST)` substitution; no Swift or Kotlin file on the iOS path reassigns a
+literal `localhost` for API / emulator / LiveKit; the helper script detects the LAN address
+rather than committing one (same detector SHY-0273 pins for `start.sh`).
+
+**Device walk** — real iPhone over USB `devicectl`: install, launch, read the device console
+for the resolved host, sign in as a persona, join a voice room, and confirm on the LiveKit
+server side that `connectionType` is not `unknown` and a `mediaTrack` is published. That last
+step is the one that distinguishes "ICE completed" from "audio flows"; SHY-0273 showed the
+first can happen without the second being checked.
+
+**Regression** — Android is untouched and must stay green: SHY-0273's 16 pins,
+`tests/scripts/` in full, and a re-walk of the Android voice journey.
+
+## Out of Scope
+
+- `BUNDLE_ID_SUFFIX` not being wired to `PRODUCT_BUNDLE_IDENTIFIER`, so the local build
+  installs as `com.shyden.shytalk` and overwrites the dev build. Real, separate, filed apart.
+- Making dev/prod iOS read a local host — they never should.
+- The three-RTC-sessions-per-join churn observed on Android in SHY-0273.
+
+## Dependencies
+
+- SHY-0273 (LiveKit advertises a reachable ICE candidate). Without it, fixing the URL only
+  gets iOS as far as the same `connectionType: "unknown"` Android had. This story is branched
+  on top of it.
+
+## Risks & Mitigations
+
+- **Risk:** relaxing the allow-list weakens a shipped build.
+  **Mitigation:** the relaxation is inside `#if DEBUG`, so it is absent from the Release
+  binary at compile time; a test asserts the public-address rejection holds unconditionally.
+- **Risk:** an RFC1918 check written with string prefixes accepts `172.32.x` or
+  `10.0.0.5.evil.com`.
+  **Mitigation:** octets are parsed and compared numerically, and both cases are explicit
+  rejection tests.
+- **Risk:** the LAN address changes between builds, as it did three times during SHY-0273.
+  **Mitigation:** the helper script detects it at build time; the app logs what it resolved.
+
+## Definition of Done
+
+- [ ] RED tests written first and seen to fail
+- [ ] iOS unit + structural pins green; Android regression suite unchanged
+- [ ] **Sign-in verified on a real iPhone against the local stack**
+- [ ] **Voice verified connecting on a real iPhone** (`connectionType` != `unknown`, audio
+      track published)
+- [ ] Release-build allow-list behaviour proven unchanged
+- [ ] Merged to develop; `released_in:` at the next release cut
+
+## Notes (running log)
+
+- **2026-08-04 17:1x WIB** — Found while device-proving SHY-0273: with Android green, the
+  iPhone was built and installed the same way and its console showed every backend pointing at
+  `localhost`. The `LOCAL_HOST` build setting had been passed exactly as the working recipe
+  documents, which is why this survived — the recipe looked followed. Operator asked for
+  everything fixed before the gauntlet runs, so this is being fixed rather than filed.

--- a/.project/stories/SHY-0275-ios-local-cannot-reach-stack.md
+++ b/.project/stories/SHY-0275-ios-local-cannot-reach-stack.md
@@ -69,9 +69,10 @@ advertising an unreachable ICE candidate (server-side), and is Android-proven.
 ## Acceptance Criteria
 
 ### Happy path
-- [ ] A real iPhone on the same Wi-Fi as the Mac reaches the local API, Firestore, Auth and RTDB
-- [ ] A tester can sign in as a seeded persona on a real iPhone against the local stack
-- [ ] Voice connects in a room on a real iPhone against the local stack
+- [x] A real iPhone on the same Wi-Fi as the Mac reaches the local API, Firestore, Auth and RTDB
+- [x] A tester can sign in as a seeded persona on a real iPhone against the local stack
+- [x] Voice connects in a room on a real iPhone against the local stack
+- [x] Every emulator a device must reach listens on the LAN, not only on loopback
 
 ### Error paths
 - [ ] When no local host is configured, the app falls back to `localhost` and says so in the
@@ -181,12 +182,20 @@ first can happen without the second being checked.
 
 ## Definition of Done
 
-- [ ] RED tests written first and seen to fail
-- [ ] iOS unit + structural pins green; Android regression suite unchanged
-- [ ] **Sign-in verified on a real iPhone against the local stack**
-- [ ] **Voice verified connecting on a real iPhone** (`connectionType` != `unknown`, audio
-      track published)
-- [ ] Release-build allow-list behaviour proven unchanged
+- [x] RED tests written first and seen to fail (7 of 11 structural pins RED before the fix;
+      3 emulator-binding pins RED before `firebase.json` changed)
+- [x] iOS unit + structural pins green; Android regression suite unchanged
+      (7462/7462 `tests/scripts`, `shared:jvmTest`, `compileKotlinIosArm64`)
+- [x] **Sign-in verified on a real iPhone against the local stack** — persona P-02,
+      watermark `UID: 50000010 · adult`, route `splash`
+- [x] **Voice verified connecting on a real iPhone** — `sdk: SWIFT`,
+      `deviceModel: iPhone18,4`, `connectionType: "udp"` in 335ms, ICE pair
+      `192.168.1.9:52089` ↔ `192.168.1.3:50477`, and `mediaTrack published
+      source: MICROPHONE mime: audio/red`
+- [x] Release-build allow-list behaviour proven unchanged — the relaxation is inside
+      `#if DEBUG`; the public-address rejections are asserted unconditionally
+- [x] `code-reviewer` findings applied (7, all mutation-verified)
+- [ ] Journey gauntlet green on both devices (local, then dev)
 - [ ] Merged to develop; `released_in:` at the next release cut
 
 ## Notes (running log)
@@ -196,3 +205,26 @@ first can happen without the second being checked.
   `localhost`. The `LOCAL_HOST` build setting had been passed exactly as the working recipe
   documents, which is why this survived — the recipe looked followed. Operator asked for
   everything fixed before the gauntlet runs, so this is being fixed rather than filed.
+- **2026-08-04 18:5x WIB** — A FOURTH cause, found only by walking it: with the host routing
+  fixed, sign-in still failed with `FIRAuthErrorDomain 17020` /
+  `NSURLErrorDomain -1004 "Could not connect to the server"` against
+  `http://192.168.1.9:9099/…/verifyPassword` (ECONNREFUSED 61). All three Firebase emulators
+  bound to `127.0.0.1` while Express (`*:3000`) and the web serve (`*:8888`) bind to all
+  interfaces — precisely why the health check passed while Auth was refused: the stack
+  *looked* reachable when it was only half reachable. `firebase.json` now binds
+  auth/firestore/database to `0.0.0.0`; the UI stays on loopback deliberately.
+- **2026-08-04 19:0x WIB** — DONE on device. Sign-in as P-02 (UID 50000010), then joined the
+  room the ANDROID phone had created (cross-device state sync working) and unmuted. LiveKit:
+  `sdk: SWIFT`, `deviceModel: iPhone18,4`, `connectionType: "udp"`, 335ms,
+  `mediaTrack published source: MICROPHONE`. iOS-local was never "unsupported" — it was four
+  bugs, three of which only a device walk could reveal.
+- **2026-08-04 19:0x WIB** — `code-reviewer`: 7 findings, all applied and mutation-verified;
+  the `isPrivateLAN` security boundary came back clean against every bypass class probed
+  (172.32, hostname-lookalikes, leading zeros, signs, unicode digits, IPv6, trailing dots,
+  and `ws://192.168.1.9@evil.com`). Two were Critical and correct: `liveKitUrl` had zero
+  tests, and the fallback chain was pinned only by a substring — so swapping the operands
+  would have stayed green while breaking dev and prod voice. Fixed by extracting
+  `resolveVoiceServerUrl` into commonMain, where it is testable at all. The no-stubs ratchet
+  then caught a stand-in `Bundle` added for a test; rather than whitelist it, resolution now
+  takes the raw plist value and is tested with real strings.
+  `Reviewed-up-to: ea75d9d6175`

--- a/express-api/tests/scripts/ios-local-host-wiring.test.js
+++ b/express-api/tests/scripts/ios-local-host-wiring.test.js
@@ -1,0 +1,179 @@
+/**
+ * SHY-0275 — the iOS local build must reach the Mac, not the phone itself.
+ *
+ * Measured on a real iPhone 2026-08-04, built with `LOCAL_HOST=192.168.1.9`
+ * passed to xcodebuild exactly as the working recipe documents:
+ *
+ *   [ShyTalk] DEBUG build — using Firebase Emulators (db=localhost:9000)
+ *   I/KoinHelper: Firebase emulators: Firestore=localhost:8080,
+ *                 Auth=localhost:9099, RTDB=localhost:9000
+ *   D/PreviewWatermark: server health unknown -> false
+ *
+ * An iPhone has no `adb reverse` equivalent, so `localhost` IS the phone —
+ * every backend call went to a port on the handset. `LOCAL_HOST` was ignored
+ * because NOTHING READ IT: `Local.xcconfig` defines LOCAL_HOST /
+ * LOCAL_API_BASE_URL / LOCAL_LIVEKIT_URL / LOCAL_FIREBASE_RTDB_URL and the
+ * only other references in the repo are its own comments. The live values
+ * were Swift/Kotlin literals.
+ *
+ * These are structural checks because the failure is SILENT and platform-only:
+ * the build succeeds, installs, launches, and simply cannot talk to anything.
+ * Nothing in CI would have caught it — CI never runs an iPhone against a local
+ * stack — so a pin over the wiring is the only automated guard available.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.join(__dirname, '..', '..', '..');
+const read = (rel) => fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+
+const INFO_PLIST = read('iosApp/iosApp/Info.plist');
+const LOCAL_XCCONFIG = read('iosApp/Configurations/Local.xcconfig');
+const APP_ENVIRONMENT = read('iosApp/iosApp/AppEnvironment.swift');
+const IOS_APP = read('iosApp/iosApp/iOSApp.swift');
+const KOIN_HELPER = read('shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/KoinHelper.kt');
+const LIVEKIT_BRIDGE = read('iosApp/iosApp/LiveKitBridge.swift');
+const IOS_VOICE = read(
+  'shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosLiveKitVoiceService.kt',
+);
+
+// Comment lines are not code. Several of these files legitimately DISCUSS
+// `localhost` in prose (explaining this very bug), so a naive substring search
+// would report on the explanation instead of on the behaviour.
+// `#` opens a comment in shell and an xcconfig, but in Swift `#if` / `#endif`
+// are COMPILE DIRECTIVES and are exactly what the security assertions below
+// read. Stripping them would have made "the relaxation is inside #if DEBUG"
+// unprovable — and, worse, silently so.
+const stripComments = (src) =>
+  src
+    .split('\n')
+    .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+    .filter((l) => !/^\s*#(?!if|endif|else|elseif)/.test(l))
+    .join('\n');
+
+describe('SHY-0275 — the local host reaches the iOS code that needs it', () => {
+  test('the files under test are non-empty', () => {
+    // Vacuous-pass guard: a renamed file would otherwise make every
+    // "does not contain a literal" assertion below trivially true.
+    for (const [name, src] of Object.entries({
+      INFO_PLIST,
+      LOCAL_XCCONFIG,
+      APP_ENVIRONMENT,
+      IOS_APP,
+      KOIN_HELPER,
+      LIVEKIT_BRIDGE,
+      IOS_VOICE,
+    })) {
+      expect({ [name]: src.length > 0 }).toEqual({ [name]: true });
+    }
+  });
+
+  test('Info.plist carries the LOCAL_HOST build setting into the bundle', () => {
+    // This is the ONLY bridge from xcconfig to running code. Without it,
+    // `LOCAL_HOST=` on the xcodebuild command line sets a value that no code
+    // can ever observe — which is how the documented recipe appeared to be
+    // followed while the app talked to itself.
+    //
+    // Mirrors the existing ShyTalkGit* keys, which use the same mechanism.
+    expect(INFO_PLIST).toMatch(/<key>ShyTalkLocalHost<\/key>\s*<string>\$\(LOCAL_HOST\)<\/string>/);
+  });
+
+  test('Local.xcconfig still defines LOCAL_HOST for the plist to substitute', () => {
+    expect(stripComments(LOCAL_XCCONFIG)).toMatch(/^LOCAL_HOST\s*=/m);
+  });
+
+  test('KoinHelper takes the emulator host as a parameter instead of fixing it', () => {
+    // This one does not carry a URL literal — it wrote `val host = "localhost"`
+    // and handed it to useEmulator() three times, which is why it needs its own
+    // assertion rather than the URL pattern below. It produced the exact three
+    // values the device console printed.
+    const code = stripComments(KOIN_HELPER);
+    expect(code).not.toMatch(/val\s+host\s*=\s*"localhost"/);
+    expect(code).toMatch(/fun\s+configureFirebaseEmulators\s*\(\s*host\s*:/);
+    // Proves the assertion above is not vacuous — it catches the original line.
+    expect(/val\s+host\s*=\s*"localhost"/.test('    val host = "localhost"')).toBe(true);
+  });
+
+  test.each([
+    ['AppEnvironment.swift (API base URL)', () => APP_ENVIRONMENT],
+    ['iOSApp.swift (Firebase RTDB URL)', () => IOS_APP],
+  ])('%s does not hard-code a localhost backend address', (_name, get) => {
+    // The three sites the device console named, one per line of its output.
+    // A literal here silently wins over anything the plist provides, because
+    // it never consults the plist at all.
+    //
+    // `localhost` as a DEFAULT is fine and expected — what must not exist is a
+    // backend URL built from the literal. So the pattern targets a scheme +
+    // localhost + port, not the bare word.
+    expect(stripComments(get())).not.toMatch(/["'](?:https?|ws):\/\/localhost:\d+/);
+  });
+
+  test('the localhost detector actually fires on the code it was written for', () => {
+    // Guards the assertion above from being loosened into a no-op: these are
+    // the three literals as they were ACTUALLY written before this story.
+    const historical = [
+      'static let localApiBaseUrl = "http://localhost:3000"',
+      'options.databaseURL = "http://localhost:9000?ns=demo-shytalk"',
+      'val liveKitUrl = "ws://localhost:7880"',
+    ];
+    for (const line of historical) {
+      expect({ line, caught: /["'](?:https?|ws):\/\/localhost:\d+/.test(line) }).toEqual({
+        line,
+        caught: true,
+      });
+    }
+    // And that a comment mentioning the same text is NOT treated as code.
+    expect(stripComments('// tried http://localhost:3000 from real iPhones')).toBe('');
+  });
+
+  test('iOS has a local LiveKit URL to fall back to', () => {
+    // express-api/src/routes/livekit.js deliberately omits `url` from the token
+    // response when NODE_ENV === 'local', leaving the client to supply its own.
+    // Android has BuildConfig.LIVEKIT_SERVER_URL; iOS had NOTHING, so it took
+    // `response.url ?: ""` and tried to connect to the empty string.
+    expect(stripComments(IOS_VOICE)).not.toMatch(/response\.url\s*\?:\s*""/);
+    expect(stripComments(IOS_VOICE)).toMatch(/liveKitUrl/);
+  });
+
+  test('the LiveKit allow-list relaxation is confined to DEBUG builds', () => {
+    // Cleartext ws:// to a private LAN address is required on a real device and
+    // must NOT exist in a shipped binary — a minors-facing app must not accept
+    // an unencrypted signalling channel (which carries the join token) from
+    // anything on the network. `#if DEBUG` removes it at compile time.
+    const code = stripComments(LIVEKIT_BRIDGE);
+    expect(code).toMatch(/#if DEBUG/);
+    // The private-LAN predicate must sit INSIDE a DEBUG guard, not beside it.
+    const debugBlocks = [...code.matchAll(/#if DEBUG([\s\S]*?)#endif/g)].map((m) => m[1]);
+    expect(debugBlocks.length).toBeGreaterThan(0);
+    expect(debugBlocks.some((b) => /isPrivateLAN|privateLan/i.test(b))).toBe(true);
+  });
+
+  test('private-LAN membership is decided NUMERICALLY, never by string prefix', () => {
+    // A `hasPrefix("172.")` check accepts 172.32.0.1, which is PUBLIC — the
+    // 172.16/12 block stops at 172.31. A `hasPrefix("10.")` check accepts the
+    // hostname 10.0.0.5.evil.com. Both are the classic way this goes wrong.
+    const code = stripComments(LIVEKIT_BRIDGE);
+    expect(code).not.toMatch(/hasPrefix\(\s*"(?:10|172|192)\./);
+    // Numeric parse of the octets is the required shape. Deliberately does NOT
+    // require the call to end right after the separator — `split` legitimately
+    // takes `omittingEmptySubsequences:` too, and a pin that breaks on a valid
+    // second argument is a pin that gets deleted.
+    expect(code).toMatch(/split\(separator:\s*"\."|components\(separatedBy:\s*"\."/);
+    expect(code).toMatch(/UInt8|Int\(/);
+    // The 172.16/12 boundary must be expressed as a RANGE. `172` alone, or a
+    // prefix test, wrongly accepts the public 172.32.x.
+    expect(code).toMatch(/16\s*\.\.\.\s*31/);
+  });
+
+  test('a helper script builds iOS-local with a DETECTED address, not a committed one', () => {
+    // This machine's LAN address changed three times across SHY-0273 alone. The
+    // Android side already detects it in start.sh; iOS needs the same or the
+    // recipe rots the moment the network changes.
+    const helper = read('scripts/dev/ios-local-install.sh');
+    expect(helper).toMatch(/route -n get default/);
+    expect(helper).toMatch(/LOCAL_HOST=/);
+    // And no committed literal address.
+    expect(stripComments(helper)).not.toMatch(/LOCAL_HOST=\s*["']?\d{1,3}(?:\.\d{1,3}){3}/);
+  });
+});

--- a/express-api/tests/scripts/ios-local-host-wiring.test.js
+++ b/express-api/tests/scripts/ios-local-host-wiring.test.js
@@ -91,8 +91,25 @@ describe('SHY-0275 — the local host reaches the iOS code that needs it', () =>
     const code = stripComments(KOIN_HELPER);
     expect(code).not.toMatch(/val\s+host\s*=\s*"localhost"/);
     expect(code).toMatch(/fun\s+configureFirebaseEmulators\s*\(\s*host\s*:/);
-    // Proves the assertion above is not vacuous — it catches the original line.
+    // The CALL SITE, not just the signature. A regression to
+    // `configureFirebaseEmulators("localhost")` — dropping the parameter and
+    // passing a literal — satisfies both assertions above and silently
+    // resurrects the exact bug this story fixes.
+    expect(code).toMatch(/configureFirebaseEmulators\(\s*localHost/);
+    // Proves the assertions are not vacuous — they catch the original lines.
     expect(/val\s+host\s*=\s*"localhost"/.test('    val host = "localhost"')).toBe(true);
+    expect(
+      /configureFirebaseEmulators\(\s*localHost/.test('configureFirebaseEmulators("localhost")'),
+    ).toBe(false);
+  });
+
+  test('iOSApp.swift forwards the resolved host into Koin', () => {
+    // `doInitKoin(localHost:)` has a Kotlin-side default, so omitting the
+    // argument still COMPILES and makes localHost always nil — reproducing the
+    // original bug with nothing red. Only a positive pin catches that.
+    const code = stripComments(IOS_APP);
+    expect(code).toMatch(/localHost:\s*env\.useEmulators\s*\?\s*AppEnvironment\.localHost/);
+    expect(code).toMatch(/liveKitUrl:\s*env\.useEmulators\s*\?\s*AppEnvironment\.localLiveKitUrl/);
   });
 
   test.each([
@@ -165,6 +182,30 @@ describe('SHY-0275 — the local host reaches the iOS code that needs it', () =>
     // prefix test, wrongly accepts the public 172.32.x.
     expect(code).toMatch(/16\s*\.\.\.\s*31/);
   });
+
+  test.each(['auth', 'firestore', 'database'])(
+    'the %s emulator listens on the LAN, not only on loopback',
+    (name) => {
+      // A real iPhone reaches this machine by LAN address and has no
+      // `adb reverse` equivalent, so an emulator bound to 127.0.0.1 REFUSES it.
+      // Measured on device: with the host routing fixed, sign-in still failed —
+      //
+      //   FIRAuthErrorDomain 17020 ERROR_NETWORK_REQUEST_FAILED
+      //   NSURLErrorDomain -1004 "Could not connect to the server"
+      //   http://192.168.1.9:9099/…/verifyPassword   ← ECONNREFUSED (61)
+      //
+      // Express (*:3000) and the web serve (*:8888) already bind to all
+      // interfaces, which is exactly why the health check passed while Auth was
+      // refused — the asymmetry made the stack look reachable when it was only
+      // half reachable.
+      //
+      // 0.0.0.0 is correct here and NOT a security regression: these are
+      // emulators holding seeded fixtures, started by a developer, on a
+      // developer's machine — the same posture Express already has.
+      const firebaseJson = JSON.parse(read('firebase.json'));
+      expect(firebaseJson.emulators?.[name]?.host).toBe('0.0.0.0');
+    },
+  );
 
   test('a helper script builds iOS-local with a DETECTED address, not a committed one', () => {
     // This machine's LAN address changed three times across SHY-0273 alone. The

--- a/express-api/tests/scripts/livekit-local-node-ip.test.js
+++ b/express-api/tests/scripts/livekit-local-node-ip.test.js
@@ -147,7 +147,10 @@ describe('SHY-0273 — the local stack reaches the REAL device it installs on', 
     // (Step 8), which is how you get an app that cannot reach its own stack.
     const buildLines = codeLines(START_SH).filter((l) => /gradlew.*assembleLocalDebug/.test(l));
     expect(buildLines).toHaveLength(1);
-    expect(buildLines[0]).toMatch(/-PlocalHost=/);
+    // Pins the VALUE, not merely the flag's presence: `-PlocalHost=10.0.2.2`
+    // is the retired-emulator alias this story exists to remove, and it would
+    // satisfy a bare `/-PlocalHost=/`.
+    expect(buildLines[0]).toMatch(/-PlocalHost=localhost\b/);
     // And prove the stripper is not simply hiding the command from the test.
     expect(
       codeLines('# ./gradlew assembleLocalDebug\n./gradlew assembleLocalDebug -PlocalHost=x'),
@@ -185,6 +188,26 @@ describe('SHY-0273 — the local stack reaches the REAL device it installs on', 
     // here rather than silently, on device, as "voice is flaky again".
     expect(PORT_LISTS[name]).toBeDefined();
     expect(PORT_LISTS[name]).toContain('7881');
+  });
+
+  test('the canonical port set is pinned, not just agreed upon', () => {
+    // The equality test below only proves the three lists match EACH OTHER, so
+    // a simultaneous identical drop — say every list losing 9002 (MinIO) — would
+    // pass every other check here while images silently stop loading on device.
+    // This pins what the set actually IS.
+    //
+    // 3000 Express · 7880 LiveKit signalling · 7881 LiveKit TCP media
+    // · 8080 Firestore · 8888 web serve · 9000 RTDB · 9002 MinIO · 9099 Auth
+    expect([...PORT_LISTS['start.sh']].sort()).toEqual([
+      '3000',
+      '7880',
+      '7881',
+      '8080',
+      '8888',
+      '9000',
+      '9002',
+      '9099',
+    ]);
   });
 
   test('the device-port lists do not drift apart', () => {

--- a/firebase.json
+++ b/firebase.json
@@ -7,9 +7,9 @@
     "rules": "database.rules.json"
   },
   "emulators": {
-    "auth": { "port": 9099 },
-    "firestore": { "port": 8080 },
-    "database": { "port": 9000 },
+    "auth": { "host": "0.0.0.0", "port": 9099 },
+    "firestore": { "host": "0.0.0.0", "port": 8080 },
+    "database": { "host": "0.0.0.0", "port": 9000 },
     "ui": { "port": 4000, "enabled": true }
   }
 }

--- a/iosApp/iosApp/AppEnvironment.swift
+++ b/iosApp/iosApp/AppEnvironment.swift
@@ -31,7 +31,37 @@ struct AppEnvironmentConfig: Equatable {
 /// `isPersonaPickerAvailable` from the password's presence.
 enum AppEnvironment {
     static let devApiBaseUrl = "https://dev-api.shytalk.shyden.co.uk"
-    static let localApiBaseUrl = "http://localhost:3000"
+
+    /// SHY-0275 — the address a LOCAL build uses to reach the developer's Mac.
+    ///
+    /// Comes from `Info.plist`'s `ShyTalkLocalHost`, substituted at build time
+    /// from the `LOCAL_HOST` build setting (`Local.xcconfig`, overridable on the
+    /// xcodebuild command line). Falls back to `localhost`, which is correct for
+    /// a Mac-hosted run and WRONG on a physical iPhone — an iPhone has no
+    /// `adb reverse` equivalent, so `localhost` is the phone itself.
+    ///
+    /// Previously these were literals and the plist value did not exist, so
+    /// `LOCAL_HOST=<mac-ip>` on the command line set a value nothing read: the
+    /// documented recipe looked followed while every backend call went to a port
+    /// on the handset. `iOSApp.swift` logs the resolved value at launch so a
+    /// wrong one is visible on first run rather than as "the app is broken".
+    static var localHost: String {
+        let raw = (Bundle.main.infoDictionary?["ShyTalkLocalHost"] as? String) ?? ""
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? "localhost" : trimmed
+    }
+
+    static var localApiBaseUrl: String { "http://\(localHost):3000" }
+
+    /// The local LiveKit signalling URL. `express-api/src/routes/livekit.js`
+    /// deliberately omits `url` from the token response when NODE_ENV is
+    /// `local`, leaving the client to supply its own — Android does this via
+    /// `BuildConfig.LIVEKIT_SERVER_URL`. iOS had no equivalent, so the voice
+    /// service fell through to `""` and refused its own connection.
+    static var localLiveKitUrl: String { "ws://\(localHost):7880" }
+
+    /// The local Realtime Database emulator URL, used to configure Firebase.
+    static var localRtdbUrl: String { "http://\(localHost):9000?ns=demo-shytalk" }
 
     /// WEB OAuth client ID for the `shytalk-dev` Firebase project — Android
     /// passes the same value via `BuildConfig.WEB_CLIENT_ID`. Needed by

--- a/iosApp/iosApp/AppEnvironment.swift
+++ b/iosApp/iosApp/AppEnvironment.swift
@@ -45,10 +45,23 @@ enum AppEnvironment {
     /// documented recipe looked followed while every backend call went to a port
     /// on the handset. `iOSApp.swift` logs the resolved value at launch so a
     /// wrong one is visible on first run rather than as "the app is broken".
-    static var localHost: String {
-        let raw = (Bundle.main.infoDictionary?["ShyTalkLocalHost"] as? String) ?? ""
-        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+    /// Info.plist key carrying the build-time `LOCAL_HOST` value.
+    static let localHostInfoKey = "ShyTalkLocalHost"
+
+    /// Takes the RAW plist value so the resolution rules are testable with real
+    /// strings — no stand-in Bundle. Every input a build can actually produce is
+    /// covered: a stamped address, an absent key (`nil`, on dev/release), and an
+    /// xcconfig that expanded to empty or whitespace.
+    ///
+    /// Absent must resolve to `localhost`, never `""`: an empty host builds
+    /// `http://:3000`, which parses fine and then fails opaquely much later.
+    static func resolveLocalHost(rawValue: String?) -> String {
+        let trimmed = (rawValue ?? "").trimmingCharacters(in: .whitespaces)
         return trimmed.isEmpty ? "localhost" : trimmed
+    }
+
+    static var localHost: String {
+        resolveLocalHost(rawValue: Bundle.main.object(forInfoDictionaryKey: localHostInfoKey) as? String)
     }
 
     static var localApiBaseUrl: String { "http://\(localHost):3000" }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -136,5 +136,13 @@
 	<string>$(SHYTALK_GIT_SHA)</string>
 	<key>ShyTalkGitDirty</key>
 	<string>$(SHYTALK_GIT_DIRTY)</string>
+	<!-- SHY-0275: the network address a LOCAL build uses to reach the developer's
+	     Mac. An iPhone has no `adb reverse` equivalent, so "localhost" is the
+	     PHONE — a local build without this reaches nothing. Local.xcconfig
+	     defines LOCAL_HOST (default "localhost"); a real device must override it
+	     with the Mac's LAN address, which scripts/dev/ios-local-install.sh
+	     detects. Empty/absent on dev + release builds, which never read it. -->
+	<key>ShyTalkLocalHost</key>
+	<string>$(LOCAL_HOST)</string>
 </dict>
 </plist>

--- a/iosApp/iosApp/LiveKitBridge.swift
+++ b/iosApp/iosApp/LiveKitBridge.swift
@@ -105,6 +105,42 @@ final class LiveKitBridgeImpl: NSObject, @unchecked Sendable, shared.LiveKitBrid
         return !token.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
+    /// Is `host` an RFC1918 private IPv4 **literal**? (SHY-0275)
+    ///
+    /// Decided by parsing the four octets NUMERICALLY, because the two ways a
+    /// string check gets this wrong are both reachable:
+    ///
+    ///   - `172.32.0.1` is **public**. The private block is 172.16–172.31, so
+    ///     `hasPrefix("172.")` hands an attacker a public host.
+    ///   - `10.0.0.5.evil.com` is a **hostname** the attacker controls, not an
+    ///     address, and `hasPrefix("10.")` accepts it.
+    ///
+    /// Requiring exactly four ASCII-numeric components in 0...255 rejects both.
+    /// ASCII is required explicitly: `Character.isNumber` is also true for
+    /// non-ASCII digit forms, which `Int()` would then refuse inconsistently.
+    ///
+    /// Not itself gated on `#if DEBUG` so it stays unit-testable; it is inert in
+    /// a Release binary because its only caller is inside the guard below.
+    static func isPrivateLAN(_ host: String) -> Bool {
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return false }
+        var octets: [Int] = []
+        for part in parts {
+            guard !part.isEmpty,
+                  part.allSatisfy({ $0.isASCII && $0.isNumber }),
+                  let value = Int(part),
+                  (0...255).contains(value)
+            else { return false }
+            octets.append(value)
+        }
+        switch (octets[0], octets[1]) {
+        case (10, _): return true
+        case (172, 16...31): return true
+        case (192, 168): return true
+        default: return false
+        }
+    }
+
     static func isAllowedURL(_ url: String) -> Bool {
         guard let parsed = URL(string: url), let host = parsed.host else { return false }
         let scheme = parsed.scheme?.lowercased() ?? ""
@@ -115,6 +151,21 @@ final class LiveKitBridgeImpl: NSObject, @unchecked Sendable, shared.LiveKitBrid
             "livekit.shytalk.shyden.co.uk",
             "livekit-eu.shytalk.shyden.co.uk",
         ]
+
+        #if DEBUG
+        // SHY-0275 — a physical iPhone reaches the developer's Mac by its LAN
+        // address; unlike Android it has no `adb reverse`, so loopback cannot
+        // serve and `ws://<mac-lan-ip>:7880` was rejected here before any
+        // network call. That is why iOS-local voice had never worked.
+        //
+        // Deliberately narrow: cleartext only, private IPv4 literals only, and
+        // compiled OUT of Release entirely — a shipped build's allow-list is
+        // byte-for-byte the expression below, unchanged. Cleartext signalling
+        // carries the join token, so this must never reach a distributable
+        // binary.
+        if scheme == "ws" && isPrivateLAN(host) { return true }
+        #endif
+
         return isLoopbackOk || (isTLS && allowedHosts.contains(host))
     }
 

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -51,10 +51,14 @@ struct iOSApp: App {
         // not a credential leak. The startup log below makes the misconfiguration
         // obvious in the device console on first launch.
         options.apiKey = "A" + String(repeating: "0", count: 38)
-        NSLog("[ShyTalk] DEBUG build — using Firebase Emulators (project=demo-shytalk, db=localhost:9000). NOT FOR PRODUCTION.")
+        // SHY-0275: log the RESOLVED host, not a fixed string. This line used to
+        // say "localhost:9000" unconditionally, so it read as confirmation even
+        // when the build was pointed somewhere else entirely — and on a real
+        // iPhone "localhost" is the phone, which is the bug it was hiding.
+        NSLog("[ShyTalk] DEBUG build — using Firebase Emulators (project=demo-shytalk, host=\(AppEnvironment.localHost)). NOT FOR PRODUCTION.")
         options.projectID = "demo-shytalk"
         options.bundleID = Bundle.main.bundleIdentifier ?? "com.shyden.shytalk"
-        options.databaseURL = "http://localhost:9000?ns=demo-shytalk"
+        options.databaseURL = AppEnvironment.localRtdbUrl
         options.storageBucket = "demo-shytalk.appspot.com"
         FirebaseApp.configure(options: options)
         variant = .local
@@ -120,7 +124,17 @@ struct iOSApp: App {
             gitBranch: gitBranch,
             gitSha: gitSha,
             gitDirty: gitDirty,
-            builtAt: builtAt
+            builtAt: builtAt,
+            // SHY-0275 — only meaningful when useEmulators is true. The Kotlin
+            // side pointed Firestore/Auth/RTDB at a fixed "localhost", which on
+            // a physical iPhone is the phone. Passed rather than derived in
+            // Kotlin so Swift stays the single owner of local URL shape, the
+            // same way apiBaseUrl already works.
+            localHost: env.useEmulators ? AppEnvironment.localHost : nil,
+            // Express omits `url` from the local token response by design, so
+            // the client must bring its own. Android has
+            // BuildConfig.LIVEKIT_SERVER_URL; this is the iOS counterpart.
+            liveKitUrl: env.useEmulators ? AppEnvironment.localLiveKitUrl : nil
         )
         NSLog(
             "[ShyTalk] build identity: %@ %@ %@@%@%@ built %@",

--- a/iosApp/iosAppTests/AgeSegregationTests.swift
+++ b/iosApp/iosAppTests/AgeSegregationTests.swift
@@ -90,4 +90,89 @@ final class AgeSegregationTests: XCTestCase {
         // it downstream with a clearer error than "missing_livekit_token").
         XCTAssertTrue(LiveKitBridgeImpl.isValidToken(" not-empty "))
     }
+
+    // MARK: - SHY-0275 — private-LAN cleartext, DEBUG builds only
+    //
+    // A physical iPhone reaches the developer's Mac by LAN address; unlike
+    // Android it has no `adb reverse`, so loopback cannot serve and
+    // `ws://<mac-lan-ip>:7880` was rejected before any network call. That is
+    // why iOS-local voice had never worked.
+    //
+    // The relaxation is compiled out of Release. These tests run in a DEBUG
+    // test build, so they assert the DEBUG behaviour; the rejection cases
+    // below are asserted unconditionally because they must hold in EVERY
+    // build, and those are the ones that matter if the guard ever slips.
+
+    func test_isPrivateLAN_acceptsAllThreeRFC1918Blocks() {
+        XCTAssertTrue(LiveKitBridgeImpl.isPrivateLAN("10.0.0.5"))
+        XCTAssertTrue(LiveKitBridgeImpl.isPrivateLAN("172.16.0.1"))
+        XCTAssertTrue(LiveKitBridgeImpl.isPrivateLAN("172.31.255.254"))
+        XCTAssertTrue(LiveKitBridgeImpl.isPrivateLAN("192.168.1.9"))
+    }
+
+    func test_isPrivateLAN_rejectsJustOutsideThe172Block() {
+        // THE case a `hasPrefix("172.")` check gets wrong: the private block is
+        // 172.16–172.31, so 172.15 and 172.32 are PUBLIC addresses.
+        XCTAssertFalse(LiveKitBridgeImpl.isPrivateLAN("172.15.0.1"))
+        XCTAssertFalse(LiveKitBridgeImpl.isPrivateLAN("172.32.0.1"))
+    }
+
+    func test_isPrivateLAN_rejectsHostnameThatMerelyStartsLikeOne() {
+        // THE case a `hasPrefix("10.")` check gets wrong — an attacker-controlled
+        // hostname, not an address. Four components are required AND each must
+        // parse as a number.
+        XCTAssertFalse(LiveKitBridgeImpl.isPrivateLAN("10.0.0.5.evil.com"))
+        XCTAssertFalse(LiveKitBridgeImpl.isPrivateLAN("192.168.1.9.attacker.net"))
+        XCTAssertFalse(LiveKitBridgeImpl.isPrivateLAN("10.0.0"))
+    }
+
+    func test_isPrivateLAN_rejectsMalformedOctets() {
+        XCTAssertFalse(LiveKitBridgeImpl.isPrivateLAN("10.0.0.256"))
+        XCTAssertFalse(LiveKitBridgeImpl.isPrivateLAN("10.0.0."))
+        XCTAssertFalse(LiveKitBridgeImpl.isPrivateLAN("10.0.0.0x5"))
+        XCTAssertFalse(LiveKitBridgeImpl.isPrivateLAN(""))
+    }
+
+    func test_isPrivateLAN_rejectsPublicAddresses() {
+        XCTAssertFalse(LiveKitBridgeImpl.isPrivateLAN("8.8.8.8"))
+        XCTAssertFalse(LiveKitBridgeImpl.isPrivateLAN("192.169.1.1"))
+        XCTAssertFalse(LiveKitBridgeImpl.isPrivateLAN("11.0.0.1"))
+    }
+
+    func test_isAllowedURL_rejectsCleartextToPublicHost_inEveryBuild() {
+        // The property that must survive the DEBUG relaxation: cleartext is
+        // permitted to a PRIVATE address only. If this ever passes, the guard
+        // has been widened into a hole.
+        XCTAssertFalse(LiveKitBridgeImpl.isAllowedURL("ws://8.8.8.8:7880"))
+        XCTAssertFalse(LiveKitBridgeImpl.isAllowedURL("ws://172.32.0.1:7880"))
+        XCTAssertFalse(LiveKitBridgeImpl.isAllowedURL("ws://evil.com:7880"))
+        XCTAssertFalse(LiveKitBridgeImpl.isAllowedURL("ws://10.0.0.5.evil.com:7880"))
+    }
+
+    #if DEBUG
+    func test_isAllowedURL_acceptsPrivateLANCleartext_inDebugOnly() {
+        XCTAssertTrue(LiveKitBridgeImpl.isAllowedURL("ws://192.168.1.9:7880"))
+        XCTAssertTrue(LiveKitBridgeImpl.isAllowedURL("ws://10.0.0.5:7880"))
+        XCTAssertTrue(LiveKitBridgeImpl.isAllowedURL("ws://172.16.0.1:7880"))
+    }
+    #endif
+
+    // MARK: - SHY-0275 — the local host reaches the URLs built from it
+
+    func test_localUrls_areBuiltFromTheResolvedHost() {
+        // These were literals containing "localhost", so a real iPhone pointed
+        // every backend call at itself. They must now derive from whatever
+        // AppEnvironment.localHost resolved to, whatever that is in this build.
+        let host = AppEnvironment.localHost
+        XCTAssertEqual(AppEnvironment.localApiBaseUrl, "http://\(host):3000")
+        XCTAssertEqual(AppEnvironment.localLiveKitUrl, "ws://\(host):7880")
+        XCTAssertEqual(AppEnvironment.localRtdbUrl, "http://\(host):9000?ns=demo-shytalk")
+    }
+
+    func test_localHost_fallsBackRatherThanReturningEmpty() {
+        // A test bundle has no ShyTalkLocalHost key, so this exercises the
+        // fallback path: it must be a usable host, never "" (which would build
+        // "http://:3000" and fail with an opaque error much later).
+        XCTAssertFalse(AppEnvironment.localHost.isEmpty)
+    }
 }

--- a/iosApp/iosAppTests/AgeSegregationTests.swift
+++ b/iosApp/iosAppTests/AgeSegregationTests.swift
@@ -157,22 +157,8 @@ final class AgeSegregationTests: XCTestCase {
     }
     #endif
 
-    // MARK: - SHY-0275 — the local host reaches the URLs built from it
-
-    func test_localUrls_areBuiltFromTheResolvedHost() {
-        // These were literals containing "localhost", so a real iPhone pointed
-        // every backend call at itself. They must now derive from whatever
-        // AppEnvironment.localHost resolved to, whatever that is in this build.
-        let host = AppEnvironment.localHost
-        XCTAssertEqual(AppEnvironment.localApiBaseUrl, "http://\(host):3000")
-        XCTAssertEqual(AppEnvironment.localLiveKitUrl, "ws://\(host):7880")
-        XCTAssertEqual(AppEnvironment.localRtdbUrl, "http://\(host):9000?ns=demo-shytalk")
-    }
-
-    func test_localHost_fallsBackRatherThanReturningEmpty() {
-        // A test bundle has no ShyTalkLocalHost key, so this exercises the
-        // fallback path: it must be a usable host, never "" (which would build
-        // "http://:3000" and fail with an opaque error much later).
-        XCTAssertFalse(AppEnvironment.localHost.isEmpty)
-    }
+    // NOTE: the `AppEnvironment.localHost` / local-URL tests live in
+    // AppEnvironmentTests.swift, where they belong — this file's subject is the
+    // LiveKit URL allow-list security boundary. Only the allow-list half of
+    // SHY-0275 is tested here.
 }

--- a/iosApp/iosAppTests/AppEnvironmentTests.swift
+++ b/iosApp/iosAppTests/AppEnvironmentTests.swift
@@ -127,4 +127,65 @@ final class AppEnvironmentTests: XCTestCase {
         XCTAssertNotNil(dev.devPersonasPassword, "dev has the picker")
         XCTAssertNil(rel.devPersonasPassword, "release does not")
     }
+
+    // ── SHY-0275 — the local host a real iPhone uses to reach the Mac ──
+    //
+    // `LOCAL_HOST` (Local.xcconfig) → `ShyTalkLocalHost` (Info.plist) →
+    // `AppEnvironment.localHost` → API / RTDB / LiveKit URLs. Before this, the
+    // URLs were literals containing `localhost`, so a physical iPhone — which
+    // has no `adb reverse` equivalent — sent every backend call to a port on
+    // ITSELF. Measured on device: `Firestore=localhost:8080` while the Mac was
+    // at 192.168.1.9.
+
+    // Resolution takes the RAW plist value, so these are real strings — no
+    // stand-in Bundle. (A Bundle subclass here would be a test double in an
+    // iOS `*Tests` target, which the no-stubs ratchet correctly rejects.)
+
+    func test_localHost_usesTheStampedAddress() {
+        // The whole point: a real iPhone must get the Mac's LAN address.
+        XCTAssertEqual(AppEnvironment.resolveLocalHost(rawValue: "192.168.1.9"), "192.168.1.9")
+    }
+
+    func test_localHost_fallsBackToLocalhostWhenTheKeyIsAbsent() {
+        // dev/release builds never stamp the key, and a Mac-hosted run wants
+        // localhost anyway. Absent must NOT become "" — that would build
+        // "http://:3000", which parses and then fails opaquely much later.
+        XCTAssertEqual(AppEnvironment.resolveLocalHost(rawValue: nil), "localhost")
+    }
+
+    func test_localHost_treatsAnUnsubstitutedOrBlankValueAsAbsent() {
+        // An xcconfig that never substituted leaves the key EMPTY rather than
+        // missing — a different input that must land in the same place.
+        XCTAssertEqual(AppEnvironment.resolveLocalHost(rawValue: ""), "localhost")
+        XCTAssertEqual(AppEnvironment.resolveLocalHost(rawValue: "   "), "localhost")
+    }
+
+    func test_localHost_trimsSurroundingWhitespace() {
+        // xcconfig values keep trailing spaces before an inline comment, which
+        // would otherwise produce "http://192.168.1.9 :3000".
+        XCTAssertEqual(AppEnvironment.resolveLocalHost(rawValue: "  192.168.1.9  "), "192.168.1.9")
+    }
+
+    func test_localHost_infoKeyMatchesTheOneInfoPlistDeclares() {
+        // The plist declares <key>ShyTalkLocalHost</key>; if these ever diverge
+        // the read silently returns nil and every URL falls back to localhost —
+        // the original bug, restored, with nothing red.
+        XCTAssertEqual(AppEnvironment.localHostInfoKey, "ShyTalkLocalHost")
+    }
+
+    func test_localUrls_areAllBuiltFromTheResolvedHost() {
+        // The three the device console named, one per line of its output.
+        let host = AppEnvironment.localHost
+        XCTAssertEqual(AppEnvironment.localApiBaseUrl, "http://\(host):3000")
+        XCTAssertEqual(AppEnvironment.localLiveKitUrl, "ws://\(host):7880")
+        XCTAssertEqual(AppEnvironment.localRtdbUrl, "http://\(host):9000?ns=demo-shytalk")
+    }
+
+    func test_localVariant_carriesTheLocalApiBaseUrl() {
+        // Ties the resolved host to what actually reaches Koin: `.local` must
+        // hand over the host-derived URL, not a literal.
+        let cfg = AppEnvironment.resolve(variant: .local, personasPassword: localEmulatorSeed)
+        XCTAssertEqual(cfg.apiBaseUrl, AppEnvironment.localApiBaseUrl)
+        XCTAssertTrue(cfg.apiBaseUrl.contains(AppEnvironment.localHost))
+    }
 }

--- a/scripts/dev/ios-local-install.sh
+++ b/scripts/dev/ios-local-install.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# SHY-0275 — build + install the iOS `Debug-Local` app on a real iPhone,
+# pointed at THIS machine's LAN address.
+#
+# Why this exists as a script rather than a documented command:
+#
+#   An iPhone has no `adb reverse` equivalent, so it can only reach the local
+#   stack by the Mac's LAN address — and that address is not stable. It changed
+#   three times over the course of SHY-0273 alone (192.168.1.13 → 10.179.17.101
+#   → 192.168.1.9). A committed literal is correct for about one evening, and a
+#   hand-typed one is correct until you move desks. So it is DETECTED here, the
+#   same way `local/start.sh` detects it for LiveKit's NODE_IP — and the two
+#   must agree, or the phone reaches the API and not the media.
+#
+# Usage:
+#   bash scripts/dev/ios-local-install.sh                 # detect, build, install
+#   LOCAL_HOST=10.0.0.7 bash scripts/dev/ios-local-install.sh   # explicit override
+#   SKIP_INSTALL=1 bash scripts/dev/ios-local-install.sh  # build only
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+XCODE="${XCODE_PATH:-/Applications/Xcode-beta.app}"
+CONFIG="Debug-Local"
+
+# Same detector as local/start.sh: follow the DEFAULT ROUTE rather than guessing
+# en0, which is what makes it correct on a machine with both Wi-Fi and Ethernet up.
+detect_lan_ip() {
+  local iface
+  iface=$(route -n get default 2>/dev/null | awk '/interface: /{print $2; exit}')
+  [ -n "$iface" ] && ipconfig getifaddr "$iface" 2>/dev/null && return 0
+  for i in en0 en1; do ipconfig getifaddr "$i" 2>/dev/null && return 0; done
+}
+
+LOCAL_HOST="${LOCAL_HOST:-$(detect_lan_ip)}"
+if [ -z "$LOCAL_HOST" ]; then
+  # Fatal, not a warning: unlike Android there is no tunnel to fall back on, so
+  # continuing would install an app that silently talks to the phone itself —
+  # exactly the failure this story exists to remove.
+  echo "ERROR: could not detect a LAN address for this machine." >&2
+  echo "       A real iPhone cannot reach 'localhost' — it has no adb reverse." >&2
+  echo "       Re-run with LOCAL_HOST=<this machine's LAN IP>." >&2
+  exit 1
+fi
+echo "==> iPhone will reach this machine at $LOCAL_HOST"
+
+# Warn loudly if LiveKit is advertising a DIFFERENT address than the app will
+# use for signalling. Both are derived the same way, so a mismatch means the
+# stack was started on another network — voice would connect and then die.
+if command -v docker >/dev/null 2>&1; then
+  NODE_IP=$(docker logs local-livekit-1 2>&1 | sed -n 's/.*"nodeIP": "\([^"]*\)".*/\1/p' | tail -1)
+  if [ -n "$NODE_IP" ] && [ "$NODE_IP" != "$LOCAL_HOST" ]; then
+    echo "  WARNING: LiveKit is advertising $NODE_IP but the app will use $LOCAL_HOST." >&2
+    echo "           Restart the stack (bash local/start.sh) so they agree." >&2
+  fi
+fi
+
+# Do NOT delete shared/build/xcode-frameworks/**/shared.framework here.
+#
+# The "Compile Kotlin Framework" phase (:shared:embedAndSignAppleFrameworkForXcode)
+# declares its output as the framework copied INSIDE the built .app — not the one
+# under shared/build. Deleting the latter therefore removes the module Swift
+# imports while leaving Xcode's up-to-date check satisfied, so the phase is
+# SKIPPED and the build dies at dependency scanning with
+# "Unable to resolve module dependency: 'shared'". Gradle is incremental and
+# rebuilds the framework on a Kotlin change by itself.
+#
+# To genuinely force it, remove the BUILT APP so the phase's declared output is
+# missing — that is the lever Xcode actually watches.
+# ALWAYS force the "Compile Kotlin Framework" phase to run, by removing the one
+# output Xcode checks for it.
+#
+# That phase does more than build the framework — it also runs
+# `syncComposeResourcesForIos`, which copies compose-resources (every locale's
+# strings) INTO the app bundle. Xcode skips the phase whenever
+# $(TARGET_BUILD_DIR)/$(FRAMEWORKS_FOLDER_PATH)/shared.framework already exists,
+# so an incremental build silently ships a bundle with no string resources and
+# the app launches, then crashes on the first screen with
+# `MissingResourceException: … strings.commonMain.cvr`. Observed exactly that.
+#
+# Gradle is incremental, so re-running the phase costs little when nothing
+# changed — far less than shipping a bundle that crashes on launch.
+rm -rf "$REPO_ROOT/iosApp/build/dd/Build/Products/$CONFIG-iphoneos/iosApp.app/Frameworks/shared.framework"
+
+# Make sure the KMP framework EXISTS before xcodebuild plans the Swift compile.
+#
+# The in-project "Compile Kotlin Framework" phase runs
+# `:shared:embedAndSignAppleFrameworkForXcode`, but it cannot BOOTSTRAP: Swift
+# resolves `import shared` against shared/build/xcode-frameworks/<config>/<sdk>,
+# whereas that phase declares its output as the copy inside the built .app. With
+# the staging directory empty, Swift's dependency scan is planned first and the
+# build dies with "Unable to resolve module dependency: 'shared'" before the
+# phase that would have fixed it ever runs.
+#
+# `embedAndSign…` cannot be invoked by hand either — it is only REGISTERED when
+# the Kotlin build type resolves, it wants that as a Gradle property (`-P`) while
+# taking everything else from Xcode's environment, and it then needs a growing
+# set of Xcode variables (PLATFORM_NAME, BUILT_PRODUCTS_DIR, CONTENTS_FOLDER_PATH
+# …) that are tedious and brittle to fake. `linkDebugFrameworkIosArm64` needs
+# NONE of them, so it is used to stage the framework and xcodebuild's own phase
+# then does the real embed + sign with the environment it alone has.
+SDK_NAME="iphoneos$(xcrun --sdk iphoneos --show-sdk-version 2>/dev/null)"
+STAGE="$REPO_ROOT/shared/build/xcode-frameworks/$CONFIG/$SDK_NAME"
+if [ ! -d "$STAGE/shared.framework" ]; then
+  echo "==> Staging the Kotlin framework ($CONFIG / $SDK_NAME)"
+  (cd "$REPO_ROOT" && ./gradlew :shared:linkDebugFrameworkIosArm64 --max-workers=1)
+  mkdir -p "$STAGE"
+  cp -R "$REPO_ROOT/shared/build/bin/iosArm64/debugFramework/shared.framework" "$STAGE/"
+fi
+
+echo "==> Building $CONFIG (LOCAL_HOST=$LOCAL_HOST)"
+cd "$REPO_ROOT/iosApp"
+# KOTLIN_FRAMEWORK_BUILD_TYPE is required: Local.xcconfig has no such line
+# (Dev.xcconfig does), so without it the KMP plugin cannot map the custom
+# configuration name to a Kotlin build type and the build fails.
+"$XCODE/Contents/Developer/usr/bin/xcodebuild" \
+  -workspace iosApp.xcworkspace -scheme iosApp -configuration "$CONFIG" \
+  -destination generic/platform=iOS -derivedDataPath build/dd \
+  DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM:-F3XX4PM3MF}" \
+  LOCAL_HOST="$LOCAL_HOST" \
+  KOTLIN_FRAMEWORK_BUILD_TYPE=debug build
+
+APP="$REPO_ROOT/iosApp/build/dd/Build/Products/$CONFIG-iphoneos/iosApp.app"
+
+# Never trust exit 0 — confirm the address actually reached the bundle. The
+# whole point of this story is that it previously did not, while every command
+# reported success.
+BAKED=$(plutil -extract ShyTalkLocalHost raw "$APP/Info.plist" 2>/dev/null || echo "")
+if [ "$BAKED" != "$LOCAL_HOST" ]; then
+  echo "ERROR: Info.plist ShyTalkLocalHost is '$BAKED', expected '$LOCAL_HOST'." >&2
+  echo "       The build setting did not reach the bundle — do NOT trust this app." >&2
+  exit 1
+fi
+echo "  Verified: bundle carries ShyTalkLocalHost=$BAKED"
+
+if [ -n "${SKIP_INSTALL:-}" ]; then
+  echo "==> SKIP_INSTALL set — built at $APP"
+  exit 0
+fi
+
+# Match the UUID by SHAPE, not by column. Device names contain spaces
+# ("Sean's iPhone"), so positional field-splitting silently yields the wrong
+# token — it produced the literal string "iPhone" and devicectl then failed on
+# a device named after a word.
+DEVICE="${IOS_DEVICE_ID:-$(xcrun devicectl list devices 2>/dev/null \
+  | grep -E 'physical' | grep -iE '(available|connected)' \
+  | grep -oE '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}' \
+  | head -1)}"
+if [ -z "$DEVICE" ]; then
+  echo "ERROR: no physical iPhone visible to devicectl." >&2
+  echo "       Connect over USB, or pass IOS_DEVICE_ID=<identifier>." >&2
+  exit 1
+fi
+
+echo "==> Installing on $DEVICE"
+xcrun devicectl device install app --device "$DEVICE" "$APP"
+echo "==> Done. Launch with:"
+echo "    xcrun devicectl device process launch --console --device $DEVICE com.shyden.shytalk"

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/BuildVariant.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/BuildVariant.kt
@@ -23,6 +23,7 @@ data class BuildVariantConfig(
     val buildVersion: String = "?",
     val deviceInfo: String = "?",
     val apiBaseUrl: String? = null,
+    val liveKitUrl: String? = null,
     val gitBranch: String = "?",
     val gitSha: String = "?",
     val gitDirty: Boolean = false,
@@ -157,6 +158,24 @@ object BuildVariant {
      * posting to a relative URL.
      */
     val apiBaseUrl: String? get() = holder.apiBaseUrl
+
+    /**
+     * Local LiveKit signalling URL for iOS (SHY-0275). `null` on dev/prod,
+     * where `express-api/src/routes/livekit.js` returns the region's URL in
+     * the token response.
+     *
+     * On `local` that route deliberately OMITS `url`, leaving the client to
+     * supply its own — Android does this from
+     * `BuildConfig.LIVEKIT_SERVER_URL`, and iOS had no counterpart at all, so
+     * `IosLiveKitVoiceService` took `response.url ?: ""` and handed the empty
+     * string to the bridge, which refused it before any network call. This is
+     * that missing counterpart, populated from Swift's
+     * `AppEnvironment.localLiveKitUrl`.
+     *
+     * Default `null` (not `""`) so a caller can tell "not configured" from
+     * "configured blank"; blank coerces to null in [initLiveKitUrl].
+     */
+    val liveKitUrl: String? get() = holder.liveKitUrl
 
     /**
      * Git branch the binary was built from (SHY-0205). Injected at
@@ -357,5 +376,17 @@ object BuildVariant {
      */
     fun initApiBaseUrl(value: String?) {
         holder = holder.copy(apiBaseUrl = value?.takeIf { it.isNotBlank() })
+    }
+
+    /**
+     * One-shot local LiveKit URL initialiser (SHY-0275). Called from
+     * `KoinHelper.doInitKoin(liveKitUrl = ...)`, itself called from Swift's
+     * `iOSApp.swift` with `AppEnvironment.localLiveKitUrl` on local builds and
+     * `nil` everywhere else. Blank coerces to null, so a build that stamps an
+     * empty setting behaves as "not configured" rather than producing a URL of
+     * `ws://:7880`. See [liveKitUrl].
+     */
+    fun initLiveKitUrl(value: String?) {
+        holder = holder.copy(liveKitUrl = value?.takeIf { it.isNotBlank() })
     }
 }

--- a/shared/src/commonMain/kotlin/com/shyden/shytalk/core/BuildVariant.kt
+++ b/shared/src/commonMain/kotlin/com/shyden/shytalk/core/BuildVariant.kt
@@ -390,3 +390,29 @@ object BuildVariant {
         holder = holder.copy(liveKitUrl = value?.takeIf { it.isNotBlank() })
     }
 }
+
+/**
+ * Which LiveKit URL should a client connect to? (SHY-0275)
+ *
+ * The server's answer wins when it gives one. On `local`,
+ * `express-api/src/routes/livekit.js` deliberately omits `url` from the token
+ * response, so the client falls back to its own build-time value — Android's
+ * `BuildConfig.LIVEKIT_SERVER_URL`, iOS's [BuildVariant.liveKitUrl].
+ *
+ * Lives here, in commonMain, rather than inline in `IosLiveKitVoiceService`
+ * because there is no `iosTest` source set: inline, the only thing pinning it
+ * was a structural check that the token `liveKitUrl` appeared somewhere in the
+ * file, which a swapped operand order (`fallback ?: response`) would satisfy
+ * while breaking voice for every dev and prod user.
+ *
+ * Returns `""` when neither is available — preserving the previous behaviour,
+ * where the bridge's own allow-list refuses the empty string before any
+ * network call rather than this throwing at a less useful moment.
+ */
+fun resolveVoiceServerUrl(
+    responseUrl: String?,
+    fallback: String?,
+): String =
+    responseUrl?.takeIf { it.isNotBlank() }
+        ?: fallback?.takeIf { it.isNotBlank() }
+        ?: ""

--- a/shared/src/commonTest/kotlin/com/shyden/shytalk/core/BuildVariantTest.kt
+++ b/shared/src/commonTest/kotlin/com/shyden/shytalk/core/BuildVariantTest.kt
@@ -22,6 +22,10 @@ class BuildVariantTest {
             builtAt = "?",
         )
         BuildVariant.initApiBaseUrl(null)
+        // SHY-0275: without this, the FIRST test that sets a liveKitUrl leaks it
+        // into every test that runs after it in this class — the slot is a
+        // process-wide singleton, so the leak is silent and order-dependent.
+        BuildVariant.initLiveKitUrl(null)
     }
 
     @Test
@@ -499,6 +503,103 @@ class BuildVariantTest {
         BuildVariant.initApiBaseUrl("http://localhost:3000")
         BuildVariant.initApiBaseUrl(null)
         assertNull(BuildVariant.apiBaseUrl)
+    }
+
+    // ── liveKitUrl (SHY-0275 — iOS local voice) ────────────────────────────
+    // express-api/src/routes/livekit.js OMITS `url` from the token response
+    // when NODE_ENV is `local`, leaving the client to supply its own. Android
+    // reads BuildConfig.LIVEKIT_SERVER_URL; iOS had no counterpart at all, so
+    // IosLiveKitVoiceService took `response.url ?: ""` and handed the empty
+    // string to the bridge, which refused its own connection before any network
+    // call. Same fail-closed shape as apiBaseUrl above.
+
+    @Test
+    fun `liveKitUrl defaults to null so dev and prod keep using the server URL`() {
+        assertNull(BuildVariant.liveKitUrl)
+    }
+
+    @Test
+    fun `initLiveKitUrl captures the local ws URL`() {
+        BuildVariant.initLiveKitUrl("ws://192.168.1.9:7880")
+        assertEquals("ws://192.168.1.9:7880", BuildVariant.liveKitUrl)
+    }
+
+    @Test
+    fun `initLiveKitUrl coerces empty string to null`() {
+        // An unstamped LOCAL_HOST would otherwise produce "ws://:7880" — a URL
+        // that parses but resolves nowhere, failing much later and opaquely.
+        BuildVariant.initLiveKitUrl("")
+        assertNull(BuildVariant.liveKitUrl)
+    }
+
+    @Test
+    fun `initLiveKitUrl coerces blank string to null`() {
+        BuildVariant.initLiveKitUrl("   ")
+        assertNull(BuildVariant.liveKitUrl)
+    }
+
+    @Test
+    fun `initLiveKitUrl can be cleared by passing null`() {
+        BuildVariant.initLiveKitUrl("ws://192.168.1.9:7880")
+        BuildVariant.initLiveKitUrl(null)
+        assertNull(BuildVariant.liveKitUrl)
+    }
+
+    @Test
+    fun `liveKitUrl and apiBaseUrl are independent slots`() {
+        // Both were added to the same holder; a copy() that clobbered the
+        // sibling would be invisible to every single-slot test above.
+        BuildVariant.initApiBaseUrl("http://192.168.1.9:3000")
+        BuildVariant.initLiveKitUrl("ws://192.168.1.9:7880")
+        assertEquals("http://192.168.1.9:3000", BuildVariant.apiBaseUrl)
+        assertEquals("ws://192.168.1.9:7880", BuildVariant.liveKitUrl)
+        BuildVariant.initLiveKitUrl(null)
+        assertEquals("http://192.168.1.9:3000", BuildVariant.apiBaseUrl)
+    }
+
+    // ── resolveVoiceServerUrl (SHY-0275) ───────────────────────────────────
+    // Extracted from IosLiveKitVoiceService so the fallback CHAIN is testable:
+    // no iosTest source set exists, and the structural pin only proved the
+    // token `liveKitUrl` appears somewhere in the file — so swapping the
+    // operand order (`fallback ?: response`) would have kept every test green
+    // while breaking voice for every dev and prod user.
+
+    @Test
+    fun `resolveVoiceServerUrl prefers the server URL over the local fallback`() {
+        assertEquals(
+            "wss://livekit-eu.shytalk.shyden.co.uk",
+            resolveVoiceServerUrl(
+                responseUrl = "wss://livekit-eu.shytalk.shyden.co.uk",
+                fallback = "ws://192.168.1.9:7880",
+            ),
+        )
+    }
+
+    @Test
+    fun `resolveVoiceServerUrl uses the local fallback when the server omits a URL`() {
+        // The `local` case: livekit.js deliberately sends no `url`.
+        assertEquals(
+            "ws://192.168.1.9:7880",
+            resolveVoiceServerUrl(responseUrl = null, fallback = "ws://192.168.1.9:7880"),
+        )
+    }
+
+    @Test
+    fun `resolveVoiceServerUrl returns empty when neither is available`() {
+        // Preserves the pre-existing behaviour exactly: the bridge's own
+        // allow-list then refuses "" before any network call.
+        assertEquals("", resolveVoiceServerUrl(responseUrl = null, fallback = null))
+    }
+
+    @Test
+    fun `resolveVoiceServerUrl treats a blank server URL as absent`() {
+        // A server that answers with "" is indistinguishable, to the bridge,
+        // from one that answers with nothing — so it must not win over a
+        // usable local fallback.
+        assertEquals(
+            "ws://192.168.1.9:7880",
+            resolveVoiceServerUrl(responseUrl = "  ", fallback = "ws://192.168.1.9:7880"),
+        )
     }
 
     // ── isPersonaPickerAvailable matrix (PR B v2 — persona picker) ──

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/core/di/KoinHelper.kt
@@ -45,6 +45,8 @@ fun doInitKoin(
     gitSha: String = "",
     gitDirty: Boolean = false,
     builtAt: String = "",
+    localHost: String? = null,
+    liveKitUrl: String? = null,
 ) {
     BuildVariant.initLocalEmulator(
         value = useEmulators,
@@ -88,13 +90,18 @@ fun doInitKoin(
     // localhost:3000 from real iPhones and locked the user on "Unable to
     // connect".
     BuildVariant.initApiBaseUrl(apiBaseUrl)
+    // SHY-0275 — same fail-closed shape as apiBaseUrl. Express omits `url` from
+    // the token response on local by design, so without this the iOS voice
+    // service fell through to "" and refused its own connection before any
+    // network call. Null on dev/prod, where the server always supplies the URL.
+    BuildVariant.initLiveKitUrl(liveKitUrl)
     if (KoinPlatformTools.defaultContext().getOrNull() != null) {
         logI("KoinHelper", "Koin already initialised — skipping")
         return
     }
     try {
         if (useEmulators) {
-            configureFirebaseEmulators()
+            configureFirebaseEmulators(localHost?.takeIf { it.isNotBlank() } ?: "localhost")
         }
         startKoin {
             modules(viewModelModule, iosPlatformModule)
@@ -126,8 +133,16 @@ fun recordAppBackgroundedForAppLock() {
     koin.get<com.shyden.shytalk.data.repository.AppLockRepository>().updateLastActiveTimestamp()
 }
 
-private fun configureFirebaseEmulators() {
-    val host = "localhost"
+/**
+ * SHY-0275 — [host] is supplied by Swift from `Info.plist`'s `ShyTalkLocalHost`
+ * (the `LOCAL_HOST` build setting). It used to be the literal `"localhost"`,
+ * which is correct for a Mac-hosted run and WRONG on a physical iPhone: an
+ * iPhone has no `adb reverse` equivalent, so `localhost` is the phone and all
+ * three emulator connections went to ports on the handset. The log line below
+ * is the one that made the bug visible, and it now prints the value actually
+ * used rather than a fixed string.
+ */
+private fun configureFirebaseEmulators(host: String) {
     Firebase.firestore.useEmulator(host, 8080)
     Firebase.auth.useEmulator(host, 9099)
     Firebase.database.useEmulator(host, 9000)

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosLiveKitVoiceService.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosLiveKitVoiceService.kt
@@ -1,6 +1,7 @@
 package com.shyden.shytalk.data.remote
 
 import com.shyden.shytalk.core.BuildVariant
+import com.shyden.shytalk.core.resolveVoiceServerUrl
 import com.shyden.shytalk.core.util.logE
 import com.shyden.shytalk.core.util.logI
 import kotlinx.coroutines.CoroutineScope
@@ -94,10 +95,15 @@ class IosLiveKitVoiceService(
             // call — indistinguishable, from the UI, from voice being broken.
             // BuildVariant.liveKitUrl is null on dev/prod, where the server
             // always answers, so this changes nothing off local.
-            val fallbackUrl = BuildVariant.liveKitUrl ?: ""
+            // The selection lives in commonMain as `resolveVoiceServerUrl` so it
+            // is unit-testable — there is no iosTest source set, and inline the
+            // only guard was a structural check that the token `liveKitUrl`
+            // appeared in this file, which a swapped operand order would satisfy
+            // while breaking voice on dev and prod.
+            val fallbackUrl = BuildVariant.liveKitUrl
             if (prewarmedToken != null && prewarmedRoomName == roomName) {
                 token = prewarmedToken!!
-                serverUrl = prewarmedUrl ?: fallbackUrl
+                serverUrl = resolveVoiceServerUrl(prewarmedUrl, fallbackUrl)
                 prewarmedToken = null
                 prewarmedUrl = null
                 prewarmedRoomName = null
@@ -107,7 +113,7 @@ class IosLiveKitVoiceService(
                 try {
                     val response = tokenService.fetchToken(roomName)
                     token = response.token
-                    serverUrl = response.url ?: fallbackUrl
+                    serverUrl = resolveVoiceServerUrl(response.url, fallbackUrl)
                 } catch (e: Exception) {
                     logE(TAG, "Token fetch failed: ${e.message}")
                     _error.value = "Failed to connect to voice: ${e.message}"

--- a/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosLiveKitVoiceService.kt
+++ b/shared/src/iosMain/kotlin/com/shyden/shytalk/data/remote/IosLiveKitVoiceService.kt
@@ -1,5 +1,6 @@
 package com.shyden.shytalk.data.remote
 
+import com.shyden.shytalk.core.BuildVariant
 import com.shyden.shytalk.core.util.logE
 import com.shyden.shytalk.core.util.logI
 import kotlinx.coroutines.CoroutineScope
@@ -84,9 +85,19 @@ class IosLiveKitVoiceService(
             // Use prewarmed token if available and matching
             val token: String
             val serverUrl: String
+            // SHY-0275 — the server does NOT always supply the URL.
+            // `express-api/src/routes/livekit.js` omits `url` from the token
+            // response when NODE_ENV is `local`, by design, leaving the client
+            // to use its own: Android reads BuildConfig.LIVEKIT_SERVER_URL.
+            // iOS had no counterpart, so both branches below fell through to
+            // "" and the bridge refused its own connection before any network
+            // call — indistinguishable, from the UI, from voice being broken.
+            // BuildVariant.liveKitUrl is null on dev/prod, where the server
+            // always answers, so this changes nothing off local.
+            val fallbackUrl = BuildVariant.liveKitUrl ?: ""
             if (prewarmedToken != null && prewarmedRoomName == roomName) {
                 token = prewarmedToken!!
-                serverUrl = prewarmedUrl ?: ""
+                serverUrl = prewarmedUrl ?: fallbackUrl
                 prewarmedToken = null
                 prewarmedUrl = null
                 prewarmedRoomName = null
@@ -96,7 +107,7 @@ class IosLiveKitVoiceService(
                 try {
                     val response = tokenService.fetchToken(roomName)
                     token = response.token
-                    serverUrl = response.url ?: ""
+                    serverUrl = response.url ?: fallbackUrl
                 } catch (e: Exception) {
                     logE(TAG, "Token fetch failed: ${e.message}")
                     _error.value = "Failed to connect to voice: ${e.message}"


### PR DESCRIPTION
Implements SHY-0275 — see `.project/stories/SHY-0275-ios-local-cannot-reach-stack.md` for full spec, AC, BDD scenarios, and DoD.

**Stacked on #1692 (SHY-0273).** Review only the three `[SHY-0275]` commits; everything below them is already under review on the base PRs.

## What was wrong

The iOS `Debug-Local` build could not reach the local stack from a physical iPhone. Not voice — **nothing**. An iPhone has no `adb reverse` equivalent, so `localhost` is the phone, and every backend call went to a port on the handset. The whole iOS-local leg of the gauntlet has been unrunnable and was being read as "iOS-local unsupported".

Four independent causes, all fixed here:

1. **`LOCAL_HOST` was dead config.** `Local.xcconfig` defines `LOCAL_HOST`, `LOCAL_API_BASE_URL`, `LOCAL_LIVEKIT_URL`, `LOCAL_FIREBASE_RTDB_URL` — and nothing read them. The live values were Swift/Kotlin literals. So passing `LOCAL_HOST=` to `xcodebuild` set a value no code could observe: the documented recipe *looked* followed. Now bridged through `Info.plist`'s `ShyTalkLocalHost`, the same mechanism the existing `ShyTalkGit*` keys use.
2. **iOS had no local LiveKit URL at all.** `routes/livekit.js` deliberately omits `url` from the token response on `local`, leaving the client to supply its own — Android has `BuildConfig.LIVEKIT_SERVER_URL`; iOS had no counterpart, so it took `response.url ?: ""` and refused its own connection.
3. **The allow-list could not express "my Mac".** `isAllowedURL` permitted cleartext `ws://` only for loopback.
4. **All three Firebase emulators bound to `127.0.0.1`** while Express (`*:3000`) and the web serve (`*:8888`) bind to all interfaces — which is exactly why the health check passed while Auth was refused with `ECONNREFUSED`. The stack *looked* reachable when it was only half reachable.

Cause 3 is a correct security boundary — cleartext signalling carries the join token — so it is relaxed only for RFC1918 literals and only inside `#if DEBUG`, compiled out of Release entirely. Membership is decided by parsing octets **numerically**: `hasPrefix("172.")` would accept the public `172.32.0.1`, and `hasPrefix("10.")` would accept the hostname `10.0.0.5.evil.com`. Both are explicit rejection tests.

## Device proof

Real iPhone Air over the LAN, sign-in as persona P-02 (UID 50000010), joined the room the **Android** phone had created, unmuted. LiveKit's own log:

```
participant active  sdk:"SWIFT"  deviceModel:"iPhone18,4"
  [local][selected:1]  udp4 host 192.168.1.9:52089
  [remote][selected:1] udp  host 192.168.1.3:50477
  connectionType:"udp"   connectTime:"334.964506ms"
mediaTrack published  source:"MICROPHONE"  mime:"audio/red"
```

ICE completing is necessary but not sufficient — the published `MICROPHONE` track is what proves audio actually flows.

## Verification

- **RED first** — 7 of 11 structural pins failed before the fix; the 3 emulator-binding pins failed before `firebase.json` changed.
- **Mutation-verified**, each mutant printed verbatim then reverted — including the operand swap in the voice-URL fallback, which previously would have stayed green while breaking dev/prod voice.
- `code-reviewer`: 7 findings, all applied. The `isPrivateLAN` boundary came back clean against every bypass class probed (`172.32`, hostname-lookalikes, leading zeros, signs, unicode digits, IPv6, trailing dots, `ws://192.168.1.9@evil.com`).
- The no-stubs ratchet caught a stand-in `Bundle` added for a test. Rather than whitelist it, resolution now takes the raw plist value and is tested with real strings — doubles count stayed at zero.
- 7462/7462 `tests/scripts` · `shared:jvmTest` · `compileKotlinIosArm64` · ktlint/eslint/prettier/shellcheck/story-validator clean · Playwright pre-push 1401 passed.

`Reviewed-up-to: ea75d9d6175`

## Still owed

Journey gauntlet on both devices (local → dev) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AS6aAUFszh5ionWDxq24qu
