### PR TITLE
chore: merge main into develop (3 Dependabot GitHub-Actions bumps)

### DIFF
--- a/.github/workflows/allure-report.yml
+++ b/.github/workflows/allure-report.yml
@@ -61,7 +61,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check if report already generated for this run
         id: check-existing
@@ -114,7 +114,7 @@ jobs:
 
       - name: Restore history from gh-pages
         if: steps.check-existing.outputs.skip != 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
           path: gh-pages

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/setup-jdk-gradle
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -859,7 +859,7 @@ jobs:
           # cond is true. `actions/checkout` parses the input as int.
           fetch-depth: ${{ inputs.ref != '' && '0' || '1' }}
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
 
@@ -927,7 +927,7 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: ${{ inputs.ref != '' && '0' || '1' }}
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Honour the optional `ref` input so the operator can deploy a
           # specific branch, tag (e.g. `v0.97.1`), or commit SHA. Falls
@@ -220,7 +220,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Honour the optional `ref` input so the operator can deploy a
           # specific branch, tag (e.g. `v0.97.1`), or commit SHA. Falls
@@ -275,7 +275,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Honour the optional `ref` input so the operator can deploy a
           # specific branch, tag (e.g. `v0.97.1`), or commit SHA. Falls
@@ -431,7 +431,7 @@ jobs:
     # net for anything unexpected before the step timeouts fire.
     timeout-minutes: 100
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Honour the optional `ref` input so the operator can deploy a
           # specific branch, tag (e.g. `v0.97.1`), or commit SHA. Falls
@@ -819,7 +819,7 @@ jobs:
     # well under the limit.
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Honour the optional `ref` input so the operator can deploy a
           # specific branch, tag (e.g. `v0.97.1`), or commit SHA. Falls
@@ -904,7 +904,7 @@ jobs:
     # warm runs complete much faster.
     timeout-minutes: 12
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: ${{ inputs.ref != '' && '0' || '1' }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -841,7 +841,7 @@ jobs:
           # cond is true. `actions/checkout` parses the input as int.
           fetch-depth: ${{ inputs.ref != '' && '0' || '1' }}
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24
 
@@ -909,7 +909,7 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: ${{ inputs.ref != '' && '0' || '1' }}
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -73,7 +73,7 @@ jobs:
       # input here, because a) for branch refs we need `origin/<branch>`
       # not the raw name, and b) the working tree contents don't matter
       # at this step — only git history does.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.validate-release.outputs.commit-sha }}
 
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.validate-release.outputs.commit-sha }}
 
@@ -355,7 +355,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.validate-release.outputs.commit-sha }}
 
@@ -449,7 +449,7 @@ jobs:
     # the real cause of the apparent slowness, not insufficient minutes).
     timeout-minutes: 100
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.validate-release.outputs.commit-sha }}
 
@@ -769,7 +769,7 @@ jobs:
       # when deploying a tag cut BEFORE this script existed (run 27388236740:
       # deploying v0.97.12 → "No such file", exit 127). The deployed APP under
       # test is the downloaded APK artifact, not this checked-out tree.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download debug APK
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -834,7 +834,7 @@ jobs:
     # for the boot+launch verification even on the cold-cache worst case.
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.validate-release.outputs.commit-sha }}
 
@@ -973,7 +973,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Create critical issue
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -152,7 +152,7 @@ jobs:
       max-parallel: ${{ needs.resolve-inputs.outputs.parallel == 'true' && 99 || 1 }}
       matrix: ${{ fromJSON(needs.resolve-inputs.outputs.android_matrix) }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.resolve-inputs.outputs.ref }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: ./.github/actions/setup-jdk-gradle
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: ./.github/actions/setup-jdk-gradle
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -115,7 +115,7 @@ jobs:
     # tests/scripts/ios-tests-build-cache.test.js (asserts ≥60).
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.resolve-inputs.outputs.ref }}
 
@@ -484,7 +484,7 @@ jobs:
       max-parallel: ${{ needs.resolve-inputs.outputs.parallel == 'true' && 99 || 1 }}
       matrix: ${{ fromJSON(needs.resolve-inputs.outputs.ios_matrix) }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.resolve-inputs.outputs.ref }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.sha }}
 

--- a/.github/workflows/manual-qa-matrix.yml
+++ b/.github/workflows/manual-qa-matrix.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '24'
           cache: npm

--- a/.github/workflows/manual-qa-matrix.yml
+++ b/.github/workflows/manual-qa-matrix.yml
@@ -68,7 +68,7 @@ jobs:
         # qa-runner workflow family beats partial SHA-pinning that
         # locks down only checkout while setup-node/cache/upload-artifact
         # stay on floating tags (per reviewer C3).
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/manual-qa-matrix.yml
+++ b/.github/workflows/manual-qa-matrix.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: '24'
           cache: npm

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -155,7 +155,7 @@ jobs:
 
       - uses: ./.github/actions/setup-jdk-gradle
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.resolve-inputs.outputs.ref }}
 
@@ -149,7 +149,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.resolve-inputs.outputs.web_matrix) }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.resolve-inputs.outputs.ref }}
 

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -155,7 +155,7 @@ jobs:
 
       - uses: ./.github/actions/setup-jdk-gradle
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -34,7 +34,7 @@ jobs:
       skip_android_e2e: ${{ steps.changes.outputs.skip_android_e2e }}
       skip_ios_e2e: ${{ steps.changes.outputs.skip_ios_e2e }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -182,7 +182,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -434,7 +434,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       # SHY-0127 Gate 1: a PR that touches a SHY story MUST have flipped it to

--- a/.github/workflows/qa-runner-driver-checks.yml
+++ b/.github/workflows/qa-runner-driver-checks.yml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/qa-runner-driver-checks.yml
+++ b/.github/workflows/qa-runner-driver-checks.yml
@@ -55,7 +55,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '24'
           cache: npm

--- a/.github/workflows/qa-runner-driver-checks.yml
+++ b/.github/workflows/qa-runner-driver-checks.yml
@@ -55,7 +55,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: '24'
           cache: npm

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -79,7 +79,7 @@ jobs:
             echo "Not a release commit — exiting early."
           fi
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: steps.inspect.outputs.is_release == 'true'
         with:
           # Need full history to walk back to the previous release tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           client-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           # Need full history to walk back to the previous release tag

--- a/.github/workflows/seed-dev-personas.yml
+++ b/.github/workflows/seed-dev-personas.yml
@@ -67,7 +67,7 @@ jobs:
     # Auth quota throttling without letting a stuck run idle forever.
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/setup-node
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 0

--- a/.github/workflows/sync-roadmap-data.yml
+++ b/.github/workflows/sync-roadmap-data.yml
@@ -58,7 +58,7 @@ jobs:
           client-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           # App-token here too (not GITHUB_TOKEN): keeps the entire

--- a/.github/workflows/sync-roadmap-data.yml
+++ b/.github/workflows/sync-roadmap-data.yml
@@ -66,7 +66,7 @@ jobs:
           # audit logs. Required by SHY-0063 § Happy path.
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "20"
 

--- a/.github/workflows/sync-roadmap-data.yml
+++ b/.github/workflows/sync-roadmap-data.yml
@@ -66,7 +66,7 @@ jobs:
           # audit logs. Required by SHY-0063 § Happy path.
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: "20"
 

--- a/.github/workflows/sync-stories-to-issues.yml
+++ b/.github/workflows/sync-stories-to-issues.yml
@@ -64,7 +64,7 @@ jobs:
     # ≈ ~330-700 calls ≈ ~2-3 min. 15 min ≈ 5× headroom.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -44,7 +44,7 @@ jobs:
     # added below for EPIC-0003 Phase 3 (real-firebase Jest tests).
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.sha }}
 

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -56,7 +56,7 @@ jobs:
       # present before they start. Reuses the repo-wide SHA pin for
       # actions/setup-java (see .github/actions/setup-jdk-gradle) to
       # satisfy the SHA-pin supply-chain guard.
-      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           java-version: '21'
           distribution: 'temurin'


### PR DESCRIPTION
Merges `main` back into `develop`. This is a HARD prerequisite before any gauntlet run or develop→main promotion ([[feedback-merge-main-into-develop-before-testing]]) — develop had drifted 3 commits behind main.

No story: this is a mechanical branch sync, so `Pre-Merge Gate` reports "no story .md in the diff".

## What main had that develop didn't

All three are Dependabot GitHub-Actions bumps that landed directly on main:

| PR | Bump |
|---|---|
| #1685 | `actions/setup-java` 5.6.0 → 5.7.0 |
| #1683 | `actions/setup-node` 6.4.0 → **7.0.0** (major) |
| #1677 | `actions/checkout` 7.0.0 → 7.0.1 (patch-updates group) |

## Verification done before pushing

- `git merge-tree` reported a **clean merge** — no conflicts.
- The diff is **19 workflow files, 45 insertions / 45 deletions, and zero non-`uses:` changed lines** — pure SHA-pin swaps, no logic changes.
- `scripts/check-action-shas.sh` passes on the merged tree.

### The setup-node major bump does NOT move the Node runtime

Worth stating explicitly because a major bump of a toolchain action normally would. Six workflows call `actions/setup-node@<sha>` **directly** rather than through the local `./.github/actions/setup-node` composite — `deploy-dev`, `integration-tests`, `manual-qa-matrix`, `playwright-tests`, `qa-runner-driver-checks`, `sync-roadmap-data`. Every one of them pins `node-version` explicitly, so v7's defaults cannot take effect:

| Workflow | node-version |
|---|---|
| deploy-dev (×2) | 24 |
| integration-tests | 24 |
| manual-qa-matrix | '24' |
| playwright-tests | 24 |
| qa-runner-driver-checks | '24' |
| **sync-roadmap-data** | **"20"** |

The composite itself declares `node-version` with `default: '24'` and is byte-identical on both branches.

## Two findings, deliberately NOT fixed here

Both arrived with Dependabot's own commits on main, so they are pre-existing rather than introduced by this sync. Fixing them inside a branch-sync PR would make the merge non-mechanical and hide them in a 45-line SHA diff. Filing as follow-ups:

1. **Pin-comment drift.** All six `setup-node` references now read `# v6` beside a SHA that resolves to `refs/tags/v7.0.0` (confirmed via the tags API). `check-action-shas.sh` verifies that actions *are* SHA-pinned but never that the comment matches the SHA, so CI cannot catch this. A comment that names the wrong version is worse than no comment — it is the thing a human reads when deciding whether a bump is risky.
2. **`sync-roadmap-data.yml` pins Node `"20"`** while every other workflow pins 24. Node 20 is past its maintenance window; this looks like drift rather than a deliberate exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014p7z8Wa2VGAMr8mJJuxVRD