### PR TITLE
fix(local): the local gate stops reporting failures that are not there

### DIFF
--- a/express-api/tests/scripts/50-matrix-cmd-stop.test.js
+++ b/express-api/tests/scripts/50-matrix-cmd-stop.test.js
@@ -159,17 +159,52 @@ describe('50-matrix.sh cmd_stop — honest stop + verification (SHY-0236)', () =
     });
   }
 
+  /**
+   * What `cmd_stop` actually said, for an assertion message.
+   *
+   * `expect(r.status).toBe(0)` on its own reports "Expected: 0, Received: 1"
+   * and nothing else — the script's own stdout/stderr, which say WHY it
+   * refused, are captured by spawnSync and thrown away. That is exactly the
+   * defect SHY-0277 fixed for journeys ("make a failing scenario say why it
+   * failed"), and it cost a full CI round trip here: a failure reproducible
+   * only on the Linux runner, reported as a bare 1.
+   *
+   * Attached to every status assertion below so a CI-only failure arrives
+   * diagnosable the first time.
+   *
+   * Thrown, not passed as a second argument to `expect`: the two-argument
+   * hint form is VITEST's. This suite is Jest, where the extra argument is
+   * not a message and quietly breaks the assertion — three tests that had
+   * been passing went red the moment it was added, which is how that was
+   * caught.
+   */
+  function expectStatus(r, expected) {
+    if (r.status !== expected) throw new Error(why(r));
+    expect(r.status).toBe(expected);
+  }
+
+  function why(r) {
+    const trim = (t) => (t || '').trim().slice(0, 2000) || '(empty)';
+    return [
+      `cmd_stop exited ${r.status}` +
+        (r.signal ? ` (signal ${r.signal})` : '') +
+        (r.error ? ` (spawn error: ${r.error.message})` : ''),
+      `--- stdout ---\n${trim(r.stdout)}`,
+      `--- stderr ---\n${trim(r.stderr)}`,
+    ].join('\n');
+  }
+
   test('clean run (dead pid, no live runners) → exit 0 and reports "0 runners remain"', () => {
     makeRun('clean-xyz', deadPid());
     const r = runStop('clean-xyz');
-    expect(r.status).toBe(0);
+    expectStatus(r, 0);
     expect(r.stdout).toMatch(/0 runners remain/);
   });
 
   test('missing pid file → dies with a clear message (exit 1)', () => {
     makeRun('nopid'); // dir but no pid file
     const r = runStop('nopid');
-    expect(r.status).toBe(1);
+    expectStatus(r, 1);
     expect(r.stderr).toMatch(/no pid file/);
   });
 
@@ -193,7 +228,7 @@ describe('50-matrix.sh cmd_stop — honest stop + verification (SHY-0236)', () =
     makeRun(id, deadPid());
     const r = runStop(id);
 
-    expect(r.status).toBe(0);
+    expectStatus(r, 0);
     expect(r.stdout).toMatch(/0 runners remain/);
     // Liveness via pgrep, NOT process.kill(pid,0): cmd_stop kills the fixture,
     // but Node (its parent) can't reap the zombie while our synchronous calls

--- a/express-api/tests/scripts/local-stack-resource-diet.test.js
+++ b/express-api/tests/scripts/local-stack-resource-diet.test.js
@@ -177,8 +177,13 @@ describe('Local-stack resource diet', () => {
     // blocks at the firebase emulators:start call indefinitely and
     // never reaches Step 3 onward. `FIREBASE_PID=$!` would capture
     // the wrong PID (the shell's, not firebase's).
+    // Matched on the FLAG and the trailing `&`, not on the literal path.
+    // The path became a variable when FRESH mode was added, and this
+    // assertion reddened -- pinning `local/firebase-emulator-data` was
+    // incidental to what it is actually about, which is that the launch is
+    // backgrounded at all.
     test('firebase emulator launch is backgrounded with trailing &', () => {
-      expect(scriptText).toMatch(/^ {2}--export-on-exit=local\/firebase-emulator-data &$/m);
+      expect(scriptText).toMatch(/^ {2}--export-on-exit=\S+ &$/m);
     });
 
     // Coverage gap (round 2): pin the FIREBASE_PID=$! capture
@@ -187,9 +192,7 @@ describe('Local-stack resource diet', () => {
     // (the trap function relies on FIREBASE_PID being valid).
     test('FIREBASE_PID is captured on the line immediately after the firebase & command', () => {
       const lines = scriptText.split('\n');
-      const ampLineIdx = lines.findIndex((l) =>
-        l.match(/^ {2}--export-on-exit=local\/firebase-emulator-data &$/),
-      );
+      const ampLineIdx = lines.findIndex((l) => l.match(/^ {2}--export-on-exit=\S+ &$/));
       expect(ampLineIdx).toBeGreaterThanOrEqual(0);
       expect(lines[ampLineIdx + 1]).toMatch(/^FIREBASE_PID=\$!$/);
     });
@@ -554,5 +557,60 @@ describe('Local-stack resource diet', () => {
         /Could not find service "livekit\.\*nonexistent"/,
       );
     });
+  });
+});
+
+/**
+ * Emulator data compounds, and the failure it causes is invisible where it
+ * bites.
+ *
+ * `--import` and `--export-on-exit` name the same path, so every run of
+ * local/start.sh imports the previous run's leftovers and writes its own on
+ * top. On 2026-08-13 that dataset had reached 7.9 MB and 843 Auth users, and
+ * `adminLogin` plus the admin tabs were slow enough to exceed Playwright's
+ * 20s test timeout: the pre-push gate reported 66 failing admin specs. None
+ * was a defect. The same spec on a clean emulator passed 11 of 11 in 24s.
+ *
+ * What is pinned here is the pair of guards that make that self-explaining:
+ * a way to start clean, and a warning before the wall rather than after it.
+ */
+describe('local/start.sh — emulator data does not compound silently', () => {
+  const startSh = () => fs.readFileSync(START_SH_PATH, 'utf-8');
+
+  it('offers FRESH=1 to start with no imported data', () => {
+    const sh = startSh();
+    expect(sh).toMatch(/FRESH:?-?/);
+    // The import flag must be OMITTED under FRESH, not merely pointed
+    // elsewhere: importing a different stale path is the same bug again.
+    expect(sh).toMatch(/IMPORT_ARGS=\(\)/);
+  });
+
+  it('still exports on exit under FRESH, so a clean run leaves clean data', () => {
+    // A FRESH run that also stopped exporting would leave the next run with
+    // nothing at all — which works, but silently discards the seeded state
+    // every time and hides that FRESH was ever used.
+    expect(startSh()).toMatch(/--export-on-exit="?\$EMULATOR_DATA/);
+  });
+
+  it('preserves the previous data rather than deleting it', () => {
+    // 7.9 MB of local state is not ours to throw away on a flag.
+    expect(startSh()).toMatch(/mv "\$EMULATOR_DATA" .*pre-fresh/);
+  });
+
+  it('warns while the dataset is still recoverable, not once tests fail', () => {
+    const sh = startSh();
+    // 4 MB: measured, not guessed. 7.9 MB was already failing and a freshly
+    // seeded export is under 1 MB, so the warning lands with room to act.
+    expect(sh).toMatch(/-gt 4096/);
+    expect(sh).toMatch(/FRESH=1 bash local\/start\.sh/);
+  });
+
+  it('names the symptom the operator will actually see', () => {
+    // A warning that says "data is large" teaches nothing. The failure
+    // presents as dozens of unrelated admin test failures, and the warning
+    // has to say so or it will be read past.
+    const sh = startSh();
+    expect(sh).toMatch(/time out|timeout/i);
+    expect(sh).toMatch(/pre-push|admin/i);
   });
 });

--- a/express-api/tests/scripts/sync-stories-to-issues.test.js
+++ b/express-api/tests/scripts/sync-stories-to-issues.test.js
@@ -25,14 +25,149 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
 const SCRIPT = path.join(REPO_ROOT, 'scripts', 'sync-stories-to-issues.sh');
 
 /** Spawn the sync script with the given args + return { code, stdout, stderr }. */
+/**
+ * A small FIXTURE corpus, so `--all` costs the same today as it will when
+ * the real corpus is twice the size.
+ *
+ * Every `--all` test used to run against the live `.project/stories` tree.
+ * That tree grew 10 -> 30 -> 221 files, the per-file bash+awk+jq overhead
+ * grew with it, and the harness timeout was bumped 15s -> 60s to keep up.
+ * It stopped keeping up: `--all --dry-run` now takes ~300s against the real
+ * corpus, `spawnSync` killed it at 60s, and the test reported the kill as
+ * the script exiting non-zero -- reading as "dry-run requires a token",
+ * which is not what happened and not true (run by hand it exits 0).
+ *
+ * Bumping the timeout a third time would buy the same amount of time again.
+ * The script already supports `STORIES_DIR` for exactly this -- a sibling
+ * suite (sync-stories-to-issues-board-fields.test.js) has always used it --
+ * so these tests point at a corpus they control. None of them asserts
+ * anything about corpus SIZE: they are about argument handling and exit
+ * codes, and three files exercise those as well as 221 do.
+ */
+/**
+ * One VALID story. Not a lookalike.
+ *
+ * `scripts/check-story-frontmatter.sh` is a real gate the sync script runs
+ * per file, and it wants ten `##` sections and eight `###` AC dimensions.
+ * The first fixture here carried only frontmatter; the script rejected every
+ * file and exited 40 -- the script being right and the fixture being wrong.
+ * Building the fixture until the REAL validator accepts it is what makes
+ * these tests exercise the same path a real story takes.
+ */
+const fixtureStory = (id, title, type) =>
+  [
+    '---',
+    `id: ${id}`,
+    'status: Draft',
+    'owner: claude',
+    'created: 2026-08-12',
+    'priority: P2',
+    'effort: M',
+    `type: ${type}`,
+    'roadmap_ids: []',
+    'pr:',
+    'mvp: false',
+    '---',
+    '',
+    `# ${id}: ${title}`,
+    '',
+    '## User Story',
+    'As a test, I want a valid story on disk, so that the sync script has something real to walk.',
+    '',
+    '## Why',
+    'A fixture that only resembles a story tests the script against a file it will never be given.',
+    '',
+    '## Acceptance Criteria',
+    '',
+    '### Happy path',
+    '- The story is listed by `--all`.',
+    '',
+    '### Error paths',
+    '- A malformed story is reported, not skipped silently.',
+    '',
+    '### Edge cases',
+    '- An empty corpus produces a summary with zero counts.',
+    '',
+    '### Performance',
+    '- Walking the fixture corpus completes well inside the harness timeout.',
+    '',
+    '### Security',
+    '- No token is required in dry-run.',
+    '',
+    '### UX',
+    '- The summary names what would change.',
+    '',
+    '### i18n',
+    '- Not applicable to a build-time script.',
+    '',
+    '### Observability',
+    '- Every decision is emitted with the story id.',
+    '',
+    '## BDD Scenarios',
+    '',
+    '```gherkin',
+    'Scenario: The sync lists a story it was given',
+    '  Given a folder holding one story',
+    '  When someone runs the sync in dry-run',
+    '  Then the summary names that story',
+    '```',
+    '',
+    '## Test Plan',
+    'Covered by tests/scripts/sync-stories-to-issues.test.js.',
+    '',
+    '## Out of Scope',
+    'Anything touching the live corpus.',
+    '',
+    '## Dependencies',
+    'None.',
+    '',
+    '## Risks & Mitigations',
+    'The fixture could drift from the real story shape; the validator is what stops that.',
+    '',
+    '## Definition of Done',
+    'The validator accepts this file.',
+    '',
+    '## Notes',
+    'Written as a fixture for the sync-script tests.',
+    '',
+  ].join('\n');
+
+/**
+ * A small FIXTURE corpus, so `--all` costs the same today as it will when
+ * the real corpus is twice the size.
+ *
+ * Every `--all` test used to run against the live `.project/stories` tree.
+ * That tree grew 10 -> 30 -> 221 files, the per-file bash+awk+jq overhead
+ * grew with it, and the harness timeout was bumped 15s -> 60s to keep up.
+ * It stopped keeping up: `--all --dry-run` took ~300s against the real
+ * corpus, `spawnSync` killed it at 60s, and the test reported the kill as
+ * the script exiting non-zero -- reading as "dry-run requires a token",
+ * which is not what happened and not true (run by hand it exits 0).
+ *
+ * Bumping the timeout a third time would buy the same amount of time again.
+ * The script already supports `STORIES_DIR` for exactly this -- a sibling
+ * suite (sync-stories-to-issues-board-fields.test.js) has always used it.
+ */
+function fixtureStories() {
+  const dir = tempDir('stories-');
+  fs.writeFileSync(
+    path.join(dir, 'SHY-9001-fixture-one.md'),
+    fixtureStory('SHY-9001', 'Fixture one', 'bug'),
+  );
+  fs.writeFileSync(
+    path.join(dir, 'SHY-9002-fixture-two.md'),
+    fixtureStory('SHY-9002', 'Fixture two', 'infra'),
+  );
+  fs.writeFileSync(
+    path.join(dir, 'SHY-9003-fixture-three.md'),
+    fixtureStory('SHY-9003', 'Fixture three', 'chore'),
+  );
+  return dir;
+}
+
 function runScript(args, opts = {}) {
-  // Timeout: was 15s when the test was authored against ~10 SHY files.
-  // As the SHY corpus grew past 30 files, --all dry-run started taking
-  // ~21s wall-clock locally (bash + awk + jq subprocess overhead per
-  // file). Bumped to 60s for ~3× headroom. The slow per-file overhead
-  // is a real perf issue tracked as a follow-up SHY (sync-stories
-  // optimisation); not in scope for SHY-0034. See [[feedback-fix-pre-
-  // existing-and-new-same]] — perf SHY filed in the same session.
+  // 60s is ample against the fixture corpus above; it was NOT against the
+  // live tree, which is what these tests used to walk. See fixtureStories.
   // SHY-0079: isolate the board-items.json sidecar per run so no test reads
   // or clobbers the real repo file. Caller-supplied BOARD_ITEMS_FILE wins.
   const env = { ...(opts.env ?? process.env) };
@@ -201,6 +336,7 @@ describe('scripts/sync-stories-to-issues.sh', () => {
       const { code, stderr } = runScript(['--all'], {
         env: {
           ...process.env,
+          STORIES_DIR: fixtureStories(),
           GH_PAT_PROJECT: '',
           GH_TOKEN: '',
         },
@@ -213,6 +349,7 @@ describe('scripts/sync-stories-to-issues.sh', () => {
       const { code } = runScript(['--all', '--dry-run'], {
         env: {
           ...process.env,
+          STORIES_DIR: fixtureStories(),
           GH_PAT_PROJECT: '',
         },
       });
@@ -228,17 +365,39 @@ describe('scripts/sync-stories-to-issues.sh', () => {
     });
   });
 
-  describe('--all --dry-run against the live stories directory', () => {
+  describe('--all --dry-run over a stories directory', () => {
+    // Was "against the live stories directory", asserting SHY-0001 and
+    // SHY-0002 by name. That coupled a test about ARGUMENT HANDLING to the
+    // contents of a corpus which has grown to 221 files -- it took ~300s,
+    // blew the harness timeout, and reported the kill as the script failing.
+    //
+    // What it actually proves is corpus-independent: given a directory of
+    // stories, --all visits EVERY one, says so, and prints a summary. Three
+    // fixture files prove that as well as 221 do -- and the fixture's own
+    // ids are asserted, so "visits every one" is checked rather than
+    // assumed from a count.
     it('exits 0, lists every SHY-NNNN file, prints summary', () => {
-      const { code, stderr } = runScript(['--all', '--dry-run']);
+      const { code, stderr } = runScript(['--all', '--dry-run'], {
+        env: { ...process.env, STORIES_DIR: fixtureStories() },
+      });
       expect(code).toBe(0);
-      // Should mention each live story.
-      expect(stderr).toMatch(/SHY-0001/);
-      expect(stderr).toMatch(/SHY-0002/);
+      for (const id of ['SHY-9001', 'SHY-9002', 'SHY-9003']) {
+        expect(stderr).toMatch(new RegExp(id));
+      }
       // Summary line (SHY-0081 v3 form: every story is a draft, no split).
       expect(stderr).toMatch(/Sync result: \d+ created, \d+ updated, \d+ skipped, \d+ failed/);
       // DRY-RUN tag visible.
       expect(stderr).toMatch(/DRY-RUN/);
+    });
+
+    // …and the LIVE tree is still what it reaches for by default. Asserted
+    // at the script, not by walking 221 files: the thing worth pinning is
+    // the default path, and executing the walk to discover it is what made
+    // this file slow in the first place.
+    it('defaults STORIES_DIR to the live .project/stories tree', () => {
+      const script = fs.readFileSync(SCRIPT, 'utf-8');
+      expect(script).toMatch(/STORIES_DIR:?=.*\.project\/stories/);
+      expect(fs.existsSync(path.join(REPO_ROOT, '.project', 'stories'))).toBe(true);
     });
   });
 

--- a/local/start.sh
+++ b/local/start.sh
@@ -101,10 +101,51 @@ cd "$PROJECT_ROOT"
 # 1g would OOM the build). `$!` after `env … cmd &` still captures
 # the right PID because env exec()s into cmd via execvp.
 # Pinned by tests/scripts/local-stack-resource-diet.test.js.
+# ---------------------------------------------------------------------------
+# Emulator data COMPOUNDS. `--import` and `--export-on-exit` name the same
+# path, so every run imports the last run's leftovers and writes its own on
+# top. Left alone the dataset grows without limit: on 2026-08-13 it had
+# reached 7.9 MB and 843 Auth users, at which point `adminLogin` and the
+# admin tabs were slow enough to blow Playwright's 20s test timeout, and the
+# pre-push gate reported 66 failing admin specs — one environment, presenting
+# as sixty-six defects. A clean emulator ran the same spec 11-passed in 24s.
+#
+# Two guards, because the failure is invisible at the point it bites:
+#   FRESH=1 bash local/start.sh   start from nothing (does not import)
+#   otherwise                      import as before, but SAY how big it is
+# The export still happens either way, so a FRESH run leaves a small, clean
+# dataset behind rather than a missing one.
+# ---------------------------------------------------------------------------
+EMULATOR_DATA="local/firebase-emulator-data"
+IMPORT_ARGS=(--import="$EMULATOR_DATA")
+
+if [ "${FRESH:-0}" = "1" ]; then
+  if [ -d "$EMULATOR_DATA" ]; then
+    STAMP="$(date +%Y%m%d-%H%M%S)"
+    mv "$EMULATOR_DATA" "${EMULATOR_DATA}.pre-fresh-${STAMP}"
+    echo "  FRESH=1 — previous emulator data kept at ${EMULATOR_DATA}.pre-fresh-${STAMP}"
+  fi
+  IMPORT_ARGS=()
+  echo "  FRESH=1 — starting emulators with NO imported data."
+elif [ -d "$EMULATOR_DATA" ]; then
+  DATA_KB="$(du -sk "$EMULATOR_DATA" 2>/dev/null | cut -f1)"
+  # 4 MB. Chosen from the measurement above, not guessed: 7.9 MB was already
+  # failing and a freshly-seeded export is well under 1 MB, so this warns with
+  # room to act rather than at the point tests start timing out.
+  if [ "${DATA_KB:-0}" -gt 4096 ]; then
+    echo ""
+    echo "  ⚠ Emulator data is $((DATA_KB / 1024)) MB and grows every run."
+    echo "    Past ~8 MB the admin Playwright specs time out in beforeEach and"
+    echo "    the pre-push gate reports dozens of failures that are not real."
+    echo "    Start clean with:  FRESH=1 bash local/start.sh"
+    echo ""
+  fi
+fi
+
 env JAVA_TOOL_OPTIONS="-Xmx1g" npx firebase emulators:start \
   --project=demo-shytalk \
-  --import=local/firebase-emulator-data \
-  --export-on-exit=local/firebase-emulator-data &
+  "${IMPORT_ARGS[@]}" \
+  --export-on-exit="$EMULATOR_DATA" &
 FIREBASE_PID=$!
 
 # =============================================================================


### PR DESCRIPTION
Two fixes to the local verification gate. Both were found while verifying
the develop→main promotion, and between them they explain why that
promotion has been stuck.

## 1. The pre-push gate reported 66 admin failures that were not real

`local/start.sh` passed the **same path** to `--import` and
`--export-on-exit`, so every run imported the previous run's leftovers and
wrote its own on top. Nothing pruned it. Measured today: **7.9 MB, 843 Auth
users**.

That is enough to make `adminLogin` and the admin tabs slower than
Playwright's 20s test timeout. The gate reported **66 failing `admin-*`
specs** — every failing spec in the run, all timing out in the same
`beforeEach`. None was a defect.

| | dirty (843 users) | clean (19 users) |
|---|---|---|
| `admin-audit-log.spec.ts` | 8 failed | **11 passed, 2 skipped** |
| full chromium suite | 1081 passed / **66 failed** / 285 did not run, 55 min | **1420 passed / 0 failed / 1 flaky, 16 min** |

Guards added, because the failure is invisible where it bites:

```
FRESH=1 bash local/start.sh   # omits --import entirely
otherwise                     # imports as before, but SAYS how big it is
```

`FRESH` still exports on exit (a clean run leaves clean data, not none) and
**moves** the old dataset aside rather than deleting it. The 4 MB warning
threshold is measured, not guessed — 7.9 MB was already failing, a freshly
seeded export is under 1 MB. The message names the symptom an operator will
actually meet, because "data is large" gets read past.

## 2. A backend test walked the live 221-file corpus

`sync-stories-to-issues.test.js` → "does NOT require GH_PAT_PROJECT in
--dry-run mode" was failing on `develop`. The harness spawns the script with
a **60s timeout**; `--all --dry-run` takes **~300s** because it walks the
live `.project/stories` tree. `spawnSync` killed it and the test reported the
kill as a non-zero exit — reading as "dry-run requires a token", which is not
what happened and not true. By hand the script exits 0.

The test's own comment predicted it: *"was 15s against ~10 SHY files… as the
corpus grew past 30… bumped to 60s"*. It has been bumped once; the corpus has
grown 7× since, so a third bump buys the same time again.

All three `--all` tests now use `STORIES_DIR` — an override the script has
always supported and a sibling suite has always used. **302s → 7s**; the whole
backend suite **455s → 194s**.

The fixture is a **valid** story, not a lookalike: the first version carried
frontmatter only and the script rejected it with `E_API=40`, which was the
script being right. It is built until `check-story-frontmatter.sh` accepts it.

## Verification

- Backend: **409 suites, 13,723 tests, all passing** against the full local
  stack (LiveKit + MinIO + Mailpit + emulators + Express).
- Web, clean emulator: **1420 passed / 1 flaky / 38 skipped**, gate green.
- Two pre-existing assertions reddened and were corrected rather than worked
  around — they pinned the literal `--export-on-exit=local/firebase-emulator-data &`
  where what they mean is the trailing `&`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Wrjs1zPLBUJLeekgSNC25